### PR TITLE
`data.azurerm_managed_disk` - add support for `location`

### DIFF
--- a/internal/services/compute/managed_disk_data_source.go
+++ b/internal/services/compute/managed_disk_data_source.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/zones"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -181,6 +182,7 @@ func dataSourceManagedDiskRead(d *pluginsdk.ResourceData, meta interface{}) erro
 
 	if model := resp.Model; model != nil {
 		d.Set("zones", zones.FlattenUntyped(model.Zones))
+		d.Set("location", location.Normalize(model.Location))
 
 		storageAccountType := ""
 		if sku := model.Sku; sku != nil {
@@ -219,8 +221,6 @@ func dataSourceManagedDiskRead(d *pluginsdk.ResourceData, meta interface{}) erro
 				diskEncryptionSetId = *props.Encryption.DiskEncryptionSetId
 			}
 			d.Set("disk_encryption_set_id", diskEncryptionSetId)
-
-			d.Set("location", model.Location)
 
 			if err := d.Set("encryption_settings", flattenManagedDiskEncryptionSettings(props.EncryptionSettingsCollection)); err != nil {
 				return fmt.Errorf("setting `encryption_settings`: %+v", err)

--- a/internal/services/compute/managed_disk_data_source.go
+++ b/internal/services/compute/managed_disk_data_source.go
@@ -112,6 +112,11 @@ func dataSourceManagedDisk() *pluginsdk.Resource {
 				},
 			},
 
+			"location": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
 			"image_reference_id": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
@@ -214,6 +219,8 @@ func dataSourceManagedDiskRead(d *pluginsdk.ResourceData, meta interface{}) erro
 				diskEncryptionSetId = *props.Encryption.DiskEncryptionSetId
 			}
 			d.Set("disk_encryption_set_id", diskEncryptionSetId)
+
+			d.Set("location", model.Location)
 
 			if err := d.Set("encryption_settings", flattenManagedDiskEncryptionSettings(props.EncryptionSettingsCollection)); err != nil {
 				return fmt.Errorf("setting `encryption_settings`: %+v", err)

--- a/internal/services/compute/managed_disk_data_source_test.go
+++ b/internal/services/compute/managed_disk_data_source_test.go
@@ -26,6 +26,7 @@ func TestAccDataSourceManagedDisk_basic(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("name").HasValue(name),
 				check.That(data.ResourceName).Key("resource_group_name").HasValue(resourceGroupName),
+				check.That(data.ResourceName).Key("location").HasValue(data.Locations.Primary),
 				check.That(data.ResourceName).Key("storage_account_type").HasValue("Premium_LRS"),
 				check.That(data.ResourceName).Key("disk_size_gb").HasValue("10"),
 				check.That(data.ResourceName).Key("tags.%").HasValue("1"),

--- a/website/docs/d/managed_disk.html.markdown
+++ b/website/docs/d/managed_disk.html.markdown
@@ -41,6 +41,8 @@ output "id" {
 
 * `image_reference_id` - The ID of the source image used for creating this Managed Disk.
 
+* `location` - The Azure location of the Managed Disk.
+
 * `os_type` - The operating system used for this Managed Disk.
 
 * `storage_account_type` - The storage account type for the Managed Disk.


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This is to add the `location` attribute to for the `azurerm_managed_disk` data provider


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [x] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

```=== RUN   TestAccDataSourceManagedDisk_basic
=== PAUSE TestAccDataSourceManagedDisk_basic
=== RUN   TestAccDataSourceManagedDisk_basic_withUltraSSD
=== PAUSE TestAccDataSourceManagedDisk_basic_withUltraSSD
=== CONT  TestAccDataSourceManagedDisk_basic
=== CONT  TestAccDataSourceManagedDisk_basic_withUltraSSD
--- PASS: TestAccDataSourceManagedDisk_basic_withUltraSSD (107.00s)
--- PASS: TestAccDataSourceManagedDisk_basic (115.78s)```

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_managed_disk` - data source, support for the `location` property output


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #29288


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
