### PR TITLE
`azurerm_postgresql_flexible_server_configuration`: should lock the replica server

### DIFF
--- a/internal/services/postgres/postgresql_flexible_server_configuration_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_configuration_resource.go
@@ -19,8 +19,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
 
-var postgresqlFlexibleServerConfigurationResourceName = "azurerm_postgresql_flexible_server_configuration"
-
 func resourcePostgresqlFlexibleServerConfiguration() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
 		Create: resourceFlexibleServerConfigurationUpdate,
@@ -80,9 +78,6 @@ func resourceFlexibleServerConfigurationUpdate(d *pluginsdk.ResourceData, meta i
 
 	locks.ByName(id.FlexibleServerName, postgresqlFlexibleServerResourceName)
 	defer locks.UnlockByName(id.FlexibleServerName, postgresqlFlexibleServerResourceName)
-
-	locks.ByName(id.ConfigurationName, postgresqlFlexibleServerConfigurationResourceName)
-	defer locks.UnlockByName(id.ConfigurationName, postgresqlFlexibleServerConfigurationResourceName)
 
 	props := configurations.ConfigurationForUpdate{
 		Properties: &configurations.ConfigurationProperties{
@@ -166,9 +161,6 @@ func resourceFlexibleServerConfigurationDelete(d *pluginsdk.ResourceData, meta i
 
 	locks.ByName(id.FlexibleServerName, postgresqlFlexibleServerResourceName)
 	defer locks.UnlockByName(id.FlexibleServerName, postgresqlFlexibleServerResourceName)
-
-	locks.ByName(id.ConfigurationName, postgresqlFlexibleServerConfigurationResourceName)
-	defer locks.UnlockByName(id.ConfigurationName, postgresqlFlexibleServerConfigurationResourceName)
 
 	resp, err := client.Get(ctx, *id)
 	if err != nil {

--- a/internal/services/postgres/postgresql_flexible_server_virtual_endpoint_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_virtual_endpoint_resource.go
@@ -243,6 +243,11 @@ func (r PostgresqlFlexibleServerVirtualEndpointResource) Update() sdk.ResourceFu
 			locks.ByName(id.FlexibleServerName, postgresqlFlexibleServerResourceName)
 			defer locks.UnlockByName(id.FlexibleServerName, postgresqlFlexibleServerResourceName)
 
+			if replicaServerId.FlexibleServerName != id.FlexibleServerName {
+				locks.ByName(replicaServerId.FlexibleServerName, postgresqlFlexibleServerResourceName)
+				defer locks.UnlockByName(replicaServerId.FlexibleServerName, postgresqlFlexibleServerResourceName)
+			}
+
 			if err := client.UpdateThenPoll(ctx, *id, virtualendpoints.VirtualEndpointResourceForPatch{
 				Properties: &virtualendpoints.VirtualEndpointResourceProperties{
 					EndpointType: pointer.To(virtualendpoints.VirtualEndpointType(virtualEndpoint.Type)),

--- a/internal/services/postgres/postgresql_flexible_server_virtual_endpoint_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_virtual_endpoint_resource.go
@@ -106,6 +106,11 @@ func (r PostgresqlFlexibleServerVirtualEndpointResource) Create() sdk.ResourceFu
 			locks.ByName(id.FlexibleServerName, postgresqlFlexibleServerResourceName)
 			defer locks.UnlockByName(id.FlexibleServerName, postgresqlFlexibleServerResourceName)
 
+			if replicaServerId.FlexibleServerName != id.FlexibleServerName {
+				locks.ByName(replicaServerId.FlexibleServerName, postgresqlFlexibleServerResourceName)
+				defer locks.UnlockByName(replicaServerId.FlexibleServerName, postgresqlFlexibleServerResourceName)
+			}
+
 			// This API can be a bit flaky if the same named resource is created/destroyed quickly
 			// usually waiting a minute or two before redeploying is enough to resolve the conflict
 			if err = client.CreateThenPoll(ctx, id, virtualendpoints.VirtualEndpointResource{


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

A locker to the replica server is also required when add a virutal endpoint. there is a internal ticket about updating configuration and creating virtual endpoint in parallel which caused an issue:

> Then, it was followed by a configuration update (UpdateConfigurationManagementOperation).
> And then it got the restart server request (RestartServerManagementOperation), which succeeded normally, however, it is right there when the create virtual endpoint requests were triggered, right in the middle of the server restart.
 
In mean time, the locker to the configuraiton name is not required while we already had a locker on the server itself.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->

## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_postgresql_flexible_server_configuration` - add locker to the replication server id


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
