### PR TITLE
`azurerm_custom_ip_prefix` - added support for the `prefix_type` property

### DIFF
--- a/internal/services/network/custom_ip_prefix_resource.go
+++ b/internal/services/network/custom_ip_prefix_resource.go
@@ -223,7 +223,7 @@ func (r CustomIpPrefixResource) Create() sdk.ResourceFunc {
 			}
 
 			if model.PrefixType != "" {
-				payload.Properties.CustomIPPrefixType = pointer.To(model.PrefixType)
+				payload.Properties.PrefixType = pointer.To(customipprefixes.CustomIPPrefixType(model.PrefixType))
 			}
 
 			if model.ParentCustomIPPrefixID != "" {
@@ -362,7 +362,7 @@ func (r CustomIpPrefixResource) Read() sdk.ResourceFunc {
 				if props := model.Properties; props != nil {
 					state.CIDR = pointer.From(props.Cidr)
 					state.InternetAdvertisingDisabled = pointer.From(props.NoInternetAdvertise)
-					state.PrefixType = pointer.From(props.CustomIPPrefixType)
+					state.PrefixType = pointer.From((*string)(props.PrefixType))
 					state.WANValidationSignedMessage = pointer.From(props.SignedMessage)
 
 					if parent := props.CustomIPPrefixParent; parent != nil {

--- a/internal/services/network/custom_ip_prefix_resource.go
+++ b/internal/services/network/custom_ip_prefix_resource.go
@@ -31,6 +31,7 @@ type CustomIpPrefixModel struct {
 	Location                    string                 `tfschema:"location"`
 	Name                        string                 `tfschema:"name"`
 	ParentCustomIPPrefixID      string                 `tfschema:"parent_custom_ip_prefix_id"`
+	PrefixType                  string                 `tfschema:"prefix_type"`
 	ROAValidityEndDate          string                 `tfschema:"roa_validity_end_date"`
 	ResourceGroupName           string                 `tfschema:"resource_group_name"`
 	Tags                        map[string]interface{} `tfschema:"tags"`
@@ -136,6 +137,17 @@ func (r CustomIpPrefixResource) Arguments() map[string]*pluginsdk.Schema {
 		"tags": commonschema.Tags(),
 
 		"zones": commonschema.ZonesMultipleOptionalForceNew(),
+
+		"prefix_type": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			ForceNew: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				"Child",
+				"Parent",
+				"Singular",
+			}, false),
+		},
 	}
 }
 
@@ -208,6 +220,10 @@ func (r CustomIpPrefixResource) Create() sdk.ResourceFunc {
 					Cidr:              &model.CIDR,
 					CommissionedState: pointer.To(customipprefixes.CommissionedStateProvisioning),
 				},
+			}
+
+			if model.PrefixType != "" {
+				payload.Properties.CustomIPPrefixType = pointer.To(model.PrefixType)
 			}
 
 			if model.ParentCustomIPPrefixID != "" {
@@ -346,6 +362,7 @@ func (r CustomIpPrefixResource) Read() sdk.ResourceFunc {
 				if props := model.Properties; props != nil {
 					state.CIDR = pointer.From(props.Cidr)
 					state.InternetAdvertisingDisabled = pointer.From(props.NoInternetAdvertise)
+					state.PrefixType = pointer.From(props.CustomIPPrefixType)
 					state.WANValidationSignedMessage = pointer.From(props.SignedMessage)
 
 					if parent := props.CustomIPPrefixParent; parent != nil {

--- a/internal/services/network/custom_ip_prefix_resource_test.go
+++ b/internal/services/network/custom_ip_prefix_resource_test.go
@@ -259,7 +259,7 @@ resource "azurerm_custom_ip_prefix" "global" {
   resource_group_name = azurerm_resource_group.test.name
 
   cidr = "%[3]s"
-
+  prefix_type                   = "Global"
   roa_validity_end_date         = "2199-12-12"
   wan_validation_signed_message = "signed message for WAN validation"
 }
@@ -269,7 +269,8 @@ resource "azurerm_custom_ip_prefix" "regional" {
   location                   = azurerm_resource_group.test.location
   resource_group_name        = azurerm_resource_group.test.name
   parent_custom_ip_prefix_id = azurerm_custom_ip_prefix.global.id
-
+  prefix_type				 = "Regional"
+  
   cidr  = cidrsubnet(azurerm_custom_ip_prefix.global.cidr, 16, 1)
   zones = ["1"]
 }
@@ -294,6 +295,7 @@ resource "azurerm_custom_ip_prefix" "global" {
 
   cidr = "%[3]s"
 
+  prefix_type				    = "Global"
   roa_validity_end_date         = "2199-12-12"
   wan_validation_signed_message = "signed message for WAN validation"
 
@@ -305,6 +307,7 @@ resource "azurerm_custom_ip_prefix" "regional" {
   location                   = azurerm_resource_group.test.location
   resource_group_name        = azurerm_resource_group.test.name
   parent_custom_ip_prefix_id = azurerm_custom_ip_prefix.global.id
+  prefix_type                = "Regional"
 
   cidr  = cidrsubnet(azurerm_custom_ip_prefix.global.cidr, 16, 1)
   zones = ["1"]
@@ -332,6 +335,7 @@ resource "azurerm_custom_ip_prefix" "global" {
 
   cidr = "%[3]s"
 
+  prefix_type                   = "Global"
   roa_validity_end_date         = "2199-12-12"
   wan_validation_signed_message = "signed message for WAN validation"
 
@@ -343,7 +347,8 @@ resource "azurerm_custom_ip_prefix" "regional" {
   location                   = azurerm_resource_group.test.location
   resource_group_name        = azurerm_resource_group.test.name
   parent_custom_ip_prefix_id = azurerm_custom_ip_prefix.global.id
-
+  prefix_type                = "Regional"
+  
   cidr  = cidrsubnet(azurerm_custom_ip_prefix.global.cidr, 16, 1)
   zones = ["1"]
 

--- a/internal/services/network/custom_ip_prefix_resource_test.go
+++ b/internal/services/network/custom_ip_prefix_resource_test.go
@@ -259,7 +259,7 @@ resource "azurerm_custom_ip_prefix" "global" {
   resource_group_name = azurerm_resource_group.test.name
 
   cidr = "%[3]s"
-  prefix_type                   = "Global"
+  prefix_type                   = "Parent"
   roa_validity_end_date         = "2199-12-12"
   wan_validation_signed_message = "signed message for WAN validation"
 }
@@ -269,7 +269,7 @@ resource "azurerm_custom_ip_prefix" "regional" {
   location                   = azurerm_resource_group.test.location
   resource_group_name        = azurerm_resource_group.test.name
   parent_custom_ip_prefix_id = azurerm_custom_ip_prefix.global.id
-  prefix_type				 = "Regional"
+  prefix_type				 = "Child"
   
   cidr  = cidrsubnet(azurerm_custom_ip_prefix.global.cidr, 16, 1)
   zones = ["1"]
@@ -295,7 +295,7 @@ resource "azurerm_custom_ip_prefix" "global" {
 
   cidr = "%[3]s"
 
-  prefix_type				    = "Global"
+  prefix_type				    = "Parent"
   roa_validity_end_date         = "2199-12-12"
   wan_validation_signed_message = "signed message for WAN validation"
 
@@ -307,7 +307,7 @@ resource "azurerm_custom_ip_prefix" "regional" {
   location                   = azurerm_resource_group.test.location
   resource_group_name        = azurerm_resource_group.test.name
   parent_custom_ip_prefix_id = azurerm_custom_ip_prefix.global.id
-  prefix_type                = "Regional"
+  prefix_type                = "Child"
 
   cidr  = cidrsubnet(azurerm_custom_ip_prefix.global.cidr, 16, 1)
   zones = ["1"]
@@ -335,7 +335,7 @@ resource "azurerm_custom_ip_prefix" "global" {
 
   cidr = "%[3]s"
 
-  prefix_type                   = "Global"
+  prefix_type                   = "Parent"
   roa_validity_end_date         = "2199-12-12"
   wan_validation_signed_message = "signed message for WAN validation"
 
@@ -347,7 +347,7 @@ resource "azurerm_custom_ip_prefix" "regional" {
   location                   = azurerm_resource_group.test.location
   resource_group_name        = azurerm_resource_group.test.name
   parent_custom_ip_prefix_id = azurerm_custom_ip_prefix.global.id
-  prefix_type                = "Regional"
+  prefix_type                = "Child"
   
   cidr  = cidrsubnet(azurerm_custom_ip_prefix.global.cidr, 16, 1)
   zones = ["1"]

--- a/website/docs/r/custom_ip_prefix.html.markdown
+++ b/website/docs/r/custom_ip_prefix.html.markdown
@@ -26,6 +26,7 @@ resource "azurerm_custom_ip_prefix" "example" {
   cidr  = "1.2.3.4/22"
   zones = ["1", "2", "3"]
 
+  prefix_type           = "Singular"
   commissioning_enabled = true
 
   roa_validity_end_date         = "2099-12-12"
@@ -49,7 +50,8 @@ resource "azurerm_custom_ip_prefix" "global" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
 
-  cidr = "2001:db8:1::/48"
+  cidr        = "2001:db8:1::/48"
+  prefix_type = "Parent"
 
   roa_validity_end_date         = "2199-12-12"
   wan_validation_signed_message = "signed message for WAN validation"
@@ -60,6 +62,7 @@ resource "azurerm_custom_ip_prefix" "regional" {
   location                   = azurerm_resource_group.test.location
   resource_group_name        = azurerm_resource_group.test.name
   parent_custom_ip_prefix_id = azurerm_custom_ip_prefix.global.id
+  prefix_type                = "Child"
 
   cidr  = cidrsubnet(azurerm_custom_ip_prefix.global.cidr, 16, 1)
   zones = ["1"]
@@ -87,6 +90,8 @@ The following arguments are supported:
 !> **Warning** Changing the value of `internet_advertising_disabled` from `true` to `false` causes the IP prefix to stop being advertised by Azure and is functionally equivalent to deleting it when used in a production setting.
 
 * `parent_custom_ip_prefix_id` - (Optional) Specifies the ID of the parent prefix. Only needed when creating a regional/child IPv6 prefix. Changing this forces a new resource to be created.
+
+* `prefix_type` - (Optional) Type of custom IP prefix. Possible values are `Child`, `Parent`, or `Singular`. Changing this forces a new resource to be created.
 
 * `roa_validity_end_date` - (Optional) The expiration date of the Route Origin Authorization (ROA) document which has been filed with the Routing Internet Registry (RIR) for this prefix. The expected format is `YYYY-MM-DD`. Required when provisioning an IPv4 prefix or IPv6 global prefix. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

In the `azurerm_custom_ip_prefix` resource, added support for the `prefix_type` property.

Here is the API reference - https://learn.microsoft.com/en-us/rest/api/virtualnetwork/custom-ip-prefixes/create-or-update?view=rest-virtualnetwork-2024-05-01&tabs=HTTP


## PR Checklist

- [X] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [X] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [X] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [X] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [X] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [X] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [X] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [X] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

Note: Tests are unable to be run for this resource without actually provisioning public IP address space. I have run the tests from the `main` branch and from this new PR's branch, and they both output the same errors. 

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_custom_ip_prefix` - added support for the `prefix_type` property

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [X] Enhancement
- [ ] Breaking Change


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
