### PR TITLE
data_factory_dataset_binary_resource: fix incorrect compression.type character casing

### DIFF
--- a/internal/services/datafactory/data_factory.go
+++ b/internal/services/datafactory/data_factory.go
@@ -13,13 +13,11 @@ import (
 	"github.com/jackofallops/kermit/sdk/datafactory/2018-06-01/datafactory" // nolint: staticcheck
 )
 
-// @tombuildsstuff: these have been ported over from the Azure SDK for Go since the service team has removed them
-// but the casing differs in the API, so we need to ensure these are normalized on our side.
 const (
-	TypeBasicDatasetCompressionTypeBZip2      string = "BZip2"
-	TypeBasicDatasetCompressionTypeDeflate    string = "Deflate"
-	TypeBasicDatasetCompressionTypeGZip       string = "GZip"
-	TypeBasicDatasetCompressionTypeTar        string = "Tar"
+	TypeBasicDatasetCompressionTypeBZip2      string = "bzip2"
+	TypeBasicDatasetCompressionTypeDeflate    string = "deflate"
+	TypeBasicDatasetCompressionTypeGZip       string = "gzip"
+	TypeBasicDatasetCompressionTypeTar        string = "tar"
 	TypeBasicDatasetCompressionTypeTarGZip    string = "TarGZip"
 	TypeBasicDatasetCompressionTypeZipDeflate string = "ZipDeflate"
 )

--- a/internal/services/datafactory/data_factory_dataset_binary_resource_test.go
+++ b/internal/services/datafactory/data_factory_dataset_binary_resource_test.go
@@ -274,7 +274,7 @@ resource "azurerm_data_factory_dataset_binary" "test" {
   }
 
   compression {
-    type  = "GZip"
+    type  = "gzip"
     level = "Optimal"
   }
 }
@@ -361,7 +361,7 @@ resource "azurerm_data_factory_dataset_binary" "test" {
   }
 
   compression {
-    type  = "GZip"
+    type  = "gzip"
     level = "Fastest"
   }
 

--- a/website/docs/r/data_factory_dataset_binary.html.markdown
+++ b/website/docs/r/data_factory_dataset_binary.html.markdown
@@ -83,7 +83,7 @@ The following supported locations for a Binary Dataset. One of these should be s
 
 A `compression` block supports the following:
 
-* `type` - (Required) The type of compression used during transport. Possible values are `BZip2`, `Deflate`, `GZip`, `Tar`, `TarGZip` and `ZipDeflate`.
+* `type` - (Required) The type of compression used during transport. Possible values are `bzip2`, `deflate`, `gzip`, `tar`, `TarGZip` and `ZipDeflate`.
 
 * `level` - (Optional) The level of compression. Possible values are `Fastest` and `Optimal`.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Fixed a bug where the `compression.type` property was not recognised by the service due to incorrect character casing.

To reproduce the bug:

1. Create a `azurerm_data_factory_dataset_binary` with compression type `GZip`, plan and apply
    ```
    resource "azurerm_data_factory_dataset_binary" "example" {
      name                = "example"
      data_factory_id     = azurerm_data_factory.example.id
      linked_service_name = azurerm_data_factory_linked_service_azure_blob_storage.example.name
    
      compression {
        type  = "GZip"
        level = "Optimal"
      }
    }
    ```

2. Observe the resource via datafactory portal, note how the compression type is "No compression", despite the API accepts the json payload "GZip" with wrong character case.

![portal-payload](https://github.com/user-attachments/assets/615b295e-c145-4ca6-b181-d8bafcb45e1f)

![portal-view](https://github.com/user-attachments/assets/5b28074e-5311-49a4-b191-fe3494583a49)


Note that after this PR is merged, existing terraform state with value "GZip" will have validation error on plan. User have to change to "gzip" and perform a "GZip" -> "gzip" update.

Separate to this I have also opened an internal chat with my colleague from the Datafactory API team, requesting a validation to be implemented on the API such that a 400 error response is returned if user supplied compression with wrong character casing.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [x] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

acctest `TestAccDataFactoryDatasetBinary_` passing: [log](...) (restricted, DM me for access)

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_data_factory_dataset_binary` - fix wrong character casing of `compression.type` property [GH-29205]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #29205 


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
