### PR TITLE
Docs: Fix `azurerm_web_application_firewall_policy` doc issue

### DIFF
--- a/website/docs/r/web_application_firewall_policy.html.markdown
+++ b/website/docs/r/web_application_firewall_policy.html.markdown
@@ -146,6 +146,8 @@ The `custom_rules` block supports the following:
 
 * `action` - (Required) Type of action. Possible values are `Allow`, `Block` and `Log`.
 
+~> **Note:** If the `rule_type` is specified as `RateLimitRule`, the `Allow` is not supported.
+
 * `rate_limit_duration` - (Optional) Specifies the duration at which the rate limit policy will be applied. Should be used with `RateLimitRule` rule type. Possible values are `FiveMins` and `OneMin`.
 
 * `rate_limit_threshold` - (Optional) Specifies the threshold value for the rate limit policy. Must be greater than or equal to 1 if provided.


### PR DESCRIPTION
After verifying the behavior of the [API ](https://github.com/Azure/azure-rest-api-specs/blob/af57daeaf232c2a59bf4ba6a522479c265e2002e/specification/network/resource-manager/Microsoft.Network/stable/2024-05-01/webapplicationfirewall.json#L177) when specifying [ruleType ](https://github.com/Azure/azure-rest-api-specs/blob/af57daeaf232c2a59bf4ba6a522479c265e2002e/specification/network/resource-manager/Microsoft.Network/stable/2024-05-01/webapplicationfirewall.json#L599C10-L599C18) as `RateLimitRule` and [action ](https://github.com/Azure/azure-rest-api-specs/blob/af57daeaf232c2a59bf4ba6a522479c265e2002e/specification/network/resource-manager/Microsoft.Network/stable/2024-05-01/webapplicationfirewall.json#L627) as `Allow`, API returns the following error. Therefore, this PR is submitted to improve the documentation description to fix #[28976](https://github.com/hashicorp/terraform-provider-azurerm/issues/28976)

`unexpected status 400 (400 Bad Request) with error: ApplicationGatewayFirewallCustomRuleInvalidAction: Custom Rule 'Rule1' action 'Allow' is not valid for rule type 'RateLimitRule' in context 'properties.customRules[0]'.`

