### PR TITLE
Update Name Pattern in Acceptance Test Guide and Tests

### DIFF
--- a/contributing/topics/reference-acceptance-testing.md
+++ b/contributing/topics/reference-acceptance-testing.md
@@ -49,22 +49,24 @@ func TestAccExampleResource_category_test2(t *testing.T) { ... }
 
 ## Acceptance Tests
 
-The Acceptance Tests for both Data Sources and Resources within this Provider use a Go struct for each test, in the form `{Name}{DataSource|Resource}Test`, for example:
+The Acceptance Tests for both Data Sources and Resources within this Provider use a Go struct for each test, in the form `{Name}{DataSource|Resource}`, for example:
 
 ```go
 // for a data source named Example:
-type ExampleDataSourceTest struct {}
+type ExampleDataSource struct {}
 
 // for a resource named Example:
-type ExampleResourceTest struct {}
+type ExampleResource struct {}
 ```
 
-This allows the test configurations to be scoped (and not used unintentionally across different resources), for example a Resource may use:
+They are differentiated from the implementation's struct by their package, which is the same as the implementation's but with a `_test` suffix. This allows the test configurations to be scoped (and not used unintentionally across different resources), for example a Resource may look like this:
 
 ```go
-type ExampleResourceTest struct {}
+package example_test
 
-func (ExampleResourceTest) basic(data acceptance.TestData) string {
+type ExampleResource struct {}
+
+func (ExampleResource) basic(data acceptance.TestData) string {
 return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -85,7 +87,7 @@ This allows the Acceptance Test for each Data Source/Resource to reference that 
 ```go
 func TestAccExampleResource_basic(t *testing.T) {
         data := acceptance.BuildTestData(t, "azurerm_example_resource", "test")
-        r := ExampleResourceTest{}
+        r := ExampleResource{}
 
         data.ResourceTest(t, r, []acceptance.TestStep{
                 {
@@ -98,6 +100,8 @@ func TestAccExampleResource_basic(t *testing.T) {
         })
 }
 ```
+
+-> **Note:** Originally, the acceptance tests were in the same package as the resource or data source. In order to avoid a name collision, test structs were suffixed with `Test`. However, moving tests to their own package made the struct suffix superfluous.
 
 ### Which Tests are Required?
 
@@ -130,7 +134,7 @@ Since the Data Source primarily exposes Computed-only fields which aren't specif
 ```go
 func TestAccExampleDataSource_complete(t *testing.T) {
         data := acceptance.BuildTestData(t, "data.azurerm_example_resource", "test")
-        r := ExampleDataSourceTest{}
+        r := ExampleDataSource{}
 
         data.ResourceTest(t, r, []acceptance.TestStep{
                 {
@@ -145,8 +149,8 @@ func TestAccExampleDataSource_complete(t *testing.T) {
         })
 }
 
-func (ExampleDataSourceTest) complete(data acceptance.TestData) string {
-	template := ExampleResourceTest{}.basic(data)
+func (ExampleDataSource) complete(data acceptance.TestData) string {
+	template := ExampleResource{}.basic(data)
     return fmt.Sprintf(`
 %[1]s
 
@@ -169,7 +173,7 @@ As we're testing the Resource, we make use of an `ImportStep` as a part of the A
 ```go
 func TestAccExampleResource_basic(t *testing.T) {
         data := acceptance.BuildTestData(t, "azurerm_example_resource", "test")
-        r := ExampleResourceTest{}
+        r := ExampleResource{}
 
         data.ResourceTest(t, r, []acceptance.TestStep{
                 {
@@ -182,7 +186,7 @@ func TestAccExampleResource_basic(t *testing.T) {
         })
 }
 
-func (ExampleResourceTest) basic(data acceptance.TestData) string {
+func (ExampleResource) basic(data acceptance.TestData) string {
     return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -206,7 +210,7 @@ As we're testing the Resource, we make use of an `ImportStep` as a part of the A
 ```go
 func TestAccExampleResource_complete(t *testing.T) {
         data := acceptance.BuildTestData(t, "azurerm_example_resource", "test")
-        r := ExampleResourceTest{}
+        r := ExampleResource{}
 
         data.ResourceTest(t, r, []acceptance.TestStep{
                 {
@@ -219,7 +223,7 @@ func TestAccExampleResource_complete(t *testing.T) {
         })
 }
 
-func (ExampleResourceTest) complete(data acceptance.TestData) string {
+func (ExampleResource) complete(data acceptance.TestData) string {
     return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -251,7 +255,7 @@ Since this test is attempting to provision the same resource, with the same iden
 ```go
 func TestAccExampleResource_basic(t *testing.T) {
         data := acceptance.BuildTestData(t, "azurerm_example_resource", "test")
-        r := ExampleResourceTest{}
+        r := ExampleResource{}
 
         data.ResourceTest(t, r, []acceptance.TestStep{
                 {
@@ -264,7 +268,7 @@ func TestAccExampleResource_basic(t *testing.T) {
         })
 }
 
-func (r ExampleResourceTest) requiresImport(data acceptance.TestData) string {
+func (r ExampleResource) requiresImport(data acceptance.TestData) string {
 	template := r.basic(data)  
     return fmt.Sprintf(`
 %[1]s
@@ -287,7 +291,7 @@ The bare-minimum example for this is provisioning the `basic` configuration and 
 ```go
 func TestAccExampleResource_update(t *testing.T) {
         data := acceptance.BuildTestData(t, "azurerm_example_resource", "test")
-        r := ExampleResourceTest{}
+        r := ExampleResource{}
 
         data.ResourceTest(t, r, []acceptance.TestStep{
             {   // first provision the resource
@@ -315,7 +319,7 @@ However, this doesn't necessarily cover all use-cases for this resource - or may
 ```go
 func TestAccExampleResource_someSetting(t *testing.T) {
     data := acceptance.BuildTestData(t, "azurerm_example_resource", "test")
-    r := ExampleResourceTest{}
+    r := ExampleResource{}
     
     data.ResourceTest(t, r, []acceptance.TestStep{
         {   // first provision the resource
@@ -342,7 +346,7 @@ func TestAccExampleResource_someSetting(t *testing.T) {
     })
 }
 
-func (ExampleResourceTest) someSettingEnabled(data acceptance.TestData) string {
+func (ExampleResource) someSettingEnabled(data acceptance.TestData) string {
     return fmt.Sprintf(`
 provider "azurerm" {
   features {}

--- a/contributing/topics/reference-acceptance-testing.md
+++ b/contributing/topics/reference-acceptance-testing.md
@@ -101,7 +101,7 @@ func TestAccExampleResource_basic(t *testing.T) {
 }
 ```
 
--> **Note:** Originally, the acceptance tests were in the same package as the resource or data source. In order to avoid a name collision, test structs were suffixed with `Test`. However, moving tests to their own package made the struct suffix superfluous.
+> Originally, the acceptance tests were in the same package as the resource or data source. In order to avoid a name collision, test structs were suffixed with `Test`. However, moving tests to their own package made the struct suffix superfluous.
 
 ### Which Tests are Required?
 

--- a/internal/services/authorization/role_assignments_data_source_test.go
+++ b/internal/services/authorization/role_assignments_data_source_test.go
@@ -11,11 +11,11 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 )
 
-type RoleAssignmentsDataSourceTest struct{}
+type RoleAssignmentsDataSource struct{}
 
 func TestAccRoleAssignmentsDataSource_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_role_assignments", "test")
-	d := RoleAssignmentsDataSourceTest{}
+	d := RoleAssignmentsDataSource{}
 
 	data.DataSourceTest(t, []acceptance.TestStep{
 		{
@@ -28,7 +28,7 @@ func TestAccRoleAssignmentsDataSource_basic(t *testing.T) {
 	})
 }
 
-func (d RoleAssignmentsDataSourceTest) basic(data acceptance.TestData) string {
+func (d RoleAssignmentsDataSource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -44,7 +44,7 @@ data "azurerm_role_assignments" "test" {
 `, d.template(data))
 }
 
-func (RoleAssignmentsDataSourceTest) template(data acceptance.TestData) string {
+func (RoleAssignmentsDataSource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}

--- a/internal/services/elastic/elasticsearch_data_source_test.go
+++ b/internal/services/elastic/elasticsearch_data_source_test.go
@@ -11,11 +11,11 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 )
 
-type ElasticsearchDataSourceTest struct{}
+type ElasticsearchDataSource struct{}
 
 func TestAccElasticsearchDataSource_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_elastic_cloud_elasticsearch", "test")
-	r := ElasticsearchDataSourceTest{}
+	r := ElasticsearchDataSource{}
 
 	data.DataSourceTest(t, []acceptance.TestStep{
 		{
@@ -36,8 +36,8 @@ func TestAccElasticsearchDataSource_basic(t *testing.T) {
 	})
 }
 
-func (ElasticsearchDataSourceTest) basic(data acceptance.TestData) string {
-	template := ElasticsearchResourceTest{}.basic(data)
+func (ElasticsearchDataSource) basic(data acceptance.TestData) string {
+	template := ElasticsearchResource{}.basic(data)
 	return fmt.Sprintf(`
 %s
 

--- a/internal/services/elastic/elasticsearch_resource_test.go
+++ b/internal/services/elastic/elasticsearch_resource_test.go
@@ -6,6 +6,7 @@ package elastic_test
 import (
 	"context"
 	"fmt"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"testing"
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
@@ -14,14 +15,13 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
-type ElasticsearchResourceTest struct{}
+type ElasticsearchResource struct{}
 
 func TestAccElasticsearch_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_elastic_cloud_elasticsearch", "test")
-	r := ElasticsearchResourceTest{}
+	r := ElasticsearchResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.basic(data),
@@ -41,7 +41,7 @@ func TestAccElasticsearch_basic(t *testing.T) {
 
 func TestAccElasticsearch_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_elastic_cloud_elasticsearch", "test")
-	r := ElasticsearchResourceTest{}
+	r := ElasticsearchResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.basic(data),
@@ -55,7 +55,7 @@ func TestAccElasticsearch_requiresImport(t *testing.T) {
 
 func TestAccElasticsearch_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_elastic_cloud_elasticsearch", "test")
-	r := ElasticsearchResourceTest{}
+	r := ElasticsearchResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.complete(data),
@@ -69,7 +69,7 @@ func TestAccElasticsearch_complete(t *testing.T) {
 
 func TestAccElasticsearch_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_elastic_cloud_elasticsearch", "test")
-	r := ElasticsearchResourceTest{}
+	r := ElasticsearchResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.basic(data),
@@ -97,7 +97,7 @@ func TestAccElasticsearch_update(t *testing.T) {
 
 func TestAccElasticsearch_logs(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_elastic_cloud_elasticsearch", "test")
-	r := ElasticsearchResourceTest{}
+	r := ElasticsearchResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			// this proves that we don't need to destroy the `logs` block separately
@@ -112,7 +112,7 @@ func TestAccElasticsearch_logs(t *testing.T) {
 
 func TestAccElasticsearch_logsUpdate(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_elastic_cloud_elasticsearch", "test")
-	r := ElasticsearchResourceTest{}
+	r := ElasticsearchResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			// create with it
@@ -141,7 +141,7 @@ func TestAccElasticsearch_logsUpdate(t *testing.T) {
 	})
 }
 
-func (r ElasticsearchResourceTest) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+func (r ElasticsearchResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := monitorsresource.ParseMonitorID(state.ID)
 	if err != nil {
 		return nil, err
@@ -150,14 +150,14 @@ func (r ElasticsearchResourceTest) Exists(ctx context.Context, client *clients.C
 	resp, err := client.Elastic.MonitorClient.MonitorsGet(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
-func (r ElasticsearchResourceTest) basic(data acceptance.TestData) string {
+func (r ElasticsearchResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -182,7 +182,7 @@ resource "azurerm_elastic_cloud_elasticsearch" "test" {
 `, data.RandomInteger, data.Locations.Primary)
 }
 
-func (r ElasticsearchResourceTest) requiresImport(data acceptance.TestData) string {
+func (r ElasticsearchResource) requiresImport(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -196,7 +196,7 @@ resource "azurerm_elastic_cloud_elasticsearch" "import" {
 `, r.basic(data))
 }
 
-func (r ElasticsearchResourceTest) update(data acceptance.TestData) string {
+func (r ElasticsearchResource) update(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -221,7 +221,7 @@ resource "azurerm_elastic_cloud_elasticsearch" "test" {
 `, data.RandomInteger, data.Locations.Primary)
 }
 
-func (r ElasticsearchResourceTest) complete(data acceptance.TestData) string {
+func (r ElasticsearchResource) complete(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -247,7 +247,7 @@ resource "azurerm_elastic_cloud_elasticsearch" "test" {
 `, data.RandomInteger, data.Locations.Primary)
 }
 
-func (r ElasticsearchResourceTest) logs(data acceptance.TestData) string {
+func (r ElasticsearchResource) logs(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -281,7 +281,7 @@ resource "azurerm_elastic_cloud_elasticsearch" "test" {
 `, data.RandomInteger, data.Locations.Primary)
 }
 
-func (r ElasticsearchResourceTest) logsUpdated(data acceptance.TestData) string {
+func (r ElasticsearchResource) logsUpdated(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}

--- a/internal/services/elastic/elasticsearch_resource_test.go
+++ b/internal/services/elastic/elasticsearch_resource_test.go
@@ -6,9 +6,9 @@ package elastic_test
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/elastic/2023-06-01/monitorsresource"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"

--- a/internal/services/keyvault/encrypted_value_data_source_test.go
+++ b/internal/services/keyvault/encrypted_value_data_source_test.go
@@ -11,13 +11,13 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 )
 
-type EncryptedValueDataSourceTest struct{}
+type EncryptedValueDataSource struct{}
 
 func TestAccEncryptedValueDataSource_encryptAndDecrypt(t *testing.T) {
 	// since this config includes both Encrypted and Decrypted we're testing both use-cases (and comparing the values below)
 	// so we only need a single test here
 	data := acceptance.BuildTestData(t, "data.azurerm_key_vault_encrypted_value", "decrypted")
-	r := EncryptedValueDataSourceTest{}
+	r := EncryptedValueDataSource{}
 	plainText, plainText2 := "this is a test", "some-secret"
 
 	data.DataSourceTest(t, []acceptance.TestStep{
@@ -33,7 +33,7 @@ func TestAccEncryptedValueDataSource_encryptAndDecrypt(t *testing.T) {
 	})
 }
 
-func (t EncryptedValueDataSourceTest) decrypt(data acceptance.TestData, plainText, plainText2 string) string {
+func (t EncryptedValueDataSource) decrypt(data acceptance.TestData, plainText, plainText2 string) string {
 	template := t.template(data)
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -80,7 +80,7 @@ data "azurerm_key_vault_encrypted_value" "decrypted3" {
 `, template, plainText, plainText2)
 }
 
-func (t EncryptedValueDataSourceTest) template(data acceptance.TestData) string {
+func (t EncryptedValueDataSource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 data "azurerm_client_config" "current" {}
 

--- a/internal/services/mssql/mssql_job_resource_test.go
+++ b/internal/services/mssql/mssql_job_resource_test.go
@@ -16,11 +16,11 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
-type MsSqlJobResourceTest struct{}
+type MsSqlJobResource struct{}
 
 func TestAccMsSqlJobResource_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_mssql_job", "test")
-	r := MsSqlJobResourceTest{}
+	r := MsSqlJobResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -35,7 +35,7 @@ func TestAccMsSqlJobResource_basic(t *testing.T) {
 
 func TestAccMsSqlJobResource_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_mssql_job", "test")
-	r := MsSqlJobResourceTest{}
+	r := MsSqlJobResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -50,7 +50,7 @@ func TestAccMsSqlJobResource_requiresImport(t *testing.T) {
 
 func TestAccMsSqlJobResource_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_mssql_job", "test")
-	r := MsSqlJobResourceTest{}
+	r := MsSqlJobResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -71,7 +71,7 @@ func TestAccMsSqlJobResource_update(t *testing.T) {
 
 func TestAccMsSqlJobResource_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_mssql_job", "test")
-	r := MsSqlJobResourceTest{}
+	r := MsSqlJobResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -84,7 +84,7 @@ func TestAccMsSqlJobResource_complete(t *testing.T) {
 	})
 }
 
-func (MsSqlJobResourceTest) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+func (MsSqlJobResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := jobs.ParseJobID(state.ID)
 	if err != nil {
 		return nil, err
@@ -98,7 +98,7 @@ func (MsSqlJobResourceTest) Exists(ctx context.Context, client *clients.Client, 
 	return pointer.To(resp.Model != nil), nil
 }
 
-func (r MsSqlJobResourceTest) basic(data acceptance.TestData) string {
+func (r MsSqlJobResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -109,7 +109,7 @@ resource "azurerm_mssql_job" "test" {
 `, r.template(data), data.RandomInteger)
 }
 
-func (r MsSqlJobResourceTest) requiresImport(data acceptance.TestData) string {
+func (r MsSqlJobResource) requiresImport(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -120,7 +120,7 @@ resource "azurerm_mssql_job" "import" {
 `, r.basic(data))
 }
 
-func (r MsSqlJobResourceTest) complete(data acceptance.TestData) string {
+func (r MsSqlJobResource) complete(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -133,7 +133,7 @@ resource "azurerm_mssql_job" "test" {
 `, r.template(data), data.RandomInteger)
 }
 
-func (MsSqlJobResourceTest) template(data acceptance.TestData) string {
+func (MsSqlJobResource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}

--- a/internal/services/mssql/mssql_job_schedule_resource_test.go
+++ b/internal/services/mssql/mssql_job_schedule_resource_test.go
@@ -18,11 +18,11 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
-type MsSqlJobScheduleResourceTest struct{}
+type MsSqlJobScheduleResource struct{}
 
 func TestAccMsSqlJobScheduleResource_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_mssql_job_schedule", "test")
-	r := MsSqlJobScheduleResourceTest{}
+	r := MsSqlJobScheduleResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -38,7 +38,7 @@ func TestAccMsSqlJobScheduleResource_basic(t *testing.T) {
 
 func TestAccMsSqlJobScheduleResource_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_mssql_job_schedule", "test")
-	r := MsSqlJobScheduleResourceTest{}
+	r := MsSqlJobScheduleResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -53,7 +53,7 @@ func TestAccMsSqlJobScheduleResource_requiresImport(t *testing.T) {
 
 func TestAccMsSqlJobScheduleResource_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_mssql_job_schedule", "test")
-	r := MsSqlJobScheduleResourceTest{}
+	r := MsSqlJobScheduleResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -79,7 +79,7 @@ func TestAccMsSqlJobScheduleResource_update(t *testing.T) {
 
 func TestAccMsSqlJobScheduleResource_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_mssql_job_schedule", "test")
-	r := MsSqlJobScheduleResourceTest{}
+	r := MsSqlJobScheduleResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -97,7 +97,7 @@ func TestAccMsSqlJobScheduleResource_complete(t *testing.T) {
 
 func TestAccMsSqlJobScheduleResource_recurringWithoutInterval(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_mssql_job_schedule", "test")
-	r := MsSqlJobScheduleResourceTest{}
+	r := MsSqlJobScheduleResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -107,7 +107,7 @@ func TestAccMsSqlJobScheduleResource_recurringWithoutInterval(t *testing.T) {
 	})
 }
 
-func (MsSqlJobScheduleResourceTest) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+func (MsSqlJobScheduleResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := jobs.ParseJobID(state.ID)
 	if err != nil {
 		return nil, err
@@ -121,7 +121,7 @@ func (MsSqlJobScheduleResourceTest) Exists(ctx context.Context, client *clients.
 	return pointer.To(resp.Model != nil), nil
 }
 
-func (MsSqlJobScheduleResourceTest) basic(data acceptance.TestData) string {
+func (MsSqlJobScheduleResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -130,10 +130,10 @@ resource "azurerm_mssql_job_schedule" "test" {
   job_id  = azurerm_mssql_job.test.id
   type    = "Once"
 }
-`, MsSqlJobResourceTest{}.basic(data))
+`, MsSqlJobResource{}.basic(data))
 }
 
-func (r MsSqlJobScheduleResourceTest) requiresImport(data acceptance.TestData) string {
+func (r MsSqlJobScheduleResource) requiresImport(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -144,7 +144,7 @@ resource "azurerm_mssql_job_schedule" "import" {
 `, r.basic(data))
 }
 
-func (r MsSqlJobScheduleResourceTest) complete(data acceptance.TestData) string {
+func (r MsSqlJobScheduleResource) complete(data acceptance.TestData) string {
 	now := time.Now()
 	startTime := now.AddDate(0, 0, 5)
 	endTime := now.AddDate(0, 0, 10)
@@ -160,10 +160,10 @@ resource "azurerm_mssql_job_schedule" "test" {
   start_time = "%[3]s"
   type       = "Recurring"
 }
-`, MsSqlJobResourceTest{}.basic(data), endTime.Format(time.RFC3339), startTime.Format(time.RFC3339))
+`, MsSqlJobResource{}.basic(data), endTime.Format(time.RFC3339), startTime.Format(time.RFC3339))
 }
 
-func (MsSqlJobScheduleResourceTest) recurringWithoutInterval(data acceptance.TestData) string {
+func (MsSqlJobScheduleResource) recurringWithoutInterval(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -172,5 +172,5 @@ resource "azurerm_mssql_job_schedule" "test" {
   job_id  = azurerm_mssql_job.test.id
   type    = "Recurring"
 }
-`, MsSqlJobResourceTest{}.basic(data))
+`, MsSqlJobResource{}.basic(data))
 }

--- a/internal/services/mssql/mssql_job_target_group_resource_test.go
+++ b/internal/services/mssql/mssql_job_target_group_resource_test.go
@@ -16,11 +16,11 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
-type MsSqlJobTargetGroupResourceTest struct{}
+type MsSqlJobTargetGroupResource struct{}
 
 func TestAccMsSqlJobTargetGroupTest_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_mssql_job_target_group", "test")
-	r := MsSqlJobTargetGroupResourceTest{}
+	r := MsSqlJobTargetGroupResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -35,7 +35,7 @@ func TestAccMsSqlJobTargetGroupTest_basic(t *testing.T) {
 
 func TestAccMsSqlJobTargetGroupTest_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_mssql_job_target_group", "test")
-	r := MsSqlJobTargetGroupResourceTest{}
+	r := MsSqlJobTargetGroupResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -50,7 +50,7 @@ func TestAccMsSqlJobTargetGroupTest_requiresImport(t *testing.T) {
 
 func TestAccMsSqlJobTargetGroupTest_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_mssql_job_target_group", "test")
-	r := MsSqlJobTargetGroupResourceTest{}
+	r := MsSqlJobTargetGroupResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -72,7 +72,7 @@ func TestAccMsSqlJobTargetGroupTest_update(t *testing.T) {
 
 func TestAccMsSqlJobTargetGroupTest_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_mssql_job_target_group", "test")
-	r := MsSqlJobTargetGroupResourceTest{}
+	r := MsSqlJobTargetGroupResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -87,7 +87,7 @@ func TestAccMsSqlJobTargetGroupTest_complete(t *testing.T) {
 
 func TestAccMsSqlJobTargetGroupTest_withDatabase(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_mssql_job_target_group", "test")
-	r := MsSqlJobTargetGroupResourceTest{}
+	r := MsSqlJobTargetGroupResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -102,7 +102,7 @@ func TestAccMsSqlJobTargetGroupTest_withDatabase(t *testing.T) {
 
 func TestAccMsSqlJobTargetGroupTest_withElasticPool(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_mssql_job_target_group", "test")
-	r := MsSqlJobTargetGroupResourceTest{}
+	r := MsSqlJobTargetGroupResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -115,7 +115,7 @@ func TestAccMsSqlJobTargetGroupTest_withElasticPool(t *testing.T) {
 	})
 }
 
-func (MsSqlJobTargetGroupResourceTest) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+func (MsSqlJobTargetGroupResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := jobtargetgroups.ParseTargetGroupID(state.ID)
 	if err != nil {
 		return nil, err
@@ -129,7 +129,7 @@ func (MsSqlJobTargetGroupResourceTest) Exists(ctx context.Context, client *clien
 	return pointer.To(resp.Model != nil), nil
 }
 
-func (r MsSqlJobTargetGroupResourceTest) basic(data acceptance.TestData) string {
+func (r MsSqlJobTargetGroupResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -140,7 +140,7 @@ resource "azurerm_mssql_job_target_group" "test" {
 `, r.template(data), data.RandomInteger)
 }
 
-func (r MsSqlJobTargetGroupResourceTest) requiresImport(data acceptance.TestData) string {
+func (r MsSqlJobTargetGroupResource) requiresImport(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -151,7 +151,7 @@ resource "azurerm_mssql_job_target_group" "import" {
 `, r.basic(data))
 }
 
-func (r MsSqlJobTargetGroupResourceTest) complete(data acceptance.TestData) string {
+func (r MsSqlJobTargetGroupResource) complete(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -168,7 +168,7 @@ resource "azurerm_mssql_job_target_group" "test" {
 `, r.template(data), data.RandomInteger)
 }
 
-func (r MsSqlJobTargetGroupResourceTest) withDatabase(data acceptance.TestData) string {
+func (r MsSqlJobTargetGroupResource) withDatabase(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -191,7 +191,7 @@ resource "azurerm_mssql_job_target_group" "test" {
 `, r.template(data), data.RandomInteger)
 }
 
-func (r MsSqlJobTargetGroupResourceTest) withElasticPool(data acceptance.TestData) string {
+func (r MsSqlJobTargetGroupResource) withElasticPool(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -228,7 +228,7 @@ resource "azurerm_mssql_job_target_group" "test" {
 `, r.template(data), data.RandomInteger)
 }
 
-func (MsSqlJobTargetGroupResourceTest) template(data acceptance.TestData) string {
+func (MsSqlJobTargetGroupResource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This PR updates the guidance for naming structs in acceptance tests and then modifies tests that used the old pattern to the new one.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

```
TF_AzureRM_AZURERM_SERVICE_PUBLIC_MSSQL
Test Results (buildID: 355174, buildNumber: 611, branch: refs/pull/29335/merge):
--- PASS: TestAccMsSqlJobScheduleResource_recurringWithoutInterval (35.23s)
--- PASS: TestAccMsSqlJobResource_requiresImport (517.34s)
--- PASS: TestAccMsSqlJobScheduleResource_requiresImport (530.02s)
--- PASS: TestAccMsSqlJobTargetGroupTest_requiresImport (532.16s)
--- PASS: TestAccMsSqlJobTargetGroupTest_complete (534.48s)
--- PASS: TestAccMsSqlJobScheduleResource_complete (541.97s)
--- PASS: TestAccMsSqlJobTargetGroupTest_basic (547.98s)
--- PASS: TestAccMsSqlJobTargetGroupTest_withDatabase (553.60s)
--- PASS: TestAccMsSqlJobResource_complete (561.91s)
--- PASS: TestAccMsSqlJobResource_basic (562.58s)
--- PASS: TestAccMsSqlJobScheduleResource_basic (564.54s)
--- PASS: TestAccMsSqlJobTargetGroupTest_withElasticPool (564.83s)
--- PASS: TestAccMsSqlJobResource_update (597.82s)
--- PASS: TestAccMsSqlJobScheduleResource_update (630.96s)
--- PASS: TestAccMsSqlJobTargetGroupTest_update (631.09s)
Build Log: https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_MSSQL/355174

============================================================

TF_AzureRM_AZURERM_SERVICE_PUBLIC_AUTHORIZATION
Test Results (buildID: 355175, buildNumber: 567, branch: refs/pull/29335/merge):
--- PASS: TestAccRoleAssignmentsDataSource_basic (154.06s)
Build Log: https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_AUTHORIZATION/355175

============================================================

TF_AzureRM_AZURERM_SERVICE_PUBLIC_ELASTIC
Test Results (buildID: 355176, buildNumber: 434, branch: refs/pull/29335/merge):
--- PASS: TestAccElasticsearchDataSource_basic (439.36s)
--- PASS: TestAccElasticsearch_basic (371.75s)
--- PASS: TestAccElasticsearch_requiresImport (443.49s)
--- PASS: TestAccElasticsearch_complete (459.11s)
--- PASS: TestAccElasticsearch_update (535.13s)
--- PASS: TestAccElasticsearch_logs (454.16s)
--- PASS: TestAccElasticsearch_logsUpdate (445.35s)
Build Log: https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_ELASTIC/355176

============================================================

TF_AzureRM_AZURERM_SERVICE_PUBLIC_KEYVAULT
Test Results (buildID: 355177, buildNumber: 532, branch: refs/pull/29335/merge):
--- PASS: TestAccEncryptedValueDataSource_encryptAndDecrypt (877.51s)
Build Log: https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_KEYVAULT/355177
```


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* Update `struct` Name Pattern in Acceptance Test Guide and Tests [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
