### PR TITLE
Fix documentation note for primary/secondary access key on `azurerm_cognitive_account`

### DIFF
--- a/website/docs/d/cognitive_account.html.markdown
+++ b/website/docs/d/cognitive_account.html.markdown
@@ -53,7 +53,7 @@ The following attributes are exported:
 
 * `secondary_access_key` - The secondary access key of the Cognitive Services Account
 
--> **NOTE:** The `primary_access_key` and `secondary_access_key` properties are only available when `location_auth_enabled` is `true`.
+-> **NOTE:** The `primary_access_key` and `secondary_access_key` properties are only available when `local_auth_enabled` is `true`.
 
 * `tags` - A mapping of tags to assigned to the resource.
 

--- a/website/docs/r/cognitive_account.html.markdown
+++ b/website/docs/r/cognitive_account.html.markdown
@@ -158,7 +158,7 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `secondary_access_key` - The secondary access key which can be used to connect to the Cognitive Service Account.
 
--> **NOTE:** The `primary_access_key` and `secondary_access_key` properties are only available when `location_auth_enabled` is set to `true`.
+-> **NOTE:** The `primary_access_key` and `secondary_access_key` properties are only available when `local_auth_enabled` is set to `true`.
 
 ---
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

The `primary_access_key` and `secondary_access_key` attributes are only available when `local_auth_enabled` is `true`. Changed from `location_auth_enabled` which is not a valid argument on this resource.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 