### PR TITLE
Add support for contactemail tag on dns_caa_record resource

### DIFF
--- a/internal/services/dns/dns_caa_record_resource.go
+++ b/internal/services/dns/dns_caa_record_resource.go
@@ -82,6 +82,7 @@ func resourceDnsCaaRecord() *pluginsdk.Resource {
 								"issue",
 								"issuewild",
 								"iodef",
+								"contactemail",
 							}, false),
 						},
 

--- a/website/docs/d/dns_caa_record.html.markdown
+++ b/website/docs/d/dns_caa_record.html.markdown
@@ -52,7 +52,7 @@ The `record` block supports:
 
 * `flags` - Extensible CAA flags, currently only 1 is implemented to set the issuer critical flag.
 
-* `tag` - A property tag, options are `issue`, `issuewild` and `iodef`.
+* `tag` - A property tag, options are `issue`, `issuewild`, `iodef`, and `contactemail`.
 
 * `value` - A property value such as a registrar domain.
 

--- a/website/docs/r/dns_caa_record.html.markdown
+++ b/website/docs/r/dns_caa_record.html.markdown
@@ -83,7 +83,7 @@ The `record` block supports:
 
 * `flags` - (Required) Extensible CAA flags, currently only 1 is implemented to set the issuer critical flag.
 
-* `tag` - (Required) A property tag, options are `issue`, `issuewild` and `iodef`.
+* `tag` - (Required) A property tag, options are `issue`, `issuewild`, `iodef`, and `contactemail`.
 
 * `value` - (Required) A property value such as a registrar domain.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Add support for the `contactemail` tag type commonly used by Microsoft DNS providers. The RFC allows any tag that is ASCII a-z: https://datatracker.ietf.org/doc/html/rfc8659#name-syntax

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 

<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->

## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

No existing tests for this resource type.

## Change Log
Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_dns_caa_record` - support for the `tag` property with value `contactemail`


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change
