### PR TITLE
Add optional Argument (system_version )  for Oracle Cloud VM Cluster creation( azurerm_oracle_cloud_vm_cluster)

### DIFF
--- a/internal/services/oracle/cloud_vm_cluster_resource.go
+++ b/internal/services/oracle/cloud_vm_cluster_resource.go
@@ -266,9 +266,10 @@ func (CloudVmClusterResource) Arguments() map[string]*pluginsdk.Schema {
 		},
 
 		"system_version": {
-			Type:     pluginsdk.TypeString,
-			Optional: true,
-			ForceNew: true,
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ForceNew:     true,
+			ValidateFunc: validate.SystemVersion,
 		},
 
 		"time_zone": {

--- a/internal/services/oracle/cloud_vm_cluster_resource.go
+++ b/internal/services/oracle/cloud_vm_cluster_resource.go
@@ -59,6 +59,7 @@ type CloudVmClusterResourceModel struct {
 	Ocid                     string                       `tfschema:"ocid"`
 	ScanListenerPortTcp      int64                        `tfschema:"scan_listener_port_tcp"`
 	ScanListenerPortTcpSsl   int64                        `tfschema:"scan_listener_port_tcp_ssl"`
+	SystemVersion            string                       `tfschema:"system_version"`
 	TimeZone                 string                       `tfschema:"time_zone"`
 	ZoneId                   string                       `tfschema:"zone_id"`
 }
@@ -264,6 +265,12 @@ func (CloudVmClusterResource) Arguments() map[string]*pluginsdk.Schema {
 			ValidateFunc: validation.IntBetween(1024, 8999),
 		},
 
+		"system_version": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			ForceNew: true,
+		},
+
 		"time_zone": {
 			Type:     pluginsdk.TypeString,
 			Optional: true,
@@ -367,6 +374,9 @@ func (r CloudVmClusterResource) Create() sdk.ResourceFunc {
 			}
 			if model.ScanListenerPortTcpSsl >= 1024 && model.ScanListenerPortTcpSsl <= 8999 {
 				param.Properties.ScanListenerPortTcpSsl = pointer.To(model.ScanListenerPortTcpSsl)
+			}
+			if model.SystemVersion != "" {
+				param.Properties.SystemVersion = pointer.To(model.SystemVersion)
 			}
 			if model.TimeZone != "" {
 				param.Properties.TimeZone = pointer.To(model.TimeZone)
@@ -494,6 +504,7 @@ func (CloudVmClusterResource) Read() sdk.ResourceFunc {
 					state.IsSparseDiskgroupEnabled = pointer.From(props.IsSparseDiskgroupEnabled)
 					state.ScanListenerPortTcp = pointer.From(props.ScanListenerPortTcp)
 					state.ScanListenerPortTcpSsl = pointer.From(props.ScanListenerPortTcpSsl)
+					state.SystemVersion = pointer.From(props.SystemVersion)
 					state.TimeZone = pointer.From(props.TimeZone)
 					state.ZoneId = pointer.From(props.ZoneId)
 				}

--- a/internal/services/oracle/cloud_vm_cluster_resource_test.go
+++ b/internal/services/oracle/cloud_vm_cluster_resource_test.go
@@ -134,8 +134,8 @@ resource "azurerm_oracle_cloud_vm_cluster" "test" {
   db_node_storage_size_in_gbs = 120
   db_servers                  = [for obj in data.azurerm_oracle_db_servers.test.db_servers : obj.ocid]
   display_name                = "OFakeVmacctest%[2]d"
-  domain                      = "ocidelegated.ocivnet.oraclevcn.com"
-  gi_version                  = "19.0.0.0"
+  domain                      = "ociofakeacctes.com"
+  gi_version                  = "23.0.0.0"
   local_backup_enabled        = true
   sparse_diskgroup_enabled    = true
   license_model               = "BringYourOwnLicense"
@@ -145,12 +145,12 @@ resource "azurerm_oracle_cloud_vm_cluster" "test" {
   subnet_id                   = azurerm_subnet.virtual_network_subnet.id
   scan_listener_port_tcp      = 1521
   scan_listener_port_tcp_ssl  = 2484
-  system_version              = "22.1.29.0.0.241108"
+  system_version              = "23.1.23.0.0.250207"
   tags = {
     test = "testTag1"
   }
   time_zone          = "UTC"
-  zone_id            = "ocid1.dns-zone.oc1.iad.aaaaaaaa4thk47bd7bc2oiuowxzdbb5takhztdb6jqhbytn3kbvwc2p4u4ua"
+  zone_id            = "ocid1.dns-zone.oc1.iad.aaaaaaaac7lyw74bnybmlek7nrsd5h3v5kjfv3aiw62menpuuwoder7yhmpa"
   virtual_network_id = azurerm_virtual_network.virtual_network.id
 }`, a.template(data), data.RandomInteger, data.Locations.Primary)
 }

--- a/internal/services/oracle/cloud_vm_cluster_resource_test.go
+++ b/internal/services/oracle/cloud_vm_cluster_resource_test.go
@@ -145,6 +145,7 @@ resource "azurerm_oracle_cloud_vm_cluster" "test" {
   subnet_id                   = azurerm_subnet.virtual_network_subnet.id
   scan_listener_port_tcp      = 1521
   scan_listener_port_tcp_ssl  = 2484
+  system_version              = "24.1.5.0.0.241016"
   tags = {
     test = "testTag1"
   }

--- a/internal/services/oracle/cloud_vm_cluster_resource_test.go
+++ b/internal/services/oracle/cloud_vm_cluster_resource_test.go
@@ -134,8 +134,8 @@ resource "azurerm_oracle_cloud_vm_cluster" "test" {
   db_node_storage_size_in_gbs = 120
   db_servers                  = [for obj in data.azurerm_oracle_db_servers.test.db_servers : obj.ocid]
   display_name                = "OFakeVmacctest%[2]d"
-  domain                      = "ociofakeacctes.com"
-  gi_version                  = "23.0.0.0"
+  domain                      = "ocidelegated.ocivnet.oraclevcn.com"
+  gi_version                  = "19.0.0.0"
   local_backup_enabled        = true
   sparse_diskgroup_enabled    = true
   license_model               = "BringYourOwnLicense"
@@ -145,12 +145,12 @@ resource "azurerm_oracle_cloud_vm_cluster" "test" {
   subnet_id                   = azurerm_subnet.virtual_network_subnet.id
   scan_listener_port_tcp      = 1521
   scan_listener_port_tcp_ssl  = 2484
-  system_version              = "24.1.5.0.0.241016"
+  system_version              = "22.1.29.0.0.241108"
   tags = {
     test = "testTag1"
   }
   time_zone          = "UTC"
-  zone_id            = "ocid1.dns-zone.oc1.iad.aaaaaaaac7lyw74bnybmlek7nrsd5h3v5kjfv3aiw62menpuuwoder7yhmpa"
+  zone_id            = "ocid1.dns-zone.oc1.iad.aaaaaaaa4thk47bd7bc2oiuowxzdbb5takhztdb6jqhbytn3kbvwc2p4u4ua"
   virtual_network_id = azurerm_virtual_network.virtual_network.id
 }`, a.template(data), data.RandomInteger, data.Locations.Primary)
 }

--- a/internal/services/oracle/validate/cloud_vm_cluster.go
+++ b/internal/services/oracle/validate/cloud_vm_cluster.go
@@ -99,3 +99,19 @@ func DataStoragePercentage(i interface{}, k string) (warnings []string, errors [
 
 	return
 }
+
+func SystemVersion(i interface{}, k string) (warnings []string, errors []error) {
+	v, ok := i.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected type of %s to be string", k))
+		return
+	}
+
+	pattern := "(?:19|22|23|24|25)\\.[0-9]+(\\.[0-9]+)*|[0-9]+(\\.[0-9]+)*"
+	re := regexp.MustCompile(pattern)
+	if !re.MatchString(v) {
+		errors = append(errors, fmt.Errorf("%s must match one of the following patterns: %v", k, pattern))
+	}
+
+	return
+}

--- a/website/docs/d/oracle_cloud_vm_cluster.html.markdown
+++ b/website/docs/d/oracle_cloud_vm_cluster.html.markdown
@@ -112,6 +112,8 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `scan_listener_port_tcp_ssl` - The TCPS Single Client Access Name (SCAN) port. The default port is 2484.
 
+* `system_version` - (Optional) Operating system version of the Exadata image.
+
 * `shape` - The model name of the Exadata hardware running the Cloud VM Cluster.
 
 * `ssh_public_keys` - The public key portion of one or more key pairs used for SSH access to the Cloud VM Cluster.

--- a/website/docs/r/oracle_cloud_vm_cluster.html.markdown
+++ b/website/docs/r/oracle_cloud_vm_cluster.html.markdown
@@ -134,8 +134,7 @@ The following arguments are supported:
 
 * `scan_listener_port_tcp_ssl` - (Optional) The TCPS Single Client Access Name (SCAN) port. The default port to 2484. Changing this forces a new Cloud VM Cluster to be created.
 
-* `system_version` - (Optional) Operating system version of the Exadata image. System version must be <= Db server major version (the first two parts of the DB server version eg 23.1.X.X.XXXX). Accepted Values for GI version 19.0.0.0 , { 22.1.30.0.0.241204, 22.1.32.0.0.250205, 22.1.31.0.0.250110, 23.1.20.0.0.241112, 23.1.21.0.0.241204, 23.1.22.0.0.250119, 23.1.23.0.0.250207} .For GI version 23.0.0.0 , allowed sytem versions are { 23.1.19.0.0.241015, 23.1.20.0.0.241112, 23.1.22.0.0.250119, 23.1.21.0.0.241204, 23.1.23.0.0.250207 }
-
+* `system_version` - (Optional) Operating system version of the Exadata image. System version must be <= Db server major version (the first two parts of the DB server version eg 23.1.X.X.XXXX). Accepted Values for GI version 19.0.0.0 are 22.1.30.0.0.241204, 22.1.32.0.0.250205, 22.1.31.0.0.250110, 23.1.20.0.0.241112, 23.1.21.0.0.241204, 23.1.22.0.0.250119, 23.1.23.0.0.250207. For GI version 23.0.0.0 allowed system versions are 23.1.19.0.0.241015, 23.1.20.0.0.241112, 23.1.22.0.0.250119, 23.1.21.0.0.241204, 23.1.23.0.0.250207.
 * `tags` - (Optional) A mapping of tags which should be assigned to the Cloud VM Cluster.
 
 * `time_zone` - (Optional) The time zone of the Cloud VM Cluster. For details, see [Exadata Infrastructure Time Zones](https://docs.cloud.oracle.com/iaas/Content/Database/References/timezones.htm). Changing this forces a new Cloud VM Cluster to be created.

--- a/website/docs/r/oracle_cloud_vm_cluster.html.markdown
+++ b/website/docs/r/oracle_cloud_vm_cluster.html.markdown
@@ -134,7 +134,8 @@ The following arguments are supported:
 
 * `scan_listener_port_tcp_ssl` - (Optional) The TCPS Single Client Access Name (SCAN) port. The default port to 2484. Changing this forces a new Cloud VM Cluster to be created.
 
-* `system_version` - (Optional) Operating system version of the Exadata image. System version must be <= Db server major version (the first two parts of the DB server version eg 23.1.X.X.XXXX). Accepted Values for GI version 19.0.0.0 are 22.1.30.0.0.241204, 22.1.32.0.0.250205, 22.1.31.0.0.250110, 23.1.20.0.0.241112, 23.1.21.0.0.241204, 23.1.22.0.0.250119, 23.1.23.0.0.250207. For GI version 23.0.0.0 allowed system versions are 23.1.19.0.0.241015, 23.1.20.0.0.241112, 23.1.22.0.0.250119, 23.1.21.0.0.241204, 23.1.23.0.0.250207.
+* `system_version` - (Optional) Operating system version of the Exadata image. System version must be <= Db server major version (the first two parts of the DB server version eg 23.1.X.X.XXXX). Accepted Values for Grid Infrastructure (GI) version 19.0.0.0 are 22.1.30.0.0.241204, 22.1.32.0.0.250205, 22.1.31.0.0.250110, 23.1.20.0.0.241112, 23.1.21.0.0.241204, 23.1.22.0.0.250119, 23.1.23.0.0.250207. For Grid Infrastructure (GI) version 23.0.0.0 allowed system versions are 23.1.19.0.0.241015, 23.1.20.0.0.241112, 23.1.22.0.0.250119, 23.1.21.0.0.241204, 23.1.23.0.0.250207.
+
 * `tags` - (Optional) A mapping of tags which should be assigned to the Cloud VM Cluster.
 
 * `time_zone` - (Optional) The time zone of the Cloud VM Cluster. For details, see [Exadata Infrastructure Time Zones](https://docs.cloud.oracle.com/iaas/Content/Database/References/timezones.htm). Changing this forces a new Cloud VM Cluster to be created.

--- a/website/docs/r/oracle_cloud_vm_cluster.html.markdown
+++ b/website/docs/r/oracle_cloud_vm_cluster.html.markdown
@@ -134,7 +134,7 @@ The following arguments are supported:
 
 * `scan_listener_port_tcp_ssl` - (Optional) The TCPS Single Client Access Name (SCAN) port. The default port to 2484. Changing this forces a new Cloud VM Cluster to be created.
 
-* `system_version` - (Optional) Operating system version of the Exadata image. System version must be <= Db server major version (the first two parts of the DB server version eg 23.1.X.X.XXXX)
+* `system_version` - (Optional) Operating system version of the Exadata image. System version must be <= Db server major version (the first two parts of the DB server version eg 23.1.X.X.XXXX). Accepted Values for GI version 19.0.0.0 , { 22.1.30.0.0.241204, 22.1.32.0.0.250205, 22.1.31.0.0.250110, 23.1.20.0.0.241112, 23.1.21.0.0.241204, 23.1.22.0.0.250119, 23.1.23.0.0.250207} .For GI version 23.0.0.0 , allowed sytem versions are { 23.1.19.0.0.241015, 23.1.20.0.0.241112, 23.1.22.0.0.250119, 23.1.21.0.0.241204, 23.1.23.0.0.250207 }
 
 * `tags` - (Optional) A mapping of tags which should be assigned to the Cloud VM Cluster.
 

--- a/website/docs/r/oracle_cloud_vm_cluster.html.markdown
+++ b/website/docs/r/oracle_cloud_vm_cluster.html.markdown
@@ -74,6 +74,7 @@ resource "azurerm_oracle_cloud_vm_cluster" "example" {
   cpu_core_count                  = 2
   hostname                        = "hostname"
   subnet_id                       = azurerm_subnet.example.id
+  system_version                  = "23.1.19.0.0.241015"
 }
 ```
 
@@ -132,6 +133,8 @@ The following arguments are supported:
 * `scan_listener_port_tcp` - (Optional) The TCP Single Client Access Name (SCAN) port. The default port to 1521. Changing this forces a new Cloud VM Cluster to be created.
 
 * `scan_listener_port_tcp_ssl` - (Optional) The TCPS Single Client Access Name (SCAN) port. The default port to 2484. Changing this forces a new Cloud VM Cluster to be created.
+
+* `system_version` - (Optional) Operating system version of the Exadata image. System version must be <= Db server major  version (the first two parts of the DB server version eg 23.1.X.X ..)
 
 * `tags` - (Optional) A mapping of tags which should be assigned to the Cloud VM Cluster.
 

--- a/website/docs/r/oracle_cloud_vm_cluster.html.markdown
+++ b/website/docs/r/oracle_cloud_vm_cluster.html.markdown
@@ -134,7 +134,7 @@ The following arguments are supported:
 
 * `scan_listener_port_tcp_ssl` - (Optional) The TCPS Single Client Access Name (SCAN) port. The default port to 2484. Changing this forces a new Cloud VM Cluster to be created.
 
-* `system_version` - (Optional) Operating system version of the Exadata image. System version must be <= Db server major  version (the first two parts of the DB server version eg 23.1.X.X ..)
+* `system_version` - (Optional) Operating system version of the Exadata image. System version must be <= Db server major version (the first two parts of the DB server version eg 23.1.X.X.XXXX)
 
 * `tags` - (Optional) A mapping of tags which should be assigned to the Cloud VM Cluster.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

- Add new optional arguments for Oracle VMCluster creation and updated related documents
       -  system_version

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [x] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

CloudVmClusterResource Test results 
![Screenshot 2025-03-17 at 2 40 23 PM](https://github.com/user-attachments/assets/492f2a1a-69d5-45b8-a5f4-359053cf5aaa)

CloudVmClusterDataSource Test results 
![Screenshot 2025-03-19 at 10 57 37 AM](https://github.com/user-attachments/assets/8932f57d-8a47-4f44-877a-acb9b9a822d0)



<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `systemVersion` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #29109 


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
