### PR TITLE
`azurerm_mssql_server` - check if `administrator_login` is not nil 

### DIFF
--- a/internal/services/mssql/mssql_server_resource.go
+++ b/internal/services/mssql/mssql_server_resource.go
@@ -761,17 +761,19 @@ func msSqlPasswordChangeWhenAADAuthOnly(ctx context.Context, d *pluginsdk.Resour
 
 // msSqlAdministratorLoginPassword checks to make sure that one of `administrator_login_password_wo` or `administrator_login_password` is set when `administrator_login` is specified.
 func msSqlAdministratorLoginPassword(ctx context.Context, d *pluginsdk.ResourceDiff, _ interface{}) (err error) {
-	adminLogin := d.GetRawConfig().AsValueMap()["administrator_login"]
-	if !adminLogin.IsNull() && adminLogin.AsString() != "" {
-		woAdminLoginPassword, err := pluginsdk.GetWriteOnlyFromDiff(d, "administrator_login_password_wo", cty.String)
-		if err != nil {
-			return err
-		}
+	adminLogin, ok := d.GetRawConfig().AsValueMap()["administrator_login"]
+	if ok {
+		if !adminLogin.IsNull() && adminLogin.AsString() != "" {
+			woAdminLoginPassword, err := pluginsdk.GetWriteOnlyFromDiff(d, "administrator_login_password_wo", cty.String)
+			if err != nil {
+				return err
+			}
 
-		password := d.GetRawConfig().AsValueMap()["administrator_login_password"]
+			password := d.GetRawConfig().AsValueMap()["administrator_login_password"]
 
-		if woAdminLoginPassword.IsNull() && password.IsNull() {
-			return fmt.Errorf("expected `administrator_login_password` or `administrator_login_password_wo` to be set when `administrator_login` is specified")
+			if woAdminLoginPassword.IsNull() && password.IsNull() {
+				return fmt.Errorf("expected `administrator_login_password` or `administrator_login_password_wo` to be set when `administrator_login` is specified")
+			}
 		}
 	}
 	return


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_mssql_server` - prevent panic by checking if `administrator_login` exists in the raw config map [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #28906


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
