### PR TITLE
`azurerm_dev_center` - support new property for `project_catalog_item_sync_enabled`

### DIFF
--- a/internal/services/devcenter/dev_center_resource.go
+++ b/internal/services/devcenter/dev_center_resource.go
@@ -60,6 +60,7 @@ func (r DevCenterResource) Arguments() map[string]*pluginsdk.Schema {
 		"project_catalog_item_sync_enabled": {
 			Type:     pluginsdk.TypeBool,
 			Optional: true,
+			Default:  false,
 		},
 		"identity": commonschema.SystemAssignedUserAssignedIdentityOptional(),
 		"tags":     commonschema.Tags(),
@@ -247,8 +248,8 @@ func (r DevCenterResource) mapDevCenterToDevCenterResourceSchema(input devcenter
 
 	output.DevCenterUri = pointer.From(input.Properties.DevCenterUri)
 
-	if v := input.Properties.ProjectCatalogSettings; v != nil && v.CatalogItemSyncEnableStatus != nil {
-		output.ProjectCatalogItemSyncEnabled = pointer.From(input.Properties.ProjectCatalogSettings.CatalogItemSyncEnableStatus) == devcenters.CatalogItemSyncEnableStatusEnabled
+	if v := input.Properties.ProjectCatalogSettings; v != nil {
+		output.ProjectCatalogItemSyncEnabled = pointer.From(v.CatalogItemSyncEnableStatus) == devcenters.CatalogItemSyncEnableStatusEnabled
 	}
 
 	return nil

--- a/internal/services/devcenter/dev_center_resource.go
+++ b/internal/services/devcenter/dev_center_resource.go
@@ -31,12 +31,13 @@ func (r DevCenterResource) ModelObject() interface{} {
 }
 
 type DevCenterResourceSchema struct {
-	DevCenterUri      string                                     `tfschema:"dev_center_uri"`
-	Identity          []identity.ModelSystemAssignedUserAssigned `tfschema:"identity"`
-	Location          string                                     `tfschema:"location"`
-	Name              string                                     `tfschema:"name"`
-	ResourceGroupName string                                     `tfschema:"resource_group_name"`
-	Tags              map[string]interface{}                     `tfschema:"tags"`
+	DevCenterUri                           string                                     `tfschema:"dev_center_uri"`
+	Identity                               []identity.ModelSystemAssignedUserAssigned `tfschema:"identity"`
+	Location                               string                                     `tfschema:"location"`
+	Name                                   string                                     `tfschema:"name"`
+	ResourceGroupName                      string                                     `tfschema:"resource_group_name"`
+	DevCenterProjectCatalogItemSyncEnabled bool                                       `tfschema:"dev_center_project_catalog_item_sync_enabled"`
+	Tags                                   map[string]interface{}                     `tfschema:"tags"`
 }
 
 func (r DevCenterResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
@@ -56,8 +57,12 @@ func (r DevCenterResource) Arguments() map[string]*pluginsdk.Schema {
 			Type:     pluginsdk.TypeString,
 		},
 		"resource_group_name": commonschema.ResourceGroupName(),
-		"identity":            commonschema.SystemAssignedUserAssignedIdentityOptional(),
-		"tags":                commonschema.Tags(),
+		"dev_center_project_catalog_item_sync_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+		},
+		"identity": commonschema.SystemAssignedUserAssignedIdentityOptional(),
+		"tags":     commonschema.Tags(),
 	}
 }
 
@@ -215,6 +220,14 @@ func (r DevCenterResource) mapDevCenterResourceSchemaToDevCenter(input DevCenter
 		output.Properties = &devcenters.DevCenterProperties{}
 	}
 
+	catalogItemSyncEnableStatus := devcenters.CatalogItemSyncEnableStatusDisabled
+	if input.DevCenterProjectCatalogItemSyncEnabled {
+		catalogItemSyncEnableStatus = devcenters.CatalogItemSyncEnableStatusEnabled
+	}
+	output.Properties.ProjectCatalogSettings = &devcenters.DevCenterProjectCatalogSettings{
+		CatalogItemSyncEnableStatus: pointer.To(catalogItemSyncEnableStatus),
+	}
+
 	return nil
 }
 
@@ -233,6 +246,10 @@ func (r DevCenterResource) mapDevCenterToDevCenterResourceSchema(input devcenter
 	}
 
 	output.DevCenterUri = pointer.From(input.Properties.DevCenterUri)
+
+	if v := input.Properties.ProjectCatalogSettings; v != nil && v.CatalogItemSyncEnableStatus != nil {
+		output.DevCenterProjectCatalogItemSyncEnabled = pointer.From(input.Properties.ProjectCatalogSettings.CatalogItemSyncEnableStatus) == devcenters.CatalogItemSyncEnableStatusEnabled
+	}
 
 	return nil
 }

--- a/internal/services/devcenter/dev_center_resource.go
+++ b/internal/services/devcenter/dev_center_resource.go
@@ -31,13 +31,13 @@ func (r DevCenterResource) ModelObject() interface{} {
 }
 
 type DevCenterResourceSchema struct {
-	DevCenterUri                           string                                     `tfschema:"dev_center_uri"`
-	Identity                               []identity.ModelSystemAssignedUserAssigned `tfschema:"identity"`
-	Location                               string                                     `tfschema:"location"`
-	Name                                   string                                     `tfschema:"name"`
-	ResourceGroupName                      string                                     `tfschema:"resource_group_name"`
-	DevCenterProjectCatalogItemSyncEnabled bool                                       `tfschema:"dev_center_project_catalog_item_sync_enabled"`
-	Tags                                   map[string]interface{}                     `tfschema:"tags"`
+	DevCenterUri                  string                                     `tfschema:"dev_center_uri"`
+	Identity                      []identity.ModelSystemAssignedUserAssigned `tfschema:"identity"`
+	Location                      string                                     `tfschema:"location"`
+	Name                          string                                     `tfschema:"name"`
+	ResourceGroupName             string                                     `tfschema:"resource_group_name"`
+	ProjectCatalogItemSyncEnabled bool                                       `tfschema:"project_catalog_item_sync_enabled"`
+	Tags                          map[string]interface{}                     `tfschema:"tags"`
 }
 
 func (r DevCenterResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
@@ -57,7 +57,7 @@ func (r DevCenterResource) Arguments() map[string]*pluginsdk.Schema {
 			Type:     pluginsdk.TypeString,
 		},
 		"resource_group_name": commonschema.ResourceGroupName(),
-		"dev_center_project_catalog_item_sync_enabled": {
+		"project_catalog_item_sync_enabled": {
 			Type:     pluginsdk.TypeBool,
 			Optional: true,
 		},
@@ -221,7 +221,7 @@ func (r DevCenterResource) mapDevCenterResourceSchemaToDevCenter(input DevCenter
 	}
 
 	catalogItemSyncEnableStatus := devcenters.CatalogItemSyncEnableStatusDisabled
-	if input.DevCenterProjectCatalogItemSyncEnabled {
+	if input.ProjectCatalogItemSyncEnabled {
 		catalogItemSyncEnableStatus = devcenters.CatalogItemSyncEnableStatusEnabled
 	}
 	output.Properties.ProjectCatalogSettings = &devcenters.DevCenterProjectCatalogSettings{
@@ -248,7 +248,7 @@ func (r DevCenterResource) mapDevCenterToDevCenterResourceSchema(input devcenter
 	output.DevCenterUri = pointer.From(input.Properties.DevCenterUri)
 
 	if v := input.Properties.ProjectCatalogSettings; v != nil && v.CatalogItemSyncEnableStatus != nil {
-		output.DevCenterProjectCatalogItemSyncEnabled = pointer.From(input.Properties.ProjectCatalogSettings.CatalogItemSyncEnableStatus) == devcenters.CatalogItemSyncEnableStatusEnabled
+		output.ProjectCatalogItemSyncEnabled = pointer.From(input.Properties.ProjectCatalogSettings.CatalogItemSyncEnableStatus) == devcenters.CatalogItemSyncEnableStatusEnabled
 	}
 
 	return nil

--- a/internal/services/devcenter/dev_center_resource_test.go
+++ b/internal/services/devcenter/dev_center_resource_test.go
@@ -146,7 +146,7 @@ resource "azurerm_dev_center" "test" {
   location                                     = azurerm_resource_group.test.location
   name                                         = "acctestdc-${var.random_string}"
   resource_group_name                          = azurerm_resource_group.test.name
-  dev_center_project_catalog_item_sync_enabled = true
+  project_catalog_item_sync_enabled = true
   tags = {
     environment = "terraform-acctests"
     some_key    = "some-value"

--- a/internal/services/devcenter/dev_center_resource_test.go
+++ b/internal/services/devcenter/dev_center_resource_test.go
@@ -143,9 +143,9 @@ provider "azurerm" {
 }
 
 resource "azurerm_dev_center" "test" {
-  location                                     = azurerm_resource_group.test.location
-  name                                         = "acctestdc-${var.random_string}"
-  resource_group_name                          = azurerm_resource_group.test.name
+  location                          = azurerm_resource_group.test.location
+  name                              = "acctestdc-${var.random_string}"
+  resource_group_name               = azurerm_resource_group.test.name
   project_catalog_item_sync_enabled = true
   tags = {
     environment = "terraform-acctests"

--- a/internal/services/devcenter/dev_center_resource_test.go
+++ b/internal/services/devcenter/dev_center_resource_test.go
@@ -143,9 +143,10 @@ provider "azurerm" {
 }
 
 resource "azurerm_dev_center" "test" {
-  location            = azurerm_resource_group.test.location
-  name                = "acctestdc-${var.random_string}"
-  resource_group_name = azurerm_resource_group.test.name
+  location                                     = azurerm_resource_group.test.location
+  name                                         = "acctestdc-${var.random_string}"
+  resource_group_name                          = azurerm_resource_group.test.name
+  dev_center_project_catalog_item_sync_enabled = true
   tags = {
     environment = "terraform-acctests"
     some_key    = "some-value"

--- a/website/docs/r/dev_center.html.markdown
+++ b/website/docs/r/dev_center.html.markdown
@@ -39,7 +39,7 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) Specifies the name of the Resource Group within which this Dev Center should exist. Changing this forces a new Dev Center to be created.
 
-* `project_catalog_item_sync_enabled` - (Optional) Should project catalogs associated with projects in this Dev Center can be configured to sync catalog items?
+* `project_catalog_item_sync_enabled` - (Optional) Whether the project catalogs associated with projects in this Dev Center are allowed to sync catalog items. Defaults to `false`.
 
 * `identity` - (Optional) An `identity` block as defined below. Specifies the Managed Identity which should be assigned to this Dev Center.
 

--- a/website/docs/r/dev_center.html.markdown
+++ b/website/docs/r/dev_center.html.markdown
@@ -39,7 +39,7 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) Specifies the name of the Resource Group within which this Dev Center should exist. Changing this forces a new Dev Center to be created.
 
-* `dev_center_project_catalog_item_sync_enabled` - (Optional) Should project catalogs associated with projects in this Dev Center can be configured to sync catalog items?
+* `project_catalog_item_sync_enabled` - (Optional) Should project catalogs associated with projects in this Dev Center can be configured to sync catalog items?
 
 * `identity` - (Optional) An `identity` block as defined below. Specifies the Managed Identity which should be assigned to this Dev Center.
 

--- a/website/docs/r/dev_center.html.markdown
+++ b/website/docs/r/dev_center.html.markdown
@@ -39,6 +39,8 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) Specifies the name of the Resource Group within which this Dev Center should exist. Changing this forces a new Dev Center to be created.
 
+* `dev_center_project_catalog_item_sync_enabled` - (Optional) Should project catalogs associated with projects in this Dev Center can be configured to sync catalog items?
+
 * `identity` - (Optional) An `identity` block as defined below. Specifies the Managed Identity which should be assigned to this Dev Center.
 
 * `tags` - (Optional) A mapping of tags which should be assigned to the Dev Center.


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description
This PR is to support new property for [`project_catalog_item_sync_enabled`](https://github.com/Azure/azure-rest-api-specs/blob/80314be566948e220c41b2793f7fb09eed724b22/specification/devcenter/resource-manager/Microsoft.DevCenter/stable/2025-02-01/devcenter.json#L4855).
<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

--- PASS: TestAccDevCenter_complete (566.37s)
--- PASS: TestAccDevCenter_update (741.16s)
--- PASS: TestAccDevCenter_requiresImport (641.16s)
--- PASS: TestAccDevCenter_basic (541.16s)

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_dev_center` - support new property for `dev_center_project_catalog_item_sync_enabled`


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/28361


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
