### PR TITLE
[Bug fix] `azurerm_express_route_circuit` - Fix `bandwidth_in_mbps` not update bug

### DIFF
--- a/internal/services/network/express_route_circuit_resource.go
+++ b/internal/services/network/express_route_circuit_resource.go
@@ -279,10 +279,6 @@ func resourceExpressRouteCircuitUpdate(d *pluginsdk.ResourceData, meta interface
 		return fmt.Errorf("retrieving %s : %s", id, err)
 	}
 
-	if err := client.CreateOrUpdateThenPoll(ctx, *id, *existing.Model); err != nil {
-		return fmt.Errorf("updating %s : %+v", id, err)
-	}
-
 	if existing.Model == nil {
 		return fmt.Errorf("retrieving %s: `model` was nil", *id)
 	}
@@ -309,7 +305,11 @@ func resourceExpressRouteCircuitUpdate(d *pluginsdk.ResourceData, meta interface
 	}
 
 	if d.HasChange("bandwidth_in_gbps") {
-		payload.Properties.BandwidthInGbps = utils.Float(d.Get("bandwidth_in_gbps").(float64))
+		payload.Properties.BandwidthInGbps = pointer.To(d.Get("bandwidth_in_gbps").(float64))
+	}
+
+	if d.HasChange("bandwidth_in_mbps") {
+		payload.Properties.ServiceProviderProperties.BandwidthInMbps = pointer.To(int64(d.Get("bandwidth_in_mbps").(int)))
 	}
 
 	if err := client.CreateOrUpdateThenPoll(ctx, *id, payload); err != nil {

--- a/internal/services/network/express_route_circuit_resource.go
+++ b/internal/services/network/express_route_circuit_resource.go
@@ -279,6 +279,10 @@ func resourceExpressRouteCircuitUpdate(d *pluginsdk.ResourceData, meta interface
 		return fmt.Errorf("retrieving %s : %s", id, err)
 	}
 
+	if err := client.CreateOrUpdateThenPoll(ctx, *id, *existing.Model); err != nil {
+		return fmt.Errorf("updating %s : %+v", id, err)
+	}
+
 	if existing.Model == nil {
 		return fmt.Errorf("retrieving %s: `model` was nil", *id)
 	}

--- a/internal/services/network/express_route_circuit_resource_test.go
+++ b/internal/services/network/express_route_circuit_resource_test.go
@@ -33,7 +33,8 @@ func TestAccExpressRouteCircuit(t *testing.T) {
 			"allowClassicOperationsUpdate": testAccExpressRouteCircuit_allowClassicOperationsUpdate,
 			"requiresImport":               testAccExpressRouteCircuit_requiresImport,
 			"data_basic":                   testAccDataSourceExpressRoute_basicMetered,
-			"bandwidthReduction":           testAccExpressRouteCircuit_bandwidthReduction,
+			"bandwidthReduction":           testAccExpressRouteCircuit_bandwidthMbpsReduction,
+			"bandwidthUpdate":              testAccExpressRouteCircuit_bandwidthMbpsUpdate,
 			"port":                         testAccExpressRouteCircuit_withExpressRoutePort,
 			"updatePort":                   testAccExpressRouteCircuit_updateExpressRoutePort,
 			"authorizationKey":             testAccExpressRouteCircuit_authorizationKey,
@@ -258,7 +259,7 @@ func testAccExpressRouteCircuit_allowClassicOperationsUpdate(t *testing.T) {
 	})
 }
 
-func testAccExpressRouteCircuit_bandwidthReduction(t *testing.T) {
+func testAccExpressRouteCircuit_bandwidthMbpsReduction(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_express_route_circuit", "test")
 	r := ExpressRouteCircuitResource{}
 
@@ -275,6 +276,28 @@ func testAccExpressRouteCircuit_bandwidthReduction(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("bandwidth_in_mbps").HasValue("50"),
+			),
+		},
+	})
+}
+
+func testAccExpressRouteCircuit_bandwidthMbpsUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_express_route_circuit", "test")
+	r := ExpressRouteCircuitResource{}
+
+	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.bandwidthReductionConfig(data, "2000"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("bandwidth_in_mbps").HasValue("2000"),
+			),
+		},
+		{
+			Config: r.bandwidthReductionConfig(data, "5000"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("bandwidth_in_mbps").HasValue("5000"),
 			),
 		},
 	})


### PR DESCRIPTION
<!--  All Submissions -->
Fix the bug that `bandwidth_in_mbps` could not be updated. 

Since the test cases depend on different configurations and environment settings, not all tests were run.
```log
=== RUN   TestAccExpressRouteCircuitAAA
=== RUN   TestAccExpressRouteCircuitAAA/basic
=== RUN   TestAccExpressRouteCircuitAAA/basic/bandwidthReduction
=== RUN   TestAccExpressRouteCircuitAAA/basic/bandwidthUpdate
--- PASS: TestAccExpressRouteCircuitAAA (631.08s)
    --- PASS: TestAccExpressRouteCircuitAAA/basic (631.08s)
        --- PASS: TestAccExpressRouteCircuitAAA/basic/bandwidthReduction (424.85s)
        --- PASS: TestAccExpressRouteCircuitAAA/basic/bandwidthUpdate (206.24s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/network       644.063s
```


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
