### PR TITLE
`azurerm_stream_analytics_job` - update validation when setting `job_storage_account`

### DIFF
--- a/internal/services/streamanalytics/stream_analytics_job_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_job_resource.go
@@ -296,12 +296,11 @@ func resourceStreamAnalyticsJobCreate(d *pluginsdk.ResourceData, meta interface{
 		props.Properties.CompatibilityLevel = pointer.To(streamingjobs.CompatibilityLevel(d.Get("compatibility_level").(string)))
 	}
 
-	if contentStoragePolicy == string(streamingjobs.ContentStoragePolicyJobStorageAccount) {
-		if v, ok := d.GetOk("job_storage_account"); ok {
-			props.Properties.JobStorageAccount = expandJobStorageAccount(v.([]interface{}))
-		} else {
-			return fmt.Errorf("`job_storage_account` must be set when `content_storage_policy` is `JobStorageAccount`")
+	if v, ok := d.GetOk("job_storage_account"); ok {
+		if contentStoragePolicy != string(streamingjobs.ContentStoragePolicyJobStorageAccount) {
+			return fmt.Errorf("`job_storage_account` must not be set when `content_storage_policy` is `SystemAccount`")
 		}
+		props.Properties.JobStorageAccount = expandJobStorageAccount(v.([]interface{}))
 	}
 
 	if jobType == string(streamingjobs.JobTypeEdge) {

--- a/website/docs/r/stream_analytics_job.html.markdown
+++ b/website/docs/r/stream_analytics_job.html.markdown
@@ -84,7 +84,9 @@ The following arguments are supported:
 
 * `content_storage_policy` - (Optional) The policy for storing stream analytics content. Possible values are `JobStorageAccount`, `SystemAccount`. Defaults to `SystemAccount`.
 
-* `job_storage_account` - (Optional) The details of the job storage account. A `job_storage_account` block as defined below. 
+* `job_storage_account` - (Optional) The details of the job storage account. A `job_storage_account` block as defined below.
+
+-> **Note:** `content_storage_policy` must be set to `JobStorageAccount` when specifying `job_storage_account`.
 
 ---
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Currently we only add `job_storage_account` to the create payload if `content_storage_policy` has been set to `JobStorageAccount` which is confusing/misleading. This updates the validation in the create to error if `content_storage_policy` hasn't been set to `JobStorageAccount` when `job_storage_account` has been specified.

The update function already contains validation to prevent this.

## Testing 

![image](https://github.com/user-attachments/assets/fd174880-ffce-4390-a3c5-6c044fb4c78f)


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_stream_analytics_job` - add validation when creating the resource to error if `content_storage_policy` hasn't been set to `JobStorageAccount` when `job_storage_account` has been specified [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
