### PR TITLE
`azurerm_managed_disk` - always set `network_access_policy` into state to fix drift detection

### DIFF
--- a/internal/services/compute/managed_disk_resource.go
+++ b/internal/services/compute/managed_disk_resource.go
@@ -30,7 +30,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceManagedDisk() *pluginsdk.Resource {
@@ -225,6 +224,7 @@ func resourceManagedDisk() *pluginsdk.Resource {
 			"network_access_policy": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
+				Default:  disks.NetworkAccessPolicyAllowAll,
 				ValidateFunc: validation.StringInSlice([]string{
 					string(disks.NetworkAccessPolicyAllowAll),
 					string(disks.NetworkAccessPolicyAllowPrivate),
@@ -362,11 +362,11 @@ func resourceManagedDiskCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 
 	diskSizeGB := d.Get("disk_size_gb").(int)
 	if diskSizeGB != 0 {
-		props.DiskSizeGB = utils.Int64(int64(diskSizeGB))
+		props.DiskSizeGB = pointer.To(int64(diskSizeGB))
 	}
 
 	if maxShares != 0 {
-		props.MaxShares = utils.Int64(int64(maxShares))
+		props.MaxShares = pointer.To(int64(maxShares))
 	}
 
 	if storageAccountType == string(disks.DiskStorageAccountTypesUltraSSDLRS) || storageAccountType == string(disks.DiskStorageAccountTypesPremiumVTwoLRS) {
@@ -387,7 +387,7 @@ func resourceManagedDiskCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 				return fmt.Errorf("[ERROR] disk_iops_read_only is only available for UltraSSD disks and PremiumV2 disks with shared disk enabled")
 			}
 
-			props.DiskIOPSReadOnly = utils.Int64(int64(v.(int)))
+			props.DiskIOPSReadOnly = pointer.To(int64(v.(int)))
 		}
 
 		if v, ok := d.GetOk("disk_mbps_read_only"); ok {
@@ -395,11 +395,11 @@ func resourceManagedDiskCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 				return fmt.Errorf("[ERROR] disk_mbps_read_only is only available for UltraSSD disks and PremiumV2 disks with shared disk enabled")
 			}
 
-			props.DiskMBpsReadOnly = utils.Int64(int64(v.(int)))
+			props.DiskMBpsReadOnly = pointer.To(int64(v.(int)))
 		}
 
 		if v, ok := d.GetOk("logical_sector_size"); ok {
-			props.CreationData.LogicalSectorSize = utils.Int64(int64(v.(int)))
+			props.CreationData.LogicalSectorSize = pointer.To(int64(v.(int)))
 		}
 	} else if d.HasChange("disk_iops_read_write") || d.HasChange("disk_mbps_read_write") || d.HasChange("disk_iops_read_only") || d.HasChange("disk_mbps_read_only") || d.HasChange("logical_sector_size") {
 		return fmt.Errorf("[ERROR] disk_iops_read_write, disk_mbps_read_write, disk_iops_read_only, disk_mbps_read_only and logical_sector_size are only available for UltraSSD disks and PremiumV2 disks")
@@ -416,8 +416,8 @@ func resourceManagedDiskCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 			return fmt.Errorf("`storage_account_id` must be specified when `create_option` is set to `Import` or `ImportSecure`")
 		}
 
-		props.CreationData.StorageAccountId = utils.String(storageAccountId)
-		props.CreationData.SourceUri = utils.String(sourceUri)
+		props.CreationData.StorageAccountId = pointer.To(storageAccountId)
+		props.CreationData.SourceUri = pointer.To(sourceUri)
 	}
 	if createOption == disks.DiskCreateOptionCopy || createOption == disks.DiskCreateOptionRestore {
 		sourceResourceId := d.Get("source_resource_id").(string)
@@ -425,16 +425,16 @@ func resourceManagedDiskCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 			return fmt.Errorf("`source_resource_id` must be specified when `create_option` is set to `Copy` or `Restore`")
 		}
 
-		props.CreationData.SourceResourceId = utils.String(sourceResourceId)
+		props.CreationData.SourceResourceId = pointer.To(sourceResourceId)
 	}
 	if createOption == disks.DiskCreateOptionFromImage {
 		if imageReferenceId := d.Get("image_reference_id").(string); imageReferenceId != "" {
 			props.CreationData.ImageReference = &disks.ImageDiskReference{
-				Id: utils.String(imageReferenceId),
+				Id: pointer.To(imageReferenceId),
 			}
 		} else if galleryImageReferenceId := d.Get("gallery_image_reference_id").(string); galleryImageReferenceId != "" {
 			props.CreationData.GalleryImageReference = &disks.ImageDiskReference{
-				Id: utils.String(galleryImageReferenceId),
+				Id: pointer.To(galleryImageReferenceId),
 			}
 		} else {
 			return fmt.Errorf("`image_reference_id` or `gallery_image_reference_id` must be specified when `create_option` is set to `FromImage`")
@@ -443,7 +443,7 @@ func resourceManagedDiskCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 
 	if createOption == disks.DiskCreateOptionUpload {
 		if uploadSizeBytes := d.Get("upload_size_bytes").(int); uploadSizeBytes != 0 {
-			props.CreationData.UploadSizeBytes = utils.Int64(int64(uploadSizeBytes))
+			props.CreationData.UploadSizeBytes = pointer.To(int64(uploadSizeBytes))
 		} else {
 			return fmt.Errorf("`upload_size_bytes` must be specified when `create_option` is set to `Upload`")
 		}
@@ -461,22 +461,16 @@ func resourceManagedDiskCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 
 		props.Encryption = &disks.Encryption{
 			Type:                encryptionType,
-			DiskEncryptionSetId: utils.String(diskEncryptionSetId),
+			DiskEncryptionSetId: pointer.To(diskEncryptionSetId),
 		}
 	}
 
-	if networkAccessPolicy := d.Get("network_access_policy").(string); networkAccessPolicy != "" {
-		policy := disks.NetworkAccessPolicy(networkAccessPolicy)
-		props.NetworkAccessPolicy = &policy
-	} else {
-		allowAllPolicy := disks.NetworkAccessPolicyAllowAll
-		props.NetworkAccessPolicy = &allowAllPolicy
-	}
+	props.NetworkAccessPolicy = pointer.To(disks.NetworkAccessPolicy(d.Get("network_access_policy").(string)))
 
 	if diskAccessID := d.Get("disk_access_id").(string); d.HasChange("disk_access_id") {
 		switch {
 		case *props.NetworkAccessPolicy == disks.NetworkAccessPolicyAllowPrivate:
-			props.DiskAccessId = utils.String(diskAccessID)
+			props.DiskAccessId = pointer.To(diskAccessID)
 		case diskAccessID != "" && *props.NetworkAccessPolicy != disks.NetworkAccessPolicyAllowPrivate:
 			return fmt.Errorf("[ERROR] disk_access_id is only available when network_access_policy is set to AllowPrivate")
 		default:
@@ -543,7 +537,7 @@ func resourceManagedDiskCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 		if disks.DiskSecurityTypesConfidentialVMDiskEncryptedWithCustomerKey != disks.DiskSecurityTypes(securityType) {
 			return fmt.Errorf("`secure_vm_disk_encryption_set_id` can only be specified when `security_type` is set to `ConfidentialVM_DiskEncryptedWithCustomerKey`")
 		}
-		props.SecurityProfile.SecureVMDiskEncryptionSetId = utils.String(secureVMDiskEncryptionId.(string))
+		props.SecurityProfile.SecureVMDiskEncryptionSetId = pointer.To(secureVMDiskEncryptionId.(string))
 	}
 
 	if d.Get("on_demand_bursting_enabled").(bool) {
@@ -558,7 +552,7 @@ func resourceManagedDiskCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 			return fmt.Errorf("`on_demand_bursting_enabled` can only be set to true when `disk_size_gb` is larger than 512GB")
 		}
 
-		props.BurstingEnabled = utils.Bool(true)
+		props.BurstingEnabled = pointer.To(true)
 	}
 
 	if v, ok := d.GetOk("hyper_v_generation"); ok {
@@ -639,7 +633,7 @@ func resourceManagedDiskUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 	}
 
 	if d.HasChange("max_shares") {
-		diskUpdate.Properties.MaxShares = utils.Int64(int64(maxShares))
+		diskUpdate.Properties.MaxShares = pointer.To(int64(maxShares))
 		var skuName disks.DiskStorageAccountTypes
 		for _, v := range disks.PossibleValuesForDiskStorageAccountTypes() {
 			if strings.EqualFold(storageAccountType, v) {
@@ -697,7 +691,7 @@ func resourceManagedDiskUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 			}
 
 			v := d.Get("disk_iops_read_only")
-			diskUpdate.Properties.DiskIOPSReadOnly = utils.Int64(int64(v.(int)))
+			diskUpdate.Properties.DiskIOPSReadOnly = pointer.To(int64(v.(int)))
 		}
 
 		if d.HasChange("disk_mbps_read_only") {
@@ -706,7 +700,7 @@ func resourceManagedDiskUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 			}
 
 			v := d.Get("disk_mbps_read_only")
-			diskUpdate.Properties.DiskMBpsReadOnly = utils.Int64(int64(v.(int)))
+			diskUpdate.Properties.DiskMBpsReadOnly = pointer.To(int64(v.(int)))
 		}
 	} else if d.HasChange("disk_iops_read_write") || d.HasChange("disk_mbps_read_write") || d.HasChange("disk_iops_read_only") || d.HasChange("disk_mbps_read_only") {
 		return fmt.Errorf("[ERROR] disk_iops_read_write, disk_mbps_read_write, disk_iops_read_only and disk_mbps_read_only are only available for UltraSSD disks and PremiumV2 disks")
@@ -741,7 +735,7 @@ func resourceManagedDiskUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 				log.Printf("[INFO] The %s, or the Virtual Machine that it's attached to, doesn't support no-downtime-resizing - requiring that the VM should be shutdown", *id)
 				shouldShutDown = true
 			}
-			diskUpdate.Properties.DiskSizeGB = utils.Int64(int64(newSize.(int)))
+			diskUpdate.Properties.DiskSizeGB = pointer.To(int64(newSize.(int)))
 		} else {
 			return fmt.Errorf("- New size must be greater than original size. Shrinking disks is not supported on Azure")
 		}
@@ -761,25 +755,21 @@ func resourceManagedDiskUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 
 			diskUpdate.Properties.Encryption = &disks.Encryption{
 				Type:                encryptionType,
-				DiskEncryptionSetId: utils.String(diskEncryptionSetId),
+				DiskEncryptionSetId: pointer.To(diskEncryptionSetId),
 			}
 		} else {
 			return fmt.Errorf("once a customer-managed key is used, you can’t change the selection back to a platform-managed key")
 		}
 	}
 
-	if networkAccessPolicy := d.Get("network_access_policy").(string); networkAccessPolicy != "" {
-		policy := disks.NetworkAccessPolicy(networkAccessPolicy)
-		diskUpdate.Properties.NetworkAccessPolicy = &policy
-	} else {
-		allowAllPolicy := disks.NetworkAccessPolicyAllowAll
-		diskUpdate.Properties.NetworkAccessPolicy = &allowAllPolicy
+	if d.HasChange("network_access_policy") {
+		diskUpdate.Properties.NetworkAccessPolicy = pointer.To(disks.NetworkAccessPolicy(d.Get("network_access_policy").(string)))
 	}
 
 	if diskAccessID := d.Get("disk_access_id").(string); d.HasChange("disk_access_id") {
 		switch {
 		case *diskUpdate.Properties.NetworkAccessPolicy == disks.NetworkAccessPolicyAllowPrivate:
-			diskUpdate.Properties.DiskAccessId = utils.String(diskAccessID)
+			diskUpdate.Properties.DiskAccessId = pointer.To(diskAccessID)
 		case diskAccessID != "" && *diskUpdate.Properties.NetworkAccessPolicy != disks.NetworkAccessPolicyAllowPrivate:
 			return fmt.Errorf("[ERROR] disk_access_id is only available when network_access_policy is set to AllowPrivate")
 		default:
@@ -812,7 +802,7 @@ func resourceManagedDiskUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 
 	if d.HasChange("on_demand_bursting_enabled") {
 		shouldShutDown = true
-		diskUpdate.Properties.BurstingEnabled = utils.Bool(onDemandBurstingEnabled)
+		diskUpdate.Properties.BurstingEnabled = pointer.To(onDemandBurstingEnabled)
 	}
 
 	// whilst we need to shut this down, if we're not attached to anything there's no point
@@ -1041,12 +1031,8 @@ func resourceManagedDiskRead(d *pluginsdk.ResourceData, meta interface{}) error 
 			d.Set("tier", props.Tier)
 			d.Set("max_shares", props.MaxShares)
 			d.Set("hyper_v_generation", string(pointer.From(props.HyperVGeneration)))
-
-			if networkAccessPolicy := props.NetworkAccessPolicy; *networkAccessPolicy != disks.NetworkAccessPolicyAllowAll {
-				d.Set("network_access_policy", string(pointer.From(props.NetworkAccessPolicy)))
-			}
+			d.Set("network_access_policy", string(pointer.From(props.NetworkAccessPolicy)))
 			d.Set("disk_access_id", props.DiskAccessId)
-
 			d.Set("public_network_access_enabled", *props.PublicNetworkAccess == disks.PublicNetworkAccessEnabled)
 
 			diskEncryptionSetId := ""


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<img width="378" alt="image" src="https://github.com/user-attachments/assets/4f1ca69f-d47b-4e71-8dfb-5401feb08bae" />

Reran one failed test:
<img width="533" alt="image" src="https://github.com/user-attachments/assets/1bd6a45b-2398-4b23-b2ed-028b91080306" />


<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
