### PR TITLE
`azurerm_cdn_frontdoor_origin_group` - `health_probe` no longer resets during update unless specified

### DIFF
--- a/internal/services/cdn/cdn_frontdoor_origin_group_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_origin_group_resource.go
@@ -245,7 +245,7 @@ func resourceCdnFrontDoorOriginGroupUpdate(d *pluginsdk.ResourceData, meta inter
 	// so we'll resend what is in the API if d.HasChange("health_probe") doesn't trigger
 	// fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/22131
 	params := &azuresdkhacks.AFDOriginGroupUpdatePropertiesParameters{
-		// HealthProbeSettings: existing.AFDOriginGroupProperties.HealthProbeSettings,
+		HealthProbeSettings: existing.AFDOriginGroupProperties.HealthProbeSettings,
 	}
 
 	// The API requires that an explicit null be passed as the 'health_probe' value to disable the health probe

--- a/internal/services/cdn/cdn_frontdoor_origin_group_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_origin_group_resource.go
@@ -236,7 +236,17 @@ func resourceCdnFrontDoorOriginGroupUpdate(d *pluginsdk.ResourceData, meta inter
 		return err
 	}
 
-	params := &azuresdkhacks.AFDOriginGroupUpdatePropertiesParameters{}
+	existing, err := client.Get(ctx, id.ResourceGroup, id.ProfileName, id.OriginGroupName)
+	if err != nil || existing.AFDOriginGroupProperties == nil {
+		return fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	// Though this is a Patch, if HealthProbeSettings is left as nil in the payload, it could reset HealthProbeSettings inadvertently
+	// so we'll resend what is in the API if d.HasChange("health_probe") doesn't trigger
+	// fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/22131
+	params := &azuresdkhacks.AFDOriginGroupUpdatePropertiesParameters{
+		// HealthProbeSettings: existing.AFDOriginGroupProperties.HealthProbeSettings,
+	}
 
 	// The API requires that an explicit null be passed as the 'health_probe' value to disable the health probe
 	// e.g. {"properties":{"healthProbeSettings":null}}

--- a/internal/services/cdn/cdn_frontdoor_origin_group_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_origin_group_resource_test.go
@@ -106,7 +106,6 @@ func TestAccCdnFrontDoorOriginGroup_disableHealthProbe(t *testing.T) {
 }
 
 func TestAccCdnFrontDoorOriginGroup_updateHealthProbe(t *testing.T) {
-	// NOTE: Regression test case for issue #22131
 	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_origin_group", "test")
 	r := CdnFrontDoorOriginGroupResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{

--- a/internal/services/cdn/cdn_frontdoor_origin_group_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_origin_group_resource_test.go
@@ -105,6 +105,38 @@ func TestAccCdnFrontDoorOriginGroup_disableHealthProbe(t *testing.T) {
 	})
 }
 
+func TestAccCdnFrontDoorOriginGroup_updateHealthProbe(t *testing.T) {
+	// NOTE: Regression test case for issue #22131
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_origin_group", "test")
+	r := CdnFrontDoorOriginGroupResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("health_probe.0.interval_in_seconds").Exists(),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.updateLoadBalancing(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("health_probe.0.interval_in_seconds").Exists(),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.disableHealthProbe(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("health_probe.0.interval_in_seconds").DoesNotExist(),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (r CdnFrontDoorOriginGroupResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.FrontDoorOriginGroupID(state.ID)
 	if err != nil {
@@ -218,6 +250,38 @@ resource "azurerm_cdn_frontdoor_origin_group" "test" {
     additional_latency_in_milliseconds = 32
     sample_size                        = 32
     successful_samples_required        = 5
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func (r CdnFrontDoorOriginGroupResource) updateLoadBalancing(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_cdn_frontdoor_origin_group" "test" {
+  name                     = "acctest-origingroup-%d"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.test.id
+  session_affinity_enabled = true
+
+  restore_traffic_time_to_healed_or_new_endpoint_in_minutes = 10
+
+  health_probe {
+    interval_in_seconds = 240
+    path                = "/"
+    protocol            = "Https"
+    request_type        = "GET"
+  }
+
+  load_balancing {
+    additional_latency_in_milliseconds = 10
+    sample_size                        = 16
+    successful_samples_required        = 3
   }
 }
 `, template, data.RandomInteger)


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR fixes an issue when `health_probe` would reset when another piece of the resource updated. 

Before the fix
```
    testcase.go:173: Step 4/9 error: Check failed: Check 2/2 error: azurerm_cdn_frontdoor_origin_group.test: Attribute 'health_probe.0.interval_in_seconds' expected to be set
--- FAIL: TestAccCdnFrontDoorOriginGroup_updateHealthProbe (616.77s)
```

After the fix
```
--- PASS: TestAccCdnFrontDoorOriginGroup_updateHealthProbe (704.93s)
```

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #22131


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
