### PR TITLE
`azurerm_dynatrace_tag_rules`: Add support for `sending_metrics_enabled`

### DIFF
--- a/internal/services/dynatrace/dynatrace_tag_rules_resource.go
+++ b/internal/services/dynatrace/dynatrace_tag_rules_resource.go
@@ -29,7 +29,8 @@ type TagRulesResourceModel struct {
 }
 
 type MetricRule struct {
-	FilteringTags []FilteringTag `tfschema:"filtering_tag"`
+	FilteringTags  []FilteringTag `tfschema:"filtering_tag"`
+	SendingMetrics bool           `tfschema:"sending_metrics_enabled"`
 }
 
 type LogRule struct {
@@ -152,6 +153,11 @@ func (r TagRulesResource) Arguments() map[string]*schema.Schema {
 								},
 							},
 						},
+					},
+					"sending_metrics_enabled": {
+						Type:     pluginsdk.TypeBool,
+						Optional: true,
+						Default:  false,
 					},
 				},
 			},

--- a/internal/services/dynatrace/dynatrace_tag_rules_resource_test.go
+++ b/internal/services/dynatrace/dynatrace_tag_rules_resource_test.go
@@ -174,7 +174,7 @@ resource "azurerm_dynatrace_tag_rules" "test" {
       value  = "Prod"
       action = "Include"
     }
-	sending_metrics_enabled = true
+    sending_metrics_enabled = true
   }
 }
 `, MonitorsResource{}.basic(data))

--- a/internal/services/dynatrace/dynatrace_tag_rules_resource_test.go
+++ b/internal/services/dynatrace/dynatrace_tag_rules_resource_test.go
@@ -174,6 +174,7 @@ resource "azurerm_dynatrace_tag_rules" "test" {
       value  = "Prod"
       action = "Include"
     }
+	sending_metrics_enabled = true
   }
 }
 `, MonitorsResource{}.basic(data))

--- a/internal/services/dynatrace/helper.go
+++ b/internal/services/dynatrace/helper.go
@@ -171,17 +171,22 @@ func FlattenMetricRules(input *tagrules.MetricRules) []MetricRule {
 		return []MetricRule{}
 	}
 
-	filteringTags := make([]FilteringTag, 0)
+	var metricRule MetricRule
 
 	if input.FilteringTags != nil {
-		filteringTags = FlattenFilteringTags(input.FilteringTags)
+		filteringTags := FlattenFilteringTags(input.FilteringTags)
+		metricRule.FilteringTags = filteringTags
 	}
 
-	return []MetricRule{
-		{
-			FilteringTags: filteringTags,
-		},
+	if input.SendingMetrics != nil {
+		if pointer.From(input.SendingMetrics) == tagrules.SendingMetricsStatusEnabled {
+			metricRule.SendingMetrics = true
+		} else {
+			metricRule.SendingMetrics = false
+		}
 	}
+
+	return []MetricRule{metricRule}
 }
 
 func ExpandMetricRules(input []MetricRule) *tagrules.MetricRules {
@@ -189,9 +194,17 @@ func ExpandMetricRules(input []MetricRule) *tagrules.MetricRules {
 		return nil
 	}
 	v := input[0]
+	var sendingMetrics tagrules.SendingMetricsStatus
+
+	if v.SendingMetrics {
+		sendingMetrics = tagrules.SendingMetricsStatusEnabled
+	} else {
+		sendingMetrics = tagrules.SendingMetricsStatusDisabled
+	}
 
 	return &tagrules.MetricRules{
-		FilteringTags: ExpandFilteringTag(v.FilteringTags),
+		FilteringTags:  ExpandFilteringTag(v.FilteringTags),
+		SendingMetrics: pointer.To(sendingMetrics),
 	}
 }
 

--- a/website/docs/r/dynatrace_tag_rules.html.markdown
+++ b/website/docs/r/dynatrace_tag_rules.html.markdown
@@ -101,6 +101,8 @@ The `metric_rule` block supports the following:
 
 * `filtering_tag` - (Optional) Filtering tag for the metric rule. A `filtering_tag` block as defined below.
 
+* `sending_metrics_enabled` - (Optional) If sending metrics is enabled. The default value is `false`.
+
 ---
 
 The `filtering_tag` block supports the following:


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Just like other Dynatrace related resources, the acc tests are ran on the service team provided subscriptions.

Here is the test result:

```
--- PASS: TestAccDynatraceTagRules_complete (408.36s)

```


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [x] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
