### PR TITLE
`azurerm_role_management_policy` - stop drift by making `approval_status` computed

### DIFF
--- a/internal/services/authorization/role_management_policy_resource.go
+++ b/internal/services/authorization/role_management_policy_resource.go
@@ -232,6 +232,7 @@ func (r RoleManagementPolicyResource) Arguments() map[string]*pluginsdk.Schema {
 						Description: "The approval stages for the activation",
 						Type:        pluginsdk.TypeList,
 						Optional:    true,
+						Computed:    true,
 						MaxItems:    1,
 						Elem: &pluginsdk.Resource{
 							Schema: map[string]*pluginsdk.Schema{

--- a/internal/services/authorization/role_management_policy_resource.go
+++ b/internal/services/authorization/role_management_policy_resource.go
@@ -232,8 +232,9 @@ func (r RoleManagementPolicyResource) Arguments() map[string]*pluginsdk.Schema {
 						Description: "The approval stages for the activation",
 						Type:        pluginsdk.TypeList,
 						Optional:    true,
-						Computed:    true,
-						MaxItems:    1,
+						// This is O+C because when `activation_rules` is specified, there will be an empty "approval_stage" populated by the API.
+						Computed: true,
+						MaxItems: 1,
 						Elem: &pluginsdk.Resource{
 							Schema: map[string]*pluginsdk.Schema{
 								"primary_approver": {

--- a/internal/services/authorization/role_management_policy_resource_test.go
+++ b/internal/services/authorization/role_management_policy_resource_test.go
@@ -511,7 +511,9 @@ resource "azurerm_role_management_policy" "test" {
   scope              = azurerm_resource_group.test.id
   role_definition_id = data.azurerm_role_definition.contributor.id
 
-  activation_rules {}
+  activation_rules {
+    maximum_duration = "PT1H"
+  }
 }
 `, r.resourceGroupTemplate(data), data.RandomString, requireApproval)
 }

--- a/internal/services/authorization/role_management_policy_resource_test.go
+++ b/internal/services/authorization/role_management_policy_resource_test.go
@@ -69,6 +69,21 @@ func TestAccRoleManagementPolicy_resourceGroup(t *testing.T) {
 	})
 }
 
+func TestAccRoleManagementPolicy_resourceGroup_activationRules(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_role_management_policy", "test")
+	r := RoleManagementPolicyResource{}
+
+	data.ResourceTestSkipCheckDestroyed(t, []acceptance.TestStep{
+		{
+			Config: r.resourceGroupMinimalActivationRules(data, false),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccRoleManagementPolicy_resourceGroup_activationRulesUpdate(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_role_management_policy", "test")
 	r := RoleManagementPolicyResource{}
@@ -484,6 +499,19 @@ resource "azurerm_role_management_policy" "test" {
       }
     }
   }
+}
+`, r.resourceGroupTemplate(data), data.RandomString, requireApproval)
+}
+
+func (r RoleManagementPolicyResource) resourceGroupMinimalActivationRules(data acceptance.TestData, requireApproval bool) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_role_management_policy" "test" {
+  scope              = azurerm_resource_group.test.id
+  role_definition_id = data.azurerm_role_definition.contributor.id
+
+  activation_rules {}
 }
 `, r.resourceGroupTemplate(data), data.RandomString, requireApproval)
 }


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Porting the PR https://github.com/hashicorp/terraform-provider-azuread/pull/1666 for the same resource in azurerm provider.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

![image](https://github.com/user-attachments/assets/e425da37-1217-4b3d-9c53-0f28a0a24d2c)



## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_role_management_policy` - stop drift by making `approval_status` computed [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #26377


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
