### PR TITLE
`azurerm_mssql_managed_instance` - fix issue with using `random_password` resource as value for `administrator_login_password`

### DIFF
--- a/internal/services/mssqlmanagedinstance/mssql_managed_instance_resource.go
+++ b/internal/services/mssqlmanagedinstance/mssql_managed_instance_resource.go
@@ -363,9 +363,10 @@ func (r MsSqlManagedInstanceResource) CustomizeDiff() sdk.ResourceFunc {
 
 			_, aadAdminOk := rd.GetOk("azure_active_directory_administrator")
 			authOnlyEnabled := rd.Get("azure_active_directory_administrator.0.azuread_authentication_only_enabled").(bool)
-			_, loginOk := rd.GetOk("administrator_login")
-			_, pwsOk := rd.GetOk("administrator_login_password")
-			if aadAdminOk && !authOnlyEnabled && (!loginOk || !pwsOk) {
+			adminLogin := rd.GetRawConfig().AsValueMap()["administrator_login"]
+			adminPassword := rd.GetRawConfig().AsValueMap()["administrator_login_password"]
+
+			if aadAdminOk && !authOnlyEnabled && (adminLogin.IsNull() || adminPassword.IsNull()) {
 				return fmt.Errorf("`administrator_login` and `administrator_login_password` are required when `azuread_authentication_only_enabled` is false")
 			}
 

--- a/internal/services/mssqlmanagedinstance/mssql_managed_instance_resource_test.go
+++ b/internal/services/mssqlmanagedinstance/mssql_managed_instance_resource_test.go
@@ -1143,6 +1143,11 @@ resource "azuread_user" "test" {
   password            = "TerrAform321!"
 }
 
+resource "random_password" "test" {
+  length  = 16
+  special = true
+}
+
 resource "azurerm_mssql_managed_instance" "test" {
   name                = "acctestsqlserver%[2]d"
   resource_group_name = azurerm_resource_group.test.name
@@ -1155,7 +1160,7 @@ resource "azurerm_mssql_managed_instance" "test" {
   vcores             = 4
 
   administrator_login          = "missadministrator"
-  administrator_login_password = "NCC-1701-D"
+  administrator_login_password = random_password.test.result
 
   identity {
     type = "SystemAssigned"


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Update `CustomizeDiff` to allow using `random_password` (and other similar resources) as the value for `administrator_login_password`


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<img width="385" alt="image" src="https://github.com/user-attachments/assets/9eb5b63d-9a58-464c-8ae2-060816f604ff" />

<img width="592" alt="image" src="https://github.com/user-attachments/assets/5fb7bce7-f2fb-4929-945d-8242307bc53d" />

![image](https://github.com/user-attachments/assets/0ff6a078-9fe0-46b2-a2b3-1919c4e9ab71)

Remaining tests are unrelated, intermittent failures


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_mssql_managed_instance` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #28614


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
