### PR TITLE
`azurerm_key_vault_secret`: revert #28494 of recreating the resource when disable `expiration_date`

### DIFF
--- a/internal/services/keyvault/key_vault_secret_resource.go
+++ b/internal/services/keyvault/key_vault_secret_resource.go
@@ -101,16 +101,6 @@ func resourceKeyVaultSecret() *pluginsdk.Resource {
 
 			"tags": tags.SchemaWithMax(15),
 		},
-
-		CustomizeDiff: pluginsdk.CustomDiffWithAll(
-			pluginsdk.ForceNewIfChange("expiration_date", func(ctx context.Context, oldVal, newVal interface{}, meta interface{}) bool {
-				// if change from non-nil to nil, we need to force new
-				if oldVal != nil && oldVal.(string) != "" {
-					return newVal == nil || newVal.(string) == ""
-				}
-				return false
-			}),
-		),
 	}
 }
 

--- a/website/docs/r/key_vault_secret.html.markdown
+++ b/website/docs/r/key_vault_secret.html.markdown
@@ -87,7 +87,7 @@ The following arguments are supported:
 
 * `not_before_date` - (Optional) Key not usable before the provided UTC datetime (Y-m-d'T'H:M:S'Z').
 
-* `expiration_date` - (Optional) Expiration UTC datetime (Y-m-d'T'H:M:S'Z'). Removing this forces a new resource to be created.
+* `expiration_date` - (Optional) Expiration UTC datetime (Y-m-d'T'H:M:S'Z').
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

<del>If the expiraion is dynamic value, it will always be empty in plan stage, This PR is to fix this issue in CustomizeDiff. </del>

as discuessed in https://github.com/hashicorp/terraform-provider-azurerm/issues/28914#issuecomment-2702606580 , the expiration_date and not_before_date fields actually can be updated by posting a new version rather than destroy-and-create the secret resource (which has a way bigger impact to users). So this PR is going to revert the forceNew logic and wait the SDK to support sending nullables values.

![image](https://github.com/user-attachments/assets/9be08cc5-e368-4954-8c05-02b07477e80d)



## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

Because this is for a forceNew logic and currently AccTest cannot cover the case. So I only add a test to update the expiration field.



## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_key_vault_secret` - revert forceNew logic when unset `expiration_date` [GH-28914]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #28914


