### PR TITLE
fix duplicate `x-ms-correlation-request-id` headers in list operations

### DIFF
--- a/internal/common/middleware.go
+++ b/internal/common/middleware.go
@@ -14,7 +14,9 @@ import (
 func correlationRequestIDMiddleware(id string) client.RequestMiddleware {
 	return func(request *http.Request) (*http.Request, error) {
 		// ensure the `X-Correlation-ID` field is set
-		request.Header.Add(HeaderCorrelationRequestID, id)
+		if request.Header.Get(HeaderCorrelationRequestID) == "" {
+			request.Header.Add(HeaderCorrelationRequestID, id)
+		}
 		return request, nil
 	}
 }


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

The `go-azure-sdk` list methods, which utilize `ExecutePaged` (https://github.com/hashicorp/go-azure-sdk/blob/6cc27674c0d8059af9f9e40958d89cb7db670600/sdk/client/client.go#L584) for pagination and subsequently `correlationRequestIDMiddleware` (https://github.com/hashicorp/go-azure-sdk/blob/6cc27674c0d8059af9f9e40958d89cb7db670600/sdk/client/client.go#L492) , were setting the `x-ms-correlation-request-id` header multiple times. This PR modifies the logic to ensure the header is set only once at the beginning of the initial request.

The error while listing Key Vault (observe from mitmproxy):
![image](https://github.com/user-attachments/assets/e8008e01-2626-4a7b-b9dc-6d1a616149dc)

![image](https://github.com/user-attachments/assets/02973e43-c037-4395-925c-e599ab2e6bce)


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

Test in my locally built version is OK

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* fix duplicate `x-ms-correlation-request-id` headers in list operations

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
