### PR TITLE
`azurerm_dynatrace_monitor`: Add support for `environment_properties`

### DIFF
--- a/internal/services/dynatrace/dynatrace_monitor_data_source.go
+++ b/internal/services/dynatrace/dynatrace_monitor_data_source.go
@@ -212,6 +212,7 @@ func (d MonitorsDataSource) Read() sdk.ResourceFunc {
 				if model.Tags != nil {
 					monitorResource.Tags = pointer.From(model.Tags)
 				}
+				metadata.SetID(id)
 				return metadata.Encode(&monitorResource)
 			}
 			return nil

--- a/internal/services/dynatrace/dynatrace_monitor_resource.go
+++ b/internal/services/dynatrace/dynatrace_monitor_resource.go
@@ -171,7 +171,6 @@ func (r MonitorsResource) Arguments() map[string]*pluginsdk.Schema {
 		"environment_properties": {
 			Type:     pluginsdk.TypeList,
 			Optional: true,
-			Computed: true,
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
 					"environment_info": {

--- a/internal/services/dynatrace/dynatrace_monitor_resource.go
+++ b/internal/services/dynatrace/dynatrace_monitor_resource.go
@@ -171,6 +171,7 @@ func (r MonitorsResource) Arguments() map[string]*pluginsdk.Schema {
 		"environment_properties": {
 			Type:     pluginsdk.TypeList,
 			Optional: true,
+			Computed: true,
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
 					"environment_info": {

--- a/internal/services/dynatrace/dynatrace_monitor_resource.go
+++ b/internal/services/dynatrace/dynatrace_monitor_resource.go
@@ -299,9 +299,12 @@ func (r MonitorsResource) Read() sdk.ResourceFunc {
 					MonitoringStatus:              monitoringStatus,
 					MarketplaceSubscriptionStatus: string(*props.MarketplaceSubscriptionStatus),
 					Identity:                      identityProps,
-					EnvironmentProperties:         FlattenDynatraceEnvironmentProperties(props.DynatraceEnvironmentProperties),
 					PlanData:                      FlattenDynatracePlanData(props.PlanData),
 					UserInfo:                      FlattenDynatraceUserInfo(props.UserInfo),
+				}
+
+				if environmentProps := metadata.ResourceData.Get("environment_properties"); environmentProps != nil && len(environmentProps.([]interface{})) > 0 {
+					state.EnvironmentProperties = FlattenDynatraceEnvironmentProperties(props.DynatraceEnvironmentProperties)
 				}
 
 				if model.Tags != nil {

--- a/internal/services/dynatrace/dynatrace_monitor_resource.go
+++ b/internal/services/dynatrace/dynatrace_monitor_resource.go
@@ -32,6 +32,7 @@ type MonitorsResourceModel struct {
 	MonitoringStatus              bool                           `tfschema:"monitoring_enabled"`
 	MarketplaceSubscriptionStatus string                         `tfschema:"marketplace_subscription"`
 	Identity                      []identity.ModelSystemAssigned `tfschema:"identity"`
+	EnvironmentProperties         []EnvironmentProperties        `tfschema:"environment_properties"`
 	PlanData                      []PlanData                     `tfschema:"plan"`
 	UserInfo                      []UserInfo                     `tfschema:"user"`
 	Tags                          map[string]string              `tfschema:"tags"`
@@ -167,6 +168,27 @@ func (r MonitorsResource) Arguments() map[string]*pluginsdk.Schema {
 			},
 		},
 
+		"environment_properties": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"environment_info": {
+						Type:     pluginsdk.TypeList,
+						Required: true,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"environment_id": {
+									Type:     pluginsdk.TypeString,
+									Required: true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+
 		"tags": tags.Schema(),
 	}
 }
@@ -210,10 +232,11 @@ func (r MonitorsResource) Create() sdk.ResourceFunc {
 				monitoringStatus = monitors.MonitoringStatusDisabled
 			}
 			monitorsProps := monitors.MonitorProperties{
-				MarketplaceSubscriptionStatus: pointer.To(monitors.MarketplaceSubscriptionStatus(model.MarketplaceSubscriptionStatus)),
-				MonitoringStatus:              pointer.To(monitoringStatus),
-				PlanData:                      ExpandDynatracePlanData(model.PlanData),
-				UserInfo:                      ExpandDynatraceUserInfo(model.UserInfo),
+				MarketplaceSubscriptionStatus:  pointer.To(monitors.MarketplaceSubscriptionStatus(model.MarketplaceSubscriptionStatus)),
+				MonitoringStatus:               pointer.To(monitoringStatus),
+				PlanData:                       ExpandDynatracePlanData(model.PlanData),
+				UserInfo:                       ExpandDynatraceUserInfo(model.UserInfo),
+				DynatraceEnvironmentProperties: ExpandDynatraceEnvironmentProperties(model.EnvironmentProperties),
 			}
 
 			dynatraceIdentity, err := expandDynatraceIdentity(model.Identity)
@@ -276,6 +299,7 @@ func (r MonitorsResource) Read() sdk.ResourceFunc {
 					MonitoringStatus:              monitoringStatus,
 					MarketplaceSubscriptionStatus: string(*props.MarketplaceSubscriptionStatus),
 					Identity:                      identityProps,
+					EnvironmentProperties:         FlattenDynatraceEnvironmentProperties(props.DynatraceEnvironmentProperties),
 					PlanData:                      FlattenDynatracePlanData(props.PlanData),
 					UserInfo:                      FlattenDynatraceUserInfo(props.UserInfo),
 				}

--- a/internal/services/dynatrace/dynatrace_monitor_resource_test.go
+++ b/internal/services/dynatrace/dynatrace_monitor_resource_test.go
@@ -223,11 +223,6 @@ resource "azurerm_dynatrace_monitor" "test" {
   tags = {
     environment = "Dev"
   }
-  lifecycle {
-    ignore_changes = [
-      environment_properties,
-    ]
-  }
 }
 
 data "azurerm_dynatrace_monitor" "data1" {

--- a/internal/services/dynatrace/dynatrace_monitor_resource_test.go
+++ b/internal/services/dynatrace/dynatrace_monitor_resource_test.go
@@ -223,6 +223,11 @@ resource "azurerm_dynatrace_monitor" "test" {
   tags = {
     environment = "Dev"
   }
+  lifecycle {
+    ignore_changes = [
+      environment_properties,
+    ]
+  }
 }
 
 data "azurerm_dynatrace_monitor" "data1" {

--- a/internal/services/dynatrace/dynatrace_monitor_resource_test.go
+++ b/internal/services/dynatrace/dynatrace_monitor_resource_test.go
@@ -191,6 +191,7 @@ resource "azurerm_dynatrace_monitor" "test" {
 `, template, data.RandomInteger, r.dynatraceInfo.UserFirstName, r.dynatraceInfo.UserLastName, r.dynatraceInfo.UserEmail, r.dynatraceInfo.UserPhoneNumber, r.dynatraceInfo.UserCountry)
 }
 
+// For `environment_properties`, since it is a computed field, we lean on ignoring changes in the lifecycle block to avoid diffs during creation.
 func (r MonitorsResource) complete(data acceptance.TestData) string {
 	template := r.template(data)
 	return fmt.Sprintf(`

--- a/internal/services/dynatrace/dynatrace_monitor_resource_test.go
+++ b/internal/services/dynatrace/dynatrace_monitor_resource_test.go
@@ -45,7 +45,7 @@ func NewDynatraceMonitorResource() MonitorsResource {
 func TestAccDynatraceMonitor_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_dynatrace_monitor", "test")
 	r := MonitorsResource{}
-	r.preCheck(t)
+	//r.preCheck(t)
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -171,11 +171,11 @@ resource "azurerm_dynatrace_monitor" "test" {
   }
 
   user {
-    first_name   = "%s"
-    last_name    = "%s"
-    email        = "%s"
-    phone_number = "%s"
-    country      = "%s"
+    first_name   = "Alice"
+    last_name    = "Bob"
+    email        = "agarwald@microsoft.com"
+    phone_number = "12345678"
+    country      = "westus2"
   }
 
   plan {
@@ -187,8 +187,14 @@ resource "azurerm_dynatrace_monitor" "test" {
   tags = {
     environment = "Dev"
   }
+  lifecycle {
+	ignore_changes = [
+		environment_properties,
+	]
+  }
+
 }
-`, template, data.RandomInteger, r.dynatraceInfo.UserFirstName, r.dynatraceInfo.UserLastName, r.dynatraceInfo.UserEmail, r.dynatraceInfo.UserPhoneNumber, r.dynatraceInfo.UserCountry)
+`, template, data.RandomInteger)
 }
 
 func (r MonitorsResource) complete(data acceptance.TestData) string {
@@ -196,7 +202,7 @@ func (r MonitorsResource) complete(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %[1]s
 
-resource "azurerm_dynatrace_monitor" "test1" {
+resource "azurerm_dynatrace_monitor" "test" {
   name                     = "acctestacc%[2]d"
   resource_group_name      = azurerm_resource_group.test.name
   location                 = azurerm_resource_group.test.location
@@ -209,7 +215,7 @@ resource "azurerm_dynatrace_monitor" "test1" {
   user {
     first_name   = "Alice"
     last_name    = "Bob"
-    email        = "alice@microsoft.com"
+    email        = "agarwald@microsoft.com"
     phone_number = "12345678"
     country      = "westus2"
   }
@@ -223,15 +229,20 @@ resource "azurerm_dynatrace_monitor" "test1" {
   tags = {
     environment = "Dev"
   }
+  lifecycle {
+	ignore_changes = [
+		environment_properties,
+	]
+  }
 }
 
-data "azurerm_dynatrace_monitor" "test1" {
-  name                = azurerm_dynatrace_monitor.test1.name
-  resource_group_name = azurerm_dynatrace_monitor.test1.resource_group_name
+data "azurerm_dynatrace_monitor" "data1" {
+  name                = azurerm_dynatrace_monitor.test.name
+  resource_group_name = azurerm_dynatrace_monitor.test.resource_group_name
 }
 
 resource "azurerm_dynatrace_monitor" "test2" {
-  name                     = "acctestacc%[3]d"
+  name                     = "acctest2acc%[3]d"
   resource_group_name      = azurerm_resource_group.test.name
   location                 = azurerm_resource_group.test.location
   marketplace_subscription = "Active"
@@ -242,14 +253,14 @@ resource "azurerm_dynatrace_monitor" "test2" {
   user {
     first_name   = "Alice"
     last_name    = "Bob"
-    email        = "alice@microsoft.com"
+    email        = "agarwald@microsoft.com"
     phone_number = "12345678"
     country      = "westus2"
   }
 
   environment_properties {
     environment_info {
-      environment_id = data.azurerm_dynatrace_monitor.test1.environment_properties.0.environment_info.0.environment_id
+      environment_id = data.azurerm_dynatrace_monitor.data1.environment_properties.0.environment_info.0.environment_id
     }
   }
 
@@ -261,6 +272,11 @@ resource "azurerm_dynatrace_monitor" "test2" {
 
   tags = {
     environment = "Dev"
+  }
+  lifecycle {
+	ignore_changes = [
+		environment_properties,
+	]
   }
 }
 `, template, data.RandomInteger, data.RandomInteger, r.dynatraceInfo.UserLastName, r.dynatraceInfo.UserFirstName, r.dynatraceInfo.UserEmail, r.dynatraceInfo.UserPhoneNumber, r.dynatraceInfo.UserCountry)

--- a/internal/services/dynatrace/dynatrace_monitor_resource_test.go
+++ b/internal/services/dynatrace/dynatrace_monitor_resource_test.go
@@ -45,7 +45,7 @@ func NewDynatraceMonitorResource() MonitorsResource {
 func TestAccDynatraceMonitor_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_dynatrace_monitor", "test")
 	r := MonitorsResource{}
-	//r.preCheck(t)
+	r.preCheck(t)
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -92,7 +92,7 @@ func TestAccDynatraceMonitor_update(t *testing.T) {
 func TestAccDynatraceMonitor_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_dynatrace_monitor", "test")
 	r := MonitorsResource{}
-	//r.preCheck(t)
+	r.preCheck(t)
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -171,11 +171,11 @@ resource "azurerm_dynatrace_monitor" "test" {
   }
 
   user {
-    first_name   = "Alice"
-    last_name    = "Bob"
-    email        = "agarwald@microsoft.com"
-    phone_number = "12345678"
-    country      = "westus2"
+    first_name   = "%s"
+    last_name    = "%s"
+    email        = "%s"
+    phone_number = "%s"
+    country      = "%s"
   }
 
   plan {
@@ -187,14 +187,8 @@ resource "azurerm_dynatrace_monitor" "test" {
   tags = {
     environment = "Dev"
   }
-  lifecycle {
-	ignore_changes = [
-		environment_properties,
-	]
-  }
-
 }
-`, template, data.RandomInteger)
+`, template, data.RandomInteger, r.dynatraceInfo.UserFirstName, r.dynatraceInfo.UserLastName, r.dynatraceInfo.UserEmail, r.dynatraceInfo.UserPhoneNumber, r.dynatraceInfo.UserCountry)
 }
 
 func (r MonitorsResource) complete(data acceptance.TestData) string {
@@ -213,11 +207,11 @@ resource "azurerm_dynatrace_monitor" "test" {
   }
 
   user {
-    first_name   = "Alice"
-    last_name    = "Bob"
-    email        = "agarwald@microsoft.com"
-    phone_number = "12345678"
-    country      = "westus2"
+    first_name   = "%[4]s"
+    last_name    = "%[5]s"
+    email        = "%[6]s"
+    phone_number = "%[7]s"
+    country      = "%[8]s"
   }
 
   plan {
@@ -230,9 +224,9 @@ resource "azurerm_dynatrace_monitor" "test" {
     environment = "Dev"
   }
   lifecycle {
-	ignore_changes = [
-		environment_properties,
-	]
+    ignore_changes = [
+      environment_properties,
+    ]
   }
 }
 
@@ -251,11 +245,11 @@ resource "azurerm_dynatrace_monitor" "test2" {
     type = "SystemAssigned"
   }
   user {
-    first_name   = "Alice"
-    last_name    = "Bob"
-    email        = "agarwald@microsoft.com"
-    phone_number = "12345678"
-    country      = "westus2"
+    first_name   = "%[4]s"
+    last_name    = "%[5]s"
+    email        = "%[6]s"
+    phone_number = "%[7]s"
+    country      = "%[8]s"
   }
 
   environment_properties {
@@ -272,11 +266,6 @@ resource "azurerm_dynatrace_monitor" "test2" {
 
   tags = {
     environment = "Dev"
-  }
-  lifecycle {
-	ignore_changes = [
-		environment_properties,
-	]
   }
 }
 `, template, data.RandomInteger, data.RandomInteger, r.dynatraceInfo.UserLastName, r.dynatraceInfo.UserFirstName, r.dynatraceInfo.UserEmail, r.dynatraceInfo.UserPhoneNumber, r.dynatraceInfo.UserCountry)

--- a/internal/services/dynatrace/helper.go
+++ b/internal/services/dynatrace/helper.go
@@ -37,6 +37,24 @@ func ExpandDynatraceUserInfo(input []UserInfo) *monitors.UserInfo {
 	})
 }
 
+func ExpandDynatraceEnvironmentProperties(input []EnvironmentProperties) *monitors.DynatraceEnvironmentProperties {
+	if len(input) == 0 {
+		return nil
+	}
+	v := input[0]
+
+	var environmentInfo monitors.EnvironmentInfo
+	if len(v.EnvironmentInfo) > 0 {
+		environmentInfo = monitors.EnvironmentInfo{
+			EnvironmentId: pointer.To(v.EnvironmentInfo[0].EnvironmentId),
+		}
+	}
+
+	return pointer.To(monitors.DynatraceEnvironmentProperties{
+		EnvironmentInfo: &environmentInfo,
+	})
+}
+
 func FlattenDynatraceEnvironmentProperties(input *monitors.DynatraceEnvironmentProperties) []EnvironmentProperties {
 	if input == nil {
 		return []EnvironmentProperties{}

--- a/website/docs/r/dynatrace_monitor.html.markdown
+++ b/website/docs/r/dynatrace_monitor.html.markdown
@@ -67,6 +67,8 @@ The following arguments are supported:
 
 * `monitoring_enabled` - (Optional) Flag specifying if the resource monitoring is enabled or disabled. Default is `true`.
 
+* `environment_properties` - (Optional) Properties of the Dynatrace environment. A `environment_properties` block as defined below.
+
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ---
@@ -100,6 +102,18 @@ A `user` block supports the following:
 * `last_name` - (Required) Last name of the user.
 
 * `phone_number` - (Required) phone number of the user by Dynatrace for contacting them if needed.
+
+---
+
+A `environment_properties` block supports the following:
+
+* `environment_info` - (Required) Information about the Dynatrace environment. A `environment_info` block as defined below.
+
+---
+
+A `environment_info` block supports the following:
+
+* `environment_id` - (Required) The ID of the Dynatrace environment to be created.
 
 ## Attributes Reference
 

--- a/website/docs/r/dynatrace_monitor.html.markdown
+++ b/website/docs/r/dynatrace_monitor.html.markdown
@@ -67,7 +67,7 @@ The following arguments are supported:
 
 * `monitoring_enabled` - (Optional) Flag specifying if the resource monitoring is enabled or disabled. Default is `true`.
 
-* `environment_properties` - (Optional) Properties of the Dynatrace environment. A `environment_properties` block as defined below.
+* `environment_properties` - (Optional) Properties of the Dynatrace environment. An `environment_properties` block as defined below.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
@@ -105,13 +105,13 @@ A `user` block supports the following:
 
 ---
 
-A `environment_properties` block supports the following:
+An `environment_properties` block supports the following:
 
-* `environment_info` - (Required) Information about the Dynatrace environment. A `environment_info` block as defined below.
+* `environment_info` - (Required) Information about the Dynatrace environment. An `environment_info` block as defined below.
 
 ---
 
-A `environment_info` block supports the following:
+An `environment_info` block supports the following:
 
 * `environment_id` - (Required) The ID of the Dynatrace environment to be created.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

As before, the acc tests of this resource will not run on Teamcity. Here's the test results on the service team provided subscription:

```
--- PASS: TestAccDynatraceMonitor_basic (323.42s)
--- PASS: TestAccDynatraceMonitor_requiresImport (345.28s)
--- PASS: TestAccDynatraceMonitor_complete (374.35s)
--- PASS: TestAccDynatraceMonitor_update (454.02s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/dynatrace     466.579s
```


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [x] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
