### PR TITLE
`azurerm_mongo_cluster` - add support for the `connection_strings` attribute

### DIFF
--- a/internal/services/mongocluster/mongo_cluster_resource.go
+++ b/internal/services/mongocluster/mongo_cluster_resource.go
@@ -6,6 +6,7 @@ package mongocluster
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"regexp"
 	"time"
 
@@ -14,7 +15,6 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/mongocluster/2024-07-01/mongoclusters"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -27,22 +27,29 @@ var _ sdk.ResourceWithUpdate = MongoClusterResource{}
 var _ sdk.ResourceWithCustomizeDiff = MongoClusterResource{}
 
 type MongoClusterResourceModel struct {
-	Name                  string            `tfschema:"name"`
-	ResourceGroupName     string            `tfschema:"resource_group_name"`
-	Location              string            `tfschema:"location"`
-	AdministratorUserName string            `tfschema:"administrator_username"`
-	AdministratorPassword string            `tfschema:"administrator_password"`
-	CreateMode            string            `tfschema:"create_mode"`
-	ShardCount            int64             `tfschema:"shard_count"`
-	SourceLocation        string            `tfschema:"source_location"`
-	SourceServerId        string            `tfschema:"source_server_id"`
-	ComputeTier           string            `tfschema:"compute_tier"`
-	HighAvailabilityMode  string            `tfschema:"high_availability_mode"`
-	PublicNetworkAccess   string            `tfschema:"public_network_access"`
-	PreviewFeatures       []string          `tfschema:"preview_features"`
-	StorageSizeInGb       int64             `tfschema:"storage_size_in_gb"`
-	Tags                  map[string]string `tfschema:"tags"`
-	Version               string            `tfschema:"version"`
+	Name                  string                         `tfschema:"name"`
+	ResourceGroupName     string                         `tfschema:"resource_group_name"`
+	Location              string                         `tfschema:"location"`
+	AdministratorUserName string                         `tfschema:"administrator_username"`
+	AdministratorPassword string                         `tfschema:"administrator_password"`
+	CreateMode            string                         `tfschema:"create_mode"`
+	ShardCount            int64                          `tfschema:"shard_count"`
+	SourceLocation        string                         `tfschema:"source_location"`
+	SourceServerId        string                         `tfschema:"source_server_id"`
+	ComputeTier           string                         `tfschema:"compute_tier"`
+	HighAvailabilityMode  string                         `tfschema:"high_availability_mode"`
+	PublicNetworkAccess   string                         `tfschema:"public_network_access"`
+	PreviewFeatures       []string                       `tfschema:"preview_features"`
+	StorageSizeInGb       int64                          `tfschema:"storage_size_in_gb"`
+	ConnectionStrings     []MongoClusterConnectionString `tfschema:"connection_strings"`
+	Tags                  map[string]string              `tfschema:"tags"`
+	Version               string                         `tfschema:"version"`
+}
+
+type MongoClusterConnectionString struct {
+	ConnectionString string `tfschema:"connection_string"`
+	Description      string `tfschema:"description"`
+	Name             string `tfschema:"name"`
 }
 
 func (r MongoClusterResource) ModelObject() interface{} {
@@ -57,12 +64,12 @@ func (r MongoClusterResource) ResourceType() string {
 	return "azurerm_mongo_cluster"
 }
 
-func (r MongoClusterResource) Arguments() map[string]*schema.Schema {
-	return map[string]*schema.Schema{
+func (r MongoClusterResource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
 		"name": {
 			ForceNew: true,
 			Required: true,
-			Type:     schema.TypeString,
+			Type:     pluginsdk.TypeString,
 			ValidateFunc: validation.StringMatch(
 				regexp.MustCompile(`^[a-z\d]([-a-z\d]{1,38}[a-z\d])$`),
 				"`name` must be between 3 and 40 characters. It can contain only lowercase letters, numbers, and hyphens (-). It must start and end with a lowercase letter or number.",
@@ -74,7 +81,7 @@ func (r MongoClusterResource) Arguments() map[string]*schema.Schema {
 		"location": commonschema.Location(),
 
 		"administrator_username": {
-			Type:         schema.TypeString,
+			Type:         pluginsdk.TypeString,
 			Optional:     true,
 			ForceNew:     true,
 			ValidateFunc: validation.StringIsNotEmpty,
@@ -82,7 +89,7 @@ func (r MongoClusterResource) Arguments() map[string]*schema.Schema {
 		},
 
 		"create_mode": {
-			Type:     schema.TypeString,
+			Type:     pluginsdk.TypeString,
 			Optional: true,
 			ForceNew: true,
 			Default:  string(mongoclusters.CreateModeDefault),
@@ -94,24 +101,24 @@ func (r MongoClusterResource) Arguments() map[string]*schema.Schema {
 		},
 
 		"preview_features": {
-			Type:     schema.TypeList,
+			Type:     pluginsdk.TypeList,
 			Optional: true,
 			ForceNew: true,
-			Elem: &schema.Schema{
-				Type:         schema.TypeString,
+			Elem: &pluginsdk.Schema{
+				Type:         pluginsdk.TypeString,
 				ValidateFunc: validation.StringInSlice(mongoclusters.PossibleValuesForPreviewFeature(), false),
 			},
 		},
 
 		"shard_count": {
-			Type:         schema.TypeInt,
+			Type:         pluginsdk.TypeInt,
 			Optional:     true,
 			ValidateFunc: validation.IntAtLeast(1),
 			ForceNew:     true,
 		},
 
 		"source_location": {
-			Type:             schema.TypeString,
+			Type:             pluginsdk.TypeString,
 			Optional:         true,
 			ForceNew:         true,
 			StateFunc:        location.StateFunc,
@@ -121,14 +128,14 @@ func (r MongoClusterResource) Arguments() map[string]*schema.Schema {
 		},
 
 		"source_server_id": {
-			Type:         schema.TypeString,
+			Type:         pluginsdk.TypeString,
 			Optional:     true,
 			ForceNew:     true,
 			ValidateFunc: mongoclusters.ValidateMongoClusterID,
 		},
 
 		"administrator_password": {
-			Type:         schema.TypeString,
+			Type:         pluginsdk.TypeString,
 			Optional:     true,
 			Sensitive:    true,
 			ValidateFunc: validation.StringIsNotEmpty,
@@ -136,7 +143,7 @@ func (r MongoClusterResource) Arguments() map[string]*schema.Schema {
 		},
 
 		"compute_tier": {
-			Type:     schema.TypeString,
+			Type:     pluginsdk.TypeString,
 			Optional: true,
 			ValidateFunc: validation.StringInSlice([]string{
 				"Free",
@@ -150,7 +157,7 @@ func (r MongoClusterResource) Arguments() map[string]*schema.Schema {
 		},
 
 		"high_availability_mode": {
-			Type:     schema.TypeString,
+			Type:     pluginsdk.TypeString,
 			Optional: true,
 			ValidateFunc: validation.StringInSlice([]string{
 				// Confirmed with service team the `SameZone` is currently not supported.
@@ -160,14 +167,14 @@ func (r MongoClusterResource) Arguments() map[string]*schema.Schema {
 		},
 
 		"public_network_access": {
-			Type:         schema.TypeString,
+			Type:         pluginsdk.TypeString,
 			Optional:     true,
 			Default:      string(mongoclusters.PublicNetworkAccessEnabled),
 			ValidateFunc: validation.StringInSlice(mongoclusters.PossibleValuesForPublicNetworkAccess(), false),
 		},
 
 		"storage_size_in_gb": {
-			Type:         schema.TypeInt,
+			Type:         pluginsdk.TypeInt,
 			Optional:     true,
 			ValidateFunc: validation.IntBetween(32, 16384),
 		},
@@ -175,7 +182,7 @@ func (r MongoClusterResource) Arguments() map[string]*schema.Schema {
 		"tags": commonschema.Tags(),
 
 		"version": {
-			Type:     schema.TypeString,
+			Type:     pluginsdk.TypeString,
 			Optional: true,
 			ValidateFunc: validation.StringInSlice([]string{
 				"5.0",
@@ -186,8 +193,30 @@ func (r MongoClusterResource) Arguments() map[string]*schema.Schema {
 	}
 }
 
-func (r MongoClusterResource) Attributes() map[string]*schema.Schema {
-	return map[string]*schema.Schema{}
+func (r MongoClusterResource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"connection_strings": {
+			Type:      pluginsdk.TypeList,
+			Sensitive: true,
+			Computed:  true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"name": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+					"description": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+					"connection_string": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+				},
+			},
+		},
+	}
 }
 
 func (r MongoClusterResource) Create() sdk.ResourceFunc {
@@ -452,6 +481,14 @@ func (r MongoClusterResource) Read() sdk.ResourceFunc {
 				state.Tags = pointer.From(model.Tags)
 			}
 
+			csResp, err := client.ListConnectionStrings(ctx, *id)
+			if err != nil {
+				return fmt.Errorf("listing connection string for %s: %+v", *id, err)
+			}
+			if model := csResp.Model; model != nil {
+				state.ConnectionStrings = flattenMongoClusterConnectionString(model.ConnectionStrings, state.AdministratorUserName, state.AdministratorPassword)
+			}
+
 			return metadata.Encode(&state)
 		},
 	}
@@ -566,6 +603,44 @@ func flattenMongoClusterPreviewFeatures(input *[]mongoclusters.PreviewFeature) [
 
 	for _, v := range *input {
 		results = append(results, string(v))
+	}
+
+	return results
+}
+
+func flattenMongoClusterConnectionString(input *[]mongoclusters.ConnectionString, userName, userPassword string) []MongoClusterConnectionString {
+	if input == nil {
+		return nil
+	}
+
+	var results []MongoClusterConnectionString
+	for _, cs := range *input {
+		var name string
+		if cs.Name != nil {
+			name = *cs.Name
+		}
+
+		var description string
+		if cs.Description != nil {
+			description = *cs.Description
+		}
+
+		var connectionString string
+		if cs.ConnectionString != nil {
+			connectionString = *cs.ConnectionString
+		}
+
+		// Password can be empty if it isn't available in the state file (e.g. during import).
+		// In this case, we simply leave the placeholder unchanged.
+		if userPassword != "" {
+			connectionString = regexp.MustCompile(`<user>:<password>`).ReplaceAllString(connectionString, url.UserPassword(userName, userPassword).String())
+		}
+
+		results = append(results, MongoClusterConnectionString{
+			Name:             name,
+			Description:      description,
+			ConnectionString: connectionString,
+		})
 	}
 
 	return results

--- a/internal/services/mongocluster/mongo_cluster_resource.go
+++ b/internal/services/mongocluster/mongo_cluster_resource.go
@@ -613,7 +613,7 @@ func flattenMongoClusterConnectionString(input *[]mongoclusters.ConnectionString
 		return nil
 	}
 
-	var results []MongoClusterConnectionString
+	results := make([]MongoClusterConnectionString, 0)
 	for _, cs := range *input {
 		var name string
 		if cs.Name != nil {

--- a/internal/services/mongocluster/mongo_cluster_resource_test.go
+++ b/internal/services/mongocluster/mongo_cluster_resource_test.go
@@ -36,12 +36,12 @@ func testAccMongoCluster_basic(t *testing.T) {
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("connection_strings.0.connection_string").HasValue(
+				check.That(data.ResourceName).Key("connection_strings.0.value").HasValue(
 					fmt.Sprintf(`mongodb+srv://adminTerraform:QAZwsx123basic@acctest-mc%d.mongocluster.cosmos.azure.com/?tls=true&authMechanism=SCRAM-SHA-256&retrywrites=false&maxIdleTimeMS=120000`,
 						data.RandomInteger)),
 			),
 		},
-		data.ImportStep("administrator_password", "create_mode", "connection_strings.0.connection_string"),
+		data.ImportStep("administrator_password", "create_mode", "connection_strings.0.value"),
 	})
 }
 
@@ -56,14 +56,14 @@ func testAccMongoCluster_update(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("administrator_password", "create_mode"),
+		data.ImportStep("administrator_password", "create_mode", "connection_strings.0.value"),
 		{
 			Config: r.update(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("administrator_password", "create_mode"),
+		data.ImportStep("administrator_password", "create_mode", "connection_strings.0.value"),
 	})
 }
 
@@ -93,14 +93,14 @@ func TestAccMongoCluster_previewFeature(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("administrator_password", "create_mode"),
+		data.ImportStep("administrator_password", "create_mode", "connection_strings.0.value"),
 		{
 			Config: r.geoReplica(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("administrator_password", "create_mode", "source_location"),
+		data.ImportStep("administrator_password", "create_mode", "source_location", "connection_strings.0.value"),
 	})
 }
 
@@ -115,7 +115,7 @@ func TestAccMongoCluster_geoReplica(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("administrator_password", "create_mode", "source_location"),
+		data.ImportStep("administrator_password", "create_mode", "source_location", "connection_strings.0.value"),
 	})
 }
 

--- a/internal/services/mongocluster/mongo_cluster_resource_test.go
+++ b/internal/services/mongocluster/mongo_cluster_resource_test.go
@@ -93,14 +93,14 @@ func TestAccMongoCluster_previewFeature(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("administrator_password", "create_mode", "connection_strings.0.value"),
+		data.ImportStep("administrator_password", "create_mode", "connection_strings.0.value", "connection_strings.1.value"),
 		{
 			Config: r.geoReplica(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("administrator_password", "create_mode", "source_location", "connection_strings.0.value"),
+		data.ImportStep("administrator_password", "create_mode", "source_location", "connection_strings.0.value", "connection_strings.1.value"),
 	})
 }
 
@@ -115,7 +115,7 @@ func TestAccMongoCluster_geoReplica(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("administrator_password", "create_mode", "source_location", "connection_strings.0.value"),
+		data.ImportStep("administrator_password", "create_mode", "source_location", "connection_strings.0.value", "connection_strings.1.value"),
 	})
 }
 

--- a/internal/services/mongocluster/mongo_cluster_resource_test.go
+++ b/internal/services/mongocluster/mongo_cluster_resource_test.go
@@ -36,9 +36,12 @@ func testAccMongoCluster_basic(t *testing.T) {
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("connection_strings.0.connection_string").HasValue(
+					fmt.Sprintf(`mongodb+srv://adminTerraform:QAZwsx123basic@acctest-mc%d.mongocluster.cosmos.azure.com/?tls=true&authMechanism=SCRAM-SHA-256&retrywrites=false&maxIdleTimeMS=120000`,
+						data.RandomInteger)),
 			),
 		},
-		data.ImportStep("administrator_password", "create_mode"),
+		data.ImportStep("administrator_password", "create_mode", "connection_strings.0.connection_string"),
 	})
 }
 
@@ -134,19 +137,12 @@ func (r MongoClusterResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
-resource "random_password" "test" {
-  length  = 8
-  numeric = true
-  upper   = true
-  lower   = true
-}
-
 resource "azurerm_mongo_cluster" "test" {
   name                   = "acctest-mc%d"
   resource_group_name    = azurerm_resource_group.test.name
   location               = azurerm_resource_group.test.location
   administrator_username = "adminTerraform"
-  administrator_password = random_password.test.result
+  administrator_password = "QAZwsx123basic"
   shard_count            = "1"
   compute_tier           = "Free"
   high_availability_mode = "Disabled"

--- a/website/docs/r/mongo_cluster.html.markdown
+++ b/website/docs/r/mongo_cluster.html.markdown
@@ -121,7 +121,7 @@ A `connection_strings` exports the following:
 
 * `description` - The description of the connection string.
 
-* `connection_string` - The Mongo Cluster connection string. The the `<user>:<password>` place holder returned from API will be replaced by the real `administrator_username` and `administrator_password` if available in the state.
+* `connection_string` - The Mongo Cluster connection string. The `<user>:<password>` place holder returned from API will be replaced by the real `administrator_username` and `administrator_password` if available in the state.
 
 ## Timeouts
 

--- a/website/docs/r/mongo_cluster.html.markdown
+++ b/website/docs/r/mongo_cluster.html.markdown
@@ -121,7 +121,7 @@ A `connection_strings` exports the following:
 
 * `description` - The description of the connection string.
 
-* `connection_string` - The Mongo Cluster connection string. The `<user>:<password>` place holder returned from API will be replaced by the real `administrator_username` and `administrator_password` if available in the state.
+* `value` - The value of the Mongo Cluster connection string. The `<user>:<password>` placeholder returned from API will be replaced by the real `administrator_username` and `administrator_password` if available in the state.
 
 ## Timeouts
 

--- a/website/docs/r/mongo_cluster.html.markdown
+++ b/website/docs/r/mongo_cluster.html.markdown
@@ -111,6 +111,18 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `id` - The ID of the MongoDB Cluster.
 
+* `connection_strings` - The list of `connection_strings` blocks as defined below.
+
+---
+
+A `connection_strings` exports the following:
+
+* `name` - The name of the connection string.
+
+* `description` - The description of the connection string.
+
+* `connection_string` - The Mongo Cluster connection string. The the `<user>:<password>` place holder returned from API will be replaced by the real `administrator_username` and `administrator_password` if available in the state.
+
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

`azurerm_mongo_cluster` - Supports `connection_strings`.

Note that the `connection_string` returned from API is a template, with `<user>:<password>` place holders. This PR replace them with the real user name and password, to make it directly usable for users. Since the password is only available in the state/config, this replacement won't occur during importing.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

```shell
💢  TF_ACC=1 go test -v -timeout=20h -parallel=20 -run=TestAccMongoCluster_basic ./internal/services/mongocluster
=== RUN   TestAccMongoCluster_basic
--- PASS: TestAccMongoCluster_basic (1181.18s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/mongocluster  1181.195s
```


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_mongo_cluster` - Supports `connection_strings` [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #28841


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
