### PR TITLE
`azurerm_key_vault_secret` - allow Key Vault Reader to make plan of secret resources with value_wo

### DIFF
--- a/internal/features/defaults.go
+++ b/internal/features/defaults.go
@@ -40,6 +40,8 @@ func Default() UserFeatures {
 			PurgeSoftDeletedHSMsOnDestroy:    true,
 			PurgeSoftDeletedHSMKeysOnDestroy: true,
 			RecoverSoftDeletedHSMKeys:        true,
+
+			SetValueWoVersionOnImport: false,
 		},
 		LogAnalyticsWorkspace: LogAnalyticsWorkspaceFeatures{
 			PermanentlyDeleteOnDestroy: false,

--- a/internal/features/defaults.go
+++ b/internal/features/defaults.go
@@ -41,6 +41,8 @@ func Default() UserFeatures {
 			PurgeSoftDeletedHSMsOnDestroy:    true,
 			PurgeSoftDeletedHSMKeysOnDestroy: true,
 			RecoverSoftDeletedHSMKeys:        true,
+
+			SetValueWoVersionOnImport: false,
 		},
 		LogAnalyticsWorkspace: LogAnalyticsWorkspaceFeatures{
 			PermanentlyDeleteOnDestroy: false,

--- a/internal/features/user_flags.go
+++ b/internal/features/user_flags.go
@@ -66,6 +66,7 @@ type KeyVaultFeatures struct {
 	RecoverSoftDeletedCerts          bool
 	RecoverSoftDeletedSecrets        bool
 	RecoverSoftDeletedHSMKeys        bool
+	SetValueWoVersionOnImport        bool
 }
 
 type TemplateDeploymentFeatures struct {

--- a/internal/provider/features.go
+++ b/internal/provider/features.go
@@ -220,6 +220,13 @@ func schemaFeatures(supportLegacyTestSuite bool) *pluginsdk.Schema {
 						Optional:    true,
 						Default:     true,
 					},
+
+					"set_value_wo_version_on_import": {
+						Description: "When enabled `value_wo_version` of `azurerm_key_vault_secret` resources will be set to 1 on import",
+						Type:        pluginsdk.TypeBool,
+						Optional:    true,
+						Default:     false,
+					},
 				},
 			},
 		},
@@ -627,6 +634,9 @@ func expandFeatures(input []interface{}) features.UserFeatures {
 			}
 			if v, ok := keyVaultRaw["recover_soft_deleted_hardware_security_module_keys"]; ok {
 				featuresMap.KeyVault.RecoverSoftDeletedHSMKeys = v.(bool)
+			}
+			if v, ok := keyVaultRaw["set_value_wo_version_on_import"]; ok {
+				featuresMap.KeyVault.SetValueWoVersionOnImport = v.(bool)
 			}
 		}
 	}

--- a/internal/provider/features_test.go
+++ b/internal/provider/features_test.go
@@ -55,6 +55,7 @@ func TestExpandFeatures(t *testing.T) {
 					RecoverSoftDeletedKeyVaults:      true,
 					RecoverSoftDeletedSecrets:        true,
 					RecoverSoftDeletedHSMKeys:        true,
+					SetValueWoVersionOnImport:        false,
 				},
 				LogAnalyticsWorkspace: features.LogAnalyticsWorkspaceFeatures{
 					PermanentlyDeleteOnDestroy: false,
@@ -149,6 +150,7 @@ func TestExpandFeatures(t *testing.T) {
 							"recover_soft_deleted_key_vaults":                             true,
 							"recover_soft_deleted_secrets":                                true,
 							"recover_soft_deleted_hardware_security_module_keys":          true,
+							"set_value_wo_version_on_import":                              false,
 						},
 					},
 					"log_analytics_workspace": []interface{}{

--- a/internal/provider/features_test.go
+++ b/internal/provider/features_test.go
@@ -55,6 +55,7 @@ func TestExpandFeatures(t *testing.T) {
 					RecoverSoftDeletedKeyVaults:      true,
 					RecoverSoftDeletedSecrets:        true,
 					RecoverSoftDeletedHSMKeys:        true,
+					SetValueWoVersionOnImport:        false,
 				},
 				LogAnalyticsWorkspace: features.LogAnalyticsWorkspaceFeatures{
 					PermanentlyDeleteOnDestroy: false,
@@ -149,6 +150,7 @@ func TestExpandFeatures(t *testing.T) {
 							"recover_soft_deleted_key_vaults":                             true,
 							"recover_soft_deleted_secrets":                                true,
 							"recover_soft_deleted_hardware_security_module_keys":          true,
+							"set_value_wo_version_on_import":                              true,
 						},
 					},
 					"log_analytics_workspace": []interface{}{
@@ -274,6 +276,7 @@ func TestExpandFeatures(t *testing.T) {
 					RecoverSoftDeletedKeyVaults:      true,
 					RecoverSoftDeletedSecrets:        true,
 					RecoverSoftDeletedHSMKeys:        true,
+					SetValueWoVersionOnImport:        true,
 				},
 				LogAnalyticsWorkspace: features.LogAnalyticsWorkspaceFeatures{
 					PermanentlyDeleteOnDestroy: true,
@@ -368,6 +371,7 @@ func TestExpandFeatures(t *testing.T) {
 							"recover_soft_deleted_key_vaults":                             false,
 							"recover_soft_deleted_secrets":                                false,
 							"recover_soft_deleted_hardware_security_module_keys":          false,
+							"set_value_wo_version_on_import":                              false,
 						},
 					},
 					"log_analytics_workspace": []interface{}{
@@ -493,6 +497,7 @@ func TestExpandFeatures(t *testing.T) {
 					RecoverSoftDeletedKeyVaults:      false,
 					RecoverSoftDeletedSecrets:        false,
 					RecoverSoftDeletedHSMKeys:        false,
+					SetValueWoVersionOnImport:        false,
 				},
 				LogAnalyticsWorkspace: features.LogAnalyticsWorkspaceFeatures{
 					PermanentlyDeleteOnDestroy: false,
@@ -854,11 +859,12 @@ func TestExpandFeaturesKeyVault(t *testing.T) {
 					RecoverSoftDeletedKeyVaults:      true,
 					RecoverSoftDeletedSecrets:        true,
 					RecoverSoftDeletedHSMKeys:        true,
+					SetValueWoVersionOnImport:        false,
 				},
 			},
 		},
 		{
-			Name: "Purge Soft Delete On Destroy and Recover Soft Deleted Key Vaults Enabled",
+			Name: "Purge Soft Delete On Destroy, Recover Soft Deleted Key Vaults Enabled, and Set value_wo_version On Import Enabled",
 			Input: []interface{}{
 				map[string]interface{}{
 					"key_vault": []interface{}{
@@ -874,6 +880,7 @@ func TestExpandFeaturesKeyVault(t *testing.T) {
 							"recover_soft_deleted_key_vaults":                             true,
 							"recover_soft_deleted_secrets":                                true,
 							"recover_soft_deleted_hardware_security_module_keys":          true,
+							"set_value_wo_version_on_import":                              true,
 						},
 					},
 				},
@@ -891,11 +898,12 @@ func TestExpandFeaturesKeyVault(t *testing.T) {
 					RecoverSoftDeletedKeyVaults:      true,
 					RecoverSoftDeletedSecrets:        true,
 					RecoverSoftDeletedHSMKeys:        true,
+					SetValueWoVersionOnImport:        true,
 				},
 			},
 		},
 		{
-			Name: "Purge Soft Delete On Destroy and Recover Soft Deleted Key Vaults Disabled",
+			Name: "Purge Soft Delete On Destroy, Recover Soft Deleted Key Vaults, and Set value_wo_version On Import Disabled",
 			Input: []interface{}{
 				map[string]interface{}{
 					"key_vault": []interface{}{
@@ -911,6 +919,7 @@ func TestExpandFeaturesKeyVault(t *testing.T) {
 							"recover_soft_deleted_key_vaults":                             false,
 							"recover_soft_deleted_secrets":                                false,
 							"recover_soft_deleted_hardware_security_module_keys":          false,
+							"set_value_wo_version_on_import":                              false,
 						},
 					},
 				},
@@ -928,6 +937,7 @@ func TestExpandFeaturesKeyVault(t *testing.T) {
 					RecoverSoftDeletedKeys:           false,
 					RecoverSoftDeletedSecrets:        false,
 					RecoverSoftDeletedHSMKeys:        false,
+					SetValueWoVersionOnImport:        false,
 				},
 			},
 		},

--- a/internal/provider/framework/config.go
+++ b/internal/provider/framework/config.go
@@ -281,6 +281,11 @@ func (p *ProviderConfig) Load(ctx context.Context, data *ProviderModel, tfVersio
 			if !feature[0].RecoverSoftDeletedHSMKeys.IsNull() && !feature[0].RecoverSoftDeletedHSMKeys.IsUnknown() {
 				f.KeyVault.RecoverSoftDeletedHSMKeys = feature[0].RecoverSoftDeletedHSMKeys.ValueBool()
 			}
+
+			f.KeyVault.SetValueWoVersionOnImport = false
+			if !feature[0].SetValueWoVersionOnImport.IsNull() && !feature[0].SetValueWoVersionOnImport.IsUnknown() {
+				f.KeyVault.SetValueWoVersionOnImport = feature[0].SetValueWoVersionOnImport.ValueBool()
+			}
 		} else {
 			f.KeyVault.PurgeSoftDeleteOnDestroy = true
 			f.KeyVault.PurgeSoftDeletedCertsOnDestroy = true
@@ -293,6 +298,7 @@ func (p *ProviderConfig) Load(ctx context.Context, data *ProviderModel, tfVersio
 			f.KeyVault.RecoverSoftDeletedKeys = true
 			f.KeyVault.RecoverSoftDeletedSecrets = true
 			f.KeyVault.RecoverSoftDeletedHSMKeys = true
+			f.KeyVault.SetValueWoVersionOnImport = false
 		}
 
 		if !features.LogAnalyticsWorkspace.IsNull() && !features.LogAnalyticsWorkspace.IsUnknown() {

--- a/internal/provider/framework/config_test.go
+++ b/internal/provider/framework/config_test.go
@@ -268,6 +268,7 @@ func defaultFeaturesList() types.List {
 		"recover_soft_deleted_key_vaults":                         basetypes.NewBoolNull(),
 		"recover_soft_deleted_keys":                               basetypes.NewBoolNull(),
 		"recover_soft_deleted_secrets":                            basetypes.NewBoolNull(),
+		"set_value_wo_version_on_import":                          basetypes.NewBoolNull(),
 	})
 	keyVaultList, _ := basetypes.NewListValue(types.ObjectType{}.WithAttributeTypes(KeyVaultAttributes), []attr.Value{keyVault})
 

--- a/internal/provider/framework/config_test.go
+++ b/internal/provider/framework/config_test.go
@@ -144,6 +144,10 @@ func TestProviderConfig_LoadDefault(t *testing.T) {
 		t.Errorf("expected key_vault.recover_soft_deleted_hsm_keys to be true")
 	}
 
+	if features.KeyVault.SetValueWoVersionOnImport {
+		t.Errorf("expected key_vault.set_value_wo_version_on_import to be false")
+	}
+
 	if features.LogAnalyticsWorkspace.PermanentlyDeleteOnDestroy {
 		t.Errorf("expected log_analytics_workspace.permanently_delete_on_destroy to be false")
 	}
@@ -268,6 +272,8 @@ func defaultFeaturesList() types.List {
 		"recover_soft_deleted_key_vaults":                         basetypes.NewBoolNull(),
 		"recover_soft_deleted_keys":                               basetypes.NewBoolNull(),
 		"recover_soft_deleted_secrets":                            basetypes.NewBoolNull(),
+		"recover_soft_deleted_hardware_security_module_keys":      basetypes.NewBoolNull(),
+		"set_value_wo_version_on_import":                          basetypes.NewBoolNull(),
 	})
 	keyVaultList, _ := basetypes.NewListValue(types.ObjectType{}.WithAttributeTypes(KeyVaultAttributes), []attr.Value{keyVault})
 

--- a/internal/provider/framework/model.go
+++ b/internal/provider/framework/model.go
@@ -145,6 +145,7 @@ type KeyVault struct {
 	RecoverSoftDeletedKeys                               types.Bool `tfsdk:"recover_soft_deleted_keys"`
 	RecoverSoftDeletedSecrets                            types.Bool `tfsdk:"recover_soft_deleted_secrets"`
 	RecoverSoftDeletedHSMKeys                            types.Bool `tfsdk:"recover_soft_deleted_hardware_security_module_keys"`
+	SetValueWoVersionOnImport                            types.Bool `tfsdk:"set_value_wo_version_on_import"`
 }
 
 var KeyVaultAttributes = map[string]attr.Type{
@@ -159,6 +160,7 @@ var KeyVaultAttributes = map[string]attr.Type{
 	"recover_soft_deleted_keys":                                   types.BoolType,
 	"recover_soft_deleted_secrets":                                types.BoolType,
 	"recover_soft_deleted_hardware_security_module_keys":          types.BoolType,
+	"set_value_wo_version_on_import":                              types.BoolType,
 }
 
 type LogAnalyticsWorkspace struct {

--- a/internal/provider/framework/provider.go
+++ b/internal/provider/framework/provider.go
@@ -394,6 +394,11 @@ func (p *azureRmFrameworkProvider) Schema(_ context.Context, _ provider.SchemaRe
 										Description: "When enabled soft-deleted `azurerm_key_vault_managed_hardware_security_module_key` resources will be restored, instead of creating new ones",
 										Optional:    true,
 									},
+
+									"set_value_wo_version_on_import": schema.BoolAttribute{
+										Description: "When enabled `value_wo_version` of `azurerm_key_vault_secret` resources will be set to 1 on import",
+										Optional:    true,
+									},
 								},
 							},
 						},

--- a/internal/services/keyvault/internal.go
+++ b/internal/services/keyvault/internal.go
@@ -151,5 +151,9 @@ func nestedItemResourceImporter(ctx context.Context, d *pluginsdk.ResourceData, 
 	}
 	d.Set("key_vault_id", keyVaultId)
 
+	if meta.(*clients.Client).Features.KeyVault.SetValueWoVersionOnImport && d.GetRawConfig().Type().HasAttribute("value_wo_version") {
+		d.Set("value_wo_version", 1)
+	}
+
 	return []*pluginsdk.ResourceData{d}, nil
 }

--- a/internal/services/keyvault/internal.go
+++ b/internal/services/keyvault/internal.go
@@ -150,5 +150,9 @@ func nestedItemResourceImporter(ctx context.Context, d *pluginsdk.ResourceData, 
 	}
 	d.Set("key_vault_id", keyVaultId)
 
+	if meta.(*clients.Client).Features.KeyVault.SetValueWoVersionOnImport && d.GetRawConfig().Type().HasAttribute("value_wo_version") {
+		d.Set("value_wo_version", 1)
+	}
+
 	return []*pluginsdk.ResourceData{d}, nil
 }

--- a/internal/services/keyvault/key_vault_secret_resource.go
+++ b/internal/services/keyvault/key_vault_secret_resource.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/keyvault"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/resources"
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -140,8 +141,9 @@ func resourceKeyVaultSecretCreate(d *pluginsdk.ResourceData, meta interface{}) e
 		return fmt.Errorf("looking up Secret %q vault url from id %q: %+v", name, *keyVaultId, err)
 	}
 
+	resourceVersionlessId := parse.NewSecretVersionlessID(keyVaultId.SubscriptionId, keyVaultId.ResourceGroupName, keyVaultId.VaultName, name).ID()
 	if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
-		existing, err := client.GetSecret(ctx, *keyVaultBaseUrl, name, "")
+		existing, err := getLatestSecret(ctx, d, meta.(*clients.Client), *keyVaultBaseUrl, name, resourceVersionlessId)
 		if err != nil {
 			if !utils.ResponseWasNotFound(existing.Response) {
 				return fmt.Errorf("checking for presence of existing Secret %q (Key Vault %q): %s", name, *keyVaultBaseUrl, err)
@@ -221,8 +223,7 @@ func resourceKeyVaultSecretCreate(d *pluginsdk.ResourceData, meta interface{}) e
 		}
 	}
 
-	// "" indicates the latest version
-	read, err := client.GetSecret(ctx, *keyVaultBaseUrl, name, "")
+	read, err := getLatestSecret(ctx, d, meta.(*clients.Client), *keyVaultBaseUrl, name, resourceVersionlessId)
 	if err != nil {
 		return err
 	}
@@ -319,8 +320,7 @@ func resourceKeyVaultSecretUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 		}
 	}
 
-	// "" indicates the latest version
-	read, err := client.GetSecret(ctx, id.KeyVaultBaseURL, id.Name, "")
+	read, err := getLatestSecret(ctx, d, meta.(*clients.Client), id.KeyVaultBaseURL, id.Name, parse.NewSecretVersionlessID(keyVaultId.SubscriptionId, keyVaultId.ResourceGroupName, keyVaultId.VaultName, id.Name).ID())
 	if err != nil {
 		return fmt.Errorf("getting Key Vault Secret %q : %+v", id.Name, err)
 	}
@@ -338,7 +338,6 @@ func resourceKeyVaultSecretUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 
 func resourceKeyVaultSecretRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	keyVaultsClient := meta.(*clients.Client).KeyVault
-	client := meta.(*clients.Client).KeyVault.ManagementClient
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -373,8 +372,8 @@ func resourceKeyVaultSecretRead(d *pluginsdk.ResourceData, meta interface{}) err
 		return nil
 	}
 
-	// we always want to get the latest version
-	resp, err := client.GetSecret(ctx, id.KeyVaultBaseURL, id.Name, "")
+	resourceVersionlessId := parse.NewSecretVersionlessID(keyVaultId.SubscriptionId, keyVaultId.ResourceGroupName, keyVaultId.VaultName, id.Name).ID()
+	resp, err := getLatestSecret(ctx, d, meta.(*clients.Client), id.KeyVaultBaseURL, id.Name, resourceVersionlessId)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			log.Printf("[DEBUG] Secret %q was not found in Key Vault at URI %q - removing from state", id.Name, id.KeyVaultBaseURL)
@@ -391,11 +390,8 @@ func resourceKeyVaultSecretRead(d *pluginsdk.ResourceData, meta interface{}) err
 	}
 
 	d.Set("name", respID.Name)
+	// Note that the value will be unset if it is a write-only value because getSecretWithoutValue does not set the value
 	d.Set("value", resp.Value)
-	// Unset value if is a write-only value
-	if _, ok := d.GetOk("value_wo_version"); ok {
-		d.Set("value", nil)
-	}
 	d.Set("version", respID.Version)
 	d.Set("content_type", resp.ContentType)
 	d.Set("versionless_id", id.VersionlessID())
@@ -416,7 +412,7 @@ func resourceKeyVaultSecretRead(d *pluginsdk.ResourceData, meta interface{}) err
 	}
 
 	d.Set("resource_id", parse.NewSecretID(keyVaultId.SubscriptionId, keyVaultId.ResourceGroupName, keyVaultId.VaultName, id.Name, id.Version).ID())
-	d.Set("resource_versionless_id", parse.NewSecretVersionlessID(keyVaultId.SubscriptionId, keyVaultId.ResourceGroupName, keyVaultId.VaultName, id.Name).ID())
+	d.Set("resource_versionless_id", resourceVersionlessId)
 
 	return tags.FlattenAndSet(d, resp.Tags)
 }
@@ -500,4 +496,66 @@ func (d deleteAndPurgeSecret) PurgeNestedItem(ctx context.Context) (autorest.Res
 func (d deleteAndPurgeSecret) NestedItemHasBeenPurged(ctx context.Context) (autorest.Response, error) {
 	resp, err := d.client.GetDeletedSecret(ctx, d.keyVaultUri, d.name)
 	return resp.Response, err
+}
+
+func getLatestSecret(ctx context.Context, d *pluginsdk.ResourceData, client *clients.Client, keyVaultBaseUrl string, name string, resourceVersionlessId string) (kv.SecretBundle, error) {
+	if _, ok := d.GetOk("value_wo_version"); ok {
+		return getSecretWithoutValue(ctx, client.Resource.ResourcesClient, resourceVersionlessId)
+	}
+	// "" indicates the latest version
+	return client.KeyVault.ManagementClient.GetSecret(ctx, keyVaultBaseUrl, name, "")
+}
+
+func getSecretWithoutValue(ctx context.Context, client *resources.ResourcesClient, resourceID string) (kv.SecretBundle, error) {
+	resp, err := client.Get(ctx, commonids.NewScopeID(resourceID))
+	secret := kv.SecretBundle{
+		Response: autorest.Response{Response: resp.HttpResponse},
+	}
+	if err != nil {
+		return secret, err
+	}
+
+	if resp.Model.Properties == nil {
+		return secret, fmt.Errorf("getting Key Vault Secret %q: missing properties", resourceID)
+	}
+
+	prop, ok := (*resp.Model.Properties).(map[string]any)
+	if !ok {
+		return secret, fmt.Errorf("getting Key Vault Secret %q: unexpected property type %T", resourceID, *resp.Model.Properties)
+	}
+
+	if v, ok := prop["secretUriWithVersion"].(string); ok {
+		secret.ID = &v
+	}
+	if v, ok := prop["contentType"].(string); ok {
+		secret.ContentType = &v
+	}
+	if attrs, ok := prop["attributes"].(map[string]any); ok {
+		secret.Attributes = &kv.SecretAttributes{}
+		if v, ok := attrs["enabled"].(bool); ok {
+			secret.Attributes.Enabled = &v
+		}
+		if v, ok := attrs["created"].(float64); ok {
+			t := date.NewUnixTimeFromSeconds(v)
+			secret.Attributes.Created = &t
+		}
+		if v, ok := attrs["updated"].(float64); ok {
+			t := date.NewUnixTimeFromSeconds(v)
+			secret.Attributes.Updated = &t
+		}
+		if v, ok := attrs["exp"].(float64); ok {
+			t := date.NewUnixTimeFromSeconds(v)
+			secret.Attributes.Expires = &t
+		}
+		if v, ok := attrs["nbf"].(float64); ok {
+			t := date.NewUnixTimeFromSeconds(v)
+			secret.Attributes.NotBefore = &t
+		}
+	}
+
+	if resp.Model.Tags != nil {
+		secret.Tags = tags.FromTypedObject(*resp.Model.Tags)
+	}
+
+	return secret, nil
 }

--- a/internal/services/keyvault/key_vault_secret_resource_test.go
+++ b/internal/services/keyvault/key_vault_secret_resource_test.go
@@ -134,6 +134,7 @@ func TestAccKeyVaultSecret_writeOnlyValueWithoutReadPermission(t *testing.T) {
 					check.That(data.ResourceName).Key("value_wo_version").HasValue("1"),
 				),
 			},
+			data.ImportStep(),
 			// Add the "Get" permission before deleting secrets
 			// because deleting secrets appears to require the "Get" permission
 			// even if GetSecret is not called explicitly
@@ -468,7 +469,11 @@ resource "azurerm_key_vault_secret" "test" {
 func (r KeyVaultSecretResource) writeOnlyValueWithoutReadPermission(data acceptance.TestData, secret string, version int) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
-  features {}
+  features {
+    key_vault {
+      set_value_wo_version_on_import = true
+    }
+  }
 }
 
 %s

--- a/internal/services/keyvault/key_vault_secret_resource_test.go
+++ b/internal/services/keyvault/key_vault_secret_resource_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -19,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	kv "github.com/jackofallops/kermit/sdk/keyvault/7.4/keyvault"
 )
@@ -114,6 +116,34 @@ func TestAccKeyVaultSecret_updateToWriteOnlyValue(t *testing.T) {
 	})
 }
 
+func TestAccKeyVaultSecret_writeOnlyValueWithoutReadPermission(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_key_vault_secret", "test")
+	r := KeyVaultSecretResource{}
+
+	resource.ParallelTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.11.0"))),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []acceptance.TestStep{
+			{
+				Config: r.writeOnlyValueWithoutReadPermission(data, "rick-and-morty", 1),
+				Check: acceptance.ComposeTestCheckFunc(
+					check.That(data.ResourceName).ExistsInAzure(r),
+					check.That(data.ResourceName).Key("value").IsEmpty(),
+					check.That(data.ResourceName).Key("value_wo_version").HasValue("1"),
+				),
+			},
+			// Add the "Get" permission before deleting secrets
+			// because deleting secrets appears to require the "Get" permission
+			// even if GetSecret is not called explicitly
+			{
+				Config: r.writeOnlyValue(data, "rick-and-morty", 1),
+			},
+		},
+	})
+}
+
 func TestAccKeyVaultSecret_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_key_vault_secret", "test")
 	r := KeyVaultSecretResource{}
@@ -157,6 +187,20 @@ func TestAccKeyVaultSecret_disappearsWhenParentKeyVaultDeleted(t *testing.T) {
 			),
 			ExpectNonEmptyPlan: true,
 		},
+	})
+}
+
+func TestAccKeyVaultSecret_disappearsWriteOnlyValue(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_key_vault_secret", "test")
+	r := KeyVaultSecretResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		data.DisappearsStep(acceptance.DisappearsStepData{
+			Config: func(data acceptance.TestData) string {
+				return r.writeOnlyValue(data, "rick-and-morty", 1)
+			},
+			TestResource: r,
+		}),
 	})
 }
 
@@ -320,13 +364,14 @@ func (KeyVaultSecretResource) Exists(ctx context.Context, clients *clients.Clien
 		return nil, fmt.Errorf("checking if key vault %q for Certificate %q in Vault at url %q exists: %v", *keyVaultId, id.Name, id.KeyVaultBaseURL, err)
 	}
 
-	// we always want to get the latest version
-	resp, err := clients.KeyVault.ManagementClient.GetSecret(ctx, id.KeyVaultBaseURL, id.Name, "")
+	// use the Resources client instead of the Key Vault client so existence can be
+	// checked without requiring permission to read the secret value.
+	resp, err := clients.Resource.ResourcesClient.Get(ctx, commonids.NewScopeID(parse.NewSecretVersionlessID(keyVaultId.SubscriptionId, keyVaultId.ResourceGroupName, keyVaultId.VaultName, id.Name).ID()))
 	if err != nil {
 		return nil, fmt.Errorf("making Read request on Azure KeyVault Secret %s: %+v", id.Name, err)
 	}
 
-	return pointer.To(resp.ID != nil), nil
+	return pointer.To(resp.Model != nil && resp.Model.Id != nil), nil
 }
 
 func (KeyVaultSecretResource) Destroy(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
@@ -418,6 +463,23 @@ resource "azurerm_key_vault_secret" "test" {
   key_vault_id     = azurerm_key_vault.test.id
 }
 `, r.template(data), data.RandomString, secret, version)
+}
+
+func (r KeyVaultSecretResource) writeOnlyValueWithoutReadPermission(data acceptance.TestData, secret string, version int) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_key_vault_secret" "test" {
+  name             = "secret-%s"
+  value_wo         = "%s"
+  value_wo_version = %d
+  key_vault_id     = azurerm_key_vault.test.id
+}
+`, r.templateWithSecretPermissions(data, []string{"Delete", "List", "Purge", "Recover", "Set"}), data.RandomString, secret, version)
 }
 
 func (r KeyVaultSecretResource) updateTags(data acceptance.TestData) string {
@@ -620,7 +682,18 @@ resource "azurerm_key_vault_secret" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString)
 }
 
-func (KeyVaultSecretResource) template(data acceptance.TestData) string {
+func (r KeyVaultSecretResource) template(data acceptance.TestData) string {
+	return r.templateWithSecretPermissions(data, []string{
+		"Get",
+		"Delete",
+		"List",
+		"Purge",
+		"Recover",
+		"Set",
+	})
+}
+
+func (KeyVaultSecretResource) templateWithSecretPermissions(data acceptance.TestData, permissions []string) string {
 	return fmt.Sprintf(`
 data "azurerm_client_config" "current" {}
 
@@ -646,19 +719,12 @@ resource "azurerm_key_vault" "test" {
       "Get",
     ]
 
-    secret_permissions = [
-      "Get",
-      "Delete",
-      "List",
-      "Purge",
-      "Recover",
-      "Set",
-    ]
+    secret_permissions = ["%s"]
   }
 
   tags = {
     environment = "Production"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, strings.Join(permissions, "\", \""))
 }

--- a/website/docs/guides/features-block.html.markdown
+++ b/website/docs/guides/features-block.html.markdown
@@ -269,6 +269,10 @@ The `key_vault` block supports the following:
 
 ~> **Note:** When recovering soft-deleted Key Vault items (Keys, Certificates, and Secrets) the Principal used by Terraform needs the `"recover"` permission.
 
+* `set_value_wo_version_on_import` - (Optional) Should the `azurerm_key_vault_secret` resource set `value_wo_version` to `1` on import? This prevents unexpected secret updates and avoids reading secret values during import. Defaults to `false`.
+
+~> **Note:** The configuration of an imported secret must also declare `value_wo_version = 1` — any other value is detected as a change on the first plan after import and causes the secret value to be rewritten from `value_wo`.
+
 ---
 
 The `log_analytics_workspace` block supports the following:


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Previously, `terraform plan` required permission to read secret values, even for resources using `value_wo`, which do not need access to the actual secret value.
This PR relaxes that requirement, allowing users with the Key Vault Reader role, which does not have permission to read secret values, to run `terraform plan` with minimal permissions.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

```console
$ make acctests SERVICE="keyvault" TESTARGS='-skip=disappearsWhenParentKeyVaultDeleted -run=TestAccKeyVaultSecret'
TF_ACC=1 go test -v ./internal/services/keyvault -skip=disappearsWhenParentKeyVaultDeleted -run=TestAccKeyVaultSecret -timeout 180m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccKeyVaultSecret_basic
=== PAUSE TestAccKeyVaultSecret_basic
=== RUN   TestAccKeyVaultSecret_writeOnlyValue
=== PAUSE TestAccKeyVaultSecret_writeOnlyValue
=== RUN   TestAccKeyVaultSecret_updateToWriteOnlyValue
=== PAUSE TestAccKeyVaultSecret_updateToWriteOnlyValue
=== RUN   TestAccKeyVaultSecret_writeOnlyValueWithoutReadPermission
=== PAUSE TestAccKeyVaultSecret_writeOnlyValueWithoutReadPermission
=== RUN   TestAccKeyVaultSecret_requiresImport
=== PAUSE TestAccKeyVaultSecret_requiresImport
=== RUN   TestAccKeyVaultSecret_disappears
=== PAUSE TestAccKeyVaultSecret_disappears
=== RUN   TestAccKeyVaultSecret_disappearsWriteOnlyValue
=== PAUSE TestAccKeyVaultSecret_disappearsWriteOnlyValue
=== RUN   TestAccKeyVaultSecret_complete
=== PAUSE TestAccKeyVaultSecret_complete
=== RUN   TestAccKeyVaultSecret_update
=== PAUSE TestAccKeyVaultSecret_update
=== RUN   TestAccKeyVaultSecret_updatingValueChangedExternally
=== PAUSE TestAccKeyVaultSecret_updatingValueChangedExternally
=== RUN   TestAccKeyVaultSecret_recovery
=== PAUSE TestAccKeyVaultSecret_recovery
=== RUN   TestAccKeyVaultSecret_withExternalAccessPolicy
=== PAUSE TestAccKeyVaultSecret_withExternalAccessPolicy
=== RUN   TestAccKeyVaultSecret_purge
=== PAUSE TestAccKeyVaultSecret_purge
=== CONT  TestAccKeyVaultSecret_basic
=== CONT  TestAccKeyVaultSecret_complete
=== CONT  TestAccKeyVaultSecret_requiresImport
=== CONT  TestAccKeyVaultSecret_updateToWriteOnlyValue
=== CONT  TestAccKeyVaultSecret_disappears
=== CONT  TestAccKeyVaultSecret_writeOnlyValueWithoutReadPermission
=== CONT  TestAccKeyVaultSecret_writeOnlyValue
=== CONT  TestAccKeyVaultSecret_recovery
--- PASS: TestAccKeyVaultSecret_disappears (252.26s)
=== CONT  TestAccKeyVaultSecret_purge
--- PASS: TestAccKeyVaultSecret_writeOnlyValueWithoutReadPermission (272.02s)
=== CONT  TestAccKeyVaultSecret_withExternalAccessPolicy
--- PASS: TestAccKeyVaultSecret_writeOnlyValue (272.12s)
=== CONT  TestAccKeyVaultSecret_updatingValueChangedExternally
--- PASS: TestAccKeyVaultSecret_updateToWriteOnlyValue (282.36s)
=== CONT  TestAccKeyVaultSecret_update
--- PASS: TestAccKeyVaultSecret_basic (283.57s)
=== CONT  TestAccKeyVaultSecret_disappearsWriteOnlyValue
--- PASS: TestAccKeyVaultSecret_requiresImport (286.22s)
--- PASS: TestAccKeyVaultSecret_recovery (514.68s)
--- PASS: TestAccKeyVaultSecret_purge (266.75s)
--- PASS: TestAccKeyVaultSecret_disappearsWriteOnlyValue (249.73s)
--- PASS: TestAccKeyVaultSecret_updatingValueChangedExternally (285.47s)
--- PASS: TestAccKeyVaultSecret_update (275.76s)
--- PASS: TestAccKeyVaultSecret_withExternalAccessPolicy (295.71s)
--- PASS: TestAccKeyVaultSecret_complete (591.40s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault      593.913s
```


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_key_vault_secret` - allow Key Vault Reader to make plan of secret resources with value_wo


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/30874


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
