### PR TITLE
New Data Source: `azurerm_role_assignments`

### DIFF
--- a/internal/provider/services_test.go
+++ b/internal/provider/services_test.go
@@ -126,7 +126,7 @@ func validateResourceTypeName(resourceType string) error {
 	}
 
 	// Role Assignments should be named `azurerm_{type}_role_assignment` for consistency
-	if strings.Contains(resourceType, "role_assignment") && !strings.HasSuffix(resourceType, "role_assignment") {
+	if strings.Contains(resourceType, "role_assignment") && (!strings.HasSuffix(resourceType, "role_assignment") && !strings.HasSuffix(resourceType, "role_assignments")) {
 		return fmt.Errorf("role assignment resources should be named `azurerm_{type}_role_assignment`")
 	}
 

--- a/internal/services/authorization/registration.go
+++ b/internal/services/authorization/registration.go
@@ -47,6 +47,7 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 
 func (r Registration) DataSources() []sdk.DataSource {
 	return []sdk.DataSource{
+		RoleAssignmentsDataSource{},
 		RoleDefinitionDataSource{},
 		RoleManagementPolicyDataSource{},
 	}

--- a/internal/services/authorization/role_assignments_data_source.go
+++ b/internal/services/authorization/role_assignments_data_source.go
@@ -1,0 +1,205 @@
+package authorization
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/authorization/2022-04-01/roleassignments"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+type RoleAssignmentsDataSource struct{}
+
+type RoleAssignmentsDataSourceModel struct {
+	Scope           string                 `tfschema:"scope"`
+	LimitAtScope    bool                   `tfschema:"limit_at_scope"`
+	PrincipalID     string                 `tfschema:"principal_id"`
+	TenantID        string                 `tfschema:"tenant_id"`
+	RoleAssignments []RoleAssignmentsModel `tfschema:"role_assignments"`
+}
+
+type RoleAssignmentsModel struct {
+	Condition                          string `tfschema:"condition"`
+	ConditionVersion                   string `tfschema:"condition_version"`
+	DelegatedManagedIdentityResourceID string `tfschema:"delegated_managed_identity_resource_id"`
+	Description                        string `tfschema:"description"`
+	PrincipalID                        string `tfschema:"principal_id"`
+	PrincipalType                      string `tfschema:"principal_type"`
+	RoleAssignmentID                   string `tfschema:"role_assignment_id"`
+	RoleAssignmentName                 string `tfschema:"role_assignment_name"`
+	RoleAssignmentScope                string `tfschema:"role_assignment_scope"`
+	RoleDefinitionID                   string `tfschema:"role_definition_id"`
+}
+
+var _ sdk.DataSource = RoleAssignmentsDataSource{}
+
+func (r RoleAssignmentsDataSource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"scope": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+		"limit_at_scope": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Default:  false,
+		},
+		"principal_id": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.IsUUID,
+		},
+		"tenant_id": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.IsUUID,
+		},
+	}
+}
+
+func (r RoleAssignmentsDataSource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"role_assignments": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"condition": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+					"condition_version": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+					"delegated_managed_identity_resource_id": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+					"description": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+					"principal_id": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+					"principal_type": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+					"role_assignment_id": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+					"role_assignment_name": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+					"role_assignment_scope": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+					"role_definition_id": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+				},
+			},
+		},
+	}
+}
+
+func (r RoleAssignmentsDataSource) ModelObject() interface{} {
+	return &RoleAssignmentsDataSourceModel{}
+}
+
+func (r RoleAssignmentsDataSource) ResourceType() string {
+	return "azurerm_role_assignments"
+}
+
+func (r RoleAssignmentsDataSource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Authorization.ScopedRoleAssignmentsClient
+
+			var state RoleAssignmentsDataSourceModel
+			if err := metadata.Decode(&state); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			id := commonids.NewScopeID(state.Scope)
+
+			options := roleassignments.DefaultListForScopeOperationOptions()
+			// Root scope requires a filter, default to `atScope()`
+			if state.Scope == "/" {
+				options.Filter = pointer.To("atScope()")
+			}
+
+			if state.TenantID != "" {
+				options.TenantId = pointer.To(state.TenantID)
+			}
+
+			if state.PrincipalID != "" {
+				options.Filter = pointer.To(fmt.Sprintf("principalId eq '%s'", state.PrincipalID))
+			}
+
+			resp, err := client.ListForScope(ctx, id, options)
+			if err != nil {
+				return fmt.Errorf("listing role assignments for %s: %+v", id, err)
+			}
+
+			metadata.SetID(id)
+
+			if model := resp.Model; model != nil {
+				state.RoleAssignments = flattenRoleAssignmentsToModel(model, state.Scope, state.LimitAtScope)
+			}
+
+			return metadata.Encode(&state)
+		},
+	}
+}
+
+func flattenRoleAssignmentsToModel(input *[]roleassignments.RoleAssignment, scope string, limitAtScope bool) []RoleAssignmentsModel {
+	result := make([]RoleAssignmentsModel, 0)
+
+	if len(*input) == 0 {
+		return result
+	}
+
+	for _, v := range *input {
+		assignment := RoleAssignmentsModel{
+			RoleAssignmentID:   pointer.From(v.Id),
+			RoleAssignmentName: pointer.From(v.Name),
+		}
+
+		if props := v.Properties; props != nil {
+			// The API returns all role assignments at, above, or below the provided scope regardless of whether `atScope()` is passed as a filter.
+			// If user set `limit_at_scope` to `true` and configuration scope != returned scope, discard
+			if limitAtScope && !strings.EqualFold(scope, pointer.From(props.Scope)) {
+				continue
+			}
+
+			assignment.Condition = pointer.From(props.Condition)
+			assignment.ConditionVersion = pointer.From(props.ConditionVersion)
+			assignment.DelegatedManagedIdentityResourceID = pointer.From(props.DelegatedManagedIdentityResourceId)
+			assignment.Description = pointer.From(props.Description)
+			assignment.PrincipalID = props.PrincipalId
+			assignment.PrincipalType = string(pointer.From(props.PrincipalType))
+			assignment.RoleAssignmentScope = pointer.From(props.Scope)
+			assignment.RoleDefinitionID = props.RoleDefinitionId
+		}
+
+		result = append(result, assignment)
+	}
+
+	return result
+}

--- a/internal/services/authorization/role_assignments_data_source.go
+++ b/internal/services/authorization/role_assignments_data_source.go
@@ -160,7 +160,7 @@ func (r RoleAssignmentsDataSource) Read() sdk.ResourceFunc {
 			metadata.SetID(id)
 
 			if model := resp.Model; model != nil {
-				state.RoleAssignments = flattenRoleAssignmentsToModel(pointer.From(model), state.Scope, state.LimitAtScope)
+				state.RoleAssignments = flattenRoleAssignmentsToModel(model, state.Scope, state.LimitAtScope)
 			}
 
 			return metadata.Encode(&state)
@@ -168,10 +168,14 @@ func (r RoleAssignmentsDataSource) Read() sdk.ResourceFunc {
 	}
 }
 
-func flattenRoleAssignmentsToModel(input []roleassignments.RoleAssignment, scope string, limitAtScope bool) []RoleAssignmentsModel {
+func flattenRoleAssignmentsToModel(input *[]roleassignments.RoleAssignment, scope string, limitAtScope bool) []RoleAssignmentsModel {
 	result := make([]RoleAssignmentsModel, 0)
 
-	for _, v := range input {
+	if len(*input) == 0 {
+		return result
+	}
+
+	for _, v := range *input {
 		assignment := RoleAssignmentsModel{
 			RoleAssignmentID:   pointer.From(v.Id),
 			RoleAssignmentName: pointer.From(v.Name),

--- a/internal/services/authorization/role_assignments_data_source.go
+++ b/internal/services/authorization/role_assignments_data_source.go
@@ -160,7 +160,7 @@ func (r RoleAssignmentsDataSource) Read() sdk.ResourceFunc {
 			metadata.SetID(id)
 
 			if model := resp.Model; model != nil {
-				state.RoleAssignments = flattenRoleAssignmentsToModel(model, state.Scope, state.LimitAtScope)
+				state.RoleAssignments = flattenRoleAssignmentsToModel(pointer.From(model), state.Scope, state.LimitAtScope)
 			}
 
 			return metadata.Encode(&state)
@@ -168,14 +168,10 @@ func (r RoleAssignmentsDataSource) Read() sdk.ResourceFunc {
 	}
 }
 
-func flattenRoleAssignmentsToModel(input *[]roleassignments.RoleAssignment, scope string, limitAtScope bool) []RoleAssignmentsModel {
+func flattenRoleAssignmentsToModel(input []roleassignments.RoleAssignment, scope string, limitAtScope bool) []RoleAssignmentsModel {
 	result := make([]RoleAssignmentsModel, 0)
 
-	if len(*input) == 0 {
-		return result
-	}
-
-	for _, v := range *input {
+	for _, v := range input {
 		assignment := RoleAssignmentsModel{
 			RoleAssignmentID:   pointer.From(v.Id),
 			RoleAssignmentName: pointer.From(v.Name),

--- a/internal/services/authorization/role_assignments_data_source_test.go
+++ b/internal/services/authorization/role_assignments_data_source_test.go
@@ -1,0 +1,72 @@
+package authorization_test
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"testing"
+)
+
+type RoleAssignmentsDataSourceTest struct{}
+
+func TestAccRoleAssignmentsDataSource_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_role_assignments", "test")
+	d := RoleAssignmentsDataSourceTest{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: d.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("principal_id").Exists(),
+				check.That(data.ResourceName).Key("role_assignments.#").HasValue("1"),
+			),
+		},
+	})
+}
+
+func (d RoleAssignmentsDataSourceTest) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_role_assignments" "test" {
+  scope = azurerm_resource_group.test.id
+  principal_id = azurerm_user_assigned_identity.test.principal_id
+
+  limit_at_scope = true
+
+  // Account for eventual consistency in Role Assignments List operation after creating a new Role Assignment
+  depends_on = [time_sleep.wait]
+}
+`, d.template(data))
+}
+
+func (RoleAssignmentsDataSourceTest) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name = "acctest-role-assignments-%[1]d"
+  location = "%s"
+}
+
+resource "azurerm_user_assigned_identity" "test" {
+  name = "acctest-uai-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location = azurerm_resource_group.test.location
+}
+
+resource "azurerm_role_assignment" "test" {
+  scope = azurerm_resource_group.test.id
+  role_definition_name = "Reader"
+  principal_id = azurerm_user_assigned_identity.test.principal_id
+}
+
+resource "time_sleep" "wait" {
+    create_duration = "30s"
+
+    depends_on = [azurerm_role_assignment.test]
+}
+`, data.RandomInteger, data.Locations.Primary)
+}

--- a/internal/services/authorization/role_assignments_data_source_test.go
+++ b/internal/services/authorization/role_assignments_data_source_test.go
@@ -29,7 +29,7 @@ func (d RoleAssignmentsDataSourceTest) basic(data acceptance.TestData) string {
 %s
 
 data "azurerm_role_assignments" "test" {
-  scope = azurerm_resource_group.test.id
+  scope        = azurerm_resource_group.test.id
   principal_id = azurerm_user_assigned_identity.test.principal_id
 
   limit_at_scope = true
@@ -47,26 +47,26 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name = "acctest-role-assignments-%[1]d"
+  name     = "acctest-role-assignments-%[1]d"
   location = "%s"
 }
 
 resource "azurerm_user_assigned_identity" "test" {
-  name = "acctest-uai-%[1]d"
+  name                = "acctest-uai-%[1]d"
   resource_group_name = azurerm_resource_group.test.name
-  location = azurerm_resource_group.test.location
+  location            = azurerm_resource_group.test.location
 }
 
 resource "azurerm_role_assignment" "test" {
-  scope = azurerm_resource_group.test.id
+  scope                = azurerm_resource_group.test.id
   role_definition_name = "Reader"
-  principal_id = azurerm_user_assigned_identity.test.principal_id
+  principal_id         = azurerm_user_assigned_identity.test.principal_id
 }
 
 resource "time_sleep" "wait" {
-    create_duration = "30s"
+  create_duration = "30s"
 
-    depends_on = [azurerm_role_assignment.test]
+  depends_on = [azurerm_role_assignment.test]
 }
 `, data.RandomInteger, data.Locations.Primary)
 }

--- a/internal/services/authorization/role_assignments_data_source_test.go
+++ b/internal/services/authorization/role_assignments_data_source_test.go
@@ -2,9 +2,10 @@ package authorization_test
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
-	"testing"
 )
 
 type RoleAssignmentsDataSourceTest struct{}

--- a/website/docs/d/role_assignments.html.markdown
+++ b/website/docs/d/role_assignments.html.markdown
@@ -14,7 +14,7 @@ Use this data source to access information about existing Role Assignments.
 
 ```hcl
 resource "azurerm_resource_group" "example" {
-  name = "example"
+  name     = "example"
   location = "West Europe"
 }
 

--- a/website/docs/d/role_assignments.html.markdown
+++ b/website/docs/d/role_assignments.html.markdown
@@ -33,7 +33,6 @@ The following arguments are supported:
 
 * `scope` - (Required) The scope at which to list Role Assignments.
 
-
 ---
 
 * `limit_at_scope` - (Optional) Whether to limit the result exactly at the specified scope and not above or below it. Defaults to `false`.

--- a/website/docs/d/role_assignments.html.markdown
+++ b/website/docs/d/role_assignments.html.markdown
@@ -1,0 +1,81 @@
+---
+subcategory: "Authorization"
+layout: "azurerm"
+page_title: "Azure Resource Manager: Data Source: azurerm_role_assignments"
+description: |-
+  Gets information about existing Role Assignments.
+---
+
+# Data Source: azurerm_role_assignments
+
+Use this data source to access information about existing Role Assignments.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name = "example"
+  location = "West Europe"
+}
+
+data "azurerm_role_assignments" "example" {
+  scope = azurerm_resource_group.example.id
+}
+
+output "id" {
+  value = data.azurerm_role_assignments.example.role_assignments
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `scope` - (Required) The scope at which to list Role Assignments.
+
+
+---
+
+* `limit_at_scope` - (Optional) Whether to limit the result exactly at the specified scope and not above or below it. Defaults to `false`.
+
+* `principal_id` - (Optional) The principal ID to filter the list of Role Assignments against.
+
+* `tenant_id` - (Optional) The tenant ID for cross-tenant requests.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported: 
+
+* `id` - The ID of this Role Assignments data source.
+
+* `role_assignments` - A `role_assignments` block as defined below.
+
+---
+
+A `role_assignments` block exports the following:
+
+* `condition` - The condition that limits the resource the role can be assigned to.
+
+* `condition_version` - The version of the condition.
+
+* `delegated_managed_identity_resource_id` - The ID of the delegated managed identity resource.
+
+* `description` - The description for this Role Assignment.
+
+* `principal_id` - The principal ID.
+
+* `principal_type` - The type of the `principal_id`.
+
+* `role_assignment_id` - The ID of the Role Assignment.
+
+* `role_assignment_name` - The name of the Role Assignment.
+
+* `role_assignment_scope` - The scope of the Role Assignment.
+
+* `role_definition_id` - The ID of the Role Definition.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Role Assignments.


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

New Data Source: `azurerm_role_assignments`

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [x] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
