### PR TITLE
`Doc Fix` - corrected the description of `data_residency_enabled`

### DIFF
--- a/website/docs/r/iothub_dps.html.markdown
+++ b/website/docs/r/iothub_dps.html.markdown
@@ -43,7 +43,7 @@ The following arguments are supported:
 
 * `allocation_policy` - (Optional) The allocation policy of the IoT Device Provisioning Service (`Hashed`, `GeoLatency` or `Static`). Defaults to `Hashed`.
 
-* `data_residency_enabled` - (Optional) Specifies if the IoT Device Provisioning Service has data residency and disaster recovery enabled. Defaults to `false`. Changing this forces a new resource to be created.
+* `data_residency_enabled` - (Optional) Specifies if the IoT Device Provisioning Service has data residency enabled, removing the cross geo-pair disaster recovery. Defaults to `false`. Changing this forces a new resource to be created.
 
 * `sku` - (Required) A `sku` block as defined below.
 


### PR DESCRIPTION
Correct the description in Terraform documentation for `data_residency_enabled` as [described ](https://learn.microsoft.com/en-us/rest/api/iot-dps/iot-dps-resource/get?view=rest-iot-dps-2025-02-01-preview&tabs=HTTP#iotdpspropertiesdescription)in the API to fix #29208.
