### PR TITLE
`azurerm_resource_group_template_deployment`: Add new template_uri parameter

### DIFF
--- a/internal/services/resource/resource_group_template_deployment_resource.go
+++ b/internal/services/resource/resource_group_template_deployment_resource.go
@@ -176,6 +176,12 @@ func resourceGroupTemplateDeploymentResourceCreate(d *pluginsdk.ResourceData, me
 		}
 	}
 
+	if templateUri, ok := d.GetOk("template_uri"); ok {
+		deployment.Properties.TemplateUri = &resources.TemplateLink{
+			Uri : utils.String(templateUri.(string)),
+		}
+	}
+
 	if v, ok := d.GetOk("parameters_content"); ok && v != "" {
 		parameters, err := expandTemplateDeploymentBody(v.(string))
 		if err != nil {

--- a/internal/services/resource/resource_group_template_deployment_resource.go
+++ b/internal/services/resource/resource_group_template_deployment_resource.go
@@ -177,8 +177,8 @@ func resourceGroupTemplateDeploymentResourceCreate(d *pluginsdk.ResourceData, me
 	}
 
 	if templateUri, ok := d.GetOk("template_uri"); ok {
-		deployment.Properties.TemplateUri = &resources.TemplateLink{
-			Uri : utils.String(templateUri.(string)),
+		deployment.Properties.TemplateLink = &resources.TemplateLink{
+			URI : utils.String(templateUri.(string)),
 		}
 	}
 


### PR DESCRIPTION
When you create an ARM template, you will likely end up with dependent templates represented as template links, such as this one:

mainTemplate.json
```
{
  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
  "contentVersion": "1.0.0.0",
  "parameters": {},
  "functions": [],
  "variables": {},
  "resources": [
    {
      "type": "Microsoft.Resources/deployments",
      "apiVersion": "2022-09-01",
      "name": "childLinked",
      "properties": {
        "mode": "Incremental",
        "templateLink": {
          "relativePath": "children/nestedChild.json"
        }
      }
    }
  ],
  "outputs": {}
}
``` 

In this case, the `mainTemplate.json` reuses a template in a relative path called `children/nestedChild.json`. In order for that to work, both templates must be accessible from the same remote location.

The above templates are deployable using the following command:

```
New-AzResourceGroupDeployment -Name linkedTemplateWithRelativePath -ResourceGroupName "myResourceGroup" -TemplateUri "https://raw.githubusercontent.com/Azure/azure-docs-json-samples/master/linked-template-relpath/mainTemplate.json"
```
This PR introduces a new "template_uri" parameter, which allows the `azurerm_resource_group_template_deployment` to behave in the same ways as the `TemplateUri` parameter for the `New-AzResourceGroupDeployment` command


<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
