### PR TITLE
`azurerm_postgresql_server` - add `administrator_login_password_wo` and `administrator_login_password_wo_version`

### DIFF
--- a/internal/services/postgres/postgresql_server_resource.go
+++ b/internal/services/postgres/postgresql_server_resource.go
@@ -20,6 +20,9 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2017-12-01/replicas"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2017-12-01/servers"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2017-12-01/serversecurityalertpolicies"
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	pluginSdkValidation "github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
@@ -114,6 +117,10 @@ func resourcePostgreSQLServer() *pluginsdk.Resource {
 			0: migration.PostgresqlServerV0ToV1{},
 		}),
 
+		ValidateRawResourceConfigFuncs: []schema.ValidateRawResourceConfigFunc{
+			pluginSdkValidation.PreferWriteOnlyAttribute(cty.GetAttrPath("administrator_login_password"), cty.GetAttrPath("administrator_login_password_wo")),
+		},
+
 		Schema: map[string]*pluginsdk.Schema{
 			"name": {
 				Type:         pluginsdk.TypeString,
@@ -148,9 +155,24 @@ func resourcePostgreSQLServer() *pluginsdk.Resource {
 			},
 
 			"administrator_login_password": {
-				Type:      pluginsdk.TypeString,
-				Optional:  true,
-				Sensitive: true,
+				Type:          pluginsdk.TypeString,
+				Optional:      true,
+				Sensitive:     true,
+				ConflictsWith: []string{"administrator_login_password_wo"},
+			},
+
+			"administrator_login_password_wo": {
+				Type:          pluginsdk.TypeString,
+				Optional:      true,
+				WriteOnly:     true,
+				ConflictsWith: []string{"administrator_login_password"},
+				RequiredWith:  []string{"administrator_login_password_wo_version"},
+			},
+
+			"administrator_login_password_wo_version": {
+				Type:         pluginsdk.TypeInt,
+				Optional:     true,
+				RequiredWith: []string{"administrator_login_password_wo"},
 			},
 
 			"auto_grow_enabled": {
@@ -417,12 +439,24 @@ func resourcePostgreSQLServerCreate(d *pluginsdk.ResourceData, meta interface{})
 	switch mode {
 	case servers.CreateModeDefault:
 		admin := d.Get("administrator_login").(string)
-		pass := d.Get("administrator_login_password").(string)
+		password := ""
+
+		if v, ok := d.GetOk("administrator_login_password"); ok {
+			password = v.(string)
+		}
+		woPassword, err := pluginsdk.GetWriteOnly(d, "administrator_login_password_wo", cty.String)
+		if err != nil {
+			return err
+		}
+		if !woPassword.IsNull() {
+			password = woPassword.AsString()
+		}
+
 		if admin == "" {
 			return fmt.Errorf("`administrator_login` must not be empty when `create_mode` is `default`")
 		}
-		if pass == "" {
-			return fmt.Errorf("`administrator_login_password` must not be empty when `create_mode` is `default`")
+		if password == "" {
+			return fmt.Errorf("`administrator_login_password_wo` or `administrator_login_password` must be set `create_mode` is `default`")
 		}
 
 		if _, ok := d.GetOk("restore_point_in_time"); ok {
@@ -432,7 +466,7 @@ func resourcePostgreSQLServerCreate(d *pluginsdk.ResourceData, meta interface{})
 		// check admin
 		props = servers.ServerPropertiesForDefaultCreate{
 			AdministratorLogin:         admin,
-			AdministratorLoginPassword: pass,
+			AdministratorLoginPassword: password,
 			InfrastructureEncryption:   &infraEncrypt,
 			PublicNetworkAccess:        &publicAccess,
 			MinimalTlsVersion:          &tlsMin,
@@ -663,8 +697,20 @@ func resourcePostgreSQLServerUpdate(d *pluginsdk.ResourceData, meta interface{})
 	}
 
 	// Update Admin Password in the separate call when Replication is stopped: https://github.com/Azure/azure-rest-api-specs/issues/16898
-	if d.HasChange("administrator_login_password") && !replicaUpdatedToDefault {
-		properties.Properties.AdministratorLoginPassword = utils.String(d.Get("administrator_login_password").(string))
+	if (d.HasChange("administrator_login_password") || d.HasChange("administrator_login_password_version")) && !replicaUpdatedToDefault {
+		password := ""
+
+		if v, ok := d.GetOk("administrator_login_password"); ok {
+			password = v.(string)
+		}
+		woPassword, err := pluginsdk.GetWriteOnly(d, "administrator_login_password_wo", cty.String)
+		if err != nil {
+			return err
+		}
+		if !woPassword.IsNull() {
+			password = woPassword.AsString()
+		}
+		properties.Properties.AdministratorLoginPassword = pointer.To(password)
 	}
 
 	if err = client.UpdateThenPoll(ctx, *id, properties); err != nil {
@@ -672,12 +718,20 @@ func resourcePostgreSQLServerUpdate(d *pluginsdk.ResourceData, meta interface{})
 	}
 
 	// Update Admin Password in a separate call when Replication is stopped: https://github.com/Azure/azure-rest-api-specs/issues/16898
-	if d.HasChange("administrator_login_password") && replicaUpdatedToDefault {
-		properties.Properties.AdministratorLoginPassword = utils.String(d.Get("administrator_login_password").(string))
+	if (d.HasChange("administrator_login_password") || d.HasChange("administrator_login_password_wo")) && replicaUpdatedToDefault {
+		password := ""
 
-		if err = client.UpdateThenPoll(ctx, *id, properties); err != nil {
-			return fmt.Errorf("updating Admin Password of %q: %+v", id, err)
+		if v, ok := d.GetOk("administrator_login_password"); ok {
+			password = v.(string)
 		}
+		woPassword, err := pluginsdk.GetWriteOnly(d, "administrator_login_password_wo", cty.String)
+		if err != nil {
+			return err
+		}
+		if !woPassword.IsNull() {
+			password = woPassword.AsString()
+		}
+		properties.Properties.AdministratorLoginPassword = pointer.To(password)
 	}
 
 	if v, ok := d.GetOk("threat_detection_policy"); ok {
@@ -717,6 +771,8 @@ func resourcePostgreSQLServerRead(d *pluginsdk.ResourceData, meta interface{}) e
 
 	d.Set("name", id.ServerName)
 	d.Set("resource_group_name", id.ResourceGroupName)
+
+	d.Set("administrator_login_password_wo_version", d.Get("administrator_login_password_wo_version").(int))
 
 	if model := resp.Model; model != nil {
 		d.Set("location", location.NormalizeNilable(&model.Location))

--- a/website/docs/r/postgresql_server.html.markdown
+++ b/website/docs/r/postgresql_server.html.markdown
@@ -58,7 +58,11 @@ The following arguments are supported:
 
 * `administrator_login` - (Optional) The Administrator login for the PostgreSQL Server. Required when `create_mode` is `Default`. Changing this forces a new resource to be created.
 
-* `administrator_login_password` - (Optional) The Password associated with the `administrator_login` for the PostgreSQL Server. Required when `create_mode` is `Default`.
+* `administrator_login_password` - (Optional) The Password associated with the `administrator_login` for the PostgreSQL Server. Either `administrator_login_password` or `administrator_login_password_wo` is required when `create_mode` is `Default`.
+
+* `administrator_login_password_wo` - (Optional, Write-Only) The Password associated with the `administrator_login` for the PostgreSQL Server. Either `administrator_login_password` or `administrator_login_password_wo` is required when `create_mode` is `Default`.
+
+* `administrator_login_password_wo_version` - (Optional) An integer value used to trigger an update for `administrator_login_password_wo`. This property should be incremented when updating `administrator_login_password_wo`.
 
 * `auto_grow_enabled` - (Optional) Enable/Disable auto-growing of the storage. Storage auto-grow prevents your server from running out of storage and becoming read-only. If storage auto grow is enabled, the storage automatically grows without impacting the workload. Defaults to `true`.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Testing 


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_postgresql_server` - add support for the `administrator_login_password_wo` and `administrator_login_password_wo_version` properties [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
