### PR TITLE
`azurerm_postgresql_flexible_server_virtual_endpoint` - is no longer removed from state when a fail-over occurs

### DIFF
--- a/internal/services/postgres/migration/postgresql_flexible_server_virtual_endpoint.go
+++ b/internal/services/postgres/migration/postgresql_flexible_server_virtual_endpoint.go
@@ -1,0 +1,64 @@
+package migration
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2024-08-01/servers"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2024-08-01/virtualendpoints"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type PostgresqlFlexibleServerVirtualEndpointV0toV1 struct{}
+
+var _ pluginsdk.StateUpgrade = PostgresqlFlexibleServerVirtualEndpointV0toV1{}
+
+func (l PostgresqlFlexibleServerVirtualEndpointV0toV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+		},
+		"source_server_id": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+		},
+		"replica_server_id": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+		},
+		"type": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+		},
+	}
+}
+
+func (l PostgresqlFlexibleServerVirtualEndpointV0toV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		oldId := rawState["id"].(string)
+		name := rawState["name"].(string)
+
+		sourceServerId, err := servers.ParseFlexibleServerID(rawState["source_server_id"].(string))
+		if err != nil {
+			return nil, err
+		}
+
+		sourceEndpointId := virtualendpoints.NewVirtualEndpointID(sourceServerId.SubscriptionId, sourceServerId.ResourceGroupName, sourceServerId.FlexibleServerName, name)
+
+		replicaServerId, err := servers.ParseFlexibleServerID(rawState["replica_server_id"].(string))
+		if err != nil {
+			return nil, err
+		}
+
+		replicaEndpointId := virtualendpoints.NewVirtualEndpointID(replicaServerId.SubscriptionId, replicaServerId.ResourceGroupName, replicaServerId.FlexibleServerName, name)
+
+		newId := commonids.NewCompositeResourceID(&sourceEndpointId, &replicaEndpointId).ID()
+
+		log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newId)
+
+		rawState["id"] = newId
+		return rawState, nil
+	}
+}

--- a/internal/services/postgres/postgresql_flexible_server_virtual_endpoint_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_virtual_endpoint_resource.go
@@ -316,7 +316,7 @@ func (r PostgresqlFlexibleServerVirtualEndpointResource) Update() sdk.ResourceFu
 					if err != nil {
 						return fmt.Errorf("retrieving %s: %+v", virtualEndpointId, err)
 					}
-					return fmt.Errorf("a failover has occurred and the `source_server_id` in the config is no longer the SourceServerId for the virtual endpoint. If you wish to change the `replica_server_id`, remove this resource from state and reimport it back in with the `replica_server_id` and `source_server_id` swapped")
+					return fmt.Errorf("a fail-over has occurred and the `source_server_id` in the config is no longer the SourceServerId for the virtual endpoint. If you wish to change the `replica_server_id`, remove this resource from state and reimport it back in with the `replica_server_id` and `source_server_id` swapped")
 				}
 				return fmt.Errorf("retrieving %s: %+v", virtualEndpointId, err)
 			}

--- a/internal/services/postgres/postgresql_flexible_server_virtual_endpoint_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_virtual_endpoint_resource.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2024-08-01/virtualendpoints"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/postgres/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 )
@@ -31,6 +32,8 @@ type PostgresqlFlexibleServerVirtualEndpointModel struct {
 
 var _ sdk.ResourceWithUpdate = PostgresqlFlexibleServerVirtualEndpointResource{}
 
+var _ sdk.ResourceWithStateMigration = PostgresqlFlexibleServerVirtualEndpointResource{}
+
 func (r PostgresqlFlexibleServerVirtualEndpointResource) ModelObject() interface{} {
 	return &PostgresqlFlexibleServerVirtualEndpointModel{}
 }
@@ -40,11 +43,31 @@ func (r PostgresqlFlexibleServerVirtualEndpointResource) ResourceType() string {
 }
 
 func (r PostgresqlFlexibleServerVirtualEndpointResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
-	return virtualendpoints.ValidateVirtualEndpointID
+	return func(input interface{}, key string) (warnings []string, errors []error) {
+		v, ok := input.(string)
+		if !ok {
+			errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+			return
+		}
+
+		if _, err := commonids.ParseCompositeResourceID(v, &virtualendpoints.VirtualEndpointId{}, &virtualendpoints.VirtualEndpointId{}); err != nil {
+			errors = append(errors, err)
+		}
+		return
+	}
 }
 
 func (r PostgresqlFlexibleServerVirtualEndpointResource) Attributes() map[string]*pluginsdk.Schema {
 	return map[string]*pluginsdk.Schema{}
+}
+
+func (r PostgresqlFlexibleServerVirtualEndpointResource) StateUpgraders() sdk.StateUpgradeData {
+	return sdk.StateUpgradeData{
+		SchemaVersion: 1,
+		Upgraders: map[int]pluginsdk.StateUpgrade{
+			0: migration.PostgresqlFlexibleServerVirtualEndpointV0toV1{},
+		},
+	}
 }
 
 func (r PostgresqlFlexibleServerVirtualEndpointResource) Arguments() map[string]*pluginsdk.Schema {
@@ -101,27 +124,30 @@ func (r PostgresqlFlexibleServerVirtualEndpointResource) Create() sdk.ResourceFu
 				return err
 			}
 
-			id := virtualendpoints.NewVirtualEndpointID(sourceServerId.SubscriptionId, sourceServerId.ResourceGroupName, sourceServerId.FlexibleServerName, virtualEndpoint.Name)
+			sourceEndpointId := virtualendpoints.NewVirtualEndpointID(sourceServerId.SubscriptionId, sourceServerId.ResourceGroupName, sourceServerId.FlexibleServerName, virtualEndpoint.Name)
+			replicaEndpointId := virtualendpoints.NewVirtualEndpointID(replicaServerId.SubscriptionId, replicaServerId.ResourceGroupName, replicaServerId.FlexibleServerName, virtualEndpoint.Name)
 
-			locks.ByName(id.FlexibleServerName, postgresqlFlexibleServerResourceName)
-			defer locks.UnlockByName(id.FlexibleServerName, postgresqlFlexibleServerResourceName)
+			locks.ByName(sourceEndpointId.FlexibleServerName, postgresqlFlexibleServerResourceName)
+			defer locks.UnlockByName(sourceEndpointId.FlexibleServerName, postgresqlFlexibleServerResourceName)
 
-			if replicaServerId.FlexibleServerName != id.FlexibleServerName {
+			if replicaServerId.FlexibleServerName != replicaEndpointId.FlexibleServerName {
 				locks.ByName(replicaServerId.FlexibleServerName, postgresqlFlexibleServerResourceName)
 				defer locks.UnlockByName(replicaServerId.FlexibleServerName, postgresqlFlexibleServerResourceName)
 			}
 
 			// This API can be a bit flaky if the same named resource is created/destroyed quickly
 			// usually waiting a minute or two before redeploying is enough to resolve the conflict
-			if err = client.CreateThenPoll(ctx, id, virtualendpoints.VirtualEndpointResource{
+			if err = client.CreateThenPoll(ctx, sourceEndpointId, virtualendpoints.VirtualEndpointResource{
 				Name: &virtualEndpoint.Name,
 				Properties: &virtualendpoints.VirtualEndpointResourceProperties{
 					EndpointType: pointer.To(virtualendpoints.VirtualEndpointType(virtualEndpoint.Type)),
 					Members:      &[]string{replicaServerId.FlexibleServerName},
 				},
 			}); err != nil {
-				return fmt.Errorf("creating %s: %+v", id, err)
+				return fmt.Errorf("creating %s: %+v", sourceEndpointId, err)
 			}
+
+			id := commonids.NewCompositeResourceID(&sourceEndpointId, &replicaEndpointId)
 
 			metadata.SetID(id)
 
@@ -139,21 +165,37 @@ func (r PostgresqlFlexibleServerVirtualEndpointResource) Read() sdk.ResourceFunc
 
 			state := PostgresqlFlexibleServerVirtualEndpointModel{}
 
-			id, err := virtualendpoints.ParseVirtualEndpointID(metadata.ResourceData.Id())
+			id, err := commonids.ParseCompositeResourceID(metadata.ResourceData.Id(), &virtualendpoints.VirtualEndpointId{}, &virtualendpoints.VirtualEndpointId{})
 			if err != nil {
 				return err
 			}
 
-			resp, err := client.Get(ctx, *id)
+			// In case of a fail-over, we need to see if the endpoint lives under the source id or the replica id
+			failOverHasOccurred := false
+			virtualEndpointId := *id.First
+			resp, err := client.Get(ctx, virtualEndpointId)
 			if err != nil {
 				if response.WasNotFound(resp.HttpResponse) {
-					log.Printf("[INFO] %s does not exist - removing from state", metadata.ResourceData.Id())
-					return metadata.MarkAsGone(id)
+					virtualEndpointId = *id.Second
+					// if the endpoint doesn't exist under the source server, look for it under the replica server
+					resp, err = client.Get(ctx, virtualEndpointId)
+					if err != nil {
+						if response.WasNotFound(resp.HttpResponse) {
+							// the endpoint was not found under the source or the replica server so it can safely be removed from state
+							log.Printf("[INFO] %s does not exist - removing from state", metadata.ResourceData.Id())
+							return metadata.MarkAsGone(id)
+						}
+						return fmt.Errorf("retrieving %s: %+v", id, err)
+					}
+					failOverHasOccurred = true
 				}
-				return fmt.Errorf("retrieving %s: %+v", id, err)
+				// if we errored and didn't find the endpoint under the replica id, then we error here
+				if !failOverHasOccurred {
+					return fmt.Errorf("retrieving %s: %+v", id, err)
+				}
 			}
 
-			state.Name = id.VirtualEndpointName
+			state.Name = virtualEndpointId.VirtualEndpointName
 
 			if model := resp.Model; model != nil {
 				if props := model.Properties; props != nil {
@@ -161,18 +203,17 @@ func (r PostgresqlFlexibleServerVirtualEndpointResource) Read() sdk.ResourceFunc
 
 					if props.Members == nil || len(*props.Members) == 0 {
 						// if members list is nil or empty, this is an endpoint that was previously deleted
-						log.Printf("[INFO] Postgresql Flexible Server Endpoint %q was previously deleted - removing from state", id.ID())
+						log.Printf("[INFO] Postgresql Flexible Server Endpoint %q was previously deleted - removing from state", id.First.ID())
 						return metadata.MarkAsGone(id)
 					}
 
-					state.SourceServerId = servers.NewFlexibleServerID(id.SubscriptionId, id.ResourceGroupName, (*props.Members)[0]).ID()
-
+					state.SourceServerId = servers.NewFlexibleServerID(id.First.SubscriptionId, id.First.ResourceGroupName, (*props.Members)[0]).ID()
 					// Model.Properties.Members can contain 1 member which means source and replica are identical, or it can contain
 					// 2 members when source and replica are different => [source_server_id, replication_server_name]
-					replicaServerId := servers.NewFlexibleServerID(id.SubscriptionId, id.ResourceGroupName, (*props.Members)[0]).ID()
+					replicaServerId := state.SourceServerId
 
 					if len(*props.Members) == 2 {
-						replicaServer, err := lookupFlexibleServerByName(ctx, flexibleServerClient, id, (*props.Members)[1], state.SourceServerId)
+						replicaServer, err := lookupFlexibleServerByName(ctx, flexibleServerClient, virtualEndpointId, (*props.Members)[1], state.SourceServerId)
 						if err != nil {
 							return err
 						}
@@ -191,6 +232,11 @@ func (r PostgresqlFlexibleServerVirtualEndpointResource) Read() sdk.ResourceFunc
 				}
 			}
 
+			// if a fail-over has occurred, the source/replica ids have swapped so we'll have to swap them back in Terraform to prevent a diff
+			if failOverHasOccurred {
+				state.SourceServerId, state.ReplicaServerId = state.ReplicaServerId, state.SourceServerId
+			}
+
 			return metadata.Encode(&state)
 		},
 	}
@@ -202,15 +248,39 @@ func (r PostgresqlFlexibleServerVirtualEndpointResource) Delete() sdk.ResourceFu
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
 			client := metadata.Client.Postgres.VirtualEndpointClient
 
-			id, err := virtualendpoints.ParseVirtualEndpointID(metadata.ResourceData.Id())
+			id, err := commonids.ParseCompositeResourceID(metadata.ResourceData.Id(), &virtualendpoints.VirtualEndpointId{}, &virtualendpoints.VirtualEndpointId{})
 			if err != nil {
 				return err
 			}
 
-			locks.ByName(id.FlexibleServerName, postgresqlFlexibleServerResourceName)
-			defer locks.UnlockByName(id.FlexibleServerName, postgresqlFlexibleServerResourceName)
+			// In case of a fail-over, we need to see if the endpoint lives under the source id or the replica id before deleting
+			failOverHasOccurred := false
+			virtualEndpointId := *id.First
+			resp, err := client.Get(ctx, virtualEndpointId)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					virtualEndpointId = *id.Second
+					// if the endpoint doesn't exist under the source server, look for it under the replica server
+					resp, err = client.Get(ctx, virtualEndpointId)
+					if err != nil {
+						if response.WasNotFound(resp.HttpResponse) {
+							// the endpoint was not found under the source or the replica server so we can exit here
+							return nil
+						}
+						return fmt.Errorf("retrieving %s: %+v", id, err)
+					}
+					failOverHasOccurred = true
+				}
+				// if we errored and didn't find the endpoint under the replica id, then we error here
+				if !failOverHasOccurred {
+					return fmt.Errorf("retrieving %s: %+v", id, err)
+				}
+			}
 
-			if err := client.DeleteThenPoll(ctx, *id); err != nil {
+			locks.ByName(virtualEndpointId.FlexibleServerName, postgresqlFlexibleServerResourceName)
+			defer locks.UnlockByName(virtualEndpointId.FlexibleServerName, postgresqlFlexibleServerResourceName)
+
+			if err := client.DeleteThenPoll(ctx, virtualEndpointId); err != nil {
 				return fmt.Errorf("deleting %s: %+v", *id, err)
 			}
 
@@ -221,7 +291,7 @@ func (r PostgresqlFlexibleServerVirtualEndpointResource) Delete() sdk.ResourceFu
 
 func (r PostgresqlFlexibleServerVirtualEndpointResource) Update() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
-		Timeout: 5 * time.Minute,
+		Timeout: 10 * time.Minute,
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
 			var virtualEndpoint PostgresqlFlexibleServerVirtualEndpointModel
 			client := metadata.Client.Postgres.VirtualEndpointClient
@@ -230,9 +300,25 @@ func (r PostgresqlFlexibleServerVirtualEndpointResource) Update() sdk.ResourceFu
 				return err
 			}
 
-			id, err := virtualendpoints.ParseVirtualEndpointID(metadata.ResourceData.Id())
+			id, err := commonids.ParseCompositeResourceID(metadata.ResourceData.Id(), &virtualendpoints.VirtualEndpointId{}, &virtualendpoints.VirtualEndpointId{})
 			if err != nil {
 				return err
+			}
+
+			// attempt to retrieve the endpoint and see if a fail-over has occurred, if so error as we shouldn't update to a different replica server with the `source_server_id` and the `replica_server_id` being swapped
+			virtualEndpointId := *id.First
+			resp, err := client.Get(ctx, virtualEndpointId)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					virtualEndpointId = virtualendpoints.NewVirtualEndpointID(id.Second.SubscriptionId, id.Second.ResourceGroupName, id.Second.FlexibleServerName, id.Second.VirtualEndpointName)
+					// if the endpoint doesn't exist under the source server, look for it under the replica server
+					_, err = client.Get(ctx, virtualEndpointId)
+					if err != nil {
+						return fmt.Errorf("retrieving %s: %+v", virtualEndpointId, err)
+					}
+					return fmt.Errorf("a failover has occurred and the `source_server_id` in the config is no longer the SourceServerId for the virtual endpoint. If you wish to change the `replica_server_id`, remove this resource from state and reimport it back in with the `replica_server_id` and `source_server_id` swapped")
+				}
+				return fmt.Errorf("retrieving %s: %+v", virtualEndpointId, err)
 			}
 
 			replicaServerId, err := servers.ParseFlexibleServerID(virtualEndpoint.ReplicaServerId)
@@ -240,15 +326,16 @@ func (r PostgresqlFlexibleServerVirtualEndpointResource) Update() sdk.ResourceFu
 				return err
 			}
 
-			locks.ByName(id.FlexibleServerName, postgresqlFlexibleServerResourceName)
-			defer locks.UnlockByName(id.FlexibleServerName, postgresqlFlexibleServerResourceName)
+			locks.ByName(id.First.FlexibleServerName, postgresqlFlexibleServerResourceName)
+			defer locks.UnlockByName(id.First.FlexibleServerName, postgresqlFlexibleServerResourceName)
 
-			if replicaServerId.FlexibleServerName != id.FlexibleServerName {
+			if replicaServerId.FlexibleServerName != id.First.FlexibleServerName {
 				locks.ByName(replicaServerId.FlexibleServerName, postgresqlFlexibleServerResourceName)
 				defer locks.UnlockByName(replicaServerId.FlexibleServerName, postgresqlFlexibleServerResourceName)
 			}
 
-			if err := client.UpdateThenPoll(ctx, *id, virtualendpoints.VirtualEndpointResourceForPatch{
+			endpointId := virtualendpoints.NewVirtualEndpointID(id.First.SubscriptionId, id.First.ResourceGroupName, id.First.FlexibleServerName, virtualEndpoint.Name)
+			if err := client.UpdateThenPoll(ctx, endpointId, virtualendpoints.VirtualEndpointResourceForPatch{
 				Properties: &virtualendpoints.VirtualEndpointResourceProperties{
 					EndpointType: pointer.To(virtualendpoints.VirtualEndpointType(virtualEndpoint.Type)),
 					Members:      pointer.To([]string{replicaServerId.FlexibleServerName}),
@@ -257,6 +344,11 @@ func (r PostgresqlFlexibleServerVirtualEndpointResource) Update() sdk.ResourceFu
 				return fmt.Errorf("updating %q: %+v", id, err)
 			}
 
+			// the id has changed and needs to be updated
+			replicaEndpointId := virtualendpoints.NewVirtualEndpointID(replicaServerId.SubscriptionId, replicaServerId.ResourceGroupName, replicaServerId.FlexibleServerName, virtualEndpoint.Name)
+			endPointId := commonids.NewCompositeResourceID(&virtualEndpointId, &replicaEndpointId)
+			metadata.SetID(endPointId)
+
 			return nil
 		},
 	}
@@ -264,7 +356,7 @@ func (r PostgresqlFlexibleServerVirtualEndpointResource) Update() sdk.ResourceFu
 
 // The flexible endpoint API does not store the location/rg information on replicas it only stores the name.
 // This lookup is safe because replicas for a given source server are *not* allowed to have identical names
-func lookupFlexibleServerByName(ctx context.Context, flexibleServerClient *servers.ServersClient, virtualEndpointId *virtualendpoints.VirtualEndpointId, replicaServerName string, sourceServerId string) (*servers.Server, error) {
+func lookupFlexibleServerByName(ctx context.Context, flexibleServerClient *servers.ServersClient, virtualEndpointId virtualendpoints.VirtualEndpointId, replicaServerName string, sourceServerId string) (*servers.Server, error) {
 	postgresServers, err := flexibleServerClient.ListCompleteMatchingPredicate(ctx, commonids.NewSubscriptionID(virtualEndpointId.SubscriptionId), servers.ServerOperationPredicate{
 		Name: &replicaServerName,
 	})

--- a/internal/services/postgres/postgresql_flexible_server_virtual_endpoint_resource_test.go
+++ b/internal/services/postgres/postgresql_flexible_server_virtual_endpoint_resource_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2024-08-01/virtualendpoints"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
@@ -95,12 +96,14 @@ func TestAccPostgresqlFlexibleServerVirtualEndpoint_identicalSourceAndReplica(t 
 }
 
 func (r PostgresqlFlexibleServerVirtualEndpointResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
-	id, err := virtualendpoints.ParseVirtualEndpointID(state.ID)
+	id, err := commonids.ParseCompositeResourceID(state.ID, &virtualendpoints.VirtualEndpointId{}, &virtualendpoints.VirtualEndpointId{})
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := clients.Postgres.VirtualEndpointClient.Get(ctx, *id)
+	virtualEndpointId := virtualendpoints.NewVirtualEndpointID(id.First.SubscriptionId, id.First.ResourceGroupName, id.First.FlexibleServerName, id.First.VirtualEndpointName)
+
+	resp, err := clients.Postgres.VirtualEndpointClient.Get(ctx, virtualEndpointId)
 	if err != nil {
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
@@ -109,12 +112,14 @@ func (r PostgresqlFlexibleServerVirtualEndpointResource) Exists(ctx context.Cont
 }
 
 func (r PostgresqlFlexibleServerVirtualEndpointResource) Destroy(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
-	id, err := virtualendpoints.ParseVirtualEndpointID(state.ID)
+	id, err := commonids.ParseCompositeResourceID(state.ID, &virtualendpoints.VirtualEndpointId{}, &virtualendpoints.VirtualEndpointId{})
 	if err != nil {
 		return nil, err
 	}
 
-	if err := client.Postgres.VirtualEndpointClient.DeleteThenPoll(ctx, *id); err != nil {
+	virtualEndpointId := virtualendpoints.NewVirtualEndpointID(id.First.SubscriptionId, id.First.ResourceGroupName, id.First.FlexibleServerName, id.First.VirtualEndpointName)
+
+	if err := client.Postgres.VirtualEndpointClient.DeleteThenPoll(ctx, virtualEndpointId); err != nil {
 		return nil, fmt.Errorf("deleting %s: %+v", *id, err)
 	}
 

--- a/website/docs/r/postgresql_flexible_server_virtual_endpoint.html.markdown
+++ b/website/docs/r/postgresql_flexible_server_virtual_endpoint.html.markdown
@@ -83,10 +83,10 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the PostgreSQL Flexible Virtual Endpoint.
-* `update` - (Defaults to 30 minutes) Used when updating the PostgreSQL Flexible Virtual Endpoint.
+* `create` - (Defaults to 10 minutes) Used when creating the PostgreSQL Flexible Virtual Endpoint.
+* `update` - (Defaults to 10 minutes) Used when updating the PostgreSQL Flexible Virtual Endpoint.
 * `read` - (Defaults to 5 minutes) Used when retrieving the PostgreSQL Flexible Virtual Endpoint.
-* `delete` - (Defaults to 30 minutes) Used when deleting the PostgreSQL Flexible Virtual Endpoint.
+* `delete` - (Defaults to 5 minutes) Used when deleting the PostgreSQL Flexible Virtual Endpoint.
 
 ## Import
 

--- a/website/docs/r/postgresql_flexible_server_virtual_endpoint.html.markdown
+++ b/website/docs/r/postgresql_flexible_server_virtual_endpoint.html.markdown
@@ -69,6 +69,8 @@ The following arguments are supported:
 
 * `replica_server_id` - (Required) The Resource ID of the *Replica* Postgres Flexible Server this should be associated with
 
+~> **Note:** If a fail-over has occurred, you will be unable to update `replica_server_id`. You can remove the resource from state and reimport it back in with `source_server_id` and `replica_server_id` flipped and then update `replica_server_id`.
+
 * `type` - (Required) The type of Virtual Endpoint. Currently only `ReadWrite` is supported.
 
 ## Attributes Reference
@@ -89,7 +91,6 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 ## Import
 
 A PostgreSQL Flexible Virtual Endpoint can be imported using the `resource id`, e.g.
-
 ```shell
-terraform import azurerm_postgresql_flexible_server_virtual_endpoint.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.DBforPostgreSQL/flexibleServers/server1/virtualEndpoints/endpoint1
+terraform import azurerm_postgresql_flexible_server_virtual_endpoint.example "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.DBforPostgreSQL/flexibleServers/sourceServerName/virtualEndpoints/endpointName|/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.DBforPostgreSQL/flexibleServers/replicaServerName/virtualEndpoints/endpointName"
 ```


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR fixes #27796 where the resource is removed from state when a fail-over occurs. Instead of removing from state, we'll check to see if the resource exists under the replica server id. If it does, we hide the fact that a fail-over occurred. We've had to update the id of the resource to account for that and we've had to prevent the ability of the `replica_server_id` from being changed if a fail-over occurred due to the myriad of edge cases we'd need to account for.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_postgresql_flexible_server_virtual_endpoint` - is no longer removed from state when a fail-over occurs[GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #27796


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
