### PR TITLE
`azurerm_ai_foundry_project`: update the document of service hub id

### DIFF
--- a/website/docs/r/ai_foundry_project.html.markdown
+++ b/website/docs/r/ai_foundry_project.html.markdown
@@ -73,8 +73,8 @@ resource "azurerm_ai_foundry" "example" {
 
 resource "azurerm_ai_foundry_project" "example" {
   name               = "example"
-  location           = azurerm_ai_services_hub.example.location
-  ai_services_hub_id = azurerm_ai_services_hub.example.id
+  location           = azurerm_ai_foundry.example.location
+  ai_services_hub_id = azurerm_ai_foundry.example.id
 }
 ```
 
@@ -86,7 +86,7 @@ The following arguments are supported:
 
 * `location` - (Required) The Azure Region where the AI Foundry Project should exist. Changing this forces a new AI Foundry Project to be created.
 
-* `ai_services_hub_id` - (Required) The AI Services Hub ID under which this Project should be created. Changing this forces a new AI Foundry Project to be created.
+* `ai_services_hub_id` - (Required) The AI Foundry ID under which this Project should be created. Changing this forces a new AI Foundry Project to be created.
 
 ---
 
@@ -112,7 +112,7 @@ A `identity` block supports the following:
 
 ## Attributes Reference
 
-In addition to the Arguments listed above - the following Attributes are exported: 
+In addition to the Arguments listed above - the following Attributes are exported:
 
 * `id` - The ID of the AI Foundry Project.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR is to fix the example and documentation of the `ai_service_hud_id` field to make if more clear and easy to understand. it's actually should referece to the `azurerm_ai_foundry`'s id field. while renaming it to `ai_foundry_id` maybe a better choice but it may introduce extra breaking change while the current name actually works.


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_ai_foundry_project` - update document of `ai_services_hub_id` [GH-29001]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #29001

