### PR TITLE
Fix Bug in `azurerm_virtual_machine_restore_point` Resource Docs

### DIFF
--- a/website/docs/r/virtual_machine_restore_point.html.markdown
+++ b/website/docs/r/virtual_machine_restore_point.html.markdown
@@ -84,8 +84,8 @@ resource "azurerm_virtual_machine_restore_point_collection" "example" {
 }
 
 resource "azurerm_virtual_machine_restore_point" "example" {
-  name                        = "example-restore-point"
-  restore_point_collection_id = azurerm_restore_point_collection.test.id
+  name                                        = "example-restore-point"
+  virtual_machine_restore_point_collection_id = azurerm_virtual_machine_restore_point_collection.example.id
 }
 ```
 

--- a/website/docs/r/virtual_machine_restore_point.html.markdown
+++ b/website/docs/r/virtual_machine_restore_point.html.markdown
@@ -95,9 +95,9 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the Virtual Machine Restore Point. Changing this forces a new resource to be created.
 
-* `restore_point_collection_id` - (Required) Specifies the name of the Virtual Machine Restore Point Collection the Virtual Machine Restore Point will be associated with. Changing this forces a new resource to be created.
+* `virtual_machine_restore_point_collection_id` - (Required) Specifies the ID of the Virtual Machine Restore Point Collection the Virtual Machine Restore Point will be associated with. Changing this forces a new resource to be created.
 
-* `crash_consistency_mode_enabled` - (Optional) Is Crash Consistent the Consistency Mode of the Virtual Machine Restore Point. Defaults to `false`. Changing this forces a new resource to be created.
+* `crash_consistency_mode_enabled` - (Optional) Whether the Consistency Mode of the Virtual Machine Restore Point is set to `CrashConsistent`. Defaults to `false`. Changing this forces a new resource to be created.
 
 * `excluded_disks` - (Optional) A list of disks that will be excluded from the Virtual Machine Restore Point. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Fix Bug in `azurerm_virtual_machine_restore_point` resource documentation. It looks like a resource type name was updated in the provider, and was only updated in part of this example. I ran plan and apply with my edit and it succeeded.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

```
❯ terraform apply
azurerm_virtual_machine_restore_point.example: Creating...
azurerm_virtual_machine_restore_point.example: Still creating... [10s elapsed]
azurerm_virtual_machine_restore_point.example: Still creating... [20s elapsed]
azurerm_virtual_machine_restore_point.example: Still creating... [30s elapsed]
azurerm_virtual_machine_restore_point.example: Still creating... [40s elapsed]
azurerm_virtual_machine_restore_point.example: Still creating... [50s elapsed]
azurerm_virtual_machine_restore_point.example: Creation complete after 54s [id=/subscriptions/1a6092a6-137e-4025-9a7c-ef77f76f2c02/resourceGroups/acctest-vmrestorepoint-wyatt/providers/Microsoft.Compute/restorePointCollections/example-collection/restorePoints/example-restore-point]

Apply complete! Resources: 7 added, 0 changed, 0 destroyed.
```


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

(Nothing to report)

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
