### PR TITLE
`azurerm_api_management_api` : Fix the error caused by `api_type` being specified as `websocket` but `service_url` is specified as an empty string

### DIFF
--- a/internal/services/apimanagement/api_management_api_resource.go
+++ b/internal/services/apimanagement/api_management_api_resource.go
@@ -351,6 +351,10 @@ func resourceApiManagementApi() *pluginsdk.Resource {
 				if values["source_api_id"].IsNull() && (values["display_name"].IsNull() || protocols == nil || len(*protocols) == 0) {
 					return errors.New("`display_name`, `protocols` are required when `source_api_id` is not set")
 				}
+
+				if d.Get("api_type").(string) == string(api.ApiTypeWebsocket) && d.Get("service_url").(string) == "" {
+					return errors.New("`service_url` is required when `api_type` is `websocket`")
+				}
 				return nil
 			}),
 		),

--- a/internal/services/apimanagement/api_management_api_resource.go
+++ b/internal/services/apimanagement/api_management_api_resource.go
@@ -438,7 +438,6 @@ func resourceApiManagementApiCreate(d *pluginsdk.ResourceData, meta interface{})
 			ApiType:                       pointer.To(soapApiType),
 			Path:                          path,
 			Protocols:                     protocols,
-			ServiceURL:                    pointer.To(serviceUrl),
 			SubscriptionKeyParameterNames: subscriptionKeyParameterNames,
 			SubscriptionRequired:          &subscriptionRequired,
 			AuthenticationSettings:        authenticationSettings,
@@ -447,6 +446,10 @@ func resourceApiManagementApiCreate(d *pluginsdk.ResourceData, meta interface{})
 			Contact:                       contactInfo,
 			License:                       licenseInfo,
 		},
+	}
+
+	if serviceUrl != "" {
+		params.Properties.ServiceURL = pointer.To(serviceUrl)
 	}
 
 	if sourceApiId != "" {

--- a/internal/services/apimanagement/api_management_api_resource_test.go
+++ b/internal/services/apimanagement/api_management_api_resource_test.go
@@ -580,7 +580,6 @@ resource "azurerm_api_management_api" "test" {
   path                = "api1"
   protocols           = ["wss"]
   revision            = "1"
-  service_url         = "wss://example.com/foo/bar"
 }
 `, r.template(data, SkuNameDeveloper), data.RandomInteger)
 }

--- a/internal/services/apimanagement/api_management_api_resource_test.go
+++ b/internal/services/apimanagement/api_management_api_resource_test.go
@@ -580,6 +580,7 @@ resource "azurerm_api_management_api" "test" {
   path                = "api1"
   protocols           = ["wss"]
   revision            = "1"
+  service_url         = "wss://example.com/foo/bar"
 }
 `, r.template(data, SkuNameDeveloper), data.RandomInteger)
 }

--- a/website/docs/r/api_management_api.html.markdown
+++ b/website/docs/r/api_management_api.html.markdown
@@ -83,6 +83,8 @@ The following arguments are supported:
 
 * `service_url` - (Optional) Absolute URL of the backend service implementing this API.
 
+-> **Note:** The `service_url` is required when `api_type` is specified as `websocket`.
+
 * `subscription_key_parameter_names` - (Optional) A `subscription_key_parameter_names` block as documented below.
 
 * `subscription_required` - (Optional) Should this API require a subscription key? Defaults to `true`.


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

The API behaves as follows:

- When `api_type` is specified as `websocket` but `service_url` is specified as an empty string(`service_url` = null or omit `service_url` attribute), the API returns error "WebSocket API type is not enabled for the service or sku".

- When `api_type` is specified as `websocket` and `service_url` is not specified, the API returns error "'serviceUrl' must not be empty."

 Submit this PR to fix [#29610](https://github.com/hashicorp/terraform-provider-azurerm/issues/29610) by not passing an empty string when `service_url` is not specified or specified as null. Also add the validation that `service_url` must be specified when `api_type` is specified as `websocket`.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

TC test results:
https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_APIMANAGEMENT/380603?buildTab=tests

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_api_management_api` - fix the error caused by `api_type` being specified as `websocket` but `service_url` is specified as an empty string [GH-29610]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #29610


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
