### PR TITLE
`azurerm_postgresql_flexible_server` - delete resource using polling url

### DIFF
--- a/internal/services/postgres/custompollers/postgresql_flexible_server_poller.go
+++ b/internal/services/postgres/custompollers/postgresql_flexible_server_poller.go
@@ -1,0 +1,126 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package custompollers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+)
+
+var _ pollers.PollerType = &postgresqlFlexibleServerPoller{}
+
+type postgresqlFlexibleServerPoller struct {
+	client   *resourcemanager.Client
+	response *http.Response
+}
+
+type operationResult struct {
+	Name      *string               `json:"name"`
+	StartTime *string               `json:"startTime"`
+	Status    pollers.PollingStatus `json:"status"`
+}
+
+var (
+	pollingSuccess = pollers.PollResult{
+		Status:       pollers.PollingStatusSucceeded,
+		PollInterval: 10 * time.Second,
+	}
+	pollingInProgress = pollers.PollResult{
+		Status:       pollers.PollingStatusInProgress,
+		PollInterval: 10 * time.Second,
+	}
+)
+
+func postgresqlFlexibleServerPollingUriForLongRunningOperation(resp *http.Response) string {
+	pollingUrl := resp.Header.Get(http.CanonicalHeaderKey("Azure-AsyncOperation"))
+	if pollingUrl == "" {
+		pollingUrl = resp.Header.Get("Location")
+	}
+	return pollingUrl
+}
+
+func NewPostgresqlFlexibleServerPoller(client *resourcemanager.Client, resp *http.Response) *postgresqlFlexibleServerPoller {
+	return &postgresqlFlexibleServerPoller{
+		client:   client,
+		response: resp,
+	}
+}
+
+func (p postgresqlFlexibleServerPoller) Poll(ctx context.Context) (*pollers.PollResult, error) {
+	pollingUrl := postgresqlFlexibleServerPollingUriForLongRunningOperation(p.response)
+	if pollingUrl == "" {
+		return nil, fmt.Errorf("no polling URL found in response")
+	}
+
+	parsedPollingUrl, err := url.Parse(pollingUrl)
+	if err != nil {
+		return nil, fmt.Errorf("invalid polling URL %q in response: %v", pollingUrl, err)
+	}
+	if !parsedPollingUrl.IsAbs() {
+		return nil, fmt.Errorf("invalid polling URL %q in response: URL was not absolute", pollingUrl)
+	}
+
+	reqOpts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+			http.StatusCreated,
+			http.StatusAccepted,
+			http.StatusNoContent,
+			http.StatusNotFound,
+		},
+		HttpMethod:    http.MethodGet,
+		OptionsObject: nil,
+		Path:          parsedPollingUrl.Path,
+	}
+
+	req, err := p.client.NewRequest(ctx, reqOpts)
+	if err != nil {
+		return nil, fmt.Errorf("building request for long-running-operation: %+v", err)
+	}
+	req.URL.RawQuery = parsedPollingUrl.RawQuery
+
+	resp, err := req.Execute(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("executing request: %+v", err)
+	}
+
+	if resp.Response != nil {
+		var respBody []byte
+		respBody, err = io.ReadAll(resp.Response.Body)
+		if err != nil {
+			return nil, fmt.Errorf("parsing response body: %+v", err)
+		}
+		resp.Response.Body.Close()
+
+		resp.Response.Body = io.NopCloser(bytes.NewReader(respBody))
+
+		contentType := resp.Response.Header.Get("Content-Type")
+		var op operationResult
+		if strings.Contains(strings.ToLower(contentType), "application/json") {
+			if err = json.Unmarshal(respBody, &op); err != nil {
+				return nil, fmt.Errorf("unmarshalling response body: %+v", err)
+			}
+		} else {
+			return nil, fmt.Errorf("internal-error: polling support for the Content-Type %q was not implemented: %+v", contentType, err)
+		}
+
+		if op.Status == pollers.PollingStatusInProgress {
+			return &pollingInProgress, nil
+		}
+	}
+
+	return &pollingSuccess, nil
+}

--- a/internal/services/postgres/postgresql_flexible_server_resource_test.go
+++ b/internal/services/postgres/postgresql_flexible_server_resource_test.go
@@ -847,6 +847,8 @@ resource "azurerm_subnet" "test" {
 resource "azurerm_private_dns_zone" "test" {
   name                = "acc%[2]d.postgres.database.azure.com"
   resource_group_name = azurerm_resource_group.test.name
+
+  depends_on = [azurerm_subnet.test]
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "test" {
@@ -854,8 +856,6 @@ resource "azurerm_private_dns_zone_virtual_network_link" "test" {
   private_dns_zone_name = azurerm_private_dns_zone.test.name
   virtual_network_id    = azurerm_virtual_network.test.id
   resource_group_name   = azurerm_resource_group.test.name
-
-  depends_on = [azurerm_subnet.test]
 }
 
 resource "azurerm_postgresql_flexible_server" "test" {
@@ -924,6 +924,8 @@ resource "azurerm_subnet" "test" {
 resource "azurerm_private_dns_zone" "test" {
   name                = "acc%[2]d.postgres.database.azure.com"
   resource_group_name = azurerm_resource_group.test.name
+
+  depends_on = [azurerm_subnet.test]
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "test" {
@@ -931,8 +933,6 @@ resource "azurerm_private_dns_zone_virtual_network_link" "test" {
   private_dns_zone_name = azurerm_private_dns_zone.test.name
   virtual_network_id    = azurerm_virtual_network.test.id
   resource_group_name   = azurerm_resource_group.test.name
-
-  depends_on = [azurerm_subnet.test]
 }
 
 resource "azurerm_postgresql_flexible_server" "test" {


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description
Recently, we received an internal incident ticket. The symptom is that users keep failing to recreate Postgresql FS with same name. After I investigated, I found that Terraform first calls the DELETE API to submit a deletion request, and then during the long-running operation (LRO) phase, it checks whether the resource exists by calling the GET API. If the resource exists, it retries the LRO; if it does not exist, it exits the operation.
Coming back to users' case, I found that after Terraform submitted the delete request, it called the GET API and found the resource as "NOT FOUND," so it exited normally. However, the delete operation was not actually finished, because when I called the azureAsyncOperation URL from the delete API response, it returned "status=InProgress", indicating that the delete operation was still ongoing.
The issue encountered by the user is caused by the inconsistency between the azureAsyncOperation and the GET API results. As I understand it, the GET API should return "NOT FOUND" only after the resource has been completely deleted. Service team confirmed that they are working on the fix.

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_postgresql_flexible_server` - delete resource using polling url


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
