### PR TITLE
`azurerm_mssql_server` - fix panic due to unknown value

### DIFF
--- a/internal/services/mssql/mssql_server_resource.go
+++ b/internal/services/mssql/mssql_server_resource.go
@@ -84,7 +84,7 @@ func resourceMsSqlServer() *pluginsdk.Resource {
 				Computed:     true,
 				ForceNew:     true,
 				AtLeastOneOf: []string{"administrator_login", "azuread_administrator.0.azuread_authentication_only"},
-				ValidateFunc: validation.StringIsNotWhiteSpace,
+				ValidateFunc: validation.StringIsNotEmpty,
 			},
 
 			"administrator_login_password": {

--- a/internal/services/mssql/mssql_server_resource.go
+++ b/internal/services/mssql/mssql_server_resource.go
@@ -84,6 +84,7 @@ func resourceMsSqlServer() *pluginsdk.Resource {
 				Computed:     true,
 				ForceNew:     true,
 				AtLeastOneOf: []string{"administrator_login", "azuread_administrator.0.azuread_authentication_only"},
+				ValidateFunc: validation.StringIsNotWhiteSpace,
 			},
 
 			"administrator_login_password": {
@@ -760,10 +761,10 @@ func msSqlPasswordChangeWhenAADAuthOnly(ctx context.Context, d *pluginsdk.Resour
 }
 
 // msSqlAdministratorLoginPassword checks to make sure that one of `administrator_login_password_wo` or `administrator_login_password` is set when `administrator_login` is specified.
-func msSqlAdministratorLoginPassword(ctx context.Context, d *pluginsdk.ResourceDiff, _ interface{}) (err error) {
+func msSqlAdministratorLoginPassword(_ context.Context, d *pluginsdk.ResourceDiff, _ interface{}) (err error) {
 	adminLogin, ok := d.GetRawConfig().AsValueMap()["administrator_login"]
 	if ok {
-		if !adminLogin.IsNull() && adminLogin.AsString() != "" {
+		if !adminLogin.IsNull() {
 			woAdminLoginPassword, err := pluginsdk.GetWriteOnlyFromDiff(d, "administrator_login_password_wo", cty.String)
 			if err != nil {
 				return err

--- a/internal/services/mssql/mssql_server_resource_test.go
+++ b/internal/services/mssql/mssql_server_resource_test.go
@@ -41,6 +41,21 @@ func TestAccMsSqlServer_basic(t *testing.T) {
 	})
 }
 
+func TestAccMsSqlServer_basicWithUnknownValue(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_mssql_server", "test")
+	r := MsSqlServerResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicWithUnknownValue(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("administrator_login_password"),
+	})
+}
+
 func TestAccMsSqlServer_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_mssql_server", "test")
 	r := MsSqlServerResource{}
@@ -410,6 +425,23 @@ resource "azurerm_mssql_server" "test" {
 `, r.template(data), data.RandomInteger)
 }
 
+func (r MsSqlServerResource) basicWithUnknownValue(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_mssql_server" "test" {
+  name                         = "acctestsqlserver%[2]d"
+  resource_group_name          = azurerm_resource_group.test.name
+  location                     = azurerm_resource_group.test.location
+  version                      = "12.0"
+  administrator_login          = "missadministrator-${random_string.test.result}"
+  administrator_login_password = "thisIsKat11"
+
+  outbound_network_restriction_enabled = true
+}
+`, r.template(data), data.RandomInteger)
+}
+
 func (r MsSqlServerResource) basicWithMinimumTLSVersionDisabled(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
@@ -513,7 +545,7 @@ resource "azurerm_mssql_server" "test" {
   resource_group_name          = azurerm_resource_group.test.name
   location                     = azurerm_resource_group.test.location
   version                      = "12.0"
-  administrator_login          = "missadministrator-${random_string.test.result}"
+  administrator_login          = "missadministrator"
   administrator_login_password = "thisIsKat11"
   minimum_tls_version          = "1.2"
 

--- a/internal/services/mssql/mssql_server_resource_test.go
+++ b/internal/services/mssql/mssql_server_resource_test.go
@@ -318,6 +318,12 @@ func TestAccMsSqlServer_writeOnlyAdminLoginPassword(t *testing.T) {
 			tfversion.SkipBelow(version.Must(version.NewVersion("1.11.0"))),
 		},
 		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"random": {
+				VersionConstraint: "=3.6.3",
+				Source:            "registry.terraform.io/hashicorp/random",
+			},
+		},
 		Steps: []resource.TestStep{
 			{
 				Config: r.writeOnlyAdminLoginPassword(data, "7h1515K4711-secret", 1),
@@ -342,6 +348,12 @@ func TestAccMsSqlServer_updateToWriteOnlyPassword(t *testing.T) {
 			tfversion.SkipBelow(version.Must(version.NewVersion("1.11.0"))),
 		},
 		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"random": {
+				VersionConstraint: "=3.6.3",
+				Source:            "registry.terraform.io/hashicorp/random",
+			},
+		},
 		Steps: []resource.TestStep{
 			{
 				Config: r.basic(data),
@@ -381,19 +393,12 @@ func (MsSqlServerResource) Exists(ctx context.Context, client *clients.Client, s
 	return pointer.To(resp.Model != nil), nil
 }
 
-func (MsSqlServerResource) basic(data acceptance.TestData) string {
+func (r MsSqlServerResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-mssql-%[1]d"
-  location = "%[2]s"
-}
+%s
 
 resource "azurerm_mssql_server" "test" {
-  name                         = "acctestsqlserver%[1]d"
+  name                         = "acctestsqlserver%[2]d"
   resource_group_name          = azurerm_resource_group.test.name
   location                     = azurerm_resource_group.test.location
   version                      = "12.0"
@@ -402,22 +407,15 @@ resource "azurerm_mssql_server" "test" {
 
   outbound_network_restriction_enabled = true
 }
-`, data.RandomInteger, data.Locations.Primary)
+`, r.template(data), data.RandomInteger)
 }
 
-func (MsSqlServerResource) basicWithMinimumTLSVersionDisabled(data acceptance.TestData) string {
+func (r MsSqlServerResource) basicWithMinimumTLSVersionDisabled(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-mssql-%[1]d"
-  location = "%[2]s"
-}
+%s
 
 resource "azurerm_mssql_server" "test" {
-  name                         = "acctestsqlserver%[1]d"
+  name                         = "acctestsqlserver%[2]d"
   resource_group_name          = azurerm_resource_group.test.name
   location                     = azurerm_resource_group.test.location
   version                      = "12.0"
@@ -429,22 +427,15 @@ resource "azurerm_mssql_server" "test" {
     type = "SystemAssigned"
   }
 }
-`, data.RandomInteger, data.Locations.Primary)
+`, r.template(data), data.RandomInteger)
 }
 
-func (MsSqlServerResource) basicWithMinimumTLSVersion(data acceptance.TestData) string {
+func (r MsSqlServerResource) basicWithMinimumTLSVersion(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-mssql-%[1]d"
-  location = "%[2]s"
-}
+%s
 
 resource "azurerm_mssql_server" "test" {
-  name                         = "acctestsqlserver%[1]d"
+  name                         = "acctestsqlserver%[2]d"
   resource_group_name          = azurerm_resource_group.test.name
   location                     = azurerm_resource_group.test.location
   version                      = "12.0"
@@ -456,7 +447,7 @@ resource "azurerm_mssql_server" "test" {
     type = "SystemAssigned"
   }
 }
-`, data.RandomInteger, data.Locations.Primary)
+`, r.template(data), data.RandomInteger)
 }
 
 func (r MsSqlServerResource) requiresImport(data acceptance.TestData) string {
@@ -474,26 +465,19 @@ resource "azurerm_mssql_server" "import" {
 `, r.basic(data))
 }
 
-func (MsSqlServerResource) complete(data acceptance.TestData) string {
+func (r MsSqlServerResource) complete(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-mssql-%[1]d"
-  location = "%[2]s"
-}
+%s
 
 resource "azurerm_virtual_network" "test" {
-  name                = "acctestvnet-%[1]d"
+  name                = "acctestvnet-%[2]d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   address_space       = ["10.5.0.0/16"]
 }
 
 resource "azurerm_subnet" "service" {
-  name                 = "acctestsnetservice-%[1]d"
+  name                 = "acctestsnetservice-%[2]d"
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.5.1.0/24"]
@@ -502,7 +486,7 @@ resource "azurerm_subnet" "service" {
 }
 
 resource "azurerm_subnet" "endpoint" {
-  name                 = "acctestsnetendpoint-%[1]d"
+  name                 = "acctestsnetendpoint-%[2]d"
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.5.2.0/24"]
@@ -525,11 +509,11 @@ resource "azurerm_user_assigned_identity" "test" {
 }
 
 resource "azurerm_mssql_server" "test" {
-  name                         = "acctestsqlserver%[1]d"
+  name                         = "acctestsqlserver%[2]d"
   resource_group_name          = azurerm_resource_group.test.name
   location                     = azurerm_resource_group.test.location
   version                      = "12.0"
-  administrator_login          = "missadministrator"
+  administrator_login          = "missadministrator-${random_string.test.result}"
   administrator_login_password = "thisIsKat11"
   minimum_tls_version          = "1.2"
 
@@ -553,41 +537,34 @@ resource "azurerm_private_dns_zone" "finance" {
 }
 
 resource "azurerm_private_endpoint" "test" {
-  name                = "acctest-privatelink-%[1]d"
+  name                = "acctest-privatelink-%[2]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   subnet_id           = azurerm_subnet.endpoint.id
 
   private_service_connection {
-    name                           = "acctest-privatelink-mssc-%[1]d"
+    name                           = "acctest-privatelink-mssc-%[2]d"
     private_connection_resource_id = azurerm_mssql_server.test.id
     subresource_names              = ["sqlServer"]
     is_manual_connection           = false
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomIntOfLength(15))
+`, r.template(data), data.RandomInteger, data.RandomIntOfLength(15))
 }
 
-func (MsSqlServerResource) completeUpdate(data acceptance.TestData) string {
+func (r MsSqlServerResource) completeUpdate(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-mssql-%[1]d"
-  location = "%[2]s"
-}
+%s
 
 resource "azurerm_virtual_network" "test" {
-  name                = "acctestvnet-%[1]d"
+  name                = "acctestvnet-%[2]d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   address_space       = ["10.5.0.0/16"]
 }
 
 resource "azurerm_subnet" "service" {
-  name                 = "acctestsnetservice-%[1]d"
+  name                 = "acctestsnetservice-%[2]d"
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.5.1.0/24"]
@@ -596,7 +573,7 @@ resource "azurerm_subnet" "service" {
 }
 
 resource "azurerm_subnet" "endpoint" {
-  name                 = "acctestsnetendpoint-%[1]d"
+  name                 = "acctestsnetendpoint-%[2]d"
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.5.2.0/24"]
@@ -619,7 +596,7 @@ resource "azurerm_user_assigned_identity" "test" {
 }
 
 resource "azurerm_mssql_server" "test" {
-  name                         = "acctestsqlserver%[1]d"
+  name                         = "acctestsqlserver%[2]d"
   resource_group_name          = azurerm_resource_group.test.name
   location                     = azurerm_resource_group.test.location
   version                      = "12.0"
@@ -647,34 +624,27 @@ resource "azurerm_private_dns_zone" "finance" {
 }
 
 resource "azurerm_private_endpoint" "test" {
-  name                = "acctest-privatelink-%[1]d"
+  name                = "acctest-privatelink-%[2]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   subnet_id           = azurerm_subnet.endpoint.id
 
   private_service_connection {
-    name                           = "acctest-privatelink-mssc-%[1]d"
+    name                           = "acctest-privatelink-mssc-%[2]d"
     private_connection_resource_id = azurerm_mssql_server.test.id
     subresource_names              = ["sqlServer"]
     is_manual_connection           = false
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomIntOfLength(15))
+`, r.template(data), data.RandomInteger, data.RandomIntOfLength(15))
 }
 
-func (MsSqlServerResource) systemAssignedIdentity(data acceptance.TestData) string {
+func (r MsSqlServerResource) systemAssignedIdentity(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-mssql-%[1]d"
-  location = "%[2]s"
-}
+%s
 
 resource "azurerm_mssql_server" "test" {
-  name                         = "acctestsqlserver%[1]d"
+  name                         = "acctestsqlserver%[2]d"
   resource_group_name          = azurerm_resource_group.test.name
   location                     = azurerm_resource_group.test.location
   version                      = "12.0"
@@ -685,19 +655,12 @@ resource "azurerm_mssql_server" "test" {
     type = "SystemAssigned"
   }
 }
-`, data.RandomInteger, data.Locations.Primary)
+`, r.template(data), data.RandomInteger)
 }
 
-func (MsSqlServerResource) userAssignedIdentity(data acceptance.TestData) string {
+func (r MsSqlServerResource) userAssignedIdentity(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-mssql-%[1]d"
-  location = "%[2]s"
-}
+%s
 
 resource "azurerm_user_assigned_identity" "test1" {
   resource_group_name = azurerm_resource_group.test.name
@@ -712,7 +675,7 @@ resource "azurerm_user_assigned_identity" "test2" {
 }
 
 resource "azurerm_mssql_server" "test" {
-  name                              = "acctestsqlserver%[1]d"
+  name                              = "acctestsqlserver%[2]d"
   resource_group_name               = azurerm_resource_group.test.name
   location                          = azurerm_resource_group.test.location
   version                           = "12.0"
@@ -725,28 +688,21 @@ resource "azurerm_mssql_server" "test" {
     identity_ids = [azurerm_user_assigned_identity.test1.id, azurerm_user_assigned_identity.test2.id]
   }
 }
-`, data.RandomInteger, data.Locations.Primary)
+`, r.template(data), data.RandomInteger)
 }
 
-func (MsSqlServerResource) systemAndUserAssignedIdentity(data acceptance.TestData) string {
+func (r MsSqlServerResource) systemAndUserAssignedIdentity(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-mssql-%[1]d"
-  location = "%[2]s"
-}
+%s
 
 resource "azurerm_user_assigned_identity" "test" {
-  name                = "acctestUAI-%[1]d"
+  name                = "acctestUAI-%[2]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
 }
 
 resource "azurerm_mssql_server" "test" {
-  name                         = "acctestsqlserver%[1]d"
+  name                         = "acctestsqlserver%[2]d"
   resource_group_name          = azurerm_resource_group.test.name
   location                     = azurerm_resource_group.test.location
   version                      = "12.0"
@@ -760,26 +716,19 @@ resource "azurerm_mssql_server" "test" {
     ]
   }
 }
-`, data.RandomInteger, data.Locations.Primary)
+`, r.template(data), data.RandomInteger)
 }
 
-func (MsSqlServerResource) aadAdmin(data acceptance.TestData) string {
+func (r MsSqlServerResource) aadAdmin(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
+%s
 
 provider "azuread" {}
 
 data "azurerm_client_config" "test" {}
 
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-mssql-%[1]d"
-  location = "%[2]s"
-}
-
 resource "azurerm_mssql_server" "test" {
-  name                         = "acctestsqlserver%[1]d"
+  name                         = "acctestsqlserver%[2]d"
   resource_group_name          = azurerm_resource_group.test.name
   location                     = azurerm_resource_group.test.location
   version                      = "12.0"
@@ -791,26 +740,19 @@ resource "azurerm_mssql_server" "test" {
     object_id      = data.azurerm_client_config.test.object_id
   }
 }
-`, data.RandomInteger, data.Locations.Primary)
+`, r.template(data), data.RandomInteger)
 }
 
-func (MsSqlServerResource) aadAdminWithAADAuthOnly(data acceptance.TestData) string {
+func (r MsSqlServerResource) aadAdminWithAADAuthOnly(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
+%s
 
 provider "azuread" {}
 
 data "azurerm_client_config" "test" {}
 
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-mssql-%[1]d"
-  location = "%[2]s"
-}
-
 resource "azurerm_mssql_server" "test" {
-  name                = "acctestsqlserver%[1]d"
+  name                = "acctestsqlserver%[2]d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   version             = "12.0"
@@ -821,23 +763,16 @@ resource "azurerm_mssql_server" "test" {
     azuread_authentication_only = true
   }
 }
-`, data.RandomInteger, data.Locations.Primary)
+`, r.template(data), data.RandomInteger)
 }
 
-func (MsSqlServerResource) updateAzureadAuthenticationOnlyWithIdentity(data acceptance.TestData, enableAzureadAuthenticationOnly bool) string {
+func (r MsSqlServerResource) updateAzureadAuthenticationOnlyWithIdentity(data acceptance.TestData, enableAzureadAuthenticationOnly bool) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
+%s
 
 provider "azuread" {}
 
 data "azurerm_client_config" "test" {}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-mssql-%[1]d"
-  location = "%[2]s"
-}
 
 resource "azurerm_user_assigned_identity" "test" {
   resource_group_name = azurerm_resource_group.test.name
@@ -846,7 +781,7 @@ resource "azurerm_user_assigned_identity" "test" {
 }
 
 resource "azurerm_mssql_server" "test" {
-  name                         = "acctestsqlserver%[1]d"
+  name                         = "acctestsqlserver%[2]d"
   resource_group_name          = azurerm_resource_group.test.name
   location                     = azurerm_resource_group.test.location
   version                      = "12.0"
@@ -867,21 +802,14 @@ resource "azurerm_mssql_server" "test" {
 
   primary_user_assigned_identity_id = azurerm_user_assigned_identity.test.id
 }
-`, data.RandomInteger, data.Locations.Primary, enableAzureadAuthenticationOnly)
+`, r.template(data), data.RandomInteger, enableAzureadAuthenticationOnly)
 }
 
-func (MsSqlServerResource) tdeCMKServerDeployment(data acceptance.TestData) string {
+func (r MsSqlServerResource) tdeCMKServerDeployment(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
+%s
 
 data "azurerm_client_config" "test" {}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-mssql-%[1]d"
-  location = "%[2]s"
-}
 
 resource "azurerm_user_assigned_identity" "test" {
   resource_group_name = azurerm_resource_group.test.name
@@ -890,7 +818,7 @@ resource "azurerm_user_assigned_identity" "test" {
 }
 
 resource "azurerm_mssql_server" "test" {
-  name                         = "acctestsqlserver%[1]d"
+  name                         = "acctestsqlserver%[2]d"
   resource_group_name          = azurerm_resource_group.test.name
   location                     = azurerm_resource_group.test.location
   version                      = "12.0"
@@ -913,7 +841,7 @@ resource "azurerm_mssql_server" "test" {
 }
 
 resource "azurerm_key_vault" "test" {
-  name                        = "vault%[1]d"
+  name                        = "vault%[2]d"
   location                    = azurerm_resource_group.test.location
   resource_group_name         = azurerm_resource_group.test.name
   enabled_for_disk_encryption = true
@@ -948,21 +876,14 @@ resource "azurerm_key_vault_key" "test" {
 
   key_opts = ["unwrapKey", "wrapKey"]
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+`, r.template(data), data.RandomInteger, data.RandomString)
 }
 
-func (MsSqlServerResource) CMKServerTags(data acceptance.TestData, tag string) string {
+func (r MsSqlServerResource) CMKServerTags(data acceptance.TestData, tag string) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
+%s
 
 data "azurerm_client_config" "test" {}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-mssql-%[1]d"
-  location = "%[2]s"
-}
 
 resource "azurerm_user_assigned_identity" "test" {
   resource_group_name = azurerm_resource_group.test.name
@@ -971,7 +892,7 @@ resource "azurerm_user_assigned_identity" "test" {
 }
 
 resource "azurerm_mssql_server" "test" {
-  name                         = "acctestsqlserver%[1]d"
+  name                         = "acctestsqlserver%[2]d"
   resource_group_name          = azurerm_resource_group.test.name
   location                     = azurerm_resource_group.test.location
   version                      = "12.0"
@@ -998,7 +919,7 @@ resource "azurerm_mssql_server" "test" {
 }
 
 resource "azurerm_key_vault" "test" {
-  name                        = "vault%[1]d"
+  name                        = "vault%[2]d"
   location                    = azurerm_resource_group.test.location
   resource_group_name         = azurerm_resource_group.test.name
   enabled_for_disk_encryption = true
@@ -1033,21 +954,14 @@ resource "azurerm_key_vault_key" "test" {
 
   key_opts = ["unwrapKey", "wrapKey"]
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, tag)
+`, r.template(data), data.RandomInteger, data.RandomString, tag)
 }
 
-func (MsSqlServerResource) CMKServerNoTags(data acceptance.TestData) string {
+func (r MsSqlServerResource) CMKServerNoTags(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
+%s
 
 data "azurerm_client_config" "test" {}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-mssql-%[1]d"
-  location = "%[2]s"
-}
 
 resource "azurerm_user_assigned_identity" "test" {
   resource_group_name = azurerm_resource_group.test.name
@@ -1056,7 +970,7 @@ resource "azurerm_user_assigned_identity" "test" {
 }
 
 resource "azurerm_mssql_server" "test" {
-  name                         = "acctestsqlserver%[1]d"
+  name                         = "acctestsqlserver%[2]d"
   resource_group_name          = azurerm_resource_group.test.name
   location                     = azurerm_resource_group.test.location
   version                      = "12.0"
@@ -1079,7 +993,7 @@ resource "azurerm_mssql_server" "test" {
 }
 
 resource "azurerm_key_vault" "test" {
-  name                        = "vault%[1]d"
+  name                        = "vault%[2]d"
   location                    = azurerm_resource_group.test.location
   resource_group_name         = azurerm_resource_group.test.name
   enabled_for_disk_encryption = true
@@ -1114,10 +1028,30 @@ resource "azurerm_key_vault_key" "test" {
 
   key_opts = ["unwrapKey", "wrapKey"]
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+`, r.template(data), data.RandomInteger, data.RandomString)
 }
 
-func (MsSqlServerResource) writeOnlyAdminLoginPassword(data acceptance.TestData, secret string, version int) string {
+func (r MsSqlServerResource) writeOnlyAdminLoginPassword(data acceptance.TestData, secret string, version int) string {
+	return fmt.Sprintf(`
+%[1]s
+
+%[2]s
+
+resource "azurerm_mssql_server" "test" {
+  name                                    = "acctestsqlserver%[3]d"
+  resource_group_name                     = azurerm_resource_group.test.name
+  location                                = azurerm_resource_group.test.location
+  version                                 = "12.0"
+  administrator_login                     = "missadministrator-${random_string.test.result}"
+  administrator_login_password_wo_version = %[4]d
+  administrator_login_password_wo         = ephemeral.azurerm_key_vault_secret.test.value
+
+  outbound_network_restriction_enabled = true
+}
+`, r.template(data), acceptance.WriteOnlyKeyVaultSecretTemplate(data, secret), data.RandomInteger, version)
+}
+
+func (MsSqlServerResource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -1128,24 +1062,10 @@ resource "azurerm_resource_group" "test" {
   location = "%[2]s"
 }
 
-%s
-
-resource "random_string" "suffix" {
+resource "random_string" "test" {
   length  = 3
   special = false
   upper   = false
 }
-
-resource "azurerm_mssql_server" "test" {
-  name                                    = "acctestsqlserver%[1]d"
-  resource_group_name                     = azurerm_resource_group.test.name
-  location                                = azurerm_resource_group.test.location
-  version                                 = "12.0"
-  administrator_login                     = "missadministrator-${random_string.suffix.result}"
-  administrator_login_password_wo_version = %[4]d
-  administrator_login_password_wo         = ephemeral.azurerm_key_vault_secret.test.value
-
-  outbound_network_restriction_enabled = true
-}
-`, data.RandomInteger, data.Locations.Primary, acceptance.WriteOnlyKeyVaultSecretTemplate(data, secret), version)
+`, data.RandomInteger, data.Locations.Primary)
 }

--- a/internal/services/mssql/mssql_server_resource_test.go
+++ b/internal/services/mssql/mssql_server_resource_test.go
@@ -1130,12 +1130,18 @@ resource "azurerm_resource_group" "test" {
 
 %s
 
+resource "random_string" "suffix" {
+  length  = 3
+  special = false
+  upper   = false
+}
+
 resource "azurerm_mssql_server" "test" {
   name                                    = "acctestsqlserver%[1]d"
   resource_group_name                     = azurerm_resource_group.test.name
   location                                = azurerm_resource_group.test.location
   version                                 = "12.0"
-  administrator_login                     = "missadministrator"
+  administrator_login                     = "missadministrator-${random_string.suffix.result}"
   administrator_login_password_wo_version = %[4]d
   administrator_login_password_wo         = ephemeral.azurerm_key_vault_secret.test.value
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

- Removed `AsString()` function call on a value that may be unknown causing a panic
- Added a validateFunc that replaces the empty string check in the CustomizeDiff for `administrator_login`
- Modified tests to force an unknown value during planning phase
- Add required ExternalProviders config and replace duplicated TF config with a template func


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<img width="275" alt="image" src="https://github.com/user-attachments/assets/9a21b2fa-b5a4-444f-b7e2-19baf3204254" />

WO tests:
```
--- PASS: TestAccMsSqlServer_writeOnlyAdminLoginPassword (1022.58s)
--- PASS: TestAccMsSqlServer_updateToWriteOnlyPassword (1255.39s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/mssql 1257.253s
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_mssql_server` - prevent panic by removing function call on a value that may be unknown [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #28948


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
