### PR TITLE
`azurerm_linux_virtual_machine` - use `CreateOrUpdate` to update `identity`

### DIFF
--- a/internal/services/compute/linux_virtual_machine_scale_set_resource_identity_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_resource_identity_test.go
@@ -89,8 +89,14 @@ func TestAccLinuxVirtualMachineScaleSet_identityUserAssigned(t *testing.T) {
 		},
 		data.ImportStep("admin_password"),
 		{
-			// second
 			Config: r.identityUserAssignedUpdated(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			Config: r.identityUserAssignedRemoved(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -287,6 +293,66 @@ resource "azurerm_linux_virtual_machine_scale_set" "test" {
     identity_ids = [
       azurerm_user_assigned_identity.test.id,
       azurerm_user_assigned_identity.other.id,
+    ]
+  }
+}
+`, r.template(data), data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func (r LinuxVirtualMachineScaleSetResource) identityUserAssignedRemoved(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acctestuai-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_user_assigned_identity" "other" {
+  name                = "acctestuai2-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_linux_virtual_machine_scale_set" "test" {
+  name                = "acctestvmss-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  disable_password_authentication = false
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "0001-com-ubuntu-server-jammy"
+    sku       = "22_04-lts"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name    = "example"
+    primary = true
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurerm_subnet.test.id
+    }
+  }
+
+  identity {
+    type = "UserAssigned"
+    identity_ids = [
+      azurerm_user_assigned_identity.test.id,
     ]
   }
 }


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Testing 

![image](https://github.com/user-attachments/assets/876e145d-4667-403d-b293-7cfac1a7d34f)

No new test failures.

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_linux_virtual_machine` - fix issue where removing a user assigned identity from `identity_ids` isn't recognised by API [GH-00000]
* `azurerm_linux_virtual_machine_scale_set` - fix issue where removing a user assigned identity from `identity_ids` isn't recognised by API [GH-00000]

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #25058


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
