### PR TITLE
azurerm_kubernetes_cluster - support for Advanced Container Networking Services (ACNS)

### DIFF
--- a/internal/services/containers/kubernetes_cluster_data_source.go
+++ b/internal/services/containers/kubernetes_cluster_data_source.go
@@ -590,6 +590,27 @@ func dataSourceKubernetesCluster() *pluginsdk.Resource {
 							Type:     pluginsdk.TypeString,
 							Computed: true,
 						},
+
+						"advanced_networking": {
+							Type:     pluginsdk.TypeList,
+							Computed: true,
+							Elem: &pluginsdk.Resource{
+								Schema: map[string]*pluginsdk.Schema{
+									"enabled": {
+										Type:     pluginsdk.TypeBool,
+										Computed: true,
+									},
+									"observability_enabled": {
+										Type:     pluginsdk.TypeBool,
+										Computed: true,
+									},
+									"fqdn_policy_enabled": {
+										Type:     pluginsdk.TypeBool,
+										Computed: true,
+									},
+								},
+							},
+						},
 					},
 				},
 			},
@@ -1370,7 +1391,41 @@ func flattenKubernetesClusterDataSourceNetworkProfile(profile *managedclusters.C
 		values["load_balancer_sku"] = string(*profile.LoadBalancerSku)
 	}
 
+	advancedNetworking := flattenKubernetesClusterDataSourceAdvancedNetworking(profile.AdvancedNetworking)
+	values["advanced_networking"] = advancedNetworking
+
 	return []interface{}{values}
+}
+
+func flattenKubernetesClusterDataSourceAdvancedNetworking(profile *managedclusters.AdvancedNetworking) []interface{} {
+	if profile == nil {
+		return []interface{}{}
+	}
+
+	advancedNetworking := make([]interface{}, 0)
+
+	acnsEnabled := false
+	if profile.Enabled != nil {
+		acnsEnabled = *profile.Enabled
+	}
+
+	observabilityEnabled := false
+	if o := profile.Observability; o != nil && o.Enabled != nil {
+		observabilityEnabled = *o.Enabled
+	}
+
+	fqdnPolicyEnabled := false
+	if s := profile.Security; s != nil && s.Enabled != nil {
+		fqdnPolicyEnabled = *s.Enabled
+	}
+
+	advancedNetworking = append(advancedNetworking, map[string]interface{}{
+		"enabled":               acnsEnabled,
+		"observability_enabled": observabilityEnabled,
+		"fqdn_policy_enabled":   fqdnPolicyEnabled,
+	})
+
+	return advancedNetworking
 }
 
 func flattenKubernetesClusterDataSourceServicePrincipalProfile(profile *managedclusters.ManagedClusterServicePrincipalProfile) []interface{} {

--- a/internal/services/containers/kubernetes_cluster_data_source.go
+++ b/internal/services/containers/kubernetes_cluster_data_source.go
@@ -600,13 +600,29 @@ func dataSourceKubernetesCluster() *pluginsdk.Resource {
 										Type:     pluginsdk.TypeBool,
 										Computed: true,
 									},
-									"observability_enabled": {
-										Type:     pluginsdk.TypeBool,
+									"observability": {
+										Type:     pluginsdk.TypeList,
 										Computed: true,
+										Elem: &pluginsdk.Resource{
+											Schema: map[string]*pluginsdk.Schema{
+												"enabled": {
+													Type:     pluginsdk.TypeBool,
+													Computed: true,
+												},
+											},
+										},
 									},
-									"fqdn_policy_enabled": {
-										Type:     pluginsdk.TypeBool,
+									"security": {
+										Type:     pluginsdk.TypeList,
 										Computed: true,
+										Elem: &pluginsdk.Resource{
+											Schema: map[string]*pluginsdk.Schema{
+												"enabled": {
+													Type:     pluginsdk.TypeBool,
+													Computed: true,
+												},
+											},
+										},
 									},
 								},
 							},
@@ -1414,15 +1430,23 @@ func flattenKubernetesClusterDataSourceAdvancedNetworking(profile *managedcluste
 		observabilityEnabled = *o.Enabled
 	}
 
-	fqdnPolicyEnabled := false
+	securityEnabled := false
 	if s := profile.Security; s != nil && s.Enabled != nil {
-		fqdnPolicyEnabled = *s.Enabled
+		securityEnabled = *s.Enabled
 	}
 
 	advancedNetworking = append(advancedNetworking, map[string]interface{}{
-		"enabled":               acnsEnabled,
-		"observability_enabled": observabilityEnabled,
-		"fqdn_policy_enabled":   fqdnPolicyEnabled,
+		"enabled": acnsEnabled,
+		"observability": []interface{}{
+			map[string]interface{}{
+				"enabled": observabilityEnabled,
+			},
+		},
+		"security": []interface{}{
+			map[string]interface{}{
+				"enabled": securityEnabled,
+			},
+		},
 	})
 
 	return advancedNetworking

--- a/internal/services/containers/kubernetes_cluster_data_source_test.go
+++ b/internal/services/containers/kubernetes_cluster_data_source_test.go
@@ -314,6 +314,70 @@ func TestAccDataSourceKubernetesCluster_advancedNetworkingKubenetComplete(t *tes
 	})
 }
 
+func TestAccDataSourceKubernetesCluster_advancedContainerNetworkingServicesDisabled(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_kubernetes_cluster", "test")
+	r := KubernetesClusterDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.advancedContainerNetworkingServicesDisabledConfig(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("network_profile.0.advanced_networking.0.enabled").HasValue("false"),
+				check.That(data.ResourceName).Key("network_profile.0.advanced_networking.0.observability_enabled").HasValue("false"),
+				check.That(data.ResourceName).Key("network_profile.0.advanced_networking.0.fqdn_policy_enabled").HasValue("false"),
+			),
+		},
+	})
+}
+
+func TestAccDataSourceKubernetesCluster_advancedContainerNetworkingServicesObservabilityEnabled(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_kubernetes_cluster", "test")
+	r := KubernetesClusterDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.advancedContainerNetworkingServicesObservabilityEnabledConfig(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("network_profile.0.advanced_networking.0.enabled").HasValue("true"),
+				check.That(data.ResourceName).Key("network_profile.0.advanced_networking.0.observability_enabled").HasValue("true"),
+				check.That(data.ResourceName).Key("network_profile.0.advanced_networking.0.fqdn_policy_enabled").HasValue("false"),
+			),
+		},
+	})
+}
+
+func TestAccDataSourceKubernetesCluster_advancedContainerNetworkingServicesFqdnPolicyEnabled(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_kubernetes_cluster", "test")
+	r := KubernetesClusterDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.advancedContainerNetworkingServicesFqdnPolicyEnabledConfig(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("network_profile.0.advanced_networking.0.enabled").HasValue("true"),
+				check.That(data.ResourceName).Key("network_profile.0.advanced_networking.0.observability_enabled").HasValue("false"),
+				check.That(data.ResourceName).Key("network_profile.0.advanced_networking.0.fqdn_policy_enabled").HasValue("true"),
+			),
+		},
+	})
+}
+
+func TestAccDataSourceKubernetesCluster_advancedContainerNetworkingServicesAllEnabled(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_kubernetes_cluster", "test")
+	r := KubernetesClusterDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.advancedContainerNetworkingServicesAllEnabledConfig(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("network_profile.0.advanced_networking.0.enabled").HasValue("true"),
+				check.That(data.ResourceName).Key("network_profile.0.advanced_networking.0.observability_enabled").HasValue("true"),
+				check.That(data.ResourceName).Key("network_profile.0.advanced_networking.0.fqdn_policy_enabled").HasValue("true"),
+			),
+		},
+	})
+}
+
 func TestAccDataSourceKubernetesCluster_addOnProfileOMS(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_kubernetes_cluster", "test")
 	r := KubernetesClusterDataSource{}
@@ -813,6 +877,50 @@ data "azurerm_kubernetes_cluster" "test" {
   resource_group_name = azurerm_kubernetes_cluster.test.resource_group_name
 }
 `, KubernetesClusterResource{}.advancedNetworkingCompleteConfig(data, "kubenet"))
+}
+
+func (KubernetesClusterDataSource) advancedContainerNetworkingServicesDisabledConfig(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_kubernetes_cluster" "test" {
+  name                = azurerm_kubernetes_cluster.test.name
+  resource_group_name = azurerm_kubernetes_cluster.test.resource_group_name
+}
+`, KubernetesClusterResource{}.advancedContainerNetworkingServicesConfig(data, false, false, false))
+}
+
+func (KubernetesClusterDataSource) advancedContainerNetworkingServicesObservabilityEnabledConfig(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_kubernetes_cluster" "test" {
+  name                = azurerm_kubernetes_cluster.test.name
+  resource_group_name = azurerm_kubernetes_cluster.test.resource_group_name
+}
+`, KubernetesClusterResource{}.advancedContainerNetworkingServicesConfig(data, true, true, false))
+}
+
+func (KubernetesClusterDataSource) advancedContainerNetworkingServicesFqdnPolicyEnabledConfig(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_kubernetes_cluster" "test" {
+  name                = azurerm_kubernetes_cluster.test.name
+  resource_group_name = azurerm_kubernetes_cluster.test.resource_group_name
+}
+`, KubernetesClusterResource{}.advancedContainerNetworkingServicesConfig(data, true, false, true))
+}
+
+func (KubernetesClusterDataSource) advancedContainerNetworkingServicesAllEnabledConfig(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_kubernetes_cluster" "test" {
+  name                = azurerm_kubernetes_cluster.test.name
+  resource_group_name = azurerm_kubernetes_cluster.test.resource_group_name
+}
+`, KubernetesClusterResource{}.advancedContainerNetworkingServicesConfig(data, true, true, true))
 }
 
 func (KubernetesClusterDataSource) addOnProfileOMSConfig(data acceptance.TestData) string {

--- a/internal/services/containers/kubernetes_cluster_data_source_test.go
+++ b/internal/services/containers/kubernetes_cluster_data_source_test.go
@@ -323,8 +323,8 @@ func TestAccDataSourceKubernetesCluster_advancedContainerNetworkingServicesDisab
 			Config: r.advancedContainerNetworkingServicesDisabledConfig(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("network_profile.0.advanced_networking.0.enabled").HasValue("false"),
-				check.That(data.ResourceName).Key("network_profile.0.advanced_networking.0.observability_enabled").HasValue("false"),
-				check.That(data.ResourceName).Key("network_profile.0.advanced_networking.0.fqdn_policy_enabled").HasValue("false"),
+				check.That(data.ResourceName).Key("network_profile.0.advanced_networking.0.observability.0.enabled").HasValue("false"),
+				check.That(data.ResourceName).Key("network_profile.0.advanced_networking.0.security.0.enabled").HasValue("false"),
 			),
 		},
 	})
@@ -339,8 +339,8 @@ func TestAccDataSourceKubernetesCluster_advancedContainerNetworkingServicesObser
 			Config: r.advancedContainerNetworkingServicesObservabilityEnabledConfig(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("network_profile.0.advanced_networking.0.enabled").HasValue("true"),
-				check.That(data.ResourceName).Key("network_profile.0.advanced_networking.0.observability_enabled").HasValue("true"),
-				check.That(data.ResourceName).Key("network_profile.0.advanced_networking.0.fqdn_policy_enabled").HasValue("false"),
+				check.That(data.ResourceName).Key("network_profile.0.advanced_networking.0.observability.0.enabled").HasValue("true"),
+				check.That(data.ResourceName).Key("network_profile.0.advanced_networking.0.security.0.enabled").HasValue("false"),
 			),
 		},
 	})
@@ -355,8 +355,8 @@ func TestAccDataSourceKubernetesCluster_advancedContainerNetworkingServicesFqdnP
 			Config: r.advancedContainerNetworkingServicesFqdnPolicyEnabledConfig(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("network_profile.0.advanced_networking.0.enabled").HasValue("true"),
-				check.That(data.ResourceName).Key("network_profile.0.advanced_networking.0.observability_enabled").HasValue("false"),
-				check.That(data.ResourceName).Key("network_profile.0.advanced_networking.0.fqdn_policy_enabled").HasValue("true"),
+				check.That(data.ResourceName).Key("network_profile.0.advanced_networking.0.observability.0.enabled").HasValue("false"),
+				check.That(data.ResourceName).Key("network_profile.0.advanced_networking.0.security.0.enabled").HasValue("true"),
 			),
 		},
 	})
@@ -371,8 +371,8 @@ func TestAccDataSourceKubernetesCluster_advancedContainerNetworkingServicesAllEn
 			Config: r.advancedContainerNetworkingServicesAllEnabledConfig(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("network_profile.0.advanced_networking.0.enabled").HasValue("true"),
-				check.That(data.ResourceName).Key("network_profile.0.advanced_networking.0.observability_enabled").HasValue("true"),
-				check.That(data.ResourceName).Key("network_profile.0.advanced_networking.0.fqdn_policy_enabled").HasValue("true"),
+				check.That(data.ResourceName).Key("network_profile.0.advanced_networking.0.observability.0.enabled").HasValue("true"),
+				check.That(data.ResourceName).Key("network_profile.0.advanced_networking.0.security.0.enabled").HasValue("true"),
 			),
 		},
 	})

--- a/internal/services/containers/kubernetes_cluster_network_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_network_resource_test.go
@@ -1677,7 +1677,7 @@ resource "azurerm_kubernetes_cluster" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, networkMode, networkPlugin, networkPolicy)
 }
 
-func (KubernetesClusterResource) advancedContainerNetworkingServicesConfig(data acceptance.TestData, enabled bool, observabilityEnabled bool, fqdnPolicyEnabled bool) string {
+func (KubernetesClusterResource) advancedContainerNetworkingServicesConfig(data acceptance.TestData, enabled bool, observabilityEnabled bool, securityEnabled bool) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -1729,14 +1729,18 @@ resource "azurerm_kubernetes_cluster" "test" {
     network_plugin_mode = "overlay"
 
     advanced_networking {
-      enabled               = %[3]t
-      observability_enabled = %[4]t
-      fqdn_policy_enabled   = %[5]t
+      enabled = %[3]t
+      observability {
+        enabled = %[4]t
+      }
+      security {
+        enabled = %[5]t
+      }
     }
 
   }
 }
-`, data.Locations.Primary, data.RandomInteger, enabled, observabilityEnabled, fqdnPolicyEnabled)
+`, data.Locations.Primary, data.RandomInteger, enabled, observabilityEnabled, securityEnabled)
 }
 
 func (KubernetesClusterResource) enableNodePublicIPConfig(data acceptance.TestData) string {

--- a/internal/services/containers/kubernetes_cluster_network_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_network_resource_test.go
@@ -1677,6 +1677,68 @@ resource "azurerm_kubernetes_cluster" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, networkMode, networkPlugin, networkPolicy)
 }
 
+func (KubernetesClusterResource) advancedContainerNetworkingServicesConfig(data acceptance.TestData, enabled bool, observabilityEnabled bool, fqdnPolicyEnabled bool) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%[2]d"
+  location = "%[1]s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%[2]d"
+  address_space       = ["10.1.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctestsubnet%[2]d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.1.0.0/24"]
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%[2]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%[2]d"
+
+  default_node_pool {
+    name           = "default"
+    node_count     = 2
+    vm_size        = "Standard_DS2_v2"
+    vnet_subnet_id = azurerm_subnet.test.id
+    upgrade_settings {
+      max_surge = "10%%"
+    }
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  network_profile {
+    network_plugin      = "azure"
+    network_policy      = "cilium"
+    network_data_plane  = "cilium"
+    network_plugin_mode = "overlay"
+
+    advanced_networking {
+      enabled               = %[3]t
+      observability_enabled = %[4]t
+      fqdn_policy_enabled   = %[5]t
+    }
+
+  }
+}
+`, data.Locations.Primary, data.RandomInteger, enabled, observabilityEnabled, fqdnPolicyEnabled)
+}
+
 func (KubernetesClusterResource) enableNodePublicIPConfig(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -114,7 +114,6 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 			}),
 			func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
 				if _, ok := d.GetOk("network_profile.0.advanced_networking"); ok {
-
 					advancedNetworkingEnabled := d.Get("network_profile.0.advanced_networking.0.enabled").(bool)
 					observabilityEnabled := d.Get("network_profile.0.advanced_networking.0.observability.0.enabled").(bool)
 					securityEnabled := d.Get("network_profile.0.advanced_networking.0.security.0.enabled").(bool)

--- a/website/docs/d/kubernetes_cluster.html.markdown
+++ b/website/docs/d/kubernetes_cluster.html.markdown
@@ -251,7 +251,7 @@ A `windows_profile` block exports the following:
 
 A `network_profile` block exports the following:
 
-* `advanced_networking` - A `advanced_networking` block as defined below.
+* `advanced_networking` - An `advanced_networking` block as defined below.
 
 * `docker_bridge_cidr` - IP address (in CIDR notation) used as the Docker bridge IP address on nodes.
 
@@ -269,7 +269,7 @@ A `network_profile` block exports the following:
 
 ---
 
-A `advanced_networking` block exports the following:
+An `advanced_networking` block exports the following:
 
 * `enabled` - Is Advanced Container Networking Services enabled?
 

--- a/website/docs/d/kubernetes_cluster.html.markdown
+++ b/website/docs/d/kubernetes_cluster.html.markdown
@@ -251,6 +251,8 @@ A `windows_profile` block exports the following:
 
 A `network_profile` block exports the following:
 
+* `advanced_networking` - A `advanced_networking` block as defined below.
+
 * `docker_bridge_cidr` - IP address (in CIDR notation) used as the Docker bridge IP address on nodes.
 
 * `dns_service_ip` - IP address within the Kubernetes service address range used by cluster service discovery (kube-dns).
@@ -264,6 +266,16 @@ A `network_profile` block exports the following:
 * `pod_cidr` - The CIDR used for pod IP addresses.
 
 * `service_cidr` - Network range used by the Kubernetes service.
+
+---
+
+A `advanced_networking` block exports the following:
+
+* `enabled` - Is Advanced Container Networking Services enabled?
+
+* `observability_enabled` - Is the Container Network Observability enabled?
+
+* `fqdn_policy_enabled` - Is the Container Network Security enabled?
 
 ---
 

--- a/website/docs/d/kubernetes_cluster.html.markdown
+++ b/website/docs/d/kubernetes_cluster.html.markdown
@@ -273,9 +273,21 @@ A `advanced_networking` block exports the following:
 
 * `enabled` - Is Advanced Container Networking Services enabled?
 
-* `observability_enabled` - Is the Container Network Observability enabled?
+* `observability` - A `observability` block as defined below.
 
-* `fqdn_policy_enabled` - Is the Container Network Security enabled?
+* `security` - A `security` block as defined below.
+
+---
+
+A `observability` block exports the following:
+
+* `enabled` - Is the Container Network Observability enabled?
+
+---
+
+A `security` block exports the following:
+
+* `enabled` - Is the Container Network Security enabled?
 
 ---
 

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -641,7 +641,7 @@ A `microsoft_defender` block supports the following:
 
 A `network_profile` block supports the following:
 
-* `advanced_networking` - (Optional) A `advanced_networking` block as defined below.
+* `advanced_networking` - (Optional) An `advanced_networking` block as defined below.
 
 * `network_plugin` - (Required) Network plugin to use for networking. Currently supported values are `azure`, `kubenet` and `none`. Changing this forces a new resource to be created.
 
@@ -699,7 +699,7 @@ Examples of how to use [AKS with Advanced Networking](https://docs.microsoft.com
 
 ---
 
-A `advanced_networking` block exports the following:
+An `advanced_networking` block exports the following:
 
 * `enabled` - Enable or disable [Advanced Container Networking Services](https://learn.microsoft.com/en-us/azure/aks/advanced-container-networking-services-overview)
 

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -641,6 +641,8 @@ A `microsoft_defender` block supports the following:
 
 A `network_profile` block supports the following:
 
+* `advanced_networking` - (Optional) A `advanced_networking` block as defined below.
+
 * `network_plugin` - (Required) Network plugin to use for networking. Currently supported values are `azure`, `kubenet` and `none`. Changing this forces a new resource to be created.
 
 -> **Note:** When `network_plugin` is set to `azure` - the `pod_cidr` field must not be set, unless specifying `network_plugin_mode` to `overlay`.
@@ -694,6 +696,20 @@ Examples of how to use [AKS with Advanced Networking](https://docs.microsoft.com
 * `load_balancer_profile` - (Optional) A `load_balancer_profile` block as defined below. This can only be specified when `load_balancer_sku` is set to `standard`. Changing this forces a new resource to be created.
 
 * `nat_gateway_profile` - (Optional) A `nat_gateway_profile` block as defined below. This can only be specified when `load_balancer_sku` is set to `standard` and `outbound_type` is set to `managedNATGateway` or `userAssignedNATGateway`. Changing this forces a new resource to be created.
+
+---
+
+A `advanced_networking` block exports the following:
+
+* `enabled` - Enable or disable [Advanced Container Networking Services](https://learn.microsoft.com/en-us/azure/aks/advanced-container-networking-services-overview)
+
+~> **Note:** Enabling this option requires at least one of the two options below to be enabled.
+
+* `observability_enabled` - (Optional) Enable or disable [Container Network Observability](https://learn.microsoft.com/en-us/azure/aks/container-network-observability-concepts?tabs=cilium). Defaults to `false`.
+
+* `fqdn_policy_enabled` - (Optional) Enable or disable [Container Network Security](https://learn.microsoft.com/en-us/azure/aks/container-network-security-concepts). Defaults to `false`.
+
+~> **Note:** This option can only be used on [clusters with Cilium as the data plane](https://learn.microsoft.com/en-us/azure/aks/advanced-container-networking-services-overview#enable-advanced-container-networking-services-on-an-existing-cluster).
 
 ---
 

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -703,11 +703,23 @@ A `advanced_networking` block exports the following:
 
 * `enabled` - Enable or disable [Advanced Container Networking Services](https://learn.microsoft.com/en-us/azure/aks/advanced-container-networking-services-overview)
 
-~> **Note:** Enabling this option requires at least one of the two options below to be enabled.
+~> **Note:** Enabling this option requires at least one of the two features below to be enabled.
 
-* `observability_enabled` - (Optional) Enable or disable [Container Network Observability](https://learn.microsoft.com/en-us/azure/aks/container-network-observability-concepts?tabs=cilium). Defaults to `false`.
+* `observability` - (Optional) A `observability` block as defined below.
 
-* `fqdn_policy_enabled` - (Optional) Enable or disable [Container Network Security](https://learn.microsoft.com/en-us/azure/aks/container-network-security-concepts). Defaults to `false`.
+* `security` - (Optional) A `security` block as defined below.
+
+---
+
+A `observability` block exports the following:
+
+* `enabled` - Enable or disable [Container Network Observability](https://learn.microsoft.com/en-us/azure/aks/container-network-observability-concepts?tabs=cilium). Defaults to `false`.
+
+---
+
+A `security` block exports the following:
+
+* `enabled` - Enable or disable [Container Network Security](https://learn.microsoft.com/en-us/azure/aks/container-network-security-concepts). Defaults to `false`.
 
 ~> **Note:** This option can only be used on [clusters with Cilium as the data plane](https://learn.microsoft.com/en-us/azure/aks/advanced-container-networking-services-overview#enable-advanced-container-networking-services-on-an-existing-cluster).
 


### PR DESCRIPTION
## Community Note
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

This adds support for controlling AKS [Advanced Container Networking Services](https://learn.microsoft.com/en-us/azure/aks/advanced-container-networking-services-overview). This adds the following API under `azurerm_kubernetes_cluster.network_profile`:

```hcl
resource "azurerm_kubernetes_cluster" "my_acns_enabled_cluster" {
  name = "my_acns_enabled_cluster"
  ...

  network_profile {
    ...

    advanced_networking {
      enabled               = true
      observability_enabled = true
      fqdn_policy_enabled   = false
    }
  }
}
```

:exclamation: NOTE: In the issue, [the suggestion](https://github.com/hashicorp/terraform-provider-azurerm/issues/27243#issuecomment-2655902061) was to make the attributes for controlling the separate features of ACNS nested blocks. However, what I saw in the [design guidelines](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/schema-design-considerations.md), was against that (to just make these flattened), and it seemed to me that this would only complicate the implementation. [I've raised this in Slack](https://terraform-azure.slack.com/archives/CJD3VK9Q9/p1741794130491509), but in lack of any response, I've gone ahead and took the flattened design. If we do want to make this nested blocks, then I'll need some input, and help to make that happen.

## PR Checklist

- [X] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [X] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [X] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [X] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [X] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”

## Changes to existing Resource / Data Source

- [X] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [X] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [X] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [X] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.

## Testing 

- [X] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

I've added tests for the Data Source, and they run successfully. I haven't added any tests for the Resource, as that's already covered in the tests under the Data Source. And looking at the tests for the Resource, there are only a few, like toggling some important settings, or upgrading the cluster (which requires multiple steps), so probably we don't want to test this specific setting there. If we do, let me know, and I can add them.

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

* `azurerm_kubernetes_cluster` - support for the network_profile.advanced_networking` block [GH-27243]

This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [X] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #27243
