### PR TITLE
New Resource: `azurerm_servicebus_namespace_customer_managed_key`

### DIFF
--- a/internal/provider/services.go
+++ b/internal/provider/services.go
@@ -213,6 +213,7 @@ func SupportedTypedServices() []sdk.TypedServiceRegistration {
 		search.Registration{},
 		securitycenter.Registration{},
 		sentinel.Registration{},
+		servicebus.Registration{},
 		serviceconnector.Registration{},
 		servicefabricmanaged.Registration{},
 		servicenetworking.Registration{},

--- a/internal/services/servicebus/registration.go
+++ b/internal/services/servicebus/registration.go
@@ -59,3 +59,15 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 
 	return resources
 }
+
+// DataSources returns the typed DataSources supported by this service
+func (r Registration) DataSources() []sdk.DataSource {
+	return []sdk.DataSource{}
+}
+
+// Resources returns the typed Resources supported by this service
+func (r Registration) Resources() []sdk.Resource {
+	return []sdk.Resource{
+		ServiceBusNamespaceCustomerManagedKeyResource{},
+	}
+}

--- a/internal/services/servicebus/servicebus_namespace_customer_managed_key_resource.go
+++ b/internal/services/servicebus/servicebus_namespace_customer_managed_key_resource.go
@@ -1,0 +1,265 @@
+package servicebus
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2022-10-01-preview/namespaces"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	keyVaultParse "github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/parse"
+	keyVaultValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type ServiceBusNamespaceCustomerManagedKeyResource struct{}
+
+type ServiceBusNamespaceCustomerManagedKeyModel struct {
+	NamespaceID                     string `tfschema:"namespace_id"`
+	KeyVaultKeyID                   string `tfschema:"key_vault_key_id"`
+	IdentityID                      string `tfschema:"identity_id"`
+	InfrastructureEncryptionEnabled bool   `tfschema:"infrastructure_encryption_enabled"`
+}
+
+var _ sdk.ResourceWithUpdate = ServiceBusNamespaceCustomerManagedKeyResource{}
+
+func (r ServiceBusNamespaceCustomerManagedKeyResource) ModelObject() interface{} {
+	return &ServiceBusNamespaceCustomerManagedKeyModel{}
+}
+
+func (r ServiceBusNamespaceCustomerManagedKeyResource) ResourceType() string {
+	return "azurerm_servicebus_namespace_customer_managed_key"
+}
+
+func (r ServiceBusNamespaceCustomerManagedKeyResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return namespaces.ValidateNamespaceID
+}
+
+func (r ServiceBusNamespaceCustomerManagedKeyResource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"namespace_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: namespaces.ValidateNamespaceID,
+		},
+		"key_vault_key_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: keyVaultValidate.NestedItemIdWithOptionalVersion,
+		},
+		"identity_id": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: commonids.ValidateUserAssignedIdentityID,
+		},
+		"infrastructure_encryption_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			ForceNew: true,
+		},
+	}
+}
+
+func (r ServiceBusNamespaceCustomerManagedKeyResource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{}
+}
+
+func (r ServiceBusNamespaceCustomerManagedKeyResource) Create() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.ServiceBus.NamespacesClient
+			var cmk ServiceBusNamespaceCustomerManagedKeyModel
+
+			if err := metadata.Decode(&cmk); err != nil {
+				return err
+			}
+
+			id, err := namespaces.ParseNamespaceID(cmk.NamespaceID)
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.Get(ctx, *id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return fmt.Errorf("%s was not found", *id)
+				}
+				return fmt.Errorf("retrieving %s: %+v", *id, err)
+			}
+
+			if resp.Model == nil {
+				return fmt.Errorf("retrieving %s: `model` is nil", *id)
+			}
+
+			if resp.Model.Properties != nil && resp.Model.Properties.Encryption != nil && resp.Model.Properties.Encryption.KeyVaultProperties != nil && len(*resp.Model.Properties.Encryption.KeyVaultProperties) > 0 {
+				return metadata.ResourceRequiresImport(r.ResourceType(), *id)
+			}
+
+			payload := resp.Model
+
+			keyId, err := keyVaultParse.ParseOptionallyVersionedNestedItemID(cmk.KeyVaultKeyID)
+			if err != nil {
+				return err
+			}
+
+			payload.Properties.Encryption = &namespaces.Encryption{
+				RequireInfrastructureEncryption: pointer.To(cmk.InfrastructureEncryptionEnabled),
+				KeySource:                       pointer.To(namespaces.KeySourceMicrosoftPointKeyVault),
+				KeyVaultProperties: &[]namespaces.KeyVaultProperties{
+					{
+						KeyName:     pointer.To(keyId.Name),
+						KeyVersion:  pointer.To(keyId.Version),
+						KeyVaultUri: pointer.To(keyId.KeyVaultBaseUrl),
+					},
+				},
+			}
+
+			if cmk.IdentityID != "" {
+				identityId, err := commonids.ParseUserAssignedIdentityID(cmk.IdentityID)
+				if err != nil {
+					return err
+				}
+				(*payload.Properties.Encryption.KeyVaultProperties)[0].Identity = &namespaces.UserAssignedIdentityProperties{
+					UserAssignedIdentity: pointer.To(identityId.ID()),
+				}
+			}
+
+			if err := client.CreateOrUpdateThenPoll(ctx, *id, *payload); err != nil {
+				return fmt.Errorf("creating Customer Managed Key for %s: %+v", *id, err)
+			}
+
+			metadata.SetID(id)
+			return nil
+		},
+	}
+}
+
+func (r ServiceBusNamespaceCustomerManagedKeyResource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.ServiceBus.NamespacesClient
+
+			id, err := namespaces.ParseNamespaceID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.Get(ctx, *id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return metadata.MarkAsGone(id)
+				}
+				return fmt.Errorf("retrieving %s: %+v", *id, err)
+			}
+
+			var state ServiceBusNamespaceCustomerManagedKeyModel
+			state.NamespaceID = id.ID()
+
+			if props := resp.Model.Properties; props != nil && props.Encryption != nil {
+				encryption := props.Encryption
+				if keyVaultProperties := encryption.KeyVaultProperties; keyVaultProperties != nil && len(*keyVaultProperties) > 0 {
+					if identity := (*keyVaultProperties)[0].Identity; identity != nil {
+						identityId, err := commonids.ParseUserAssignedIdentityIDInsensitively(pointer.From(identity.UserAssignedIdentity))
+						if err != nil {
+							return err
+						}
+						state.IdentityID = identityId.ID()
+					}
+
+					keyVaultKeyId, err := keyVaultParse.NewNestedItemID(pointer.From((*keyVaultProperties)[0].KeyVaultUri), keyVaultParse.NestedItemTypeKey, pointer.From((*keyVaultProperties)[0].KeyName), pointer.From((*keyVaultProperties)[0].KeyVersion))
+					if err != nil {
+						return fmt.Errorf("parsing `key_vault_key_id`: %+v", err)
+					}
+					state.KeyVaultKeyID = keyVaultKeyId.ID()
+				}
+				state.InfrastructureEncryptionEnabled = pointer.From(encryption.RequireInfrastructureEncryption)
+			}
+			return metadata.Encode(&state)
+		},
+	}
+}
+
+func (r ServiceBusNamespaceCustomerManagedKeyResource) Update() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.ServiceBus.NamespacesClient
+			var cmk ServiceBusNamespaceCustomerManagedKeyModel
+
+			if err := metadata.Decode(&cmk); err != nil {
+				return err
+			}
+
+			id, err := namespaces.ParseNamespaceID(cmk.NamespaceID)
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.Get(ctx, *id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return fmt.Errorf("%s was not found", *id)
+				}
+				return fmt.Errorf("retrieving %s: %+v", *id, err)
+			}
+
+			if resp.Model == nil {
+				return fmt.Errorf("retrieving %s: `model` is nil", *id)
+			}
+
+			if resp.Model.Properties == nil {
+				return fmt.Errorf("retrieving %s: `properties` is nil", *id)
+			}
+
+			if resp.Model.Properties.Encryption == nil || resp.Model.Properties.Encryption.KeyVaultProperties == nil || len(*resp.Model.Properties.Encryption.KeyVaultProperties) == 0 {
+				return fmt.Errorf("retrieving %s: Customer Managed Key was not found", *id)
+			}
+
+			payload := resp.Model
+
+			if metadata.ResourceData.HasChange("key_vault_key_id") {
+				keyId, err := keyVaultParse.ParseOptionallyVersionedNestedItemID(cmk.KeyVaultKeyID)
+				if err != nil {
+					return err
+				}
+
+				(*payload.Properties.Encryption.KeyVaultProperties)[0].KeyName = pointer.To(keyId.Name)
+				(*payload.Properties.Encryption.KeyVaultProperties)[0].KeyVersion = pointer.To(keyId.Version)
+				(*payload.Properties.Encryption.KeyVaultProperties)[0].KeyVaultUri = pointer.To(keyId.KeyVaultBaseUrl)
+			}
+
+			if metadata.ResourceData.HasChange("identity_id") {
+				identityId, err := commonids.ParseUserAssignedIdentityID(cmk.IdentityID)
+				if err != nil {
+					return err
+				}
+				(*payload.Properties.Encryption.KeyVaultProperties)[0].Identity = &namespaces.UserAssignedIdentityProperties{
+					UserAssignedIdentity: pointer.To(identityId.ID()),
+				}
+			}
+
+			if err := client.CreateOrUpdateThenPoll(ctx, *id, *payload); err != nil {
+				return fmt.Errorf("updating Customer Managed Key for %s: %+v", *id, err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func (r ServiceBusNamespaceCustomerManagedKeyResource) Delete() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			log.Printf(`[INFO] Customer Managed Keys cannot be removed from Servicebus Namespaces once added. To remove the Customer Managed Key, delete and recreate the parent Servicebus Namespace`)
+			return nil
+		},
+	}
+}

--- a/internal/services/servicebus/servicebus_namespace_customer_managed_key_resource_test.go
+++ b/internal/services/servicebus/servicebus_namespace_customer_managed_key_resource_test.go
@@ -1,0 +1,447 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+package servicebus_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2022-10-01-preview/namespaces"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type ServicebusNamespaceCustomerManagedKeyResource struct{}
+
+func TestAccServicebusNamespaceCustomerManagedKey_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_servicebus_namespace_customer_managed_key", "test")
+	r := ServicebusNamespaceCustomerManagedKeyResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccServicebusNamespaceCustomerManagedKey_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_servicebus_namespace_customer_managed_key", "test")
+	r := ServicebusNamespaceCustomerManagedKeyResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccServicebusNamespaceCustomerManagedKey_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_servicebus_namespace_customer_managed_key", "test")
+	r := ServicebusNamespaceCustomerManagedKeyResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func TestAccServicebusNamespaceCustomerManagedKey_updated(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_servicebus_namespace_customer_managed_key", "test")
+	r := ServicebusNamespaceCustomerManagedKeyResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.updated(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccServicebusNamespaceCustomerManagedKey_userAssignedIdentityUpdated(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_servicebus_namespace_customer_managed_key", "test")
+	r := ServicebusNamespaceCustomerManagedKeyResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.userAssigned(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.userAssignedUpdated(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (r ServicebusNamespaceCustomerManagedKeyResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := namespaces.ParseNamespaceID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.ServiceBus.NamespacesClient.Get(ctx, *id)
+	if err != nil {
+		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	if resp.Model == nil || resp.Model.Properties.Encryption == nil {
+		return pointer.To(false), nil
+	}
+	return pointer.To(true), nil
+}
+
+func (r ServicebusNamespaceCustomerManagedKeyResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctest-sb-%d"
+  location = "%s"
+}
+
+resource "azurerm_servicebus_namespace" "test" {
+  name                         = "acctestservicebusnamespace-%d"
+  location                     = azurerm_resource_group.test.location
+  resource_group_name          = azurerm_resource_group.test.name
+  sku                          = "Premium"
+  premium_messaging_partitions = 1
+  capacity                     = 1
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  lifecycle {
+    ignore_changes = [customer_managed_key]
+  }
+}
+
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_key_vault" "test" {
+  name                        = "acctest-key-vault-%s"
+  location                    = azurerm_resource_group.test.location
+  resource_group_name         = azurerm_resource_group.test.name
+  enabled_for_disk_encryption = true
+  tenant_id                   = data.azurerm_client_config.current.tenant_id
+  soft_delete_retention_days  = 7
+  purge_protection_enabled    = true
+
+  sku_name = "standard"
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+
+    key_permissions = [
+      "Create",
+      "Decrypt",
+      "Encrypt",
+      "Delete",
+      "Get",
+      "List",
+      "Purge",
+      "UnwrapKey",
+      "WrapKey",
+      "Verify",
+      "GetRotationPolicy"
+    ]
+    secret_permissions = [
+      "Set",
+    ]
+  }
+
+  access_policy {
+    tenant_id = azurerm_servicebus_namespace.test.identity[0].tenant_id
+    object_id = azurerm_servicebus_namespace.test.identity[0].principal_id
+
+    key_permissions = [
+      "Create",
+      "Decrypt",
+      "Encrypt",
+      "Delete",
+      "Get",
+      "List",
+      "Purge",
+      "UnwrapKey",
+      "WrapKey",
+      "Verify",
+      "GetRotationPolicy"
+    ]
+    secret_permissions = [
+      "Set",
+    ]
+  }
+}
+
+resource "azurerm_key_vault_key" "test" {
+  name         = "acctestkey-%s"
+  key_vault_id = azurerm_key_vault.test.id
+  key_type     = "RSA"
+  key_size     = 2048
+
+  key_opts = [
+    "decrypt",
+    "encrypt",
+    "sign",
+    "unwrapKey",
+    "verify",
+    "wrapKey",
+  ]
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomString, data.RandomString)
+}
+
+func (r ServicebusNamespaceCustomerManagedKeyResource) templateUserAssigned(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctest-sb-%[1]d"
+  location = "%s"
+}
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acctestUAI-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_key_vault" "test" {
+  name                     = "acctestkv%[3]s"
+  location                 = azurerm_resource_group.test.location
+  resource_group_name      = azurerm_resource_group.test.name
+  tenant_id                = data.azurerm_client_config.current.tenant_id
+  sku_name                 = "standard"
+  purge_protection_enabled = true
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+    key_permissions = [
+      "Get", "Create", "Delete", "List", "Restore", "Recover", "UnwrapKey", "WrapKey", "Purge", "Encrypt", "Decrypt", "Sign", "Verify", "GetRotationPolicy"
+    ]
+    secret_permissions = [
+      "Get",
+    ]
+  }
+
+  access_policy {
+    tenant_id = azurerm_user_assigned_identity.test.tenant_id
+    object_id = azurerm_user_assigned_identity.test.principal_id
+    key_permissions = [
+      "Get", "Create", "Delete", "List", "Restore", "Recover", "UnwrapKey", "WrapKey", "Purge", "Encrypt", "Decrypt", "Sign", "Verify", "GetRotationPolicy"
+    ]
+    secret_permissions = [
+      "Get",
+    ]
+  }
+}
+
+resource "azurerm_key_vault_key" "test" {
+  name         = "acctestkvkey%[3]s"
+  key_vault_id = azurerm_key_vault.test.id
+  key_type     = "RSA"
+  key_size     = 2048
+  key_opts     = ["decrypt", "encrypt", "sign", "unwrapKey", "verify", "wrapKey"]
+}
+
+resource "azurerm_servicebus_namespace" "test" {
+  name                         = "acctestservicebusnamespace-%[1]d"
+  location                     = azurerm_resource_group.test.location
+  resource_group_name          = azurerm_resource_group.test.name
+  sku                          = "Premium"
+  premium_messaging_partitions = 1
+  capacity                     = 1
+
+  identity {
+    type = "UserAssigned"
+    identity_ids = [
+      azurerm_user_assigned_identity.test.id,
+    ]
+  }
+
+  lifecycle {
+    ignore_changes = [customer_managed_key]
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}
+
+func (r ServicebusNamespaceCustomerManagedKeyResource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_servicebus_namespace_customer_managed_key" "test" {
+  namespace_id     = azurerm_servicebus_namespace.test.id
+  key_vault_key_id = azurerm_key_vault_key.test.id
+}
+`, r.template(data))
+}
+
+func (r ServicebusNamespaceCustomerManagedKeyResource) complete(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_servicebus_namespace_customer_managed_key" "test" {
+  namespace_id                      = azurerm_servicebus_namespace.test.id
+  key_vault_key_id                  = azurerm_key_vault_key.test.id
+  infrastructure_encryption_enabled = false
+}
+`, r.template(data))
+}
+
+func (r ServicebusNamespaceCustomerManagedKeyResource) requiresImport(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+resource "azurerm_servicebus_namespace_customer_managed_key" "import" {
+  namespace_id     = azurerm_servicebus_namespace.test.id
+  key_vault_key_id = azurerm_key_vault_key.test.id
+}
+`, r.template(data))
+}
+
+func (r ServicebusNamespaceCustomerManagedKeyResource) updated(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_key_vault" "test2" {
+  name                        = "acctest-key-vault-2%s"
+  location                    = azurerm_resource_group.test.location
+  resource_group_name         = azurerm_resource_group.test.name
+  enabled_for_disk_encryption = true
+  tenant_id                   = data.azurerm_client_config.current.tenant_id
+  soft_delete_retention_days  = 7
+  purge_protection_enabled    = true
+
+  sku_name = "standard"
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+
+    key_permissions = [
+      "Create",
+      "Decrypt",
+      "Encrypt",
+      "Delete",
+      "Get",
+      "List",
+      "Purge",
+      "UnwrapKey",
+      "WrapKey",
+      "Verify",
+      "GetRotationPolicy"
+    ]
+    secret_permissions = [
+      "Set",
+    ]
+  }
+
+  access_policy {
+    tenant_id = azurerm_servicebus_namespace.test.identity[0].tenant_id
+    object_id = azurerm_servicebus_namespace.test.identity[0].principal_id
+
+    key_permissions = [
+      "Create",
+      "Decrypt",
+      "Encrypt",
+      "Delete",
+      "Get",
+      "List",
+      "Purge",
+      "UnwrapKey",
+      "WrapKey",
+      "Verify",
+      "GetRotationPolicy"
+    ]
+    secret_permissions = [
+      "Set",
+    ]
+  }
+}
+
+resource "azurerm_key_vault_key" "test2" {
+  name         = "acctestkey2-%s"
+  key_vault_id = azurerm_key_vault.test.id
+  key_type     = "RSA"
+  key_size     = 2048
+
+  key_opts = [
+    "decrypt",
+    "encrypt",
+    "sign",
+    "unwrapKey",
+    "verify",
+    "wrapKey",
+  ]
+}
+
+resource "azurerm_servicebus_namespace_customer_managed_key" "test" {
+  namespace_id                      = azurerm_servicebus_namespace.test.id
+  key_vault_key_id                  = azurerm_key_vault_key.test2.id
+  infrastructure_encryption_enabled = false
+}
+`, r.template(data), data.RandomString, data.RandomString)
+}
+
+func (r ServicebusNamespaceCustomerManagedKeyResource) userAssigned(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_servicebus_namespace_customer_managed_key" "test" {
+  namespace_id                      = azurerm_servicebus_namespace.test.id
+  key_vault_key_id                  = azurerm_key_vault_key.test.id
+  identity_id                       = azurerm_user_assigned_identity.test.id
+  infrastructure_encryption_enabled = true
+}
+`, r.templateUserAssigned(data))
+}
+
+func (r ServicebusNamespaceCustomerManagedKeyResource) userAssignedUpdated(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_servicebus_namespace_customer_managed_key" "test" {
+  namespace_id                      = azurerm_servicebus_namespace.test.id
+  key_vault_key_id                  = azurerm_key_vault_key.test.id
+  identity_id                       = azurerm_user_assigned_identity.test.id
+  infrastructure_encryption_enabled = true
+}
+`, r.templateUserAssigned(data))
+}

--- a/website/docs/r/servicebus_namespace.html.markdown
+++ b/website/docs/r/servicebus_namespace.html.markdown
@@ -83,7 +83,7 @@ An `identity` block supports the following:
 
 -> **Note:** Once customer-managed key encryption has been enabled, it cannot be disabled.
 
--> **Note:** The `customer_managed_key` block should only be used for Service Bus Namespaces with a User Assigned identity. To create a Customer Managed Key for a Service Bus Namespaces with a System Assigned identity, use the `azurerm_servicebus_namespace_customer_managed_key` resource and add `customer_managed_key` to `ignore_changes`.
+-> **Note:** The `customer_managed_key` block should only be used for Service Bus Namespaces with a User Assigned identity. To create a Customer Managed Key for a Service Bus Namespace with a System Assigned identity, use the `azurerm_servicebus_namespace_customer_managed_key` resource and add `customer_managed_key` to `ignore_changes`.
 
 ---
 

--- a/website/docs/r/servicebus_namespace.html.markdown
+++ b/website/docs/r/servicebus_namespace.html.markdown
@@ -38,7 +38,7 @@ resource "azurerm_servicebus_namespace" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the ServiceBus Namespace resource . Changing this forces a new resource to be created.
+* `name` - (Required) Specifies the name of the Service Bus Namespace resource . Changing this forces a new resource to be created.
 
 * `resource_group_name` - (Required) The name of the resource group in which to Changing this forces a new resource to be created.
     create the namespace.
@@ -73,9 +73,9 @@ The following arguments are supported:
 
 An `identity` block supports the following:
 
-* `type` - (Required) Specifies the type of Managed Service Identity that should be configured on this ServiceBus Namespace. Possible values are `SystemAssigned`, `UserAssigned`, `SystemAssigned, UserAssigned` (to enable both).
+* `type` - (Required) Specifies the type of Managed Service Identity that should be configured on this Service Bus Namespace. Possible values are `SystemAssigned`, `UserAssigned`, `SystemAssigned, UserAssigned` (to enable both).
 
-* `identity_ids` - (Optional) Specifies a list of User Assigned Managed Identity IDs to be assigned to this ServiceBus namespace.
+* `identity_ids` - (Optional) Specifies a list of User Assigned Managed Identity IDs to be assigned to this Service Bus namespace.
 
 ~> **NOTE:** This is required when `type` is set to `UserAssigned` or `SystemAssigned, UserAssigned`.
 
@@ -83,11 +83,13 @@ An `identity` block supports the following:
 
 -> **Note:** Once customer-managed key encryption has been enabled, it cannot be disabled.
 
+-> **Note:** The `customer_managed_key` block should only be used for Service Bus Namespaces with a User Assigned identity. To create a Customer Managed Key for a Service Bus Namespaces with a System Assigned identity, use the `azurerm_servicebus_namespace_customer_managed_key` resource and add `customer_managed_key` to `ignore_changes`.
+
 ---
 
 A `customer_managed_key` block supports the following:
 
-* `key_vault_key_id` - (Required) The ID of the Key Vault Key which should be used to Encrypt the data in this ServiceBus Namespace.
+* `key_vault_key_id` - (Required) The ID of the Key Vault Key which should be used to Encrypt the data in this Service Bus Namespace.
 
 * `identity_id` - (Required) The ID of the User Assigned Identity that has access to the key.
 
@@ -105,7 +107,7 @@ A `network_rule_set` block supports the following:
 
 * `trusted_services_allowed` - (Optional) Are Azure Services that are known and trusted for this resource type are allowed to bypass firewall configuration? See [Trusted Microsoft Services](https://github.com/MicrosoftDocs/azure-docs/blob/master/articles/service-bus-messaging/includes/service-bus-trusted-services.md)
 
-* `ip_rules` - (Optional) One or more IP Addresses, or CIDR Blocks which should be able to access the ServiceBus Namespace.
+* `ip_rules` - (Optional) One or more IP Addresses, or CIDR Blocks which should be able to access the Service Bus Namespace.
 
 * `network_rules` - (Optional) One or more `network_rules` blocks as defined below.
 
@@ -113,27 +115,27 @@ A `network_rule_set` block supports the following:
 
 A `network_rules` block supports the following:
 
-* `subnet_id` - (Required) The Subnet ID which should be able to access this ServiceBus Namespace.
+* `subnet_id` - (Required) The Subnet ID which should be able to access this Service Bus Namespace.
 
-* `ignore_missing_vnet_service_endpoint` - (Optional) Should the ServiceBus Namespace Network Rule Set ignore missing Virtual Network Service Endpoint option in the Subnet? Defaults to `false`.
+* `ignore_missing_vnet_service_endpoint` - (Optional) Should the Service Bus Namespace Network Rule Set ignore missing Virtual Network Service Endpoint option in the Subnet? Defaults to `false`.
 
 ## Attributes Reference
 
 In addition to the Arguments listed above - the following Attributes are exported:
 
-* `id` - The ServiceBus Namespace ID.
+* `id` - The Service Bus Namespace ID.
 
-* `identity` - An `identity` block as defined below, which contains the Managed Service Identity information for this ServiceBus Namespace.
+* `identity` - An `identity` block as defined below, which contains the Managed Service Identity information for this Service Bus Namespace.
 
-* `endpoint` - The URL to access the ServiceBus Namespace.
+* `endpoint` - The URL to access the Service Bus Namespace.
 
 ---
 
 A `identity` block exports the following:
 
-* `principal_id` - The Principal ID for the Service Principal associated with the Managed Service Identity of this ServiceBus Namespace.
+* `principal_id` - The Principal ID for the Service Principal associated with the Managed Service Identity of this Service Bus Namespace.
 
-* `tenant_id` - The Tenant ID for the Service Principal associated with the Managed Service Identity of this ServiceBus Namespace.
+* `tenant_id` - The Tenant ID for the Service Principal associated with the Managed Service Identity of this Service Bus Namespace.
 
 ---
 
@@ -151,18 +153,18 @@ The following attributes are exported only if there is an authorization rule nam
 
 A `identity` block exports the following:
 
-* `principal_id` - The Principal ID for the Service Principal associated with the Managed Service Identity of this ServiceBus Namespace.
+* `principal_id` - The Principal ID for the Service Principal associated with the Managed Service Identity of this Service Bus Namespace.
 
-* `tenant_id` - The Tenant ID for the Service Principal associated with the Managed Service Identity of this ServiceBus Namespace.
+* `tenant_id` - The Tenant ID for the Service Principal associated with the Managed Service Identity of this Service Bus Namespace.
 
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the ServiceBus Namespace.
-* `update` - (Defaults to 30 minutes) Used when updating the ServiceBus Namespace.
-* `read` - (Defaults to 5 minutes) Used when retrieving the ServiceBus Namespace.
-* `delete` - (Defaults to 30 minutes) Used when deleting the ServiceBus Namespace.
+* `create` - (Defaults to 30 minutes) Used when creating the Service Bus Namespace.
+* `update` - (Defaults to 30 minutes) Used when updating the Service Bus Namespace.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Service Bus Namespace.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Service Bus Namespace.
 
 ## Import
 

--- a/website/docs/r/servicebus_namespace_customer_managed_key.html.markdown
+++ b/website/docs/r/servicebus_namespace_customer_managed_key.html.markdown
@@ -1,0 +1,161 @@
+---
+subcategory: "Messaging"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_servicebus_namespace"
+description: |-
+  Manages a ServiceBus Namespace Customer Managed Key.
+---
+
+# azurerm_servicebus_namespace_customer_managed_key
+
+Manages a ServiceBus Namespace Customer Managed Key.
+
+!> **Note:** It is not possible to remove the Customer Managed Key from the ServiceBus Namespace once it's been added. To remove the Customer Managed Key, the parent ServiceBus Namespace must be deleted and recreated.
+
+## Example Usage
+
+```hcl
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example-resource-group"
+  location = "West Europe"
+}
+
+resource "azurerm_servicebus_namespace" "example" {
+  name                         = "example-servicebus-namespace"
+  location                     = azurerm_resource_group.example.location
+  resource_group_name          = azurerm_resource_group.example.name
+  sku                          = "Premium"
+  premium_messaging_partitions = 1
+  capacity                     = 1
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  lifecycle {
+    ignore_changes = [customer_managed_key]
+  }
+}
+
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_key_vault" "example" {
+  name                        = "example-key-vault"
+  location                    = azurerm_resource_group.example.location
+  resource_group_name         = azurerm_resource_group.example.name
+  enabled_for_disk_encryption = true
+  tenant_id                   = data.azurerm_client_config.current.tenant_id
+  soft_delete_retention_days  = 7
+  purge_protection_enabled    = true
+
+  sku_name = "standard"
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+
+    key_permissions = [
+      "Create",
+      "Decrypt",
+      "Encrypt",
+      "Delete",
+      "Get",
+      "List",
+      "Purge",
+      "UnwrapKey",
+      "WrapKey",
+      "Verify",
+      "GetRotationPolicy"
+    ]
+    secret_permissions = [
+      "Set",
+    ]
+  }
+
+  access_policy {
+    tenant_id = azurerm_servicebus_namespace.example.identity[0].tenant_id
+    object_id = azurerm_servicebus_namespace.example.identity[0].principal_id
+
+    key_permissions = [
+      "Create",
+      "Decrypt",
+      "Encrypt",
+      "Delete",
+      "Get",
+      "List",
+      "Purge",
+      "UnwrapKey",
+      "WrapKey",
+      "Verify",
+      "GetRotationPolicy"
+    ]
+    secret_permissions = [
+      "Set",
+    ]
+  }
+}
+
+resource "azurerm_key_vault_key" "example" {
+  name         = "example-key-vault-key"
+  key_vault_id = azurerm_key_vault.example.id
+  key_type     = "RSA"
+  key_size     = 2048
+
+  key_opts = [
+    "decrypt",
+    "encrypt",
+    "sign",
+    "unwrapKey",
+    "verify",
+    "wrapKey",
+  ]
+}
+
+resource "azurerm_servicebus_namespace_customer_managed_key" "example" {
+  namespace_id     = azurerm_servicebus_namespace.example.id
+  key_vault_key_id = azurerm_key_vault_key.example.id
+}
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `namespace_id` - (Required) The ID of the Service Bus namespace. Changing this forces a new resource to be created.
+
+* `key_vault_key_id` - (Required) The ID of the Key Vault Key which should be used to Encrypt the data in this ServiceBus Namespace.
+
+* `identity_id` - (Optional) The ID of the User Assigned Identity that has access to the key.
+
+-> **Note:** If `identity_id` is not specified, the System Assigned Identity of the ServiceBus Namespace will be used.
+
+* `infrastructure_encryption_enabled` - (Optional) Used to specify whether enable Infrastructure Encryption. Changing this forces a new resource to be created.
+
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ServiceBus Namespace ID.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the ServiceBus Namespace Customer Managed Key.
+* `read` - (Defaults to 5 minutes) Used when retrieving the ServiceBus Namespace Customer Managed Key.
+* `update` - (Defaults to 30 minutes) Used when updating the ServiceBus Namespace Customer Managed Key.
+
+## Import
+
+Service Bus Namespace Customer Managed Key can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_servicebus_namespace_customer_managed_key.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.ServiceBus/namespaces/sbns1
+```

--- a/website/docs/r/servicebus_namespace_customer_managed_key.html.markdown
+++ b/website/docs/r/servicebus_namespace_customer_managed_key.html.markdown
@@ -12,7 +12,7 @@ Manages a Service Bus Namespace Customer Managed Key.
 
 !> **Note:** It is not possible to remove the Customer Managed Key from the Service Bus Namespace once it's been added. To remove the Customer Managed Key, the parent Service Bus Namespace must be deleted and recreated.
 
--> **Note:** This resource should only be used to create a Customer Managed Key for Service Bus Namespaces with SystemAssigned identities. The `customer_managed_key` block in `azurerm_servicebus_namespace` should be used to create a Customer Managed Key for a Service Bus Namespaces with a UserAssigned identity.
+-> **Note:** This resource should only be used to create a Customer Managed Key for Service Bus Namespaces with System Assigned identities. The `customer_managed_key` block in `azurerm_servicebus_namespace` should be used to create a Customer Managed Key for a Service Bus Namespace with a User Assigned identity.
 
 ## Example Usage
 

--- a/website/docs/r/servicebus_namespace_customer_managed_key.html.markdown
+++ b/website/docs/r/servicebus_namespace_customer_managed_key.html.markdown
@@ -3,14 +3,16 @@ subcategory: "Messaging"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_servicebus_namespace"
 description: |-
-  Manages a ServiceBus Namespace Customer Managed Key.
+  Manages a Service Bus Namespace Customer Managed Key.
 ---
 
 # azurerm_servicebus_namespace_customer_managed_key
 
-Manages a ServiceBus Namespace Customer Managed Key.
+Manages a Service Bus Namespace Customer Managed Key.
 
-!> **Note:** It is not possible to remove the Customer Managed Key from the ServiceBus Namespace once it's been added. To remove the Customer Managed Key, the parent ServiceBus Namespace must be deleted and recreated.
+!> **Note:** It is not possible to remove the Customer Managed Key from the Service Bus Namespace once it's been added. To remove the Customer Managed Key, the parent Service Bus Namespace must be deleted and recreated.
+
+-> **Note:** This resource should only be used to create a Customer Managed Key for Service Bus Namespaces with SystemAssigned identities. The `customer_managed_key` block in `azurerm_servicebus_namespace` should be used to create a Customer Managed Key for a Service Bus Namespaces with a UserAssigned identity.
 
 ## Example Usage
 
@@ -129,28 +131,23 @@ The following arguments are supported:
 
 * `namespace_id` - (Required) The ID of the Service Bus namespace. Changing this forces a new resource to be created.
 
-* `key_vault_key_id` - (Required) The ID of the Key Vault Key which should be used to Encrypt the data in this ServiceBus Namespace.
-
-* `identity_id` - (Optional) The ID of the User Assigned Identity that has access to the key.
-
--> **Note:** If `identity_id` is not specified, the System Assigned Identity of the ServiceBus Namespace will be used.
+* `key_vault_key_id` - (Required) The ID of the Key Vault Key which should be used to Encrypt the data in this Service Bus Namespace.
 
 * `infrastructure_encryption_enabled` - (Optional) Used to specify whether enable Infrastructure Encryption. Changing this forces a new resource to be created.
-
 
 ## Attributes Reference
 
 In addition to the Arguments listed above - the following Attributes are exported:
 
-* `id` - The ServiceBus Namespace ID.
+* `id` - The Service Bus Namespace ID.
 
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the ServiceBus Namespace Customer Managed Key.
-* `read` - (Defaults to 5 minutes) Used when retrieving the ServiceBus Namespace Customer Managed Key.
-* `update` - (Defaults to 30 minutes) Used when updating the ServiceBus Namespace Customer Managed Key.
+* `create` - (Defaults to 30 minutes) Used when creating the Service Bus Namespace Customer Managed Key.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Service Bus Namespace Customer Managed Key.
+* `update` - (Defaults to 30 minutes) Used when updating the Service Bus Namespace Customer Managed Key.
 
 ## Import
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR adds support for the new resource `azurerm_servicebus_namespace_customer_managed_key`


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->

## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

```
=== RUN   TestAccServicebusNamespaceCustomerManagedKey_basic
=== PAUSE TestAccServicebusNamespaceCustomerManagedKey_basic
=== CONT  TestAccServicebusNamespaceCustomerManagedKey_basic
--- PASS: TestAccServicebusNamespaceCustomerManagedKey_basic (581.52s)
=== RUN   TestAccServicebusNamespaceCustomerManagedKey_complete
=== PAUSE TestAccServicebusNamespaceCustomerManagedKey_complete
=== CONT  TestAccServicebusNamespaceCustomerManagedKey_complete
--- PASS: TestAccServicebusNamespaceCustomerManagedKey_complete (584.67s)
=== RUN   TestAccServicebusNamespaceCustomerManagedKey_requiresImport
=== PAUSE TestAccServicebusNamespaceCustomerManagedKey_requiresImport
=== CONT  TestAccServicebusNamespaceCustomerManagedKey_requiresImport
--- PASS: TestAccServicebusNamespaceCustomerManagedKey_requiresImport (529.35s)
=== RUN   TestAccServicebusNamespaceCustomerManagedKey_updated
=== PAUSE TestAccServicebusNamespaceCustomerManagedKey_updated
=== CONT  TestAccServicebusNamespaceCustomerManagedKey_updated
--- PASS: TestAccServicebusNamespaceCustomerManagedKey_updated (780.80s)
=== RUN   TestAccServicebusNamespaceCustomerManagedKey_userAssignedIdentityUpdated
=== PAUSE TestAccServicebusNamespaceCustomerManagedKey_userAssignedIdentityUpdated
=== CONT  TestAccServicebusNamespaceCustomerManagedKey_userAssignedIdentityUpdated
--- PASS: TestAccServicebusNamespaceCustomerManagedKey_userAssignedIdentityUpdated (496.32s)
PASS
```


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* New Resource: `azurerm_servicebus_namespace_customer_managed_key` [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #21313


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
