### PR TITLE
New Resource: `azurerm_stream_analytics_job_storage_account`

### DIFF
--- a/internal/services/streamanalytics/registration.go
+++ b/internal/services/streamanalytics/registration.go
@@ -27,6 +27,7 @@ func (r Registration) Resources() []sdk.Resource {
 	return []sdk.Resource{
 		ClusterResource{},
 		JobScheduleResource{},
+		JobStorageAccountResource{},
 		ManagedPrivateEndpointResource{},
 		OutputFunctionResource{},
 		OutputTableResource{},

--- a/internal/services/streamanalytics/stream_analytics_job_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_job_resource.go
@@ -481,12 +481,12 @@ func resourceStreamAnalyticsJobUpdate(d *pluginsdk.ResourceData, meta interface{
 	}
 
 	if d.HasChange("content_storage_policy") {
-		payload.Properties.ContentStoragePolicy = pointer.To(streamingjobs.ContentStoragePolicy(d.Get("contentStoragePolicy").(string)))
+		payload.Properties.ContentStoragePolicy = pointer.To(streamingjobs.ContentStoragePolicy(d.Get("content_storage_policy").(string)))
 	}
 
 	if d.HasChange("job_storage_account") {
 		storageAccount := d.Get("job_storage_account").([]interface{})
-		if d.Get("contentStoragePolicy").(string) == string(streamingjobs.ContentStoragePolicyJobStorageAccount) {
+		if d.Get("content_storage_policy").(string) == string(streamingjobs.ContentStoragePolicyJobStorageAccount) {
 			if len(storageAccount) == 0 {
 				return fmt.Errorf("`job_storage_account` must be set when `content_storage_policy` is `JobStorageAccount`")
 			}
@@ -564,7 +564,7 @@ func resourceStreamAnalyticsJobDelete(d *pluginsdk.ResourceData, meta interface{
 }
 
 func expandJobStorageAccount(input []interface{}) *streamingjobs.JobStorageAccount {
-	if input == nil {
+	if input == nil || len(input) == 0 {
 		return nil
 	}
 

--- a/internal/services/streamanalytics/stream_analytics_job_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_job_resource.go
@@ -564,7 +564,7 @@ func resourceStreamAnalyticsJobDelete(d *pluginsdk.ResourceData, meta interface{
 }
 
 func expandJobStorageAccount(input []interface{}) *streamingjobs.JobStorageAccount {
-	if input == nil || len(input) == 0 {
+	if len(input) == 0 {
 		return nil
 	}
 

--- a/internal/services/streamanalytics/stream_analytics_job_storage_account_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_job_storage_account_resource.go
@@ -1,0 +1,292 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+package streamanalytics
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2021-10-01-preview/streamingjobs"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+type JobStorageAccountResource struct{}
+
+type JobStorageAccountModel struct {
+	JobId              string `tfschema:"stream_analytics_job_id"`
+	AuthenticationMode string `tfschema:"authentication_mode"`
+	StorageAccountKey  string `tfschema:"storage_account_key"`
+	StorageAccountName string `tfschema:"storage_account_name"`
+}
+
+var _ sdk.ResourceWithUpdate = JobStorageAccountResource{}
+var _ sdk.ResourceWithCustomizeDiff = JobStorageAccountResource{}
+
+func (r JobStorageAccountResource) ModelObject() interface{} {
+	return &JobStorageAccountModel{}
+}
+
+func (r JobStorageAccountResource) ResourceType() string {
+	return "azurerm_stream_analytics_job_storage_account"
+}
+
+func (r JobStorageAccountResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return streamingjobs.ValidateStreamingJobID
+}
+
+func (r JobStorageAccountResource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"stream_analytics_job_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: streamingjobs.ValidateStreamingJobID,
+		},
+
+		"authentication_mode": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: validation.StringInSlice(streamingjobs.PossibleValuesForAuthenticationMode(), false),
+		},
+
+		"storage_account_name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"storage_account_key": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			Sensitive:    true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+	}
+}
+
+func (r JobStorageAccountResource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{}
+}
+
+func (r JobStorageAccountResource) CustomizeDiff() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 15 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			var config JobStorageAccountModel
+			if err := metadata.DecodeDiff(&config); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			//if config.AuthenticationMode == string(streamingjobs.AuthenticationModeMsi) && config.StorageAccountKey != "" {
+			//	return fmt.Errorf("`storage_account_key` cannot be set if `authentication_mode` is `Msi`")
+			//}
+			//
+			//if config.AuthenticationMode == string(streamingjobs.AuthenticationModeConnectionString) && config.StorageAccountKey == "" {
+			//	return fmt.Errorf("`storage_account_key` cannot be empty if `authentication_mode` is `ConnectionString`")
+			//}
+
+			return nil
+		},
+	}
+}
+
+func (r JobStorageAccountResource) Create() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 90 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.StreamAnalytics.JobsClient
+
+			var model JobStorageAccountModel
+			if err := metadata.Decode(&model); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			id, err := streamingjobs.ParseStreamingJobID(model.JobId)
+			if err != nil {
+				return err
+			}
+
+			locks.ByID(id.ID())
+			defer locks.UnlockByID(id.ID())
+
+			existing, err := client.Get(ctx, *id, streamingjobs.DefaultGetOperationOptions())
+			if err != nil && !response.WasNotFound(existing.HttpResponse) {
+				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+			}
+			// TODO better check here
+			if !response.WasNotFound(existing.HttpResponse) && existing.Model.Properties.JobStorageAccount != nil {
+				return metadata.ResourceRequiresImport(r.ResourceType(), id)
+			}
+
+			payload := streamingjobs.StreamingJob{
+				Properties: &streamingjobs.StreamingJobProperties{
+					JobStorageAccount: &streamingjobs.JobStorageAccount{
+						AccountName:        pointer.To(model.StorageAccountName),
+						AuthenticationMode: pointer.To(streamingjobs.AuthenticationMode(model.AuthenticationMode)),
+					},
+				},
+			}
+
+			if model.AuthenticationMode == string(streamingjobs.AuthenticationModeMsi) && model.StorageAccountKey != "" {
+				return fmt.Errorf("`storage_account_key` cannot be set if `authentication_mode` is `Msi`")
+			}
+
+			if model.AuthenticationMode == string(streamingjobs.AuthenticationModeConnectionString) && model.StorageAccountKey == "" {
+				return fmt.Errorf("`storage_account_key` cannot be empty if `authentication_mode` is `ConnectionString`")
+			}
+
+			if model.StorageAccountKey != "" {
+				payload.Properties.JobStorageAccount.AccountKey = pointer.To(model.StorageAccountKey)
+			}
+
+			if _, err := client.Update(ctx, *id, payload, streamingjobs.DefaultUpdateOperationOptions()); err != nil {
+				return fmt.Errorf("creating Job Storage Account for %s: %+v", id, err)
+			}
+
+			metadata.SetID(id)
+
+			return nil
+		},
+	}
+}
+
+func (r JobStorageAccountResource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.StreamAnalytics.JobsClient
+
+			id, err := streamingjobs.ParseStreamingJobID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.Get(ctx, *id, streamingjobs.DefaultGetOperationOptions())
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) || resp.Model == nil || resp.Model.Properties == nil || resp.Model.Properties.JobStorageAccount == nil {
+					return metadata.MarkAsGone(id)
+				}
+				return fmt.Errorf("retrieving %s: %+v", *id, err)
+			}
+
+			state := JobStorageAccountModel{
+				JobId: id.ID(),
+			}
+
+			if model := resp.Model; model != nil {
+				if props := model.Properties; props != nil {
+					if jobStorage := props.JobStorageAccount; jobStorage != nil {
+						state.AuthenticationMode = string(pointer.From(jobStorage.AuthenticationMode))
+						state.StorageAccountKey = metadata.ResourceData.Get("storage_account_key").(string)
+						state.StorageAccountName = pointer.From(jobStorage.AccountName)
+
+					}
+				}
+			}
+
+			return metadata.Encode(&state)
+		},
+	}
+}
+
+func (r JobStorageAccountResource) Update() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 90 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.StreamAnalytics.JobsClient
+
+			var model JobStorageAccountModel
+			if err := metadata.Decode(&model); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			id, err := streamingjobs.ParseStreamingJobID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			locks.ByID(id.ID())
+			defer locks.UnlockByID(id.ID())
+
+			_, err = client.Get(ctx, *id, streamingjobs.DefaultGetOperationOptions())
+			if err != nil {
+				return fmt.Errorf("retrieving %s: %+v", id, err)
+			}
+
+			payload := streamingjobs.StreamingJob{
+				Properties: &streamingjobs.StreamingJobProperties{
+					JobStorageAccount: &streamingjobs.JobStorageAccount{},
+				},
+			}
+
+			if metadata.ResourceData.HasChange("authentication_mode") {
+				payload.Properties.JobStorageAccount.AuthenticationMode = pointer.To(streamingjobs.AuthenticationMode(model.AuthenticationMode))
+			}
+
+			if metadata.ResourceData.HasChange("storage_account_name") {
+				payload.Properties.JobStorageAccount.AccountName = pointer.To(model.StorageAccountName)
+			}
+
+			if metadata.ResourceData.HasChange("storage_account_key") {
+				if model.StorageAccountKey != "" {
+					payload.Properties.JobStorageAccount.AccountName = pointer.To(model.StorageAccountKey)
+				}
+			}
+
+			if _, err := client.Update(ctx, *id, payload, streamingjobs.DefaultUpdateOperationOptions()); err != nil {
+				return fmt.Errorf("updating Job Storage Account for %s: %+v", id, err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func (r JobStorageAccountResource) Delete() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 90 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.StreamAnalytics.JobsClient
+
+			id, err := streamingjobs.ParseStreamingJobID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			locks.ByID(id.ID())
+			defer locks.UnlockByID(id.ID())
+
+			existing, err := client.Get(ctx, *id, streamingjobs.DefaultGetOperationOptions())
+			if err != nil {
+				return fmt.Errorf("retrieving %s: %+v", id, err)
+			}
+
+			if existing.Model == nil {
+				return fmt.Errorf("retrieving %s: `model` was nil", id)
+			}
+			if existing.Model.Properties == nil {
+				return fmt.Errorf("retrieving %s: `properties` was nil", id)
+			}
+			if existing.Model.Properties.JobStorageAccount == nil {
+				return fmt.Errorf("retrieving %s: `properties.JobStorage` was nil", id)
+			}
+
+			payload := existing.Model
+
+			// We're unable to remove the Job Storage Account using the PATCH call, the only way to remove it is by using the PUT
+			payload.Properties.JobStorageAccount = nil
+
+			if err := client.CreateOrReplaceThenPoll(ctx, *id, *payload, streamingjobs.DefaultCreateOrReplaceOperationOptions()); err != nil {
+				return fmt.Errorf("deleting Job Storage Account for %s: %+v", *id, err)
+			}
+
+			return nil
+		},
+	}
+}

--- a/internal/services/streamanalytics/stream_analytics_job_storage_account_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_job_storage_account_resource.go
@@ -168,7 +168,6 @@ func (r JobStorageAccountResource) Read() sdk.ResourceFunc {
 						state.AuthenticationMode = string(pointer.From(jobStorage.AuthenticationMode))
 						state.StorageAccountKey = metadata.ResourceData.Get("storage_account_key").(string)
 						state.StorageAccountName = pointer.From(jobStorage.AccountName)
-
 					}
 				}
 			}

--- a/internal/services/streamanalytics/stream_analytics_job_storage_account_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_job_storage_account_resource.go
@@ -197,11 +197,6 @@ func (r JobStorageAccountResource) Update() sdk.ResourceFunc {
 			locks.ByID(id.ID())
 			defer locks.UnlockByID(id.ID())
 
-			_, err = client.Get(ctx, *id, streamingjobs.DefaultGetOperationOptions())
-			if err != nil {
-				return fmt.Errorf("retrieving %s: %+v", id, err)
-			}
-
 			payload := streamingjobs.StreamingJob{
 				Properties: &streamingjobs.StreamingJobProperties{
 					JobStorageAccount: &streamingjobs.JobStorageAccount{},

--- a/internal/services/streamanalytics/stream_analytics_job_storage_account_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_job_storage_account_resource.go
@@ -79,7 +79,7 @@ func (r JobStorageAccountResource) Attributes() map[string]*pluginsdk.Schema {
 
 func (r JobStorageAccountResource) Create() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
-		Timeout: 90 * time.Minute,
+		Timeout: 30 * time.Minute,
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
 			client := metadata.Client.StreamAnalytics.JobsClient
 
@@ -179,7 +179,7 @@ func (r JobStorageAccountResource) Read() sdk.ResourceFunc {
 
 func (r JobStorageAccountResource) Update() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
-		Timeout: 90 * time.Minute,
+		Timeout: 30 * time.Minute,
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
 			client := metadata.Client.StreamAnalytics.JobsClient
 
@@ -212,7 +212,7 @@ func (r JobStorageAccountResource) Update() sdk.ResourceFunc {
 
 			if metadata.ResourceData.HasChange("storage_account_key") {
 				if model.StorageAccountKey != "" {
-					payload.Properties.JobStorageAccount.AccountName = pointer.To(model.StorageAccountKey)
+					payload.Properties.JobStorageAccount.AccountKey = pointer.To(model.StorageAccountKey)
 				}
 			}
 
@@ -227,7 +227,7 @@ func (r JobStorageAccountResource) Update() sdk.ResourceFunc {
 
 func (r JobStorageAccountResource) Delete() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
-		Timeout: 90 * time.Minute,
+		Timeout: 30 * time.Minute,
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
 			client := metadata.Client.StreamAnalytics.JobsClient
 

--- a/internal/services/streamanalytics/stream_analytics_job_storage_account_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_job_storage_account_resource.go
@@ -100,8 +100,10 @@ func (r JobStorageAccountResource) Create() sdk.ResourceFunc {
 			if err != nil && !response.WasNotFound(existing.HttpResponse) {
 				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
 			}
-			// TODO better check here
-			if !response.WasNotFound(existing.HttpResponse) && existing.Model.Properties.JobStorageAccount != nil {
+
+			jobStorageAccountExists := existing.Model != nil && existing.Model.Properties != nil && existing.Model.Properties.JobStorageAccount != nil
+
+			if !response.WasNotFound(existing.HttpResponse) && jobStorageAccountExists {
 				return metadata.ResourceRequiresImport(r.ResourceType(), id)
 			}
 

--- a/internal/services/streamanalytics/stream_analytics_job_storage_account_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_job_storage_account_resource.go
@@ -26,7 +26,6 @@ type JobStorageAccountModel struct {
 }
 
 var _ sdk.ResourceWithUpdate = JobStorageAccountResource{}
-var _ sdk.ResourceWithCustomizeDiff = JobStorageAccountResource{}
 
 func (r JobStorageAccountResource) ModelObject() interface{} {
 	return &JobStorageAccountModel{}
@@ -50,9 +49,13 @@ func (r JobStorageAccountResource) Arguments() map[string]*pluginsdk.Schema {
 		},
 
 		"authentication_mode": {
-			Type:         pluginsdk.TypeString,
-			Required:     true,
-			ValidateFunc: validation.StringInSlice(streamingjobs.PossibleValuesForAuthenticationMode(), false),
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				string(streamingjobs.AuthenticationModeMsi),
+				string(streamingjobs.AuthenticationModeConnectionString),
+				// auth mode `UserToken` is not supported
+			}, false),
 		},
 
 		"storage_account_name": {
@@ -72,28 +75,6 @@ func (r JobStorageAccountResource) Arguments() map[string]*pluginsdk.Schema {
 
 func (r JobStorageAccountResource) Attributes() map[string]*pluginsdk.Schema {
 	return map[string]*pluginsdk.Schema{}
-}
-
-func (r JobStorageAccountResource) CustomizeDiff() sdk.ResourceFunc {
-	return sdk.ResourceFunc{
-		Timeout: 15 * time.Minute,
-		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
-			var config JobStorageAccountModel
-			if err := metadata.DecodeDiff(&config); err != nil {
-				return fmt.Errorf("decoding: %+v", err)
-			}
-
-			//if config.AuthenticationMode == string(streamingjobs.AuthenticationModeMsi) && config.StorageAccountKey != "" {
-			//	return fmt.Errorf("`storage_account_key` cannot be set if `authentication_mode` is `Msi`")
-			//}
-			//
-			//if config.AuthenticationMode == string(streamingjobs.AuthenticationModeConnectionString) && config.StorageAccountKey == "" {
-			//	return fmt.Errorf("`storage_account_key` cannot be empty if `authentication_mode` is `ConnectionString`")
-			//}
-
-			return nil
-		},
-	}
 }
 
 func (r JobStorageAccountResource) Create() sdk.ResourceFunc {

--- a/internal/services/streamanalytics/stream_analytics_job_storage_account_resource_test.go
+++ b/internal/services/streamanalytics/stream_analytics_job_storage_account_resource_test.go
@@ -117,14 +117,12 @@ func (r StreamAnalyticsJobStorageAccountResource) requiresImport(data acceptance
 	return fmt.Sprintf(`
 %s
 
-%s
-
 resource "azurerm_stream_analytics_job_storage_account" "import" {
   stream_analytics_job_id = azurerm_stream_analytics_job_storage_account.test.stream_analytics_job_id
   storage_account_name    = azurerm_stream_analytics_job_storage_account.test.storage_account_name
   authentication_mode     = azurerm_stream_analytics_job_storage_account.test.authentication_mode
 }
-`, r.template(data), r.basic(data))
+`, r.basic(data))
 }
 
 func (r StreamAnalyticsJobStorageAccountResource) template(data acceptance.TestData) string {
@@ -147,11 +145,10 @@ resource "azurerm_storage_account" "test" {
 }
 
 resource "azurerm_stream_analytics_job" "test" {
-  name                   = "acctestjob-%[1]d"
-  resource_group_name    = azurerm_resource_group.test.name
-  location               = azurerm_resource_group.test.location
-  streaming_units        = 3
-  content_storage_policy = "JobStorageAccount"
+  name                = "acctestjob-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  streaming_units     = 3
 
   tags = {
     environment = "Test"

--- a/internal/services/streamanalytics/stream_analytics_job_storage_account_resource_test.go
+++ b/internal/services/streamanalytics/stream_analytics_job_storage_account_resource_test.go
@@ -1,0 +1,177 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package streamanalytics_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2021-10-01-preview/streamingjobs"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type StreamAnalyticsJobStorageAccountResource struct{}
+
+func TestAccStreamAnalyticsJobStorageAccount_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_stream_analytics_job_storage_account", "test")
+	r := StreamAnalyticsJobStorageAccountResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccStreamAnalyticsJobStorageAccount_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_stream_analytics_job_storage_account", "test")
+	r := StreamAnalyticsJobStorageAccountResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.connectionString(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("storage_account_key"),
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccStreamAnalyticsJobStorageAccount_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_stream_analytics_job_storage_account", "test")
+	r := StreamAnalyticsJobStorageAccountResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func (r StreamAnalyticsJobStorageAccountResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := streamingjobs.ParseStreamingJobID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.StreamAnalytics.JobsClient.Get(ctx, *id, streamingjobs.DefaultGetOperationOptions())
+	if err != nil {
+		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
+	}
+
+	if resp.Model == nil || resp.Model.Properties == nil || resp.Model.Properties.JobStorageAccount == nil {
+		return pointer.To(false), nil
+	}
+
+	return pointer.To(resp.Model != nil), nil
+}
+
+func (r StreamAnalyticsJobStorageAccountResource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_stream_analytics_job_storage_account" "test" {
+  stream_analytics_job_id = azurerm_stream_analytics_job.test.id
+  storage_account_name    = azurerm_storage_account.test.name
+  authentication_mode     = "Msi"
+}
+`, r.template(data))
+}
+
+func (r StreamAnalyticsJobStorageAccountResource) connectionString(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_stream_analytics_job_storage_account" "test" {
+  stream_analytics_job_id = azurerm_stream_analytics_job.test.id
+  storage_account_name    = azurerm_storage_account.test.name
+  storage_account_key     = azurerm_storage_account.test.primary_access_key
+  authentication_mode     = "ConnectionString"
+}
+
+
+`, r.template(data))
+}
+
+func (r StreamAnalyticsJobStorageAccountResource) requiresImport(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+%s
+
+resource "azurerm_stream_analytics_job_storage_account" "import" {
+  stream_analytics_job_id = azurerm_stream_analytics_job_storage_account.test.stream_analytics_job_id
+  storage_account_name    = azurerm_stream_analytics_job_storage_account.test.storage_account_name
+  authentication_mode     = azurerm_stream_analytics_job_storage_account.test.authentication_mode
+}
+`, r.template(data), r.basic(data))
+}
+
+func (r StreamAnalyticsJobStorageAccountResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctestacc%[3]s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_stream_analytics_job" "test" {
+  name                = "acctestjob-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  streaming_units     = 3
+
+  tags = {
+    environment = "Test"
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  transformation_query = <<QUERY
+    SELECT *
+    INTO [YourOutputAlias]
+    FROM [YourInputAlias]
+QUERY
+
+
+  lifecycle {
+    ignore_changes = [job_storage_account]
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}

--- a/internal/services/streamanalytics/stream_analytics_job_storage_account_resource_test.go
+++ b/internal/services/streamanalytics/stream_analytics_job_storage_account_resource_test.go
@@ -70,28 +70,6 @@ func TestAccStreamAnalyticsJobStorageAccount_update(t *testing.T) {
 	})
 }
 
-func TestAccStreamAnalyticsJobStorageAccount_updateResource(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_stream_analytics_job", "test")
-	r := StreamAnalyticsJobStorageAccountResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.template2(data),
-			//Check:  acceptance.ComposeTestCheckFunc(
-			//// check.That(data.ResourceName).ExistsInAzure(r),
-			//),
-		},
-		//data.ImportStep(),
-		{
-			Config: r.basic(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-	})
-}
-
 func (r StreamAnalyticsJobStorageAccountResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := streamingjobs.ParseStreamingJobID(state.ID)
 	if err != nil {
@@ -193,55 +171,6 @@ QUERY
   lifecycle {
     ignore_changes = [job_storage_account]
   }
-}
-`, data.RandomInteger, data.Locations.Primary, data.RandomString)
-}
-
-func (r StreamAnalyticsJobStorageAccountResource) template2(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%[1]d"
-  location = "%[2]s"
-}
-
-resource "azurerm_storage_account" "test" {
-  name                     = "acctestacc%[3]s"
-  resource_group_name      = azurerm_resource_group.test.name
-  location                 = azurerm_resource_group.test.location
-  account_tier             = "Standard"
-  account_replication_type = "LRS"
-}
-
-resource "azurerm_stream_analytics_job" "test" {
-  name                   = "acctestjob-%[1]d"
-  resource_group_name    = azurerm_resource_group.test.name
-  location               = azurerm_resource_group.test.location
-  streaming_units        = 3
-  content_storage_policy = "JobStorageAccount"
-
-  job_storage_account {
-    authentication_mode = "ConnectionString"
-    account_name        = azurerm_storage_account.test.name
-    account_key         = azurerm_storage_account.test.primary_access_key
-  }
-
-  tags = {
-    environment = "Test"
-  }
-
-  identity {
-    type = "SystemAssigned"
-  }
-
-  transformation_query = <<QUERY
-    SELECT *
-    INTO [YourOutputAlias]
-    FROM [YourInputAlias]
-QUERY
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }

--- a/website/docs/r/stream_analytics_job.html.markdown
+++ b/website/docs/r/stream_analytics_job.html.markdown
@@ -88,6 +88,8 @@ The following arguments are supported:
 
 ---
 
+~> **Note**: This block should be added to `ignore_changes` if the Stream Analytics' Job Storage Account is being managed by the `azurerm_stream_analytics_job_storage_account` resource.
+
 A `job_storage_account` block supports the following:
 
 * `authentication_mode` - (Optional) The authentication mode of the storage account. The only supported value is `ConnectionString`. Defaults to `ConnectionString`.

--- a/website/docs/r/stream_analytics_job_storage_account.html.markdown
+++ b/website/docs/r/stream_analytics_job_storage_account.html.markdown
@@ -32,7 +32,7 @@ resource "azurerm_stream_analytics_job" "example" {
   output_error_policy                      = "Drop"
   streaming_units                          = 3
   sku_name                                 = "StandardV2"
-  
+
   identity {
     type = "SystemAssigned"
   }
@@ -46,7 +46,7 @@ resource "azurerm_stream_analytics_job" "example" {
     INTO [YourOutputAlias]
     FROM [YourInputAlias]
 QUERY
-  
+
   lifecycle {
     ignore_changes = [job_storage_account]
   }

--- a/website/docs/r/stream_analytics_job_storage_account.html.markdown
+++ b/website/docs/r/stream_analytics_job_storage_account.html.markdown
@@ -1,0 +1,100 @@
+---
+subcategory: "Stream Analytics"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_stream_analytics_job_storage_account"
+description: |-
+  Manages a Stream Analytics Job Storage Account.
+---
+
+# azurerm_stream_analytics_job_storage_account
+
+Manages a Stream Analytics Job Storage Account. Use this resource for managing the Job Storage Account using `Msi` authentication with a `SystemAssigned` identity.
+
+~> **Note:** The Job Storage Account for a Stream Analytics Job can be managed on the `azurerm_stream_analytics_job` resource with the `job_storage_account` block, or with this resource. We do not recommend managing the Job Storage Account through both means as this can lead to conflicts.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_stream_analytics_job" "example" {
+  name                                     = "example-job"
+  resource_group_name                      = azurerm_resource_group.example.name
+  location                                 = azurerm_resource_group.example.location
+  compatibility_level                      = "1.2"
+  data_locale                              = "en-GB"
+  events_late_arrival_max_delay_in_seconds = 60
+  events_out_of_order_max_delay_in_seconds = 50
+  events_out_of_order_policy               = "Adjust"
+  output_error_policy                      = "Drop"
+  streaming_units                          = 3
+  sku_name                                 = "StandardV2"
+  
+  identity {
+    type = "SystemAssigned"
+  }
+
+  tags = {
+    environment = "Example"
+  }
+
+  transformation_query = <<QUERY
+    SELECT *
+    INTO [YourOutputAlias]
+    FROM [YourInputAlias]
+QUERY
+  
+  lifecycle {
+    ignore_changes = [job_storage_account]
+  }
+}
+
+resource "azurerm_stream_analytics_job_storage_account" "test" {
+  stream_analytics_job_id = azurerm_stream_analytics_job.test.id
+  storage_account_name    = azurerm_storage_account.test.name
+  authentication_mode     = "Msi"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `stream_analytics_job_id` - (Required) The ID of the Stream Analytics Job. Changing this forces a new resource to be created.
+
+* `authentication_mode` - (Required) The authentication mode for the Stream Analytics Job's Storage Account. Possible values are `ConnectionString`, `Msi`, and `UserToken`.
+
+-> **Note:** The parent Stream Analytics Job must have the `identity` block set when using the `Msi` as the `authentication_mode`.
+
+* `storage_account_name` - (Required) The Storage Account name for the Stream Analytics Job.
+
+* `storage_account_key` - (Optional) The Storage Account Key for the Stream Analytics Job should run.
+
+-> **Note:** `storage_account_key` must be specified when `authentication_mode` is `ConnectionString` and must be absent if `authentication_mode` is `Msi`.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the Stream Analytics Job.
+
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Stream Analytics Job Storage Account.
+* `update` - (Defaults to 30 minutes) Used when updating the Stream Analytics Job Storage Account.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Stream Analytics Job Storage Account.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Stream Analytics Job Storage Account.
+
+## Import
+
+Stream Analytics Job Storage Accounts can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_stream_analytics_job_storage_account.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.StreamAnalytics/streamingJobs/job1
+```

--- a/website/docs/r/stream_analytics_job_storage_account.html.markdown
+++ b/website/docs/r/stream_analytics_job_storage_account.html.markdown
@@ -67,7 +67,7 @@ The following arguments are supported:
 
 * `authentication_mode` - (Required) The authentication mode for the Stream Analytics Job's Storage Account. Possible values are `ConnectionString`, `Msi`, and `UserToken`.
 
--> **Note:** The parent Stream Analytics Job must have the `identity` block set when using the `Msi` as the `authentication_mode`.
+-> **Note:** The parent Stream Analytics Job must have the `identity` block set when using `Msi` as the `authentication_mode`.
 
 * `storage_account_name` - (Required) The Storage Account name for the Stream Analytics Job.
 
@@ -80,7 +80,6 @@ The following arguments are supported:
 In addition to the Arguments listed above - the following Attributes are exported:
 
 * `id` - The ID of the Stream Analytics Job.
-
 
 ## Timeouts
 

--- a/website/docs/r/stream_analytics_job_storage_account.html.markdown
+++ b/website/docs/r/stream_analytics_job_storage_account.html.markdown
@@ -52,9 +52,17 @@ QUERY
   }
 }
 
-resource "azurerm_stream_analytics_job_storage_account" "test" {
-  stream_analytics_job_id = azurerm_stream_analytics_job.test.id
-  storage_account_name    = azurerm_storage_account.test.name
+resource "azurerm_storage_account" "example" {
+  name                     = "exampleaccount"
+  resource_group_name      = azurerm_resource_group.example.name
+  location                 = azurerm_resource_group.example.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_stream_analytics_job_storage_account" "example" {
+  stream_analytics_job_id = azurerm_stream_analytics_job.example.id
+  storage_account_name    = azurerm_storage_account.example.name
   authentication_mode     = "Msi"
 }
 ```
@@ -65,13 +73,13 @@ The following arguments are supported:
 
 * `stream_analytics_job_id` - (Required) The ID of the Stream Analytics Job. Changing this forces a new resource to be created.
 
-* `authentication_mode` - (Required) The authentication mode for the Stream Analytics Job's Storage Account. Possible values are `ConnectionString`, `Msi`, and `UserToken`.
+* `authentication_mode` - (Required) The authentication mode for the Stream Analytics Job's Storage Account. Possible values are `ConnectionString`, and `Msi`.
 
 -> **Note:** The parent Stream Analytics Job must have the `identity` block set when using `Msi` as the `authentication_mode`.
 
 * `storage_account_name` - (Required) The Storage Account name for the Stream Analytics Job.
 
-* `storage_account_key` - (Optional) The Storage Account Key for the Stream Analytics Job should run.
+* `storage_account_key` - (Optional) The Storage Account Key for accessing the Storage Account of the Stream Analytics Job.
 
 -> **Note:** `storage_account_key` must be specified when `authentication_mode` is `ConnectionString` and must be absent if `authentication_mode` is `Msi`.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

- Adds a virtual resource to enable `Msi` authentication with a `SystemAssigned` identity on the storage account for a stream analytics job
- Fixes some panics in the parent stream analytics job resource

## Testing 

![image](https://github.com/user-attachments/assets/1a599edb-c112-4152-954e-ab77f6fb9c28)

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_stream_analytics_job_storage_account` [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [x] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Closes #19351

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
