### PR TITLE
azurerm_virtual_desktop_msix_package: new resource to support MSIX application for Azure Virtual Desktop

### DIFF
--- a/internal/services/desktopvirtualization/client/client.go
+++ b/internal/services/desktopvirtualization/client/client.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/applicationgroup"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/desktop"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/hostpool"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/msixpackage"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/scalingplan"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/sessionhost"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/workspace"
@@ -21,6 +22,7 @@ type Client struct {
 	ApplicationsClient      *application.ApplicationClient
 	DesktopsClient          *desktop.DesktopClient
 	HostPoolsClient         *hostpool.HostPoolClient
+	MSIXPackageClient       *msixpackage.MSIXPackageClient
 	SessionHostsClient      *sessionhost.SessionHostClient
 	ScalingPlansClient      *scalingplan.ScalingPlanClient
 	WorkspacesClient        *workspace.WorkspaceClient
@@ -51,6 +53,12 @@ func NewClient(o *common.ClientOptions) (*Client, error) {
 	}
 	o.Configure(hostPoolsClient.Client, o.Authorizers.ResourceManager)
 
+	msixPackageClient, err := msixpackage.NewMSIXPackageClientWithBaseURI(o.Environment.ResourceManager)
+	if err != nil {
+		return nil, fmt.Errorf("building MSIXPackage Client: %+v", err)
+	}
+	o.Configure(msixPackageClient.Client, o.Authorizers.ResourceManager)
+
 	sessionHostsClient, err := sessionhost.NewSessionHostClientWithBaseURI(o.Environment.ResourceManager)
 	if err != nil {
 		return nil, fmt.Errorf("building SessionHost Client: %+v", err)
@@ -74,6 +82,7 @@ func NewClient(o *common.ClientOptions) (*Client, error) {
 		ApplicationsClient:      applicationsClient,
 		DesktopsClient:          desktopsClient,
 		HostPoolsClient:         hostPoolsClient,
+		MSIXPackageClient:       msixPackageClient,
 		SessionHostsClient:      sessionHostsClient,
 		ScalingPlansClient:      scalingPlansClient,
 		WorkspacesClient:        workspacesClient,

--- a/internal/services/desktopvirtualization/registration.go
+++ b/internal/services/desktopvirtualization/registration.go
@@ -38,7 +38,9 @@ func (r Registration) DataSources() []sdk.DataSource {
 }
 
 func (r Registration) Resources() []sdk.Resource {
-	return []sdk.Resource{}
+	return []sdk.Resource{
+		VirtualDesktopMSIXPackageResource{},
+	}
 }
 
 // SupportedDataSources returns the supported Data Sources supported by this Service

--- a/internal/services/desktopvirtualization/virtual_desktop_application_resource_test.go
+++ b/internal/services/desktopvirtualization/virtual_desktop_application_resource_test.go
@@ -90,6 +90,20 @@ func TestAccVirtualDesktopApplication_requiresImport(t *testing.T) {
 	})
 }
 
+func TestAccVirtualDesktopApplication_msixType(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_virtual_desktop_application", "test")
+	r := VirtualDesktopApplicationResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.msixType(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+	})
+}
+
 func (VirtualDesktopApplicationResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := application.ParseApplicationID(state.ID)
 	if err != nil {
@@ -116,7 +130,7 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_virtual_desktop_host_pool" "test" {
-  name                = "acctestHP"
+  name                = "acctestHP%d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   type                = "Pooled"
@@ -137,7 +151,7 @@ resource "azurerm_virtual_desktop_application" "test" {
   path                         = "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe"
   command_line_argument_policy = "DoNotAllow"
 }
-`, data.RandomInteger, data.Locations.Secondary, data.RandomIntOfLength(8), data.RandomIntOfLength(8))
+`, data.RandomInteger, data.Locations.Secondary, data.RandomIntOfLength(8), data.RandomIntOfLength(8), data.RandomIntOfLength(8))
 }
 
 func (VirtualDesktopApplicationResource) complete(data acceptance.TestData) string {
@@ -152,7 +166,7 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_virtual_desktop_host_pool" "test" {
-  name                 = "acctestHP"
+  name                 = "acctestHP%d"
   location             = azurerm_resource_group.test.location
   resource_group_name  = azurerm_resource_group.test.name
   validate_environment = true
@@ -186,7 +200,7 @@ resource "azurerm_virtual_desktop_application" "test" {
   icon_path                    = "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe"
   icon_index                   = 1
 }
-`, data.RandomInteger, data.Locations.Secondary, data.RandomIntOfLength(8), data.RandomIntOfLength(8))
+`, data.RandomInteger, data.Locations.Secondary, data.RandomIntOfLength(8), data.RandomIntOfLength(8), data.RandomIntOfLength(8))
 }
 
 func (r VirtualDesktopApplicationResource) requiresImport(data acceptance.TestData) string {
@@ -201,4 +215,65 @@ resource "azurerm_virtual_desktop_application" "import" {
 
 }
 `, r.basic(data))
+}
+
+func (VirtualDesktopApplicationResource) msixType(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-vdesktop-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_desktop_host_pool" "test" {
+  name                = "acctestHP%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  type                = "Pooled"
+  load_balancer_type  = "BreadthFirst"
+}
+
+resource "azurerm_virtual_desktop_application_group" "test" {
+  name                = "acctestAG%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  type                = "RemoteApp"
+  host_pool_id        = azurerm_virtual_desktop_host_pool.test.id
+}
+
+resource "azurerm_virtual_desktop_msix_package" "test" {
+  name                  = "acctestMSIXPackage%d"
+  host_pool_name        = azurerm_virtual_desktop_host_pool.test.name
+  resource_group_name   = azurerm_resource_group.test.name
+  image_path            = "\\\\path\\to\\image.vhd"
+  last_updated_in_utc   = "2021-09-01T00:00:00"
+
+  package_application {
+    app_id            = "app-1"
+    app_user_model_id = "app-user-model-1"
+    description       = "Testing app 1"
+    friendly_name     = "I am your friendly neighbourhood testing app 1"
+    icon_image_name   = "icon.png"
+    raw_icon          = "VGhpcyBpcyBhIHN0cmluZyB0byBoYXNo"
+    raw_png           = "VGhpcyBpcyBhIHN0cmluZyB0byBwYWdl"
+  }
+
+  package_family_name   = "msix-package-family-1"
+  package_name          = "msix-package-1"
+  package_relative_path = "path\\to\\package"
+  version               = "0.0.0.1"
+}
+
+resource "azurerm_virtual_desktop_application" "test" {
+  name                         = "acctestAG%d"
+  application_group_id         = azurerm_virtual_desktop_application_group.test.id
+  command_line_argument_policy = "DoNotAllow"
+  application_type             = "MsixApplication"
+  msix_package_app_id          = azurerm_virtual_desktop_msix_package.test.package_application[0].app_id
+  msix_package_family_name     = azurerm_virtual_desktop_msix_package.test.package_family_name
+}
+`, data.RandomInteger, data.Locations.Secondary, data.RandomIntOfLength(8), data.RandomIntOfLength(8), data.RandomIntOfLength(8), data.RandomIntOfLength(8))
 }

--- a/internal/services/desktopvirtualization/virtual_desktop_msix_package_resource.go
+++ b/internal/services/desktopvirtualization/virtual_desktop_msix_package_resource.go
@@ -1,0 +1,383 @@
+package desktopvirtualization
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/msixpackage"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+var _ sdk.Resource = VirtualDesktopMSIXPackageResource{}
+
+type VirtualDesktopMSIXPackageResource struct{}
+
+type PackageApplicationModel struct {
+	AppId          string `tfschema:"app_id"`
+	AppUserModelId string `tfschema:"app_user_model_id"`
+	Description    string `tfschema:"description"`
+	FriendlyName   string `tfschema:"friendly_name"`
+	IconImageName  string `tfschema:"icon_image_name"`
+	RawIcon        string `tfschema:"raw_icon"`
+	RawPng         string `tfschema:"raw_png"`
+}
+
+type PackageDependencyModel struct {
+	DependencyName string `tfschema:"dependency_name"`
+	MinVersion     string `tfschema:"min_version"`
+	Publisher      string `tfschema:"publisher"`
+}
+
+type VirtualDesktopMSIXPackageResourceModel struct {
+	// ID fields
+
+	Name              string `tfschema:"name"`
+	HostPoolName      string `tfschema:"host_pool_name"`
+	ResourceGroupName string `tfschema:"resource_group_name"`
+
+	// Required fields
+
+	ImagePath           string                    `tfschema:"image_path"`
+	LastUpdatedInUTC    string                    `tfschema:"last_updated_in_utc"`
+	PackageApplications []PackageApplicationModel `tfschema:"package_application"`
+	PackageFamilyName   string                    `tfschema:"package_family_name"`
+	PackageName         string                    `tfschema:"package_name"`
+	PackageRelativePath string                    `tfschema:"package_relative_path"`
+	Version             string                    `tfschema:"version"`
+
+	// Optional fields
+
+	DisplayName                string                   `tfschema:"display_name"`
+	Enabled                    bool                     `tfschema:"enabled"`
+	PackageDependencies        []PackageDependencyModel `tfschema:"package_dependency"`
+	RegularRegistrationEnabled bool                     `tfschema:"regular_registration_enabled"`
+}
+
+func requiredNotEmptyStringForceNewSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:         schema.TypeString,
+		Required:     true,
+		ForceNew:     true,
+		ValidateFunc: validation.StringIsNotEmpty,
+	}
+}
+
+func (VirtualDesktopMSIXPackageResource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": requiredNotEmptyStringForceNewSchema(),
+
+		"host_pool_name": requiredNotEmptyStringForceNewSchema(),
+
+		"resource_group_name": commonschema.ResourceGroupName(),
+
+		"image_path": requiredNotEmptyStringForceNewSchema(),
+
+		"last_updated_in_utc": requiredNotEmptyStringForceNewSchema(),
+
+		"package_application": {
+			Type:     pluginsdk.TypeList,
+			MinItems: 1,
+			Required: true,
+			ForceNew: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"app_id": requiredNotEmptyStringForceNewSchema(),
+
+					"app_user_model_id": requiredNotEmptyStringForceNewSchema(),
+
+					"description": requiredNotEmptyStringForceNewSchema(),
+
+					"friendly_name": requiredNotEmptyStringForceNewSchema(),
+
+					"icon_image_name": requiredNotEmptyStringForceNewSchema(),
+
+					"raw_icon": requiredNotEmptyStringForceNewSchema(),
+
+					"raw_png": requiredNotEmptyStringForceNewSchema(),
+				},
+			},
+		},
+
+		"package_family_name": requiredNotEmptyStringForceNewSchema(),
+
+		"package_name": requiredNotEmptyStringForceNewSchema(),
+
+		"package_relative_path": requiredNotEmptyStringForceNewSchema(),
+
+		"version": requiredNotEmptyStringForceNewSchema(),
+
+		"display_name": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"enabled": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  true,
+		},
+
+		"package_dependency": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"dependency_name": requiredNotEmptyStringForceNewSchema(),
+
+					"min_version": requiredNotEmptyStringForceNewSchema(),
+
+					"publisher": requiredNotEmptyStringForceNewSchema(),
+				},
+			},
+		},
+
+		"regular_registration_enabled": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  true,
+		},
+	}
+}
+
+func (VirtualDesktopMSIXPackageResource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{}
+}
+
+func (VirtualDesktopMSIXPackageResource) ModelObject() interface{} {
+	return &VirtualDesktopMSIXPackageResourceModel{}
+}
+
+func (VirtualDesktopMSIXPackageResource) ResourceType() string {
+	return "azurerm_virtual_desktop_msix_package"
+}
+
+func (r VirtualDesktopMSIXPackageResource) Create() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.DesktopVirtualization.MSIXPackageClient
+
+			subscriptionId := metadata.Client.Account.SubscriptionId
+
+			var config VirtualDesktopMSIXPackageResourceModel
+			if err := metadata.Decode(&config); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			id := msixpackage.NewMsixPackageID(subscriptionId, config.ResourceGroupName, config.HostPoolName, config.Name)
+
+			existing, err := client.Get(ctx, id)
+			if err != nil && !response.WasNotFound(existing.HttpResponse) {
+				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+			}
+			if !response.WasNotFound(existing.HttpResponse) {
+				return metadata.ResourceRequiresImport(r.ResourceType(), id)
+			}
+
+			payload := msixpackage.MSIXPackage{
+				Properties: msixpackage.MSIXPackageProperties{
+					DisplayName:           pointer.To(config.DisplayName),
+					ImagePath:             pointer.To(config.ImagePath),
+					IsActive:              pointer.To(config.Enabled),
+					IsRegularRegistration: pointer.To(config.RegularRegistrationEnabled),
+					LastUpdated:           pointer.To(config.LastUpdatedInUTC),
+					PackageApplications:   expandPackageApplications(config.PackageApplications),
+					PackageDependencies:   expandPackageDependencies(config.PackageDependencies),
+					PackageFamilyName:     pointer.To(config.PackageFamilyName),
+					PackageName:           pointer.To(config.PackageName),
+					PackageRelativePath:   pointer.To(config.PackageRelativePath),
+					Version:               pointer.To(config.Version),
+				},
+			}
+
+			if _, err := client.CreateOrUpdate(ctx, id, payload); err != nil {
+				return fmt.Errorf("creating %s: %+v", id, err)
+			}
+
+			metadata.SetID(id)
+			return nil
+		},
+	}
+}
+
+func expandPackageApplications(packageApplicationModel []PackageApplicationModel) *[]msixpackage.MsixPackageApplications {
+	packageApplications := make([]msixpackage.MsixPackageApplications, 0)
+	for _, model := range packageApplicationModel {
+		packageApplications = append(packageApplications, msixpackage.MsixPackageApplications{
+			AppId:          pointer.To(model.AppId),
+			AppUserModelID: pointer.To(model.AppUserModelId),
+			Description:    pointer.To(model.Description),
+			FriendlyName:   pointer.To(model.FriendlyName),
+			IconImageName:  pointer.To(model.IconImageName),
+			RawIcon:        pointer.To(model.RawIcon),
+			RawPng:         pointer.To(model.RawPng),
+		})
+	}
+	return &packageApplications
+}
+
+func expandPackageDependencies(packageDependencyModel []PackageDependencyModel) *[]msixpackage.MsixPackageDependencies {
+	packageDependencies := make([]msixpackage.MsixPackageDependencies, 0)
+	for _, model := range packageDependencyModel {
+		packageDependencies = append(packageDependencies, msixpackage.MsixPackageDependencies{
+			DependencyName: pointer.To(model.DependencyName),
+			MinVersion:     pointer.To(model.MinVersion),
+			Publisher:      pointer.To(model.Publisher),
+		})
+	}
+	return &packageDependencies
+}
+
+func (r VirtualDesktopMSIXPackageResource) Update() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.DesktopVirtualization.MSIXPackageClient
+
+			id, err := msixpackage.ParseMsixPackageID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			var config VirtualDesktopMSIXPackageResourceModel
+			if err := metadata.Decode(&config); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			existing, err := client.Get(ctx, *id)
+			if err != nil {
+				return fmt.Errorf("retrieving %s: %+v", *id, err)
+			}
+
+			if existing.Model == nil {
+				return fmt.Errorf("retrieving %s: `model` was nil", *id)
+			}
+
+			payload := existing.Model
+
+			if metadata.ResourceData.HasChange("display_name") {
+				payload.Properties.DisplayName = pointer.To(config.DisplayName)
+			}
+
+			if metadata.ResourceData.HasChange("enabled") {
+				payload.Properties.IsActive = pointer.To(config.Enabled)
+			}
+
+			if metadata.ResourceData.HasChange("regular_registration_enabled") {
+				payload.Properties.IsRegularRegistration = pointer.To(config.RegularRegistrationEnabled)
+			}
+
+			if _, err := client.CreateOrUpdate(ctx, *id, *payload); err != nil {
+				return fmt.Errorf("updating %s: %+v", *id, err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func (VirtualDesktopMSIXPackageResource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.DesktopVirtualization.MSIXPackageClient
+
+			id, err := msixpackage.ParseMsixPackageID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.Get(ctx, *id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return metadata.MarkAsGone(id)
+				}
+				return fmt.Errorf("retrieving %s: %+v", *id, err)
+			}
+
+			if resp.Model == nil {
+				return fmt.Errorf("retrieving %s: `model` was nil", *id)
+			}
+
+			props := resp.Model.Properties
+
+			state := VirtualDesktopMSIXPackageResourceModel{
+				Name:                       id.MsixPackageName,
+				HostPoolName:               id.HostPoolName,
+				ResourceGroupName:          id.ResourceGroupName,
+				ImagePath:                  pointer.From(props.ImagePath),
+				LastUpdatedInUTC:           pointer.From(props.LastUpdated),
+				PackageApplications:        *flattenPackageApplications(props.PackageApplications),
+				PackageFamilyName:          pointer.From(props.PackageFamilyName),
+				PackageName:                pointer.From(props.PackageName),
+				PackageRelativePath:        pointer.From(props.PackageRelativePath),
+				Version:                    pointer.From(props.Version),
+				DisplayName:                pointer.From(props.DisplayName),
+				Enabled:                    pointer.From(props.IsActive),
+				PackageDependencies:        *flattenPackageDependencies(props.PackageDependencies),
+				RegularRegistrationEnabled: pointer.From(props.IsRegularRegistration),
+			}
+
+			return metadata.Encode(&state)
+		},
+	}
+}
+
+func flattenPackageApplications(msixPackageApplications *[]msixpackage.MsixPackageApplications) *[]PackageApplicationModel {
+	models := make([]PackageApplicationModel, 0)
+	for _, msixPackageApplication := range pointer.From(msixPackageApplications) {
+		models = append(models, PackageApplicationModel{
+			AppId:          pointer.From(msixPackageApplication.AppId),
+			AppUserModelId: pointer.From(msixPackageApplication.AppUserModelID),
+			Description:    pointer.From(msixPackageApplication.Description),
+			FriendlyName:   pointer.From(msixPackageApplication.FriendlyName),
+			IconImageName:  pointer.From(msixPackageApplication.IconImageName),
+			RawIcon:        pointer.From(msixPackageApplication.RawIcon),
+			RawPng:         pointer.From(msixPackageApplication.RawPng),
+		})
+	}
+	return &models
+}
+
+func flattenPackageDependencies(msixPackageDependencies *[]msixpackage.MsixPackageDependencies) *[]PackageDependencyModel {
+	models := make([]PackageDependencyModel, 0)
+	for _, msixPackageDependency := range pointer.From(msixPackageDependencies) {
+		models = append(models, PackageDependencyModel{
+			DependencyName: pointer.From(msixPackageDependency.DependencyName),
+			MinVersion:     pointer.From(msixPackageDependency.MinVersion),
+			Publisher:      pointer.From(msixPackageDependency.Publisher),
+		})
+	}
+	return &models
+}
+
+func (VirtualDesktopMSIXPackageResource) Delete() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.DesktopVirtualization.MSIXPackageClient
+
+			id, err := msixpackage.ParseMsixPackageID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			if _, err := client.Delete(ctx, *id); err != nil {
+				return fmt.Errorf("deleting %s: %+v", *id, err)
+			}
+			return nil
+		},
+	}
+}
+
+func (VirtualDesktopMSIXPackageResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return msixpackage.ValidateMsixPackageID
+}

--- a/internal/services/desktopvirtualization/virtual_desktop_msix_package_resource_test.go
+++ b/internal/services/desktopvirtualization/virtual_desktop_msix_package_resource_test.go
@@ -1,0 +1,236 @@
+package desktopvirtualization_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/msixpackage"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type VirtualDesktopMSIXPackageTestResource struct{}
+
+func TestAccVirtualDesktopMSIXPackage_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_virtual_desktop_msix_package", "test")
+	r := VirtualDesktopMSIXPackageTestResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data, false),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccVirtualDesktopMSIXPackage_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_virtual_desktop_msix_package", "test")
+	r := VirtualDesktopMSIXPackageTestResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data, false),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func TestAccVirtualDesktopMSIXPackage_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_virtual_desktop_msix_package", "test")
+	r := VirtualDesktopMSIXPackageTestResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccVirtualDesktopMSIXPackage_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_virtual_desktop_msix_package", "test")
+	r := VirtualDesktopMSIXPackageTestResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (VirtualDesktopMSIXPackageTestResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := msixpackage.ParseMsixPackageID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.DesktopVirtualization.MSIXPackageClient.Get(ctx, *id)
+	if err != nil {
+		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
+	}
+
+	return pointer.To(resp.Model != nil), nil
+}
+
+func (VirtualDesktopMSIXPackageTestResource) basic(data acceptance.TestData, withPackageDependencies bool) string {
+	packageDependencies := ""
+	if withPackageDependencies {
+		packageDependencies = `
+  package_dependency {
+    dependency_name = "dependency-1"
+    min_version     = "0.0.0.2"
+    publisher       = "publisher-1"
+  }
+`
+	}
+
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-vdesktop-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_desktop_host_pool" "test" {
+  name                = "acctestHP-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  type                = "Pooled"
+  load_balancer_type  = "BreadthFirst"
+}
+
+resource "azurerm_virtual_desktop_msix_package" "test" {
+  name                  = "acctestMSIXPackage"
+  host_pool_name        = azurerm_virtual_desktop_host_pool.test.name
+  resource_group_name   = azurerm_resource_group.test.name
+  image_path            = "//path/to/image.vhd"
+  last_updated_in_utc   = "2021-09-01T00:00:00"
+
+  package_application {
+    app_id            = "app-1"
+    app_user_model_id = "app-user-model-1"
+    description       = "Testing app 1"
+    friendly_name     = "I am your friendly neighbourhood testing app 1"
+    icon_image_name   = "icon.png"
+    raw_icon          = "VGhpcyBpcyBhIHN0cmluZyB0byBoYXNo"
+    raw_png           = "VGhpcyBpcyBhIHN0cmluZyB0byBwYWdl"
+  }
+
+  package_family_name   = "msix-package-family-1"
+  package_name          = "msix-package-1"
+  package_relative_path = "path/to/package"
+  version               = "0.0.0.1"
+
+  %s
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, packageDependencies)
+}
+
+func (r VirtualDesktopMSIXPackageTestResource) requiresImport(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_virtual_desktop_msix_package" "import" {
+  name                  = "acctestMSIXPackage"
+  host_pool_name        = azurerm_virtual_desktop_host_pool.test.name
+  resource_group_name   = azurerm_resource_group.test.name
+  image_path            = "//path/to/image.vhd"
+  last_updated_in_utc   = "2021-09-01T00:00:00"
+
+  package_application {
+    app_id            = "app-1"
+    app_user_model_id = "app-user-model-1"
+    description       = "Testing app 1"
+    friendly_name     = "I am your friendly neighbourhood testing app 1"
+    icon_image_name   = "icon.png"
+    raw_icon          = "VGhpcyBpcyBhIHN0cmluZyB0byBoYXNo"
+    raw_png           = "VGhpcyBpcyBhIHN0cmluZyB0byBwYWdl"
+  }
+
+  package_family_name   = "msix-package-family-1"
+  package_name          = "msix-package-1"
+  package_relative_path = "path/to/package"
+  version               = "0.0.0.1"
+}
+`, r.basic(data, false))
+}
+
+func (r VirtualDesktopMSIXPackageTestResource) complete(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-vdesktop-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_desktop_host_pool" "test" {
+  name                = "acctestHP-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  type                = "Pooled"
+  load_balancer_type  = "BreadthFirst"
+}
+
+resource "azurerm_virtual_desktop_msix_package" "test" {
+  name                  = "acctestMSIXPackage"
+  host_pool_name        = azurerm_virtual_desktop_host_pool.test.name
+  resource_group_name   = azurerm_resource_group.test.name
+  image_path            = "//path/to/image.vhd"
+  last_updated_in_utc   = "2021-09-01T00:00:00"
+
+  package_application {
+    app_id            = "app-1"
+    app_user_model_id = "app-user-model-1"
+    description       = "Testing app 1"
+    friendly_name     = "I am your friendly neighbourhood testing app 1"
+    icon_image_name   = "icon.png"
+    raw_icon          = "VGhpcyBpcyBhIHN0cmluZyB0byBoYXNo"
+    raw_png           = "VGhpcyBpcyBhIHN0cmluZyB0byBwYWdl"
+  }
+
+  package_family_name   = "msix-package-family-1"
+  package_name          = "msix-package-1"
+  package_relative_path = "path/to/package"
+  version               = "0.0.0.1"
+
+  display_name = "acctestMSIXPackage"
+  enabled = true
+  
+  package_dependency {
+    dependency_name = "dependency-1"
+    min_version     = "0.0.0.2"
+    publisher       = "publisher-1"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/msixpackage/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/msixpackage/README.md
@@ -1,0 +1,111 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/msixpackage` Documentation
+
+The `msixpackage` SDK allows for interaction with Azure Resource Manager `desktopvirtualization` (API Version `2022-02-10-preview`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/msixpackage"
+```
+
+
+### Client Initialization
+
+```go
+client := msixpackage.NewMSIXPackageClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `MSIXPackageClient.CreateOrUpdate`
+
+```go
+ctx := context.TODO()
+id := msixpackage.NewMsixPackageID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostPoolName", "msixPackageName")
+
+payload := msixpackage.MSIXPackage{
+	// ...
+}
+
+
+read, err := client.CreateOrUpdate(ctx, id, payload)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `MSIXPackageClient.Delete`
+
+```go
+ctx := context.TODO()
+id := msixpackage.NewMsixPackageID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostPoolName", "msixPackageName")
+
+read, err := client.Delete(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `MSIXPackageClient.Get`
+
+```go
+ctx := context.TODO()
+id := msixpackage.NewMsixPackageID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostPoolName", "msixPackageName")
+
+read, err := client.Get(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `MSIXPackageClient.List`
+
+```go
+ctx := context.TODO()
+id := msixpackage.NewHostPoolID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostPoolName")
+
+// alternatively `client.List(ctx, id)` can be used to do batched pagination
+items, err := client.ListComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `MSIXPackageClient.Update`
+
+```go
+ctx := context.TODO()
+id := msixpackage.NewMsixPackageID("12345678-1234-9876-4563-123456789012", "example-resource-group", "hostPoolName", "msixPackageName")
+
+payload := msixpackage.MSIXPackagePatch{
+	// ...
+}
+
+
+read, err := client.Update(ctx, id, payload)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/msixpackage/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/msixpackage/client.go
@@ -1,0 +1,26 @@
+package msixpackage
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type MSIXPackageClient struct {
+	Client *resourcemanager.Client
+}
+
+func NewMSIXPackageClientWithBaseURI(sdkApi sdkEnv.Api) (*MSIXPackageClient, error) {
+	client, err := resourcemanager.NewClient(sdkApi, "msixpackage", defaultApiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating MSIXPackageClient: %+v", err)
+	}
+
+	return &MSIXPackageClient{
+		Client: client,
+	}, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/msixpackage/id_hostpool.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/msixpackage/id_hostpool.go
@@ -1,0 +1,130 @@
+package msixpackage
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&HostPoolId{})
+}
+
+var _ resourceids.ResourceId = &HostPoolId{}
+
+// HostPoolId is a struct representing the Resource ID for a Host Pool
+type HostPoolId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	HostPoolName      string
+}
+
+// NewHostPoolID returns a new HostPoolId struct
+func NewHostPoolID(subscriptionId string, resourceGroupName string, hostPoolName string) HostPoolId {
+	return HostPoolId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		HostPoolName:      hostPoolName,
+	}
+}
+
+// ParseHostPoolID parses 'input' into a HostPoolId
+func ParseHostPoolID(input string) (*HostPoolId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&HostPoolId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := HostPoolId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseHostPoolIDInsensitively parses 'input' case-insensitively into a HostPoolId
+// note: this method should only be used for API response data and not user input
+func ParseHostPoolIDInsensitively(input string) (*HostPoolId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&HostPoolId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := HostPoolId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *HostPoolId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.HostPoolName, ok = input.Parsed["hostPoolName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "hostPoolName", input)
+	}
+
+	return nil
+}
+
+// ValidateHostPoolID checks that 'input' can be parsed as a Host Pool ID
+func ValidateHostPoolID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseHostPoolID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Host Pool ID
+func (id HostPoolId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.DesktopVirtualization/hostPools/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.HostPoolName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Host Pool ID
+func (id HostPoolId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftDesktopVirtualization", "Microsoft.DesktopVirtualization", "Microsoft.DesktopVirtualization"),
+		resourceids.StaticSegment("staticHostPools", "hostPools", "hostPools"),
+		resourceids.UserSpecifiedSegment("hostPoolName", "hostPoolName"),
+	}
+}
+
+// String returns a human-readable description of this Host Pool ID
+func (id HostPoolId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Host Pool Name: %q", id.HostPoolName),
+	}
+	return fmt.Sprintf("Host Pool (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/msixpackage/id_msixpackage.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/msixpackage/id_msixpackage.go
@@ -1,0 +1,139 @@
+package msixpackage
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&MsixPackageId{})
+}
+
+var _ resourceids.ResourceId = &MsixPackageId{}
+
+// MsixPackageId is a struct representing the Resource ID for a Msix Package
+type MsixPackageId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	HostPoolName      string
+	MsixPackageName   string
+}
+
+// NewMsixPackageID returns a new MsixPackageId struct
+func NewMsixPackageID(subscriptionId string, resourceGroupName string, hostPoolName string, msixPackageName string) MsixPackageId {
+	return MsixPackageId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		HostPoolName:      hostPoolName,
+		MsixPackageName:   msixPackageName,
+	}
+}
+
+// ParseMsixPackageID parses 'input' into a MsixPackageId
+func ParseMsixPackageID(input string) (*MsixPackageId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&MsixPackageId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := MsixPackageId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseMsixPackageIDInsensitively parses 'input' case-insensitively into a MsixPackageId
+// note: this method should only be used for API response data and not user input
+func ParseMsixPackageIDInsensitively(input string) (*MsixPackageId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&MsixPackageId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := MsixPackageId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *MsixPackageId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.HostPoolName, ok = input.Parsed["hostPoolName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "hostPoolName", input)
+	}
+
+	if id.MsixPackageName, ok = input.Parsed["msixPackageName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "msixPackageName", input)
+	}
+
+	return nil
+}
+
+// ValidateMsixPackageID checks that 'input' can be parsed as a Msix Package ID
+func ValidateMsixPackageID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseMsixPackageID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Msix Package ID
+func (id MsixPackageId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.DesktopVirtualization/hostPools/%s/msixPackages/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.HostPoolName, id.MsixPackageName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Msix Package ID
+func (id MsixPackageId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftDesktopVirtualization", "Microsoft.DesktopVirtualization", "Microsoft.DesktopVirtualization"),
+		resourceids.StaticSegment("staticHostPools", "hostPools", "hostPools"),
+		resourceids.UserSpecifiedSegment("hostPoolName", "hostPoolName"),
+		resourceids.StaticSegment("staticMsixPackages", "msixPackages", "msixPackages"),
+		resourceids.UserSpecifiedSegment("msixPackageName", "msixPackageName"),
+	}
+}
+
+// String returns a human-readable description of this Msix Package ID
+func (id MsixPackageId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Host Pool Name: %q", id.HostPoolName),
+		fmt.Sprintf("Msix Package Name: %q", id.MsixPackageName),
+	}
+	return fmt.Sprintf("Msix Package (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/msixpackage/method_createorupdate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/msixpackage/method_createorupdate.go
@@ -1,0 +1,58 @@
+package msixpackage
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateOrUpdateOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *MSIXPackage
+}
+
+// CreateOrUpdate ...
+func (c MSIXPackageClient) CreateOrUpdate(ctx context.Context, id MsixPackageId, input MSIXPackage) (result CreateOrUpdateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPut,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model MSIXPackage
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/msixpackage/method_delete.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/msixpackage/method_delete.go
@@ -1,0 +1,47 @@
+package msixpackage
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeleteOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// Delete ...
+func (c MSIXPackageClient) Delete(ctx context.Context, id MsixPackageId) (result DeleteOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusNoContent,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodDelete,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/msixpackage/method_get.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/msixpackage/method_get.go
@@ -1,0 +1,53 @@
+package msixpackage
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *MSIXPackage
+}
+
+// Get ...
+func (c MSIXPackageClient) Get(ctx context.Context, id MsixPackageId) (result GetOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model MSIXPackage
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/msixpackage/method_list.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/msixpackage/method_list.go
@@ -1,0 +1,105 @@
+package msixpackage
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]MSIXPackage
+}
+
+type ListCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []MSIXPackage
+}
+
+type ListCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *ListCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// List ...
+func (c MSIXPackageClient) List(ctx context.Context, id HostPoolId) (result ListOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Pager:      &ListCustomPager{},
+		Path:       fmt.Sprintf("%s/msixPackages", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]MSIXPackage `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListComplete retrieves all the results into a single object
+func (c MSIXPackageClient) ListComplete(ctx context.Context, id HostPoolId) (ListCompleteResult, error) {
+	return c.ListCompleteMatchingPredicate(ctx, id, MSIXPackageOperationPredicate{})
+}
+
+// ListCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c MSIXPackageClient) ListCompleteMatchingPredicate(ctx context.Context, id HostPoolId, predicate MSIXPackageOperationPredicate) (result ListCompleteResult, err error) {
+	items := make([]MSIXPackage, 0)
+
+	resp, err := c.List(ctx, id)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/msixpackage/method_update.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/msixpackage/method_update.go
@@ -1,0 +1,57 @@
+package msixpackage
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpdateOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *MSIXPackage
+}
+
+// Update ...
+func (c MSIXPackageClient) Update(ctx context.Context, id MsixPackageId, input MSIXPackagePatch) (result UpdateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPatch,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model MSIXPackage
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/msixpackage/model_msixpackage.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/msixpackage/model_msixpackage.go
@@ -1,0 +1,16 @@
+package msixpackage
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/systemdata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type MSIXPackage struct {
+	Id         *string                `json:"id,omitempty"`
+	Name       *string                `json:"name,omitempty"`
+	Properties MSIXPackageProperties  `json:"properties"`
+	SystemData *systemdata.SystemData `json:"systemData,omitempty"`
+	Type       *string                `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/msixpackage/model_msixpackageapplications.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/msixpackage/model_msixpackageapplications.go
@@ -1,0 +1,14 @@
+package msixpackage
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type MsixPackageApplications struct {
+	AppId          *string `json:"appId,omitempty"`
+	AppUserModelID *string `json:"appUserModelID,omitempty"`
+	Description    *string `json:"description,omitempty"`
+	FriendlyName   *string `json:"friendlyName,omitempty"`
+	IconImageName  *string `json:"iconImageName,omitempty"`
+	RawIcon        *string `json:"rawIcon,omitempty"`
+	RawPng         *string `json:"rawPng,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/msixpackage/model_msixpackagedependencies.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/msixpackage/model_msixpackagedependencies.go
@@ -1,0 +1,10 @@
+package msixpackage
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type MsixPackageDependencies struct {
+	DependencyName *string `json:"dependencyName,omitempty"`
+	MinVersion     *string `json:"minVersion,omitempty"`
+	Publisher      *string `json:"publisher,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/msixpackage/model_msixpackagepatch.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/msixpackage/model_msixpackagepatch.go
@@ -1,0 +1,11 @@
+package msixpackage
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type MSIXPackagePatch struct {
+	Id         *string                     `json:"id,omitempty"`
+	Name       *string                     `json:"name,omitempty"`
+	Properties *MSIXPackagePatchProperties `json:"properties,omitempty"`
+	Type       *string                     `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/msixpackage/model_msixpackagepatchproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/msixpackage/model_msixpackagepatchproperties.go
@@ -1,0 +1,10 @@
+package msixpackage
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type MSIXPackagePatchProperties struct {
+	DisplayName           *string `json:"displayName,omitempty"`
+	IsActive              *bool   `json:"isActive,omitempty"`
+	IsRegularRegistration *bool   `json:"isRegularRegistration,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/msixpackage/model_msixpackageproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/msixpackage/model_msixpackageproperties.go
@@ -1,0 +1,36 @@
+package msixpackage
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type MSIXPackageProperties struct {
+	DisplayName           *string                    `json:"displayName,omitempty"`
+	ImagePath             *string                    `json:"imagePath,omitempty"`
+	IsActive              *bool                      `json:"isActive,omitempty"`
+	IsRegularRegistration *bool                      `json:"isRegularRegistration,omitempty"`
+	LastUpdated           *string                    `json:"lastUpdated,omitempty"`
+	PackageApplications   *[]MsixPackageApplications `json:"packageApplications,omitempty"`
+	PackageDependencies   *[]MsixPackageDependencies `json:"packageDependencies,omitempty"`
+	PackageFamilyName     *string                    `json:"packageFamilyName,omitempty"`
+	PackageName           *string                    `json:"packageName,omitempty"`
+	PackageRelativePath   *string                    `json:"packageRelativePath,omitempty"`
+	Version               *string                    `json:"version,omitempty"`
+}
+
+func (o *MSIXPackageProperties) GetLastUpdatedAsTime() (*time.Time, error) {
+	if o.LastUpdated == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.LastUpdated, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *MSIXPackageProperties) SetLastUpdatedAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.LastUpdated = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/msixpackage/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/msixpackage/predicates.go
@@ -1,0 +1,27 @@
+package msixpackage
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type MSIXPackageOperationPredicate struct {
+	Id   *string
+	Name *string
+	Type *string
+}
+
+func (p MSIXPackageOperationPredicate) Matches(input MSIXPackage) bool {
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/msixpackage/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/msixpackage/version.go
@@ -1,0 +1,10 @@
+package msixpackage
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2022-02-10-preview"
+
+func userAgent() string {
+	return "hashicorp/go-azure-sdk/msixpackage/2022-02-10-preview"
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -463,6 +463,7 @@ github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02
 github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/applicationgroup
 github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/desktop
 github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/hostpool
+github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/msixpackage
 github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/scalingplan
 github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/sessionhost
 github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/workspace

--- a/website/docs/r/virtual_desktop_application.html.markdown
+++ b/website/docs/r/virtual_desktop_application.html.markdown
@@ -66,6 +66,42 @@ resource "azurerm_virtual_desktop_application" "chrome" {
 }
 ```
 
+With MSIX application type, associated to a MSIX package.
+
+```hcl
+resource "azurerm_virtual_desktop_msix_package" "example" {
+  name                = "example-msix-package"
+  host_pool_name      = azurerm_virtual_desktop_host_pool.pooledbreadthfirst.name
+  resource_group_name = azurerm_resource_group.example.name
+  image_path          = "\\path\to\image.vhd"
+  last_updated_in_utc = "2021-09-01T00:00:00"
+
+  package_application {
+    app_id            = "my-app-1"
+    app_user_model_id = "user-model-id"
+    description       = "Description of my app 1"
+    friendly_name     = "App1"
+    icon_image_name   = "icon.ico"
+    raw_png           = "VGhpcyBpcyBhIHN0cmluZyB0byBoYXNo"
+    raw_icon          = "VGhpcyBpcyBhIHN0cmluZyB0byBoYXNo"
+  }
+
+  package_family_name   = "example-package-family-name"
+  package_name          = "example-package-name"
+  package_relative_path = "relative\\path"
+  version               = "0.0.0.1"
+}
+
+resource "azurerm_virtual_desktop_application" "example" {
+  name                         = "example-msix-app"
+  application_group_id         = azurerm_virtual_desktop_application_group.remoteapp.id
+  command_line_argument_policy = "DoNotAllow"
+  msix_package_app_id          = azurerm_virtual_desktop_msix_package.example.package_application[0].app_id
+  msix_package_family_name     = azurerm_virtual_desktop_msix_package.example.package_family_name
+  application_type             = "MsixApplication"
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -78,7 +114,7 @@ The following arguments are supported:
 
 * `description` - (Optional) Option to set a description for the Virtual Desktop Application.
 
-* `path` - (Required) The file path location of the app on the Virtual Desktop OS.
+* `path` - (Optional) The file path location of the app on the Virtual Desktop OS. Required for `InBuilt` application type, but should not be specified for `MsixApplication`.
 
 * `command_line_argument_policy` - (Required) Specifies whether this published application can be launched with command line arguments provided by the client, command line arguments specified at publish time, or no command line arguments at all. Possible values include: `DoNotAllow`, `Allow`, `Require`.
 
@@ -89,6 +125,12 @@ The following arguments are supported:
 * `icon_path` - (Optional) Specifies the path for an icon which will be used for this Virtual Desktop Application.
 
 * `icon_index` - (Optional) The index of the icon you wish to use.
+
+* `application_type` - (Optional) The remote application type. Possible values include: `InBuilt`, `MsixApplication`. Defaults to `InBuilt`.
+
+* `msix_package_app_id` - (Optional) The package application id for MSIX applications. This corresponds to the `app_id` argument in `package_application` block in `azurerm_virtual_desktop_msix_package`.
+
+* `msix_package_family_name` - (Optional) The package family name for MSIX applications. This corresponds to the `package_family_name` argument in `azurerm_virtual_desktop_msix_package`.
 
 ## Attributes Reference
 

--- a/website/docs/r/virtual_desktop_msix_package.html.markdown
+++ b/website/docs/r/virtual_desktop_msix_package.html.markdown
@@ -1,0 +1,141 @@
+---
+subcategory: "Desktop Virtualization"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_virtual_desktop_msix_package"
+description: |-
+  Manages a Virtual Desktop MSIX package.
+---
+
+# azurerm_virtual_desktop_msix_package
+
+Manages a Virtual Desktop MSIX package.
+
+## Example Usage
+
+```hcl
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "rg-example-virtualdesktop"
+  location = "West Europe"
+}
+
+resource "azurerm_virtual_desktop_host_pool" "pooledbreadthfirst" {
+  name                = "pooledbreadthfirst"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+
+  type               = "Pooled"
+  load_balancer_type = "BreadthFirst"
+}
+
+resource "azurerm_virtual_desktop_msix_package" "example" {
+  name                = "example-msix-package"
+  host_pool_name      = azurerm_virtual_desktop_host_pool.pooledbreadthfirst.name
+  resource_group_name = azurerm_resource_group.example.name
+  image_path          = "\\path\to\image.vhd"
+  last_updated_in_utc = "2021-09-01T00:00:00"
+
+  package_application {
+    app_id            = "my-app-1"
+    app_user_model_id = "user-model-id"
+    description       = "Description of my app 1"
+    friendly_name     = "App1"
+    icon_image_name   = "icon.ico"
+    raw_png           = "VGhpcyBpcyBhIHN0cmluZyB0byBoYXNo"
+    raw_icon          = "VGhpcyBpcyBhIHN0cmluZyB0byBoYXNo"
+  }
+  
+  package_family_name   = "example-package-family-name"
+  package_name          = "example-package-name"
+  package_relative_path = "relative\\path"
+  version               = "0.0.0.1"
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The version specific package full name of the MSIX package within the specified host pool. Changing this forces a new Virtual Desktop MSIX package to be created.
+
+* `host_pool_name` - (Required) The name of the host pool within the specified resource group. Changing this forces a new Virtual Desktop MSIX package to be created.
+
+* `resource_group_name` - (Required) The name of the Resource Group where the Virtual Desktop MSIX package should exist. Changing this forces a new Virtual Desktop MSIX package to be created.
+
+* `image_path` - (Required) VHD/CIM image path on the Network Share. Changing this forces a new Virtual Desktop MSIX package to be created.
+
+* `last_updated_in_utc` - (Required) Date Package was last updated, found in the appxmanifest.xml. RFC3339 format without the time offset, for example: "2021-09-01T00:00:00". Changing this forces a new Virtual Desktop MSIX package to be created.
+
+* `package_application` - (Required) One or more `package_application` blocks as defined below. Changing this forces a new Virtual Desktop MSIX package to be created.
+
+* `package_family_name` - (Required) Package Family Name from appxmanifest.xml. Contains Package Name and Publisher name. Changing this forces a new Virtual Desktop MSIX package to be created.
+
+* `package_name` - (Required) Package Name from appxmanifest.xml. Changing this forces a new Virtual Desktop MSIX package to be created.
+
+* `package_relative_path` - (Required) Relative Path to the package inside the image. Changing this forces a new Virtual Desktop MSIX package to be created.
+
+* `version` - (Required) Package version found in the appxmanifest.xml. Example: "1.0.0.1". Changing this forces a new Virtual Desktop MSIX package to be created.
+
+---
+
+* `display_name` - (Optional) User friendly Name to be displayed in the portal.
+
+* `enabled` - (Optional) Make this version of the package the active one across the host pool. Defaults to `true`.
+
+* `package_dependency` - (Optional) One or more `package_dependency` blocks as defined below.
+
+* `regular_registration_enabled` - (Optional) Specifies how to register the package in feed. Defaults to `true`.
+
+---
+
+A `package_application` block supports the following:
+
+* `app_id` - (Required) The package application id, found in appxmanifest.xml. Changing this forces a new Virtual Desktop MSIX package to be created.
+
+* `app_user_model_id` - (Required) Used to activate the package application. Found in appxmanifest.xml. Changing this forces a new Virtual Desktop MSIX package to be created.
+
+* `description` - (Required) The description of the package application. Changing this forces a new Virtual Desktop MSIX package to be created.
+
+* `friendly_name` - (Required) User friendly name of the package application. Changing this forces a new Virtual Desktop MSIX package to be created.
+
+* `icon_image_name` - (Required) Icon image name. Changing this forces a new Virtual Desktop MSIX package to be created.
+
+* `raw_icon` - (Required) Base64-encoded byte array of the icon file. Changing this forces a new Virtual Desktop MSIX package to be created.
+
+* `raw_png` - (Required) Base64-encoded byte array of the png file. Changing this forces a new Virtual Desktop MSIX package to be created.
+
+---
+
+A `package_dependency` block supports the following:
+
+* `dependency_name` - (Required) The name of the package dependency. Changing this forces a new Virtual Desktop MSIX package to be created.
+
+* `min_version` - (Required) Required version of the dependency. Changing this forces a new Virtual Desktop MSIX package to be created.
+
+* `publisher` - (Required) The package publisher name. Changing this forces a new Virtual Desktop MSIX package to be created.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the Virtual Desktop MSIX package.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Virtual Desktop MSIX package.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Virtual Desktop MSIX package.
+* `update` - (Defaults to 30 minutes) Used when updating the Virtual Desktop MSIX package.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Virtual Desktop MSIX package.
+
+## Import
+
+Virtual Desktop MSIX packages can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_virtual_desktop_msix_package.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myGroup1/providers/Microsoft.DesktopVirtualization/hostPools/myHostPool1/msixPackages/myMsixPackage1
+```


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Popular ask: #15611: Support MSIX package for `azurerm_virtual_desktop_application`. This involves the addition of new resource `azurerm_virtual_desktop_msix_package` and additional attributes added to `azurerm_virtual_desktop_application`.

Entity relationship:

```mermaid
flowchart LR

A[Host pool] -->B[Application group]
A --> C[MSIX package]
B --> D[Application]
D --> C
```

Summary of the changes:
- Made `path` attribute optional in `azurerm_virtual_desktop_application`: it cannot be specified for MSIX application type
- Added 2 new attributes to `azurerm_virtual_desktop_application` to support MSIX application
- Created new resource `azurerm_virtual_desktop_msix_package`
- vendor msixpackage subfolder of go-azure-sdk/../desktopvirtualization

Feature docs: https://learn.microsoft.com/en-us/azure/virtual-desktop/publish-applications-stream-remoteapp?tabs=portal

REST APIs:
- [MSIX package](https://learn.microsoft.com/en-us/rest/api/desktopvirtualization/msix-packages/create-or-update?view=rest-desktopvirtualization-2024-04-03&tabs=HTTP)
- [Application](https://learn.microsoft.com/en-us/rest/api/desktopvirtualization/applications/create-or-update?view=rest-desktopvirtualization-2024-04-03&tabs=HTTP)

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

Acctest command and output:

- Command: `make acctests SERVICE='desktopvirtualization' TESTARGS='-run="TestAccVirtualDesktopApplication_"' TESTTIMEOUT='120m'`, Output: [link](https://microsoftapc-my.sharepoint.com/:u:/g/personal/tangerry_microsoft_com/EQBK3YvUuxRKsul6XvCeXA4BlR_QRZvuyTVTHUIsInPN6w?e=pyaiWE)
- Command: `make acctests SERVICE='desktopvirtualization' TESTARGS='-run="TestAccVirtualDesktopMSIXPackage_"' TESTTIMEOUT='120m`, Output: [link](https://microsoftapc-my.sharepoint.com/:u:/g/personal/tangerry_microsoft_com/EYrjR4ALByVJj8PbQ8RsmvgBijm1AgtgdAWdahqCih8nSg?e=RJxc70)


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_virtual_desktop_msix_package` - new resource to support MSIX application for Azure Virtual Desktop [GH-15611]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [x] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #15611 


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
