### PR TITLE
feat(azurerm_dashboard_grafana_managed_private_endpoint) add privatelink_service_url

### DIFF
--- a/internal/services/dashboard/dashboard_grafana_managed_private_endpoint_resource.go
+++ b/internal/services/dashboard/dashboard_grafana_managed_private_endpoint_resource.go
@@ -32,6 +32,7 @@ type ManagedPrivateEndpointModel struct {
 	Tags                      map[string]string `tfschema:"tags"`
 	GroupIds                  []string          `tfschema:"group_ids"`
 	RequestMessage            string            `tfschema:"request_message"`
+	PrivateLinkServiceURL     string            `tfschema:"private_link_service_url"`
 }
 
 type ManagedPrivateEndpointId struct {
@@ -105,6 +106,12 @@ func (r ManagedPrivateEndpointResource) Arguments() map[string]*pluginsdk.Schema
 			Optional:     true,
 			ValidateFunc: validation.StringIsNotEmpty,
 		},
+
+		"private_link_service_url": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
 	}
 }
 
@@ -145,6 +152,7 @@ func (r ManagedPrivateEndpointResource) Create() sdk.ResourceFunc {
 					PrivateLinkResourceId:     &model.PrivateLinkResourceId,
 					PrivateLinkResourceRegion: &model.PrivateLinkResourceRegion,
 					RequestMessage:            &model.RequestMessage,
+					PrivateLinkServiceURL:     &model.PrivateLinkServiceURL,
 				},
 				Tags: &model.Tags,
 			}
@@ -193,6 +201,7 @@ func (r ManagedPrivateEndpointResource) Read() sdk.ResourceFunc {
 					state.PrivateLinkResourceId = pointer.From(props.PrivateLinkResourceId)
 					state.PrivateLinkResourceRegion = pointer.From(props.PrivateLinkResourceRegion)
 					state.RequestMessage = pointer.From(props.RequestMessage)
+					state.PrivateLinkServiceURL = pointer.From(props.PrivateLinkServiceURL)
 				}
 			}
 

--- a/internal/services/dashboard/dashboard_grafana_managed_private_endpoint_resource_test.go
+++ b/internal/services/dashboard/dashboard_grafana_managed_private_endpoint_resource_test.go
@@ -166,6 +166,8 @@ resource "azurerm_dashboard_grafana_managed_private_endpoint" "test" {
   }
 
   request_message = "please approve"
+
+  private_link_service_url = "example.com"
 }
 `, template, data.RandomIntOfLength(8))
 }
@@ -188,6 +190,8 @@ resource "azurerm_dashboard_grafana_managed_private_endpoint" "test" {
   }
 
   request_message = "please approve"
+
+  private_link_service_url = "example.com"
 }
 `, template, data.RandomIntOfLength(8))
 }

--- a/website/docs/r/dashboard_grafana_managed_private_endpoint.html.markdown
+++ b/website/docs/r/dashboard_grafana_managed_private_endpoint.html.markdown
@@ -46,6 +46,7 @@ resource "azurerm_dashboard_grafana_managed_private_endpoint" "example" {
   private_link_resource_id     = azurerm_monitor_workspace.example.id
   group_ids                    = ["prometheusMetrics"]
   private_link_resource_region = azurerm_dashboard_grafana.example.location
+  private_link_service_url     = "mydomain.com"
 }
 ```
 
@@ -68,6 +69,8 @@ The following arguments are supported:
 - `private_link_resource_region` - (Optional) The region in which to create the private link. Changing this forces a new Dashboard Grafana Managed Private Endpoint to be created.
 
 - `request_message` - (Optional) A message to provide in the request which will be seen by approvers.
+
+- `private_link_service_url` - (Optional) A domain name for this endpoint to be used within Grafana
 
 - `tags` - (Optional) A mapping of tags which should be assigned to the Dashboard Grafana Managed Private Endpoint.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

adds privatelink_service_url, to allow setting a domain name for the private endpoint, that can be used inside Grafana, for datasources or alerts


## PR Checklist

- [x ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [x ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_dashboard_grafana_managed_private_endpoint` - support for the `private_link_service_url` property [GH-29465]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #29465


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
