### PR TITLE
`azurerm_netapp_pool` - add support for `cool_access_enabled`

### DIFF
--- a/internal/services/netapp/netapp_pool_data_source.go
+++ b/internal/services/netapp/netapp_pool_data_source.go
@@ -88,7 +88,7 @@ func dataSourceNetAppPoolRead(d *pluginsdk.ResourceData, meta interface{}) error
 	d.Set("resource_group_name", id.ResourceGroupName)
 
 	if model := resp.Model; model != nil {
-		d.Set("location", location.NormalizeNilable(&model.Location))
+		d.Set("location", location.Normalize(model.Location))
 
 		props := model.Properties
 		d.Set("service_level", string(props.ServiceLevel))

--- a/internal/services/netapp/netapp_pool_data_source.go
+++ b/internal/services/netapp/netapp_pool_data_source.go
@@ -57,6 +57,11 @@ func dataSourceNetAppPool() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
 			},
+
+			"cool_access_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -84,9 +89,12 @@ func dataSourceNetAppPoolRead(d *pluginsdk.ResourceData, meta interface{}) error
 
 	if model := resp.Model; model != nil {
 		d.Set("location", location.NormalizeNilable(&model.Location))
-		d.Set("service_level", string(model.Properties.ServiceLevel))
-		d.Set("size_in_tb", model.Properties.Size/1099511627776)
-		d.Set("encryption_type", string(pointer.From(model.Properties.EncryptionType)))
+
+		props := model.Properties
+		d.Set("service_level", string(props.ServiceLevel))
+		d.Set("size_in_tb", props.Size/1099511627776)
+		d.Set("encryption_type", string(pointer.From(props.EncryptionType)))
+		d.Set("cool_access_enabled", pointer.From(props.CoolAccess))
 	}
 
 	return nil

--- a/internal/services/netapp/netapp_pool_resource.go
+++ b/internal/services/netapp/netapp_pool_resource.go
@@ -100,8 +100,21 @@ func resourceNetAppPool() *pluginsdk.Resource {
 				}, false),
 			},
 
+			"cool_access_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
 			"tags": commonschema.Tags(),
 		},
+
+		CustomizeDiff: pluginsdk.CustomDiffWithAll(
+			// `cool_access_enabled` cannot be disabled
+			pluginsdk.ForceNewIfChange("cool_access_enabled", func(ctx context.Context, old, new, meta interface{}) bool {
+				return old.(bool) && !new.(bool)
+			}),
+		),
 	}
 
 	return resource
@@ -138,6 +151,7 @@ func resourceNetAppPoolCreate(d *pluginsdk.ResourceData, meta interface{}) error
 			ServiceLevel:   capacitypools.ServiceLevel(d.Get("service_level").(string)),
 			Size:           sizeInBytes,
 			EncryptionType: &encryptionType,
+			CoolAccess:     pointer.To(d.Get("cool_access_enabled").(bool)),
 		},
 		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
 	}
@@ -185,6 +199,10 @@ func resourceNetAppPoolUpdate(d *pluginsdk.ResourceData, meta interface{}) error
 	if d.HasChange("qos_type") {
 		qosType := capacitypools.QosType(d.Get("qos_type").(string))
 		update.Properties.QosType = &qosType
+	}
+
+	if d.HasChange("cool_access_enabled") {
+		update.Properties.CoolAccess = pointer.To(d.Get("cool_access_enabled").(bool))
 	}
 
 	if d.HasChange("tags") {
@@ -244,6 +262,7 @@ func resourceNetAppPoolRead(d *pluginsdk.ResourceData, meta interface{}) error {
 		}
 		d.Set("qos_type", qosType)
 		d.Set("encryption_type", string(pointer.From(poolProperties.EncryptionType)))
+		d.Set("cool_access_enabled", pointer.From(poolProperties.CoolAccess))
 
 		return tags.FlattenAndSet(d, model.Tags)
 	}

--- a/website/docs/d/netapp_pool.html.markdown
+++ b/website/docs/d/netapp_pool.html.markdown
@@ -46,7 +46,7 @@ The following attributes are exported:
 
 * `encryption_type` - The encryption type of the pool.
 
-* `cool_access_enabled` - Can the pool hold cool access enabled volumes?
+* `cool_access_enabled` - Whether the NetApp Pool can hold cool access enabled volumes.
 
 ---
 

--- a/website/docs/d/netapp_pool.html.markdown
+++ b/website/docs/d/netapp_pool.html.markdown
@@ -46,6 +46,8 @@ The following attributes are exported:
 
 * `encryption_type` - The encryption type of the pool.
 
+* `cool_access_enabled` - Can the pool hold cool access enabled volumes?
+
 ---
 
 ## Timeouts

--- a/website/docs/r/netapp_pool.html.markdown
+++ b/website/docs/r/netapp_pool.html.markdown
@@ -50,13 +50,17 @@ The following arguments are supported:
 
 * `size_in_tb` - (Required) Provisioned size of the pool in TB. Value must be between `1` and `2048`.
 
-~> **NOTE** `2` TB capacity pool sizing is currently in preview. You can only take advantage of the `2` TB minimum if all the volumes in the capacity pool are using `Standard` network features. If any volume is using `Basic` network features, the minimum size is `4` TB. Please see the product [documentation](https://learn.microsoft.com/azure/azure-netapp-files/azure-netapp-files-set-up-capacity-pool) for more information.
+~> **Note:** `2` TB capacity pool sizing is currently in preview. You can only take advantage of the `2` TB minimum if all the volumes in the capacity pool are using `Standard` network features. If any volume is using `Basic` network features, the minimum size is `4` TB. Please see the product [documentation](https://learn.microsoft.com/azure/azure-netapp-files/azure-netapp-files-set-up-capacity-pool) for more information.
 
-~> **NOTE** The maximum `size_in_tb` is goverened by regional quotas. You may request additional capacity from Azure, currently up to `2048`.
+~> **Note:** The maximum `size_in_tb` is goverened by regional quotas. You may request additional capacity from Azure, currently up to `2048`.
 
 * `qos_type` - (Optional) QoS Type of the pool. Valid values include `Auto` or `Manual`. Defaults to `Auto`.
 
 * `encryption_type` - (Optional) The encryption type of the pool. Valid values include `Single`, and `Double`. Defaults to `Single`. Changing this forces a new resource to be created.
+
+* `cool_access_enabled` - (Optional) Can the pool hold cool access enabled volumes? Defaults to `false`. 
+
+~> **Note:** Disabling `cool_access_enabled` is not allowed and forces a new resource to be created.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 

--- a/website/docs/r/netapp_pool.html.markdown
+++ b/website/docs/r/netapp_pool.html.markdown
@@ -58,7 +58,7 @@ The following arguments are supported:
 
 * `encryption_type` - (Optional) The encryption type of the pool. Valid values include `Single`, and `Double`. Defaults to `Single`. Changing this forces a new resource to be created.
 
-* `cool_access_enabled` - (Optional) Can the pool hold cool access enabled volumes? Defaults to `false`. 
+* `cool_access_enabled` - (Optional) Whether the NetApp Pool can hold cool access enabled volumes. Defaults to `false`.
 
 ~> **Note:** Disabling `cool_access_enabled` is not allowed and forces a new resource to be created.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_netapp_pool` - add support for `cool_access_enabled` [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
