### PR TITLE
[Dependencies:] `azurerm_mssql_server_vulnerability_assessment` - update to version `2023-08-01-preview/serversecurityalertpolicies` API

### DIFF
--- a/internal/services/mssql/mssql_server_vulnerability_assessment_resource.go
+++ b/internal/services/mssql/mssql_server_vulnerability_assessment_resource.go
@@ -278,7 +278,7 @@ func resourceMsSqlServerVulnerabilityAssessmentUpdate(d *pluginsdk.ResourceData,
 	// NOTE: This resource cannot implement the 'd.HasChange' pattern
 	// to support the 'lifecycle' 'ignore_changes' Meta-Argument...
 	// If the field does not have any changes, it will not be included
-	// in the the code block that is passed to the RP which is causing
+	// in the code block that is passed to the RP which is causing
 	// the permissions error to be thrown by the RP...
 
 	if v, ok := d.GetOk("storage_account_access_key"); ok {

--- a/internal/services/mssql/mssql_server_vulnerability_assessment_resource.go
+++ b/internal/services/mssql/mssql_server_vulnerability_assessment_resource.go
@@ -115,8 +115,6 @@ func resourceMsSqlServerVulnerabilityAssessmentCreate(d *pluginsdk.ResourceData,
 
 	serverId := commonids.NewSqlServerID(alertId.SubscriptionId, alertId.ResourceGroup, alertId.ServerName)
 
-	// NOTE: The Alert Policy needs to be 'enabled' to set a Vulnerability Assessment Policy
-	// which is why we are looking it up here...
 	alertResult, err := alertClient.Get(ctx, serverId)
 	if err != nil {
 		return fmt.Errorf("retrieving mssql server security alert policy: %+v", err)
@@ -184,9 +182,9 @@ func resourceMsSqlServerVulnerabilityAssessmentRead(d *pluginsdk.ResourceData, m
 
 	serverId := commonids.NewSqlServerID(id.SubscriptionId, id.ResourceGroup, id.ServerName)
 
-	vulnerabilityPolicy, err := client.Get(ctx, serverId)
+	vulnerability, err := client.Get(ctx, serverId)
 	if err != nil {
-		if response.WasNotFound(vulnerabilityPolicy.HttpResponse) {
+		if response.WasNotFound(vulnerability.HttpResponse) {
 			log.Printf("[WARN] mssql server vulnerability assessment %s: not found", id)
 			d.SetId("")
 			return nil
@@ -195,54 +193,55 @@ func resourceMsSqlServerVulnerabilityAssessmentRead(d *pluginsdk.ResourceData, m
 		return fmt.Errorf("retrieving mssql server vulnerability assessment %s: %+v", *id, err)
 	}
 
-	// NOTE: 'server_security_alert_policy_id' does not exist in the Server Vulnerability API
-	// properties so we need to look it up here...
-	alertPolicy, err := alertClient.Get(ctx, serverId)
+	alert, err := alertClient.Get(ctx, serverId)
 	if err != nil {
-		if response.WasNotFound(alertPolicy.HttpResponse) {
-			log.Printf("[WARN] mssql server security alert policy %s: not found", serverId)
-			d.SetId("")
-			return nil
-		}
-
 		return fmt.Errorf("retrieving mssql server security alert policy by ID: %+v", err)
 	}
 
-	alertModel := alertPolicy.Model
-	if alertModel == nil {
+	model := alert.Model
+
+	if model == nil {
 		return fmt.Errorf("retrieving mssql server security alert policy %s: model was nil", serverId)
 	}
 
-	if alertModel.Id == nil {
+	if model.Id == nil {
 		return fmt.Errorf("retrieving mssql server security alert policy %s: Id was nil", serverId)
 	}
 
-	d.Set("server_security_alert_policy_id", alertModel.Id)
+	d.Set("server_security_alert_policy_id", model.Id)
 
-	if vulnerabilityModel := vulnerabilityPolicy.Model; vulnerabilityModel != nil {
-		if props := vulnerabilityModel.Properties; props != nil {
-			d.Set("storage_container_path", props.StorageContainerPath)
+	recurringScans := make([]interface{}, 0)
+	var storageContainerPath string
 
-			if props.StorageAccountAccessKey != nil {
-				d.Set("storage_account_access_key", props.StorageAccountAccessKey)
-			}
-
-			if props.StorageContainerSasKey != nil {
-				d.Set("storage_container_sas_key", props.StorageContainerSasKey)
-			}
-
-			if props.RecurringScans != nil {
-				d.Set("recurring_scans", flattenRecurringScans(props.RecurringScans))
-			}
+	if model := vulnerability.Model; model != nil {
+		if props := model.Properties; props != nil {
+			storageContainerPath = props.StorageContainerPath
+			recurringScans = flattenRecurringScans(props.RecurringScans)
 		}
 	}
+
+	d.Set("storage_container_path", storageContainerPath)
+	d.Set("recurring_scans", recurringScans)
+
+	var storageAccountAccessKey string
+	if v, ok := d.GetOk("storage_account_access_key"); ok {
+		storageAccountAccessKey = v.(string)
+	}
+	d.Set("storage_account_access_key", storageAccountAccessKey)
+
+	var storageContainerSasKey string
+	if v, ok := d.GetOk("storage_container_sas_key"); ok {
+		storageContainerSasKey = v.(string)
+	}
+	d.Set("storage_container_sas_key", storageContainerSasKey)
 
 	return nil
 }
 
 func resourceMsSqlServerVulnerabilityAssessmentUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).MSSQL.ServerVulnerabilityAssessmentsClient
-	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
+	alertClient := meta.(*clients.Client).MSSQL.ServerSecurityAlertPoliciesClient
+	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	id, err := parse.ServerVulnerabilityAssessmentID(d.Id())
@@ -252,54 +251,60 @@ func resourceMsSqlServerVulnerabilityAssessmentUpdate(d *pluginsdk.ResourceData,
 
 	serverId := commonids.NewSqlServerID(id.SubscriptionId, id.ResourceGroup, id.ServerName)
 
-	result, err := client.Get(ctx, serverId)
+	alert, err := alertClient.Get(ctx, serverId)
 	if err != nil {
-		return fmt.Errorf("retrieving mssql server vulnerability assessment %s: %+v", *id, err)
+		return fmt.Errorf("retrieving mssql server security alert policy: %+v", err)
 	}
 
-	model := result.Model
-	if model == nil {
-		return fmt.Errorf("retrieving mssql server vulnerability assessment %s: model was nil", *id)
+	if alert.Model == nil {
+		return fmt.Errorf("retrieving mssql server security alert policy %s: model was nil", serverId)
 	}
 
-	if model.Properties == nil {
-		return fmt.Errorf("retrieving mssql server vulnerability assessment %s: properties was nil", *id)
+	if alert.Model.Properties == nil {
+		return fmt.Errorf("retrieving mssql server security alert policy properties %s: properties was nil", serverId)
 	}
 
-	log.Printf("[INFO] preparing arguments for mssql server vulnerability assessment creation")
+	if alert.Model.Properties.State != serversecurityalertpolicies.SecurityAlertsPolicyStateEnabled {
+		return fmt.Errorf("mssql server security alert policy is not 'enabled'")
+	}
+
+	log.Printf("[INFO] preparing arguments for mssql server vulnerability assessment update")
 
 	payload := servervulnerabilityassessments.ServerVulnerabilityAssessment{}
+	props := &servervulnerabilityassessments.ServerVulnerabilityAssessmentProperties{}
 
-	props := model.Properties
+	props.StorageContainerPath = d.Get("storage_container_path").(string)
 
-	if d.HasChange("storage_container_path") {
-		if v, ok := d.GetOk("storage_container_path"); ok {
-			props.StorageContainerPath = v.(string)
-		}
+	// NOTE: This resource cannot implement the 'd.HasChange' pattern
+	// to support the 'lifecycle' 'ignore_changes' Meta-Argument...
+	// If the field does not have any changes, it will not be included
+	// in the the code block that is passed to the RP which is causing
+	// the permissions error to be thrown by the RP...
+
+	if v, ok := d.GetOk("storage_account_access_key"); ok {
+		props.StorageAccountAccessKey = pointer.To(v.(string))
 	}
 
-	if d.HasChange("storage_account_access_key") {
-		if v, ok := d.GetOk("storage_account_access_key"); ok {
-			props.StorageAccountAccessKey = pointer.To(v.(string))
-		}
+	if v, ok := d.GetOk("storage_container_sas_key"); ok {
+		props.StorageContainerSasKey = pointer.To(v.(string))
 	}
 
-	if d.HasChange("storage_container_sas_key") {
-		if v, ok := d.GetOk("storage_container_sas_key"); ok {
-			props.StorageContainerSasKey = pointer.To(v.(string))
-		}
-	}
+	// NOTE: If this code block is not in the configuration file
+	// the value will be taken from the state file and will not
+	// show a diff if the 'recurring_scans' code block has been
+	// removed from the configuration file. The only way to reset the
+	// 'recurring_scans' code block values from the actual
+	// Vulnerability Assessment in Azure is to explicitly define
+	// an empty code block (e.g., 'recurring_scans {}')...
 
-	if d.HasChange("recurring_scans") {
-		if _, ok := d.GetOk("recurring_scans"); ok {
-			props.RecurringScans = expandRecurringScans(d)
-		}
+	if _, ok := d.GetOk("recurring_scans"); ok {
+		props.RecurringScans = expandRecurringScans(d)
 	}
 
 	payload.Properties = props
 
-	_, err = client.CreateOrUpdate(ctx, serverId, payload)
-	if err != nil {
+	result, err := client.CreateOrUpdate(ctx, serverId, payload)
+	if err != nil || result.Model == nil || result.Model.Id == nil {
 		return fmt.Errorf("updating mssql server vulnerability assessment %s : %v", id, err)
 	}
 
@@ -359,16 +364,18 @@ func expandRecurringScans(d *pluginsdk.ResourceData) *servervulnerabilityassessm
 func flattenRecurringScans(props *servervulnerabilityassessments.VulnerabilityAssessmentRecurringScansProperties) []interface{} {
 	result := make(map[string]interface{})
 
-	if enabled := props.IsEnabled; enabled != nil {
-		result["enabled"] = *props.IsEnabled
-	}
+	if props != nil {
+		if enabled := props.IsEnabled; enabled != nil {
+			result["enabled"] = *props.IsEnabled
+		}
 
-	if emailSubscriptionAdmins := props.EmailSubscriptionAdmins; emailSubscriptionAdmins != nil {
-		result["email_subscription_admins"] = *props.EmailSubscriptionAdmins
-	}
+		if emailSubscriptionAdmins := props.EmailSubscriptionAdmins; emailSubscriptionAdmins != nil {
+			result["email_subscription_admins"] = *props.EmailSubscriptionAdmins
+		}
 
-	if props.Emails != nil {
-		result["emails"] = *props.Emails
+		if props.Emails != nil {
+			result["emails"] = *props.Emails
+		}
 	}
 
 	return []interface{}{result}

--- a/internal/services/mssql/mssql_server_vulnerability_assessment_resource.go
+++ b/internal/services/mssql/mssql_server_vulnerability_assessment_resource.go
@@ -271,17 +271,22 @@ func resourceMsSqlServerVulnerabilityAssessmentUpdate(d *pluginsdk.ResourceData,
 	}
 
 	props := vulnerabilityAssessment.Properties
-
-	if v, ok := d.GetOk("storage_account_access_key"); ok {
-		props.StorageAccountAccessKey = utils.String(v.(string))
+	if d.HasChange("storage_account_access_key") {
+		if v, ok := d.GetOk("storage_account_access_key"); ok {
+			props.StorageAccountAccessKey = utils.String(v.(string))
+		}
 	}
 
-	if v, ok := d.GetOk("storage_container_sas_key"); ok {
-		props.StorageContainerSasKey = utils.String(v.(string))
+	if d.HasChange("storage_container_sas_key") {
+		if v, ok := d.GetOk("storage_container_sas_key"); ok {
+			props.StorageContainerSasKey = utils.String(v.(string))
+		}
 	}
 
-	if _, ok := d.GetOk("recurring_scans"); ok {
-		props.RecurringScans = expandRecurringScans(d)
+	if d.HasChange("recurring_scans") {
+		if _, ok := d.GetOk("recurring_scans"); ok {
+			props.RecurringScans = expandRecurringScans(d)
+		}
 	}
 
 	vulnerabilityResult, err := client.CreateOrUpdate(ctx, serverId, vulnerabilityAssessment)

--- a/internal/services/mssql/mssql_server_vulnerability_assessment_resource.go
+++ b/internal/services/mssql/mssql_server_vulnerability_assessment_resource.go
@@ -52,7 +52,6 @@ func resourceMsSqlServerVulnerabilityAssessment() *pluginsdk.Resource {
 			"storage_container_path": {
 				Type:         pluginsdk.TypeString,
 				Required:     true,
-				ForceNew:     true,
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
 
@@ -112,22 +111,6 @@ func resourceMsSqlServerVulnerabilityAssessment() *pluginsdk.Resource {
 				}
 
 				return nil
-			}),
-
-			pluginsdk.ForceNewIfChange("storage_account_access_key", func(ctx context.Context, old, new, meta interface{}) bool {
-				if old.(string) != "" {
-					return old.(string) != new.(string)
-				}
-
-				return false
-			}),
-
-			pluginsdk.ForceNewIfChange("storage_container_sas_key", func(ctx context.Context, old, new, meta interface{}) bool {
-				if old.(string) != "" {
-					return old.(string) != new.(string)
-				}
-
-				return false
 			}),
 		),
 	}

--- a/internal/services/mssql/mssql_server_vulnerability_assessment_resource.go
+++ b/internal/services/mssql/mssql_server_vulnerability_assessment_resource.go
@@ -4,6 +4,7 @@
 package mssql
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"time"
@@ -51,6 +52,7 @@ func resourceMsSqlServerVulnerabilityAssessment() *pluginsdk.Resource {
 			"storage_container_path": {
 				Type:         pluginsdk.TypeString,
 				Required:     true,
+				ForceNew:     true,
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
 
@@ -99,6 +101,35 @@ func resourceMsSqlServerVulnerabilityAssessment() *pluginsdk.Resource {
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
 		},
+
+		CustomizeDiff: pluginsdk.CustomDiffWithAll(
+			pluginsdk.CustomizeDiffShim(func(ctx context.Context, d *pluginsdk.ResourceDiff, v interface{}) error {
+				accessKey := d.GetRawConfig().AsValueMap()["storage_account_access_key"]
+				sasKey := d.GetRawConfig().AsValueMap()["storage_container_sas_key"]
+
+				if accessKey.IsNull() && sasKey.IsNull() {
+					return fmt.Errorf("at least one of 'storage_account_access_key' or 'storage_container_sas_key' properties must be set, got nil, nil")
+				}
+
+				return nil
+			}),
+
+			pluginsdk.ForceNewIfChange("storage_account_access_key", func(ctx context.Context, old, new, meta interface{}) bool {
+				if old.(string) != "" {
+					return old.(string) != new.(string)
+				}
+
+				return false
+			}),
+
+			pluginsdk.ForceNewIfChange("storage_container_sas_key", func(ctx context.Context, old, new, meta interface{}) bool {
+				if old.(string) != "" {
+					return old.(string) != new.(string)
+				}
+
+				return false
+			}),
+		),
 	}
 }
 
@@ -151,9 +182,38 @@ func resourceMsSqlServerVulnerabilityAssessmentCreate(d *pluginsdk.ResourceData,
 		props.StorageContainerSasKey = pointer.To(v.(string))
 	}
 
-	if _, ok := d.GetOk("recurring_scans"); ok {
-		props.RecurringScans = expandRecurringScans(d)
+	recurringScanProps := servervulnerabilityassessments.VulnerabilityAssessmentRecurringScansProperties{}
+
+	if v, ok := d.GetOk("recurring_scans"); ok {
+		rs := v.([]interface{})
+
+		if len(rs) != 0 {
+			v := rs[0].(map[string]interface{})
+
+			var enabled *bool
+			if isEnabled, ok := v["enabled"]; ok {
+				enabled = pointer.To(isEnabled.(bool))
+			}
+			recurringScanProps.IsEnabled = enabled
+
+			var emailSubscriptionAdmins *bool
+			if emailAdmins, ok := v["email_subscription_admins"]; ok {
+				emailSubscriptionAdmins = pointer.To(emailAdmins.(bool))
+			}
+			recurringScanProps.EmailSubscriptionAdmins = emailSubscriptionAdmins
+
+			var emails *[]string
+			if _, ok := v["emails"]; ok {
+				config := make([]string, 0)
+				for _, email := range v["emails"].([]interface{}) {
+					config = append(config, email.(string))
+				}
+				emails = pointer.To(config)
+			}
+			recurringScanProps.Emails = emails
+		}
 	}
+	props.RecurringScans = pointer.To(recurringScanProps)
 
 	payload.Properties = props
 
@@ -208,28 +268,49 @@ func resourceMsSqlServerVulnerabilityAssessmentRead(d *pluginsdk.ResourceData, m
 		return fmt.Errorf("retrieving mssql server security alert policy %s: Id was nil", serverId)
 	}
 
-	d.Set("server_security_alert_policy_id", model.Id)
-
 	recurringScans := make([]interface{}, 0)
 	var storageContainerPath string
+	var storageAccountAccessKey string
+	var storageContainerSasKey string
+	recurringScansResult := make(map[string]interface{})
 
-	if model := vulnerability.Model; model != nil {
-		if props := model.Properties; props != nil {
+	if vModel := vulnerability.Model; vModel != nil {
+		if props := vModel.Properties; props != nil {
 			storageContainerPath = props.StorageContainerPath
-			recurringScans = flattenRecurringScans(props.RecurringScans)
+
+			if recurringScansProps := props.RecurringScans; recurringScansProps != nil {
+				var enabled bool
+				if recurringScansProps.IsEnabled != nil {
+					enabled = *recurringScansProps.IsEnabled
+				}
+				recurringScansResult["enabled"] = enabled
+
+				var emailAdmins bool
+				if recurringScansProps.EmailSubscriptionAdmins != nil {
+					emailAdmins = *recurringScansProps.EmailSubscriptionAdmins
+				}
+				recurringScansResult["email_subscription_admins"] = emailAdmins
+
+				var emails []string
+				if recurringScansProps.Emails != nil {
+					emails = *recurringScansProps.Emails
+				}
+				recurringScansResult["emails"] = emails
+			}
+
+			recurringScans = []interface{}{recurringScansResult}
 		}
 	}
 
+	d.Set("server_security_alert_policy_id", model.Id)
 	d.Set("storage_container_path", storageContainerPath)
 	d.Set("recurring_scans", recurringScans)
 
-	var storageAccountAccessKey string
 	if v, ok := d.GetOk("storage_account_access_key"); ok {
 		storageAccountAccessKey = v.(string)
 	}
 	d.Set("storage_account_access_key", storageAccountAccessKey)
 
-	var storageContainerSasKey string
 	if v, ok := d.GetOk("storage_container_sas_key"); ok {
 		storageContainerSasKey = v.(string)
 	}
@@ -271,16 +352,67 @@ func resourceMsSqlServerVulnerabilityAssessmentUpdate(d *pluginsdk.ResourceData,
 	log.Printf("[INFO] preparing arguments for mssql server vulnerability assessment update")
 
 	payload := servervulnerabilityassessments.ServerVulnerabilityAssessment{}
-	props := &servervulnerabilityassessments.ServerVulnerabilityAssessmentProperties{}
 
-	props.StorageContainerPath = d.Get("storage_container_path").(string)
+	result, err := client.Get(ctx, serverId)
+	if err != nil {
+		return fmt.Errorf("retrieving mssql server vulnerability assessment policy: %+v", err)
+	}
 
-	// NOTE: This resource cannot implement the 'd.HasChange' pattern
-	// to support the 'lifecycle' 'ignore_changes' Meta-Argument...
-	// If the field does not have any changes, it will not be included
-	// in the code block that is passed to the RP which is causing
-	// the permissions error to be thrown by the RP...
+	if result.Model == nil {
+		return fmt.Errorf("retrieving mssql server vulnerability assessment policy %s: model was nil", serverId)
+	}
 
+	props := result.Model.Properties
+
+	if props == nil {
+		return fmt.Errorf("retrieving mssql server vulnerability assessment policy %s: properties was nil", serverId)
+	}
+
+	if d.HasChange("storage_container_path") {
+		props.StorageContainerPath = d.Get("storage_container_path").(string)
+	}
+
+	if d.HasChange("recurring_scans") {
+		var isEnabled *bool
+		var emailSubscriptionAdmins *bool
+		emails := make([]string, 0)
+
+		recurringProps := servervulnerabilityassessments.VulnerabilityAssessmentRecurringScansProperties{
+			EmailSubscriptionAdmins: emailSubscriptionAdmins,
+			Emails:                  pointer.To(emails),
+			IsEnabled:               isEnabled,
+		}
+
+		if rs, ok := d.GetOk("recurring_scans"); ok {
+			recurringScans := rs.([]interface{})
+
+			if len(recurringScans) != 0 {
+				v := recurringScans[0].(map[string]interface{})
+
+				if enabled, ok := v["enabled"]; ok {
+					isEnabled = pointer.To(enabled.(bool))
+				}
+				recurringProps.IsEnabled = isEnabled
+
+				if emailAdmins, ok := v["email_subscription_admins"]; ok {
+					emailSubscriptionAdmins = pointer.To(emailAdmins.(bool))
+				}
+				recurringProps.EmailSubscriptionAdmins = emailSubscriptionAdmins
+
+				if _, ok := v["emails"]; ok {
+					for _, email := range v["emails"].([]interface{}) {
+						emails = append(emails, email.(string))
+					}
+				}
+				recurringProps.Emails = pointer.To(emails)
+			}
+		}
+
+		props.RecurringScans = pointer.To(recurringProps)
+	}
+
+	// NOTE: 'storage_account_access_key' and 'storage_container_sas_key'
+	// are not returned by the API...
 	if v, ok := d.GetOk("storage_account_access_key"); ok {
 		props.StorageAccountAccessKey = pointer.To(v.(string))
 	}
@@ -289,22 +421,10 @@ func resourceMsSqlServerVulnerabilityAssessmentUpdate(d *pluginsdk.ResourceData,
 		props.StorageContainerSasKey = pointer.To(v.(string))
 	}
 
-	// NOTE: If this code block is not in the configuration file
-	// the value will be taken from the state file and will not
-	// show a diff if the 'recurring_scans' code block has been
-	// removed from the configuration file. The only way to reset the
-	// 'recurring_scans' code block values from the actual
-	// Vulnerability Assessment in Azure is to explicitly define
-	// an empty code block (e.g., 'recurring_scans {}')...
-
-	if _, ok := d.GetOk("recurring_scans"); ok {
-		props.RecurringScans = expandRecurringScans(d)
-	}
-
 	payload.Properties = props
 
-	result, err := client.CreateOrUpdate(ctx, serverId, payload)
-	if err != nil || result.Model == nil || result.Model.Id == nil {
+	update, err := client.CreateOrUpdate(ctx, serverId, payload)
+	if err != nil || update.Model == nil || update.Model.Id == nil {
 		return fmt.Errorf("updating mssql server vulnerability assessment %s : %v", id, err)
 	}
 
@@ -330,53 +450,4 @@ func resourceMsSqlServerVulnerabilityAssessmentDelete(d *pluginsdk.ResourceData,
 	}
 
 	return nil
-}
-
-func expandRecurringScans(d *pluginsdk.ResourceData) *servervulnerabilityassessments.VulnerabilityAssessmentRecurringScansProperties {
-	props := servervulnerabilityassessments.VulnerabilityAssessmentRecurringScansProperties{}
-
-	vs := d.Get("recurring_scans").([]interface{})
-	if len(vs) == 0 {
-		return &props
-	}
-
-	v := vs[0].(map[string]interface{})
-
-	if enabled, ok := v["enabled"]; ok {
-		props.IsEnabled = pointer.To(enabled.(bool))
-	}
-
-	if emailSubscriptionAdmins, ok := v["email_subscription_admins"]; ok {
-		props.EmailSubscriptionAdmins = pointer.To(emailSubscriptionAdmins.(bool))
-	}
-
-	if _, ok := v["emails"]; ok {
-		emails := make([]string, 0)
-		for _, uri := range v["emails"].([]interface{}) {
-			emails = append(emails, uri.(string))
-		}
-		props.Emails = &emails
-	}
-
-	return &props
-}
-
-func flattenRecurringScans(props *servervulnerabilityassessments.VulnerabilityAssessmentRecurringScansProperties) []interface{} {
-	result := make(map[string]interface{})
-
-	if props != nil {
-		if enabled := props.IsEnabled; enabled != nil {
-			result["enabled"] = *props.IsEnabled
-		}
-
-		if emailSubscriptionAdmins := props.EmailSubscriptionAdmins; emailSubscriptionAdmins != nil {
-			result["email_subscription_admins"] = *props.EmailSubscriptionAdmins
-		}
-
-		if props.Emails != nil {
-			result["emails"] = *props.Emails
-		}
-	}
-
-	return []interface{}{result}
 }

--- a/internal/services/mssql/mssql_server_vulnerability_assessment_resource.go
+++ b/internal/services/mssql/mssql_server_vulnerability_assessment_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-08-01-preview/serversecurityalertpolicies"
@@ -18,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceMsSqlServerVulnerabilityAssessment() *pluginsdk.Resource {
@@ -104,69 +104,64 @@ func resourceMsSqlServerVulnerabilityAssessment() *pluginsdk.Resource {
 
 func resourceMsSqlServerVulnerabilityAssessmentCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).MSSQL.ServerVulnerabilityAssessmentsClient
-	policyClient := meta.(*clients.Client).MSSQL.ServerSecurityAlertPoliciesClient
+	alertClient := meta.(*clients.Client).MSSQL.ServerSecurityAlertPoliciesClient
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	policyId, err := parse.ServerSecurityAlertPolicyID(d.Get("server_security_alert_policy_id").(string))
+	alertId, err := parse.ServerSecurityAlertPolicyID(d.Get("server_security_alert_policy_id").(string))
 	if err != nil {
 		return err
 	}
 
-	serverId := commonids.NewSqlServerID(policyId.SubscriptionId, policyId.ResourceGroup, policyId.ServerName)
+	serverId := commonids.NewSqlServerID(alertId.SubscriptionId, alertId.ResourceGroup, alertId.ServerName)
 
-	result, err := policyClient.Get(ctx, serverId)
+	// NOTE: The Alert Policy needs to be 'enabled' to set a Vulnerability Assessment Policy
+	// which is why we are looking it up here...
+	alertResult, err := alertClient.Get(ctx, serverId)
 	if err != nil {
-		return fmt.Errorf("retrieving Security Alert Policy: %+v", err)
+		return fmt.Errorf("retrieving mssql server security alert policy: %+v", err)
 	}
 
-	model := result.Model
+	model := alertResult.Model
 	if model == nil {
-		return fmt.Errorf("retrieving %s: model was nil", serverId)
+		return fmt.Errorf("retrieving mssql server security alert policy %s: model was nil", serverId)
 	}
 
-	policyProps := model.Properties
-	if policyProps == nil {
-		return fmt.Errorf("retrieving %s Security Alert Policy Properties: Properties were nil", serverId)
+	alertProps := model.Properties
+	if alertProps == nil {
+		return fmt.Errorf("retrieving mssql server security alert policy properties %s: properties was nil", serverId)
 	}
 
-	if policyProps.State != serversecurityalertpolicies.SecurityAlertsPolicyStateEnabled {
-		return fmt.Errorf("security alert policy is not enabled")
+	if alertProps.State != serversecurityalertpolicies.SecurityAlertsPolicyStateEnabled {
+		return fmt.Errorf("mssql server security alert policy is not 'enabled'")
 	}
 
 	log.Printf("[INFO] preparing arguments for mssql server vulnerability assessment creation")
 
 	id := parse.NewServerVulnerabilityAssessmentID(serverId.SubscriptionId, serverId.ResourceGroupName, serverId.ServerName, "default")
 
-	storageContainerPath := d.Get("storage_container_path").(string)
+	payload := servervulnerabilityassessments.ServerVulnerabilityAssessment{}
+	props := &servervulnerabilityassessments.ServerVulnerabilityAssessmentProperties{}
 
-	vulnerabilityAssessment := servervulnerabilityassessments.ServerVulnerabilityAssessment{
-		Properties: &servervulnerabilityassessments.ServerVulnerabilityAssessmentProperties{
-			StorageContainerPath: storageContainerPath,
-		},
-	}
-
-	props := vulnerabilityAssessment.Properties
+	props.StorageContainerPath = d.Get("storage_container_path").(string)
 
 	if v, ok := d.GetOk("storage_account_access_key"); ok {
-		props.StorageAccountAccessKey = utils.String(v.(string))
+		props.StorageAccountAccessKey = pointer.To(v.(string))
 	}
 
 	if v, ok := d.GetOk("storage_container_sas_key"); ok {
-		props.StorageContainerSasKey = utils.String(v.(string))
+		props.StorageContainerSasKey = pointer.To(v.(string))
 	}
 
 	if _, ok := d.GetOk("recurring_scans"); ok {
 		props.RecurringScans = expandRecurringScans(d)
 	}
 
-	vulnerabilityResult, err := client.CreateOrUpdate(ctx, serverId, vulnerabilityAssessment)
-	if err != nil {
-		return fmt.Errorf("updating %s : %v", id, err)
-	}
+	payload.Properties = props
 
-	if vulnerabilityResult.Model == nil || vulnerabilityResult.Model.Id == nil {
-		return fmt.Errorf("reading %s", id)
+	result, err := client.CreateOrUpdate(ctx, serverId, payload)
+	if err != nil || result.Model == nil || result.Model.Id == nil {
+		return fmt.Errorf("creating mssql server vulnerability assessment %s : %v", id, err)
 	}
 
 	d.SetId(id.ID())
@@ -176,6 +171,7 @@ func resourceMsSqlServerVulnerabilityAssessmentCreate(d *pluginsdk.ResourceData,
 
 func resourceMsSqlServerVulnerabilityAssessmentRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).MSSQL.ServerVulnerabilityAssessmentsClient
+	alertClient := meta.(*clients.Client).MSSQL.ServerSecurityAlertPoliciesClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -188,34 +184,51 @@ func resourceMsSqlServerVulnerabilityAssessmentRead(d *pluginsdk.ResourceData, m
 
 	serverId := commonids.NewSqlServerID(id.SubscriptionId, id.ResourceGroup, id.ServerName)
 
-	result, err := client.Get(ctx, serverId)
+	vulnerabilityPolicy, err := client.Get(ctx, serverId)
 	if err != nil {
-		if response.WasNotFound(result.HttpResponse) {
-			log.Printf("[WARN] mssql server vulnerability assessment %v not found", id)
+		if response.WasNotFound(vulnerabilityPolicy.HttpResponse) {
+			log.Printf("[WARN] mssql server vulnerability assessment %s: not found", id)
 			d.SetId("")
 			return nil
 		}
 
-		return fmt.Errorf("retrieving %s: %+v", *id, err)
+		return fmt.Errorf("retrieving mssql server vulnerability assessment %s: %+v", *id, err)
 	}
 
-	policyClient := meta.(*clients.Client).MSSQL.LegacyServerSecurityAlertPoliciesClient
-	policy, err := policyClient.Get(ctx, id.ResourceGroup, id.ServerName)
+	// NOTE: 'server_security_alert_policy_id' does not exist in the Server Vulnerability API
+	// properties so we need to look it up here...
+	alertPolicy, err := alertClient.Get(ctx, serverId)
 	if err != nil {
-		return fmt.Errorf("retrieving Security Alert Policy by ID: %+v", err)
-	}
-	d.Set("server_security_alert_policy_id", policy.ID)
+		if response.WasNotFound(alertPolicy.HttpResponse) {
+			log.Printf("[WARN] mssql server security alert policy %s: not found", serverId)
+			d.SetId("")
+			return nil
+		}
 
-	if model := result.Model; model != nil {
-		if props := model.Properties; props != nil {
+		return fmt.Errorf("retrieving mssql server security alert policy by ID: %+v", err)
+	}
+
+	alertModel := alertPolicy.Model
+	if alertModel == nil {
+		return fmt.Errorf("retrieving mssql server security alert policy %s: model was nil", serverId)
+	}
+
+	if alertModel.Id == nil {
+		return fmt.Errorf("retrieving mssql server security alert policy %s: Id was nil", serverId)
+	}
+
+	d.Set("server_security_alert_policy_id", alertModel.Id)
+
+	if vulnerabilityModel := vulnerabilityPolicy.Model; vulnerabilityModel != nil {
+		if props := vulnerabilityModel.Properties; props != nil {
 			d.Set("storage_container_path", props.StorageContainerPath)
 
-			if v, ok := d.GetOk("storage_account_access_key"); ok {
-				d.Set("storage_account_access_key", v)
+			if props.StorageAccountAccessKey != nil {
+				d.Set("storage_account_access_key", props.StorageAccountAccessKey)
 			}
 
-			if v, ok := d.GetOk("storage_container_sas_key"); ok {
-				d.Set("storage_container_sas_key", v)
+			if props.StorageContainerSasKey != nil {
+				d.Set("storage_container_sas_key", props.StorageContainerSasKey)
 			}
 
 			if props.RecurringScans != nil {
@@ -223,63 +236,57 @@ func resourceMsSqlServerVulnerabilityAssessmentRead(d *pluginsdk.ResourceData, m
 			}
 		}
 	}
+
 	return nil
 }
 
 func resourceMsSqlServerVulnerabilityAssessmentUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).MSSQL.ServerVulnerabilityAssessmentsClient
-	policyClient := meta.(*clients.Client).MSSQL.ServerSecurityAlertPoliciesClient
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	policyId, err := parse.ServerSecurityAlertPolicyID(d.Get("server_security_alert_policy_id").(string))
+	id, err := parse.ServerVulnerabilityAssessmentID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	serverId := commonids.NewSqlServerID(policyId.SubscriptionId, policyId.ResourceGroup, policyId.ServerName)
+	serverId := commonids.NewSqlServerID(id.SubscriptionId, id.ResourceGroup, id.ServerName)
 
-	result, err := policyClient.Get(ctx, serverId)
+	result, err := client.Get(ctx, serverId)
 	if err != nil {
-		return fmt.Errorf("retrieving Security Alert Policy: %+v", err)
+		return fmt.Errorf("retrieving mssql server vulnerability assessment %s: %+v", *id, err)
 	}
 
 	model := result.Model
 	if model == nil {
-		return fmt.Errorf("retrieving %s: model was nil", serverId)
+		return fmt.Errorf("retrieving mssql server vulnerability assessment %s: model was nil", *id)
 	}
 
-	policyProps := model.Properties
-	if policyProps == nil {
-		return fmt.Errorf("retrieving %s Security Alert Policy Properties: Properties were nil", serverId)
-	}
-
-	if policyProps.State != serversecurityalertpolicies.SecurityAlertsPolicyStateEnabled {
-		return fmt.Errorf("security alert policy is not enabled")
+	if model.Properties == nil {
+		return fmt.Errorf("retrieving mssql server vulnerability assessment %s: properties was nil", *id)
 	}
 
 	log.Printf("[INFO] preparing arguments for mssql server vulnerability assessment creation")
 
-	id := parse.NewServerVulnerabilityAssessmentID(serverId.SubscriptionId, serverId.ResourceGroupName, serverId.ServerName, "default")
+	payload := servervulnerabilityassessments.ServerVulnerabilityAssessment{}
 
-	storageContainerPath := d.Get("storage_container_path").(string)
+	props := model.Properties
 
-	vulnerabilityAssessment := servervulnerabilityassessments.ServerVulnerabilityAssessment{
-		Properties: &servervulnerabilityassessments.ServerVulnerabilityAssessmentProperties{
-			StorageContainerPath: storageContainerPath,
-		},
+	if d.HasChange("storage_container_path") {
+		if v, ok := d.GetOk("storage_container_path"); ok {
+			props.StorageContainerPath = v.(string)
+		}
 	}
 
-	props := vulnerabilityAssessment.Properties
 	if d.HasChange("storage_account_access_key") {
 		if v, ok := d.GetOk("storage_account_access_key"); ok {
-			props.StorageAccountAccessKey = utils.String(v.(string))
+			props.StorageAccountAccessKey = pointer.To(v.(string))
 		}
 	}
 
 	if d.HasChange("storage_container_sas_key") {
 		if v, ok := d.GetOk("storage_container_sas_key"); ok {
-			props.StorageContainerSasKey = utils.String(v.(string))
+			props.StorageContainerSasKey = pointer.To(v.(string))
 		}
 	}
 
@@ -289,13 +296,11 @@ func resourceMsSqlServerVulnerabilityAssessmentUpdate(d *pluginsdk.ResourceData,
 		}
 	}
 
-	vulnerabilityResult, err := client.CreateOrUpdate(ctx, serverId, vulnerabilityAssessment)
-	if err != nil {
-		return fmt.Errorf("updating %s : %v", id, err)
-	}
+	payload.Properties = props
 
-	if vulnerabilityResult.Model == nil || vulnerabilityResult.Model.Id == nil {
-		return fmt.Errorf("reading %s", id)
+	_, err = client.CreateOrUpdate(ctx, serverId, payload)
+	if err != nil {
+		return fmt.Errorf("updating mssql server vulnerability assessment %s : %v", id, err)
 	}
 
 	return resourceMsSqlServerVulnerabilityAssessmentRead(d, meta)
@@ -306,7 +311,7 @@ func resourceMsSqlServerVulnerabilityAssessmentDelete(d *pluginsdk.ResourceData,
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] deleting mssql server vulnerability assessment.")
+	log.Printf("[INFO] deleting mssql server vulnerability assessment")
 
 	id, err := parse.ServerVulnerabilityAssessmentID(d.Id())
 	if err != nil {
@@ -316,7 +321,7 @@ func resourceMsSqlServerVulnerabilityAssessmentDelete(d *pluginsdk.ResourceData,
 	serverId := commonids.NewSqlServerID(id.SubscriptionId, id.ResourceGroup, id.ServerName)
 
 	if _, err = client.Delete(ctx, serverId); err != nil {
-		return fmt.Errorf("deleting %s: %v", *id, err)
+		return fmt.Errorf("deleting mssql server vulnerability assessment %s: %v", *id, err)
 	}
 
 	return nil
@@ -333,11 +338,11 @@ func expandRecurringScans(d *pluginsdk.ResourceData) *servervulnerabilityassessm
 	v := vs[0].(map[string]interface{})
 
 	if enabled, ok := v["enabled"]; ok {
-		props.IsEnabled = utils.Bool(enabled.(bool))
+		props.IsEnabled = pointer.To(enabled.(bool))
 	}
 
 	if emailSubscriptionAdmins, ok := v["email_subscription_admins"]; ok {
-		props.EmailSubscriptionAdmins = utils.Bool(emailSubscriptionAdmins.(bool))
+		props.EmailSubscriptionAdmins = pointer.To(emailSubscriptionAdmins.(bool))
 	}
 
 	if _, ok := v["emails"]; ok {

--- a/internal/services/mssql/mssql_server_vulnerability_assessment_resource.go
+++ b/internal/services/mssql/mssql_server_vulnerability_assessment_resource.go
@@ -8,9 +8,9 @@ import (
 	"log"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/preview/sql/mgmt/v5.0/sql" // nolint: staticcheck
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-08-01-preview/serversecurityalertpolicies"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-08-01-preview/servervulnerabilityassessments"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -23,9 +23,9 @@ import (
 
 func resourceMsSqlServerVulnerabilityAssessment() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
-		Create: resourceMsSqlServerVulnerabilityAssessmentCreateUpdate,
+		Create: resourceMsSqlServerVulnerabilityAssessmentCreate,
 		Read:   resourceMsSqlServerVulnerabilityAssessmentRead,
-		Update: resourceMsSqlServerVulnerabilityAssessmentCreateUpdate,
+		Update: resourceMsSqlServerVulnerabilityAssessmentUpdate,
 		Delete: resourceMsSqlServerVulnerabilityAssessmentDelete,
 
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
@@ -102,9 +102,10 @@ func resourceMsSqlServerVulnerabilityAssessment() *pluginsdk.Resource {
 	}
 }
 
-func resourceMsSqlServerVulnerabilityAssessmentCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+func resourceMsSqlServerVulnerabilityAssessmentCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).MSSQL.ServerVulnerabilityAssessmentsClient
-	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	policyClient := meta.(*clients.Client).MSSQL.ServerSecurityAlertPoliciesClient
+	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	policyId, err := parse.ServerSecurityAlertPolicyID(d.Get("server_security_alert_policy_id").(string))
@@ -112,19 +113,30 @@ func resourceMsSqlServerVulnerabilityAssessmentCreateUpdate(d *pluginsdk.Resourc
 		return err
 	}
 
-	policyClient := meta.(*clients.Client).MSSQL.LegacyServerSecurityAlertPoliciesClient
+	serverId := commonids.NewSqlServerID(policyId.SubscriptionId, policyId.ResourceGroup, policyId.ServerName)
 
-	policy, err := policyClient.Get(ctx, policyId.ResourceGroup, policyId.ServerName)
+	result, err := policyClient.Get(ctx, serverId)
 	if err != nil {
 		return fmt.Errorf("retrieving Security Alert Policy: %+v", err)
 	}
-	if policy.State != sql.SecurityAlertsPolicyStateEnabled {
+
+	model := result.Model
+	if model == nil {
+		return fmt.Errorf("retrieving %s: model was nil", serverId)
+	}
+
+	policyProps := model.Properties
+	if policyProps == nil {
+		return fmt.Errorf("retrieving %s Security Alert Policy Properties: Properties were nil", serverId)
+	}
+
+	if policyProps.State != serversecurityalertpolicies.SecurityAlertsPolicyStateEnabled {
 		return fmt.Errorf("security alert policy is not enabled")
 	}
 
-	log.Printf("[INFO] preparing arguments for mssql server vulnerability assessment creation.")
+	log.Printf("[INFO] preparing arguments for mssql server vulnerability assessment creation")
 
-	id := parse.NewServerVulnerabilityAssessmentID(policyId.SubscriptionId, policyId.ResourceGroup, policyId.ServerName, "default")
+	id := parse.NewServerVulnerabilityAssessmentID(serverId.SubscriptionId, serverId.ResourceGroupName, serverId.ServerName, "default")
 
 	storageContainerPath := d.Get("storage_container_path").(string)
 
@@ -148,14 +160,12 @@ func resourceMsSqlServerVulnerabilityAssessmentCreateUpdate(d *pluginsdk.Resourc
 		props.RecurringScans = expandRecurringScans(d)
 	}
 
-	serverId := commonids.NewSqlServerID(id.SubscriptionId, id.ResourceGroup, id.ServerName)
-
-	result, err := client.CreateOrUpdate(ctx, serverId, vulnerabilityAssessment)
+	vulnerabilityResult, err := client.CreateOrUpdate(ctx, serverId, vulnerabilityAssessment)
 	if err != nil {
 		return fmt.Errorf("updating %s : %v", id, err)
 	}
 
-	if result.Model == nil || result.Model.Id == nil {
+	if vulnerabilityResult.Model == nil || vulnerabilityResult.Model.Id == nil {
 		return fmt.Errorf("reading %s", id)
 	}
 
@@ -214,6 +224,76 @@ func resourceMsSqlServerVulnerabilityAssessmentRead(d *pluginsdk.ResourceData, m
 		}
 	}
 	return nil
+}
+
+func resourceMsSqlServerVulnerabilityAssessmentUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).MSSQL.ServerVulnerabilityAssessmentsClient
+	policyClient := meta.(*clients.Client).MSSQL.ServerSecurityAlertPoliciesClient
+	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	policyId, err := parse.ServerSecurityAlertPolicyID(d.Get("server_security_alert_policy_id").(string))
+	if err != nil {
+		return err
+	}
+
+	serverId := commonids.NewSqlServerID(policyId.SubscriptionId, policyId.ResourceGroup, policyId.ServerName)
+
+	result, err := policyClient.Get(ctx, serverId)
+	if err != nil {
+		return fmt.Errorf("retrieving Security Alert Policy: %+v", err)
+	}
+
+	model := result.Model
+	if model == nil {
+		return fmt.Errorf("retrieving %s: model was nil", serverId)
+	}
+
+	policyProps := model.Properties
+	if policyProps == nil {
+		return fmt.Errorf("retrieving %s Security Alert Policy Properties: Properties were nil", serverId)
+	}
+
+	if policyProps.State != serversecurityalertpolicies.SecurityAlertsPolicyStateEnabled {
+		return fmt.Errorf("security alert policy is not enabled")
+	}
+
+	log.Printf("[INFO] preparing arguments for mssql server vulnerability assessment creation")
+
+	id := parse.NewServerVulnerabilityAssessmentID(serverId.SubscriptionId, serverId.ResourceGroupName, serverId.ServerName, "default")
+
+	storageContainerPath := d.Get("storage_container_path").(string)
+
+	vulnerabilityAssessment := servervulnerabilityassessments.ServerVulnerabilityAssessment{
+		Properties: &servervulnerabilityassessments.ServerVulnerabilityAssessmentProperties{
+			StorageContainerPath: storageContainerPath,
+		},
+	}
+
+	props := vulnerabilityAssessment.Properties
+
+	if v, ok := d.GetOk("storage_account_access_key"); ok {
+		props.StorageAccountAccessKey = utils.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("storage_container_sas_key"); ok {
+		props.StorageContainerSasKey = utils.String(v.(string))
+	}
+
+	if _, ok := d.GetOk("recurring_scans"); ok {
+		props.RecurringScans = expandRecurringScans(d)
+	}
+
+	vulnerabilityResult, err := client.CreateOrUpdate(ctx, serverId, vulnerabilityAssessment)
+	if err != nil {
+		return fmt.Errorf("updating %s : %v", id, err)
+	}
+
+	if vulnerabilityResult.Model == nil || vulnerabilityResult.Model.Id == nil {
+		return fmt.Errorf("reading %s", id)
+	}
+
+	return resourceMsSqlServerVulnerabilityAssessmentRead(d, meta)
 }
 
 func resourceMsSqlServerVulnerabilityAssessmentDelete(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/mssql/mssql_server_vulnerability_assessment_resource_test.go
+++ b/internal/services/mssql/mssql_server_vulnerability_assessment_resource_test.go
@@ -56,6 +56,13 @@ func TestAccMsSqlServerVulnerabilityAssessment_update(t *testing.T) {
 			),
 		},
 		data.ImportStep("storage_account_access_key"),
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("storage_account_access_key"),
 	})
 }
 
@@ -86,7 +93,6 @@ func (r MsSqlServerVulnerabilityAssessmentResource) basic(data acceptance.TestDa
 resource "azurerm_mssql_server_vulnerability_assessment" "test" {
   server_security_alert_policy_id = azurerm_mssql_server_security_alert_policy.test.id
   storage_container_path          = "${azurerm_storage_account.test.primary_blob_endpoint}${azurerm_storage_container.test.name}/"
-  storage_account_access_key      = azurerm_storage_account.test.primary_access_key
 }
 `, r.server(data))
 }
@@ -98,7 +104,6 @@ func (r MsSqlServerVulnerabilityAssessmentResource) update(data acceptance.TestD
 resource "azurerm_mssql_server_vulnerability_assessment" "test" {
   server_security_alert_policy_id = azurerm_mssql_server_security_alert_policy.test.id
   storage_container_path          = "${azurerm_storage_account.test.primary_blob_endpoint}${azurerm_storage_container.test.name}/"
-  storage_account_access_key      = azurerm_storage_account.test.primary_access_key
 
   recurring_scans {
     enabled                   = true

--- a/internal/services/mssql/mssql_server_vulnerability_assessment_resource_test.go
+++ b/internal/services/mssql/mssql_server_vulnerability_assessment_resource_test.go
@@ -6,7 +6,6 @@ package mssql_test
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -23,7 +22,6 @@ type MsSqlServerVulnerabilityAssessmentResource struct{}
 
 func TestAccMsSqlServerVulnerabilityAssessment_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_mssql_server_vulnerability_assessment", "test")
-	data = setTestDataLocationBySubscription(data)
 
 	r := MsSqlServerVulnerabilityAssessmentResource{}
 
@@ -40,7 +38,6 @@ func TestAccMsSqlServerVulnerabilityAssessment_basic(t *testing.T) {
 
 func TestAccMsSqlServerVulnerabilityAssessment_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_mssql_server_vulnerability_assessment", "test")
-	data = setTestDataLocationBySubscription(data)
 
 	r := MsSqlServerVulnerabilityAssessmentResource{}
 
@@ -80,16 +77,6 @@ func (MsSqlServerVulnerabilityAssessmentResource) Exists(ctx context.Context, cl
 	}
 
 	return pointer.To(resp.Model != nil), nil
-}
-
-// Sets the tests 'Primary' and 'Secondary' locations based on the 'ARM_MICROSOFT_TEST' environment variable due to subscription quota policies
-func setTestDataLocationBySubscription(data acceptance.TestData) acceptance.TestData {
-	if isMicrosoftTest := os.Getenv("ARM_MICROSOFT_TEST"); isMicrosoftTest != "" {
-		data.Locations.Primary = "eastus"
-		data.Locations.Secondary = "swedencentral"
-	}
-
-	return data
 }
 
 func (r MsSqlServerVulnerabilityAssessmentResource) basic(data acceptance.TestData) string {

--- a/internal/services/mssql/mssql_server_vulnerability_assessment_resource_test.go
+++ b/internal/services/mssql/mssql_server_vulnerability_assessment_resource_test.go
@@ -93,6 +93,9 @@ func (r MsSqlServerVulnerabilityAssessmentResource) basic(data acceptance.TestDa
 resource "azurerm_mssql_server_vulnerability_assessment" "test" {
   server_security_alert_policy_id = azurerm_mssql_server_security_alert_policy.test.id
   storage_container_path          = "${azurerm_storage_account.test.primary_blob_endpoint}${azurerm_storage_container.test.name}/"
+  storage_account_access_key      = azurerm_storage_account.test.primary_access_key
+
+  recurring_scans {}
 }
 `, r.server(data))
 }
@@ -104,6 +107,7 @@ func (r MsSqlServerVulnerabilityAssessmentResource) update(data acceptance.TestD
 resource "azurerm_mssql_server_vulnerability_assessment" "test" {
   server_security_alert_policy_id = azurerm_mssql_server_security_alert_policy.test.id
   storage_container_path          = "${azurerm_storage_account.test.primary_blob_endpoint}${azurerm_storage_container.test.name}/"
+  storage_account_access_key      = azurerm_storage_account.test.primary_access_key
 
   recurring_scans {
     enabled                   = true
@@ -135,10 +139,6 @@ resource "azurerm_mssql_server" "test" {
   version                      = "12.0"
   administrator_login          = "mradministrator"
   administrator_login_password = "thisIsDog11"
-
-  identity {
-    type = "SystemAssigned"
-  }
 }
 
 resource "azurerm_storage_account" "test" {
@@ -147,15 +147,6 @@ resource "azurerm_storage_account" "test" {
   location                 = "%[2]s"
   account_tier             = "Standard"
   account_replication_type = "GRS"
-
-  network_rules {
-    default_action = "Deny"
-    bypass         = ["AzureServices"]
-
-    private_link_access {
-      endpoint_resource_id = azurerm_mssql_server.test.id
-    }
-  }
 }
 
 resource "azurerm_storage_container" "test" {

--- a/internal/services/mssql/mssql_server_vulnerability_assessment_resource_test.go
+++ b/internal/services/mssql/mssql_server_vulnerability_assessment_resource_test.go
@@ -6,6 +6,7 @@ package mssql_test
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -20,8 +21,10 @@ import (
 
 type MsSqlServerVulnerabilityAssessmentResource struct{}
 
-func TestAccAzureRMMssqlServerVulnerabilityAssessment_basic(t *testing.T) {
+func TestAccMsSqlServerVulnerabilityAssessment_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_mssql_server_vulnerability_assessment", "test")
+	data = setTestDataLocationBySubscription(data)
+
 	r := MsSqlServerVulnerabilityAssessmentResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -35,8 +38,10 @@ func TestAccAzureRMMssqlServerVulnerabilityAssessment_basic(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMMssqlServerVulnerabilityAssessment_update(t *testing.T) {
+func TestAccMsSqlServerVulnerabilityAssessment_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_mssql_server_vulnerability_assessment", "test")
+	data = setTestDataLocationBySubscription(data)
+
 	r := MsSqlServerVulnerabilityAssessmentResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -75,6 +80,16 @@ func (MsSqlServerVulnerabilityAssessmentResource) Exists(ctx context.Context, cl
 	}
 
 	return pointer.To(resp.Model != nil), nil
+}
+
+// Sets the tests 'Primary' and 'Secondary' locations based on the 'ARM_MICROSOFT_TEST' environment variable due to subscription quota policies
+func setTestDataLocationBySubscription(data acceptance.TestData) acceptance.TestData {
+	if isMicrosoftTest := os.Getenv("ARM_MICROSOFT_TEST"); isMicrosoftTest != "" {
+		data.Locations.Primary = "eastus"
+		data.Locations.Secondary = "swedencentral"
+	}
+
+	return data
 }
 
 func (r MsSqlServerVulnerabilityAssessmentResource) basic(data acceptance.TestData) string {

--- a/internal/services/mssql/mssql_server_vulnerability_assessment_resource_test.go
+++ b/internal/services/mssql/mssql_server_vulnerability_assessment_resource_test.go
@@ -130,6 +130,10 @@ resource "azurerm_mssql_server" "test" {
   version                      = "12.0"
   administrator_login          = "mradministrator"
   administrator_login_password = "thisIsDog11"
+
+  identity {
+    type = "SystemAssigned"
+  }
 }
 
 resource "azurerm_storage_account" "test" {
@@ -138,6 +142,15 @@ resource "azurerm_storage_account" "test" {
   location                 = "%[2]s"
   account_tier             = "Standard"
   account_replication_type = "GRS"
+
+  network_rules {
+    default_action = "Deny"
+    bypass         = ["AzureServices"]
+
+    private_link_access {
+      endpoint_resource_id = azurerm_mssql_server.test.id
+    }
+  }
 }
 
 resource "azurerm_storage_container" "test" {

--- a/website/docs/r/mssql_server_vulnerability_assessment.html.markdown
+++ b/website/docs/r/mssql_server_vulnerability_assessment.html.markdown
@@ -74,23 +74,23 @@ The following arguments are supported:
 
 * `server_security_alert_policy_id` - (Required) The id of the security alert policy of the MS SQL Server. Changing this forces a new resource to be created.
 
-* `storage_container_path` - (Required) Specifies the blob storage container path that will hold the scan results (e.g. <https://example.blob.core.windows.net/example/>). Changing this forces a new resource to be created.
+* `storage_container_path` - (Required) Specifies the blob storage container path that will hold the scan results (e.g., <https://example.blob.core.windows.net/example/>).
 
-* `storage_account_access_key` - (Optional) Specifies the primary access key of the blob storage endpoint. Changing this forces a new resource to be created.
+* `storage_account_access_key` - (Optional) Specifies the primary access key of the blob storage endpoint.
 
 -> **Note:** The `storage_account_access_key` only applies if the storage account is not behind a virtual network or a firewall.
 
--> **Note:** If the `storage_container_sas_key` is not defined the `storage_account_access_key` is required.
+-> **Note:** If the `storage_account_access_key` property is not defined the `storage_container_sas_key` property is required.
 
-* `storage_container_sas_key` - (Optional) Specifies the shared access signature (SAS Key) that has write access to the blob container specified in `storage_container_path` parameter. Changing this forces a new resource to be created.
+* `storage_container_sas_key` - (Optional) Specifies the shared access signature (SAS Key) that has write access to the blob container specified in `storage_container_path` property.
 
 -> **Note:** The `storage_container_sas_key` only applies if the storage account is not behind a virtual network or a firewall.
 
--> **Note:** If the `storage_account_access_key` is not defined the `storage_container_sas_key` is required.
+-> **Note:** If the `storage_container_sas_key` property is not defined the `storage_account_access_key` property is required.
 
 * `recurring_scans` - (Optional) A `recurring_scans` block as defined below.
 
--> **Note:** Since the `recurring_scans` code block is persisted to the state file, simply removing the code block from your configuration file will not remove it from the associated Azure resource. To explicitly unset these values in Azure, you must define an empty `recurring_scans` code block (e.g., `recurring_scans {}`) in your configuration file.
+-> **Note:** To reset the `recurring_scans` code block to it's default values you must explicitly define an empty `recurring_scans` code block (e.g., `recurring_scans {}`) in your configuration file.
 
 ---
 

--- a/website/docs/r/mssql_server_vulnerability_assessment.html.markdown
+++ b/website/docs/r/mssql_server_vulnerability_assessment.html.markdown
@@ -74,17 +74,21 @@ The following arguments are supported:
 
 * `server_security_alert_policy_id` - (Required) The id of the security alert policy of the MS SQL Server. Changing this forces a new resource to be created.
 
-* `storage_container_path` - (Required) A blob storage container path to hold the scan results (e.g. <https://example.blob.core.windows.net/VaScans/>).
+* `storage_container_path` - (Required) Specifies the blob storage container path that will hold the scan results (e.g. <https://example.blob.core.windows.net/example/>). Changing this forces a new resource to be created.
 
-* `storage_account_access_key` - (Optional) Specifies the identifier key of the storage account for vulnerability assessment scan results. If `storage_container_sas_key` isn't specified, `storage_account_access_key` is required.
+* `storage_account_access_key` - (Optional) Specifies the primary access key of the blob storage endpoint. Changing this forces a new resource to be created.
 
 -> **Note:** The `storage_account_access_key` only applies if the storage account is not behind a virtual network or a firewall.
 
-* `storage_container_sas_key` - (Optional) A shared access signature (SAS Key) that has write access to the blob container specified in `storage_container_path` parameter. If `storage_account_access_key` isn't specified, `storage_container_sas_key` is required.
+-> **Note:** If the `storage_container_sas_key` is not defined the `storage_account_access_key` is required.
+
+* `storage_container_sas_key` - (Optional) Specifies the shared access signature (SAS Key) that has write access to the blob container specified in `storage_container_path` parameter. Changing this forces a new resource to be created.
 
 -> **Note:** The `storage_container_sas_key` only applies if the storage account is not behind a virtual network or a firewall.
 
-* `recurring_scans` - (Optional) The recurring scans settings. The `recurring_scans` block supports fields documented below.
+-> **Note:** If the `storage_account_access_key` is not defined the `storage_container_sas_key` is required.
+
+* `recurring_scans` - (Optional) A `recurring_scans` block as defined below.
 
 -> **Note:** Since the `recurring_scans` code block is persisted to the state file, simply removing the code block from your configuration file will not remove it from the associated Azure resource. To explicitly unset these values in Azure, you must define an empty `recurring_scans` code block (e.g., `recurring_scans {}`) in your configuration file.
 

--- a/website/docs/r/mssql_server_vulnerability_assessment.html.markdown
+++ b/website/docs/r/mssql_server_vulnerability_assessment.html.markdown
@@ -86,6 +86,8 @@ The following arguments are supported:
 
 * `recurring_scans` - (Optional) The recurring scans settings. The `recurring_scans` block supports fields documented below.
 
+-> **Note:** Since the `recurring_scans` code block is persisted to the state file, simply removing the code block from your configuration file will not remove it from the associated Azure resource. To explicitly unset these values in Azure, you must define an empty `recurring_scans` code block (e.g., `recurring_scans {}`) in your configuration file.
+
 ---
 
 The `recurring_scans` block supports the following:


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Update the `azurerm_mssql_server_vulnerability_assessment` resource to use the `2023-08-01-preview/serversecurityalertpolicies` and `2023-08-01-preview/servervulnerabilityassessments` APIs due to deprecation of the `2014-04-01` APIs on `31 October 2025`.

* dependencies - `serversecurityalertpolicies` API updated to version `2023-08-01-preview/serversecurityalertpolicies`
* dependencies - `servervulnerabilityassessments` API updated to version `2023-08-01-preview/servervulnerabilityassessments`
* `azurerm_mssql_server_vulnerability_assessment` - `storage_account_access_key` or `storage_container_sas_key` property is a `required` field

## PR Checklist

- [X] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [X] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [X] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [X] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [X] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [X] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [X] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [X] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

![image](https://github.com/user-attachments/assets/c22605c5-58f8-4d7a-8ea7-3ec676b4f092)

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

ENHANCEMENTS:

* dependencies - `serversecurityalertpolicies` API updated to version `2023-08-01-preview/serversecurityalertpolicies` [GH-00000]
* dependencies - `servervulnerabilityassessments` API updated to version `2023-08-01-preview/servervulnerabilityassessments` [GH-00000]
* `azurerm_mssql_server_vulnerability_assessment` - `storage_account_access_key` or `storage_container_sas_key` property is a `required` field [GH-00000]

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [X] Dependency
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
