### PR TITLE
`azurerm_traffic_manager_nested_endpoint` - revert priority back to O+C since API increments the default value

### DIFF
--- a/internal/services/trafficmanager/nested_endpoint_resource.go
+++ b/internal/services/trafficmanager/nested_endpoint_resource.go
@@ -122,7 +122,6 @@ func resourceNestedEndpoint() *pluginsdk.Resource {
 				Optional: true,
 				// NOTE: O+C the API dynamically increments the default value for priority depending on the number of endpoints
 				Computed:     true,
-				Default:      1,
 				ValidateFunc: validation.IntBetween(1, 1000),
 			},
 

--- a/internal/services/trafficmanager/nested_endpoint_resource.go
+++ b/internal/services/trafficmanager/nested_endpoint_resource.go
@@ -118,8 +118,10 @@ func resourceNestedEndpoint() *pluginsdk.Resource {
 			},
 
 			"priority": {
-				Type:         pluginsdk.TypeInt,
-				Optional:     true,
+				Type:     pluginsdk.TypeInt,
+				Optional: true,
+				// NOTE: O+C the API dynamically increments the default value for priority depending on the number of endpoints
+				Computed:     true,
 				Default:      1,
 				ValidateFunc: validation.IntBetween(1, 1000),
 			},

--- a/internal/services/trafficmanager/nested_endpoint_resource_test.go
+++ b/internal/services/trafficmanager/nested_endpoint_resource_test.go
@@ -49,6 +49,21 @@ func TestAccNestedEndpoint_priority(t *testing.T) {
 	})
 }
 
+func TestAccNestedEndpoint_multipleEndpointsWithDynamicPriority(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_traffic_manager_nested_endpoint", "test")
+	r := NestedEndpointResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.multiple(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccNestedEndpoint_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_traffic_manager_nested_endpoint", "test")
 	r := NestedEndpointResource{}
@@ -338,4 +353,45 @@ resource "azurerm_traffic_manager_nested_endpoint" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary)
+}
+
+func (r NestedEndpointResource) multiple(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_traffic_manager_profile" "child2" {
+  name                   = "acctesttmpchild%[2]d-2"
+  resource_group_name    = azurerm_resource_group.test.name
+  traffic_routing_method = "Priority"
+
+  dns_config {
+    relative_name = "acctesttmpchild%[2]d"
+    ttl           = 30
+  }
+
+  monitor_config {
+    protocol = "HTTPS"
+    port     = 443
+    path     = "/"
+  }
+}
+
+resource "azurerm_traffic_manager_nested_endpoint" "test" {
+  name                    = "acctestend-parent%[2]d"
+  target_resource_id      = azurerm_traffic_manager_profile.child.id
+  profile_id              = azurerm_traffic_manager_profile.parent.id
+  minimum_child_endpoints = 5
+}
+
+resource "azurerm_traffic_manager_nested_endpoint" "test2" {
+  name                    = "acctestend-parent%[2]d-2"
+  target_resource_id      = azurerm_traffic_manager_profile.child2.id
+  profile_id              = azurerm_traffic_manager_profile.parent.id
+  minimum_child_endpoints = 5
+}
+`, r.template(data), data.RandomInteger)
 }

--- a/internal/services/trafficmanager/nested_endpoint_resource_test.go
+++ b/internal/services/trafficmanager/nested_endpoint_resource_test.go
@@ -369,7 +369,7 @@ resource "azurerm_traffic_manager_profile" "child2" {
   traffic_routing_method = "Priority"
 
   dns_config {
-    relative_name = "acctesttmpchild%[2]d"
+    relative_name = "acctesttmpchild%[2]d-2"
     ttl           = 30
   }
 

--- a/website/docs/r/traffic_manager_nested_endpoint.html.markdown
+++ b/website/docs/r/traffic_manager_nested_endpoint.html.markdown
@@ -106,7 +106,7 @@ The following arguments are supported:
 
 * `minimum_required_child_endpoints_ipv6` - (Optional) This argument specifies the minimum number of IPv6 (DNS record type AAAA) endpoints that must be ‘online’ in the child profile in order for the parent profile to direct traffic to any of the endpoints in that child profile. This argument only applies to Endpoints of type `nestedEndpoints` and 
 
-* `priority` - (Optional) Specifies the priority of this Endpoint, this must be specified for Profiles using the `Priority` traffic routing method. Supports values between 1 and 1000, with no Endpoints sharing the same value. If omitted the value will be computed in order of creation. Defaults to `1`.
+* `priority` - (Optional) Specifies the priority of this Endpoint, this must be specified for Profiles using the `Priority` traffic routing method. Supports values between 1 and 1000, with no Endpoints sharing the same value. If omitted the value will be computed in order of creation.
 
 * `geo_mappings` - (Optional) A list of Geographic Regions used to distribute traffic, such as `WORLD`, `UK` or `DE`. The same location can't be specified in two endpoints. [See the Geographic Hierarchies documentation for more information](https://docs.microsoft.com/rest/api/trafficmanager/geographichierarchies/getdefault).
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Revert the `priority` property back to O+C, similar to #27966

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- x ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

```
❯ tftest trafficmanager TestAccNestedEndpoint_
=== RUN   TestAccNestedEndpoint_basic
=== PAUSE TestAccNestedEndpoint_basic
=== RUN   TestAccNestedEndpoint_priority
=== PAUSE TestAccNestedEndpoint_priority
=== RUN   TestAccNestedEndpoint_multipleEndpointsWithDynamicPriority
=== PAUSE TestAccNestedEndpoint_multipleEndpointsWithDynamicPriority
=== RUN   TestAccNestedEndpoint_requiresImport
=== PAUSE TestAccNestedEndpoint_requiresImport
=== RUN   TestAccNestedEndpoint_complete
=== PAUSE TestAccNestedEndpoint_complete
=== RUN   TestAccNestedEndpoint_subnet
=== PAUSE TestAccNestedEndpoint_subnet
=== CONT  TestAccNestedEndpoint_basic
=== CONT  TestAccNestedEndpoint_multipleEndpointsWithDynamicPriority
=== CONT  TestAccNestedEndpoint_requiresImport
=== CONT  TestAccNestedEndpoint_subnet
=== CONT  TestAccNestedEndpoint_complete
=== CONT  TestAccNestedEndpoint_priority
--- PASS: TestAccNestedEndpoint_requiresImport (78.51s)
--- PASS: TestAccNestedEndpoint_basic (88.08s)
--- PASS: TestAccNestedEndpoint_subnet (93.83s)
--- PASS: TestAccNestedEndpoint_priority (97.17s)
--- PASS: TestAccNestedEndpoint_multipleEndpointsWithDynamicPriority (103.26s)
--- PASS: TestAccNestedEndpoint_complete (163.46s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/trafficmanager        163.499s```
```
<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_traffic_manager_nested_endpoint` - revert priority back to O+C since API increments the default value [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #29191


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
