### PR TITLE
private dns fallback

### DIFF
--- a/internal/services/privatedns/private_dns_zone_virtual_network_link_data_source.go
+++ b/internal/services/privatedns/private_dns_zone_virtual_network_link_data_source.go
@@ -5,6 +5,7 @@ package privatedns
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
@@ -48,6 +49,11 @@ func dataSourcePrivateDnsZoneVirtualNetworkLink() *pluginsdk.Resource {
 				Computed: true,
 			},
 
+			"fallback_to_internet": {
+				Type:     pluginsdk.TypeBool,
+				Computed: true,
+			},
+
 			"tags": commonschema.TagsDataSource(),
 		},
 	}
@@ -78,6 +84,11 @@ func dataSourcePrivateDnsZoneVirtualNetworkLinkRead(d *pluginsdk.ResourceData, m
 	if model := resp.Model; model != nil {
 		if props := model.Properties; props != nil {
 			d.Set("registration_enabled", props.RegistrationEnabled)
+
+			d.Set("fallback_to_internet", false)
+			if strings.HasPrefix(id.PrivateDnsZoneName, "privatelink.") && *props.ResolutionPolicy == virtualnetworklinks.ResolutionPolicyNxDomainRedirect {
+				d.Set("fallback_to_internet", true)
+			}
 
 			if network := props.VirtualNetwork; network != nil {
 				d.Set("virtual_network_id", network.Id)

--- a/internal/services/privatedns/private_dns_zone_virtual_network_link_data_source_test.go
+++ b/internal/services/privatedns/private_dns_zone_virtual_network_link_data_source_test.go
@@ -31,6 +31,7 @@ func TestAccDataSourcePrivateDnsZoneVirtualNetworkLink_basic(t *testing.T) {
 				check.That(data.ResourceName).Key("virtual_network_id").MatchesOtherKey(check.That(vnetName).Key("id")),
 				check.That(data.ResourceName).Key("private_dns_zone_name").MatchesOtherKey(check.That(zoneName).Key("name")),
 				check.That(data.ResourceName).Key("registration_enabled").HasValue("false"),
+				check.That(data.ResourceName).Key("fallback_to_internet").HasValue("false"),
 				check.That(data.ResourceName).Key("tags.%").HasValue("0"),
 			),
 		},

--- a/internal/services/privatedns/private_dns_zone_virtual_network_link_resource_test.go
+++ b/internal/services/privatedns/private_dns_zone_virtual_network_link_resource_test.go
@@ -47,6 +47,20 @@ func TestAccPrivateDnsZoneVirtualNetworkLink_complete(t *testing.T) {
 	})
 }
 
+func TestAccPrivateDnsZoneVirtualNetworkLink_fallbackToInternet(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_private_dns_zone_virtual_network_link", "test")
+	r := PrivateDnsZoneVirtualNetworkLinkResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.fallbackToInternet(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccPrivateDnsZoneVirtualNetworkLink_crossTenant(t *testing.T) {
 	// Multiple tenants are needed for this test
 	altTenantId := os.Getenv("ARM_TENANT_ID_ALT")
@@ -192,6 +206,44 @@ resource "azurerm_private_dns_zone_virtual_network_link" "test" {
   registration_enabled  = true
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func (PrivateDnsZoneVirtualNetworkLinkResource) fallbackToInternet(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "vnet%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  address_space       = ["10.0.0.0/16"]
+
+  subnet {
+    name             = "subnet1"
+    address_prefixes = ["10.0.1.0/24"]
+  }
+}
+
+resource "azurerm_private_dns_zone" "test" {
+  name                = "privatelink.blob.core.windows.net"
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_private_dns_zone_virtual_network_link" "test" {
+  name                  = "acctestVnetZone%d.com"
+  private_dns_zone_name = azurerm_private_dns_zone.test.name
+  virtual_network_id    = azurerm_virtual_network.test.id
+  resource_group_name   = azurerm_resource_group.test.name
+  fallback_to_internet  = true
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
 
 func (PrivateDnsZoneVirtualNetworkLinkResource) crossTenant(data acceptance.TestData, altTenantId, subscriptionIdAltTenant string) string {

--- a/website/docs/d/private_dns_zone_virtual_network_link.html.markdown
+++ b/website/docs/d/private_dns_zone_virtual_network_link.html.markdown
@@ -40,6 +40,8 @@ output "private_dns_a_record_id" {
 
 * `registration_enabled` - Whether the auto-registration of virtual machine records in the virtual network in the Private DNS zone is enabled or not.
 
+* `fallback_to_internet` - Whether the zone is configured to fallback to Azure based public DNS resolution if it cannot find a record.
+
 * `tags` - A mapping of tags to assign to the resource.
 
 ## Timeouts

--- a/website/docs/r/private_dns_zone_virtual_network_link.html.markdown
+++ b/website/docs/r/private_dns_zone_virtual_network_link.html.markdown
@@ -52,6 +52,9 @@ The following arguments are supported:
 
 * `registration_enabled` - (Optional) Is auto-registration of virtual machine records in the virtual network in the Private DNS zone enabled? Defaults to `false`.
 
+* `fallback_to_internet` - (Optional) Should Azure DNS use Azure based public DNS resolution for this zone if it cannot find a record? Defaults to `false`.
+~> **Note:** fallback_to_internet can only be enabled for Azure private link DNS zones.
+
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ## Attributes Reference


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This change allows for internet fall back to be enabled for private dns zone VNET links, if the zone is for a private link enabled resource e.g `privatelink.blob.core.windows.net`.  The new attribute I've added is called `fallback_to_internet` and controls  the ResolutionPolicy property of the link  where the zone name beings with `privatelink.` .

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [x] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

=== RUN   TestAccDataSourcePrivateDnsZoneVirtualNetworkLink_basic
=== PAUSE TestAccDataSourcePrivateDnsZoneVirtualNetworkLink_basic
=== CONT  TestAccDataSourcePrivateDnsZoneVirtualNetworkLink_basic
--- PASS: TestAccDataSourcePrivateDnsZoneVirtualNetworkLink_basic (316.91s)

=== RUN   TestAccPrivateDnsZoneVirtualNetworkLink_fallbackToInternet
=== PAUSE TestAccPrivateDnsZoneVirtualNetworkLink_fallbackToInternet
=== CONT  TestAccPrivateDnsZoneVirtualNetworkLink_fallbackToInternet
--- PASS: TestAccPrivateDnsZoneVirtualNetworkLink_fallbackToInternet (338.56s)

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_private_dns_zone_virtual_network_link` - support for the `fallback_to_internet` property [GH-29196
* ]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #29196 


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
