### PR TITLE
`azurerm_web_pubsub_custom_certificate` - fix  crash when `custom_certificate_id` is in another Subscription

### DIFF
--- a/internal/services/signalr/web_pubsub_custom_certificate_resource.go
+++ b/internal/services/signalr/web_pubsub_custom_certificate_resource.go
@@ -165,11 +165,12 @@ func (r CustomCertWebPubsubResource) Read() sdk.ResourceFunc {
 			if err != nil {
 				return fmt.Errorf("getting key vault base uri from %s: %+v", id, err)
 			}
-			vaultId, err := commonids.ParseKeyVaultID(*keyVaultIdRaw)
-			if err != nil {
-				return fmt.Errorf("parsing key vault %s: %+v", vaultId, err)
+			if keyVaultIdRaw != nil {
+				vaultId, err := commonids.ParseKeyVaultID(*keyVaultIdRaw)
+				if err != nil {
+					return fmt.Errorf("parsing key vault %s: %+v", vaultId, err)
+				}
 			}
-
 			certVersion := ""
 			if resp.Model.Properties.KeyVaultSecretVersion != nil {
 				certVersion = *resp.Model.Properties.KeyVaultSecretVersion


### PR DESCRIPTION
<!-- What type of PR is this? -->
This is a (please select all that apply):

- [X] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fix [#29401](https://github.com/hashicorp/terraform-provider-azurerm/issues/29401).