### PR TITLE
`azurerm_app_configuration_(feature|key)` - suppress ID case differences

### DIFF
--- a/internal/services/appconfiguration/app_configuration_feature_resource.go
+++ b/internal/services/appconfiguration/app_configuration_feature_resource.go
@@ -25,6 +25,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appconfiguration/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 	"github.com/jackofallops/kermit/sdk/appconfiguration/1.0/appconfiguration"
@@ -58,10 +59,13 @@ type FeatureResourceModel struct {
 func (k FeatureResource) Arguments() map[string]*pluginsdk.Schema {
 	return map[string]*pluginsdk.Schema{
 		"configuration_store_id": {
-			Type:         pluginsdk.TypeString,
-			Required:     true,
-			ForceNew:     true,
-			ValidateFunc: configurationstores.ValidateConfigurationStoreID,
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+			// User-specified segments are lowercased in the API response
+			// tracked in https://github.com/Azure/azure-rest-api-specs/issues/24337
+			DiffSuppressFunc: suppress.CaseDifference,
+			ValidateFunc:     configurationstores.ValidateConfigurationStoreID,
 		},
 		"description": {
 			Type:     pluginsdk.TypeString,

--- a/internal/services/appconfiguration/app_configuration_key_resource.go
+++ b/internal/services/appconfiguration/app_configuration_key_resource.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appconfiguration/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 	"github.com/jackofallops/kermit/sdk/appconfiguration/1.0/appconfiguration"
@@ -59,10 +60,13 @@ type VaultKeyReference struct {
 func (k KeyResource) Arguments() map[string]*pluginsdk.Schema {
 	return map[string]*pluginsdk.Schema{
 		"configuration_store_id": {
-			Type:         pluginsdk.TypeString,
-			Required:     true,
-			ForceNew:     true,
-			ValidateFunc: configurationstores.ValidateConfigurationStoreID,
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+			// User-specified segments are lowercased in the API response
+			// tracked in https://github.com/Azure/azure-rest-api-specs/issues/24337
+			DiffSuppressFunc: suppress.CaseDifference,
+			ValidateFunc:     configurationstores.ValidateConfigurationStoreID,
 		},
 		"key": {
 			Type:         pluginsdk.TypeString,
@@ -196,22 +200,22 @@ func (k KeyResource) Create() sdk.ResourceFunc {
 			}
 
 			entity := appconfiguration.KeyValue{
-				Key:   utils.String(model.Key),
-				Label: utils.String(model.Label),
+				Key:   pointer.To(model.Key),
+				Label: pointer.To(model.Label),
 				Tags:  tags.Expand(model.Tags),
 			}
 
 			switch model.Type {
 			case KeyTypeKV:
-				entity.ContentType = utils.String(model.ContentType)
-				entity.Value = utils.String(model.Value)
+				entity.ContentType = pointer.To(model.ContentType)
+				entity.Value = pointer.To(model.Value)
 			case KeyTypeVault:
-				entity.ContentType = utils.String(VaultKeyContentType)
+				entity.ContentType = pointer.To(VaultKeyContentType)
 				ref, err := json.Marshal(VaultKeyReference{URI: model.VaultKeyReference})
 				if err != nil {
 					return fmt.Errorf("while encoding vault key reference: %+v", err)
 				}
-				entity.Value = utils.String(string(ref))
+				entity.Value = pointer.To(string(ref))
 			}
 
 			if _, err = client.PutKeyValue(ctx, model.Key, model.Label, &entity, "", ""); err != nil {
@@ -364,22 +368,22 @@ func (k KeyResource) Update() sdk.ResourceFunc {
 
 			if metadata.ResourceData.HasChange("value") || metadata.ResourceData.HasChange("content_type") || metadata.ResourceData.HasChange("tags") || metadata.ResourceData.HasChange("type") || metadata.ResourceData.HasChange("vault_key_reference") {
 				entity := appconfiguration.KeyValue{
-					Key:   utils.String(model.Key),
-					Label: utils.String(model.Label),
+					Key:   pointer.To(model.Key),
+					Label: pointer.To(model.Label),
 					Tags:  tags.Expand(model.Tags),
 				}
 
 				switch model.Type {
 				case KeyTypeKV:
-					entity.ContentType = utils.String(model.ContentType)
-					entity.Value = utils.String(model.Value)
+					entity.ContentType = pointer.To(model.ContentType)
+					entity.Value = pointer.To(model.Value)
 				case KeyTypeVault:
-					entity.ContentType = utils.String(VaultKeyContentType)
+					entity.ContentType = pointer.To(VaultKeyContentType)
 					ref, err := json.Marshal(VaultKeyReference{URI: model.VaultKeyReference})
 					if err != nil {
 						return fmt.Errorf("while encoding vault key reference: %+v", err)
 					}
-					entity.Value = utils.String(string(ref))
+					entity.Value = pointer.To(string(ref))
 				}
 				if _, err = client.PutKeyValue(ctx, model.Key, model.Label, &entity, "", ""); err != nil {
 					return fmt.Errorf("while updating key/label pair %s/%s: %+v", model.Key, model.Label, err)


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

The list API used by these resources doesn't preserve user-specified segment casing in the response. To avoid constant replacement plans, ignore diff until the API bug is fixed.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<img width="374" alt="image" src="https://github.com/user-attachments/assets/f129ccc9-988d-4437-9c62-b577c4df3826" />

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #23315
Fixes #24999

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
