### PR TITLE
`azurerm_postgresql_flexible_server`: force new when downgrading `storage_mb`

### DIFF
--- a/internal/services/postgres/postgresql_flexible_server_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_resource.go
@@ -536,10 +536,7 @@ func resourcePostgresqlFlexibleServerCreate(d *pluginsdk.ResourceData, meta inte
 		return fmt.Errorf("expanding `sku_name` for %s: %v", id, err)
 	}
 
-	storage, err := expandArmServerStorage(d)
-	if err != nil {
-		return err
-	}
+	storage := expandArmServerStorage(d)
 	var storageMb int
 
 	if storage.StorageSizeGB == nil || *storage.StorageSizeGB == 0 {
@@ -891,10 +888,7 @@ func resourcePostgresqlFlexibleServerUpdate(d *pluginsdk.ResourceData, meta inte
 
 	if d.HasChange("auto_grow_enabled") || d.HasChange("storage_mb") || d.HasChange("storage_tier") {
 		// TODO remove the additional update after https://github.com/Azure/azure-rest-api-specs/issues/22867 is fixed
-		storage, err := expandArmServerStorage(d)
-		if err != nil {
-			return err
-		}
+		storage := expandArmServerStorage(d)
 
 		storageUpdateParameters := servers.ServerForUpdate{
 			Properties: &servers.ServerPropertiesForUpdate{
@@ -1047,7 +1041,7 @@ func expandArmServerMaintenanceWindow(input []interface{}) *servers.MaintenanceW
 	return &maintenanceWindow
 }
 
-func expandArmServerStorage(d *pluginsdk.ResourceData) (*servers.Storage, error) {
+func expandArmServerStorage(d *pluginsdk.ResourceData) *servers.Storage {
 	storage := servers.Storage{}
 
 	autoGrow := servers.StorageAutoGrowDisabled
@@ -1055,12 +1049,6 @@ func expandArmServerStorage(d *pluginsdk.ResourceData) (*servers.Storage, error)
 		autoGrow = servers.StorageAutoGrowEnabled
 	}
 	storage.AutoGrow = &autoGrow
-
-	// storage_mb can only be scaled up...
-	oldStorageMbRaw, newStorageMbRaw := d.GetChange("storage_mb")
-	if newStorageMbRaw.(int) < oldStorageMbRaw.(int) {
-		return nil, fmt.Errorf("'storage_mb' can only be scaled up, expected the new 'storage_mb' value (%d) to be larger than the previous 'storage_mb' value (%d)", newStorageMbRaw.(int), oldStorageMbRaw.(int))
-	}
 
 	if v, ok := d.GetOk("storage_mb"); ok {
 		storage.StorageSizeGB = pointer.FromInt64(int64(v.(int) / 1024))
@@ -1070,7 +1058,7 @@ func expandArmServerStorage(d *pluginsdk.ResourceData) (*servers.Storage, error)
 		storage.Tier = pointer.To(servers.AzureManagedDiskPerformanceTiers(v.(string)))
 	}
 
-	return &storage, nil
+	return &storage
 }
 
 func expandArmServerBackup(d *pluginsdk.ResourceData) *servers.Backup {

--- a/internal/services/postgres/postgresql_flexible_server_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_resource.go
@@ -401,6 +401,11 @@ func resourcePostgresqlFlexibleServer() *pluginsdk.Resource {
 			newMb = newStorageMbRaw.(int)
 			newTier = newTierRaw.(string)
 
+			// if newMb is smaller than oldStorageMb, it's a downgrade need to trigger a force new
+			if newMb > 0 && oldStorageMbRaw.(int) > newMb {
+				diff.ForceNew("storage_mb")
+			}
+
 			// if newMb or newTier values are empty,
 			// assign the default values that will
 			// be assigned in the create func...

--- a/internal/services/postgres/postgresql_flexible_server_resource_test.go
+++ b/internal/services/postgres/postgresql_flexible_server_resource_test.go
@@ -467,25 +467,6 @@ func TestAccPostgresqlFlexibleServer_invalidStorageTier(t *testing.T) {
 	})
 }
 
-func TestAccPostgresqlFlexibleServer_invalidStorageMbScaling(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_postgresql_flexible_server", "test")
-	r := PostgresqlFlexibleServerResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.invalidStorageMbScaling(data, "524288"),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep("administrator_password", "create_mode"),
-		{
-			Config:      r.invalidStorageMbScaling(data, "262144"),
-			ExpectError: regexp.MustCompile("'storage_mb' can only be scaled up"),
-		},
-	})
-}
-
 func TestAccPostgresqlFlexibleServer_invalidStorageTierScalingStorageMb(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_postgresql_flexible_server", "test")
 	r := PostgresqlFlexibleServerResource{}

--- a/internal/services/postgres/postgresql_flexible_server_resource_test.go
+++ b/internal/services/postgres/postgresql_flexible_server_resource_test.go
@@ -1438,25 +1438,6 @@ resource "azurerm_postgresql_flexible_server" "test" {
 `, r.template(data), data.RandomInteger)
 }
 
-func (r PostgresqlFlexibleServerResource) invalidStorageMbScaling(data acceptance.TestData, storageMb string) string {
-	return fmt.Sprintf(`
-%s
-
-resource "azurerm_postgresql_flexible_server" "test" {
-  name                   = "acctest-fs-%d"
-  resource_group_name    = azurerm_resource_group.test.name
-  location               = azurerm_resource_group.test.location
-  administrator_login    = "adminTerraform"
-  administrator_password = "QAZwsx123"
-  storage_mb             = %s
-  storage_tier           = "P20"
-  version                = "12"
-  sku_name               = "GP_Standard_D2s_v3"
-  zone                   = "2"
-}
-`, r.template(data), data.RandomInteger, storageMb)
-}
-
 func (r PostgresqlFlexibleServerResource) invalidStorageTierScaling(data acceptance.TestData, storageTier string, storageMb string) string {
 	return fmt.Sprintf(`
 %s

--- a/website/docs/r/postgresql_flexible_server.html.markdown
+++ b/website/docs/r/postgresql_flexible_server.html.markdown
@@ -151,7 +151,7 @@ The following arguments are supported:
 
 ~> **Note:** If the `storage_mb` field is undefined on the initial deployment of the PostgreSQL Flexible Server resource it will default to `32768`. If the `storage_mb` field has been defined and then removed, the `storage_mb` field will retain the previously defined value.
 
-~> **Note:** The `storage_mb` can only be scaled up, for example, you can scale the `storage_mb` from `32768` to `65536`, but not from `65536` to `32768`.
+~> **Note:** The `storage_mb` can only be scaled up, for example, you can scale the `storage_mb` from `32768` to `65536`, but not from `65536` to `32768`. Scaling down `storage_mb` forces a new PostgreSQL Flexible Server to be created.
 
 * `storage_tier` - (Optional) The name of storage performance tier for IOPS of the PostgreSQL Flexible Server. Possible values are `P4`, `P6`, `P10`, `P15`,`P20`, `P30`,`P40`, `P50`,`P60`, `P70` or `P80`. Default value is dependant on the `storage_mb` value. Please see the `storage_tier` defaults based on `storage_mb` table below.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

We should tag the resource force new rather than raising an error. fixes #28942 

related links: #25986


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

```
Terraform will perform the following actions:

  # azurerm_postgresql_flexible_server.test must be replaced
-/+ resource "azurerm_postgresql_flexible_server" "test" {
      - administrator_password_wo_version = 0 -> null
      ~ backup_retention_days             = 7 -> (known after apply)
      ~ fqdn                              = "xuwu1-pg1.postgres.database.azure.com" -> (known after apply)
      ~ id                                = "/subscriptions/xxx/resourceGroups/RG-xuwu1-Case/providers/Microsoft.DBforPostgreSQL/flexibleServers/xuwu1-pg1" -> (known after apply)
      ~ name                              = "xuwu1-pg1" -> "xuwu1-pg2" # forces replacement
      + private_dns_zone_id               = (known after apply)
      ~ storage_mb                        = 131072 -> 65536 # forces replacement
      ~ storage_tier                      = "P10" -> (known after apply)
      - tags                              = {} -> null
        # (13 unchanged attributes hidden)

      ~ authentication (known after apply)
      - authentication {
          - active_directory_auth_enabled = false -> null
          - password_auth_enabled         = true -> null
            # (1 unchanged attribute hidden)
        }
    }

Plan: 1 to add, 0 to change, 1 to destroy.
....
azurerm_postgresql_flexible_server.test: Still creating... [4m0s elapsed]
azurerm_postgresql_flexible_server.test: Creation complete after 4m8s [id=/subscriptions/xxx/resourceGroups/RG-xuwu1-Case/providers/Microsoft.DBforPostgreSQL/flexibleServers/xuwu1-pg2]

Apply complete! Resources: 1 added, 0 changed, 1 destroyed.
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_postgresql_flexible_server` - force new when downgrading `storage_mb` property [GH-28942]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #28942


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
