### PR TITLE
`azurerm_network_interface`: `tags` can now be updated when NIC is attached to a private endpoint

### DIFF
--- a/internal/services/network/network_interface_resource.go
+++ b/internal/services/network/network_interface_resource.go
@@ -332,7 +332,8 @@ func resourceNetworkInterfaceUpdate(d *pluginsdk.ResourceData, meta interface{})
 	payload := existing.Model
 
 	// For NIC attached to private endpoint, tags cannot be updated using PUT.
-	// It has to use the specific update tag PATCH API
+	// It has to use the specific update tag PATCH API.
+	// An issue has been raised to improve the API design: https://github.com/Azure/azure-rest-api-specs/issues/34437
 	propsOtherThanTagsUpdated := false
 	attachedToPrivateEndpoint := payload.Properties.PrivateEndpoint != nil && pointer.From(payload.Properties.PrivateEndpoint.Id) != ""
 

--- a/internal/services/network/network_interface_resource_test.go
+++ b/internal/services/network/network_interface_resource_test.go
@@ -377,6 +377,28 @@ func TestAccNetworkInterface_pointToGatewayLB(t *testing.T) {
 	})
 }
 
+func TestAccNetworkInterface_tagsOfNicAttachedToPrivateEndpointCanBeUpdated(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_network_interface", "test")
+	r := NetworkInterfaceResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.privateEndpoint(data, false),
+		},
+		{
+			Config: r.privateEndpointNic(data, ""),
+		},
+		data.ImportStep(),
+		{
+			Config: r.privateEndpointNic(data, `
+  tags = {
+   someTagKey = "someTagValue"
+  }`),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (t NetworkInterfaceResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := commonids.ParseNetworkInterfaceID(state.ID)
 	if err != nil {
@@ -979,6 +1001,80 @@ resource "azurerm_network_interface" "test" {
   }
 }
 `, r.template(data), data.RandomInteger)
+}
+
+func (r NetworkInterfaceResource) privateEndpoint(data acceptance.TestData, peDependsOnNic bool) string {
+	peDependsOn := ""
+	if peDependsOnNic {
+		// Needed once NIC is imported, so Terraform destroy the private endpoint first
+		peDependsOn = "depends_on = [ azurerm_network_interface.test ]"
+	}
+
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_storage_account" "test" {
+  name                     = "sa%[2]d"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_private_endpoint" "test" {
+  name                = "acctestpe-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  subnet_id                     = azurerm_subnet.test.id
+  custom_network_interface_name = "acctestnic-%[2]d"
+
+  private_service_connection {
+    name                           = "acctestpsc-%[2]d"
+    private_connection_resource_id = azurerm_storage_account.test.id
+    is_manual_connection           = false
+    subresource_names              = ["blob"]
+  }
+
+  %[3]s
+}
+
+`, r.template(data), data.RandomInteger, peDependsOn)
+}
+
+func (r NetworkInterfaceResource) privateEndpointNic(data acceptance.TestData, tags string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+import {
+  id = "/subscriptions/%[2]s/resourceGroups/${azurerm_resource_group.test.name}/providers/Microsoft.Network/networkInterfaces/acctestnic-%[3]d"
+  to = azurerm_network_interface.test
+}
+
+resource "azurerm_network_interface" "test" {
+  accelerated_networking_enabled = false
+  ip_forwarding_enabled          = false
+  location                       = "australiaeast"
+  name                           = "acctestnic-%[3]d"
+  resource_group_name            = azurerm_resource_group.test.name
+
+  ip_configuration {
+    name                          = "test"
+    primary                       = true
+    private_ip_address            = "10.0.2.4"
+    private_ip_address_allocation = "Dynamic"
+    private_ip_address_version    = "IPv4"
+    subnet_id                     = azurerm_subnet.test.id
+  }
+
+  lifecycle {
+    # The real ip_configuration.name is difficult to get, opt-out instead since we only care about tags update
+    ignore_changes = [ ip_configuration ]
+  }
+
+%[4]s
+}
+`, r.privateEndpoint(data, true), data.Client().SubscriptionID, data.RandomInteger, tags)
 }
 
 func (NetworkInterfaceResource) template(data acceptance.TestData) string {

--- a/internal/services/network/network_interface_resource_test.go
+++ b/internal/services/network/network_interface_resource_test.go
@@ -1047,7 +1047,7 @@ func (r NetworkInterfaceResource) privateEndpointNic(data acceptance.TestData, t
 %[1]s
 
 import {
-  id = "/subscriptions/%[2]s/resourceGroups/${azurerm_resource_group.test.name}/providers/Microsoft.Network/networkInterfaces/acctestnic-%[3]d"
+  id = "/subscriptions/%[2]s/resourceGroups/acctestRG-%[3]d/providers/Microsoft.Network/networkInterfaces/acctestnic-%[3]d"
   to = azurerm_network_interface.test
 }
 

--- a/internal/services/network/network_interface_resource_test.go
+++ b/internal/services/network/network_interface_resource_test.go
@@ -1054,7 +1054,7 @@ import {
 resource "azurerm_network_interface" "test" {
   accelerated_networking_enabled = false
   ip_forwarding_enabled          = false
-  location                       = "australiaeast"
+  location                       = azurerm_resource_group.test.location
   name                           = "acctestnic-%[3]d"
   resource_group_name            = azurerm_resource_group.test.name
 

--- a/internal/services/network/network_interface_resource_test.go
+++ b/internal/services/network/network_interface_resource_test.go
@@ -1069,7 +1069,7 @@ resource "azurerm_network_interface" "test" {
 
   lifecycle {
     # The real ip_configuration.name is difficult to get, opt-out instead since we only care about tags update
-    ignore_changes = [ ip_configuration ]
+    ignore_changes = [ip_configuration]
   }
 
 %[4]s


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Changes how tags are updated to fix 400 error when updating a tag of NIC that is attached to a private endpoint.

To reproduce the problem:

1. Create a private endpoint, a built-in NIC will be injected
2. Figure out the id and payload of this builtin NIC using CLI: `az network nic show -g my-rg-name -n my.nic.name` and import the NIC into TF
3. Update the NIC tag using TF

Expected: tags can be updated
Actual: tag update fails with 400 error "CannotModifyNicAttachedToPrivateEndpoint"

Note that network interface API [has a dedicated operation to update tags](https://learn.microsoft.com/en-us/rest/api/virtualnetwork/network-interfaces/update-tags?view=rest-virtualnetwork-2024-05-01&tabs=HTTP). This suggest this is the recommended to update tags rather than using PUT.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] ~~(For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.~~


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

acctest were run and all tests passing. The 2 FAILs also present on the main branch

```
--- PASS: TestAccNetworkInterface_disappears (684.06s)
--- PASS: TestAccNetworkInterface_requiresImport (725.81s)
--- PASS: TestAccNetworkInterface_ipv6 (737.80s)
--- PASS: TestAccNetworkInterface_basic (764.17s)
--- PASS: TestAccNetworkInterface_static (793.18s)
--- FAIL: TestAccNetworkInterface_edgeZone (104.59s)
--- PASS: TestAccNetworkInterface_multipleIPConfigurations (859.77s)
--- PASS: TestAccNetworkInterface_internalDomainNameLabel (883.99s)
--- PASS: TestAccNetworkInterface_multipleIPConfigurationsSecondaryAsPrimary (906.21s)
--- FAIL: TestAccNetworkInterface_auxiliary (922.26s)
--- PASS: TestAccNetworkInterface_pointToGatewayLB (943.92s)
--- PASS: TestAccNetworkInterface_updateMultipleParameters (989.07s)
--- PASS: TestAccNetworkInterface_update (1013.29s)
--- PASS: TestAccNetworkInterface_dnsServers (1038.44s)
--- PASS: TestAccNetworkInterface_enableAcceleratedNetworking (1050.97s)
--- PASS: TestAccNetworkInterface_tags (411.13s)
--- PASS: TestAccNetworkInterface_tagsOfNicAttachedToPrivateEndpointCanBeUpdated (435.90s)
--- PASS: TestAccNetworkInterface_publicIP (538.16s)
--- PASS: TestAccNetworkInterface_enableIPForwarding (453.14s)
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_network_interface` - allow tags to be updated when NIC is attached to a private endpoint


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
n/a, problem discovered via Azure customer support escalation


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
