### PR TITLE
`azurerm_container_app` (and job) support for `secret` mounts

### DIFF
--- a/internal/services/containerapps/container_app_resource_test.go
+++ b/internal/services/containerapps/container_app_resource_test.go
@@ -835,6 +835,24 @@ resource "azurerm_container_app" "test" {
         name        = "key-vault-secret"
         secret_name = "key-vault-secret"
       }
+      volume_mounts {
+        name     = "secret-mount"
+        path     = "/tmp/testdata"
+        sub_path = "subdirectory"
+      }
+    }
+  }
+  
+  volume {
+    name        = "key-vault-mounts"
+    storage_type = "Secret"
+    secret {
+      name      = "key-vault-secret"
+      path      = "/tmp/key-vault-secret
+    }
+    secret {
+      name      = "key-vault-secret"
+      path      = "/tmp/key-vault-secret-2
     }
   }
 

--- a/website/docs/d/container_app.html.markdown
+++ b/website/docs/d/container_app.html.markdown
@@ -95,6 +95,16 @@ A `volume` block supports the following:
 
 * `mount_options` - Mount options used while mounting the AzureFile.
 
+* `secret` - A `secret` block as detailed below.
+
+---
+
+A `secret` block supports the following:
+
+* `path` - Mount path for the secret
+
+* `name` - Reference by name to the secret
+
 ---
 
 A `init_container` block supports the following:

--- a/website/docs/r/container_app.html.markdown
+++ b/website/docs/r/container_app.html.markdown
@@ -192,6 +192,16 @@ A `volume` block supports the following:
 
 * `mount_options` - Mount options used while mounting the AzureFile. Must be a comma-separated string e.g. `dir_mode=0751,file_mode=0751`.
 
+* `secret` - (Optional) A `secret` block as detailed below
+
+---
+
+A `secret` block supports:
+
+* `path` - Mount path for the secret to filesystem
+
+* `name` - A reference by name to a container app secret
+
 ---
 
 An `init_container` block supports:

--- a/website/docs/r/container_app_job.html.markdown
+++ b/website/docs/r/container_app_job.html.markdown
@@ -308,6 +308,16 @@ A `volume` block supports the following:
 
 * `mount_options` - Mount options used while mounting the AzureFile. Must be a comma-separated string e.g. `dir_mode=0751,file_mode=0751`.
 
+* `secret` - (Optional) A `secret` block as detailed below
+
+---
+
+A `secret` block supports:
+
+* `path` - Mount path for the secret to filesystem
+
+* `name` - A reference by name to a container app secret
+
 ---
 
 A `secret` block supports the following:


### PR DESCRIPTION
Addresses #25448


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Adds support for secret volume items in container resources. API ref https://learn.microsoft.com/en-us/rest/api/resource-manager/containerapps/container-apps/get?view=rest-resource-manager-containerapps-2024-03-01&tabs=HTTP#volume

Only unit tested.

Took minor liberty in naming.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”

## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

```
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/containerapps/validate	(cached)
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_container_app` (and job) support for `secret` mounts (addresses #25448)

This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #25448


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
