### PR TITLE
`azurerm_ai_foundry_project`: add support for `primary_user_assigned_identity`

### DIFF
--- a/internal/services/machinelearning/ai_foundry_project_resource.go
+++ b/internal/services/machinelearning/ai_foundry_project_resource.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
@@ -26,15 +27,16 @@ import (
 type AIFoundryProject struct{}
 
 type AIFoundryProjectModel struct {
-	Name                      string                                     `tfschema:"name"`
-	Location                  string                                     `tfschema:"location"`
-	AIServicesHubId           string                                     `tfschema:"ai_services_hub_id"`
-	Identity                  []identity.ModelSystemAssignedUserAssigned `tfschema:"identity"`
-	HighBusinessImpactEnabled bool                                       `tfschema:"high_business_impact_enabled"`
-	Description               string                                     `tfschema:"description"`
-	FriendlyName              string                                     `tfschema:"friendly_name"`
-	ProjectId                 string                                     `tfschema:"project_id"`
-	Tags                      map[string]interface{}                     `tfschema:"tags"`
+	Name                        string                                     `tfschema:"name"`
+	Location                    string                                     `tfschema:"location"`
+	AIServicesHubId             string                                     `tfschema:"ai_services_hub_id"`
+	Identity                    []identity.ModelSystemAssignedUserAssigned `tfschema:"identity"`
+	HighBusinessImpactEnabled   bool                                       `tfschema:"high_business_impact_enabled"`
+	Description                 string                                     `tfschema:"description"`
+	PrimaryUserAssignedIdentity string                                     `tfschema:"primary_user_assigned_identity"`
+	FriendlyName                string                                     `tfschema:"friendly_name"`
+	ProjectId                   string                                     `tfschema:"project_id"`
+	Tags                        map[string]interface{}                     `tfschema:"tags"`
 }
 
 func (r AIFoundryProject) ModelObject() interface{} {
@@ -103,6 +105,12 @@ func (r AIFoundryProject) Arguments() map[string]*pluginsdk.Schema {
 			// NOTE: O+C creating a project that has encryption enabled with system assigned identity will set this property to true
 			Computed: true,
 			ForceNew: true,
+		},
+
+		"primary_user_assigned_identity": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: commonids.ValidateUserAssignedIdentityID,
 		},
 
 		"description": {
@@ -177,6 +185,14 @@ func (r AIFoundryProject) Create() sdk.ResourceFunc {
 				payload.Identity = expandedIdentity
 			}
 
+			if model.PrimaryUserAssignedIdentity != "" {
+				userAssignedId, err := commonids.ParseUserAssignedIdentityID(model.PrimaryUserAssignedIdentity)
+				if err != nil {
+					return err
+				}
+				payload.Properties.PrimaryUserAssignedIdentity = pointer.To(userAssignedId.ID())
+			}
+
 			if model.Description != "" {
 				payload.Properties.Description = pointer.To(model.Description)
 			}
@@ -240,6 +256,14 @@ func (r AIFoundryProject) Update() sdk.ResourceFunc {
 
 			if metadata.ResourceData.HasChange("description") {
 				payload.Properties.Description = pointer.To(state.Description)
+			}
+
+			if metadata.ResourceData.HasChange("primary_user_assigned_identity") {
+				userAssignedId, err := commonids.ParseUserAssignedIdentityID(state.PrimaryUserAssignedIdentity)
+				if err != nil {
+					return err
+				}
+				payload.Properties.PrimaryUserAssignedIdentity = pointer.To(userAssignedId.ID())
 			}
 
 			if metadata.ResourceData.HasChange("friendly_name") {
@@ -313,6 +337,7 @@ func (r AIFoundryProject) Read() sdk.ResourceFunc {
 					hub.FriendlyName = pointer.From(props.FriendlyName)
 					hub.HighBusinessImpactEnabled = pointer.From(props.HbiWorkspace)
 					hub.ProjectId = pointer.From(props.WorkspaceId)
+					hub.PrimaryUserAssignedIdentity = pointer.From(props.PrimaryUserAssignedIdentity)
 				}
 			}
 

--- a/internal/services/machinelearning/ai_foundry_project_resource.go
+++ b/internal/services/machinelearning/ai_foundry_project_resource.go
@@ -111,6 +111,7 @@ func (r AIFoundryProject) Arguments() map[string]*pluginsdk.Schema {
 			Type:         pluginsdk.TypeString,
 			Optional:     true,
 			ValidateFunc: commonids.ValidateUserAssignedIdentityID,
+			RequiredWith: []string{"identity"},
 		},
 
 		"description": {

--- a/internal/services/machinelearning/ai_foundry_project_resource_test.go
+++ b/internal/services/machinelearning/ai_foundry_project_resource_test.go
@@ -153,18 +153,6 @@ resource "azurerm_role_assignment" "test" {
   principal_id         = azurerm_user_assigned_identity.test.principal_id
 }
 
-resource "azurerm_user_assigned_identity" "test2" {
-  location            = azurerm_resource_group.test.location
-  name                = "acctestuai2-%[2]d"
-  resource_group_name = azurerm_resource_group.test.name
-}
-
-resource "azurerm_role_assignment" "test2" {
-  scope                = azurerm_resource_group.test.id
-  role_definition_name = "Reader"
-  principal_id         = azurerm_user_assigned_identity.test2.principal_id
-}
-
 resource "azurerm_key_vault_access_policy" "test2" {
   key_vault_id = azurerm_key_vault.test.id
   tenant_id    = azurerm_user_assigned_identity.test.tenant_id
@@ -175,18 +163,7 @@ resource "azurerm_key_vault_access_policy" "test2" {
     "Get",
   ]
 }
-
-resource "azurerm_key_vault_access_policy" "test3" {
-  key_vault_id = azurerm_key_vault.test.id
-  tenant_id    = azurerm_user_assigned_identity.test2.tenant_id
-  object_id    = azurerm_user_assigned_identity.test2.client_id
-
-  key_permissions = [
-    "Create",
-    "Get",
-  ]
-}
-  `, AIFoundry{}.basic(data), data.RandomInteger)
+`, AIFoundry{}.basic(data), data.RandomInteger)
 }
 
 func (r AIFoundryProject) userIdentity(data acceptance.TestData) string {
@@ -212,6 +189,29 @@ resource "azurerm_ai_foundry_project" "test" {
 func (r AIFoundryProject) userIdentityUpdate(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
+
+resource "azurerm_user_assigned_identity" "test2" {
+  location            = azurerm_resource_group.test.location
+  name                = "acctestuai2-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_role_assignment" "test2" {
+  scope                = azurerm_resource_group.test.id
+  role_definition_name = "Reader"
+  principal_id         = azurerm_user_assigned_identity.test2.principal_id
+}
+
+resource "azurerm_key_vault_access_policy" "test3" {
+  key_vault_id = azurerm_key_vault.test.id
+  tenant_id    = azurerm_user_assigned_identity.test2.tenant_id
+  object_id    = azurerm_user_assigned_identity.test2.client_id
+
+  key_permissions = [
+    "Create",
+    "Get",
+  ]
+}
 
 resource "azurerm_ai_foundry_project" "test" {
   name                           = "acctestaip-%[2]d"

--- a/internal/services/machinelearning/ai_foundry_project_resource_test.go
+++ b/internal/services/machinelearning/ai_foundry_project_resource_test.go
@@ -221,7 +221,7 @@ resource "azurerm_ai_foundry_project" "test" {
 
   identity {
     type         = "UserAssigned"
-    identity_ids = [azurerm_user_assigned_identity.test.id]
+    identity_ids = [azurerm_user_assigned_identity.test.id, azurerm_user_assigned_identity.test2.id]
   }
 
   depends_on = [azurerm_key_vault_access_policy.test2, azurerm_role_assignment.test2]

--- a/internal/services/machinelearning/ai_foundry_project_resource_test.go
+++ b/internal/services/machinelearning/ai_foundry_project_resource_test.go
@@ -33,6 +33,28 @@ func TestAccAIFoundryProject_basic(t *testing.T) {
 	})
 }
 
+func TestAccAIFoundryProject_userIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_ai_foundry_project", "test")
+	r := AIFoundryProject{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.userIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.userIdentityUpdate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccAIFoundryProject_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_ai_foundry_project", "test")
 	r := AIFoundryProject{}
@@ -113,6 +135,98 @@ resource "azurerm_ai_foundry_project" "test" {
   }
 }
 `, AIFoundry{}.basic(data), data.RandomInteger)
+}
+
+func (r AIFoundryProject) userIdentityTempalte(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_user_assigned_identity" "test" {
+  location            = azurerm_resource_group.test.location
+  name                = "acctestuai-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_role_assignment" "test" {
+  scope                = azurerm_resource_group.test.id
+  role_definition_name = "Reader"
+  principal_id         = azurerm_user_assigned_identity.test.principal_id
+}
+
+resource "azurerm_user_assigned_identity" "test2" {
+  location            = azurerm_resource_group.test.location
+  name                = "acctestuai2-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_role_assignment" "test2" {
+  scope                = azurerm_resource_group.test.id
+  role_definition_name = "Reader"
+  principal_id         = azurerm_user_assigned_identity.test2.principal_id
+}
+
+resource "azurerm_key_vault_access_policy" "test2" {
+  key_vault_id = azurerm_key_vault.test.id
+  tenant_id    = azurerm_user_assigned_identity.test.tenant_id
+  object_id    = azurerm_user_assigned_identity.test.client_id
+
+  key_permissions = [
+    "Create",
+    "Get",
+  ]
+}
+
+resource "azurerm_key_vault_access_policy" "test3" {
+  key_vault_id = azurerm_key_vault.test.id
+  tenant_id    = azurerm_user_assigned_identity.test2.tenant_id
+  object_id    = azurerm_user_assigned_identity.test2.client_id
+
+  key_permissions = [
+    "Create",
+    "Get",
+  ]
+}
+  `, AIFoundry{}.basic(data), data.RandomInteger)
+}
+
+func (r AIFoundryProject) userIdentity(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_ai_foundry_project" "test" {
+  name                           = "acctestaip-%[2]d"
+  location                       = azurerm_ai_foundry.test.location
+  ai_services_hub_id             = azurerm_ai_foundry.test.id
+  primary_user_assigned_identity = azurerm_user_assigned_identity.test.id
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.test.id]
+  }
+
+  depends_on = [azurerm_key_vault_access_policy.test2, azurerm_role_assignment.test]
+}
+`, r.userIdentityTempalte(data), data.RandomInteger)
+}
+
+func (r AIFoundryProject) userIdentityUpdate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_ai_foundry_project" "test" {
+  name                           = "acctestaip-%[2]d"
+  location                       = azurerm_ai_foundry.test.location
+  ai_services_hub_id             = azurerm_ai_foundry.test.id
+  primary_user_assigned_identity = azurerm_user_assigned_identity.test2.id
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.test.id]
+  }
+
+  depends_on = [azurerm_key_vault_access_policy.test2, azurerm_role_assignment.test2]
+}
+`, r.userIdentityTempalte(data), data.RandomInteger)
 }
 
 func (r AIFoundryProject) complete(data acceptance.TestData) string {

--- a/internal/services/machinelearning/ai_foundry_project_resource_test.go
+++ b/internal/services/machinelearning/ai_foundry_project_resource_test.go
@@ -137,7 +137,7 @@ resource "azurerm_ai_foundry_project" "test" {
 `, AIFoundry{}.basic(data), data.RandomInteger)
 }
 
-func (r AIFoundryProject) userIdentityTempalte(data acceptance.TestData) string {
+func (r AIFoundryProject) userIdentityTemplate(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -183,7 +183,7 @@ resource "azurerm_ai_foundry_project" "test" {
 
   depends_on = [azurerm_key_vault_access_policy.test2, azurerm_role_assignment.test]
 }
-`, r.userIdentityTempalte(data), data.RandomInteger)
+`, r.userIdentityTemplate(data), data.RandomInteger)
 }
 
 func (r AIFoundryProject) userIdentityUpdate(data acceptance.TestData) string {
@@ -226,7 +226,7 @@ resource "azurerm_ai_foundry_project" "test" {
 
   depends_on = [azurerm_key_vault_access_policy.test2, azurerm_role_assignment.test2]
 }
-`, r.userIdentityTempalte(data), data.RandomInteger)
+`, r.userIdentityTemplate(data), data.RandomInteger)
 }
 
 func (r AIFoundryProject) complete(data acceptance.TestData) string {

--- a/website/docs/r/ai_foundry_project.html.markdown
+++ b/website/docs/r/ai_foundry_project.html.markdown
@@ -71,40 +71,10 @@ resource "azurerm_ai_foundry" "example" {
   }
 }
 
-resource "azurerm_user_assigned_identity" "example" {
-  location            = azurerm_resource_group.example.location
-  name                = "identity-example"
-  resource_group_name = azurerm_resource_group.example.name
-}
-
-resource "azurerm_role_assignment" "example" {
-  scope                = azurerm_resource_group.example.id
-  role_definition_name = "Reader"
-  principal_id         = azurerm_user_assigned_identity.example.principal_id
-}
-
-resource "azurerm_key_vault_access_policy" "example2" {
-  key_vault_id = azurerm_key_vault.example.id
-  tenant_id    = azurerm_user_assigned_identity.example.tenant_id
-  object_id    = azurerm_user_assigned_identity.example.client_id
-
-  key_permissions = [
-    "Create",
-    "Get",
-  ]
-}
-
-
 resource "azurerm_ai_foundry_project" "example" {
   name                           = "example"
   location                       = azurerm_ai_foundry.example.location
   ai_services_hub_id             = azurerm_ai_foundry.example.id
-  primary_user_assigned_identity = azurerm_user_assigned_identity.example.id
-
-  identity {
-    type         = "UserAssigned"
-    identity_ids = [azurerm_user_assigned_identity.example.id]
-  }
 }
 ```
 

--- a/website/docs/r/ai_foundry_project.html.markdown
+++ b/website/docs/r/ai_foundry_project.html.markdown
@@ -72,9 +72,9 @@ resource "azurerm_ai_foundry" "example" {
 }
 
 resource "azurerm_ai_foundry_project" "example" {
-  name                           = "example"
-  location                       = azurerm_ai_foundry.example.location
-  ai_services_hub_id             = azurerm_ai_foundry.example.id
+  name               = "example"
+  location           = azurerm_ai_foundry.example.location
+  ai_services_hub_id = azurerm_ai_foundry.example.id
 }
 ```
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

The user identity should specifid by separate field as `PrimaryUserAssignedIdentity`. API Spec reference: https://github.com/Azure/azure-rest-api-specs/blob/c488b4a741cb78f93514d7a9d3332d08ea7b32e1/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2024-04-01/workspaceRP.json#L1812

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

![image](https://github.com/user-attachments/assets/26fe625c-6e9d-49dd-99f8-6437697be2c3)


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_ai_foundry_project`: add support for `primary_user_assigned_identity` property [GH-29074]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [x] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #29074
