### PR TITLE
azurerm_databricks_workspace: databricks_workspace.force_delete feature

### DIFF
--- a/internal/features/defaults.go
+++ b/internal/features/defaults.go
@@ -83,8 +83,8 @@ func Default() UserFeatures {
 			DeleteBackupsOnBackupVaultDestroy: false,
 			PreventVolumeDestruction:          true,
 		},
-		Databricks: DatabricksFeatures{
-			WorkspaceDeleteUnityCatalogDataOnDestroy: false,
+		DatabricksWorkspace: DatabricksWorkspaceFeatures{
+			ForceDelete: false,
 		},
 	}
 }

--- a/internal/features/defaults.go
+++ b/internal/features/defaults.go
@@ -83,5 +83,8 @@ func Default() UserFeatures {
 			DeleteBackupsOnBackupVaultDestroy: false,
 			PreventVolumeDestruction:          true,
 		},
+		Databricks: DatabricksFeatures{
+			WorkspaceDeleteUnityCatalogDataOnDestroy: false,
+		},
 	}
 }

--- a/internal/features/user_flags.go
+++ b/internal/features/user_flags.go
@@ -22,6 +22,7 @@ type UserFeatures struct {
 	MachineLearning          MachineLearningFeatures
 	RecoveryService          RecoveryServiceFeatures
 	NetApp                   NetAppFeatures
+	Databricks               DatabricksFeatures
 }
 
 type CognitiveAccountFeatures struct {
@@ -115,4 +116,8 @@ type RecoveryServiceFeatures struct {
 type NetAppFeatures struct {
 	DeleteBackupsOnBackupVaultDestroy bool
 	PreventVolumeDestruction          bool
+}
+
+type DatabricksFeatures struct {
+	WorkspaceDeleteUnityCatalogDataOnDestroy bool
 }

--- a/internal/features/user_flags.go
+++ b/internal/features/user_flags.go
@@ -22,7 +22,7 @@ type UserFeatures struct {
 	MachineLearning          MachineLearningFeatures
 	RecoveryService          RecoveryServiceFeatures
 	NetApp                   NetAppFeatures
-	Databricks               DatabricksFeatures
+	DatabricksWorkspace      DatabricksWorkspaceFeatures
 }
 
 type CognitiveAccountFeatures struct {
@@ -118,6 +118,6 @@ type NetAppFeatures struct {
 	PreventVolumeDestruction          bool
 }
 
-type DatabricksFeatures struct {
-	WorkspaceDeleteUnityCatalogDataOnDestroy bool
+type DatabricksWorkspaceFeatures struct {
+	ForceDelete bool
 }

--- a/internal/provider/features.go
+++ b/internal/provider/features.go
@@ -424,7 +424,7 @@ func schemaFeatures(supportLegacyTestSuite bool) *pluginsdk.Schema {
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
 					"force_delete": {
-						Description: "When enabled, the managed resource group that contains the Unity Catalog data will be deleted when the workspace is destroyed.",
+						Description: "When enabled, the managed resource group that contains the Unity Catalog data will be forcibly deleted when the workspace is destroyed, regardless of contents.",
 						Type:        pluginsdk.TypeBool,
 						Optional:    true,
 						Default:     false,

--- a/internal/provider/features.go
+++ b/internal/provider/features.go
@@ -416,6 +416,22 @@ func schemaFeatures(supportLegacyTestSuite bool) *pluginsdk.Schema {
 				},
 			},
 		},
+
+		"databricks": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"workspace_delete_unity_catalog_data_on_destroy": {
+						Description: "When enabled, Unity Catalog data will be deleted when the workspace is destroyed.",
+						Type:        pluginsdk.TypeBool,
+						Optional:    true,
+						Default:     false,
+					},
+				},
+			},
+		},
 	}
 
 	// this is a temporary hack to enable us to gradually add provider blocks to test configurations
@@ -691,6 +707,16 @@ func expandFeatures(input []interface{}) features.UserFeatures {
 			}
 			if v, ok := netappRaw["prevent_volume_destruction"]; ok {
 				featuresMap.NetApp.PreventVolumeDestruction = v.(bool)
+			}
+		}
+	}
+
+	if raw, ok := val["databricks"]; ok {
+		items := raw.([]interface{})
+		if len(items) > 0 {
+			databricksRaw := items[0].(map[string]interface{})
+			if v, ok := databricksRaw["workspace_delete_unity_catalog_data_on_destroy"]; ok {
+				featuresMap.Databricks.WorkspaceDeleteUnityCatalogDataOnDestroy = v.(bool)
 			}
 		}
 	}

--- a/internal/provider/features.go
+++ b/internal/provider/features.go
@@ -417,14 +417,14 @@ func schemaFeatures(supportLegacyTestSuite bool) *pluginsdk.Schema {
 			},
 		},
 
-		"databricks": {
+		"databricks_workspace": {
 			Type:     pluginsdk.TypeList,
 			Optional: true,
 			MaxItems: 1,
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
-					"workspace_delete_unity_catalog_data_on_destroy": {
-						Description: "When enabled, Unity Catalog data will be deleted when the workspace is destroyed.",
+					"force_delete": {
+						Description: "When enabled, the managed resource group that contains the Unity Catalog data will be deleted when the workspace is destroyed.",
 						Type:        pluginsdk.TypeBool,
 						Optional:    true,
 						Default:     false,
@@ -711,12 +711,12 @@ func expandFeatures(input []interface{}) features.UserFeatures {
 		}
 	}
 
-	if raw, ok := val["databricks"]; ok {
+	if raw, ok := val["databricks_workspace"]; ok {
 		items := raw.([]interface{})
 		if len(items) > 0 {
 			databricksRaw := items[0].(map[string]interface{})
-			if v, ok := databricksRaw["workspace_delete_unity_catalog_data_on_destroy"]; ok {
-				featuresMap.Databricks.WorkspaceDeleteUnityCatalogDataOnDestroy = v.(bool)
+			if v, ok := databricksRaw["force_delete"]; ok {
+				featuresMap.DatabricksWorkspace.ForceDelete = v.(bool)
 			}
 		}
 	}

--- a/internal/provider/features_test.go
+++ b/internal/provider/features_test.go
@@ -96,8 +96,8 @@ func TestExpandFeatures(t *testing.T) {
 					DeleteBackupsOnBackupVaultDestroy: false,
 					PreventVolumeDestruction:          true,
 				},
-				Databricks: features.DatabricksFeatures{
-					WorkspaceDeleteUnityCatalogDataOnDestroy: false,
+				DatabricksWorkspace: features.DatabricksWorkspaceFeatures{
+					ForceDelete: false,
 				},
 			},
 		},
@@ -216,9 +216,9 @@ func TestExpandFeatures(t *testing.T) {
 							"prevent_volume_destruction":             true,
 						},
 					},
-					"databricks": []interface{}{
+					"databricks_workspace": []interface{}{
 						map[string]interface{}{
-							"workspace_delete_unity_catalog_data_on_destroy": true,
+							"force_delete": true,
 						},
 					},
 				},
@@ -299,8 +299,8 @@ func TestExpandFeatures(t *testing.T) {
 					DeleteBackupsOnBackupVaultDestroy: true,
 					PreventVolumeDestruction:          true,
 				},
-				Databricks: features.DatabricksFeatures{
-					WorkspaceDeleteUnityCatalogDataOnDestroy: true,
+				DatabricksWorkspace: features.DatabricksWorkspaceFeatures{
+					ForceDelete: true,
 				},
 			},
 		},
@@ -419,9 +419,9 @@ func TestExpandFeatures(t *testing.T) {
 							"prevent_volume_destruction":             false,
 						},
 					},
-					"databricks": []interface{}{
+					"databricks_workspace": []interface{}{
 						map[string]interface{}{
-							"workspace_delete_unity_catalog_data_on_destroy": false,
+							"force_delete": false,
 						},
 					},
 				},
@@ -502,8 +502,8 @@ func TestExpandFeatures(t *testing.T) {
 					DeleteBackupsOnBackupVaultDestroy: false,
 					PreventVolumeDestruction:          false,
 				},
-				Databricks: features.DatabricksFeatures{
-					WorkspaceDeleteUnityCatalogDataOnDestroy: false,
+				DatabricksWorkspace: features.DatabricksWorkspaceFeatures{
+					ForceDelete: false,
 				},
 			},
 		},
@@ -1888,7 +1888,7 @@ func TestExpandFeaturesNetApp(t *testing.T) {
 	}
 }
 
-func TestExpandFeaturesDatabricks(t *testing.T) {
+func TestExpandFeaturesDatabricksWorkspace(t *testing.T) {
 	testData := []struct {
 		Name     string
 		Input    []interface{}
@@ -1899,46 +1899,46 @@ func TestExpandFeaturesDatabricks(t *testing.T) {
 			Name: "Empty Block",
 			Input: []interface{}{
 				map[string]interface{}{
-					"databricks": []interface{}{},
+					"databricks_workspace": []interface{}{},
 				},
 			},
 			Expected: features.UserFeatures{
-				Databricks: features.DatabricksFeatures{
-					WorkspaceDeleteUnityCatalogDataOnDestroy: false,
+				DatabricksWorkspace: features.DatabricksWorkspaceFeatures{
+					ForceDelete: false,
 				},
 			},
 		},
 		{
-			Name: "Databricks Features Enabled",
+			Name: "Databricks Workspace Features Enabled",
 			Input: []interface{}{
 				map[string]interface{}{
-					"databricks": []interface{}{
+					"databricks_workspace": []interface{}{
 						map[string]interface{}{
-							"workspace_delete_unity_catalog_data_on_destroy": true,
+							"force_delete": true,
 						},
 					},
 				},
 			},
 			Expected: features.UserFeatures{
-				Databricks: features.DatabricksFeatures{
-					WorkspaceDeleteUnityCatalogDataOnDestroy: true,
+				DatabricksWorkspace: features.DatabricksWorkspaceFeatures{
+					ForceDelete: true,
 				},
 			},
 		},
 		{
-			Name: "Databricks Features Disabled",
+			Name: "Databricks Workspace Features Disabled",
 			Input: []interface{}{
 				map[string]interface{}{
-					"databricks": []interface{}{
+					"databricks_workspace": []interface{}{
 						map[string]interface{}{
-							"workspace_delete_unity_catalog_data_on_destroy": false,
+							"force_delete": false,
 						},
 					},
 				},
 			},
 			Expected: features.UserFeatures{
-				Databricks: features.DatabricksFeatures{
-					WorkspaceDeleteUnityCatalogDataOnDestroy: false,
+				DatabricksWorkspace: features.DatabricksWorkspaceFeatures{
+					ForceDelete: false,
 				},
 			},
 		},
@@ -1947,8 +1947,8 @@ func TestExpandFeaturesDatabricks(t *testing.T) {
 	for _, testCase := range testData {
 		t.Logf("[DEBUG] Test Case: %q", testCase.Name)
 		result := expandFeatures(testCase.Input)
-		if !reflect.DeepEqual(result.Databricks, testCase.Expected.Databricks) {
-			t.Fatalf("Expected %+v but got %+v", result.Databricks, testCase.Expected.Databricks)
+		if !reflect.DeepEqual(result.DatabricksWorkspace, testCase.Expected.DatabricksWorkspace) {
+			t.Fatalf("Expected %+v but got %+v", result.DatabricksWorkspace, testCase.Expected.DatabricksWorkspace)
 		}
 	}
 }

--- a/internal/provider/features_test.go
+++ b/internal/provider/features_test.go
@@ -96,6 +96,9 @@ func TestExpandFeatures(t *testing.T) {
 					DeleteBackupsOnBackupVaultDestroy: false,
 					PreventVolumeDestruction:          true,
 				},
+				Databricks: features.DatabricksFeatures{
+					WorkspaceDeleteUnityCatalogDataOnDestroy: false,
+				},
 			},
 		},
 		{
@@ -213,6 +216,11 @@ func TestExpandFeatures(t *testing.T) {
 							"prevent_volume_destruction":             true,
 						},
 					},
+					"databricks": []interface{}{
+						map[string]interface{}{
+							"workspace_delete_unity_catalog_data_on_destroy": true,
+						},
+					},
 				},
 			},
 			Expected: features.UserFeatures{
@@ -290,6 +298,9 @@ func TestExpandFeatures(t *testing.T) {
 				NetApp: features.NetAppFeatures{
 					DeleteBackupsOnBackupVaultDestroy: true,
 					PreventVolumeDestruction:          true,
+				},
+				Databricks: features.DatabricksFeatures{
+					WorkspaceDeleteUnityCatalogDataOnDestroy: true,
 				},
 			},
 		},
@@ -408,6 +419,11 @@ func TestExpandFeatures(t *testing.T) {
 							"prevent_volume_destruction":             false,
 						},
 					},
+					"databricks": []interface{}{
+						map[string]interface{}{
+							"workspace_delete_unity_catalog_data_on_destroy": false,
+						},
+					},
 				},
 			},
 			Expected: features.UserFeatures{
@@ -485,6 +501,9 @@ func TestExpandFeatures(t *testing.T) {
 				NetApp: features.NetAppFeatures{
 					DeleteBackupsOnBackupVaultDestroy: false,
 					PreventVolumeDestruction:          false,
+				},
+				Databricks: features.DatabricksFeatures{
+					WorkspaceDeleteUnityCatalogDataOnDestroy: false,
 				},
 			},
 		},
@@ -1865,6 +1884,71 @@ func TestExpandFeaturesNetApp(t *testing.T) {
 		result := expandFeatures(testCase.Input)
 		if !reflect.DeepEqual(result.Subscription, testCase.Expected.Subscription) {
 			t.Fatalf("Expected %+v but got %+v", result.Subscription, testCase.Expected.Subscription)
+		}
+	}
+}
+
+func TestExpandFeaturesDatabricks(t *testing.T) {
+	testData := []struct {
+		Name     string
+		Input    []interface{}
+		EnvVars  map[string]interface{}
+		Expected features.UserFeatures
+	}{
+		{
+			Name: "Empty Block",
+			Input: []interface{}{
+				map[string]interface{}{
+					"databricks": []interface{}{},
+				},
+			},
+			Expected: features.UserFeatures{
+				Databricks: features.DatabricksFeatures{
+					WorkspaceDeleteUnityCatalogDataOnDestroy: false,
+				},
+			},
+		},
+		{
+			Name: "Databricks Features Enabled",
+			Input: []interface{}{
+				map[string]interface{}{
+					"databricks": []interface{}{
+						map[string]interface{}{
+							"workspace_delete_unity_catalog_data_on_destroy": true,
+						},
+					},
+				},
+			},
+			Expected: features.UserFeatures{
+				Databricks: features.DatabricksFeatures{
+					WorkspaceDeleteUnityCatalogDataOnDestroy: true,
+				},
+			},
+		},
+		{
+			Name: "Databricks Features Disabled",
+			Input: []interface{}{
+				map[string]interface{}{
+					"databricks": []interface{}{
+						map[string]interface{}{
+							"workspace_delete_unity_catalog_data_on_destroy": false,
+						},
+					},
+				},
+			},
+			Expected: features.UserFeatures{
+				Databricks: features.DatabricksFeatures{
+					WorkspaceDeleteUnityCatalogDataOnDestroy: false,
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testData {
+		t.Logf("[DEBUG] Test Case: %q", testCase.Name)
+		result := expandFeatures(testCase.Input)
+		if !reflect.DeepEqual(result.Databricks, testCase.Expected.Databricks) {
+			t.Fatalf("Expected %+v but got %+v", result.Databricks, testCase.Expected.Databricks)
 		}
 	}
 }

--- a/internal/provider/framework/config.go
+++ b/internal/provider/framework/config.go
@@ -509,20 +509,20 @@ func (p *ProviderConfig) Load(ctx context.Context, data *ProviderModel, tfVersio
 			f.NetApp.PreventVolumeDestruction = true
 		}
 
-		if !features.Databricks.IsNull() && !features.Databricks.IsUnknown() {
-			var feature []Databricks
-			d := features.Databricks.ElementsAs(ctx, &feature, true)
+		if !features.DatabricksWorkspace.IsNull() && !features.DatabricksWorkspace.IsUnknown() {
+			var feature []DatabricksWorkspace
+			d := features.DatabricksWorkspace.ElementsAs(ctx, &feature, true)
 			diags.Append(d...)
 			if diags.HasError() {
 				return
 			}
 
-			f.Databricks.WorkspaceDeleteUnityCatalogDataOnDestroy = false
-			if !feature[0].WorkspaceDeleteUnityCatalogDataOnDestroy.IsNull() && !feature[0].WorkspaceDeleteUnityCatalogDataOnDestroy.IsUnknown() {
-				f.Databricks.WorkspaceDeleteUnityCatalogDataOnDestroy = feature[0].WorkspaceDeleteUnityCatalogDataOnDestroy.ValueBool()
+			f.DatabricksWorkspace.ForceDelete = false
+			if !feature[0].ForceDelete.IsNull() && !feature[0].ForceDelete.IsUnknown() {
+				f.DatabricksWorkspace.ForceDelete = feature[0].ForceDelete.ValueBool()
 			}
 		} else {
-			f.Databricks.WorkspaceDeleteUnityCatalogDataOnDestroy = false
+			f.DatabricksWorkspace.ForceDelete = false
 		}
 	}
 

--- a/internal/provider/framework/config.go
+++ b/internal/provider/framework/config.go
@@ -508,6 +508,22 @@ func (p *ProviderConfig) Load(ctx context.Context, data *ProviderModel, tfVersio
 			f.NetApp.DeleteBackupsOnBackupVaultDestroy = false
 			f.NetApp.PreventVolumeDestruction = true
 		}
+
+		if !features.Databricks.IsNull() && !features.Databricks.IsUnknown() {
+			var feature []Databricks
+			d := features.Databricks.ElementsAs(ctx, &feature, true)
+			diags.Append(d...)
+			if diags.HasError() {
+				return
+			}
+
+			f.Databricks.WorkspaceDeleteUnityCatalogDataOnDestroy = false
+			if !feature[0].WorkspaceDeleteUnityCatalogDataOnDestroy.IsNull() && !feature[0].WorkspaceDeleteUnityCatalogDataOnDestroy.IsUnknown() {
+				f.Databricks.WorkspaceDeleteUnityCatalogDataOnDestroy = feature[0].WorkspaceDeleteUnityCatalogDataOnDestroy.ValueBool()
+			}
+		} else {
+			f.Databricks.WorkspaceDeleteUnityCatalogDataOnDestroy = false
+		}
 	}
 
 	p.clientBuilder.Features = f

--- a/internal/provider/framework/config_test.go
+++ b/internal/provider/framework/config_test.go
@@ -214,6 +214,10 @@ func TestProviderConfig_LoadDefault(t *testing.T) {
 	if !features.NetApp.PreventVolumeDestruction {
 		t.Errorf("expected netapp.PreventVolumeDestruction to be true")
 	}
+
+	if !features.Databricks.WorkspaceDeleteUnityCatalogDataOnDestroy {
+		t.Errorf("expected databricks.WorkspaceDeleteUnityCatalogDataOnDestroy to be true")
+	}
 }
 
 // TODO - helper functions to make setting up test date more easily so we can add more configuration coverage
@@ -329,6 +333,11 @@ func defaultFeaturesList() types.List {
 	})
 	netappList, _ := basetypes.NewListValue(types.ObjectType{}.WithAttributeTypes(NetAppAttributes), []attr.Value{netapp})
 
+	databricks, _ := basetypes.NewObjectValueFrom(context.Background(), DatabricksAttributes, map[string]attr.Value{
+		"purge_soft_delete_on_destroy": basetypes.NewBoolNull(),
+	})
+	databricksList, _ := basetypes.NewListValue(types.ObjectType{}.WithAttributeTypes(DatabricksAttributes), []attr.Value{databricks})
+
 	fData, d := basetypes.NewObjectValue(FeaturesAttributes, map[string]attr.Value{
 		"api_management":             apiManagementList,
 		"app_configuration":          appConfigurationList,
@@ -348,6 +357,7 @@ func defaultFeaturesList() types.List {
 		"recovery_service":           recoveryServicesList,
 		"recovery_services_vaults":   recoveryServicesVaultsList,
 		"netapp":                     netappList,
+		"databricks":                 databricksList,
 	})
 
 	fmt.Printf("%+v", d)

--- a/internal/provider/framework/config_test.go
+++ b/internal/provider/framework/config_test.go
@@ -215,8 +215,8 @@ func TestProviderConfig_LoadDefault(t *testing.T) {
 		t.Errorf("expected netapp.PreventVolumeDestruction to be true")
 	}
 
-	if !features.DatabricksWorkspace.ForceDelete {
-		t.Errorf("expected databricks_workspace.ForceDelete to be true")
+	if features.DatabricksWorkspace.ForceDelete {
+		t.Errorf("expected databricks_workspace.ForceDelete to be false")
 	}
 }
 

--- a/internal/provider/framework/config_test.go
+++ b/internal/provider/framework/config_test.go
@@ -334,7 +334,7 @@ func defaultFeaturesList() types.List {
 	netappList, _ := basetypes.NewListValue(types.ObjectType{}.WithAttributeTypes(NetAppAttributes), []attr.Value{netapp})
 
 	databricks, _ := basetypes.NewObjectValueFrom(context.Background(), DatabricksAttributes, map[string]attr.Value{
-		"purge_soft_delete_on_destroy": basetypes.NewBoolNull(),
+		"workspace_delete_unity_catalog_data_on_destroy": basetypes.NewBoolNull(),
 	})
 	databricksList, _ := basetypes.NewListValue(types.ObjectType{}.WithAttributeTypes(DatabricksAttributes), []attr.Value{databricks})
 

--- a/internal/provider/framework/config_test.go
+++ b/internal/provider/framework/config_test.go
@@ -215,8 +215,8 @@ func TestProviderConfig_LoadDefault(t *testing.T) {
 		t.Errorf("expected netapp.PreventVolumeDestruction to be true")
 	}
 
-	if !features.Databricks.WorkspaceDeleteUnityCatalogDataOnDestroy {
-		t.Errorf("expected databricks.WorkspaceDeleteUnityCatalogDataOnDestroy to be true")
+	if !features.DatabricksWorkspace.ForceDelete {
+		t.Errorf("expected databricks_workspace.ForceDelete to be true")
 	}
 }
 
@@ -333,10 +333,10 @@ func defaultFeaturesList() types.List {
 	})
 	netappList, _ := basetypes.NewListValue(types.ObjectType{}.WithAttributeTypes(NetAppAttributes), []attr.Value{netapp})
 
-	databricks, _ := basetypes.NewObjectValueFrom(context.Background(), DatabricksAttributes, map[string]attr.Value{
-		"workspace_delete_unity_catalog_data_on_destroy": basetypes.NewBoolNull(),
+	databricksWorkspace, _ := basetypes.NewObjectValueFrom(context.Background(), DatabricksWorkspaceAttributes, map[string]attr.Value{
+		"force_delete": basetypes.NewBoolNull(),
 	})
-	databricksList, _ := basetypes.NewListValue(types.ObjectType{}.WithAttributeTypes(DatabricksAttributes), []attr.Value{databricks})
+	databricksWorkspaceList, _ := basetypes.NewListValue(types.ObjectType{}.WithAttributeTypes(DatabricksWorkspaceAttributes), []attr.Value{databricksWorkspace})
 
 	fData, d := basetypes.NewObjectValue(FeaturesAttributes, map[string]attr.Value{
 		"api_management":             apiManagementList,
@@ -357,7 +357,7 @@ func defaultFeaturesList() types.List {
 		"recovery_service":           recoveryServicesList,
 		"recovery_services_vaults":   recoveryServicesVaultsList,
 		"netapp":                     netappList,
-		"databricks":                 databricksList,
+		"databricks_workspace":       databricksWorkspaceList,
 	})
 
 	fmt.Printf("%+v", d)

--- a/internal/provider/framework/model.go
+++ b/internal/provider/framework/model.go
@@ -60,6 +60,7 @@ type Features struct {
 	RecoveryService          types.List `tfsdk:"recovery_service"`
 	RecoveryServicesVaults   types.List `tfsdk:"recovery_services_vaults"`
 	NetApp                   types.List `tfsdk:"netapp"`
+	Databricks               types.List `tfsdk:"databricks"`
 }
 
 // FeaturesAttributes and the other block attribute vars are required for unit testing on the Load func
@@ -83,6 +84,7 @@ var FeaturesAttributes = map[string]attr.Type{
 	"recovery_service":           types.ListType{}.WithElementType(types.ObjectType{}.WithAttributeTypes(RecoveryServiceAttributes)),
 	"recovery_services_vaults":   types.ListType{}.WithElementType(types.ObjectType{}.WithAttributeTypes(RecoveryServiceVaultsAttributes)),
 	"netapp":                     types.ListType{}.WithElementType(types.ObjectType{}.WithAttributeTypes(NetAppAttributes)),
+	"databricks":                 types.ListType{}.WithElementType(types.ObjectType{}.WithAttributeTypes(DatabricksAttributes)),
 }
 
 type APIManagement struct {
@@ -269,4 +271,12 @@ type NetApp struct {
 var NetAppAttributes = map[string]attr.Type{
 	"delete_backups_on_backup_vault_destroy": types.BoolType,
 	"prevent_volume_destruction":             types.BoolType,
+}
+
+type Databricks struct {
+	WorkspaceDeleteUnityCatalogDataOnDestroy types.Bool `tfsdk:"workspace_delete_unity_catalog_data_on_destroy"`
+}
+
+var DatabricksAttributes = map[string]attr.Type{
+	"workspace_delete_unity_catalog_data_on_destroy": types.BoolType,
 }

--- a/internal/provider/framework/model.go
+++ b/internal/provider/framework/model.go
@@ -60,7 +60,7 @@ type Features struct {
 	RecoveryService          types.List `tfsdk:"recovery_service"`
 	RecoveryServicesVaults   types.List `tfsdk:"recovery_services_vaults"`
 	NetApp                   types.List `tfsdk:"netapp"`
-	Databricks               types.List `tfsdk:"databricks"`
+	DatabricksWorkspace      types.List `tfsdk:"databricks_workspace"`
 }
 
 // FeaturesAttributes and the other block attribute vars are required for unit testing on the Load func
@@ -84,7 +84,7 @@ var FeaturesAttributes = map[string]attr.Type{
 	"recovery_service":           types.ListType{}.WithElementType(types.ObjectType{}.WithAttributeTypes(RecoveryServiceAttributes)),
 	"recovery_services_vaults":   types.ListType{}.WithElementType(types.ObjectType{}.WithAttributeTypes(RecoveryServiceVaultsAttributes)),
 	"netapp":                     types.ListType{}.WithElementType(types.ObjectType{}.WithAttributeTypes(NetAppAttributes)),
-	"databricks":                 types.ListType{}.WithElementType(types.ObjectType{}.WithAttributeTypes(DatabricksAttributes)),
+	"databricks_workspace":       types.ListType{}.WithElementType(types.ObjectType{}.WithAttributeTypes(DatabricksWorkspaceAttributes)),
 }
 
 type APIManagement struct {
@@ -273,10 +273,10 @@ var NetAppAttributes = map[string]attr.Type{
 	"prevent_volume_destruction":             types.BoolType,
 }
 
-type Databricks struct {
-	WorkspaceDeleteUnityCatalogDataOnDestroy types.Bool `tfsdk:"workspace_delete_unity_catalog_data_on_destroy"`
+type DatabricksWorkspace struct {
+	ForceDelete types.Bool `tfsdk:"force_delete"`
 }
 
-var DatabricksAttributes = map[string]attr.Type{
-	"workspace_delete_unity_catalog_data_on_destroy": types.BoolType,
+var DatabricksWorkspaceAttributes = map[string]attr.Type{
+	"force_delete": types.BoolType,
 }

--- a/internal/provider/framework/provider.go
+++ b/internal/provider/framework/provider.go
@@ -496,7 +496,7 @@ func (p *azureRmFrameworkProvider) Schema(_ context.Context, _ provider.SchemaRe
 								Attributes: map[string]schema.Attribute{
 									"force_delete": schema.BoolAttribute{
 										Optional:    true,
-										Description: "When enabled, the managed resource group that contains the Unity Catalog data will be deleted when the workspace is destroyed.",
+										Description: "When enabled, the managed resource group that contains the Unity Catalog data will be forcibly deleted when the workspace is destroyed, regardless of contents.",
 									},
 								},
 							},

--- a/internal/provider/framework/provider.go
+++ b/internal/provider/framework/provider.go
@@ -491,6 +491,16 @@ func (p *azureRmFrameworkProvider) Schema(_ context.Context, _ provider.SchemaRe
 								},
 							},
 						},
+						"databricks": schema.ListNestedBlock{
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"workspace_delete_unity_catalog_data_on_destroy": schema.BoolAttribute{
+										Optional:    true,
+										Description: "When enabled, Unity Catalog data will be deleted when the workspace is destroyed.",
+									},
+								},
+							},
+						},
 					},
 				},
 			},

--- a/internal/provider/framework/provider.go
+++ b/internal/provider/framework/provider.go
@@ -491,12 +491,12 @@ func (p *azureRmFrameworkProvider) Schema(_ context.Context, _ provider.SchemaRe
 								},
 							},
 						},
-						"databricks": schema.ListNestedBlock{
+						"databricks_workspace": schema.ListNestedBlock{
 							NestedObject: schema.NestedBlockObject{
 								Attributes: map[string]schema.Attribute{
-									"workspace_delete_unity_catalog_data_on_destroy": schema.BoolAttribute{
+									"force_delete": schema.BoolAttribute{
 										Optional:    true,
-										Description: "When enabled, Unity Catalog data will be deleted when the workspace is destroyed.",
+										Description: "When enabled, the managed resource group that contains the Unity Catalog data will be deleted when the workspace is destroyed.",
 									},
 								},
 							},

--- a/internal/services/databricks/databricks_workspace_resource.go
+++ b/internal/services/databricks/databricks_workspace_resource.go
@@ -924,7 +924,7 @@ func resourceDatabricksWorkspaceDelete(d *pluginsdk.ResourceData, meta interface
 		return err
 	}
 
-	deleteOperationOptions := workspaces.DeleteOperationOptions{}
+	deleteOperationOptions := workspaces.DefaultDeleteOperationOptions()
 	if meta.(*clients.Client).Features.DatabricksWorkspace.ForceDelete {
 		deleteOperationOptions.ForceDeletion = pointer.To(true)
 	}

--- a/internal/services/databricks/databricks_workspace_resource.go
+++ b/internal/services/databricks/databricks_workspace_resource.go
@@ -924,7 +924,12 @@ func resourceDatabricksWorkspaceDelete(d *pluginsdk.ResourceData, meta interface
 		return err
 	}
 
-	if err = client.DeleteThenPoll(ctx, *id, workspaces.DeleteOperationOptions{}); err != nil {
+	deleteOperationOptions := workspaces.DeleteOperationOptions{}
+	if meta.(*clients.Client).Features.Databricks.WorkspaceDeleteUnityCatalogDataOnDestroy {
+		deleteOperationOptions.ForceDeletion = pointer.To(true)
+	}
+
+	if err = client.DeleteThenPoll(ctx, *id, deleteOperationOptions); err != nil {
 		return fmt.Errorf("deleting %s: %+v", *id, err)
 	}
 

--- a/internal/services/databricks/databricks_workspace_resource.go
+++ b/internal/services/databricks/databricks_workspace_resource.go
@@ -925,7 +925,7 @@ func resourceDatabricksWorkspaceDelete(d *pluginsdk.ResourceData, meta interface
 	}
 
 	deleteOperationOptions := workspaces.DeleteOperationOptions{}
-	if meta.(*clients.Client).Features.Databricks.WorkspaceDeleteUnityCatalogDataOnDestroy {
+	if meta.(*clients.Client).Features.DatabricksWorkspace.ForceDelete {
 		deleteOperationOptions.ForceDeletion = pointer.To(true)
 	}
 

--- a/internal/services/databricks/databricks_workspace_resource_test.go
+++ b/internal/services/databricks/databricks_workspace_resource_test.go
@@ -515,13 +515,13 @@ func TestAccDatabricksWorkspace_enhancedComplianceSecurityWithInvalidComplianceS
 	})
 }
 
-func TestAccDatabricksWorkspace_withWorkspaceDeleteUnityCatalogDataOnDestroyFeatureSetToTrue(t *testing.T) {
+func TestAccDatabricksWorkspace_withForceDeleteSetToTrue(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_databricks_workspace", "test")
 	r := DatabricksWorkspaceResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.workspaceForceDeletionOnDestroy(data, true),
+			Config: r.workspaceForceDelete(data, true),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -529,13 +529,13 @@ func TestAccDatabricksWorkspace_withWorkspaceDeleteUnityCatalogDataOnDestroyFeat
 	})
 }
 
-func TestAccDatabricksWorkspace_withWorkspaceDeleteUnityCatalogDataOnDestroyFeatureSetToFalse(t *testing.T) {
+func TestAccDatabricksWorkspace_withForceDeleteSetToFalse(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_databricks_workspace", "test")
 	r := DatabricksWorkspaceResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.workspaceForceDeletionOnDestroy(data, false),
+			Config: r.workspaceForceDelete(data, false),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -3130,12 +3130,12 @@ resource "azurerm_databricks_workspace" "test" {
   `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, sku, automaticClusterUpdateEnabled, complianceSecurityProfileEnabled, complianceSecurityProfileStandardsStr, enhancedSecurityMonitoringEnabled)
 }
 
-func (DatabricksWorkspaceResource) workspaceForceDeletionOnDestroy(data acceptance.TestData, workspaceForceDeletionOnDestroyFeature bool) string {
+func (DatabricksWorkspaceResource) workspaceForceDelete(data acceptance.TestData, forceDelete bool) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {
-    databricks {
-      workspace_delete_unity_catalog_data_on_destroy = %t
+    databricks_workspace {
+      force_delete = %t
     }
   }
 }
@@ -3151,5 +3151,5 @@ resource "azurerm_databricks_workspace" "test" {
   location            = azurerm_resource_group.test.location
   sku                 = "premium"
 }
-  `, workspaceForceDeletionOnDestroyFeature, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+  `, forceDelete, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/databricks/databricks_workspace_resource_test.go
+++ b/internal/services/databricks/databricks_workspace_resource_test.go
@@ -515,6 +515,12 @@ func TestAccDatabricksWorkspace_enhancedComplianceSecurityWithInvalidComplianceS
 	})
 }
 
+// TODO: the ideal test would be:
+// 1. Create workspace
+// 2. Issue SELECT CURRENT_METASTORE(); SQL to populate Unity Catalog
+// 3. Destroy workspace
+// 4. Assert no dangling resource
+// But currently this is not feasible because step 2 require Databricks API call which involves token setup via UI console
 func TestAccDatabricksWorkspace_withForceDeleteSetToTrue(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_databricks_workspace", "test")
 	r := DatabricksWorkspaceResource{}

--- a/internal/services/databricks/databricks_workspace_resource_test.go
+++ b/internal/services/databricks/databricks_workspace_resource_test.go
@@ -515,12 +515,23 @@ func TestAccDatabricksWorkspace_enhancedComplianceSecurityWithInvalidComplianceS
 	})
 }
 
-// TODO: the ideal test would be:
+// TODO: this test does not yet cover the entire flow. Ideally the test should be:
+//
 // 1. Create workspace
-// 2. Issue SELECT CURRENT_METASTORE(); SQL to populate Unity Catalog
-// 3. Destroy workspace
-// 4. Assert no dangling resource
-// But currently this is not feasible because step 2 require Databricks API call which involves token setup via UI console
+// 2. Destroy workspace with force delete set to true
+// 3. Check managed resource group is deleted
+//
+// # Not sure yet how to do step 3 as there is no PostDestroy hook in acceptance.TestStep
+//
+// There are certain condition that automatically enables Unity Catalog assignment for newly created workspaces.
+// The "isUcEnabled" prop can be used to determine if workspace has Unity Catalog enabled.
+// See MS doc: https://learn.microsoft.com/en-us/azure/databricks/data-governance/unity-catalog/enable-workspaces
+//
+// The expected behaviour of force deletion with regards to isUcEnabled is as follows:
+//
+// 1. If isUcEnabled is true, forceDeletion set to true, the managed resource group (MRG) will be deleted upon workspace deletion.
+// 2. If isUcEnabled is true, forceDeletion set to false (default), MRG will be left intact.
+// 3. If isUcEnabled is false, MRG will be deleted irrespective of forceDeletion setting.
 func TestAccDatabricksWorkspace_withForceDeleteSetToTrue(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_databricks_workspace", "test")
 	r := DatabricksWorkspaceResource{}

--- a/website/docs/guides/features-block.html.markdown
+++ b/website/docs/guides/features-block.html.markdown
@@ -181,7 +181,7 @@ The `cognitive_account` block supports the following:
 
 The `databricks_workspace` block supports the following:
 
-* `force_delete` - (Optional) Should the managed resource group that contains the Unity Catalog data be deleted when the `azurerm_databricks_workspace` is destroyed? Defaults to `false`.
+* `force_delete` - (Optional) Should the managed resource group that contains the Unity Catalog data be forcibly deleted when the `azurerm_databricks_workspace` is destroyed? Defaults to `false`.
 
 ---
 

--- a/website/docs/guides/features-block.html.markdown
+++ b/website/docs/guides/features-block.html.markdown
@@ -45,8 +45,8 @@ provider "azurerm" {
       purge_soft_delete_on_destroy = true
     }
 
-    databricks {
-      workspace_delete_unity_catalog_data_on_destroy = false
+    databricks_workspace {
+      force_delete = false
     }
 
     key_vault {
@@ -125,7 +125,7 @@ The `features` block supports the following:
 
 * `cognitive_account` - (Optional) A `cognitive_account` block as defined below.
 
-* `databricks` - (Optional) A `databricks` block as defined below.
+* `databricks_workspace` - (Optional) A `databricks_workspace` block as defined below.
 
 * `key_vault` - (Optional) A `key_vault` block as defined below.
 
@@ -179,9 +179,9 @@ The `cognitive_account` block supports the following:
 
 ---
 
-The `databricks` block supports the following:
+The `databricks_workspace` block supports the following:
 
-* `workspace_delete_unity_catalog_data_on_destroy` - (Optional) Should the Unity Catalog data be deleted when the `azurerm_databricks_workspace` is destroyed? Defaults to `false`.
+* `force_delete` - (Optional) Should the managed resource group that contains the Unity Catalog data be deleted when the `azurerm_databricks_workspace` is destroyed? Defaults to `false`.
 
 ---
 

--- a/website/docs/guides/features-block.html.markdown
+++ b/website/docs/guides/features-block.html.markdown
@@ -45,6 +45,10 @@ provider "azurerm" {
       purge_soft_delete_on_destroy = true
     }
 
+    databricks {
+      workspace_delete_unity_catalog_data_on_destroy = false
+    }
+
     key_vault {
       purge_soft_delete_on_destroy    = true
       recover_soft_deleted_key_vaults = true
@@ -121,6 +125,8 @@ The `features` block supports the following:
 
 * `cognitive_account` - (Optional) A `cognitive_account` block as defined below.
 
+* `databricks` - (Optional) A `databricks` block as defined below.
+
 * `key_vault` - (Optional) A `key_vault` block as defined below.
 
 * `log_analytics_workspace` - (Optional) A `log_analytics_workspace` block as defined below.
@@ -170,6 +176,12 @@ The `application_insights` block supports the following:
 The `cognitive_account` block supports the following:
 
 * `purge_soft_delete_on_destroy` - (Optional) Should the `azurerm_cognitive_account` resources be permanently deleted (e.g. purged) when destroyed? Defaults to `true`.
+
+---
+
+The `databricks` block supports the following:
+
+* `workspace_delete_unity_catalog_data_on_destroy` - (Optional) Should the Unity Catalog data be deleted when the `azurerm_databricks_workspace` is destroyed? Defaults to `false`.
 
 ---
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Fixes #28959 where Unity Catalog data associated to a Databricks workspace isn't deleted when the workspace is destroyed. The behavior is shielded behind a new feature `databricks_workspace.force_delete`.

Steps to reproduce the bug:
1. Deploy a Databricks workspace via Terraform
2. Launch the workspace, execute the SQL `SELECT CURRENT_METASTORE();`, this will populate some Unity Catalog data
3. Do a Terraform destroy

- Expected: All resources related to the workspace are deleted
- Actual: The managed resource group is left behind and has to be manually deleted via portal

With this PR, user can supply `workspace_delete_unity_catalog_data_on_destroy` feature to delete all associated Unity Catalog data when the workspace is destroyed:

```
provider "azurerm" {
  features {
    databricks_workspace {
      force_delete = true
    }
  }
}
```

The default value if not provided is `false` to avoid breaking change.

MS Learn doc about this behaviour: https://learn.microsoft.com/en-us/azure/databricks/admin/account-settings/account?WT.mc_id=Portal-Microsoft_Azure_Databricks#delete-an-azure-databricks-service

The ARM REST API for workspace delete: https://learn.microsoft.com/en-us/rest/api/databricks/workspaces/delete?view=rest-databricks-2024-05-01&tabs=HTTP

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [] ~~(For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.~~


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

Acc test log: [link](https://microsoftapc-my.sharepoint.com/:u:/g/personal/tangerry_microsoft_com/ETHMwvjnNT1HrHqjc-u_4a4BxeWuHDtdXbtkJHP7BMEzCA?e=MeBXkQ) (restricted, DM me for access)

The following acctests failure are pre-existing in main branch:

```
» grep -e '--- FAIL' acctests_TestAccDatabricksWorkspace_2025-03-18T1229+1100.log
--- FAIL: TestAccDatabricksWorkspace_loadBalancerSecureClusterConnectivity (553.04s)
--- FAIL: TestAccDatabricksWorkspace_managedServicesRootDbfsCMKAndPrivateLink (1112.96s)
--- FAIL: TestAccDatabricksWorkspace_machineLearning (1342.51s)
--- FAIL: TestAccDatabricksWorkspace_managedServicesAndRootDbfsCMK (1652.30s)
--- FAIL: TestAccDatabricksWorkspace_managedServices (1650.91s)
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_databricks_workspace` - Added `workspace_delete_unity_catalog_data_on_destroy` feature [GH-28959]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #28959 


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
