### PR TITLE
New Relic - Skip Tests while delete issues are investigated

### DIFF
--- a/internal/services/newrelic/new_relic_monitor_resource_test.go
+++ b/internal/services/newrelic/new_relic_monitor_resource_test.go
@@ -22,6 +22,8 @@ import (
 type NewRelicMonitorResource struct{}
 
 func TestAccNewRelicMonitor_basic(t *testing.T) {
+	t.Skip("skipping as they fail intermittently and New Relic support is needed to clean them up")
+
 	data := acceptance.BuildTestData(t, "azurerm_new_relic_monitor", "test")
 	r := NewRelicMonitorResource{}
 	effectiveDate := time.Now().Add(time.Hour * 7).Format(time.RFC3339)
@@ -38,6 +40,8 @@ func TestAccNewRelicMonitor_basic(t *testing.T) {
 }
 
 func TestAccNewRelicMonitor_requiresImport(t *testing.T) {
+	t.Skip("skipping as they fail intermittently and New Relic support is needed to clean them up")
+
 	data := acceptance.BuildTestData(t, "azurerm_new_relic_monitor", "test")
 	r := NewRelicMonitorResource{}
 	effectiveDate := time.Now().Add(time.Hour * 7).Format(time.RFC3339)
@@ -57,6 +61,8 @@ func TestAccNewRelicMonitor_requiresImport(t *testing.T) {
 }
 
 func TestAccNewRelicMonitor_complete(t *testing.T) {
+	t.Skip("skipping as they fail intermittently and New Relic support is needed to clean them up")
+
 	const AccountIdEnv = "ARM_ACCTEST_NEW_RELIC_ACCOUNT_ID"
 	const OrgIdEnv = "ARM_ACCTEST_NEW_RELIC_ORG_ID"
 
@@ -84,6 +90,8 @@ func TestAccNewRelicMonitor_complete(t *testing.T) {
 }
 
 func TestAccNewRelicMonitor_identity(t *testing.T) {
+	t.Skip("skipping as they fail intermittently and New Relic support is needed to clean them up")
+
 	data := acceptance.BuildTestData(t, "azurerm_new_relic_monitor", "test")
 	r := NewRelicMonitorResource{}
 	effectiveDate := time.Now().Add(time.Hour * 7).Format(time.RFC3339)

--- a/internal/services/newrelic/new_relic_tag_rule_resource_test.go
+++ b/internal/services/newrelic/new_relic_tag_rule_resource_test.go
@@ -21,6 +21,8 @@ import (
 type NewRelicTagRuleResource struct{}
 
 func TestAccNewRelicTagRule_basic(t *testing.T) {
+	t.Skip("skipping as they fail intermittently and New Relic support is needed to clean them up")
+
 	data := acceptance.BuildTestData(t, "azurerm_new_relic_tag_rule", "test")
 	r := NewRelicTagRuleResource{}
 	email := "27362230-e2d8-4c73-9ee3-fdef83459ca3@example.com"
@@ -36,6 +38,8 @@ func TestAccNewRelicTagRule_basic(t *testing.T) {
 }
 
 func TestAccNewRelicTagRule_requiresImport(t *testing.T) {
+	t.Skip("skipping as they fail intermittently and New Relic support is needed to clean them up")
+
 	data := acceptance.BuildTestData(t, "azurerm_new_relic_tag_rule", "test")
 	r := NewRelicTagRuleResource{}
 	email := "85b5febd-127d-4633-9c25-bcfea555af46@example.com"
@@ -54,6 +58,8 @@ func TestAccNewRelicTagRule_requiresImport(t *testing.T) {
 }
 
 func TestAccNewRelicTagRule_complete(t *testing.T) {
+	t.Skip("skipping as they fail intermittently and New Relic support is needed to clean them up")
+
 	data := acceptance.BuildTestData(t, "azurerm_new_relic_tag_rule", "test")
 	r := NewRelicTagRuleResource{}
 	email := "672d9312-65a7-484c-870d-94584850a423@example.com"
@@ -69,6 +75,8 @@ func TestAccNewRelicTagRule_complete(t *testing.T) {
 }
 
 func TestAccNewRelicTagRule_update(t *testing.T) {
+	t.Skip("skipping as they fail intermittently and New Relic support is needed to clean them up")
+
 	data := acceptance.BuildTestData(t, "azurerm_new_relic_tag_rule", "test")
 	r := NewRelicTagRuleResource{}
 	email := "f0ff47c3-3aed-45b0-b239-260d9625045a@example.com"


### PR DESCRIPTION
New Relic Monitors sometimes fail to create which makes deleting them impossible without reaching out to New Relic Support. While this is investigated, we'll turn off New Relic testing