### PR TITLE
`azurerm_storage_share` - Migrate resource id from the real ARM id to data action id (to be used in role assignment/definition)

### DIFF
--- a/internal/services/storage/migration/share_test.go
+++ b/internal/services/storage/migration/share_test.go
@@ -95,3 +95,24 @@ func TestShareV1ToV2(t *testing.T) {
 		t.Logf("[DEBUG] Ok!")
 	}
 }
+
+func TestShareV2ToV3(t *testing.T) {
+	input := map[string]interface{}{
+		"id": "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Storage/storageAccounts/acct1/fileServices/default/shares/share1",
+	}
+
+	expected := map[string]interface{}{
+		"id": "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Storage/storageAccounts/acct1/fileServices/default/fileshares/share1",
+	}
+
+	actual, err := ShareV2ToV3{}.UpgradeFunc()(context.TODO(), input, struct{}{})
+	if err != nil {
+		t.Fatalf("Expected no error but got: %s", err)
+	}
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatalf("Expected %+v. Got %+v. But expected them to be the same", expected, actual)
+	}
+
+	t.Logf("[DEBUG] Ok!")
+}

--- a/internal/services/storage/storage_share_resource_test.go
+++ b/internal/services/storage/storage_share_resource_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/jackofallops/giovanni/storage/2023-11-03/file/shares"
 )
@@ -635,13 +636,14 @@ func (r StorageShareResource) Exists(ctx context.Context, client *clients.Client
 		return pointer.To(props != nil), nil
 	}
 
-	id, err := fileshares.ParseShareID(state.ID)
+	id, err := parse.StorageShareResourceManagerID(state.ID)
 	if err != nil {
 		return nil, err
 	}
-	existing, err := client.Storage.ResourceManager.FileShares.Get(ctx, *id, fileshares.DefaultGetOperationOptions())
+	sid := fileshares.NewShareID(id.SubscriptionId, id.ResourceGroup, id.StorageAccountName, id.FileshareName)
+	existing, err := client.Storage.ResourceManager.FileShares.Get(ctx, sid, fileshares.DefaultGetOperationOptions())
 	if err != nil {
-		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
+		return nil, fmt.Errorf("retrieving %s: %+v", sid, err)
 	}
 
 	return pointer.To(existing.Model != nil), nil

--- a/website/docs/r/storage_share.html.markdown
+++ b/website/docs/r/storage_share.html.markdown
@@ -123,5 +123,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Storage Shares can be imported using the `id`, e.g.
 
 ```shell
-terraform import azurerm_storage_share.exampleShare /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Storage/storageAccounts/myAccount/fileServices/default/shares/exampleShare
+terraform import azurerm_storage_share.exampleShare /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Storage/storageAccounts/myAccount/fileServices/default/fileshares/exampleShare
 ```


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR conditionally migrate the resource id to its data action form, which is the previously exported `resource_manager_id`, which is used for role assignment/definition. This is actually a mismatch between the real resource id vs action defined in azure RBAC. See https://github.com/Azure/azure-rest-api-specs/issues/24568 for details.

I'm not sure if this is a good idea as now we are regarding the TF resource id as the data action id, instead of its real ARM id (as it was). Whilst from the compatibility perspective, seems this is something we have to do.. I've submit an internal ticket to SRP to report this inconsistency anyway.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [x] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

```shell
$ TF_ACC=1 go test -v -timeout=20h -parallel=20 -run='TestAccStorageShare_basic' ./internal/services/storage
=== RUN   TestAccStorageShare_basicDeprecated
=== PAUSE TestAccStorageShare_basicDeprecated
=== RUN   TestAccStorageShare_basic
=== PAUSE TestAccStorageShare_basic
=== CONT  TestAccStorageShare_basicDeprecated
=== CONT  TestAccStorageShare_basic
--- PASS: TestAccStorageShare_basic (164.40s)
--- PASS: TestAccStorageShare_basicDeprecated (165.56s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/storage       165.590s
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_storage_share` - Migrate resource id from the real ARM id to data action id (to be used in role assignment/definition) [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #28832


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
