### PR TITLE
`azurerm_container_app_environment_storage`: add support for file protocol `NFS` vis the `nfs_server` property

### DIFF
--- a/internal/services/containerapps/container_app_environment_storage_resource.go
+++ b/internal/services/containerapps/container_app_environment_storage_resource.go
@@ -27,7 +27,7 @@ type ContainerAppEnvironmentStorageModel struct {
 	AccessKey                 string `tfschema:"access_key"`
 	ShareName                 string `tfschema:"share_name"`
 	AccessMode                string `tfschema:"access_mode"`
-	NfsServer                 string `tfschema:"nfs_server"`
+	NfsServer                 string `tfschema:"nfs_server_url"`
 }
 
 var _ sdk.ResourceWithUpdate = ContainerAppEnvironmentStorageResource{}
@@ -68,7 +68,7 @@ func (r ContainerAppEnvironmentStorageResource) Arguments() map[string]*pluginsd
 			ForceNew:      true,
 			ValidateFunc:  storageValidate.StorageAccountName,
 			RequiredWith:  []string{"access_key"},
-			ConflictsWith: []string{"nfs_server"},
+			ConflictsWith: []string{"nfs_server_url"},
 			Description:   "The Azure Storage Account in which the Share to be used is located.",
 		},
 
@@ -99,7 +99,7 @@ func (r ContainerAppEnvironmentStorageResource) Arguments() map[string]*pluginsd
 			Description: "The access mode to connect this storage to the Container App. Possible values include `ReadOnly` and `ReadWrite`.",
 		},
 
-		"nfs_server": {
+		"nfs_server_url": {
 			Type:          pluginsdk.TypeString,
 			Optional:      true,
 			ForceNew:      true,

--- a/internal/services/containerapps/container_app_environment_storage_resource_test.go
+++ b/internal/services/containerapps/container_app_environment_storage_resource_test.go
@@ -138,7 +138,6 @@ resource "azurerm_container_app_environment_storage" "test" {
   container_app_environment_id = azurerm_container_app_environment.test.id
   share_name                   = "/${azurerm_storage_account.test.name}/${azurerm_storage_share.test.name}"
   access_mode                  = "ReadWrite"
-  azure_file_protocol          = "NFS"
   nfs_server                   = "${azurerm_storage_account.test.name}.file.core.windows.net"
 }
 `, r.template(data), data.RandomInteger)

--- a/internal/services/containerapps/container_app_environment_storage_resource_test.go
+++ b/internal/services/containerapps/container_app_environment_storage_resource_test.go
@@ -138,7 +138,7 @@ resource "azurerm_container_app_environment_storage" "test" {
   container_app_environment_id = azurerm_container_app_environment.test.id
   share_name                   = "/${azurerm_storage_account.test.name}/${azurerm_storage_share.test.name}"
   access_mode                  = "ReadWrite"
-  nfs_server                   = "${azurerm_storage_account.test.name}.file.core.windows.net"
+  nfs_server_url               = "${azurerm_storage_account.test.name}.file.core.windows.net"
 }
 `, r.template(data), data.RandomInteger)
 }

--- a/internal/services/containerapps/container_app_environment_storage_resource_test.go
+++ b/internal/services/containerapps/container_app_environment_storage_resource_test.go
@@ -34,6 +34,21 @@ func TestAccContainerAppEnvironmentStorage_basic(t *testing.T) {
 	})
 }
 
+func TestAccContainerAppEnvironmentStorage_nfsBasic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_app_environment_storage", "test")
+	r := ContainerAppEnvironmentStorageResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.nfsBasic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccContainerAppEnvironmentStorage_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_container_app_environment_storage", "test")
 	r := ContainerAppEnvironmentStorageResource{}
@@ -106,6 +121,25 @@ resource "azurerm_container_app_environment_storage" "test" {
   access_key                   = azurerm_storage_account.test.primary_access_key
   share_name                   = azurerm_storage_share.test.name
   access_mode                  = "ReadWrite"
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r ContainerAppEnvironmentStorageResource) nfsBasic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_container_app_environment_storage" "test" {
+  name                         = "testacc-caes-%[2]d"
+  container_app_environment_id = azurerm_container_app_environment.test.id
+  share_name                   = "/${azurerm_storage_account.test.name}/${azurerm_storage_share.test.name}"
+  access_mode                  = "ReadWrite"
+  azure_file_protocol          = "NFS"
+  nfs_server                   = "${azurerm_storage_account.test.name}.file.core.windows.net"
 }
 `, r.template(data), data.RandomInteger)
 }

--- a/website/docs/r/container_app_environment_storage.html.markdown
+++ b/website/docs/r/container_app_environment_storage.html.markdown
@@ -73,9 +73,7 @@ The following arguments are supported:
 
 * `access_mode` - (Required) The access mode to connect this storage to the Container App. Possible values include `ReadOnly` and `ReadWrite`. Changing this forces a new resource to be created.
 
-* `azure_file_protocol` - (Optional) The protocol to use for the Azure File Share. Possible values include `SMB` and `NFS`. Defaults to `SMB`. Changing this forces a new resource to be created.
-
-* `nfs_server` - (Optional) The NFS server to use for the Azure File Share. This is only applicable if `azure_file_protocol` is set to `NFS`. Changing this forces a new resource to be created.
+* `nfs_server` - (Optional) The NFS server to use for the Azure File Share. Changing this forces a new resource to be created.
 * 
 ## Attributes Reference
 

--- a/website/docs/r/container_app_environment_storage.html.markdown
+++ b/website/docs/r/container_app_environment_storage.html.markdown
@@ -73,7 +73,7 @@ The following arguments are supported:
 
 * `access_mode` - (Required) The access mode to connect this storage to the Container App. Possible values include `ReadOnly` and `ReadWrite`. Changing this forces a new resource to be created.
 
-* `nfs_server` - (Optional) The NFS server to use for the Azure File Share. Changing this forces a new resource to be created.
+* `nfs_server_url` - (Optional) The NFS server to use for the Azure File Share, the format will be `yourstorageaccountname.file.core.windows.net`. Changing this forces a new resource to be created.
 * 
 ## Attributes Reference
 

--- a/website/docs/r/container_app_environment_storage.html.markdown
+++ b/website/docs/r/container_app_environment_storage.html.markdown
@@ -65,14 +65,18 @@ The following arguments are supported:
 
 * `container_app_environment_id` - (Required) The ID of the Container App Environment to which this storage belongs. Changing this forces a new resource to be created.
 
-* `account_name` - (Required) The Azure Storage Account in which the Share to be used is located. Changing this forces a new resource to be created.
+* `account_name` - (Optional) The Azure Storage Account in which the Share to be used is located. Changing this forces a new resource to be created.
 
-* `access_key` - (Required) The Storage Account Access Key.
+* `access_key` - (Optional) The Storage Account Access Key.
 
 * `share_name` - (Required) The name of the Azure Storage Share to use. Changing this forces a new resource to be created.
 
 * `access_mode` - (Required) The access mode to connect this storage to the Container App. Possible values include `ReadOnly` and `ReadWrite`. Changing this forces a new resource to be created.
 
+* `azure_file_protocol` - (Optional) The protocol to use for the Azure File Share. Possible values include `SMB` and `NFS`. Defaults to `SMB`. Changing this forces a new resource to be created.
+
+* `nfs_server` - (Optional) The NFS server to use for the Azure File Share. This is only applicable if `azure_file_protocol` is set to `NFS`. Changing this forces a new resource to be created.
+* 
 ## Attributes Reference
 
 In addition to the Arguments listed above - the following Attributes are exported:


### PR DESCRIPTION


<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Currently the container app environment storage resource supports NFS file protocol.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [x] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #[29304](https://github.com/hashicorp/terraform-provider-azurerm/issues/29304)


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
