### PR TITLE
`azurerm_postgresql_flexible_server`: lock source server when creating replica server

### DIFF
--- a/internal/services/postgres/postgresql_flexible_server_configuration_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_configuration_resource.go
@@ -129,7 +129,7 @@ func resourceFlexibleServerConfigurationRead(d *pluginsdk.ResourceData, meta int
 		return err
 	}
 
-	// if the server has already been deleted, we don't need to do anything
+	// if the server has already been deleted, we need also mark it as gone
 	serverID := servers.NewFlexibleServerID(id.SubscriptionId, id.ResourceGroupName, id.FlexibleServerName)
 	if exists, _ := meta.(*clients.Client).Postgres.FlexibleServersClient.Get(ctx, serverID); response.WasNotFound(exists.HttpResponse) {
 		log.Printf("[WARN] server %s was not found, removing from state", serverID)

--- a/internal/services/postgres/postgresql_flexible_server_configuration_resource_test.go
+++ b/internal/services/postgres/postgresql_flexible_server_configuration_resource_test.go
@@ -304,12 +304,12 @@ resource "azurerm_postgresql_flexible_server_configuration" "test" {
 }
 
 resource "azurerm_postgresql_flexible_server" "replica" {
-  name                   = "acctest-replica-%d"
-  resource_group_name    = azurerm_resource_group.test.name
-  location               = azurerm_resource_group.test.location
-  zone                   = azurerm_postgresql_flexible_server.test.zone
-  create_mode            = "Replica"
-  source_server_id       = azurerm_postgresql_flexible_server.test.id
+  name                = "acctest-replica-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  zone                = azurerm_postgresql_flexible_server.test.zone
+  create_mode         = "Replica"
+  source_server_id    = azurerm_postgresql_flexible_server.test.id
 }
 `, r.template(data), name, value, data.RandomInteger)
 }

--- a/internal/services/postgres/postgresql_flexible_server_configuration_resource_test.go
+++ b/internal/services/postgres/postgresql_flexible_server_configuration_resource_test.go
@@ -214,6 +214,23 @@ func TestAccFlexibleServerConfiguration_restartServerForStaticParameters(t *test
 	})
 }
 
+func TestAccFlexibleServerConfiguration_staticParameterWithReplica(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_postgresql_flexible_server_configuration", "test")
+	r := PostgresqlFlexibleServerConfigurationResource{}
+	name := "cron.max_running_jobs"
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.staticParameterWithReplica(data, name, "5"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("name").HasValue(name),
+				check.That(data.ResourceName).Key("value").HasValue("5"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccFlexibleServerConfiguration_doesNotRestartServer_whenFeatureIsDisabled(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_postgresql_flexible_server_configuration", "test")
 	r := PostgresqlFlexibleServerConfigurationResource{}
@@ -274,6 +291,27 @@ resource "azurerm_postgresql_flexible_server_configuration" "test" {
   value     = "%s"
 }
 `, r.template(data), name, value)
+}
+
+func (r PostgresqlFlexibleServerConfigurationResource) staticParameterWithReplica(data acceptance.TestData, name, value string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_postgresql_flexible_server_configuration" "test" {
+  name      = "%s"
+  server_id = azurerm_postgresql_flexible_server.test.id
+  value     = "%s"
+}
+
+resource "azurerm_postgresql_flexible_server" "replica" {
+  name                   = "acctest-replica-%d"
+  resource_group_name    = azurerm_resource_group.test.name
+  location               = azurerm_resource_group.test.location
+  zone                   = azurerm_postgresql_flexible_server.test.zone
+  create_mode            = "Replica"
+  source_server_id       = azurerm_postgresql_flexible_server.test.id
+}
+`, r.template(data), name, value, data.RandomInteger)
 }
 
 func (PostgresqlFlexibleServerConfigurationResource) multiplePostgresqlFlexibleServerConfigurations(data acceptance.TestData) string {


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Related to #29219 #29177 #28298, #28203

The source server will be Updating status when creating a replica flexible server, so we need to add a lock to source server to avoid conflict operations on the source server: one scenario is the creation of replica server and configurations on the source server at the same time, the restart operation on the source server will fail because the source server is in Updating status as the following test shows:

```
=== CONT  TestAccFlexibleServerConfiguration_staticParameterWithReplica
    /home/xuwu/azure/azurerm/internal/services/postgres/testcase.go:173: Step 1/3 error: Error running apply: exit status 1

        Error: restarting server Configuration (Subscription: "2639d6d0-2ddc-460e-86e7-e9d9be665c42"
        Resource Group Name: "acctestRG-postgresql-250414162523427482"
        Flexible Server Name: "acctest-fs-250414162523427482"
        Configuration Name: "cron.max_running_jobs"): polling after ServersRestart: polling failed: the Azure API returned the following error:

        Status: "ServerIsNotReady"
        Code: ""
        Message: "Restart or Stop Server can only be performed on Started servers. Sever Name = acctest-fs-250414162523427482, Current Server State = Updating"
        Activity Id: ""

        ---

        API Response:

        ----[start]----
        {"name":"86c4e7b8-7854-4af6-9c1b-31fb29dae8ec","status":"Failed","startTime":"2025-04-14T06:30:18.213Z","error":{"code":"ServerIsNotReady","message":"Restart or Stop Server can only be performed on Started servers. Sever Name = acctest-fs-250414162523427482, Current Server State = Updating"}}
        -----[end]-----


          with azurerm_postgresql_flexible_server_configuration.test,
          on terraform_plugin_test.tf line 55, in resource "azurerm_postgresql_flexible_server_configuration" "test":
          55: resource "azurerm_postgresql_flexible_server_configuration" "test" {

--- FAIL: TestAccFlexibleServerConfiguration_staticParameterWithReplica (751.64s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-azurerm/internal/services/postgres      751.666s
```

This PR also add a check to the server configuration, if the parent server resource is deleted, then we directly mark it as gone.



## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

```
--- PASS: TestAccFlexibleServerConfiguration_staticParameterWithReplica (1107.80s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/postgres      1107.826s
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_postgresql_flexible_server`: lock source server when creating replica server [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
