### PR TITLE
`azurerm_data_factory_linked_service_sftp` - separate create and update methods

### DIFF
--- a/internal/services/datafactory/data_factory_linked_service_sftp_resource.go
+++ b/internal/services/datafactory/data_factory_linked_service_sftp_resource.go
@@ -370,7 +370,7 @@ func resourceDataFactoryLinkedServiceSFTPUpdate(d *pluginsdk.ResourceData, meta 
 		return fmt.Errorf("updating %s: %+v", id, err)
 	}
 
-	return nil
+	return resourceDataFactoryLinkedServiceSFTPRead(d, meta)
 }
 
 func resourceDataFactoryLinkedServiceSFTPDelete(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/datafactory/data_factory_linked_service_sftp_resource.go
+++ b/internal/services/datafactory/data_factory_linked_service_sftp_resource.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/datafactory/2018-06-01/factories"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -21,9 +22,9 @@ import (
 
 func resourceDataFactoryLinkedServiceSFTP() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
-		Create: resourceDataFactoryLinkedServiceSFTPCreateUpdate,
+		Create: resourceDataFactoryLinkedServiceSFTPCreate,
 		Read:   resourceDataFactoryLinkedServiceSFTPRead,
-		Update: resourceDataFactoryLinkedServiceSFTPCreateUpdate,
+		Update: resourceDataFactoryLinkedServiceSFTPUpdate,
 		Delete: resourceDataFactoryLinkedServiceSFTPDelete,
 
 		Importer: pluginsdk.ImporterValidatingResourceIdThen(func(id string) error {
@@ -133,10 +134,10 @@ func resourceDataFactoryLinkedServiceSFTP() *pluginsdk.Resource {
 	}
 }
 
-func resourceDataFactoryLinkedServiceSFTPCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+func resourceDataFactoryLinkedServiceSFTPCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).DataFactory.LinkedServiceClient
 	subscriptionId := meta.(*clients.Client).DataFactory.LinkedServiceClient.SubscriptionID
-	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	dataFactoryId, err := factories.ParseFactoryID(d.Get("data_factory_id").(string))
@@ -211,7 +212,7 @@ func resourceDataFactoryLinkedServiceSFTPCreateUpdate(d *pluginsdk.ResourceData,
 	}
 
 	if _, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.FactoryName, id.Name, linkedService, ""); err != nil {
-		return fmt.Errorf("creating/updating Data Factory SFTP Anonymous %s: %+v", id, err)
+		return fmt.Errorf("creating %s: %+v", id, err)
 	}
 
 	d.SetId(id.ID())
@@ -281,6 +282,92 @@ func resourceDataFactoryLinkedServiceSFTPRead(d *pluginsdk.ResourceData, meta in
 		if hostKeyFingerprint := props.HostKeyFingerprint; hostKeyFingerprint != nil {
 			d.Set("host_key_fingerprint", hostKeyFingerprint)
 		}
+	}
+
+	return nil
+}
+
+func resourceDataFactoryLinkedServiceSFTPUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).DataFactory.LinkedServiceClient
+	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.LinkedServiceID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Get(ctx, id.ResourceGroup, id.FactoryName, id.Name, "")
+	if err != nil {
+		return fmt.Errorf("retrieving %s: %+v", *id, err)
+	}
+
+	if resp.Properties == nil {
+		return fmt.Errorf("retrieving %s: `properties` is nil", id)
+	}
+
+	sftp, ok := resp.Properties.AsSftpServerLinkedService()
+	if !ok {
+		return fmt.Errorf("classifying Data Factory Linked Service SFTP %q (Data Factory %q / Resource Group %q): Expected: %q Received: %q", id.Name, id.FactoryName, id.ResourceGroup, datafactory.TypeBasicLinkedServiceTypeSftp, *resp.Type)
+	}
+
+	if d.HasChange("authentication_type") {
+		sftp.AuthenticationType = datafactory.SftpAuthenticationType(d.Get("authentication_type").(string))
+	}
+
+	if d.HasChange("host") {
+		sftp.Host = pointer.To(d.Get("host").(string))
+	}
+
+	if d.HasChange("port") {
+		sftp.Port = pointer.To(d.Get("port").(string))
+	}
+
+	if d.HasChange("username") {
+		sftp.UserName = pointer.To(d.Get("username").(string))
+	}
+
+	if d.HasChange("password") {
+		sftp.Password = datafactory.SecureString{
+			Value: pointer.To(d.Get("password").(string)),
+			Type:  datafactory.TypeSecureString,
+		}
+	}
+
+	if d.HasChange("skip_host_key_validation") {
+		sftp.SkipHostKeyValidation = pointer.To(d.Get("skip_host_key_validation").(bool))
+	}
+
+	if d.HasChange("host_key_fingerprint") {
+		sftp.HostKeyFingerprint = pointer.To(d.Get("host_key_fingerprint").(string))
+	}
+
+	if d.HasChange("description") {
+		sftp.Description = pointer.To(d.Get("description").(string))
+	}
+
+	if d.HasChange("parameters") {
+		sftp.Parameters = expandLinkedServiceParameters(d.Get("parameters").(map[string]interface{}))
+	}
+
+	if d.HasChange("integration_runtime_name") {
+		sftp.ConnectVia = expandDataFactoryLinkedServiceIntegrationRuntime(d.Get("integration_runtime_name").(string))
+	}
+
+	if d.HasChange("additional_properties") {
+		sftp.AdditionalProperties = d.Get("additional_properties").(map[string]interface{})
+	}
+
+	if d.HasChange("annotations") {
+		sftp.Annotations = pointer.To(d.Get("annotations").([]interface{}))
+	}
+
+	linkedService := datafactory.LinkedServiceResource{
+		Properties: sftp,
+	}
+
+	if _, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.FactoryName, id.Name, linkedService, ""); err != nil {
+		return fmt.Errorf("updating %s: %+v", id, err)
 	}
 
 	return nil


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This PR separates the combined CreateUpdate multi-purpose function into dedicated create and update functions. This will yield additional functional and behavioural benefits, e.g. using `HasChange()`

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
