### PR TITLE
`azurerm_log_analytics_workspace` - add check for soft-deleted but linked workspaces

### DIFF
--- a/internal/services/loganalytics/client/client.go
+++ b/internal/services/loganalytics/client/client.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/storageinsights"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/workspaces"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/clusters"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/deletedworkspaces"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/tables"
 	featureWorkspaces "github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/operationsmanagement/2015-11-01-preview/solution"
@@ -26,6 +27,7 @@ type Client struct {
 	ClusterClient              *clusters.ClustersClient
 	DataExportClient           *dataexport.DataExportClient
 	DataSourcesClient          *datasources.DataSourcesClient
+	DeletedWorkspacesClient    *deletedworkspaces.DeletedWorkspacesClient
 	LinkedServicesClient       *linkedservices.LinkedServicesClient
 	LinkedStorageAccountClient *linkedstorageaccounts.LinkedStorageAccountsClient
 	QueryPacksClient           *querypacks.QueryPacksClient
@@ -56,6 +58,12 @@ func NewClient(o *common.ClientOptions) (*Client, error) {
 		return nil, fmt.Errorf("building DataSources client: %+v", err)
 	}
 	o.Configure(dataSourcesClient.Client, o.Authorizers.ResourceManager)
+
+	deletedWorkspacesClient, err := deletedworkspaces.NewDeletedWorkspacesClientWithBaseURI(o.Environment.ResourceManager)
+	if err != nil {
+		return nil, fmt.Errorf("building Deleted Workspaces Client: %+v", err)
+	}
+	o.Configure(deletedWorkspacesClient.Client, o.Authorizers.ResourceManager)
 
 	workspacesClient, err := workspaces.NewWorkspacesClientWithBaseURI(o.Environment.ResourceManager)
 	if err != nil {
@@ -121,6 +129,7 @@ func NewClient(o *common.ClientOptions) (*Client, error) {
 		ClusterClient:              clusterClient,
 		DataExportClient:           dataExportClient,
 		DataSourcesClient:          dataSourcesClient,
+		DeletedWorkspacesClient:    deletedWorkspacesClient,
 		LinkedServicesClient:       linkedServicesClient,
 		LinkedStorageAccountClient: linkedStorageAccountClient,
 		QueryPacksClient:           queryPacksClient,

--- a/internal/services/loganalytics/log_analytics_workspace_resource_test.go
+++ b/internal/services/loganalytics/log_analytics_workspace_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/insights/2023-03-11/datacollectionrules"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/workspaces"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type LogAnalyticsWorkspaceResource struct{}
@@ -420,7 +420,7 @@ func (t LogAnalyticsWorkspaceResource) Exists(ctx context.Context, clients *clie
 		return nil, fmt.Errorf("readingLog Analytics Workspace (%s): %+v", id.String(), err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (LogAnalyticsWorkspaceResource) basic(data acceptance.TestData) string {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/deletedworkspaces/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/deletedworkspaces/README.md
@@ -1,0 +1,53 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/deletedworkspaces` Documentation
+
+The `deletedworkspaces` SDK allows for interaction with Azure Resource Manager `operationalinsights` (API Version `2022-10-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+import "github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/deletedworkspaces"
+```
+
+
+### Client Initialization
+
+```go
+client := deletedworkspaces.NewDeletedWorkspacesClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `DeletedWorkspacesClient.List`
+
+```go
+ctx := context.TODO()
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+
+read, err := client.List(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `DeletedWorkspacesClient.ListByResourceGroup`
+
+```go
+ctx := context.TODO()
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+
+read, err := client.ListByResourceGroup(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/deletedworkspaces/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/deletedworkspaces/client.go
@@ -1,0 +1,26 @@
+package deletedworkspaces
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeletedWorkspacesClient struct {
+	Client *resourcemanager.Client
+}
+
+func NewDeletedWorkspacesClientWithBaseURI(sdkApi sdkEnv.Api) (*DeletedWorkspacesClient, error) {
+	client, err := resourcemanager.NewClient(sdkApi, "deletedworkspaces", defaultApiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating DeletedWorkspacesClient: %+v", err)
+	}
+
+	return &DeletedWorkspacesClient{
+		Client: client,
+	}, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/deletedworkspaces/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/deletedworkspaces/constants.go
@@ -1,0 +1,245 @@
+package deletedworkspaces
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CapacityReservationLevel int64
+
+const (
+	CapacityReservationLevelFiveHundred  CapacityReservationLevel = 500
+	CapacityReservationLevelFiveThousand CapacityReservationLevel = 5000
+	CapacityReservationLevelFourHundred  CapacityReservationLevel = 400
+	CapacityReservationLevelOneHundred   CapacityReservationLevel = 100
+	CapacityReservationLevelOneThousand  CapacityReservationLevel = 1000
+	CapacityReservationLevelThreeHundred CapacityReservationLevel = 300
+	CapacityReservationLevelTwoHundred   CapacityReservationLevel = 200
+	CapacityReservationLevelTwoThousand  CapacityReservationLevel = 2000
+)
+
+func PossibleValuesForCapacityReservationLevel() []int64 {
+	return []int64{
+		int64(CapacityReservationLevelFiveHundred),
+		int64(CapacityReservationLevelFiveThousand),
+		int64(CapacityReservationLevelFourHundred),
+		int64(CapacityReservationLevelOneHundred),
+		int64(CapacityReservationLevelOneThousand),
+		int64(CapacityReservationLevelThreeHundred),
+		int64(CapacityReservationLevelTwoHundred),
+		int64(CapacityReservationLevelTwoThousand),
+	}
+}
+
+type DataIngestionStatus string
+
+const (
+	DataIngestionStatusApproachingQuota      DataIngestionStatus = "ApproachingQuota"
+	DataIngestionStatusForceOff              DataIngestionStatus = "ForceOff"
+	DataIngestionStatusForceOn               DataIngestionStatus = "ForceOn"
+	DataIngestionStatusOverQuota             DataIngestionStatus = "OverQuota"
+	DataIngestionStatusRespectQuota          DataIngestionStatus = "RespectQuota"
+	DataIngestionStatusSubscriptionSuspended DataIngestionStatus = "SubscriptionSuspended"
+)
+
+func PossibleValuesForDataIngestionStatus() []string {
+	return []string{
+		string(DataIngestionStatusApproachingQuota),
+		string(DataIngestionStatusForceOff),
+		string(DataIngestionStatusForceOn),
+		string(DataIngestionStatusOverQuota),
+		string(DataIngestionStatusRespectQuota),
+		string(DataIngestionStatusSubscriptionSuspended),
+	}
+}
+
+func (s *DataIngestionStatus) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseDataIngestionStatus(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseDataIngestionStatus(input string) (*DataIngestionStatus, error) {
+	vals := map[string]DataIngestionStatus{
+		"approachingquota":      DataIngestionStatusApproachingQuota,
+		"forceoff":              DataIngestionStatusForceOff,
+		"forceon":               DataIngestionStatusForceOn,
+		"overquota":             DataIngestionStatusOverQuota,
+		"respectquota":          DataIngestionStatusRespectQuota,
+		"subscriptionsuspended": DataIngestionStatusSubscriptionSuspended,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := DataIngestionStatus(input)
+	return &out, nil
+}
+
+type PublicNetworkAccessType string
+
+const (
+	PublicNetworkAccessTypeDisabled PublicNetworkAccessType = "Disabled"
+	PublicNetworkAccessTypeEnabled  PublicNetworkAccessType = "Enabled"
+)
+
+func PossibleValuesForPublicNetworkAccessType() []string {
+	return []string{
+		string(PublicNetworkAccessTypeDisabled),
+		string(PublicNetworkAccessTypeEnabled),
+	}
+}
+
+func (s *PublicNetworkAccessType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parsePublicNetworkAccessType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parsePublicNetworkAccessType(input string) (*PublicNetworkAccessType, error) {
+	vals := map[string]PublicNetworkAccessType{
+		"disabled": PublicNetworkAccessTypeDisabled,
+		"enabled":  PublicNetworkAccessTypeEnabled,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := PublicNetworkAccessType(input)
+	return &out, nil
+}
+
+type WorkspaceEntityStatus string
+
+const (
+	WorkspaceEntityStatusCanceled            WorkspaceEntityStatus = "Canceled"
+	WorkspaceEntityStatusCreating            WorkspaceEntityStatus = "Creating"
+	WorkspaceEntityStatusDeleting            WorkspaceEntityStatus = "Deleting"
+	WorkspaceEntityStatusFailed              WorkspaceEntityStatus = "Failed"
+	WorkspaceEntityStatusProvisioningAccount WorkspaceEntityStatus = "ProvisioningAccount"
+	WorkspaceEntityStatusSucceeded           WorkspaceEntityStatus = "Succeeded"
+	WorkspaceEntityStatusUpdating            WorkspaceEntityStatus = "Updating"
+)
+
+func PossibleValuesForWorkspaceEntityStatus() []string {
+	return []string{
+		string(WorkspaceEntityStatusCanceled),
+		string(WorkspaceEntityStatusCreating),
+		string(WorkspaceEntityStatusDeleting),
+		string(WorkspaceEntityStatusFailed),
+		string(WorkspaceEntityStatusProvisioningAccount),
+		string(WorkspaceEntityStatusSucceeded),
+		string(WorkspaceEntityStatusUpdating),
+	}
+}
+
+func (s *WorkspaceEntityStatus) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseWorkspaceEntityStatus(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseWorkspaceEntityStatus(input string) (*WorkspaceEntityStatus, error) {
+	vals := map[string]WorkspaceEntityStatus{
+		"canceled":            WorkspaceEntityStatusCanceled,
+		"creating":            WorkspaceEntityStatusCreating,
+		"deleting":            WorkspaceEntityStatusDeleting,
+		"failed":              WorkspaceEntityStatusFailed,
+		"provisioningaccount": WorkspaceEntityStatusProvisioningAccount,
+		"succeeded":           WorkspaceEntityStatusSucceeded,
+		"updating":            WorkspaceEntityStatusUpdating,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := WorkspaceEntityStatus(input)
+	return &out, nil
+}
+
+type WorkspaceSkuNameEnum string
+
+const (
+	WorkspaceSkuNameEnumCapacityReservation  WorkspaceSkuNameEnum = "CapacityReservation"
+	WorkspaceSkuNameEnumFree                 WorkspaceSkuNameEnum = "Free"
+	WorkspaceSkuNameEnumLACluster            WorkspaceSkuNameEnum = "LACluster"
+	WorkspaceSkuNameEnumPerGBTwoZeroOneEight WorkspaceSkuNameEnum = "PerGB2018"
+	WorkspaceSkuNameEnumPerNode              WorkspaceSkuNameEnum = "PerNode"
+	WorkspaceSkuNameEnumPremium              WorkspaceSkuNameEnum = "Premium"
+	WorkspaceSkuNameEnumStandalone           WorkspaceSkuNameEnum = "Standalone"
+	WorkspaceSkuNameEnumStandard             WorkspaceSkuNameEnum = "Standard"
+)
+
+func PossibleValuesForWorkspaceSkuNameEnum() []string {
+	return []string{
+		string(WorkspaceSkuNameEnumCapacityReservation),
+		string(WorkspaceSkuNameEnumFree),
+		string(WorkspaceSkuNameEnumLACluster),
+		string(WorkspaceSkuNameEnumPerGBTwoZeroOneEight),
+		string(WorkspaceSkuNameEnumPerNode),
+		string(WorkspaceSkuNameEnumPremium),
+		string(WorkspaceSkuNameEnumStandalone),
+		string(WorkspaceSkuNameEnumStandard),
+	}
+}
+
+func (s *WorkspaceSkuNameEnum) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseWorkspaceSkuNameEnum(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseWorkspaceSkuNameEnum(input string) (*WorkspaceSkuNameEnum, error) {
+	vals := map[string]WorkspaceSkuNameEnum{
+		"capacityreservation": WorkspaceSkuNameEnumCapacityReservation,
+		"free":                WorkspaceSkuNameEnumFree,
+		"lacluster":           WorkspaceSkuNameEnumLACluster,
+		"pergb2018":           WorkspaceSkuNameEnumPerGBTwoZeroOneEight,
+		"pernode":             WorkspaceSkuNameEnumPerNode,
+		"premium":             WorkspaceSkuNameEnumPremium,
+		"standalone":          WorkspaceSkuNameEnumStandalone,
+		"standard":            WorkspaceSkuNameEnumStandard,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := WorkspaceSkuNameEnum(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/deletedworkspaces/method_list.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/deletedworkspaces/method_list.go
@@ -1,0 +1,55 @@
+package deletedworkspaces
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *WorkspaceListResult
+}
+
+// List ...
+func (c DeletedWorkspacesClient) List(ctx context.Context, id commonids.SubscriptionId) (result ListOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       fmt.Sprintf("%s/providers/Microsoft.OperationalInsights/deletedWorkspaces", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model WorkspaceListResult
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/deletedworkspaces/method_listbyresourcegroup.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/deletedworkspaces/method_listbyresourcegroup.go
@@ -1,0 +1,55 @@
+package deletedworkspaces
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListByResourceGroupOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *WorkspaceListResult
+}
+
+// ListByResourceGroup ...
+func (c DeletedWorkspacesClient) ListByResourceGroup(ctx context.Context, id commonids.ResourceGroupId) (result ListByResourceGroupOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       fmt.Sprintf("%s/providers/Microsoft.OperationalInsights/deletedWorkspaces", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model WorkspaceListResult
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/deletedworkspaces/model_privatelinkscopedresource.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/deletedworkspaces/model_privatelinkscopedresource.go
@@ -1,0 +1,9 @@
+package deletedworkspaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateLinkScopedResource struct {
+	ResourceId *string `json:"resourceId,omitempty"`
+	ScopeId    *string `json:"scopeId,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/deletedworkspaces/model_workspace.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/deletedworkspaces/model_workspace.go
@@ -1,0 +1,21 @@
+package deletedworkspaces
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/systemdata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type Workspace struct {
+	Etag       *string                           `json:"etag,omitempty"`
+	Id         *string                           `json:"id,omitempty"`
+	Identity   *identity.SystemOrUserAssignedMap `json:"identity,omitempty"`
+	Location   string                            `json:"location"`
+	Name       *string                           `json:"name,omitempty"`
+	Properties *WorkspaceProperties              `json:"properties,omitempty"`
+	SystemData *systemdata.SystemData            `json:"systemData,omitempty"`
+	Tags       *map[string]string                `json:"tags,omitempty"`
+	Type       *string                           `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/deletedworkspaces/model_workspacecapping.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/deletedworkspaces/model_workspacecapping.go
@@ -1,0 +1,10 @@
+package deletedworkspaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type WorkspaceCapping struct {
+	DailyQuotaGb        *float64             `json:"dailyQuotaGb,omitempty"`
+	DataIngestionStatus *DataIngestionStatus `json:"dataIngestionStatus,omitempty"`
+	QuotaNextResetTime  *string              `json:"quotaNextResetTime,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/deletedworkspaces/model_workspacefeatures.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/deletedworkspaces/model_workspacefeatures.go
@@ -1,0 +1,12 @@
+package deletedworkspaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type WorkspaceFeatures struct {
+	ClusterResourceId                           *string `json:"clusterResourceId,omitempty"`
+	DisableLocalAuth                            *bool   `json:"disableLocalAuth,omitempty"`
+	EnableDataExport                            *bool   `json:"enableDataExport,omitempty"`
+	EnableLogAccessUsingOnlyResourcePermissions *bool   `json:"enableLogAccessUsingOnlyResourcePermissions,omitempty"`
+	ImmediatePurgeDataOn30Days                  *bool   `json:"immediatePurgeDataOn30Days,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/deletedworkspaces/model_workspacelistresult.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/deletedworkspaces/model_workspacelistresult.go
@@ -1,0 +1,8 @@
+package deletedworkspaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type WorkspaceListResult struct {
+	Value *[]Workspace `json:"value,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/deletedworkspaces/model_workspaceproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/deletedworkspaces/model_workspaceproperties.go
@@ -1,0 +1,20 @@
+package deletedworkspaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type WorkspaceProperties struct {
+	CreatedDate                         *string                      `json:"createdDate,omitempty"`
+	CustomerId                          *string                      `json:"customerId,omitempty"`
+	DefaultDataCollectionRuleResourceId *string                      `json:"defaultDataCollectionRuleResourceId,omitempty"`
+	Features                            *WorkspaceFeatures           `json:"features,omitempty"`
+	ForceCmkForQuery                    *bool                        `json:"forceCmkForQuery,omitempty"`
+	ModifiedDate                        *string                      `json:"modifiedDate,omitempty"`
+	PrivateLinkScopedResources          *[]PrivateLinkScopedResource `json:"privateLinkScopedResources,omitempty"`
+	ProvisioningState                   *WorkspaceEntityStatus       `json:"provisioningState,omitempty"`
+	PublicNetworkAccessForIngestion     *PublicNetworkAccessType     `json:"publicNetworkAccessForIngestion,omitempty"`
+	PublicNetworkAccessForQuery         *PublicNetworkAccessType     `json:"publicNetworkAccessForQuery,omitempty"`
+	RetentionInDays                     *int64                       `json:"retentionInDays,omitempty"`
+	Sku                                 *WorkspaceSku                `json:"sku,omitempty"`
+	WorkspaceCapping                    *WorkspaceCapping            `json:"workspaceCapping,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/deletedworkspaces/model_workspacesku.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/deletedworkspaces/model_workspacesku.go
@@ -1,0 +1,10 @@
+package deletedworkspaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type WorkspaceSku struct {
+	CapacityReservationLevel *CapacityReservationLevel `json:"capacityReservationLevel,omitempty"`
+	LastSkuUpdate            *string                   `json:"lastSkuUpdate,omitempty"`
+	Name                     WorkspaceSkuNameEnum      `json:"name"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/deletedworkspaces/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/deletedworkspaces/version.go
@@ -1,0 +1,10 @@
+package deletedworkspaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2022-10-01"
+
+func userAgent() string {
+	return "hashicorp/go-azure-sdk/deletedworkspaces/2022-10-01"
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -874,6 +874,7 @@ github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-0
 github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/storageinsights
 github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/workspaces
 github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/clusters
+github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/deletedworkspaces
 github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/tables
 github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces
 github.com/hashicorp/go-azure-sdk/resource-manager/operationsmanagement/2015-11-01-preview/solution

--- a/website/docs/r/log_analytics_workspace.html.markdown
+++ b/website/docs/r/log_analytics_workspace.html.markdown
@@ -43,13 +43,13 @@ The following arguments are supported:
 
 * `local_authentication_disabled` - (Optional) Specifies if the log Analytics workspace should enforce authentication using Azure AD. Defaults to `false`.
 
-* `sku` - (Optional) Specifies the SKU of the Log Analytics Workspace. Possible values are `PerNode`, `Premium`, `Standard`, `Standalone`, `Unlimited`, `CapacityReservation`, and `PerGB2018` (new SKU as of `2018-04-03`). Defaults to `PerGB2018`.
+* `sku` - (Optional) Specifies the SKU of the Log Analytics Workspace. Possible values are `PerNode`, `Premium`, `Standard`, `Standalone`, `Unlimited`, `CapacityReservation`, `PerGB2018`, and `LACluster`. Defaults to `PerGB2018`.
 
-~> **Note:** A new pricing model took effect on `2018-04-03`, which requires the SKU `PerGB2018`. If you've provisioned resources before this date you have the option of remaining with the previous Pricing SKU and using the other SKUs defined above. More information about [the Pricing SKUs is available at the following URI](https://aka.ms/PricingTierWarning).
+~> **Note:** `sku` should only be set to `LACluster` when the Log Analytics Workspace is linked to a Log Analytics Cluster. Additionally, `sku` cannot be modified while linked.
 
-~> **Note:** Changing `sku` forces a new Log Analytics Workspace to be created, except when changing between `PerGB2018` and `CapacityReservation`. However, changing `sku` to `CapacityReservation` or changing `reservation_capacity_in_gb_per_day` to a higher tier will lead to a 31-days commitment period, during which the SKU cannot be changed to a lower one. Please refer to [official documentation](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/cost-logs#commitment-tiers) for further information.
+~> **Note:** Changing `sku` forces a new Log Analytics Workspace to be created, except when changing between `PerGB2018` and `CapacityReservation`. Changing `sku` to `CapacityReservation` or changing `reservation_capacity_in_gb_per_day` to a higher tier will lead to a 31-days commitment period, during which the SKU cannot be changed to a lower one. Please refer to [official documentation](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/cost-logs#commitment-tiers) for further information.
 
-~> **Note:** If an `azurerm_log_analytics_workspace` is connected to an `azurerm_log_analytics_cluster` via an `azurerm_log_analytics_linked_service` you will not be able to modify the workspaces `sku` field until the link between the workspace and the cluster has been broken by deleting the `azurerm_log_analytics_linked_service` resource. All other fields are modifiable while the workspace is linked to a cluster.
+-> **Note:** A new pricing model took effect on `2018-04-03`, which requires the SKU `PerGB2018`. If you've provisioned resources before this date you have the option of remaining with the previous Pricing SKU and using the other SKUs defined above. More information about [the Pricing SKUs is available at the following URI](https://aka.ms/PricingTierWarning).
 
 * `retention_in_days` - (Optional) The workspace data retention in days. Possible values are between `30` and `730`.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Prequisite: #29120

Supersedes #27522

Probably easier to review if #29120 is merged first.

This resolves an issue raised internally, if a workspace is linked to a log analytics cluster outside of Terraform, then deleted without unlinking first, recreation of the resource using Terraform caused an error as the `sku` cannot be updated while linked and `LACluster` was not an option for `sku`.

This PR does 2 things:
1. Add `LACluster` to `sku` to allow a user to update to this value once linked, avoiding a diff.
2. Adds a check for soft-deleted and linked workspaces, if one is found, the provider will override `sku` to `LACluster` during the create.

As testing this requires a manual step, I've added `terraform plan`/`terraform apply` outputs to show the fix is working.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

Existing tests:

<img width="382" alt="image" src="https://github.com/user-attachments/assets/da5b4970-8a2e-47ad-af93-6b4c0e36f3af" />


No additional test added as mentioned in description.

<details>
<summary>terraform output</summary>

```
#### Destroy linked workspace ####
Terraform will perform the following actions:

  # azurerm_log_analytics_workspace.test will be destroyed
  # (because azurerm_log_analytics_workspace.test is not in configuration)

  ...

  Plan: 0 to add, 0 to change, 1 to destroy.

  ...

  Apply complete! Resources: 0 added, 0 changed, 1 destroyed.

#### Recreate soft-deleted linked workspace on v4.23.0 ####

Terraform will perform the following actions:

  # azurerm_log_analytics_workspace.test will be created

  ...

  Plan: 1 to add, 0 to change, 0 to destroy.

  ...

  azurerm_log_analytics_workspace.test: Creating...
  ╷
  │ Error: performing CreateOrUpdate: unexpected status 400 (400 Bad Request) with error: InvalidParameter: Sku cannot be changed while workspace is linked to an Log Analytics Cluster.
  │
  │   with azurerm_log_analytics_workspace.test,
  │   on main.tf line 24, in resource "azurerm_log_analytics_workspace" "test":
  │   24: resource "azurerm_log_analytics_workspace" "test" {
  │
  ╵

#### Recreate soft-deleted linked workspace with changes ####

Terraform will perform the following actions:

  # azurerm_log_analytics_workspace.test will be created

  ...

  Plan: 1 to add, 0 to change, 0 to destroy.

  ...

  azurerm_log_analytics_workspace.test: Creating...
  azurerm_log_analytics_workspace.test: Still creating... [10s elapsed]
  azurerm_log_analytics_workspace.test: Still creating... [20s elapsed]
  azurerm_log_analytics_workspace.test: Creation complete after 26s [id=/subscriptions/<id>/resourceGroups/mp-acctestRG-linkedlaw2/providers/Microsoft.OperationalInsights/workspaces/acctest-LAW-0318]

#### Plan output after recreate (without changing config) ####

Terraform will perform the following actions:

  # azurerm_log_analytics_workspace.test will be updated in-place
  ~ resource "azurerm_log_analytics_workspace" "test" {
        id                                      = "/subscriptions/<id>/resourceGroups/mp-acctestRG-linkedlaw2/providers/Microsoft.OperationalInsights/workspaces/acctest-LAW-0318"
        name                                    = "acctest-LAW-0318"
      ~ sku                                     = "LACluster" -> "PerGB2018" // As expected, cluster sku is `LACluster` in state, config still `PerGB2018`
        tags                                    = {}
        # (14 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

#### Plan output after recreate (config updated) ####

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```

</details>

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #28743


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
