### PR TITLE
Tests - fix tests updating `ForceNew` properties

### DIFF
--- a/internal/services/appconfiguration/app_configuration_key_resource_test.go
+++ b/internal/services/appconfiguration/app_configuration_key_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appconfiguration/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 	"github.com/jackofallops/kermit/sdk/appconfiguration/1.0/appconfiguration"
 )
 
@@ -157,7 +157,7 @@ func TestAccAppConfigurationKey_basicNoValue(t *testing.T) {
 	r := AppConfigurationKeyResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.basic(data),
+			Config: r.basicNoLabel(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -238,7 +238,7 @@ func (t AppConfigurationKeyResource) Exists(ctx context.Context, clients *client
 		return nil, fmt.Errorf("while checking for key's %q existence: %+v", nestedItemId.Key, err)
 	}
 
-	return utils.Bool(res.Response.StatusCode == 200), nil
+	return pointer.To(res.Response.StatusCode == 200), nil
 }
 
 func (t AppConfigurationKeyResource) base(data acceptance.TestData) string {

--- a/internal/services/appconfiguration/app_configuration_resource_test.go
+++ b/internal/services/appconfiguration/app_configuration_resource_test.go
@@ -737,7 +737,7 @@ resource "azurerm_app_configuration" "test" {
   local_auth_enabled                               = true
   public_network_access                            = "Enabled"
   purge_protection_enabled                         = false
-  soft_delete_retention_days                       = 1
+  soft_delete_retention_days                       = 7
 
   identity {
     type = "UserAssigned"
@@ -919,7 +919,7 @@ resource "azurerm_app_configuration" "test" {
   local_auth_enabled         = true
   public_network_access      = "Enabled"
   purge_protection_enabled   = true
-  soft_delete_retention_days = 1
+  soft_delete_retention_days = 7
 
   identity {
     type = "UserAssigned"

--- a/internal/services/appservice/linux_function_app_resource_test.go
+++ b/internal/services/appservice/linux_function_app_resource_test.go
@@ -4537,7 +4537,7 @@ provider "azurerm" {
 %s
 
 resource "azurerm_linux_function_app" "test" {
-  name                       = "acctestWA-%d"
+  name                       = "acctest-LFA-%d"
   location                   = azurerm_resource_group.test.location
   resource_group_name        = azurerm_resource_group.test.name
   service_plan_id            = azurerm_service_plan.test.id
@@ -4567,7 +4567,7 @@ provider "azurerm" {
 %s
 
 resource "azurerm_linux_function_app" "test" {
-  name                       = "acctestWA-%d"
+  name                       = "acctest-LFA-%d"
   location                   = azurerm_resource_group.test.location
   resource_group_name        = azurerm_resource_group.test.name
   service_plan_id            = azurerm_service_plan.test.id

--- a/internal/services/confidentialledger/confidential_ledger_resource_test.go
+++ b/internal/services/confidentialledger/confidential_ledger_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/confidentialledger/2022-05-13/confidentialledger"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ConfidentialLedgerResource struct{}
@@ -134,7 +134,7 @@ func (ConfidentialLedgerResource) Exists(ctx context.Context, clients *clients.C
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r ConfidentialLedgerResource) public(data acceptance.TestData) string {
@@ -307,7 +307,7 @@ resource "azurerm_confidential_ledger" "test" {
   name                = "acctest-tfci-%[2]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-  ledger_type         = "Public"
+  ledger_type         = "Private"
 
   azuread_based_service_principal {
     ledger_role_name = "Administrator"

--- a/internal/services/eventgrid/eventgrid_event_subscription_resource_test.go
+++ b/internal/services/eventgrid/eventgrid_event_subscription_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2022-06-15/eventsubscriptions"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type EventGridEventSubscriptionResource struct{}
@@ -435,7 +435,7 @@ func (EventGridEventSubscriptionResource) Exists(ctx context.Context, clients *c
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (EventGridEventSubscriptionResource) basic(data acceptance.TestData) string {
@@ -563,7 +563,7 @@ resource "azurerm_storage_blob" "test" {
 }
 
 resource "azurerm_eventgrid_event_subscription" "test" {
-  name  = "acctest-eg-%[1]d"
+  name  = "acctesteg-%[1]d"
   scope = azurerm_resource_group.test.id
 
   storage_queue_endpoint {

--- a/internal/services/loganalytics/log_analytics_storage_insights_resource_test.go
+++ b/internal/services/loganalytics/log_analytics_storage_insights_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/storageinsights"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type LogAnalyticsStorageInsightsResource struct{}
@@ -117,10 +117,10 @@ func (t LogAnalyticsStorageInsightsResource) Exists(ctx context.Context, clients
 
 	resp, err := clients.LogAnalytics.StorageInsightsClient.StorageInsightConfigsGet(ctx, *id)
 	if err != nil {
-		return nil, fmt.Errorf("readingLog Analytics Storage Insights (%s): %+v", id.String(), err)
+		return nil, fmt.Errorf("retrieving Log Analytics Storage Insights (%s): %+v", id.String(), err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (LogAnalyticsStorageInsightsResource) template(data acceptance.TestData) string {
@@ -188,7 +188,7 @@ func (r LogAnalyticsStorageInsightsResource) complete(data acceptance.TestData) 
 %s
 
 resource "azurerm_log_analytics_storage_insights" "test" {
-  name                = "acctest-LA-%d"
+  name                = "acctest-la-%d"
   resource_group_name = azurerm_resource_group.test.name
   workspace_id        = azurerm_log_analytics_workspace.test.id
 

--- a/internal/services/privatedns/private_dns_srv_record_resource_test.go
+++ b/internal/services/privatedns/private_dns_srv_record_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/privatedns/2024-06-01/recordsets"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type PrivateDnsSrvRecordResource struct{}
@@ -90,7 +90,7 @@ func TestAccPrivateDnsSrvRecord_withTags(t *testing.T) {
 	})
 }
 
-func (t PrivateDnsSrvRecordResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+func (r PrivateDnsSrvRecordResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := recordsets.ParseRecordTypeID(state.ID)
 	if err != nil {
 		return nil, err
@@ -98,30 +98,18 @@ func (t PrivateDnsSrvRecordResource) Exists(ctx context.Context, clients *client
 
 	resp, err := clients.PrivateDns.RecordSetsClient.Get(ctx, *id)
 	if err != nil {
-		return nil, fmt.Errorf("reading Private DNS SRV Record (%s): %+v", id.String(), err)
+		return nil, fmt.Errorf("retrieving Private DNS SRV Record (%s): %+v", id.String(), err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
-func (PrivateDnsSrvRecordResource) basic(data acceptance.TestData) string {
+func (r PrivateDnsSrvRecordResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-prvdns-%d"
-  location = "%s"
-}
-
-resource "azurerm_private_dns_zone" "test" {
-  name                = "testzone%d.com"
-  resource_group_name = azurerm_resource_group.test.name
-}
+%s
 
 resource "azurerm_private_dns_srv_record" "test" {
-  name                = "testaccsrv%d"
+  name                = "acctestsrv%d"
   resource_group_name = azurerm_resource_group.test.name
   zone_name           = azurerm_private_dns_zone.test.name
   ttl                 = 300
@@ -139,7 +127,7 @@ resource "azurerm_private_dns_srv_record" "test" {
     target   = "target2.contoso.com"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+`, r.template(data), data.RandomInteger)
 }
 
 func (r PrivateDnsSrvRecordResource) requiresImport(data acceptance.TestData) string {
@@ -167,24 +155,12 @@ resource "azurerm_private_dns_srv_record" "import" {
 `, r.basic(data))
 }
 
-func (PrivateDnsSrvRecordResource) updateRecords(data acceptance.TestData) string {
+func (r PrivateDnsSrvRecordResource) updateRecords(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_private_dns_zone" "test" {
-  name                = "testzone%d.com"
-  resource_group_name = azurerm_resource_group.test.name
-}
+%s
 
 resource "azurerm_private_dns_srv_record" "test" {
-  name                = "test%d"
+  name                = "acctestsrv%d"
   resource_group_name = azurerm_resource_group.test.name
   zone_name           = azurerm_private_dns_zone.test.name
   ttl                 = 300
@@ -207,27 +183,15 @@ resource "azurerm_private_dns_srv_record" "test" {
     target   = "target3.contoso.com"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+`, r.template(data), data.RandomInteger)
 }
 
-func (PrivateDnsSrvRecordResource) withTags(data acceptance.TestData) string {
+func (r PrivateDnsSrvRecordResource) withTags(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_private_dns_zone" "test" {
-  name                = "testzone%d.com"
-  resource_group_name = azurerm_resource_group.test.name
-}
+%s
 
 resource "azurerm_private_dns_srv_record" "test" {
-  name                = "test%d"
+  name                = "acctestsrv%d"
   resource_group_name = azurerm_resource_group.test.name
   zone_name           = azurerm_private_dns_zone.test.name
   ttl                 = 300
@@ -249,27 +213,15 @@ resource "azurerm_private_dns_srv_record" "test" {
     cost_center = "MSFT"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+`, r.template(data), data.RandomInteger)
 }
 
-func (PrivateDnsSrvRecordResource) withTagsUpdate(data acceptance.TestData) string {
+func (r PrivateDnsSrvRecordResource) withTagsUpdate(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_private_dns_zone" "test" {
-  name                = "testzone%d.com"
-  resource_group_name = azurerm_resource_group.test.name
-}
+%s
 
 resource "azurerm_private_dns_srv_record" "test" {
-  name                = "test%d"
+  name                = "acctestsrv%d"
   resource_group_name = azurerm_resource_group.test.name
   zone_name           = azurerm_private_dns_zone.test.name
   ttl                 = 300
@@ -290,5 +242,23 @@ resource "azurerm_private_dns_srv_record" "test" {
     environment = "staging"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+`, r.template(data), data.RandomInteger)
+}
+
+func (PrivateDnsSrvRecordResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-prvdns-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_private_dns_zone" "test" {
+  name                = "testzone%[1]d.com"
+  resource_group_name = azurerm_resource_group.test.name
+}
+`, data.RandomInteger, data.Locations.Primary)
 }


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Updated test configs for tests failing due to updating `ForceNew` properties such as `name` and `resource_group_name`. There are many more but these were quick easy wins.

## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<details>
<summary>Test logs</summary>

```
=== RUN   TestAccAppConfiguration_update
=== PAUSE TestAccAppConfiguration_update
=== CONT  TestAccAppConfiguration_update
--- PASS: TestAccAppConfiguration_update (963.94s)

=== RUN   TestAccAppConfigurationKey_basicNoValue
=== PAUSE TestAccAppConfigurationKey_basicNoValue
=== CONT  TestAccAppConfigurationKey_basicNoValue
--- PASS: TestAccAppConfigurationKey_basicNoValue (683.36s)

=== RUN   TestAccLinuxFunctionApp_withStorageAccountBlockUpdate
=== PAUSE TestAccLinuxFunctionApp_withStorageAccountBlockUpdate
=== CONT  TestAccLinuxFunctionApp_withStorageAccountBlockUpdate
--- PASS: TestAccLinuxFunctionApp_withStorageAccountBlockUpdate (1113.04s)

=== RUN   TestAccConfidentialLedger_certBased
=== PAUSE TestAccConfidentialLedger_certBased
=== CONT  TestAccConfidentialLedger_certBased
--- PASS: TestAccConfidentialLedger_certBased (507.98s)

=== RUN   TestAccEventGridEventSubscription_update
=== PAUSE TestAccEventGridEventSubscription_update
=== CONT  TestAccEventGridEventSubscription_update
--- PASS: TestAccEventGridEventSubscription_update (204.31s)

=== RUN   TestAccLogAnalyticsStorageInsights_update
=== PAUSE TestAccLogAnalyticsStorageInsights_update
=== CONT  TestAccLogAnalyticsStorageInsights_update
--- PASS: TestAccLogAnalyticsStorageInsights_update (412.34s)

=== RUN   TestAccPrivateDnsSrvRecord_updateRecords
=== PAUSE TestAccPrivateDnsSrvRecord_updateRecords
=== CONT  TestAccPrivateDnsSrvRecord_updateRecords
--- PASS: TestAccPrivateDnsSrvRecord_updateRecords (147.90s)
```

</details>

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
