### PR TITLE
 Open Support Cognitive Services Accounts for Outbound PEs for AML (continued)

### DIFF
--- a/internal/services/machinelearning/machine_learning_workspace_network_outbound_rule_private_endpoint_resource.go
+++ b/internal/services/machinelearning/machine_learning_workspace_network_outbound_rule_private_endpoint_resource.go
@@ -22,6 +22,7 @@ import (
 var resourceTypeSupportSubResType = map[string][]string{
 	"Microsoft.KeyVault":                {"vault"},
 	"Microsoft.Cache":                   {"redisCache"},
+	"Microsoft.CognitiveServices":       {"account"},
 	"Microsoft.MachineLearningServices": {"amlworkspace"},
 	"Microsoft.Storage":                 {"blob", "table", "queue", "file", "web", "dfs"},
 }
@@ -78,6 +79,7 @@ func (r WorkspaceNetworkOutboundRulePrivateEndpoint) Arguments() map[string]*plu
 			Required: true,
 			ForceNew: true,
 			ValidateFunc: validation.StringInSlice([]string{
+				"account",
 				"vault",
 				"amlworkspace",
 				"blob",

--- a/internal/services/machinelearning/machine_learning_workspace_network_outbound_rule_private_endpoint_resource_test.go
+++ b/internal/services/machinelearning/machine_learning_workspace_network_outbound_rule_private_endpoint_resource_test.go
@@ -82,6 +82,22 @@ func TestAccMachineLearningWorkspaceNetworkOutboundRulePrivateEndpoint_workspace
 	})
 }
 
+func TestAccMachineLearningWorkspaceNetworkOutboundRulePrivateEndpoint_cognitiveAccount(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_machine_learning_workspace_network_outbound_rule_private_endpoint", "test")
+	r := WorkspaceNetworkOutboundPrivateEndpointResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.withCognitiveAccount(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("service_resource_id").Exists(),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccMachineLearningWorkspaceNetworkOutboundRulePrivateEndpoint_redis(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_machine_learning_workspace_network_outbound_rule_private_endpoint", "test")
 	r := WorkspaceNetworkOutboundPrivateEndpointResource{}

--- a/internal/services/machinelearning/machine_learning_workspace_network_outbound_rule_private_endpoint_resource_test.go
+++ b/internal/services/machinelearning/machine_learning_workspace_network_outbound_rule_private_endpoint_resource_test.go
@@ -446,7 +446,7 @@ resource "azurerm_machine_learning_workspace" "test2" {
   }
 }
 
-resource "azurerm_cognitive_account" "testaccount" {
+resource "azurerm_cognitive_account" "test" {
 	name                = "acctestcogaccount-%[3]s"
 	location            = azurerm_resource_group.test.location
 	resource_group_name = azurerm_resource_group.test.name
@@ -458,7 +458,7 @@ resource "azurerm_cognitive_account" "testaccount" {
 resource "azurerm_machine_learning_workspace_network_outbound_rule_private_endpoint" "test" {
   name                = "acctest-CSA-outboundrule-%[3]s"
   workspace_id        = azurerm_machine_learning_workspace.test.id
-  service_resource_id = azure_cognitive_account.testaccount.id
+  service_resource_id = azure_cognitive_account.test.id
   sub_resource_target = "account"
 }
 `, template, data.RandomInteger, data.RandomStringOfLength(6))

--- a/website/docs/r/machine_learning_workspace_network_outbound_rule_private_endpoint.html.markdown
+++ b/website/docs/r/machine_learning_workspace_network_outbound_rule_private_endpoint.html.markdown
@@ -93,9 +93,10 @@ The following arguments are supported:
 ~> **Note** Supported service resources: **Key Vault**, **Storage Account**, **Machine Learning Workspace**, **Redis**.
 
 * `sub_resource_target` - (Required) Specifies the Sub Resource of the service resource to connect to. Possible values are `vault`,`amlworkspace`,`blob`,`table`,`queue`,`file`,`web`,`dfs`, `redisCache`. Changing this forces a new resource to be created.
-  
+
   | Service                    | Sub Resource Type                         |
   |----------------------------|-------------------------------------------|
+  | Cognitive Services         | `account`                                 |
   | Machine Learning Workspace | `amlworkspace`                            |
   | Redis                      | `redisCache`                              |
   | Storage Account            | `blob`,`table`,`queue`,`file`,`web`,`dfs` |


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

azurerm_machine_learning_workspace_network_outbound_rule_private_endpoint - Updating property sub_resource_target to support Cognitive Services Accounts, which are a valid outbound private endpoint target for Machine Learning Workspaces.

This PR adds the missing Cognitive Services "Account" Sub Type for Private Endpoints in managed Machine Learning Outbound Networks.

Currently this type is unsupported by the Terraform resource, but is supported in Azure:

`╷
│ Error: expected sub_resource_target to be one of ["vault" "amlworkspace" "blob" "table" "queue" "file" "web" "dfs" "redisCache"], got account
│ 
│   with module.copilot-fine-tuning.azurerm_machine_learning_workspace_network_outbound_rule_private_endpoint.pe-cog-svc-account,
│   on ../modules/orcav2/aml.tf line 127, in resource "azurerm_machine_learning_workspace_network_outbound_rule_private_endpoint" "pe":
│  127:   sub_resource_target = "account"`
## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
