### PR TITLE
`azurerm_logic_app_standard` - support `vnet_content_share_enabled`

### DIFF
--- a/internal/services/logic/logic_app_standard_resource.go
+++ b/internal/services/logic/logic_app_standard_resource.go
@@ -205,6 +205,11 @@ func resourceLogicAppStandard() *pluginsdk.Resource {
 				Default:  "~4",
 			},
 
+			"vnet_content_share_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+			},
+
 			"virtual_network_subnet_id": {
 				Type:         pluginsdk.TypeString,
 				Optional:     true,
@@ -344,12 +349,13 @@ func resourceLogicAppStandardCreate(d *pluginsdk.ResourceData, meta interface{})
 		Location: location.Normalize(d.Get("location").(string)),
 		Tags:     tags.Expand(d.Get("tags").(map[string]interface{})),
 		Properties: &webapps.SiteProperties{
-			ServerFarmId:          pointer.To(d.Get("app_service_plan_id").(string)),
-			Enabled:               pointer.To(d.Get("enabled").(bool)),
-			ClientAffinityEnabled: pointer.To(d.Get("client_affinity_enabled").(bool)),
-			ClientCertEnabled:     pointer.To(clientCertEnabled),
-			HTTPSOnly:             pointer.To(d.Get("https_only").(bool)),
-			SiteConfig:            &siteConfig,
+			ServerFarmId:            pointer.To(d.Get("app_service_plan_id").(string)),
+			Enabled:                 pointer.To(d.Get("enabled").(bool)),
+			ClientAffinityEnabled:   pointer.To(d.Get("client_affinity_enabled").(bool)),
+			ClientCertEnabled:       pointer.To(clientCertEnabled),
+			HTTPSOnly:               pointer.To(d.Get("https_only").(bool)),
+			SiteConfig:              &siteConfig,
+			VnetContentShareEnabled: pointer.To(d.Get("vnet_content_share_enabled").(bool)),
 		},
 	}
 
@@ -493,6 +499,11 @@ func resourceLogicAppStandardUpdate(d *pluginsdk.ResourceData, meta interface{})
 		} else {
 			siteEnvelope.Properties.SiteConfig.PublicNetworkAccess = pointer.To(helpers.PublicNetworkAccessDisabled)
 		}
+	}
+
+	if d.HasChange("vnet_content_share_enabled") {
+		vnetContentShareEnabled := d.Get("vnet_content_share_enabled").(bool)
+		siteEnvelope.Properties.VnetContentShareEnabled = pointer.To(vnetContentShareEnabled)
 	}
 
 	if !features.FivePointOh() { // Until 5.0 the site_config value of this must be reflected back into the top-level property if not set there
@@ -641,6 +652,7 @@ func resourceLogicAppStandardRead(d *pluginsdk.ResourceData, meta interface{}) e
 			d.Set("client_affinity_enabled", pointer.From(props.ClientAffinityEnabled))
 			d.Set("custom_domain_verification_id", pointer.From(props.CustomDomainVerificationId))
 			d.Set("virtual_network_subnet_id", pointer.From(props.VirtualNetworkSubnetId))
+			d.Set("vnet_content_share_enabled", pointer.From(props.VnetContentShareEnabled))
 			d.Set("public_network_access", pointer.From(props.PublicNetworkAccess))
 
 			clientCertMode := ""

--- a/internal/services/logic/logic_app_standard_resource.go
+++ b/internal/services/logic/logic_app_standard_resource.go
@@ -502,8 +502,7 @@ func resourceLogicAppStandardUpdate(d *pluginsdk.ResourceData, meta interface{})
 	}
 
 	if d.HasChange("vnet_content_share_enabled") {
-		vnetContentShareEnabled := d.Get("vnet_content_share_enabled").(bool)
-		siteEnvelope.Properties.VnetContentShareEnabled = pointer.To(vnetContentShareEnabled)
+		siteEnvelope.Properties.VnetContentShareEnabled = pointer.To(d.Get("vnet_content_share_enabled").(bool))
 	}
 
 	if !features.FivePointOh() { // Until 5.0 the site_config value of this must be reflected back into the top-level property if not set there

--- a/internal/services/logic/logic_app_standard_resource_test.go
+++ b/internal/services/logic/logic_app_standard_resource_test.go
@@ -1031,6 +1031,14 @@ func TestAccLogicAppStandard_vnetContentShareEnabled(t *testing.T) {
 			Config: r.vnetContentShareEnabled(data, true),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("vnet_content_share_enabled").HasValue("true"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.vnetContentShareEnabled(data, false),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("vnet_content_share_enabled").HasValue("false"),
 			),
 		},

--- a/internal/services/logic/logic_app_standard_resource_test.go
+++ b/internal/services/logic/logic_app_standard_resource_test.go
@@ -1014,6 +1014,30 @@ func TestAccLogicAppStandard_publicNetworkAccessEnabled(t *testing.T) {
 	})
 }
 
+func TestAccLogicAppStandard_vnetContentShareEnabled(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_logic_app_standard", "test")
+	r := LogicAppStandardResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.vnetContentShareEnabled(data, false),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("vnet_content_share_enabled").HasValue("false"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.vnetContentShareEnabled(data, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("vnet_content_share_enabled").HasValue("false"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (r LogicAppStandardResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := commonids.ParseLogicAppId(state.ID)
 	if err != nil {
@@ -2249,6 +2273,22 @@ resource "azurerm_logic_app_standard" "test" {
   site_config {
     public_network_access_enabled = %t
   }
+}
+`, r.template(data), data.RandomInteger, enabled)
+}
+
+func (r LogicAppStandardResource) vnetContentShareEnabled(data acceptance.TestData, enabled bool) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_logic_app_standard" "test" {
+  name                       = "acctest-%d-func"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  app_service_plan_id        = azurerm_app_service_plan.test.id
+  storage_account_name       = azurerm_storage_account.test.name
+  storage_account_access_key = azurerm_storage_account.test.primary_access_key
+  vnet_content_share_enabled = %t
 }
 `, r.template(data), data.RandomInteger, enabled)
 }

--- a/internal/services/logic/logic_app_standard_resource_test.go
+++ b/internal/services/logic/logic_app_standard_resource_test.go
@@ -2282,13 +2282,15 @@ func (r LogicAppStandardResource) vnetContentShareEnabled(data acceptance.TestDa
 %s
 
 resource "azurerm_logic_app_standard" "test" {
-  name                       = "acctest-%d-func"
-  location                   = azurerm_resource_group.test.location
-  resource_group_name        = azurerm_resource_group.test.name
-  app_service_plan_id        = azurerm_app_service_plan.test.id
-  storage_account_name       = azurerm_storage_account.test.name
-  storage_account_access_key = azurerm_storage_account.test.primary_access_key
-  vnet_content_share_enabled = %t
+  name                                     = "acctest-%d-func"
+  location                                 = azurerm_resource_group.test.location
+  resource_group_name                      = azurerm_resource_group.test.name
+  app_service_plan_id                      = azurerm_app_service_plan.test.id
+  storage_account_name                     = azurerm_storage_account.test.name
+  storage_account_access_key               = azurerm_storage_account.test.primary_access_key
+  vnet_content_share_enabled               = %t
+  scm_publish_basic_authentication_enabled = false
+  ftp_publish_basic_authentication_enabled = false
 }
 `, r.template(data), data.RandomInteger, enabled)
 }

--- a/website/docs/r/logic_app_standard.html.markdown
+++ b/website/docs/r/logic_app_standard.html.markdown
@@ -163,6 +163,8 @@ The following arguments are supported:
 
 ~> **Note:** Assigning the `virtual_network_subnet_id` property requires [RBAC permissions on the subnet](https://docs.microsoft.com/en-us/azure/app-service/overview-vnet-integration#permissions)
 
+* `vnet_content_share_enabled` - (Optional) Specifies whether allow routing traffic between the Logic App and Storage Account content share through a virutal network. Defaults to `false`.
+
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ---

--- a/website/docs/r/logic_app_standard.html.markdown
+++ b/website/docs/r/logic_app_standard.html.markdown
@@ -163,7 +163,7 @@ The following arguments are supported:
 
 ~> **Note:** Assigning the `virtual_network_subnet_id` property requires [RBAC permissions on the subnet](https://docs.microsoft.com/en-us/azure/app-service/overview-vnet-integration#permissions)
 
-* `vnet_content_share_enabled` - (Optional) Specifies whether allow routing traffic between the Logic App and Storage Account content share through a virutal network. Defaults to `false`.
+* `vnet_content_share_enabled` - (Optional) Specifies whether allow routing traffic between the Logic App and Storage Account content share through a virtual network. Defaults to `false`.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Reference: https://learn.microsoft.com/en-us/azure/azure-functions/storage-considerations?tabs=azure-cli#consistent-routing-through-virtual-networks

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

```
❯ tftest logic TestAccLogicAppStandard_vnetContentShareEnabled
=== RUN   TestAccLogicAppStandard_vnetContentShareEnabled
=== PAUSE TestAccLogicAppStandard_vnetContentShareEnabled
=== CONT  TestAccLogicAppStandard_vnetContentShareEnabled
--- PASS: TestAccLogicAppStandard_vnetContentShareEnabled (796.31s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/logic 796.391s
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_logic_app_standard` - support `vnet_content_share_enabled` [GH-28879]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #28850


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
