### PR TITLE
`azurerm_private_endpoint_application_security_group_association` - remove resource from state file when the resource does not exist

### DIFF
--- a/internal/services/network/private_endpoint_application_security_group_association_resource.go
+++ b/internal/services/network/private_endpoint_application_security_group_association_resource.go
@@ -88,7 +88,7 @@ func (p PrivateEndpointApplicationSecurityGroupAssociationResource) Create() sdk
 			}
 
 			if response.WasNotFound(existingPrivateEndpoint.HttpResponse) {
-				return fmt.Errorf("PrivateEndpoint %q does not exsits", privateEndpointId)
+				return fmt.Errorf("PrivateEndpoint %q does not exsit", privateEndpointId)
 			}
 
 			if existingPrivateEndpoint.Model == nil || existingPrivateEndpoint.Model.Properties == nil {
@@ -101,7 +101,7 @@ func (p PrivateEndpointApplicationSecurityGroupAssociationResource) Create() sdk
 			}
 
 			if response.WasNotFound(existingASG.HttpResponse) {
-				return fmt.Errorf("ApplicationSecurityGroup %q does not exsits", ASGId)
+				return fmt.Errorf("ApplicationSecurityGroup %q does not exsit", ASGId)
 			}
 
 			if existingASG.Model == nil || existingASG.Model.Properties == nil {
@@ -186,7 +186,8 @@ func (p PrivateEndpointApplicationSecurityGroupAssociationResource) Read() sdk.R
 			}
 
 			if response.WasNotFound(existingPrivateEndpoint.HttpResponse) {
-				return fmt.Errorf("PrivateEndpoint %q does not exsits", privateEndpointId)
+				log.Printf("%s was not found - removing from state!", *privateEndpointId)
+				return metadata.MarkAsGone(resourceId)
 			}
 
 			existingASG, err := ASGClient.Get(ctx, *ASGId)
@@ -195,7 +196,8 @@ func (p PrivateEndpointApplicationSecurityGroupAssociationResource) Read() sdk.R
 			}
 
 			if response.WasNotFound(existingASG.HttpResponse) {
-				return fmt.Errorf("ApplicationSecurityGroup %q does not exsits", ASGId)
+				log.Printf("%s was not found - removing from state!", *ASGId)
+				return metadata.MarkAsGone(resourceId)
 			}
 
 			// flag: application security group exists in private endpoint configuration
@@ -212,7 +214,7 @@ func (p PrivateEndpointApplicationSecurityGroupAssociationResource) Read() sdk.R
 				}
 			}
 			if !ASGInPE {
-				log.Printf("ApplicationSecurityGroup %q does not exsits in %q, removing from state.", ASGId, privateEndpointId)
+				log.Printf("ApplicationSecurityGroup %q does not exsit in %q, removing from state.", ASGId, privateEndpointId)
 				err := metadata.MarkAsGone(resourceId)
 				if err != nil {
 					return err
@@ -264,7 +266,7 @@ func (p PrivateEndpointApplicationSecurityGroupAssociationResource) Delete() sdk
 			}
 
 			if response.WasNotFound(existingPrivateEndpoint.HttpResponse) {
-				return fmt.Errorf("PrivateEndpoint %q does not exsits", privateEndpointId)
+				return fmt.Errorf("PrivateEndpoint %q does not exsit", privateEndpointId)
 			}
 
 			if existingPrivateEndpoint.Model == nil || existingPrivateEndpoint.Model.Properties == nil {
@@ -277,7 +279,7 @@ func (p PrivateEndpointApplicationSecurityGroupAssociationResource) Delete() sdk
 			}
 
 			if response.WasNotFound(existingASG.HttpResponse) {
-				return fmt.Errorf("ApplicationSecurityGroup %q does not exsits", ASGId)
+				return fmt.Errorf("ApplicationSecurityGroup %q does not exsit", ASGId)
 			}
 
 			resourceId := parse.NewPrivateEndpointApplicationSecurityGroupAssociationId(*privateEndpointId, *ASGId)

--- a/internal/services/network/private_endpoint_application_security_group_association_resource.go
+++ b/internal/services/network/private_endpoint_application_security_group_association_resource.go
@@ -88,7 +88,7 @@ func (p PrivateEndpointApplicationSecurityGroupAssociationResource) Create() sdk
 			}
 
 			if response.WasNotFound(existingPrivateEndpoint.HttpResponse) {
-				return fmt.Errorf("PrivateEndpoint %q does not exsit", privateEndpointId)
+				return fmt.Errorf("PrivateEndpoint %q does not exist", privateEndpointId)
 			}
 
 			if existingPrivateEndpoint.Model == nil || existingPrivateEndpoint.Model.Properties == nil {
@@ -101,7 +101,7 @@ func (p PrivateEndpointApplicationSecurityGroupAssociationResource) Create() sdk
 			}
 
 			if response.WasNotFound(existingASG.HttpResponse) {
-				return fmt.Errorf("ApplicationSecurityGroup %q does not exsit", ASGId)
+				return fmt.Errorf("ApplicationSecurityGroup %q does not exist", ASGId)
 			}
 
 			if existingASG.Model == nil || existingASG.Model.Properties == nil {
@@ -214,7 +214,7 @@ func (p PrivateEndpointApplicationSecurityGroupAssociationResource) Read() sdk.R
 				}
 			}
 			if !ASGInPE {
-				log.Printf("ApplicationSecurityGroup %q does not exsit in %q, removing from state.", ASGId, privateEndpointId)
+				log.Printf("ApplicationSecurityGroup %q does not exist in %q, removing from state.", ASGId, privateEndpointId)
 				err := metadata.MarkAsGone(resourceId)
 				if err != nil {
 					return err
@@ -266,7 +266,7 @@ func (p PrivateEndpointApplicationSecurityGroupAssociationResource) Delete() sdk
 			}
 
 			if response.WasNotFound(existingPrivateEndpoint.HttpResponse) {
-				return fmt.Errorf("PrivateEndpoint %q does not exsit", privateEndpointId)
+				return fmt.Errorf("PrivateEndpoint %q does not exist", privateEndpointId)
 			}
 
 			if existingPrivateEndpoint.Model == nil || existingPrivateEndpoint.Model.Properties == nil {
@@ -279,7 +279,7 @@ func (p PrivateEndpointApplicationSecurityGroupAssociationResource) Delete() sdk
 			}
 
 			if response.WasNotFound(existingASG.HttpResponse) {
-				return fmt.Errorf("ApplicationSecurityGroup %q does not exsit", ASGId)
+				return fmt.Errorf("ApplicationSecurityGroup %q does not exist", ASGId)
 			}
 
 			resourceId := parse.NewPrivateEndpointApplicationSecurityGroupAssociationId(*privateEndpointId, *ASGId)


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description
Currently TF will throw error when the resource doesn't exist. It's unexpected. The resource should be removed from state file when the resource does not exist.
<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

--- PASS: TestAccPrivateEndpointApplicationSecurityGroupAssociationResource_basic (397.08s)
--- PASS: TestAccPrivateEndpointApplicationSecurityGroupAssociationResource_updatePrivateEndpoint (389.76s)
--- PASS: TestAccPrivateEndpointApplicationSecurityGroupAssociationResource_requiresImport (343.90s)
--- PASS: TestAccPrivateEndpointApplicationSecurityGroupAssociationResource_deleted (346.66s)

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_private_endpoint_application_security_group_association` - remove resource from state file when the resource does not exist


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/29528


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
