### PR TITLE
`doc`: update two examples using depreacated `azurerm_sql_server` and `azurerm_sql_database`

### DIFF
--- a/website/docs/r/mssql_database_vulnerability_assessment_rule_baseline.html.markdown
+++ b/website/docs/r/mssql_database_vulnerability_assessment_rule_baseline.html.markdown
@@ -21,7 +21,7 @@ resource "azurerm_resource_group" "example" {
   location = "West Europe"
 }
 
-resource "azurerm_sql_server" "example" {
+resource "azurerm_mssql_server" "example" {
   name                         = "mysqlserver"
   resource_group_name          = azurerm_resource_group.example.name
   location                     = azurerm_resource_group.example.location
@@ -46,16 +46,13 @@ resource "azurerm_storage_container" "example" {
 
 resource "azurerm_mssql_server_security_alert_policy" "example" {
   resource_group_name = azurerm_resource_group.example.name
-  server_name         = azurerm_sql_server.example.name
+  server_name         = azurerm_mssql_server.example.name
   state               = "Enabled"
 }
 
-resource "azurerm_sql_database" "example" {
-  name                = "mysqldatabase"
-  resource_group_name = azurerm_resource_group.example.name
-  server_name         = azurerm_sql_server.example.name
-  location            = azurerm_resource_group.example.location
-  edition             = "Standard"
+resource "azurerm_mssql_database" "example" {
+  name      = "mysqldatabase"
+  server_id = azurerm_mssql_server.test.id
 }
 
 resource "azurerm_mssql_server_vulnerability_assessment" "example" {
@@ -66,7 +63,7 @@ resource "azurerm_mssql_server_vulnerability_assessment" "example" {
 
 resource "azurerm_mssql_database_vulnerability_assessment_rule_baseline" "example" {
   server_vulnerability_assessment_id = azurerm_mssql_server_vulnerability_assessment.example.id
-  database_name                      = azurerm_sql_database.example.name
+  database_name                      = azurerm_mssql_database.example.name
   rule_id                            = "VA2065"
   baseline_name                      = "master"
   baseline_result {

--- a/website/docs/r/stream_analytics_output_mssql.html.markdown
+++ b/website/docs/r/stream_analytics_output_mssql.html.markdown
@@ -23,7 +23,7 @@ data "azurerm_stream_analytics_job" "example" {
   resource_group_name = azurerm_resource_group.example.name
 }
 
-resource "azurerm_sql_server" "example" {
+resource "azurerm_mssql_server" "example" {
   name                         = "example-server"
   resource_group_name          = azurerm_resource_group.example.name
   location                     = azurerm_resource_group.example.location
@@ -32,15 +32,9 @@ resource "azurerm_sql_server" "example" {
   administrator_login_password = "example-password"
 }
 
-resource "azurerm_sql_database" "example" {
-  name                             = "exampledb"
-  resource_group_name              = azurerm_resource_group.example.name
-  location                         = azurerm_resource_group.example.location
-  server_name                      = azurerm_sql_server.example.name
-  requested_service_objective_name = "S0"
-  collation                        = "SQL_LATIN1_GENERAL_CP1_CI_AS"
-  max_size_bytes                   = "268435456000"
-  create_mode                      = "Default"
+resource "azurerm_mssql_database" "example" {
+  name      = "exampledb"
+  server_id = azurerm_mssql_server.test.id
 }
 
 resource "azurerm_stream_analytics_output_mssql" "example" {
@@ -51,7 +45,7 @@ resource "azurerm_stream_analytics_output_mssql" "example" {
   server   = azurerm_sql_server.example.fully_qualified_domain_name
   user     = azurerm_sql_server.example.administrator_login
   password = azurerm_sql_server.example.administrator_login_password
-  database = azurerm_sql_database.example.name
+  database = azurerm_mssql_database.example.name
   table    = "ExampleTable"
 }
 ```
@@ -68,7 +62,7 @@ The following arguments are supported:
 
 * `server` - (Required) The SQL server url. Changing this forces a new resource to be created.
 
-* `user` - (Optional) Username used to login to the Microsoft SQL Server. Changing this forces a new resource to be created. Required if `authentication_mode` is `ConnectionString`. 
+* `user` - (Optional) Username used to login to the Microsoft SQL Server. Changing this forces a new resource to be created. Required if `authentication_mode` is `ConnectionString`.
 
 * `database` - (Required) The MS SQL database name where the reference table exists. Changing this forces a new resource to be created.
 

--- a/website/docs/r/stream_analytics_output_mssql.html.markdown
+++ b/website/docs/r/stream_analytics_output_mssql.html.markdown
@@ -42,9 +42,9 @@ resource "azurerm_stream_analytics_output_mssql" "example" {
   stream_analytics_job_name = data.azurerm_stream_analytics_job.example.name
   resource_group_name       = data.azurerm_stream_analytics_job.example.resource_group_name
 
-  server   = azurerm_sql_server.example.fully_qualified_domain_name
-  user     = azurerm_sql_server.example.administrator_login
-  password = azurerm_sql_server.example.administrator_login_password
+  server   = azurerm_mssql_server.example.fully_qualified_domain_name
+  user     = azurerm_mssql_server.example.administrator_login
+  password = azurerm_mssql_server.example.administrator_login_password
   database = azurerm_mssql_database.example.name
   table    = "ExampleTable"
 }


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Only to update in the example of the documentation. `azurerm_sql_server` and `azurerm_sql_database` are deprecated, moved to `azurerm_mssql_server` and `azurerm_mssql_database`.
