### PR TITLE
`azurerm_workloads_sap_*` - support for the `managed_resources_network_access_type` property

### DIFF
--- a/internal/services/workloads/workloads_sap_discovery_virtual_instance_resource_test.go
+++ b/internal/services/workloads/workloads_sap_discovery_virtual_instance_resource_test.go
@@ -198,14 +198,15 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_workloads_sap_discovery_virtual_instance" "test" {
-  name                              = "%s"
-  resource_group_name               = azurerm_resource_group.test.name
-  location                          = azurerm_resource_group.test.location
-  environment                       = "NonProd"
-  sap_product                       = "S4HANA"
-  managed_resource_group_name       = "acctestmanagedRG%d"
-  central_server_virtual_machine_id = "%s"
-  managed_storage_account_name      = "acctestmanagedsa%s"
+  name                                  = "%s"
+  resource_group_name                   = azurerm_resource_group.test.name
+  location                              = azurerm_resource_group.test.location
+  environment                           = "NonProd"
+  sap_product                           = "S4HANA"
+  managed_resource_group_name           = "acctestmanagedRG%d"
+  central_server_virtual_machine_id     = "%s"
+  managed_storage_account_name          = "acctestmanagedsa%s"
+  managed_resources_network_access_type = "Private"
 
   identity {
     type = "UserAssigned"
@@ -234,14 +235,15 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_workloads_sap_discovery_virtual_instance" "test" {
-  name                              = "%s"
-  resource_group_name               = azurerm_resource_group.test.name
-  location                          = azurerm_resource_group.test.location
-  environment                       = "NonProd"
-  sap_product                       = "S4HANA"
-  managed_resource_group_name       = "acctestmanagedRG%d"
-  central_server_virtual_machine_id = "%s"
-  managed_storage_account_name      = "acctestmanagedsa%s"
+  name                                  = "%s"
+  resource_group_name                   = azurerm_resource_group.test.name
+  location                              = azurerm_resource_group.test.location
+  environment                           = "NonProd"
+  sap_product                           = "S4HANA"
+  managed_resource_group_name           = "acctestmanagedRG%d"
+  central_server_virtual_machine_id     = "%s"
+  managed_storage_account_name          = "acctestmanagedsa%s"
+  managed_resources_network_access_type = "Public"
 
   tags = {
     env = "Test2"

--- a/internal/services/workloads/workloads_sap_single_node_virtual_instance_resource_test.go
+++ b/internal/services/workloads/workloads_sap_single_node_virtual_instance_resource_test.go
@@ -157,10 +157,13 @@ resource "azurerm_virtual_network" "test" {
 }
 
 resource "azurerm_subnet" "test" {
-  name                 = "acctest-subnet-%d"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes     = ["10.0.2.0/24"]
+  name                                          = "acctest-subnet-%d"
+  resource_group_name                           = azurerm_resource_group.test.name
+  virtual_network_name                          = azurerm_virtual_network.test.name
+  address_prefixes                              = ["10.0.2.0/24"]
+  private_endpoint_network_policies             = "Disabled"
+  private_link_service_network_policies_enabled = true
+  service_endpoints                             = ["Microsoft.Storage"]
 }
 
 resource "azurerm_resource_group" "app" {
@@ -292,23 +295,16 @@ provider "azurerm" {
   }
 }
 
-resource "azurerm_storage_account" "test" {
-  name                     = "acctestsa%s"
-  resource_group_name      = azurerm_resource_group.test.name
-  location                 = azurerm_resource_group.test.location
-  account_tier             = "Standard"
-  account_replication_type = "LRS"
-}
-
 resource "azurerm_workloads_sap_single_node_virtual_instance" "test" {
-  name                        = "X%d"
-  resource_group_name         = azurerm_resource_group.test.name
-  location                    = azurerm_resource_group.test.location
-  environment                 = "NonProd"
-  sap_product                 = "S4HANA"
-  managed_resource_group_name = "acctestManagedRG%d"
-  app_location                = azurerm_resource_group.app.location
-  sap_fqdn                    = "sap.bpaas.com"
+  name                                  = "X%d"
+  resource_group_name                   = azurerm_resource_group.test.name
+  location                              = azurerm_resource_group.test.location
+  environment                           = "NonProd"
+  sap_product                           = "S4HANA"
+  managed_resource_group_name           = "acctestManagedRG%d"
+  app_location                          = azurerm_resource_group.app.location
+  sap_fqdn                              = "sap.bpaas.com"
+  managed_resources_network_access_type = "Private"
 
   single_server_configuration {
     app_resource_group_name = azurerm_resource_group.app.name
@@ -404,7 +400,7 @@ resource "azurerm_workloads_sap_single_node_virtual_instance" "test" {
     azurerm_role_assignment.test
   ]
 }
-`, r.template(data), data.RandomString, sapVISNameSuffix, data.RandomInteger)
+`, r.template(data), sapVISNameSuffix, data.RandomInteger)
 }
 
 func (r WorkloadsSAPSingleNodeVirtualInstanceResource) update(data acceptance.TestData, sapVISNameSuffix int) string {
@@ -419,23 +415,16 @@ provider "azurerm" {
   }
 }
 
-resource "azurerm_storage_account" "test" {
-  name                     = "acctestsa%s"
-  resource_group_name      = azurerm_resource_group.test.name
-  location                 = azurerm_resource_group.test.location
-  account_tier             = "Standard"
-  account_replication_type = "LRS"
-}
-
 resource "azurerm_workloads_sap_single_node_virtual_instance" "test" {
-  name                        = "X%d"
-  resource_group_name         = azurerm_resource_group.test.name
-  location                    = azurerm_resource_group.test.location
-  environment                 = "NonProd"
-  sap_product                 = "S4HANA"
-  managed_resource_group_name = "acctestManagedRG%d"
-  app_location                = azurerm_resource_group.app.location
-  sap_fqdn                    = "sap.bpaas.com"
+  name                                  = "X%d"
+  resource_group_name                   = azurerm_resource_group.test.name
+  location                              = azurerm_resource_group.test.location
+  environment                           = "NonProd"
+  sap_product                           = "S4HANA"
+  managed_resource_group_name           = "acctestManagedRG%d"
+  app_location                          = azurerm_resource_group.app.location
+  sap_fqdn                              = "sap.bpaas.com"
+  managed_resources_network_access_type = "Public"
 
   single_server_configuration {
     app_resource_group_name = azurerm_resource_group.app.name
@@ -519,7 +508,7 @@ resource "azurerm_workloads_sap_single_node_virtual_instance" "test" {
     azurerm_role_assignment.test
   ]
 }
-`, r.template(data), data.RandomString, sapVISNameSuffix, data.RandomInteger)
+`, r.template(data), sapVISNameSuffix, data.RandomInteger)
 }
 
 func SAPSingleNodeVirtualInstanceNameSuffix() int {

--- a/internal/services/workloads/workloads_sap_three_tier_virtual_instance_resource_test.go
+++ b/internal/services/workloads/workloads_sap_three_tier_virtual_instance_resource_test.go
@@ -177,10 +177,13 @@ resource "azurerm_virtual_network" "test" {
 }
 
 resource "azurerm_subnet" "test" {
-  name                 = "acctest-subnet-%d"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes     = ["10.0.2.0/24"]
+  name                                          = "acctest-subnet-%d"
+  resource_group_name                           = azurerm_resource_group.test.name
+  virtual_network_name                          = azurerm_virtual_network.test.name
+  address_prefixes                              = ["10.0.2.0/24"]
+  private_endpoint_network_policies             = "Disabled"
+  private_link_service_network_policies_enabled = true
+  service_endpoints                             = ["Microsoft.Storage"]
 }
 
 resource "azurerm_resource_group" "app" {
@@ -412,23 +415,16 @@ provider "azurerm" {
   }
 }
 
-resource "azurerm_storage_account" "test" {
-  name                     = "acctestsa%s"
-  resource_group_name      = azurerm_resource_group.test.name
-  location                 = azurerm_resource_group.test.location
-  account_tier             = "Standard"
-  account_replication_type = "LRS"
-}
-
 resource "azurerm_workloads_sap_three_tier_virtual_instance" "test" {
-  name                        = "X%d"
-  resource_group_name         = azurerm_resource_group.test.name
-  location                    = azurerm_resource_group.test.location
-  environment                 = "NonProd"
-  sap_product                 = "S4HANA"
-  managed_resource_group_name = "acctestManagedRG%d"
-  app_location                = azurerm_resource_group.app.location
-  sap_fqdn                    = "sap.bpaas.com"
+  name                                  = "X%d"
+  resource_group_name                   = azurerm_resource_group.test.name
+  location                              = azurerm_resource_group.test.location
+  environment                           = "NonProd"
+  sap_product                           = "S4HANA"
+  managed_resource_group_name           = "acctestManagedRG%d"
+  app_location                          = azurerm_resource_group.app.location
+  sap_fqdn                              = "sap.bpaas.com"
+  managed_resources_network_access_type = "Private"
 
   three_tier_configuration {
     app_resource_group_name = azurerm_resource_group.app.name
@@ -649,7 +645,7 @@ resource "azurerm_workloads_sap_three_tier_virtual_instance" "test" {
     azurerm_role_assignment.test
   ]
 }
-`, r.template(data), data.RandomString, sapVISNameSuffix, data.RandomInteger, data.RandomString, data.RandomString, data.RandomString)
+`, r.template(data), sapVISNameSuffix, data.RandomInteger, data.RandomString, data.RandomString, data.RandomString)
 }
 
 func (r WorkloadsSAPThreeTierVirtualInstanceResource) update(data acceptance.TestData, sapVISNameSuffix int) string {
@@ -664,23 +660,16 @@ provider "azurerm" {
   }
 }
 
-resource "azurerm_storage_account" "test" {
-  name                     = "acctestsa%s"
-  resource_group_name      = azurerm_resource_group.test.name
-  location                 = azurerm_resource_group.test.location
-  account_tier             = "Standard"
-  account_replication_type = "LRS"
-}
-
 resource "azurerm_workloads_sap_three_tier_virtual_instance" "test" {
-  name                        = "X%d"
-  resource_group_name         = azurerm_resource_group.test.name
-  location                    = azurerm_resource_group.test.location
-  environment                 = "NonProd"
-  sap_product                 = "S4HANA"
-  managed_resource_group_name = "acctestManagedRG%d"
-  app_location                = azurerm_resource_group.app.location
-  sap_fqdn                    = "sap.bpaas.com"
+  name                                  = "X%d"
+  resource_group_name                   = azurerm_resource_group.test.name
+  location                              = azurerm_resource_group.test.location
+  environment                           = "NonProd"
+  sap_product                           = "S4HANA"
+  managed_resource_group_name           = "acctestManagedRG%d"
+  app_location                          = azurerm_resource_group.app.location
+  sap_fqdn                              = "sap.bpaas.com"
+  managed_resources_network_access_type = "Public"
 
   three_tier_configuration {
     app_resource_group_name = azurerm_resource_group.app.name
@@ -889,7 +878,7 @@ resource "azurerm_workloads_sap_three_tier_virtual_instance" "test" {
     azurerm_role_assignment.test
   ]
 }
-`, r.template(data), data.RandomString, sapVISNameSuffix, data.RandomInteger, data.RandomString, data.RandomString, data.RandomString)
+`, r.template(data), sapVISNameSuffix, data.RandomInteger, data.RandomString, data.RandomString, data.RandomString)
 }
 
 func RandomInt() int {

--- a/website/docs/r/workloads_sap_discovery_virtual_instance.html.markdown
+++ b/website/docs/r/workloads_sap_discovery_virtual_instance.html.markdown
@@ -63,6 +63,8 @@ The following arguments are supported:
 
 * `managed_resource_group_name` - (Optional) The name of the managed Resource Group for the SAP Discovery Virtual Instance. Changing this forces a new resource to be created.
 
+* `managed_resources_network_access_type` - (Optional) The network access type for managed resources. Possible values are `Private` and `Public`. Defaults to `Public`.
+
 * `managed_storage_account_name` - (Optional) The name of the custom Storage Account created by the service in the managed Resource Group. Changing this forces a new resource to be created.
 
 * `tags` - (Optional) A mapping of tags which should be assigned to the SAP Discovery Virtual Instance.

--- a/website/docs/r/workloads_sap_single_node_virtual_instance.html.markdown
+++ b/website/docs/r/workloads_sap_single_node_virtual_instance.html.markdown
@@ -192,6 +192,8 @@ The following arguments are supported:
 
 * `managed_resource_group_name` - (Optional) The name of the managed Resource Group for the SAP Single Node Virtual Instance. Changing this forces a new resource to be created.
 
+* `managed_resources_network_access_type` - (Optional) The network access type for managed resources. Possible values are `Private` and `Public`. Defaults to `Public`.
+
 * `tags` - (Optional) A mapping of tags which should be assigned to the SAP Single Node Virtual Instance.
 
 ---

--- a/website/docs/r/workloads_sap_three_tier_virtual_instance.html.markdown
+++ b/website/docs/r/workloads_sap_three_tier_virtual_instance.html.markdown
@@ -329,6 +329,8 @@ The following arguments are supported:
 
 * `managed_resource_group_name` - (Optional) The name of the managed Resource Group for the SAP Three Tier Virtual Instance. Changing this forces a new resource to be created.
 
+* `managed_resources_network_access_type` - (Optional) The network access type for managed resources. Possible values are `Private` and `Public`. Defaults to `Public`.
+
 * `tags` - (Optional) A mapping of tags which should be assigned to the SAP Three Tier Virtual Instance.
 
 ---


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description
Service team asks us to support new feature "[managedResourcesNetworkAccessType](https://github.com/Azure/azure-rest-api-specs-pr/blob/bc9d87f57db0daa39d30315e3687c2c759f60595/specification/workloads/resource-manager/Microsoft.Workloads/SAPVirtualInstance/stable/2024-09-01/SAPVirtualInstance.json#L3246)".
<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

--- PASS: TestAccWorkloadsSAPSingleNodeVirtualInstance_basic (2055.50s)
--- PASS: TestAccWorkloadsSAPSingleNodeVirtualInstance_requiresImport (2227.49s)
--- PASS: TestAccWorkloadsSAPSingleNodeVirtualInstance_complete (2173.28s)
--- PASS: TestAccWorkloadsSAPSingleNodeVirtualInstance_update (2959.14s)
--- PASS: TestAccWorkloadsSAPThreeTierVirtualInstance_basic (2882.43s)
--- PASS: TestAccWorkloadsSAPThreeTierVirtualInstance_requiresImport (2915.06s)
--- PASS: TestAccWorkloadsSAPThreeTierVirtualInstance_complete (2951.19s)
--- PASS: TestAccWorkloadsSAPThreeTierVirtualInstance_update (3566.87s)
--- PASS: TestAccWorkloadsSAPDiscoveryVirtualInstanceSequential/sapVirtualInstance/basic (982.93s)
--- PASS: TestAccWorkloadsSAPDiscoveryVirtualInstanceSequential/sapVirtualInstance/requiresImport (1067.22s)
--- PASS: TestAccWorkloadsSAPDiscoveryVirtualInstanceSequential/sapVirtualInstance/complete (1730.71s)
--- PASS: TestAccWorkloadsSAPDiscoveryVirtualInstanceSequential/sapVirtualInstance/update (1875.86s)

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_workloads_sap_*` - support for the `managed_resources_network_access_type` property


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
