### PR TITLE
`azurerm_vpn_gateway` - support for new readonly property `ip_configuration`

### DIFF
--- a/internal/services/network/vpn_gateway_data_source.go
+++ b/internal/services/network/vpn_gateway_data_source.go
@@ -5,9 +5,9 @@ package network
 
 import (
 	"fmt"
-	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"

--- a/internal/services/network/vpn_gateway_data_source.go
+++ b/internal/services/network/vpn_gateway_data_source.go
@@ -5,6 +5,7 @@ package network
 
 import (
 	"fmt"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
@@ -138,6 +139,29 @@ func dataSourceVPNGateway() *pluginsdk.Resource {
 				},
 			},
 
+			"ip_configuration": {
+				Type:     pluginsdk.TypeList,
+				Computed: true,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"id": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+
+						"private_ip_address": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+
+						"public_ip_address": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+
 			"scale_unit": {
 				Type:     pluginsdk.TypeInt,
 				Computed: true,
@@ -175,6 +199,10 @@ func dataSourceVPNGatewayRead(d *pluginsdk.ResourceData, meta interface{}) error
 		if props := model.Properties; props != nil {
 			if err := d.Set("bgp_settings", dataSourceFlattenVPNGatewayBGPSettings(props.BgpSettings)); err != nil {
 				return fmt.Errorf("Error setting `bgp_settings`: %+v", err)
+			}
+
+			if err := d.Set("ip_configuration", dataSourceFlattenVPNGatewayIpConfiguration(props.IPConfigurations)); err != nil {
+				return fmt.Errorf("setting `ip_configuration`: %+v", err)
 			}
 
 			scaleUnit := 0
@@ -251,4 +279,21 @@ func dataSourceFlattenVPNGatewayIPConfigurationBgpPeeringAddress(input virtualwa
 			"tunnel_ips":          utils.FlattenStringSlice(input.TunnelIPAddresses),
 		},
 	}
+}
+
+func dataSourceFlattenVPNGatewayIpConfiguration(input *[]virtualwans.VpnGatewayIPConfiguration) []interface{} {
+	result := make([]interface{}, 0)
+	if input == nil {
+		return result
+	}
+
+	for _, item := range *input {
+		result = append(result, map[string]interface{}{
+			"id":                 pointer.From(item.Id),
+			"private_ip_address": pointer.From(item.PrivateIPAddress),
+			"public_ip_address":  pointer.From(item.PublicIPAddress),
+		})
+	}
+
+	return result
 }

--- a/internal/services/network/vpn_gateway_data_source_test.go
+++ b/internal/services/network/vpn_gateway_data_source_test.go
@@ -29,6 +29,7 @@ func TestAccVPNGatewayDataSource_complete(t *testing.T) {
 				check.That(data.ResourceName).Key("bgp_settings.0.instance_1_bgp_peering_address.0.tunnel_ips.0").Exists(),
 				check.That(data.ResourceName).Key("bgp_settings.0.instance_1_bgp_peering_address.0.default_ips.0").Exists(),
 				check.That(data.ResourceName).Key("bgp_settings.0.instance_1_bgp_peering_address.0.ip_configuration_id").Exists(),
+				check.That(data.ResourceName).Key("ip_configuration.#").HasValue("2"),
 			),
 		},
 	})

--- a/internal/services/network/vpn_gateway_resource_test.go
+++ b/internal/services/network/vpn_gateway_resource_test.go
@@ -27,6 +27,7 @@ func TestAccVPNGateway_basic(t *testing.T) {
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("ip_configuration.#").HasValue("2"),
 			),
 		},
 		data.ImportStep(),

--- a/website/docs/d/vpn_gateway.html.markdown
+++ b/website/docs/d/vpn_gateway.html.markdown
@@ -39,6 +39,8 @@ output "azurerm_vpn_gateway_id" {
 
 * `bgp_settings` - A `bgp_settings` block as defined below.
 
+* `ip_configuration` - An `ip_configuration` block as defined below.
+
 * `scale_unit` -  The Scale Unit of this VPN Gateway.
 
 * `tags` - A mapping of tags assigned to the VPN Gateway.
@@ -82,6 +84,16 @@ A `instance_bgp_peering_address` block exports the following:
 * `default_ips` - The list of default BGP peering addresses which belong to the pre-defined VPN Gateway IP configuration.
 
 * `tunnel_ips` - The list of tunnel public IP addresses which belong to the pre-defined VPN Gateway IP configuration.
+
+---
+
+An `ip_configuration` block exports the following:
+
+* `id` - The identifier of the IP configuration for the VPN Gateway.
+
+* `private_ip_address` - The private IP address of this IP configuration.
+
+* `public_ip_address` - The public IP address of this IP configuration.
 
 ## Timeouts
 

--- a/website/docs/r/vpn_gateway.html.markdown
+++ b/website/docs/r/vpn_gateway.html.markdown
@@ -97,6 +97,8 @@ In addition to the arguments above, the following attributes are exported:
 
 * `bgp_settings` - A `bgp_settings` block as defined below.
 
+* `ip_configuration` - An `ip_configuration` block as defined below.
+
 ---
 
 A `bgp_settings` block exports the following:
@@ -116,6 +118,16 @@ A `instance_bgp_peering_address` block exports the following:
 * `default_ips` - The list of default BGP peering addresses which belong to the pre-defined VPN Gateway IP configuration.
 
 * `tunnel_ips` - The list of tunnel public IP addresses which belong to the pre-defined VPN Gateway IP configuration.
+
+---
+
+An `ip_configuration` block exports the following:
+
+* `id` - The identifier of the IP configuration for the VPN Gateway.
+
+* `private_ip_address` - The private IP address of this IP configuration.
+
+* `public_ip_address` - The public IP address of this IP configuration.
 
 ## Timeouts
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description
This is to support new readonly property [ip_configuration](https://github.com/Azure/azure-rest-api-specs/blob/7c1e8a2c1e18ac0dd65b88f00447992ed86fcc0f/specification/network/resource-manager/Microsoft.Network/stable/2024-05-01/virtualWan.json#L7513) on azurerm_vpn_gateway.
<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

TestAccVPNGatewayDataSource_:
--- PASS: TestAccVPNGatewayDataSource_complete (4954.46s)

TestAccVPNGateway_(Below test case is also failed with same error on Teamcity Daily Run. So it's not related with this PR):
![image](https://github.com/user-attachments/assets/118bbfd4-02ee-4d38-96f4-11f7a590a56d)

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_vpn_gateway` - support for new readonly property `ip_configuration`


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/28437


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
