### PR TITLE
Change default os disk type to ephemeral

### DIFF
--- a/internal/services/containers/kubernetes_cluster_node_pool_data_source.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_data_source.go
@@ -255,7 +255,7 @@ func dataSourceKubernetesClusterNodePoolRead(d *pluginsdk.ResourceData, meta int
 		}
 		d.Set("os_disk_size_gb", osDiskSizeGB)
 
-		osDiskType := agentpools.OSDiskTypeManaged
+		osDiskType := agentpools.OSDiskTypeEphemeral
 		if props.OsDiskType != nil && *props.OsDiskType != "" {
 			osDiskType = *props.OsDiskType
 		}

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -246,7 +246,7 @@ func resourceKubernetesClusterNodePoolSchema() map[string]*pluginsdk.Schema {
 		"os_disk_type": {
 			Type:     pluginsdk.TypeString,
 			Optional: true,
-			Default:  agentpools.OSDiskTypeManaged,
+			Default:  agentpools.OSDiskTypeEphemeral,
 			ValidateFunc: validation.StringInSlice([]string{
 				string(agentpools.OSDiskTypeEphemeral),
 				string(agentpools.OSDiskTypeManaged),
@@ -1128,7 +1128,7 @@ func resourceKubernetesClusterNodePoolRead(d *pluginsdk.ResourceData, meta inter
 		}
 		d.Set("os_disk_size_gb", osDiskSizeGB)
 
-		osDiskType := agentpools.OSDiskTypeManaged
+		osDiskType := agentpools.OSDiskTypeEphemeral
 		if v := props.OsDiskType; v != nil && *v != "" {
 			osDiskType = *v
 		}

--- a/internal/services/containers/kubernetes_nodepool.go
+++ b/internal/services/containers/kubernetes_nodepool.go
@@ -166,7 +166,7 @@ func SchemaDefaultNodePool() *pluginsdk.Schema {
 					"os_disk_type": {
 						Type:     pluginsdk.TypeString,
 						Optional: true,
-						Default:  agentpools.OSDiskTypeManaged,
+						Default:  agentpools.OSDiskTypeEphemeral,
 						ValidateFunc: validation.StringInSlice([]string{
 							string(managedclusters.OSDiskTypeEphemeral),
 							string(managedclusters.OSDiskTypeManaged),
@@ -842,7 +842,7 @@ func ExpandDefaultNodePool(d *pluginsdk.ResourceData) (*[]managedclusters.Manage
 		profile.OsDiskSizeGB = utils.Int64(osDiskSizeGB)
 	}
 
-	profile.OsDiskType = pointer.To(managedclusters.OSDiskTypeManaged)
+	profile.OsDiskType = pointer.To(managedclusters.OSDiskTypeEphemeral)
 	if osDiskType := raw["os_disk_type"].(string); osDiskType != "" {
 		profile.OsDiskType = pointer.To(managedclusters.OSDiskType(osDiskType))
 	}
@@ -1226,7 +1226,7 @@ func FlattenDefaultNodePool(input *[]managedclusters.ManagedClusterAgentPoolProf
 		osDiskSizeGB = int(*agentPool.OsDiskSizeGB)
 	}
 
-	osDiskType := managedclusters.OSDiskTypeManaged
+	osDiskType := managedclusters.OSDiskTypeEphemeral
 	if agentPool.OsDiskType != nil {
 		osDiskType = *agentPool.OsDiskType
 	}


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
