### PR TITLE
[Enhance] `azurerm_application_insights` - Add `computed=true` to `workspace_id`

### DIFF
--- a/internal/services/applicationinsights/application_insights_resource.go
+++ b/internal/services/applicationinsights/application_insights_resource.go
@@ -78,6 +78,7 @@ func resourceApplicationInsights() *pluginsdk.Resource {
 				}, false),
 			},
 
+			// NOTE: O+C A Log Analytics Workspace will be attached to the Application Insight by default, which should be computed=true
 			"workspace_id": {
 				Type:         pluginsdk.TypeString,
 				Optional:     true,

--- a/internal/services/applicationinsights/application_insights_resource.go
+++ b/internal/services/applicationinsights/application_insights_resource.go
@@ -81,6 +81,7 @@ func resourceApplicationInsights() *pluginsdk.Resource {
 			"workspace_id": {
 				Type:         pluginsdk.TypeString,
 				Optional:     true,
+				Computed:     true,
 				ValidateFunc: workspaces.ValidateWorkspaceID,
 			},
 


### PR DESCRIPTION
<!--  All Submissions -->
Since a default Log Analytics Workspace will be attached to Application Insights, the `workspace_id` in Application Insights should be `computed=true`.

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

```log
=== RUN   TestAccApplicationInsights_basicWeb
=== PAUSE TestAccApplicationInsights_basicWeb
=== RUN   TestAccApplicationInsights_requiresImport
=== PAUSE TestAccApplicationInsights_requiresImport
=== RUN   TestAccApplicationInsights_basicJava
=== PAUSE TestAccApplicationInsights_basicJava
=== RUN   TestAccApplicationInsights_basicMobileCenter
=== PAUSE TestAccApplicationInsights_basicMobileCenter
=== RUN   TestAccApplicationInsights_basicOther
=== PAUSE TestAccApplicationInsights_basicOther
=== RUN   TestAccApplicationInsights_basicPhone
=== PAUSE TestAccApplicationInsights_basicPhone
=== RUN   TestAccApplicationInsights_basicStore
=== PAUSE TestAccApplicationInsights_basicStore
=== RUN   TestAccApplicationInsights_basiciOS
=== PAUSE TestAccApplicationInsights_basiciOS
=== RUN   TestAccApplicationInsights_basicWorkspaceMode
=== PAUSE TestAccApplicationInsights_basicWorkspaceMode
=== RUN   TestAccApplicationInsights_complete
=== PAUSE TestAccApplicationInsights_complete
=== RUN   TestAccApplicationInsights_withInternetQueryEnabled
=== PAUSE TestAccApplicationInsights_withInternetQueryEnabled
=== RUN   TestAccApplicationInsights_withInternetIngestionEnabled
=== PAUSE TestAccApplicationInsights_withInternetIngestionEnabled
=== RUN   TestAccApplicationInsights_disableGeneratedRule
=== PAUSE TestAccApplicationInsights_disableGeneratedRule
=== CONT  TestAccApplicationInsights_basicWeb
=== CONT  TestAccApplicationInsights_basiciOS
=== CONT  TestAccApplicationInsights_withInternetQueryEnabled
=== CONT  TestAccApplicationInsights_disableGeneratedRule
=== CONT  TestAccApplicationInsights_withInternetIngestionEnabled
=== CONT  TestAccApplicationInsights_complete
=== CONT  TestAccApplicationInsights_basicStore
=== CONT  TestAccApplicationInsights_basicOther
=== CONT  TestAccApplicationInsights_basicMobileCenter
=== CONT  TestAccApplicationInsights_basicWorkspaceMode
=== CONT  TestAccApplicationInsights_basicPhone
=== CONT  TestAccApplicationInsights_basicJava
=== CONT  TestAccApplicationInsights_requiresImport
--- PASS: TestAccApplicationInsights_basicOther (307.26s)
--- PASS: TestAccApplicationInsights_requiresImport (325.07s)
--- PASS: TestAccApplicationInsights_basicJava (356.88s)
--- PASS: TestAccApplicationInsights_basicStore (359.83s)
--- PASS: TestAccApplicationInsights_basicPhone (377.89s)
--- PASS: TestAccApplicationInsights_basicMobileCenter (407.00s)
--- PASS: TestAccApplicationInsights_complete (413.29s)
--- PASS: TestAccApplicationInsights_withInternetQueryEnabled (482.23s)
--- PASS: TestAccApplicationInsights_withInternetIngestionEnabled (483.31s)
--- PASS: TestAccApplicationInsights_basicWorkspaceMode (590.94s)
--- PASS: TestAccApplicationInsights_disableGeneratedRule (984.21s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/applicationinsights   1005.132s
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
