### PR TITLE
`azurerm_site_recovery_replicated_vm` - support `failover_test_static_ip_secondary`, `target_static_ip_secondary`, `failover_test_subnet_name_secondary`, `target_subnet_name_secondary`, `failover_test_public_ip_address_id_secondary`, `recovery_load_balancer_backend_address_pool_ids_secondary` and `recovery_public_ip_address_id_secondary`

### DIFF
--- a/internal/services/recoveryservices/site_recovery_replicated_vm_resource_test.go
+++ b/internal/services/recoveryservices/site_recovery_replicated_vm_resource_test.go
@@ -252,6 +252,21 @@ func TestAccSiteRecoveryReplicatedVm_targetVirtualMachineSize(t *testing.T) {
 	})
 }
 
+func TestAccSiteRecoveryReplicatedVm_withSecondaryIpConfiguration(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_site_recovery_replicated_vm", "test")
+	r := SiteRecoveryReplicatedVmResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.secondaryIpConfiguration(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (SiteRecoveryReplicatedVmResource) template(data acceptance.TestData) string {
 	tags := ""
 	if strings.HasPrefix(strings.ToLower(data.Client().SubscriptionID), "85b3dbca") {
@@ -340,7 +355,7 @@ resource "azurerm_site_recovery_protection_container_mapping" "test" {
 resource "azurerm_virtual_network" "test1" {
   name                = "net-%[1]d"
   resource_group_name = azurerm_resource_group.test.name
-  address_space       = ["192.168.1.0/24"]
+  address_space       = ["192.168.0.0/16"]
   location            = azurerm_site_recovery_fabric.test1.location
 }
 
@@ -354,7 +369,7 @@ resource "azurerm_subnet" "test1" {
 resource "azurerm_virtual_network" "test2" {
   name                = "net2-%[1]d"
   resource_group_name = azurerm_resource_group.test2.name
-  address_space       = ["192.168.2.0/24"]
+  address_space       = ["192.168.0.0/16"]
   location            = azurerm_site_recovery_fabric.test2.location
 }
 
@@ -2523,6 +2538,87 @@ resource "azurerm_site_recovery_replicated_vm" "test" {
   ]
 }
 `, r.vmSizeTemplate(data, "Standard_B2s"), data.RandomInteger)
+}
+
+func (r SiteRecoveryReplicatedVmResource) secondaryIpConfiguration(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_virtual_network" "secondary" {
+  name                = "net3-%[2]d"
+  resource_group_name = azurerm_resource_group.test2.name
+  address_space       = ["192.168.0.0/16"]
+  location            = azurerm_site_recovery_fabric.test2.location
+}
+
+resource "azurerm_subnet" "secondary" {
+  name                 = "snet3"
+  resource_group_name  = azurerm_resource_group.test2.name
+  virtual_network_name = azurerm_virtual_network.secondary.name
+  address_prefixes     = ["192.168.2.0/24"]
+}
+
+resource "azurerm_subnet" "tfo" {
+  name                 = "snet4"
+  resource_group_name  = azurerm_resource_group.test2.name
+  virtual_network_name = azurerm_virtual_network.secondary.name
+  address_prefixes     = ["192.168.3.0/24"]
+}
+
+resource "azurerm_public_ip" "tfo" {
+  name                = "pubip%[2]d-tfo"
+  allocation_method   = "Static"
+  location            = azurerm_resource_group.test2.location
+  resource_group_name = azurerm_resource_group.test2.name
+  sku                 = "Basic"
+}
+
+resource "azurerm_public_ip" "secondary" {
+  name                = "pubip%[2]d-secondary"
+  allocation_method   = "Static"
+  location            = azurerm_resource_group.test2.location
+  resource_group_name = azurerm_resource_group.test2.name
+  sku                 = "Basic"
+}
+
+resource "azurerm_site_recovery_replicated_vm" "test" {
+  name                                      = "repl-%[2]d"
+  resource_group_name                       = azurerm_resource_group.test2.name
+  recovery_vault_name                       = azurerm_recovery_services_vault.test.name
+  source_vm_id                              = azurerm_virtual_machine.test.id
+  source_recovery_fabric_name               = azurerm_site_recovery_fabric.test1.name
+  recovery_replication_policy_id            = azurerm_site_recovery_replication_policy.test.id
+  source_recovery_protection_container_name = azurerm_site_recovery_protection_container.test1.name
+
+  target_resource_group_id                = azurerm_resource_group.test2.id
+  target_recovery_fabric_id               = azurerm_site_recovery_fabric.test2.id
+  target_recovery_protection_container_id = azurerm_site_recovery_protection_container.test2.id
+  test_network_id                         = azurerm_virtual_network.secondary.id
+
+  managed_disk {
+    disk_id                    = azurerm_virtual_machine.test.storage_os_disk[0].managed_disk_id
+    staging_storage_account_id = azurerm_storage_account.test.id
+    target_resource_group_id   = azurerm_resource_group.test2.id
+    target_disk_type           = "Premium_LRS"
+    target_replica_disk_type   = "Premium_LRS"
+  }
+
+  network_interface {
+    source_network_interface_id                    = azurerm_network_interface.test.id
+    target_subnet_name                             = azurerm_subnet.test2.name
+    recovery_public_ip_address_id                  = azurerm_public_ip.test-recovery.id
+    failover_test_subnet_name                      = azurerm_subnet.tfo.name
+    failover_test_public_ip_address_id             = azurerm_public_ip.tfo.id
+    target_subnet_name_secondary                   = azurerm_subnet.secondary.name
+    recovery_public_ip_address_id_secondary = azurerm_public_ip.secondary.id
+  }
+
+  depends_on = [
+    azurerm_site_recovery_protection_container_mapping.test,
+    azurerm_site_recovery_network_mapping.test,
+  ]
+}
+`, r.template(data), data.RandomInteger)
 }
 
 func (r SiteRecoveryReplicatedVmResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {

--- a/website/docs/r/site_recovery_replicated_vm.html.markdown
+++ b/website/docs/r/site_recovery_replicated_vm.html.markdown
@@ -308,17 +308,31 @@ A `network_interface` block supports the following:
 
 * `target_static_ip` - (Optional) Static IP to assign when a failover is done.
 
+* `target_static_ip_secondary` - (Optional) Static IP to assign in secondary ip configuration when a failover is done.
+
 * `target_subnet_name` - (Optional) Name of the subnet to use when a failover is done.
+
+* `target_subnet_name_secondary` - (Optional) Name of the subnet to use in secondary ip configuration when a failover is done.
 
 * `recovery_load_balancer_backend_address_pool_ids` - (Optional) A list of IDs of Load Balancer Backend Address Pools to use when a failover is done.
 
+* `recovery_load_balancer_backend_address_pool_ids_secondary` - (Optional) A list of IDs of Load Balancer Backend Address Pools to use in the secondary ip configuration when a failover is done.
+
 * `recovery_public_ip_address_id` - (Optional) Id of the public IP object to use when a failover is done.
+
+* `recovery_public_ip_address_id_secondary` - (Optional) Id of the public IP object to use in secondary ip configuration when a failover is done.
 
 * `failover_test_static_ip` - (Optional) Static IP to assign when a test failover is done.
 
+* `failover_test_static_ip_secondary` - (Optional) Static IP to assign in secondary ip configuration when a test failover is done.
+
 * `failover_test_subnet_name` - (Optional) Name of the subnet to use when a test failover is done.
 
+* `failover_test_subnet_name_secondary` - (Optional) Name of the subnet to use in secondary ip configuration when a test failover is done.
+
 * `failover_test_public_ip_address_id` - (Optional) Id of the public IP object to use when a test failover is done.
+
+* `failover_test_public_ip_address_id_secondary` - (Optional) Id of the public IP object to use in secondary ip configuration when a test failover is done.
 
 ---
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

In progress
<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #28773


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
