### PR TITLE
[Bug:] `azurerm_cdn_frontdoor_rule` - fix shared schema validation to point to the `rules` package instead of `waf` package for `url_path_condition` code block `operator` property

### DIFF
--- a/internal/services/cdn/cdn_frontdoor_rule_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_rule_resource.go
@@ -60,10 +60,8 @@ func resourceCdnFrontDoorRule() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
 				Default:  string(rules.MatchProcessingBehaviorContinue),
-				ValidateFunc: validation.StringInSlice([]string{
-					string(rules.MatchProcessingBehaviorContinue),
-					string(rules.MatchProcessingBehaviorStop),
-				}, false),
+				ValidateFunc: validation.StringInSlice(rules.PossibleValuesForMatchProcessingBehavior(),
+					false),
 			},
 
 			"order": {
@@ -89,23 +87,16 @@ func resourceCdnFrontDoorRule() *pluginsdk.Resource {
 									"redirect_type": {
 										Type:     pluginsdk.TypeString,
 										Required: true,
-										ValidateFunc: validation.StringInSlice([]string{
-											string(rules.RedirectTypeMoved),
-											string(rules.RedirectTypeFound),
-											string(rules.RedirectTypeTemporaryRedirect),
-											string(rules.RedirectTypePermanentRedirect),
-										}, false),
+										ValidateFunc: validation.StringInSlice(rules.PossibleValuesForRedirectType(),
+											false),
 									},
 
 									"redirect_protocol": {
 										Type:     pluginsdk.TypeString,
 										Optional: true,
 										Default:  string(rules.DestinationProtocolMatchRequest),
-										ValidateFunc: validation.StringInSlice([]string{
-											string(rules.DestinationProtocolMatchRequest),
-											string(rules.DestinationProtocolHTTP),
-											string(rules.DestinationProtocolHTTPS),
-										}, false),
+										ValidateFunc: validation.StringInSlice(rules.PossibleValuesForDestinationProtocol(),
+											false),
 									},
 
 									// NOTE: it is valid for the destination path to be an empty string,
@@ -184,11 +175,8 @@ func resourceCdnFrontDoorRule() *pluginsdk.Resource {
 									"header_action": {
 										Type:     pluginsdk.TypeString,
 										Required: true,
-										ValidateFunc: validation.StringInSlice([]string{
-											string(rules.HeaderActionAppend),
-											string(rules.HeaderActionOverwrite),
-											string(rules.HeaderActionDelete),
-										}, false),
+										ValidateFunc: validation.StringInSlice(rules.PossibleValuesForHeaderAction(),
+											false),
 									},
 
 									"header_name": {
@@ -215,11 +203,8 @@ func resourceCdnFrontDoorRule() *pluginsdk.Resource {
 									"header_action": {
 										Type:     pluginsdk.TypeString,
 										Required: true,
-										ValidateFunc: validation.StringInSlice([]string{
-											string(rules.HeaderActionAppend),
-											string(rules.HeaderActionOverwrite),
-											string(rules.HeaderActionDelete),
-										}, false),
+										ValidateFunc: validation.StringInSlice(rules.PossibleValuesForHeaderAction(),
+											false),
 									},
 
 									"header_name": {
@@ -254,23 +239,16 @@ func resourceCdnFrontDoorRule() *pluginsdk.Resource {
 									"forwarding_protocol": {
 										Type:     pluginsdk.TypeString,
 										Optional: true,
-										ValidateFunc: validation.StringInSlice([]string{
-											string(rules.ForwardingProtocolHTTPOnly),
-											string(rules.ForwardingProtocolHTTPSOnly),
-											string(rules.ForwardingProtocolMatchRequest),
-										}, false),
+										ValidateFunc: validation.StringInSlice(rules.PossibleValuesForForwardingProtocol(),
+											false),
 									},
 
 									// Removed Default value for issue #19008
 									"query_string_caching_behavior": {
 										Type:     pluginsdk.TypeString,
 										Optional: true,
-										ValidateFunc: validation.StringInSlice([]string{
-											string(rules.RuleQueryStringCachingBehaviorIgnoreQueryString),
-											string(rules.RuleQueryStringCachingBehaviorUseQueryString),
-											string(rules.RuleQueryStringCachingBehaviorIgnoreSpecifiedQueryStrings),
-											string(rules.RuleQueryStringCachingBehaviorIncludeSpecifiedQueryStrings),
-										}, false),
+										ValidateFunc: validation.StringInSlice(rules.PossibleValuesForRuleQueryStringCachingBehavior(),
+											false),
 									},
 
 									// NOTE: CSV implemented as a list, code already written for the expanded and flatten to CSV
@@ -450,7 +428,7 @@ func resourceCdnFrontDoorRule() *pluginsdk.Resource {
 
 							Elem: &pluginsdk.Resource{
 								Schema: map[string]*pluginsdk.Schema{
-									"operator":         schemaCdnFrontDoorOperator(),
+									"operator":         schemaCdnFrontDoorUrlPathOperator(),
 									"negate_condition": schemaCdnFrontDoorNegateCondition(),
 									"match_values":     schemaCdnFrontDoorUrlPathConditionMatchValues(),
 									"transforms":       schemaCdnFrontDoorRuleTransforms(),

--- a/internal/services/cdn/cdn_frontdoor_shared_schema.go
+++ b/internal/services/cdn/cdn_frontdoor_shared_schema.go
@@ -5,17 +5,29 @@ package cdn
 
 import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2024-09-01/rules"
-	waf "github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2024-02-01/webapplicationfirewallpolicies"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cdn/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 )
 
+// Fix for issue: #29415, the 'rules.PossibleValuesForQueryStringOperator()' contains the
+// standard 10 operators...
 func schemaCdnFrontDoorOperator() *pluginsdk.Schema {
 	return &pluginsdk.Schema{
 		Type:     pluginsdk.TypeString,
 		Required: true,
-		ValidateFunc: validation.StringInSlice(waf.PossibleValuesForOperator(),
+		ValidateFunc: validation.StringInSlice(rules.PossibleValuesForQueryStringOperator(),
+			false),
+	}
+}
+
+// Fix for issue: #29415, the 'rules.PossibleValuesForURLPathOperator()' contains the
+// standard 10 operator plus the additional 'Wildcard' operator...
+func schemaCdnFrontDoorUrlPathOperator() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeString,
+		Required: true,
+		ValidateFunc: validation.StringInSlice(rules.PossibleValuesForURLPathOperator(),
 			false),
 	}
 }
@@ -24,10 +36,9 @@ func schemaCdnFrontDoorOperatorEqualOnly() *pluginsdk.Schema {
 	return &pluginsdk.Schema{
 		Type:     pluginsdk.TypeString,
 		Optional: true,
-		Default:  string(waf.OperatorEqual),
-		ValidateFunc: validation.StringInSlice([]string{
-			string(waf.OperatorEqual),
-		}, false),
+		Default:  string(rules.OperatorEqual),
+		ValidateFunc: validation.StringInSlice(rules.PossibleValuesForOperator(),
+			false),
 	}
 }
 
@@ -35,12 +46,9 @@ func schemaCdnFrontDoorOperatorRemoteAddress() *pluginsdk.Schema {
 	return &pluginsdk.Schema{
 		Type:     pluginsdk.TypeString,
 		Optional: true,
-		Default:  string(waf.OperatorIPMatch),
-		ValidateFunc: validation.StringInSlice([]string{
-			string(waf.OperatorAny),
-			string(waf.OperatorIPMatch),
-			string(waf.OperatorGeoMatch),
-		}, false),
+		Default:  string(rules.RemoteAddressOperatorIPMatch),
+		ValidateFunc: validation.StringInSlice(rules.PossibleValuesForRemoteAddressOperator(),
+			false),
 	}
 }
 
@@ -48,11 +56,9 @@ func schemaCdnFrontDoorOperatorSocketAddress() *pluginsdk.Schema {
 	return &pluginsdk.Schema{
 		Type:     pluginsdk.TypeString,
 		Optional: true,
-		Default:  string(waf.OperatorIPMatch),
-		ValidateFunc: validation.StringInSlice([]string{
-			string(waf.OperatorAny),
-			string(waf.OperatorIPMatch),
-		}, false),
+		Default:  string(rules.SocketAddrOperatorIPMatch),
+		ValidateFunc: validation.StringInSlice(rules.PossibleValuesForSocketAddrOperator(),
+			false),
 	}
 }
 
@@ -101,11 +107,8 @@ func schemaCdnFrontDoorSslProtocolMatchValues() *pluginsdk.Schema {
 
 		Elem: &pluginsdk.Schema{
 			Type: pluginsdk.TypeString,
-			ValidateFunc: validation.StringInSlice([]string{
-				string(rules.SslProtocolTLSvOne),
-				string(rules.SslProtocolTLSvOnePointOne),
-				string(rules.SslProtocolTLSvOnePointTwo),
-			}, false),
+			ValidateFunc: validation.StringInSlice(rules.PossibleValuesForSslProtocol(),
+				false),
 		},
 	}
 }
@@ -144,15 +147,8 @@ func schemaCdnFrontDoorRequestMethodMatchValues() *pluginsdk.Schema {
 
 		Elem: &pluginsdk.Schema{
 			Type: pluginsdk.TypeString,
-			ValidateFunc: validation.StringInSlice([]string{
-				"GET",
-				"POST",
-				"PUT",
-				"DELETE",
-				"HEAD",
-				"OPTIONS",
-				"TRACE",
-			}, false),
+			ValidateFunc: validation.StringInSlice(rules.PossibleValuesForRequestMethodMatchValue(),
+				false),
 		},
 	}
 }
@@ -165,11 +161,9 @@ func schemaCdnFrontDoorProtocolMatchValues() *pluginsdk.Schema {
 
 		Elem: &pluginsdk.Schema{
 			Type:    pluginsdk.TypeString,
-			Default: "HTTP",
-			ValidateFunc: validation.StringInSlice([]string{
-				"HTTP",
-				"HTTPS",
-			}, false),
+			Default: rules.RequestSchemeMatchValueHTTP,
+			ValidateFunc: validation.StringInSlice(rules.PossibleValuesForRequestSchemeMatchValue(),
+				false),
 		},
 	}
 }
@@ -182,10 +176,8 @@ func schemaCdnFrontDoorIsDeviceMatchValues() *pluginsdk.Schema {
 
 		Elem: &pluginsdk.Schema{
 			Type: pluginsdk.TypeString,
-			ValidateFunc: validation.StringInSlice([]string{
-				"Mobile",
-				"Desktop",
-			}, false),
+			ValidateFunc: validation.StringInSlice(rules.PossibleValuesForIsDeviceMatchValue(),
+				false),
 		},
 	}
 }
@@ -216,7 +208,7 @@ func schemaCdnFrontDoorRuleTransforms() *pluginsdk.Schema {
 
 		Elem: &pluginsdk.Schema{
 			Type: pluginsdk.TypeString,
-			ValidateFunc: validation.StringInSlice(waf.PossibleValuesForTransformType(),
+			ValidateFunc: validation.StringInSlice(rules.PossibleValuesForTransform(),
 				false),
 		},
 	}

--- a/website/docs/r/cdn_frontdoor_rule.html.markdown
+++ b/website/docs/r/cdn_frontdoor_rule.html.markdown
@@ -152,7 +152,7 @@ The following arguments are supported:
 
 * `order` - (Required) The order in which the rules will be applied for the Front Door Endpoint. The order value should be sequential and begin at `1`(e.g. `1`, `2`, `3`...). A Front Door Rule with a lesser order value will be applied before a rule with a greater order value.
 
-->**NOTE:** If the Front Door Rule has an order value of `0` they do not require any conditions and the actions will always be applied.
+-> **Note:** If the Front Door Rule has an order value of `0` they do not require any conditions and the actions will always be applied.
 
 * `actions` - (Required) An `actions` block as defined below.
 
@@ -164,7 +164,7 @@ The following arguments are supported:
 
 An `actions` block supports the following:
 
-->**NOTE:** You may include up to 5 separate actions in the `actions` block.
+-> **Note:** You may include up to 5 separate actions in the `actions` block.
 
 Some actions support `Action Server Variables` which provide access to structured information about the request. For more information about `Action Server Variables` see the `Action Server Variables` as defined below.
 
@@ -198,25 +198,23 @@ An `url_redirect_action` block supports the following:
 
 A `route_configuration_override_action` block supports the following:
 
-->**NOTE:** In the v3.x of the provider the `cache_duration`, `cache_behavior` and `query_string_caching_behavior` will have default values. You can use Terraform's [ignore_changes](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#ignore_changes) functionality to ignore these default values. In v4.0 of the provider the `cache_duration`, `cache_behavior` and `query_string_caching_behavior` will **NOT** have default values and will need to be explicitly set in the configuration file.
-
 * `cache_duration` - (Optional) When Cache behavior is set to `Override` or `SetIfMissing`, this field specifies the cache duration to use. The maximum duration is 366 days specified in the `d.HH:MM:SS` format(e.g. `365.23:59:59`). If the desired maximum cache duration is less than 1 day then the maximum cache duration should be specified in the `HH:MM:SS` format(e.g. `23:59:59`).
 
 * `cdn_frontdoor_origin_group_id` - (Optional) The Front Door Origin Group resource ID that the request should be routed to. This overrides the configuration specified in the Front Door Endpoint route.
 
 * `forwarding_protocol` - (Optional) The forwarding protocol the request will be redirected as. This overrides the configuration specified in the route to be associated with. Possible values include `MatchRequest`, `HttpOnly` or `HttpsOnly`.
 
-->**NOTE:** If the `cdn_frontdoor_origin_group_id` is not defined you cannot set the `forwarding_protocol`.
+-> **Note:** If the `cdn_frontdoor_origin_group_id` is not defined you cannot set the `forwarding_protocol`.
 
 * `query_string_caching_behavior` - (Optional) `IncludeSpecifiedQueryStrings` query strings specified in the `query_string_parameters` field get included when the cache key gets generated. `UseQueryString` cache every unique URL, each unique URL will have its own cache key. `IgnoreSpecifiedQueryStrings` query strings specified in the `query_string_parameters` field get excluded when the cache key gets generated. `IgnoreQueryString` query strings aren't considered when the cache key gets generated. Possible values include `IgnoreQueryString`, `UseQueryString`, `IgnoreSpecifiedQueryStrings` or `IncludeSpecifiedQueryStrings`.
 
 * `query_string_parameters` - (Optional) A list of query string parameter names.
 
-->**NOTE:** `query_string_parameters` is a required field when the `query_string_caching_behavior` is set to `IncludeSpecifiedQueryStrings` or `IgnoreSpecifiedQueryStrings`.
+-> **Note:** `query_string_parameters` is a required field when the `query_string_caching_behavior` is set to `IncludeSpecifiedQueryStrings` or `IgnoreSpecifiedQueryStrings`.
 
 * `compression_enabled` - (Optional) Should the Front Door dynamically compress the content? Possible values include `true` or `false`.
 
-->**NOTE:** Content won't be compressed on AzureFrontDoor when requested content is smaller than `1 byte` or larger than `1 MB`.
+-> **Note:** Content won't be compressed on AzureFrontDoor when requested content is smaller than `1 byte` or larger than `1 MB`.
 
 * `cache_behavior` - (Optional) `HonorOrigin` the Front Door will always honor origin response header directive. If the origin directive is missing, Front Door will cache contents anywhere from `1` to `3` days. `OverrideAlways` the TTL value returned from your Front Door Origin is overwritten with the value specified in the action. This behavior will only be applied if the response is cacheable. `OverrideIfOriginMissing` if no TTL value gets returned from your Front Door Origin, the rule sets the TTL to the value specified in the action. This behavior will only be applied if the response is cacheable. `Disabled` the Front Door will not cache the response contents, irrespective of Front Door Origin response directives. Possible values include `HonorOrigin`, `OverrideAlways`, `OverrideIfOriginMissing` or `Disabled`.
 
@@ -236,13 +234,13 @@ A `request_header_action` block supports the following:
 
 * `header_action` - (Required) The action to be taken on the specified `header_name`. Possible values include `Append`, `Overwrite` or `Delete`.
 
--> **NOTE:** `Append` causes the specified header to be added to the request with the specified value. If the header is already present, the value is appended to the existing header value using string concatenation. No delimiters are added. `Overwrite` causes specified header to be added to the request with the specified value. If the header is already present, the specified value overwrites the existing value. `Delete` causes the header to be deleted from the request.
+-> **Note:** `Append` causes the specified header to be added to the request with the specified value. If the header is already present, the value is appended to the existing header value using string concatenation. No delimiters are added. `Overwrite` causes specified header to be added to the request with the specified value. If the header is already present, the specified value overwrites the existing value. `Delete` causes the header to be deleted from the request.
 
 * `header_name` - (Required) The name of the header to modify.
 
 * `value` - (Optional) The value to append or overwrite.
 
-->**NOTE:** `value` is required if the `header_action` is set to `Append` or `Overwrite`.
+-> **Note:** `value` is required if the `header_action` is set to `Append` or `Overwrite`.
 
 ---
 
@@ -250,19 +248,19 @@ A `response_header_action` block supports the following:
 
 * `header_action` - (Required) The action to be taken on the specified `header_name`. Possible values include `Append`, `Overwrite` or `Delete`.
 
--> **NOTE:** `Append` causes the specified header to be added to the request with the specified value. If the header is already present, the value is appended to the existing header value using string concatenation. No delimiters are added. `Overwrite` causes specified header to be added to the request with the specified value. If the header is already present, the specified value overwrites the existing value. `Delete` causes the header to be deleted from the request.
+-> **Note:** `Append` causes the specified header to be added to the request with the specified value. If the header is already present, the value is appended to the existing header value using string concatenation. No delimiters are added. `Overwrite` causes specified header to be added to the request with the specified value. If the header is already present, the specified value overwrites the existing value. `Delete` causes the header to be deleted from the request.
 
 * `header_name` - (Required) The name of the header to modify.
 
 * `value` - (Optional) The value to append or overwrite.
 
-->**NOTE:** `value` is required if the `header_action` is set to `Append` or `Overwrite`.
+-> **Note:** `value` is required if the `header_action` is set to `Append` or `Overwrite`.
 
 ---
 
 A `conditions` block supports the following:
 
-->**NOTE:** You may include up to 10 separate conditions in the `conditions` block.
+-> **Note:** You may include up to 10 separate conditions in the `conditions` block.
 
 * `remote_address_condition` - (Optional) A `remote_address_condition` block as defined below.
 
@@ -362,13 +360,13 @@ A `socket_address_condition` block supports the following:
 
 * `operator` - (Optional) The type of match. The Possible values are `IpMatch` or `Any`. Defaults to `IPMatch`.
 
-->**NOTE:** If the value of the `operator` field is set to `IpMatch` then the `match_values` field is also required.
+-> **Note:** If the value of the `operator` field is set to `IpMatch` then the `match_values` field is also required.
 
 * `negate_condition` - (Optional) If `true` operator becomes the opposite of its value. Possible values `true` or `false`. Defaults to `false`. Details can be found in the `Condition Operator List` below.
 
 * `match_values` - (Optional) Specify one or more IP address ranges. If multiple IP address ranges are specified, they're evaluated using `OR` logic.
 
-->**NOTE:** See the `Specifying IP Address Ranges` section below on how to correctly define the `match_values` field.
+-> **Note:** See the `Specifying IP Address Ranges` section below on how to correctly define the `match_values` field.
 
 ---
 
@@ -382,7 +380,7 @@ A `remote_address_condition` block supports the following:
 
 * `match_values` - (Optional) For the IP Match or IP Not Match operators: specify one or more IP address ranges. If multiple IP address ranges are specified, they're evaluated using `OR` logic. For the Geo Match or Geo Not Match operators: specify one or more locations using their country code.
 
-->**NOTE:** See the `Specifying IP Address Ranges` section below on how to correctly define the `match_values` field.
+-> **Note:** See the `Specifying IP Address Ranges` section below on how to correctly define the `match_values` field.
 
 ---
 
@@ -462,7 +460,7 @@ A `request_body_condition` block supports the following:
 
 ->The `request_body_condition` identifies requests based on specific text that appears in the body of the request.
 
-->**NOTE:** If a request body exceeds `64 KB` in size, only the first `64 KB` will be considered for the request body match condition.
+-> **Note:** If a request body exceeds `64 KB` in size, only the first `64 KB` will be considered for the request body match condition.
 
 * `operator` - (Required) A Conditional operator. Possible values include `Any`, `Equal`, `Contains`, `BeginsWith`, `EndsWith`, `LessThan`, `LessThanOrEqual`, `GreaterThan`, `GreaterThanOrEqual` or `RegEx`. Details can be found in the `Condition Operator List` below.
 
@@ -488,9 +486,9 @@ A `request_scheme_condition` block supports the following:
 
 An `url_path_condition` block supports the following:
 
-->The `url_path_condition` identifies requests that include the specified path in the request URL. The path is the part of the URL after the hostname and a slash(e.g. in the URL `https://www.contoso.com/files/secure/file1.pdf`, the path is `files/secure/file1.pdf`).
+-> **Note:** The `url_path_condition` identifies requests that include the specified path in the request URL. The path is the part of the URL after the hostname and a slash(e.g. in the URL `https://www.contoso.com/files/secure/file1.pdf`, the path is `files/secure/file1.pdf`).
 
-* `operator` - (Required) A Conditional operator. Possible values include `Any`, `Equal`, `Contains`, `BeginsWith`, `EndsWith`, `LessThan`, `LessThanOrEqual`, `GreaterThan`, `GreaterThanOrEqual` or `RegEx`. Details can be found in the `Condition Operator List` below.
+* `operator` - (Required) A Conditional operator. Possible values include `Any`, `Equal`, `Contains`, `BeginsWith`, `EndsWith`, `LessThan`, `LessThanOrEqual`, `GreaterThan`, `GreaterThanOrEqual`, `RegEx` or `Wildcard`. Details can be found in the `Condition Operator List` below.
 
 * `negate_condition` - (Optional) If `true` operator becomes the opposite of its value. Possible values `true` or `false`. Defaults to `false`. Details can be found in the `Condition Operator List` below.
 
@@ -522,7 +520,7 @@ An `url_filename_condition` block supports the following:
 
 * `match_values` - (Optional) A list of one or more string or integer values(e.g. "1") representing the value of the request file name to match. If multiple values are specified, they're evaluated using `OR` logic.
 
--> **NOTE:** The `match_values` field is only optional if the `operator` is set to `Any`.
+-> **Note:** The `match_values` field is only optional if the `operator` is set to `Any`.
 
 * `negate_condition` - (Optional) If `true` operator becomes the opposite of its value. Possible values `true` or `false`. Defaults to `false`. Details can be found in the `Condition Operator List` below.
 
@@ -645,7 +643,8 @@ For rules that accept values from the standard operator list, the following oper
 | Greater Than or Equal      | Matches when the length of the value is greater than or equal to the specified integer. | GreaterThanOrEqual |
 | Begins With                | Matches when the value begins with the specified string. | BeginsWith |
 | Ends With                  | Matches when the value ends with the specified string. | EndsWith |
-| RegEx                      | Matches when the value matches the specified regular expression. See below for further details. | RegEx |
+| RegEx                      | Matches when the value matches the specified regular expression. See `Condition Regular Expressions` below for more details. | RegEx |
+| Wildcard                   | Matches when the request path matches a wildcard expression. See `Condition Wildcard Expression` below for more details. | Wildcard | 
 | Not Any                    | Matches when there is no value. | Any and negateCondition = true |
 | Not Equal                  | Matches when the value does not match the specified string. | Equal and negateCondition : true |
 | Not Contains               | Matches when the value does not contain the specified string. | Contains and negateCondition = true |
@@ -655,7 +654,8 @@ For rules that accept values from the standard operator list, the following oper
 | Not Greater Than or Equals | Matches when the length of the value is not greater than or equal to the specified integer. | GreaterThanOrEqual and negateCondition = true |
 | Not Begins With            | Matches when the value does not begin with the specified string. | BeginsWith and negateCondition = true |
 | Not Ends With              | Matches when the value does not end with the specified string. | EndsWith and negateCondition = true |
-| Not RegEx                  | Matches when the value does not match the specified regular expression. See `Condition Regular Expressions` for further details. | RegEx and negateCondition = true |
+| Not RegEx                  | Matches when the value does not match the specified regular expression. See `Condition Regular Expressions` for more details. | RegEx and negateCondition = true |
+| Not Wildcard               | Matches when the request path does not match a wildcard expression. See `Condition Wildcard Expression` below for more details. | Wildcard and negateCondition = true |
 
 ---
 
@@ -673,6 +673,10 @@ Regular expressions **don't** support the following operations:
 * The `\K` start of match reset directive.
 * Callouts and embedded code.
 * Atomic grouping and possessive quantifiers.
+
+## Condition Wildcard Expression
+
+A wildcard expression can include the * character to match zero or more characters within the path. For example, the wildcard expression `files/customer*/file.pdf` matches the paths `files/customer1/file.pdf`, `files/customer109/file.pdf`, and `files/customer/file.pdf`, but doesn't match `files/customer2/anotherfile.pdf`.
 
 ---
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Fixed the schema validation function to point to the `rules` package instead of the `waf` package for the `url_path_condition` code block `operator` property, which resulted in the below error during import when a valid `Wildcard` operator was defined:

```Bash
Error: expected conditions.0.url_path_condition.0.operator to be one of ["Any" "BeginsWith" "Contains" "EndsWith" "Equal" "GeoMatch" "GreaterThan" "GreaterThanOrEqual" "IPMatch" "LessThan" "LessThanOrEqual" "RegEx"], got Wildcard
```


## PR Checklist

- [X] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [X] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [X] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [X] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [X] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [X] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [X] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [X] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [X] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_cdn_frontdoor_rule` - fix shared schema validation to point to the `rules` package instead of `waf` package for `url_path_condition` code block `operator` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [X] Bug Fix
- [ ] New Feature (e.g., adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #29415


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
