### PR TITLE
Add default import error for association resources

### DIFF
--- a/helpers/tf/errors.go
+++ b/helpers/tf/errors.go
@@ -10,3 +10,8 @@ func ImportAsExistsError(resourceName, id string) error {
 	msg := "A resource with the ID %q already exists - to be managed via Terraform this resource needs to be imported into the State. Please see the resource documentation for %q for more information."
 	return fmt.Errorf(msg, id, resourceName)
 }
+
+func ImportAsExistsAssociationError(resourceName, parentId, childId string) error {
+	msg := "An association between %q and %q already exists - to be managed via Terraform this association needs to be imported into the State. Please see the resource documentation for %q for more information."
+	return fmt.Errorf(msg, parentId, childId, resourceName)
+}

--- a/internal/acceptance/steps.go
+++ b/internal/acceptance/steps.go
@@ -148,3 +148,13 @@ func (td TestData) RequiresImportErrorStep(configBuilder func(data TestData) str
 		ExpectError: RequiresImportError(td.ResourceType),
 	}
 }
+
+// RequiresImportAssociationErrorStep returns a Test Step which expects a Requires Import
+// error for an association resource to be returned when running this step
+func (td TestData) RequiresImportAssociationErrorStep(configBuilder func(data TestData) string) resource.TestStep {
+	config := configBuilder(td)
+	return resource.TestStep{
+		Config:      config,
+		ExpectError: RequiresImportAssociationError(td.ResourceType),
+	}
+}

--- a/internal/acceptance/testing.go
+++ b/internal/acceptance/testing.go
@@ -91,3 +91,8 @@ func RequiresImportError(resourceName string) *regexp.Regexp {
 	message := "to be managed via Terraform this resource needs to be imported into the State. Please see the resource documentation for %q for more information."
 	return regexp.MustCompile(fmt.Sprintf(message, resourceName))
 }
+
+func RequiresImportAssociationError(resourceName string) *regexp.Regexp {
+	message := "to be managed via Terraform this association needs to be imported into the State. Please see the resource documentation for %q for more information."
+	return regexp.MustCompile(fmt.Sprintf(message, resourceName))
+}


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This PR adds a default error (and related test step) for import errors on association resources (e.g. `azurerm_subnet_route_table_association`)

If merged, I'd like to then replace all `tf.ImportAsExists` error messages in association resources with this new error. 

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

N/A

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
