### PR TITLE
Correct formatting for azurerm_linux_web_app backup.schedule.start_time

### DIFF
--- a/internal/services/appservice/helpers/common_web_app_schema.go
+++ b/internal/services/appservice/helpers/common_web_app_schema.go
@@ -941,7 +941,7 @@ func ExpandBackupConfig(backupConfigs []Backup) (*webapps.BackupRequest, error) 
 		if err != nil {
 			return nil, fmt.Errorf("parsing back up start_time: %+v", err)
 		}
-		result.Properties.BackupSchedule.StartTime = pointer.To(dateTimeToStart.String())
+		result.Properties.BackupSchedule.StartTime = pointer.To(dateTimeToStart.Format("2006-01-02T15:04:05.999999"))
 	}
 
 	return result, nil
@@ -1124,7 +1124,7 @@ func FlattenBackupConfig(backupRequest *webapps.BackupRequest) []Backup {
 			RetentionPeriodDays:  schedule.RetentionPeriodInDays,
 		}
 
-		startTimeAsTime, err := time.Parse(time.RFC3339, *schedule.StartTime)
+		startTimeAsTime, err := time.Parse("2006-01-02T15:04:05.999999", *schedule.StartTime)
 		if err == nil {
 			if schedule.StartTime != nil && !startTimeAsTime.IsZero() {
 				backupSchedule.StartTime = startTimeAsTime.Format(time.RFC3339)
@@ -1132,7 +1132,7 @@ func FlattenBackupConfig(backupRequest *webapps.BackupRequest) []Backup {
 		}
 
 		if schedule.LastExecutionTime != nil {
-			lastExecutionTimeAsTime, err := time.Parse(time.RFC3339, *schedule.LastExecutionTime)
+			lastExecutionTimeAsTime, err := time.Parse("2006-01-02T15:04:05.999999", *schedule.LastExecutionTime)
 			if err == nil {
 				if schedule.LastExecutionTime != nil && !lastExecutionTimeAsTime.IsZero() {
 					backupSchedule.LastExecutionTime = lastExecutionTimeAsTime.Format(time.RFC3339)


### PR DESCRIPTION
## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

The code expected the value from the REST API to be in RFC3339, but the value provided was not in a layout Go would parse. For example, Go expected "2006-01-02T15:04:05Z07:00" but Azure provided "2025-04-03T17:02:36.011657". This was causing the provider to not properly read the value from the API (resulting in the state storing `""`) and not succeeded in updating the value on the physical resource.

Value is still sorted in state and provided in configs in Go's RFC3339 layout, but now when using the REST API it will provide and parse the Azure layout. No state changes or migration necessary.

## PR Checklist

- [X] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [X] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [X] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [X] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [X] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_linux_web_app ` - format backup.schedule.start_time correctly for API [GH-29254]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [X] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #24776

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
