### PR TITLE
Rcsk/changelog permissions update

### DIFF
--- a/.github/workflows/changelog_entry.yml
+++ b/.github/workflows/changelog_entry.yml
@@ -1,0 +1,34 @@
+name: GetChangelogEntry
+
+permissions:
+  pull-requests: write
+  contents: write
+
+on:
+  pull_request:
+    # Inputs the workflow accepts.
+    types: [closed]
+
+jobs:
+  pull-commit-message:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        continue-on-error: true
+      - name: get merge commit message 
+        id: pull
+        run: |
+         pull_number="$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")" 
+         commit_message="$(git log --pretty="format:%b")"
+         echo message="$commit_message [GH-$pull_number]"  >> $GITHUB_OUTPUT
+      - name: Save changelog entry
+        env:
+            CHANGELOG_ENTRY: ${{ steps.pull.outputs.message }}
+        run: |
+            echo "$CHANGELOG_ENTRY" > changelog_entry.txt
+      - uses: actions/upload-artifact@v4
+        with:
+            name: changelog_entry
+            path: changelog_entry.txt
+            overwrite: true

--- a/.github/workflows/changelog_entry.yml
+++ b/.github/workflows/changelog_entry.yml
@@ -27,7 +27,7 @@ jobs:
             CHANGELOG_ENTRY: ${{ steps.pull.outputs.message }}
         run: |
             echo "$CHANGELOG_ENTRY" > changelog_entry.txt
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
             name: changelog_entry
             path: changelog_entry.txt

--- a/.github/workflows/update_changelog.yml
+++ b/.github/workflows/update_changelog.yml
@@ -82,8 +82,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true
         run: |
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config user.name "github-actions[bot]"
+          git config user.name "hc-github-team-tf-azure"
+          git config user.email "<>"
           
           #new pull request for new release needs the headers all added to the top
           FILE="CHANGELOG.md"
@@ -125,8 +125,8 @@ jobs:
             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true
         run: |
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config user.name "github-actions[bot]"
+          git config user.name "hc-github-team-tf-azure"
+          git config user.email "<>"
           
           go run internal/tools/changelog-updater/update_changelog.go CHANGELOG.md '${{ needs.changelog-entry.outputs.entry }}'
           

--- a/.github/workflows/update_changelog.yml
+++ b/.github/workflows/update_changelog.yml
@@ -28,7 +28,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Download artifact from "Get Changelog Entry" workflow
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e #v4.2.1
         with:
           name: changelog_entry # Match name used in changelog_entry.yml upload artifact step
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update_changelog.yml
+++ b/.github/workflows/update_changelog.yml
@@ -1,38 +1,52 @@
-name: Update Changelog with new commit
+name: Update Changelog PR
 
 permissions:
   pull-requests: write
   contents: write
 
 on:
-  pull_request:
-    # Inputs the workflow accepts.
-    types: [closed]
+  workflow_run:
+    workflows: [GetChangelogEntry]
+    types:
+      - completed
 
 jobs:
-  pull-commit-message:
-    if: github.event.pull_request.merged == true
+  # if there is a changelog entry, check for PR Open
+  download:
     runs-on: ubuntu-latest
     outputs:
       message: ${{ steps.pull.outputs.message }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        continue-on-error: true
-      - name: get merge commit message 
+      - name: Get run ID of "Test" workflow
+        id: get-run-id
+        run: |
+          OTHER_REPO="${{ github.repository }}"
+          WF_NAME="GetChangelogEntry"
+          RUN_ID=`gh run --repo ${OTHER_REPO} list --workflow ${WF_NAME} --json databaseId --jq .[0].databaseId`
+          echo "Detected latest run id of ${RUN_ID} for workflow ${WF_NAME}"
+          echo "run-id=${RUN_ID}" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Download artifact from "Get Changelog Entry" workflow
+        uses: actions/download-artifact@v4
+        with:
+          name: changelog_entry # Match name used in changelog_entry.yml upload artifact step
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          run-id: ${{ steps.get-run-id.outputs.run-id }}
+      - name: 'Store entry'
         id: pull
         run: |
-         pull_number="$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")" 
-         commit_message="$(git log --pretty="format:%b")"
-         echo message="$commit_message [GH-$pull_number]"  >> $GITHUB_OUTPUT
+          echo message="$(cat changelog_entry.txt)"  >> $GITHUB_OUTPUT
   # check-for-changelog-entry
   changelog-entry:
     # if contains to check for bug, enhancement, feature
-    if: ${{ contains(needs.pull-commit-message.outputs.message, '[BUG]') || contains(needs.pull-commit-message.outputs.message, '[ENHANCEMENT]') || contains(needs.pull-commit-message.outputs.message, '[FEATURE]') }}
+    if: ${{ contains(needs.download.outputs.message, '[BUG]') || contains(needs.download.outputs.message, '[ENHANCEMENT]') || contains(needs.download.outputs.message, '[FEATURE]') }}
     runs-on: ubuntu-latest
-    needs: pull-commit-message
+    needs: download
     outputs:
       optIn: ${{ steps.in.outputs.bool }}
-      entry: ${{  needs.pull-commit-message.outputs.message  }}
+      entry: ${{  needs.download.outputs.message  }}
     steps:
       - name: changelog entry opt in
         id: in
@@ -82,8 +96,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true
         run: |
-          git config user.name "hc-github-team-tf-azure"
-          git config user.email "<>"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
           
           #new pull request for new release needs the headers all added to the top
           FILE="CHANGELOG.md"
@@ -125,8 +139,8 @@ jobs:
             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true
         run: |
-          git config user.name "hc-github-team-tf-azure"
-          git config user.email "<>"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
           
           go run internal/tools/changelog-updater/update_changelog.go CHANGELOG.md '${{ needs.changelog-entry.outputs.entry }}'
           


### PR DESCRIPTION
The original workflow is made to be triggered on: pull_request instead of pull_request_target because access to the merge commit message is needed. But then because of pull_request, the permissions on the workflow do not allow a changelog PR to be opened if the merged PR is from a fork. 

This PR splits the actions into 2 workflows, the first is able to grab the merge commit message and create the changelog entry, then it kicks off a second workflow that does have the permissions required for a new PR to be opened.

I tested this on my personal repo, and tested with a forked contribution. It is still possible there may be new permissions uncovered but this should fix the error that's currently surfacing. 

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [X] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change
