### PR TITLE
dependencies: `azurerm_mssql_server_security_alert_policy` - update to API version `2023-08-01-preview/serversecurityalertpolicies`

### DIFF
--- a/internal/services/mssql/mssql_server_security_alert_policy_resource.go
+++ b/internal/services/mssql/mssql_server_security_alert_policy_resource.go
@@ -166,7 +166,7 @@ func resourceMsSqlServerSecurityAlertPolicyCreate(d *pluginsdk.ResourceData, met
 
 	err := client.CreateOrUpdateThenPoll(ctx, serverId, alertPolicy)
 	if err != nil {
-		return fmt.Errorf("creating mssql server security alert policy: %v", err)
+		return fmt.Errorf("creating mssql server security alert policy: %+v", err)
 	}
 
 	policy, err := client.Get(ctx, serverId)
@@ -207,7 +207,7 @@ func resourceMsSqlServerSecurityAlertPolicyRead(d *pluginsdk.ResourceData, meta 
 	policy, err := client.Get(ctx, serverId)
 	if err != nil {
 		if response.WasNotFound(policy.HttpResponse) {
-			log.Printf("[WARN] mssql server security alert policy %v not found", id)
+			log.Printf("[WARN] mssql server security alert policy %s: not found", id)
 			d.SetId("")
 			return nil
 		}
@@ -355,7 +355,7 @@ func resourceMsSqlServerSecurityAlertPolicyUpdate(d *pluginsdk.ResourceData, met
 
 	err = client.CreateOrUpdateThenPoll(ctx, serverId, alertPolicy)
 	if err != nil {
-		return fmt.Errorf("updating mssql server security alert policy: %v", err)
+		return fmt.Errorf("updating mssql server security alert policy: %+v", err)
 	}
 
 	return resourceMsSqlServerSecurityAlertPolicyRead(d, meta)
@@ -383,11 +383,11 @@ func resourceMsSqlServerSecurityAlertPolicyDelete(d *pluginsdk.ResourceData, met
 
 	err = client.CreateOrUpdateThenPoll(ctx, serverId, disabledPolicy)
 	if err != nil {
-		return fmt.Errorf("updating mssql server security alert policy: %v", err)
+		return fmt.Errorf("updating mssql server security alert policy: %+v", err)
 	}
 
 	if _, err = client.Get(ctx, serverId); err != nil {
-		return fmt.Errorf("deleting mssql server security alert policy: %v", err)
+		return fmt.Errorf("deleting mssql server security alert policy: %+v", err)
 	}
 
 	return nil

--- a/internal/services/mssql/mssql_server_security_alert_policy_resource_test.go
+++ b/internal/services/mssql/mssql_server_security_alert_policy_resource_test.go
@@ -95,11 +95,11 @@ func (r MsSqlServerSecurityAlertPolicyResource) basic(data acceptance.TestData) 
 %[1]s
 
 resource "azurerm_mssql_server_security_alert_policy" "test" {
-  resource_group_name        = azurerm_resource_group.test.name
-  server_name                = azurerm_mssql_server.test.name
-  state                      = "Enabled"
-  retention_days             = 20
-  email_account_admins       = true
+  resource_group_name  = azurerm_resource_group.test.name
+  server_name          = azurerm_mssql_server.test.name
+  state                = "Enabled"
+  retention_days       = 20
+  email_account_admins = true
 
   disabled_alerts = [
     "Sql_Injection",

--- a/internal/services/mssql/mssql_server_security_alert_policy_resource_test.go
+++ b/internal/services/mssql/mssql_server_security_alert_policy_resource_test.go
@@ -44,63 +44,63 @@ func TestAccMsSqlServerSecurityAlertPolicy_update(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.basic(data), // Minimal config with enabled state
+			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep("storage_account_access_key"),
 		{
-			Config: r.updateStepOne(data), // Update minimal config with disabled alerts and email addresses
+			Config: r.disableAlertsEmail(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep("storage_account_access_key"),
 		{
-			Config: r.updateStepTwo(data), // Update with storage account details, disabled alerts and email addresses
+			Config: r.storageAccountDisableAlertsEmail(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep("storage_account_access_key"),
 		{
-			Config: r.updateStepThree(data), // Update to remove storage account details with disabled alerts and email addresses
+			Config: r.disableAlertsEmail(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep("storage_account_access_key"),
 		{
-			Config: r.basic(data), // Update back to minimal config without storage account details, disabled alerts and email addresses
+			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep("storage_account_access_key"),
 		{
-			Config: r.updateStepTwo(data), // Update with storage account details, disabled alerts and email addresses
+			Config: r.storageAccountDisableAlertsEmail(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep("storage_account_access_key"),
 		{
-			Config: r.updateStepFour(data), // Update with different storage account details with disabled alerts and email addresses
+			Config: r.secondayStorageAccountDisableAlertsEmail(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep("storage_account_access_key"),
 		{
-			Config: r.updateStepFive(data), // Update back to previous storage account details without disabled alerts and email addresses
+			Config: r.storageAccountOnly(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep("storage_account_access_key"),
 		{
-			Config: r.updateStepSix(data), // Update back to minimal config with disabled state without storage account details, disabled alerts and email addresses
+			Config: r.disabled(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -158,7 +158,7 @@ resource "azurerm_mssql_server_security_alert_policy" "test" {
 `, r.server(data))
 }
 
-func (r MsSqlServerSecurityAlertPolicyResource) updateStepOne(data acceptance.TestData) string {
+func (r MsSqlServerSecurityAlertPolicyResource) disableAlertsEmail(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -180,7 +180,7 @@ resource "azurerm_mssql_server_security_alert_policy" "test" {
 `, r.server(data))
 }
 
-func (r MsSqlServerSecurityAlertPolicyResource) updateStepTwo(data acceptance.TestData) string {
+func (r MsSqlServerSecurityAlertPolicyResource) storageAccountDisableAlertsEmail(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -204,29 +204,7 @@ resource "azurerm_mssql_server_security_alert_policy" "test" {
 `, r.server(data))
 }
 
-func (r MsSqlServerSecurityAlertPolicyResource) updateStepThree(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-%[1]s
-
-resource "azurerm_mssql_server_security_alert_policy" "test" {
-  resource_group_name = azurerm_resource_group.test.name
-  server_name         = azurerm_mssql_server.test.name
-  state               = "Enabled"
-
-  disabled_alerts = [
-    "Sql_Injection",
-    "Data_Exfiltration"
-  ]
-
-  email_addresses = [
-    "email@example1.com",
-    "email@example2.com"
-  ]
-}
-`, r.server(data))
-}
-
-func (r MsSqlServerSecurityAlertPolicyResource) updateStepFour(data acceptance.TestData) string {
+func (r MsSqlServerSecurityAlertPolicyResource) secondayStorageAccountDisableAlertsEmail(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -250,7 +228,7 @@ resource "azurerm_mssql_server_security_alert_policy" "test" {
 `, r.server(data))
 }
 
-func (r MsSqlServerSecurityAlertPolicyResource) updateStepFive(data acceptance.TestData) string {
+func (r MsSqlServerSecurityAlertPolicyResource) storageAccountOnly(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -264,7 +242,7 @@ resource "azurerm_mssql_server_security_alert_policy" "test" {
 `, r.server(data))
 }
 
-func (r MsSqlServerSecurityAlertPolicyResource) updateStepSix(data acceptance.TestData) string {
+func (r MsSqlServerSecurityAlertPolicyResource) disabled(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %[1]s
 

--- a/internal/services/mssql/mssql_server_security_alert_policy_resource_test.go
+++ b/internal/services/mssql/mssql_server_security_alert_policy_resource_test.go
@@ -6,7 +6,6 @@ package mssql_test
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -23,7 +22,6 @@ type MsSqlServerSecurityAlertPolicyResource struct{}
 
 func TestAccMsSqlServerSecurityAlertPolicy_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_mssql_server_security_alert_policy", "test")
-	data = setTestDataLocationBySubscription(data)
 
 	r := MsSqlServerSecurityAlertPolicyResource{}
 
@@ -40,7 +38,6 @@ func TestAccMsSqlServerSecurityAlertPolicy_basic(t *testing.T) {
 
 func TestAccMsSqlServerSecurityAlertPolicy_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_mssql_server_security_alert_policy", "test")
-	data = setTestDataLocationBySubscription(data)
 
 	r := MsSqlServerSecurityAlertPolicyResource{}
 
@@ -84,16 +81,6 @@ func (MsSqlServerSecurityAlertPolicyResource) Exists(ctx context.Context, client
 	}
 
 	return pointer.To(model.Id != nil), nil
-}
-
-// Sets the tests 'Primary' and 'Secondary' locations based on the 'ARM_MICROSOFT_TEST' environment variable due to subscription quota policies
-func setTestDataLocationBySubscription(data acceptance.TestData) acceptance.TestData {
-	if isMicrosoftTest := os.Getenv("ARM_MICROSOFT_TEST"); isMicrosoftTest != "" {
-		data.Locations.Primary = "eastus"
-		data.Locations.Secondary = "swedencentral"
-	}
-
-	return data
 }
 
 func (r MsSqlServerSecurityAlertPolicyResource) basic(data acceptance.TestData) string {

--- a/website/docs/r/mssql_server_security_alert_policy.html.markdown
+++ b/website/docs/r/mssql_server_security_alert_policy.html.markdown
@@ -75,11 +75,13 @@ The following arguments are supported:
 
 -> **Note:** The `storage_account_access_key` field is required when the `storage_endpoint` field has been set.
 
-* `storage_account_access_key` - (Optional) Specifies the primary access key of the Threat Detection audit logs blob storage endpoint. Changing this forces a new resource to be created.
-
--> **Note:** The `storage_endpoint` field is required when the `storage_account_access_key` field has been set.
-
 -> **Note:**  Storage accounts configured with `shared_access_key_enabled = false` cannot be used for the `storage_endpoint` field.
+
+* `storage_account_access_key` - (Optional) Specifies the primary access key of the Threat Detection audit logs blob storage endpoint.
+
+-> **Note:** The `storage_account_access_key` only applies if the storage account is not behind a virtual network or a firewall.
+
+---
 
 ## Attributes Reference
 

--- a/website/docs/r/mssql_server_security_alert_policy.html.markdown
+++ b/website/docs/r/mssql_server_security_alert_policy.html.markdown
@@ -44,11 +44,12 @@ resource "azurerm_mssql_server_security_alert_policy" "example" {
   state                      = "Enabled"
   storage_endpoint           = azurerm_storage_account.example.primary_blob_endpoint
   storage_account_access_key = azurerm_storage_account.example.primary_access_key
+  retention_days             = 20
+
   disabled_alerts = [
     "Sql_Injection",
     "Data_Exfiltration"
   ]
-  retention_days = 20
 }
 ```
 
@@ -72,7 +73,11 @@ The following arguments are supported:
 
 * `storage_endpoint` - (Optional) Specifies the blob storage endpoint that will hold all Threat Detection audit logs (e.g., `https://example.blob.core.windows.net`).
 
-* `storage_account_access_key` - (Optional) Specifies the identifier key of the Threat Detection audit storage account. This is mandatory when you use the `storage_endpoint` field to specify a storage account blob endpoint.
+-> **Note:** The `storage_account_access_key` field is required when the `storage_endpoint` field has been set.
+
+* `storage_account_access_key` - (Optional) Specifies the primary access key of the Threat Detection audit logs blob storage endpoint. Changing this forces a new resource to be created.
+
+-> **Note:** The `storage_endpoint` field is required when the `storage_account_access_key` field has been set.
 
 -> **Note:**  Storage accounts configured with `shared_access_key_enabled = false` cannot be used for the `storage_endpoint` field.
 

--- a/website/docs/r/mssql_server_security_alert_policy.html.markdown
+++ b/website/docs/r/mssql_server_security_alert_policy.html.markdown
@@ -60,21 +60,21 @@ The following arguments are supported:
 
 * `server_name` - (Required) Specifies the name of the MS SQL Server. Changing this forces a new resource to be created.
 
-* `state` - (Required) Specifies the state of the policy, whether it is enabled or disabled or a policy has not been applied yet on the specific database server. Possible values are `Disabled`, `Enabled` and `New`.
+* `state` - (Required) Specifies the state of the policy. Possible values are `Disabled` or `Enabled`.
 
 * `disabled_alerts` - (Optional) Specifies an array of alerts that are disabled. Allowed values are: `Sql_Injection`, `Sql_Injection_Vulnerability`, `Access_Anomaly`, `Data_Exfiltration`, `Unsafe_Action`.
 
-* `email_account_admins` - (Optional) Boolean flag which specifies if the alert is sent to the account administrators or not. Defaults to `false`.
+* `email_account_admins` - (Optional) Are the alerts sent to the account administrators? Possible values are `true` or `false`. Defaults to `false`.
 
 * `email_addresses` - (Optional) Specifies an array of email addresses to which the alert is sent.
 
-* `retention_days` - (Optional) Specifies the number of days to keep in the Threat Detection audit logs. Defaults to `0`.
+* `retention_days` - (Optional) Specifies the number of days to keep the Threat Detection audit logs. Defaults to `0`.
 
-* `storage_endpoint` - (Optional) Specifies the blob storage endpoint (e.g. <https://example.blob.core.windows.net>). This blob storage will hold all Threat Detection audit logs.
+* `storage_endpoint` - (Optional) Specifies the blob storage endpoint that will hold all Threat Detection audit logs (e.g., `https://example.blob.core.windows.net`).
 
-* `storage_account_access_key` - (Optional) Specifies the identifier key of the Threat Detection audit storage account. This is mandatory when you use `storage_endpoint` to specify a storage account blob endpoint.
+* `storage_account_access_key` - (Optional) Specifies the identifier key of the Threat Detection audit storage account. This is mandatory when you use the `storage_endpoint` field to specify a storage account blob endpoint.
 
--> **NOTE:**  Please note that storage accounts configured with `shared_access_key_enabled = false` cannot be used to configure `azurerm_mssql_server_security_alert_policy` with `storage_endpoint` for now.
+-> **Note:**  Storage accounts configured with `shared_access_key_enabled = false` cannot be used for the `storage_endpoint` field.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Update the `azurerm_mssql_server_security_alert_policy` resource to use the `2023-08-01-preview/serversecurityalertpolicies` API due to deprecation of the `2014-04-01` APIs on `31 October 2025`.

**BREAKING CHANGE:** 

* The `state` field no longer supports the `New` value in the `2023-08-01-preview/serversecurityalertpolicies` API.

## PR Checklist

- [X] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [X] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [X] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [X] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [X] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”

## Changes to existing Resource / Data Source

- [X] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [X] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [X] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [X] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

![image](https://github.com/user-attachments/assets/a94014e0-70f2-470c-b8c4-6ea514c7727a)

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

NOTE: This release contains a breaking change to the `mssql_server_security_alert_policy` resource. The `state` field no longer supports the `New` value in the `2023-08-01-preview/serversecurityalertpolicies` API.

**BREAKING CHANGE:** 

* `azurerm_mssql_server_security_alert_policy`  - The `state` field no longer supports the `New` value in the `2023-08-01-preview/serversecurityalertpolicies` API. [GH-00000]

ENHANCEMENTS:

dependencies - `serversecurityalertpolicies` API updated to version `2023-08-01-preview/serversecurityalertpolicies` [GH-00000]

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [X] Dependency
- [X] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
