### PR TITLE
Allow Managed HSM IDs in Key Vault nested items

### DIFF
--- a/internal/services/keyvault/parse/nested_item.go
+++ b/internal/services/keyvault/parse/nested_item.go
@@ -50,10 +50,6 @@ func NewNestedItemID(keyVaultBaseUrl string, nestedItemType NestedItemObjectType
 		keyVaultUrl.Host = hostParts[0]
 	}
 
-	if strings.Contains(strings.ToLower(keyVaultBaseUrl), ".managedhsm.") {
-		return nil, fmt.Errorf("internal-error: Managed HSM IDs are not supported as Key Vault Nested Items")
-	}
-
 	return &NestedItemId{
 		KeyVaultBaseUrl: keyVaultUrl.String(),
 		NestedItemType:  nestedItemType,
@@ -117,9 +113,6 @@ func ParseOptionallyVersionedNestedItemID(input string) (*NestedItemId, error) {
 }
 
 func parseNestedItemId(id string) (*NestedItemId, error) {
-	if strings.Contains(strings.ToLower(id), ".managedhsm.") {
-		return nil, fmt.Errorf("internal-error: Managed HSM IDs are not supported as Key Vault Nested Items")
-	}
 	// versioned example: https://tharvey-keyvault.vault.azure.net/type/bird/fdf067c93bbb4b22bff4d8b7a9a56217
 	// versionless example: https://tharvey-keyvault.vault.azure.net/type/bird/
 	idURL, err := url.ParseRequestURI(id)

--- a/internal/services/keyvault/parse/nested_item_test.go
+++ b/internal/services/keyvault/parse/nested_item_test.go
@@ -37,7 +37,7 @@ func TestNewNestedItemID(t *testing.T) {
 			Scenario:        "mhsm valid, with port",
 			keyVaultBaseUrl: "https://test.managedhsm.azure.net:443",
 			Expected:        "https://test.managedhsm.azure.net/keys/test/testVersionString",
-			ExpectError:     true,
+			ExpectError:     false,
 		},
 	}
 	for _, tc := range cases {
@@ -126,7 +126,13 @@ func TestParseNestedItemID(t *testing.T) {
 		},
 		{
 			Input:       "https://my-keyvault.managedhsm.azure.net/keys/castle/1492",
-			ExpectError: true,
+			ExpectError: false,
+			Expected: NestedItemId{
+				Name:            "castle",
+				KeyVaultBaseUrl: "https://my-keyvault.managedhsm.azure.net/",
+				Version:         "1492",
+				NestedItemType:  NestedItemTypeKey,
+			},
 		},
 		{
 			Input:       "https://my-keyvault.vault.azure.net/secrets/bird/fdf067c93bbb4b22bff4d8b7a9a56217/XXX",
@@ -226,7 +232,13 @@ func TestParseOptionallyVersionedNestedItemID(t *testing.T) {
 		},
 		{
 			Input:       "https://my-keyvault.managedhsm.azure.net/keys/castle/1492",
-			ExpectError: true,
+			ExpectError: false,
+			Expected: NestedItemId{
+				Name:            "castle",
+				KeyVaultBaseUrl: "https://my-keyvault.managedhsm.azure.net/",
+				Version:         "1492",
+				NestedItemType:  NestedItemTypeKey,
+			},
 		},
 		{
 			Input:       "https://my-keyvault.vault.azure.net/secrets/bird/fdf067c93bbb4b22bff4d8b7a9a56217/XXX",


### PR DESCRIPTION
# PR Template for Allow Managed HSM IDs in Key Vault nested items

## Community Note
* Please vote on this PR by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

This PR removes the restriction that blocks Managed HSM IDs from being used as Key Vault nested items. The current implementation returns an error message "internal-error: Managed HSM IDs are not supported as Key Vault Nested Items" when attempting to use Managed HSM keys.

The Azure API and Portal fully support using Managed HSM keys with various services like PostgreSQL Flexible Server. This change aligns the provider with Azure's actual capabilities, allowing users to reference Managed HSM keys in Terraform configurations.

The fix is minimal and simply removes the explicit error-producing checks in the parsing functions.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.

## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally.

## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass.

I've updated the existing tests to allow Managed HSM URLs where they were previously expected to fail. All modified tests pass locally after my changes.

## Change Log

* `key_vault` - allow Managed HSM IDs to be used as Key Vault Nested Items [GH-26338]

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change

## Related Issue(s)
Fixes #26338 #26357 #26392 #27436 #27450 #27451 #27738 #27739