### PR TITLE
`azurerm_api_management_api` : when specifying `import`, the values of  `display_name`, `protocols` and `description` are ignored when updating resource

### DIFF
--- a/internal/services/apimanagement/api_management_api_resource.go
+++ b/internal/services/apimanagement/api_management_api_resource.go
@@ -519,9 +519,9 @@ func resourceApiManagementApiUpdate(d *pluginsdk.ResourceData, meta interface{})
 	}
 	prop := &api.ApiCreateOrUpdateProperties{
 		Path:                          existing.Path,
-		Protocols:                     existing.Protocols,
+		Protocols:                     protocols,
 		ServiceURL:                    existing.ServiceURL,
-		Description:                   existing.Description,
+		Description:                   pointer.To(d.Get("description").(string)),
 		ApiVersionDescription:         existing.ApiVersionDescription,
 		ApiRevisionDescription:        existing.ApiRevisionDescription,
 		SubscriptionRequired:          existing.SubscriptionRequired,
@@ -530,7 +530,7 @@ func resourceApiManagementApiUpdate(d *pluginsdk.ResourceData, meta interface{})
 		Contact:                       existing.Contact,
 		License:                       existing.License,
 		SourceApiId:                   existing.SourceApiId,
-		DisplayName:                   existing.DisplayName,
+		DisplayName:                   pointer.To(displayName),
 		ApiVersion:                    existing.ApiVersion,
 		ApiVersionSetId:               existing.ApiVersionSetId,
 		TermsOfServiceURL:             existing.TermsOfServiceURL,
@@ -542,10 +542,6 @@ func resourceApiManagementApiUpdate(d *pluginsdk.ResourceData, meta interface{})
 		prop.Path = path
 	}
 
-	if d.HasChange("protocols") {
-		prop.Protocols = protocols
-	}
-
 	if d.HasChange("api_type") {
 		prop.Type = pointer.To(apiType)
 		prop.ApiType = pointer.To(soapApiType)
@@ -553,10 +549,6 @@ func resourceApiManagementApiUpdate(d *pluginsdk.ResourceData, meta interface{})
 
 	if d.HasChange("service_url") {
 		prop.ServiceURL = pointer.To(serviceUrl)
-	}
-
-	if d.HasChange("description") {
-		prop.Description = pointer.To(d.Get("description").(string))
 	}
 
 	if d.HasChange("revision_description") {
@@ -603,10 +595,6 @@ func resourceApiManagementApiUpdate(d *pluginsdk.ResourceData, meta interface{})
 
 	if d.HasChange("source_api_id") {
 		prop.SourceApiId = pointer.To(sourceApiId)
-	}
-
-	if d.HasChange("display_name") {
-		prop.DisplayName = pointer.To(displayName)
 	}
 
 	if d.HasChange("version") {

--- a/internal/services/apimanagement/api_management_api_resource_test.go
+++ b/internal/services/apimanagement/api_management_api_resource_test.go
@@ -229,6 +229,13 @@ func TestAccApiManagementApi_importOpenapi(t *testing.T) {
 			),
 		},
 		data.ImportStep("import"),
+		{
+			Config: r.importOpenapiUpdate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("import"),
 	})
 }
 
@@ -605,11 +612,32 @@ resource "azurerm_api_management_api" "test" {
   api_management_name = azurerm_api_management.test.name
   display_name        = "api1"
   path                = "api1"
-  protocols           = ["https"]
+  protocols           = ["http"]
   revision            = "current"
 
   import {
     content_value  = file("testdata/api_management_api_openapi.yaml")
+    content_format = "openapi"
+  }
+}
+`, r.template(data, SkuNameConsumption), data.RandomInteger)
+}
+
+func (r ApiManagementApiResource) importOpenapiUpdate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_api_management_api" "test" {
+  name                = "acctestapi-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  api_management_name = azurerm_api_management.test.name
+  display_name        = "api1"
+  path                = "api1"
+  protocols           = ["http"]
+  revision            = "current"
+
+  import {
+    content_value  = file("testdata/api_management_api_openapi_update.yaml")
     content_format = "openapi"
   }
 }

--- a/internal/services/apimanagement/testdata/api_management_api_openapi_update.yaml
+++ b/internal/services/apimanagement/testdata/api_management_api_openapi_update.yaml
@@ -1,0 +1,36 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+openapi: 3.0.0
+info:
+  title: api1update
+  description: apiupdate
+  version: 2.0.0
+servers:
+  - url: "https://terraform.com/test/v1/api1"
+    description: testUpdate
+paths:
+  /default:
+    post:
+      operationId: default
+      summary: Default
+      description: Default operation update
+      responses:
+        "200":
+          description: Accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/response"
+components:
+  schemas:
+    response:
+      type: object
+      properties:
+        status:
+          type: string
+          example: success
+  securitySchemes:
+    basicAuth:
+      type: http
+      scheme: basic


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

After the the creation and update methods are separated, when updating resources, if the values ​​of `description`, `protocols` and `display_name` have not changed, the values ​​specified by the user in the configuration will be ignored and replaced by the value corresponding to `content_value` of `import`. Therefore, submit this PR to fix #29502 and #29503.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

![image](https://github.com/user-attachments/assets/aede4a14-d367-4a45-b704-beab8d134c15)


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_api_management_api` - when specifying `import`, the value of  `display_name`, `protocols` and `description` are ignored when updating resource [GH-29502， GH-29503]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #29502, #29503


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
