### PR TITLE
`azurerm_app_configuration` - support `developer` as a valid `sku` ; allow downgrading sku from `premium` to `standard`

### DIFF
--- a/internal/services/appconfiguration/app_configuration_resource.go
+++ b/internal/services/appconfiguration/app_configuration_resource.go
@@ -169,6 +169,7 @@ func resourceAppConfiguration() *pluginsdk.Resource {
 				Default:  "free",
 				ValidateFunc: validation.StringInSlice([]string{
 					"free",
+					"developer",
 					"standard",
 					"premium",
 				}, false),

--- a/internal/services/appconfiguration/app_configuration_resource.go
+++ b/internal/services/appconfiguration/app_configuration_resource.go
@@ -53,10 +53,10 @@ func resourceAppConfiguration() *pluginsdk.Resource {
 		}),
 
 		CustomizeDiff: pluginsdk.CustomDiffWithAll(
-			// sku cannot be downgraded
+			// sku cannot be downgraded from a production tier (`premium` or `standard`) to a non-production tier (`developer` or `free`), or downgraded from `developer` to `free`
 			// https://learn.microsoft.com/azure/azure-app-configuration/faq#can-i-upgrade-or-downgrade-an-app-configuration-store
 			pluginsdk.ForceNewIfChange("sku", func(ctx context.Context, old, new, meta interface{}) bool {
-				return old == "premium" || new == "free"
+				return ((old == "premium" || old == "standard") && new == "developer") || new == "free"
 			}),
 
 			pluginsdk.CustomizeDiffShim(func(ctx context.Context, d *pluginsdk.ResourceDiff, _ interface{}) error {

--- a/internal/services/appconfiguration/app_configuration_resource_test.go
+++ b/internal/services/appconfiguration/app_configuration_resource_test.go
@@ -49,7 +49,7 @@ func TestAccAppConfiguration_standard(t *testing.T) {
 	})
 }
 
-func TestAccAppConfiguration_upgradesku(t *testing.T) {
+func TestAccAppConfiguration_skuUpdated(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_app_configuration", "test")
 	r := AppConfigurationResource{}
 
@@ -63,6 +63,13 @@ func TestAccAppConfiguration_upgradesku(t *testing.T) {
 		data.ImportStep(),
 		{
 			Config: r.premium(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.standard(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),

--- a/website/docs/r/app_configuration.html.markdown
+++ b/website/docs/r/app_configuration.html.markdown
@@ -175,7 +175,7 @@ The following arguments are supported:
 
 * `replica` - (Optional) One or more `replica` blocks as defined below.
 
-* `sku` - (Optional) The SKU name of the App Configuration. Possible values are `free`, `standard` and `premium`. Defaults to `free`.
+* `sku` - (Optional) The SKU name of the App Configuration. Possible values are `free`, `developer`,  `standard` and `premium`. Defaults to `free`.
 
 ~> **Note:** Azure does not support downgrading `sku`. Downgrading from `premium` tier to `standard` or `free`, or from `standard` to `free`, forces a new resource to be created.
 

--- a/website/docs/r/app_configuration.html.markdown
+++ b/website/docs/r/app_configuration.html.markdown
@@ -175,9 +175,9 @@ The following arguments are supported:
 
 * `replica` - (Optional) One or more `replica` blocks as defined below.
 
-* `sku` - (Optional) The SKU name of the App Configuration. Possible values are `free`, `developer`,  `standard` and `premium`. Defaults to `free`.
+* `sku` - (Optional) The SKU name of the App Configuration. Possible values are `free`, `developer`, `standard` and `premium`. Defaults to `free`.
 
-~> **Note:** Azure does not support downgrading `sku` to a non-production tier (`developer` or `free`). Downgrading from `premium` tier to `developer` or `free`, from `standard` to `developer` or `free`, or from `developer` to `free`, forces a new resource to be created.
+~> **Note:** Azure does not support downgrading `sku` to a lower tier, except from `premium` to `standard`. Downgrading will force a new resource to be created.
 
 * `soft_delete_retention_days` - (Optional) The number of days that items should be retained for once soft-deleted. This field only works for `standard` sku. This value can be between `1` and `7` days. Defaults to `7`. Changing this forces a new resource to be created.
 

--- a/website/docs/r/app_configuration.html.markdown
+++ b/website/docs/r/app_configuration.html.markdown
@@ -177,7 +177,7 @@ The following arguments are supported:
 
 * `sku` - (Optional) The SKU name of the App Configuration. Possible values are `free`, `developer`,  `standard` and `premium`. Defaults to `free`.
 
-~> **Note:** Azure does not support downgrading `sku`. Downgrading from `premium` tier to `standard` or `free`, or from `standard` to `free`, forces a new resource to be created.
+~> **Note:** Azure does not support downgrading `sku` to a non-production tier (`developer` or `free`). Downgrading from `premium` tier to `developer` or `free`, from `standard` to `developer` or `free`, or from `developer` to `free`, forces a new resource to be created.
 
 * `soft_delete_retention_days` - (Optional) The number of days that items should be retained for once soft-deleted. This field only works for `standard` sku. This value can be between `1` and `7` days. Defaults to `7`. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->
`azurerm_app_configuration` - suppote `developer` as a available `sku` 
this PR also allows downgrading sku from `premium` to `standard` as the Azure API and doc has been updated https://learn.microsoft.com/en-us/azure/azure-app-configuration/faq#can-i-upgrade-or-downgrade-an-app-configuration-store

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->
![image](https://github.com/user-attachments/assets/5f7ce26e-b6cd-4128-81c6-49dcbd85f40d)


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_app_configuration` - support `developer` as a valid `sku`
* `azurerm_app_configuration` - allow downgrading `sku` from `premium` to `standard`



<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/29488


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
