### PR TITLE
Dependencies: update `go-azure-sdk` to `v0.20250520.1180806`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,8 +17,8 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-azure-helpers v0.72.0
-	github.com/hashicorp/go-azure-sdk/resource-manager v0.20250409.1192141
-	github.com/hashicorp/go-azure-sdk/sdk v0.20250409.1192141
+	github.com/hashicorp/go-azure-sdk/resource-manager v0.20250520.1180806
+	github.com/hashicorp/go-azure-sdk/sdk v0.20250520.1180806
 	github.com/hashicorp/go-cty v1.4.1
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -92,10 +92,10 @@ github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-azure-helpers v0.72.0 h1:eOCpXBkDYYMESkOBC0LgPMNUdiLPtQxv7sCW/hHdUbw=
 github.com/hashicorp/go-azure-helpers v0.72.0/go.mod h1:Omirva2gGNrhN4pigurl5RN7u3BoaN0bco8ZSbdaNy8=
-github.com/hashicorp/go-azure-sdk/resource-manager v0.20250409.1192141 h1:Pcg1YL7B6iWG9UWKgvd3v2d7K9Zp43bNePmRP52HYB4=
-github.com/hashicorp/go-azure-sdk/resource-manager v0.20250409.1192141/go.mod h1:MZGY8UAS8jtXSqZSDF7O6QTsAe09N21AAdQbUREKeX4=
-github.com/hashicorp/go-azure-sdk/sdk v0.20250409.1192141 h1:t8kLm2lV5I7RQ0RpnQ8hxSfsLWUo/xpq1nBpSdxIguQ=
-github.com/hashicorp/go-azure-sdk/sdk v0.20250409.1192141/go.mod h1:/LiVkre6Py4M8+xkSHgJieWkHWv03USdwg5x/zeX9Rc=
+github.com/hashicorp/go-azure-sdk/resource-manager v0.20250520.1180806 h1:MEENQuAsDwRwHSB6eGpnA6E/7NOpVjqvdS2VTyydWHA=
+github.com/hashicorp/go-azure-sdk/resource-manager v0.20250520.1180806/go.mod h1:ZeFAzmaxJEZrvJJB663ylkKmAjQOaLiZ1owVa0kghCo=
+github.com/hashicorp/go-azure-sdk/sdk v0.20250520.1180806 h1:nteX2b+diNtQ7dGZxCVvkEQ4QDnO4rFRmQPChvVWaaE=
+github.com/hashicorp/go-azure-sdk/sdk v0.20250520.1180806/go.mod h1:/LiVkre6Py4M8+xkSHgJieWkHWv03USdwg5x/zeX9Rc=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=
 github.com/hashicorp/go-checkpoint v0.5.0/go.mod h1:7nfLNL10NsxqO4iWuW6tWW0HjZuDrwkBuEQsVcpCOgg=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=

--- a/internal/services/oracle/oracle_db_nodes_data_source.go
+++ b/internal/services/oracle/oracle_db_nodes_data_source.go
@@ -211,7 +211,7 @@ func (d DBNodesDataSource) Read() sdk.ResourceFunc {
 			}
 			id := dbnodes.NewCloudVMClusterID(subscriptionId, parsedCloudVmClusterId.ResourceGroupName, parsedCloudVmClusterId.CloudVmClusterName)
 
-			resp, err := client.ListByCloudVMCluster(ctx, id)
+			resp, err := client.ListByParent(ctx, id)
 			if err != nil {
 				if response.WasNotFound(resp.HttpResponse) {
 					return fmt.Errorf("%s was not found", id)

--- a/internal/services/oracle/oracle_db_servers_data_source.go
+++ b/internal/services/oracle/oracle_db_servers_data_source.go
@@ -197,7 +197,7 @@ func (d DBServersDataSource) Read() sdk.ResourceFunc {
 
 			id := dbservers.NewCloudExadataInfrastructureID(subscriptionId, state.ResourceGroupName, state.CloudExadataInfrastructureName)
 
-			resp, err := client.ListByCloudExadataInfrastructure(ctx, id)
+			resp, err := client.ListByParent(ctx, id)
 			if err != nil {
 				if response.WasNotFound(resp.HttpResponse) {
 					return fmt.Errorf("%s was not found", id)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datafactory/2018-06-01/linkedservices/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datafactory/2018-06-01/linkedservices/constants.go
@@ -9,6 +9,44 @@ import (
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See NOTICE.txt in the project root for license information.
 
+type AmazonRdsForOracleAuthenticationType string
+
+const (
+	AmazonRdsForOracleAuthenticationTypeBasic AmazonRdsForOracleAuthenticationType = "Basic"
+)
+
+func PossibleValuesForAmazonRdsForOracleAuthenticationType() []string {
+	return []string{
+		string(AmazonRdsForOracleAuthenticationTypeBasic),
+	}
+}
+
+func (s *AmazonRdsForOracleAuthenticationType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseAmazonRdsForOracleAuthenticationType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseAmazonRdsForOracleAuthenticationType(input string) (*AmazonRdsForOracleAuthenticationType, error) {
+	vals := map[string]AmazonRdsForOracleAuthenticationType{
+		"basic": AmazonRdsForOracleAuthenticationTypeBasic,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := AmazonRdsForOracleAuthenticationType(input)
+	return &out, nil
+}
+
 type AmazonRdsForSqlAuthenticationType string
 
 const (
@@ -827,6 +865,47 @@ func parseImpalaAuthenticationType(input string) (*ImpalaAuthenticationType, err
 
 	// otherwise presume it's an undefined value and best-effort it
 	out := ImpalaAuthenticationType(input)
+	return &out, nil
+}
+
+type ImpalaThriftTransportProtocol string
+
+const (
+	ImpalaThriftTransportProtocolBinary ImpalaThriftTransportProtocol = "Binary"
+	ImpalaThriftTransportProtocolHTTP   ImpalaThriftTransportProtocol = "HTTP"
+)
+
+func PossibleValuesForImpalaThriftTransportProtocol() []string {
+	return []string{
+		string(ImpalaThriftTransportProtocolBinary),
+		string(ImpalaThriftTransportProtocolHTTP),
+	}
+}
+
+func (s *ImpalaThriftTransportProtocol) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseImpalaThriftTransportProtocol(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseImpalaThriftTransportProtocol(input string) (*ImpalaThriftTransportProtocol, error) {
+	vals := map[string]ImpalaThriftTransportProtocol{
+		"binary": ImpalaThriftTransportProtocolBinary,
+		"http":   ImpalaThriftTransportProtocolHTTP,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ImpalaThriftTransportProtocol(input)
 	return &out, nil
 }
 

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datafactory/2018-06-01/linkedservices/model_amazonrdsforlinkedservicetypeproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datafactory/2018-06-01/linkedservices/model_amazonrdsforlinkedservicetypeproperties.go
@@ -9,24 +9,66 @@ import (
 // Licensed under the MIT License. See NOTICE.txt in the project root for license information.
 
 type AmazonRdsForLinkedServiceTypeProperties struct {
-	ConnectionString    interface{} `json:"connectionString"`
-	EncryptedCredential *string     `json:"encryptedCredential,omitempty"`
-	Password            SecretBase  `json:"password"`
+	AuthenticationType        *AmazonRdsForOracleAuthenticationType `json:"authenticationType,omitempty"`
+	ConnectionString          *interface{}                          `json:"connectionString,omitempty"`
+	CryptoChecksumClient      *interface{}                          `json:"cryptoChecksumClient,omitempty"`
+	CryptoChecksumTypesClient *interface{}                          `json:"cryptoChecksumTypesClient,omitempty"`
+	EnableBulkLoad            *bool                                 `json:"enableBulkLoad,omitempty"`
+	EncryptedCredential       *string                               `json:"encryptedCredential,omitempty"`
+	EncryptionClient          *interface{}                          `json:"encryptionClient,omitempty"`
+	EncryptionTypesClient     *interface{}                          `json:"encryptionTypesClient,omitempty"`
+	FetchSize                 *int64                                `json:"fetchSize,omitempty"`
+	FetchTswtzAsTimestamp     *bool                                 `json:"fetchTswtzAsTimestamp,omitempty"`
+	InitialLobFetchSize       *int64                                `json:"initialLobFetchSize,omitempty"`
+	InitializationString      *interface{}                          `json:"initializationString,omitempty"`
+	Password                  SecretBase                            `json:"password"`
+	Server                    *interface{}                          `json:"server,omitempty"`
+	StatementCacheSize        *int64                                `json:"statementCacheSize,omitempty"`
+	SupportV1DataTypes        *bool                                 `json:"supportV1DataTypes,omitempty"`
+	Username                  *interface{}                          `json:"username,omitempty"`
 }
 
 var _ json.Unmarshaler = &AmazonRdsForLinkedServiceTypeProperties{}
 
 func (s *AmazonRdsForLinkedServiceTypeProperties) UnmarshalJSON(bytes []byte) error {
 	var decoded struct {
-		ConnectionString    interface{} `json:"connectionString"`
-		EncryptedCredential *string     `json:"encryptedCredential,omitempty"`
+		AuthenticationType        *AmazonRdsForOracleAuthenticationType `json:"authenticationType,omitempty"`
+		ConnectionString          *interface{}                          `json:"connectionString,omitempty"`
+		CryptoChecksumClient      *interface{}                          `json:"cryptoChecksumClient,omitempty"`
+		CryptoChecksumTypesClient *interface{}                          `json:"cryptoChecksumTypesClient,omitempty"`
+		EnableBulkLoad            *bool                                 `json:"enableBulkLoad,omitempty"`
+		EncryptedCredential       *string                               `json:"encryptedCredential,omitempty"`
+		EncryptionClient          *interface{}                          `json:"encryptionClient,omitempty"`
+		EncryptionTypesClient     *interface{}                          `json:"encryptionTypesClient,omitempty"`
+		FetchSize                 *int64                                `json:"fetchSize,omitempty"`
+		FetchTswtzAsTimestamp     *bool                                 `json:"fetchTswtzAsTimestamp,omitempty"`
+		InitialLobFetchSize       *int64                                `json:"initialLobFetchSize,omitempty"`
+		InitializationString      *interface{}                          `json:"initializationString,omitempty"`
+		Server                    *interface{}                          `json:"server,omitempty"`
+		StatementCacheSize        *int64                                `json:"statementCacheSize,omitempty"`
+		SupportV1DataTypes        *bool                                 `json:"supportV1DataTypes,omitempty"`
+		Username                  *interface{}                          `json:"username,omitempty"`
 	}
 	if err := json.Unmarshal(bytes, &decoded); err != nil {
 		return fmt.Errorf("unmarshaling: %+v", err)
 	}
 
+	s.AuthenticationType = decoded.AuthenticationType
 	s.ConnectionString = decoded.ConnectionString
+	s.CryptoChecksumClient = decoded.CryptoChecksumClient
+	s.CryptoChecksumTypesClient = decoded.CryptoChecksumTypesClient
+	s.EnableBulkLoad = decoded.EnableBulkLoad
 	s.EncryptedCredential = decoded.EncryptedCredential
+	s.EncryptionClient = decoded.EncryptionClient
+	s.EncryptionTypesClient = decoded.EncryptionTypesClient
+	s.FetchSize = decoded.FetchSize
+	s.FetchTswtzAsTimestamp = decoded.FetchTswtzAsTimestamp
+	s.InitialLobFetchSize = decoded.InitialLobFetchSize
+	s.InitializationString = decoded.InitializationString
+	s.Server = decoded.Server
+	s.StatementCacheSize = decoded.StatementCacheSize
+	s.SupportV1DataTypes = decoded.SupportV1DataTypes
+	s.Username = decoded.Username
 
 	var temp map[string]json.RawMessage
 	if err := json.Unmarshal(bytes, &temp); err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datafactory/2018-06-01/linkedservices/model_azuredatabrickslinkedservicetypeproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datafactory/2018-06-01/linkedservices/model_azuredatabrickslinkedservicetypeproperties.go
@@ -12,6 +12,7 @@ type AzureDatabricksLinkedServiceTypeProperties struct {
 	AccessToken                 SecretBase              `json:"accessToken"`
 	Authentication              *interface{}            `json:"authentication,omitempty"`
 	Credential                  *CredentialReference    `json:"credential,omitempty"`
+	DataSecurityMode            *interface{}            `json:"dataSecurityMode,omitempty"`
 	Domain                      interface{}             `json:"domain"`
 	EncryptedCredential         *string                 `json:"encryptedCredential,omitempty"`
 	ExistingClusterId           *interface{}            `json:"existingClusterId,omitempty"`
@@ -36,6 +37,7 @@ func (s *AzureDatabricksLinkedServiceTypeProperties) UnmarshalJSON(bytes []byte)
 	var decoded struct {
 		Authentication              *interface{}            `json:"authentication,omitempty"`
 		Credential                  *CredentialReference    `json:"credential,omitempty"`
+		DataSecurityMode            *interface{}            `json:"dataSecurityMode,omitempty"`
 		Domain                      interface{}             `json:"domain"`
 		EncryptedCredential         *string                 `json:"encryptedCredential,omitempty"`
 		ExistingClusterId           *interface{}            `json:"existingClusterId,omitempty"`
@@ -59,6 +61,7 @@ func (s *AzureDatabricksLinkedServiceTypeProperties) UnmarshalJSON(bytes []byte)
 
 	s.Authentication = decoded.Authentication
 	s.Credential = decoded.Credential
+	s.DataSecurityMode = decoded.DataSecurityMode
 	s.Domain = decoded.Domain
 	s.EncryptedCredential = decoded.EncryptedCredential
 	s.ExistingClusterId = decoded.ExistingClusterId

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datafactory/2018-06-01/linkedservices/model_hivelinkedservicetypeproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datafactory/2018-06-01/linkedservices/model_hivelinkedservicetypeproperties.go
@@ -9,45 +9,47 @@ import (
 // Licensed under the MIT License. See NOTICE.txt in the project root for license information.
 
 type HiveLinkedServiceTypeProperties struct {
-	AllowHostNameCNMismatch   *bool                        `json:"allowHostNameCNMismatch,omitempty"`
-	AllowSelfSignedServerCert *bool                        `json:"allowSelfSignedServerCert,omitempty"`
-	AuthenticationType        HiveAuthenticationType       `json:"authenticationType"`
-	EnableSsl                 *bool                        `json:"enableSsl,omitempty"`
-	EncryptedCredential       *string                      `json:"encryptedCredential,omitempty"`
-	HTTPPath                  *interface{}                 `json:"httpPath,omitempty"`
-	Host                      interface{}                  `json:"host"`
-	Password                  SecretBase                   `json:"password"`
-	Port                      *int64                       `json:"port,omitempty"`
-	ServerType                *HiveServerType              `json:"serverType,omitempty"`
-	ServiceDiscoveryMode      *bool                        `json:"serviceDiscoveryMode,omitempty"`
-	ThriftTransportProtocol   *HiveThriftTransportProtocol `json:"thriftTransportProtocol,omitempty"`
-	TrustedCertPath           *interface{}                 `json:"trustedCertPath,omitempty"`
-	UseNativeQuery            *bool                        `json:"useNativeQuery,omitempty"`
-	UseSystemTrustStore       *bool                        `json:"useSystemTrustStore,omitempty"`
-	Username                  *interface{}                 `json:"username,omitempty"`
-	ZooKeeperNameSpace        *interface{}                 `json:"zooKeeperNameSpace,omitempty"`
+	AllowHostNameCNMismatch           *bool                        `json:"allowHostNameCNMismatch,omitempty"`
+	AllowSelfSignedServerCert         *bool                        `json:"allowSelfSignedServerCert,omitempty"`
+	AuthenticationType                HiveAuthenticationType       `json:"authenticationType"`
+	EnableServerCertificateValidation *bool                        `json:"enableServerCertificateValidation,omitempty"`
+	EnableSsl                         *bool                        `json:"enableSsl,omitempty"`
+	EncryptedCredential               *string                      `json:"encryptedCredential,omitempty"`
+	HTTPPath                          *interface{}                 `json:"httpPath,omitempty"`
+	Host                              interface{}                  `json:"host"`
+	Password                          SecretBase                   `json:"password"`
+	Port                              *int64                       `json:"port,omitempty"`
+	ServerType                        *HiveServerType              `json:"serverType,omitempty"`
+	ServiceDiscoveryMode              *bool                        `json:"serviceDiscoveryMode,omitempty"`
+	ThriftTransportProtocol           *HiveThriftTransportProtocol `json:"thriftTransportProtocol,omitempty"`
+	TrustedCertPath                   *interface{}                 `json:"trustedCertPath,omitempty"`
+	UseNativeQuery                    *bool                        `json:"useNativeQuery,omitempty"`
+	UseSystemTrustStore               *bool                        `json:"useSystemTrustStore,omitempty"`
+	Username                          *interface{}                 `json:"username,omitempty"`
+	ZooKeeperNameSpace                *interface{}                 `json:"zooKeeperNameSpace,omitempty"`
 }
 
 var _ json.Unmarshaler = &HiveLinkedServiceTypeProperties{}
 
 func (s *HiveLinkedServiceTypeProperties) UnmarshalJSON(bytes []byte) error {
 	var decoded struct {
-		AllowHostNameCNMismatch   *bool                        `json:"allowHostNameCNMismatch,omitempty"`
-		AllowSelfSignedServerCert *bool                        `json:"allowSelfSignedServerCert,omitempty"`
-		AuthenticationType        HiveAuthenticationType       `json:"authenticationType"`
-		EnableSsl                 *bool                        `json:"enableSsl,omitempty"`
-		EncryptedCredential       *string                      `json:"encryptedCredential,omitempty"`
-		HTTPPath                  *interface{}                 `json:"httpPath,omitempty"`
-		Host                      interface{}                  `json:"host"`
-		Port                      *int64                       `json:"port,omitempty"`
-		ServerType                *HiveServerType              `json:"serverType,omitempty"`
-		ServiceDiscoveryMode      *bool                        `json:"serviceDiscoveryMode,omitempty"`
-		ThriftTransportProtocol   *HiveThriftTransportProtocol `json:"thriftTransportProtocol,omitempty"`
-		TrustedCertPath           *interface{}                 `json:"trustedCertPath,omitempty"`
-		UseNativeQuery            *bool                        `json:"useNativeQuery,omitempty"`
-		UseSystemTrustStore       *bool                        `json:"useSystemTrustStore,omitempty"`
-		Username                  *interface{}                 `json:"username,omitempty"`
-		ZooKeeperNameSpace        *interface{}                 `json:"zooKeeperNameSpace,omitempty"`
+		AllowHostNameCNMismatch           *bool                        `json:"allowHostNameCNMismatch,omitempty"`
+		AllowSelfSignedServerCert         *bool                        `json:"allowSelfSignedServerCert,omitempty"`
+		AuthenticationType                HiveAuthenticationType       `json:"authenticationType"`
+		EnableServerCertificateValidation *bool                        `json:"enableServerCertificateValidation,omitempty"`
+		EnableSsl                         *bool                        `json:"enableSsl,omitempty"`
+		EncryptedCredential               *string                      `json:"encryptedCredential,omitempty"`
+		HTTPPath                          *interface{}                 `json:"httpPath,omitempty"`
+		Host                              interface{}                  `json:"host"`
+		Port                              *int64                       `json:"port,omitempty"`
+		ServerType                        *HiveServerType              `json:"serverType,omitempty"`
+		ServiceDiscoveryMode              *bool                        `json:"serviceDiscoveryMode,omitempty"`
+		ThriftTransportProtocol           *HiveThriftTransportProtocol `json:"thriftTransportProtocol,omitempty"`
+		TrustedCertPath                   *interface{}                 `json:"trustedCertPath,omitempty"`
+		UseNativeQuery                    *bool                        `json:"useNativeQuery,omitempty"`
+		UseSystemTrustStore               *bool                        `json:"useSystemTrustStore,omitempty"`
+		Username                          *interface{}                 `json:"username,omitempty"`
+		ZooKeeperNameSpace                *interface{}                 `json:"zooKeeperNameSpace,omitempty"`
 	}
 	if err := json.Unmarshal(bytes, &decoded); err != nil {
 		return fmt.Errorf("unmarshaling: %+v", err)
@@ -56,6 +58,7 @@ func (s *HiveLinkedServiceTypeProperties) UnmarshalJSON(bytes []byte) error {
 	s.AllowHostNameCNMismatch = decoded.AllowHostNameCNMismatch
 	s.AllowSelfSignedServerCert = decoded.AllowSelfSignedServerCert
 	s.AuthenticationType = decoded.AuthenticationType
+	s.EnableServerCertificateValidation = decoded.EnableServerCertificateValidation
 	s.EnableSsl = decoded.EnableSsl
 	s.EncryptedCredential = decoded.EncryptedCredential
 	s.HTTPPath = decoded.HTTPPath

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datafactory/2018-06-01/linkedservices/model_impalalinkedservicetypeproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datafactory/2018-06-01/linkedservices/model_impalalinkedservicetypeproperties.go
@@ -9,33 +9,37 @@ import (
 // Licensed under the MIT License. See NOTICE.txt in the project root for license information.
 
 type ImpalaLinkedServiceTypeProperties struct {
-	AllowHostNameCNMismatch   *bool                    `json:"allowHostNameCNMismatch,omitempty"`
-	AllowSelfSignedServerCert *bool                    `json:"allowSelfSignedServerCert,omitempty"`
-	AuthenticationType        ImpalaAuthenticationType `json:"authenticationType"`
-	EnableSsl                 *bool                    `json:"enableSsl,omitempty"`
-	EncryptedCredential       *string                  `json:"encryptedCredential,omitempty"`
-	Host                      interface{}              `json:"host"`
-	Password                  SecretBase               `json:"password"`
-	Port                      *int64                   `json:"port,omitempty"`
-	TrustedCertPath           *interface{}             `json:"trustedCertPath,omitempty"`
-	UseSystemTrustStore       *bool                    `json:"useSystemTrustStore,omitempty"`
-	Username                  *interface{}             `json:"username,omitempty"`
+	AllowHostNameCNMismatch           *bool                          `json:"allowHostNameCNMismatch,omitempty"`
+	AllowSelfSignedServerCert         *bool                          `json:"allowSelfSignedServerCert,omitempty"`
+	AuthenticationType                ImpalaAuthenticationType       `json:"authenticationType"`
+	EnableServerCertificateValidation *bool                          `json:"enableServerCertificateValidation,omitempty"`
+	EnableSsl                         *bool                          `json:"enableSsl,omitempty"`
+	EncryptedCredential               *string                        `json:"encryptedCredential,omitempty"`
+	Host                              interface{}                    `json:"host"`
+	Password                          SecretBase                     `json:"password"`
+	Port                              *int64                         `json:"port,omitempty"`
+	ThriftTransportProtocol           *ImpalaThriftTransportProtocol `json:"thriftTransportProtocol,omitempty"`
+	TrustedCertPath                   *interface{}                   `json:"trustedCertPath,omitempty"`
+	UseSystemTrustStore               *bool                          `json:"useSystemTrustStore,omitempty"`
+	Username                          *interface{}                   `json:"username,omitempty"`
 }
 
 var _ json.Unmarshaler = &ImpalaLinkedServiceTypeProperties{}
 
 func (s *ImpalaLinkedServiceTypeProperties) UnmarshalJSON(bytes []byte) error {
 	var decoded struct {
-		AllowHostNameCNMismatch   *bool                    `json:"allowHostNameCNMismatch,omitempty"`
-		AllowSelfSignedServerCert *bool                    `json:"allowSelfSignedServerCert,omitempty"`
-		AuthenticationType        ImpalaAuthenticationType `json:"authenticationType"`
-		EnableSsl                 *bool                    `json:"enableSsl,omitempty"`
-		EncryptedCredential       *string                  `json:"encryptedCredential,omitempty"`
-		Host                      interface{}              `json:"host"`
-		Port                      *int64                   `json:"port,omitempty"`
-		TrustedCertPath           *interface{}             `json:"trustedCertPath,omitempty"`
-		UseSystemTrustStore       *bool                    `json:"useSystemTrustStore,omitempty"`
-		Username                  *interface{}             `json:"username,omitempty"`
+		AllowHostNameCNMismatch           *bool                          `json:"allowHostNameCNMismatch,omitempty"`
+		AllowSelfSignedServerCert         *bool                          `json:"allowSelfSignedServerCert,omitempty"`
+		AuthenticationType                ImpalaAuthenticationType       `json:"authenticationType"`
+		EnableServerCertificateValidation *bool                          `json:"enableServerCertificateValidation,omitempty"`
+		EnableSsl                         *bool                          `json:"enableSsl,omitempty"`
+		EncryptedCredential               *string                        `json:"encryptedCredential,omitempty"`
+		Host                              interface{}                    `json:"host"`
+		Port                              *int64                         `json:"port,omitempty"`
+		ThriftTransportProtocol           *ImpalaThriftTransportProtocol `json:"thriftTransportProtocol,omitempty"`
+		TrustedCertPath                   *interface{}                   `json:"trustedCertPath,omitempty"`
+		UseSystemTrustStore               *bool                          `json:"useSystemTrustStore,omitempty"`
+		Username                          *interface{}                   `json:"username,omitempty"`
 	}
 	if err := json.Unmarshal(bytes, &decoded); err != nil {
 		return fmt.Errorf("unmarshaling: %+v", err)
@@ -44,10 +48,12 @@ func (s *ImpalaLinkedServiceTypeProperties) UnmarshalJSON(bytes []byte) error {
 	s.AllowHostNameCNMismatch = decoded.AllowHostNameCNMismatch
 	s.AllowSelfSignedServerCert = decoded.AllowSelfSignedServerCert
 	s.AuthenticationType = decoded.AuthenticationType
+	s.EnableServerCertificateValidation = decoded.EnableServerCertificateValidation
 	s.EnableSsl = decoded.EnableSsl
 	s.EncryptedCredential = decoded.EncryptedCredential
 	s.Host = decoded.Host
 	s.Port = decoded.Port
+	s.ThriftTransportProtocol = decoded.ThriftTransportProtocol
 	s.TrustedCertPath = decoded.TrustedCertPath
 	s.UseSystemTrustStore = decoded.UseSystemTrustStore
 	s.Username = decoded.Username

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datafactory/2018-06-01/linkedservices/model_sparklinkedservicetypeproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datafactory/2018-06-01/linkedservices/model_sparklinkedservicetypeproperties.go
@@ -9,39 +9,41 @@ import (
 // Licensed under the MIT License. See NOTICE.txt in the project root for license information.
 
 type SparkLinkedServiceTypeProperties struct {
-	AllowHostNameCNMismatch   *bool                         `json:"allowHostNameCNMismatch,omitempty"`
-	AllowSelfSignedServerCert *bool                         `json:"allowSelfSignedServerCert,omitempty"`
-	AuthenticationType        SparkAuthenticationType       `json:"authenticationType"`
-	EnableSsl                 *bool                         `json:"enableSsl,omitempty"`
-	EncryptedCredential       *string                       `json:"encryptedCredential,omitempty"`
-	HTTPPath                  *interface{}                  `json:"httpPath,omitempty"`
-	Host                      interface{}                   `json:"host"`
-	Password                  SecretBase                    `json:"password"`
-	Port                      int64                         `json:"port"`
-	ServerType                *SparkServerType              `json:"serverType,omitempty"`
-	ThriftTransportProtocol   *SparkThriftTransportProtocol `json:"thriftTransportProtocol,omitempty"`
-	TrustedCertPath           *interface{}                  `json:"trustedCertPath,omitempty"`
-	UseSystemTrustStore       *bool                         `json:"useSystemTrustStore,omitempty"`
-	Username                  *interface{}                  `json:"username,omitempty"`
+	AllowHostNameCNMismatch           *bool                         `json:"allowHostNameCNMismatch,omitempty"`
+	AllowSelfSignedServerCert         *bool                         `json:"allowSelfSignedServerCert,omitempty"`
+	AuthenticationType                SparkAuthenticationType       `json:"authenticationType"`
+	EnableServerCertificateValidation *bool                         `json:"enableServerCertificateValidation,omitempty"`
+	EnableSsl                         *bool                         `json:"enableSsl,omitempty"`
+	EncryptedCredential               *string                       `json:"encryptedCredential,omitempty"`
+	HTTPPath                          *interface{}                  `json:"httpPath,omitempty"`
+	Host                              interface{}                   `json:"host"`
+	Password                          SecretBase                    `json:"password"`
+	Port                              int64                         `json:"port"`
+	ServerType                        *SparkServerType              `json:"serverType,omitempty"`
+	ThriftTransportProtocol           *SparkThriftTransportProtocol `json:"thriftTransportProtocol,omitempty"`
+	TrustedCertPath                   *interface{}                  `json:"trustedCertPath,omitempty"`
+	UseSystemTrustStore               *bool                         `json:"useSystemTrustStore,omitempty"`
+	Username                          *interface{}                  `json:"username,omitempty"`
 }
 
 var _ json.Unmarshaler = &SparkLinkedServiceTypeProperties{}
 
 func (s *SparkLinkedServiceTypeProperties) UnmarshalJSON(bytes []byte) error {
 	var decoded struct {
-		AllowHostNameCNMismatch   *bool                         `json:"allowHostNameCNMismatch,omitempty"`
-		AllowSelfSignedServerCert *bool                         `json:"allowSelfSignedServerCert,omitempty"`
-		AuthenticationType        SparkAuthenticationType       `json:"authenticationType"`
-		EnableSsl                 *bool                         `json:"enableSsl,omitempty"`
-		EncryptedCredential       *string                       `json:"encryptedCredential,omitempty"`
-		HTTPPath                  *interface{}                  `json:"httpPath,omitempty"`
-		Host                      interface{}                   `json:"host"`
-		Port                      int64                         `json:"port"`
-		ServerType                *SparkServerType              `json:"serverType,omitempty"`
-		ThriftTransportProtocol   *SparkThriftTransportProtocol `json:"thriftTransportProtocol,omitempty"`
-		TrustedCertPath           *interface{}                  `json:"trustedCertPath,omitempty"`
-		UseSystemTrustStore       *bool                         `json:"useSystemTrustStore,omitempty"`
-		Username                  *interface{}                  `json:"username,omitempty"`
+		AllowHostNameCNMismatch           *bool                         `json:"allowHostNameCNMismatch,omitempty"`
+		AllowSelfSignedServerCert         *bool                         `json:"allowSelfSignedServerCert,omitempty"`
+		AuthenticationType                SparkAuthenticationType       `json:"authenticationType"`
+		EnableServerCertificateValidation *bool                         `json:"enableServerCertificateValidation,omitempty"`
+		EnableSsl                         *bool                         `json:"enableSsl,omitempty"`
+		EncryptedCredential               *string                       `json:"encryptedCredential,omitempty"`
+		HTTPPath                          *interface{}                  `json:"httpPath,omitempty"`
+		Host                              interface{}                   `json:"host"`
+		Port                              int64                         `json:"port"`
+		ServerType                        *SparkServerType              `json:"serverType,omitempty"`
+		ThriftTransportProtocol           *SparkThriftTransportProtocol `json:"thriftTransportProtocol,omitempty"`
+		TrustedCertPath                   *interface{}                  `json:"trustedCertPath,omitempty"`
+		UseSystemTrustStore               *bool                         `json:"useSystemTrustStore,omitempty"`
+		Username                          *interface{}                  `json:"username,omitempty"`
 	}
 	if err := json.Unmarshal(bytes, &decoded); err != nil {
 		return fmt.Errorf("unmarshaling: %+v", err)
@@ -50,6 +52,7 @@ func (s *SparkLinkedServiceTypeProperties) UnmarshalJSON(bytes []byte) error {
 	s.AllowHostNameCNMismatch = decoded.AllowHostNameCNMismatch
 	s.AllowSelfSignedServerCert = decoded.AllowSelfSignedServerCert
 	s.AuthenticationType = decoded.AuthenticationType
+	s.EnableServerCertificateValidation = decoded.EnableServerCertificateValidation
 	s.EnableSsl = decoded.EnableSsl
 	s.EncryptedCredential = decoded.EncryptedCredential
 	s.HTTPPath = decoded.HTTPPath

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2024-05-01/loadbalancers/model_loadbalancerhealthperruleperbackendaddress.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2024-05-01/loadbalancers/model_loadbalancerhealthperruleperbackendaddress.go
@@ -4,8 +4,8 @@ package loadbalancers
 // Licensed under the MIT License. See NOTICE.txt in the project root for license information.
 
 type LoadBalancerHealthPerRulePerBackendAddress struct {
-	IPAddress                         *string                          `json:"ipAddress,omitempty"`
-	NetworkInterfaceIPConfigurationId *NetworkInterfaceIPConfiguration `json:"networkInterfaceIPConfigurationId,omitempty"`
-	Reason                            *string                          `json:"reason,omitempty"`
-	State                             *string                          `json:"state,omitempty"`
+	IPAddress                         *string `json:"ipAddress,omitempty"`
+	NetworkInterfaceIPConfigurationId *string `json:"networkInterfaceIPConfigurationId,omitempty"`
+	Reason                            *string `json:"reason,omitempty"`
+	State                             *string `json:"state,omitempty"`
 }

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2024-05-01/networkmanageractiveconfigurations/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2024-05-01/networkmanageractiveconfigurations/constants.go
@@ -138,6 +138,8 @@ func parseGroupMemberType(input string) (*GroupMemberType, error) {
 type ProvisioningState string
 
 const (
+	ProvisioningStateCanceled  ProvisioningState = "Canceled"
+	ProvisioningStateCreating  ProvisioningState = "Creating"
 	ProvisioningStateDeleting  ProvisioningState = "Deleting"
 	ProvisioningStateFailed    ProvisioningState = "Failed"
 	ProvisioningStateSucceeded ProvisioningState = "Succeeded"
@@ -146,6 +148,8 @@ const (
 
 func PossibleValuesForProvisioningState() []string {
 	return []string{
+		string(ProvisioningStateCanceled),
+		string(ProvisioningStateCreating),
 		string(ProvisioningStateDeleting),
 		string(ProvisioningStateFailed),
 		string(ProvisioningStateSucceeded),
@@ -168,6 +172,8 @@ func (s *ProvisioningState) UnmarshalJSON(bytes []byte) error {
 
 func parseProvisioningState(input string) (*ProvisioningState, error) {
 	vals := map[string]ProvisioningState{
+		"canceled":  ProvisioningStateCanceled,
+		"creating":  ProvisioningStateCreating,
 		"deleting":  ProvisioningStateDeleting,
 		"failed":    ProvisioningStateFailed,
 		"succeeded": ProvisioningStateSucceeded,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2024-05-01/networkmanageractiveconnectivityconfigurations/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2024-05-01/networkmanageractiveconnectivityconfigurations/constants.go
@@ -217,6 +217,8 @@ func parseIsGlobal(input string) (*IsGlobal, error) {
 type ProvisioningState string
 
 const (
+	ProvisioningStateCanceled  ProvisioningState = "Canceled"
+	ProvisioningStateCreating  ProvisioningState = "Creating"
 	ProvisioningStateDeleting  ProvisioningState = "Deleting"
 	ProvisioningStateFailed    ProvisioningState = "Failed"
 	ProvisioningStateSucceeded ProvisioningState = "Succeeded"
@@ -225,6 +227,8 @@ const (
 
 func PossibleValuesForProvisioningState() []string {
 	return []string{
+		string(ProvisioningStateCanceled),
+		string(ProvisioningStateCreating),
 		string(ProvisioningStateDeleting),
 		string(ProvisioningStateFailed),
 		string(ProvisioningStateSucceeded),
@@ -247,6 +251,8 @@ func (s *ProvisioningState) UnmarshalJSON(bytes []byte) error {
 
 func parseProvisioningState(input string) (*ProvisioningState, error) {
 	vals := map[string]ProvisioningState{
+		"canceled":  ProvisioningStateCanceled,
+		"creating":  ProvisioningStateCreating,
 		"deleting":  ProvisioningStateDeleting,
 		"failed":    ProvisioningStateFailed,
 		"succeeded": ProvisioningStateSucceeded,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2024-05-01/networkmanagereffectiveconnectivityconfiguration/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2024-05-01/networkmanagereffectiveconnectivityconfiguration/constants.go
@@ -217,6 +217,8 @@ func parseIsGlobal(input string) (*IsGlobal, error) {
 type ProvisioningState string
 
 const (
+	ProvisioningStateCanceled  ProvisioningState = "Canceled"
+	ProvisioningStateCreating  ProvisioningState = "Creating"
 	ProvisioningStateDeleting  ProvisioningState = "Deleting"
 	ProvisioningStateFailed    ProvisioningState = "Failed"
 	ProvisioningStateSucceeded ProvisioningState = "Succeeded"
@@ -225,6 +227,8 @@ const (
 
 func PossibleValuesForProvisioningState() []string {
 	return []string{
+		string(ProvisioningStateCanceled),
+		string(ProvisioningStateCreating),
 		string(ProvisioningStateDeleting),
 		string(ProvisioningStateFailed),
 		string(ProvisioningStateSucceeded),
@@ -247,6 +251,8 @@ func (s *ProvisioningState) UnmarshalJSON(bytes []byte) error {
 
 func parseProvisioningState(input string) (*ProvisioningState, error) {
 	vals := map[string]ProvisioningState{
+		"canceled":  ProvisioningStateCanceled,
+		"creating":  ProvisioningStateCreating,
 		"deleting":  ProvisioningStateDeleting,
 		"failed":    ProvisioningStateFailed,
 		"succeeded": ProvisioningStateSucceeded,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2024-05-01/networkmanagereffectivesecurityadminrules/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2024-05-01/networkmanagereffectivesecurityadminrules/constants.go
@@ -138,6 +138,8 @@ func parseGroupMemberType(input string) (*GroupMemberType, error) {
 type ProvisioningState string
 
 const (
+	ProvisioningStateCanceled  ProvisioningState = "Canceled"
+	ProvisioningStateCreating  ProvisioningState = "Creating"
 	ProvisioningStateDeleting  ProvisioningState = "Deleting"
 	ProvisioningStateFailed    ProvisioningState = "Failed"
 	ProvisioningStateSucceeded ProvisioningState = "Succeeded"
@@ -146,6 +148,8 @@ const (
 
 func PossibleValuesForProvisioningState() []string {
 	return []string{
+		string(ProvisioningStateCanceled),
+		string(ProvisioningStateCreating),
 		string(ProvisioningStateDeleting),
 		string(ProvisioningStateFailed),
 		string(ProvisioningStateSucceeded),
@@ -168,6 +172,8 @@ func (s *ProvisioningState) UnmarshalJSON(bytes []byte) error {
 
 func parseProvisioningState(input string) (*ProvisioningState, error) {
 	vals := map[string]ProvisioningState{
+		"canceled":  ProvisioningStateCanceled,
+		"creating":  ProvisioningStateCreating,
 		"deleting":  ProvisioningStateDeleting,
 		"failed":    ProvisioningStateFailed,
 		"succeeded": ProvisioningStateSucceeded,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2024-06-01/autonomousdatabasebackups/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2024-06-01/autonomousdatabasebackups/README.md
@@ -65,14 +65,14 @@ if model := read.Model; model != nil {
 ```
 
 
-### Example Usage: `AutonomousDatabaseBackupsClient.ListByAutonomousDatabase`
+### Example Usage: `AutonomousDatabaseBackupsClient.ListByParent`
 
 ```go
 ctx := context.TODO()
 id := autonomousdatabasebackups.NewAutonomousDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "autonomousDatabaseName")
 
-// alternatively `client.ListByAutonomousDatabase(ctx, id)` can be used to do batched pagination
-items, err := client.ListByAutonomousDatabaseComplete(ctx, id)
+// alternatively `client.ListByParent(ctx, id)` can be used to do batched pagination
+items, err := client.ListByParentComplete(ctx, id)
 if err != nil {
 	// handle the error
 }

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2024-06-01/autonomousdatabasebackups/method_listbyparent.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2024-06-01/autonomousdatabasebackups/method_listbyparent.go
@@ -12,22 +12,22 @@ import (
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See NOTICE.txt in the project root for license information.
 
-type ListByAutonomousDatabaseOperationResponse struct {
+type ListByParentOperationResponse struct {
 	HttpResponse *http.Response
 	OData        *odata.OData
 	Model        *[]AutonomousDatabaseBackup
 }
 
-type ListByAutonomousDatabaseCompleteResult struct {
+type ListByParentCompleteResult struct {
 	LatestHttpResponse *http.Response
 	Items              []AutonomousDatabaseBackup
 }
 
-type ListByAutonomousDatabaseCustomPager struct {
+type ListByParentCustomPager struct {
 	NextLink *odata.Link `json:"nextLink"`
 }
 
-func (p *ListByAutonomousDatabaseCustomPager) NextPageLink() *odata.Link {
+func (p *ListByParentCustomPager) NextPageLink() *odata.Link {
 	defer func() {
 		p.NextLink = nil
 	}()
@@ -35,15 +35,15 @@ func (p *ListByAutonomousDatabaseCustomPager) NextPageLink() *odata.Link {
 	return p.NextLink
 }
 
-// ListByAutonomousDatabase ...
-func (c AutonomousDatabaseBackupsClient) ListByAutonomousDatabase(ctx context.Context, id AutonomousDatabaseId) (result ListByAutonomousDatabaseOperationResponse, err error) {
+// ListByParent ...
+func (c AutonomousDatabaseBackupsClient) ListByParent(ctx context.Context, id AutonomousDatabaseId) (result ListByParentOperationResponse, err error) {
 	opts := client.RequestOptions{
 		ContentType: "application/json; charset=utf-8",
 		ExpectedStatusCodes: []int{
 			http.StatusOK,
 		},
 		HttpMethod: http.MethodGet,
-		Pager:      &ListByAutonomousDatabaseCustomPager{},
+		Pager:      &ListByParentCustomPager{},
 		Path:       fmt.Sprintf("%s/autonomousDatabaseBackups", id.ID()),
 	}
 
@@ -74,16 +74,16 @@ func (c AutonomousDatabaseBackupsClient) ListByAutonomousDatabase(ctx context.Co
 	return
 }
 
-// ListByAutonomousDatabaseComplete retrieves all the results into a single object
-func (c AutonomousDatabaseBackupsClient) ListByAutonomousDatabaseComplete(ctx context.Context, id AutonomousDatabaseId) (ListByAutonomousDatabaseCompleteResult, error) {
-	return c.ListByAutonomousDatabaseCompleteMatchingPredicate(ctx, id, AutonomousDatabaseBackupOperationPredicate{})
+// ListByParentComplete retrieves all the results into a single object
+func (c AutonomousDatabaseBackupsClient) ListByParentComplete(ctx context.Context, id AutonomousDatabaseId) (ListByParentCompleteResult, error) {
+	return c.ListByParentCompleteMatchingPredicate(ctx, id, AutonomousDatabaseBackupOperationPredicate{})
 }
 
-// ListByAutonomousDatabaseCompleteMatchingPredicate retrieves all the results and then applies the predicate
-func (c AutonomousDatabaseBackupsClient) ListByAutonomousDatabaseCompleteMatchingPredicate(ctx context.Context, id AutonomousDatabaseId, predicate AutonomousDatabaseBackupOperationPredicate) (result ListByAutonomousDatabaseCompleteResult, err error) {
+// ListByParentCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c AutonomousDatabaseBackupsClient) ListByParentCompleteMatchingPredicate(ctx context.Context, id AutonomousDatabaseId, predicate AutonomousDatabaseBackupOperationPredicate) (result ListByParentCompleteResult, err error) {
 	items := make([]AutonomousDatabaseBackup, 0)
 
-	resp, err := c.ListByAutonomousDatabase(ctx, id)
+	resp, err := c.ListByParent(ctx, id)
 	if err != nil {
 		result.LatestHttpResponse = resp.HttpResponse
 		err = fmt.Errorf("loading results: %+v", err)
@@ -97,7 +97,7 @@ func (c AutonomousDatabaseBackupsClient) ListByAutonomousDatabaseCompleteMatchin
 		}
 	}
 
-	result = ListByAutonomousDatabaseCompleteResult{
+	result = ListByParentCompleteResult{
 		LatestHttpResponse: resp.HttpResponse,
 		Items:              items,
 	}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2024-06-01/autonomousdatabasebackups/model_autonomousdatabasebackupupdate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2024-06-01/autonomousdatabasebackups/model_autonomousdatabasebackupupdate.go
@@ -1,8 +1,16 @@
 package autonomousdatabasebackups
 
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/systemdata"
+)
+
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See NOTICE.txt in the project root for license information.
 
 type AutonomousDatabaseBackupUpdate struct {
-	Properties *AutonomousDatabaseBackupUpdateProperties `json:"properties,omitempty"`
+	Id         *string                             `json:"id,omitempty"`
+	Name       *string                             `json:"name,omitempty"`
+	Properties *AutonomousDatabaseBackupProperties `json:"properties,omitempty"`
+	SystemData *systemdata.SystemData              `json:"systemData,omitempty"`
+	Type       *string                             `json:"type,omitempty"`
 }

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2024-06-01/autonomousdatabasebackups/model_autonomousdatabasebackupupdateproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2024-06-01/autonomousdatabasebackups/model_autonomousdatabasebackupupdateproperties.go
@@ -1,8 +1,0 @@
-package autonomousdatabasebackups
-
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
-
-type AutonomousDatabaseBackupUpdateProperties struct {
-	RetentionPeriodInDays *int64 `json:"retentionPeriodInDays,omitempty"`
-}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2024-06-01/dbnodes/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2024-06-01/dbnodes/README.md
@@ -53,14 +53,14 @@ if model := read.Model; model != nil {
 ```
 
 
-### Example Usage: `DbNodesClient.ListByCloudVMCluster`
+### Example Usage: `DbNodesClient.ListByParent`
 
 ```go
 ctx := context.TODO()
 id := dbnodes.NewCloudVMClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "cloudVmClusterName")
 
-// alternatively `client.ListByCloudVMCluster(ctx, id)` can be used to do batched pagination
-items, err := client.ListByCloudVMClusterComplete(ctx, id)
+// alternatively `client.ListByParent(ctx, id)` can be used to do batched pagination
+items, err := client.ListByParentComplete(ctx, id)
 if err != nil {
 	// handle the error
 }

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2024-06-01/dbnodes/method_listbyparent.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2024-06-01/dbnodes/method_listbyparent.go
@@ -12,22 +12,22 @@ import (
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See NOTICE.txt in the project root for license information.
 
-type ListByCloudVMClusterOperationResponse struct {
+type ListByParentOperationResponse struct {
 	HttpResponse *http.Response
 	OData        *odata.OData
 	Model        *[]DbNode
 }
 
-type ListByCloudVMClusterCompleteResult struct {
+type ListByParentCompleteResult struct {
 	LatestHttpResponse *http.Response
 	Items              []DbNode
 }
 
-type ListByCloudVMClusterCustomPager struct {
+type ListByParentCustomPager struct {
 	NextLink *odata.Link `json:"nextLink"`
 }
 
-func (p *ListByCloudVMClusterCustomPager) NextPageLink() *odata.Link {
+func (p *ListByParentCustomPager) NextPageLink() *odata.Link {
 	defer func() {
 		p.NextLink = nil
 	}()
@@ -35,15 +35,15 @@ func (p *ListByCloudVMClusterCustomPager) NextPageLink() *odata.Link {
 	return p.NextLink
 }
 
-// ListByCloudVMCluster ...
-func (c DbNodesClient) ListByCloudVMCluster(ctx context.Context, id CloudVMClusterId) (result ListByCloudVMClusterOperationResponse, err error) {
+// ListByParent ...
+func (c DbNodesClient) ListByParent(ctx context.Context, id CloudVMClusterId) (result ListByParentOperationResponse, err error) {
 	opts := client.RequestOptions{
 		ContentType: "application/json; charset=utf-8",
 		ExpectedStatusCodes: []int{
 			http.StatusOK,
 		},
 		HttpMethod: http.MethodGet,
-		Pager:      &ListByCloudVMClusterCustomPager{},
+		Pager:      &ListByParentCustomPager{},
 		Path:       fmt.Sprintf("%s/dbNodes", id.ID()),
 	}
 
@@ -74,16 +74,16 @@ func (c DbNodesClient) ListByCloudVMCluster(ctx context.Context, id CloudVMClust
 	return
 }
 
-// ListByCloudVMClusterComplete retrieves all the results into a single object
-func (c DbNodesClient) ListByCloudVMClusterComplete(ctx context.Context, id CloudVMClusterId) (ListByCloudVMClusterCompleteResult, error) {
-	return c.ListByCloudVMClusterCompleteMatchingPredicate(ctx, id, DbNodeOperationPredicate{})
+// ListByParentComplete retrieves all the results into a single object
+func (c DbNodesClient) ListByParentComplete(ctx context.Context, id CloudVMClusterId) (ListByParentCompleteResult, error) {
+	return c.ListByParentCompleteMatchingPredicate(ctx, id, DbNodeOperationPredicate{})
 }
 
-// ListByCloudVMClusterCompleteMatchingPredicate retrieves all the results and then applies the predicate
-func (c DbNodesClient) ListByCloudVMClusterCompleteMatchingPredicate(ctx context.Context, id CloudVMClusterId, predicate DbNodeOperationPredicate) (result ListByCloudVMClusterCompleteResult, err error) {
+// ListByParentCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c DbNodesClient) ListByParentCompleteMatchingPredicate(ctx context.Context, id CloudVMClusterId, predicate DbNodeOperationPredicate) (result ListByParentCompleteResult, err error) {
 	items := make([]DbNode, 0)
 
-	resp, err := c.ListByCloudVMCluster(ctx, id)
+	resp, err := c.ListByParent(ctx, id)
 	if err != nil {
 		result.LatestHttpResponse = resp.HttpResponse
 		err = fmt.Errorf("loading results: %+v", err)
@@ -97,7 +97,7 @@ func (c DbNodesClient) ListByCloudVMClusterCompleteMatchingPredicate(ctx context
 		}
 	}
 
-	result = ListByCloudVMClusterCompleteResult{
+	result = ListByParentCompleteResult{
 		LatestHttpResponse: resp.HttpResponse,
 		Items:              items,
 	}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2024-06-01/dbservers/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2024-06-01/dbservers/README.md
@@ -36,14 +36,14 @@ if model := read.Model; model != nil {
 ```
 
 
-### Example Usage: `DbServersClient.ListByCloudExadataInfrastructure`
+### Example Usage: `DbServersClient.ListByParent`
 
 ```go
 ctx := context.TODO()
 id := dbservers.NewCloudExadataInfrastructureID("12345678-1234-9876-4563-123456789012", "example-resource-group", "cloudExadataInfrastructureName")
 
-// alternatively `client.ListByCloudExadataInfrastructure(ctx, id)` can be used to do batched pagination
-items, err := client.ListByCloudExadataInfrastructureComplete(ctx, id)
+// alternatively `client.ListByParent(ctx, id)` can be used to do batched pagination
+items, err := client.ListByParentComplete(ctx, id)
 if err != nil {
 	// handle the error
 }

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2024-06-01/dbservers/method_listbyparent.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2024-06-01/dbservers/method_listbyparent.go
@@ -12,22 +12,22 @@ import (
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See NOTICE.txt in the project root for license information.
 
-type ListByCloudExadataInfrastructureOperationResponse struct {
+type ListByParentOperationResponse struct {
 	HttpResponse *http.Response
 	OData        *odata.OData
 	Model        *[]DbServer
 }
 
-type ListByCloudExadataInfrastructureCompleteResult struct {
+type ListByParentCompleteResult struct {
 	LatestHttpResponse *http.Response
 	Items              []DbServer
 }
 
-type ListByCloudExadataInfrastructureCustomPager struct {
+type ListByParentCustomPager struct {
 	NextLink *odata.Link `json:"nextLink"`
 }
 
-func (p *ListByCloudExadataInfrastructureCustomPager) NextPageLink() *odata.Link {
+func (p *ListByParentCustomPager) NextPageLink() *odata.Link {
 	defer func() {
 		p.NextLink = nil
 	}()
@@ -35,15 +35,15 @@ func (p *ListByCloudExadataInfrastructureCustomPager) NextPageLink() *odata.Link
 	return p.NextLink
 }
 
-// ListByCloudExadataInfrastructure ...
-func (c DbServersClient) ListByCloudExadataInfrastructure(ctx context.Context, id CloudExadataInfrastructureId) (result ListByCloudExadataInfrastructureOperationResponse, err error) {
+// ListByParent ...
+func (c DbServersClient) ListByParent(ctx context.Context, id CloudExadataInfrastructureId) (result ListByParentOperationResponse, err error) {
 	opts := client.RequestOptions{
 		ContentType: "application/json; charset=utf-8",
 		ExpectedStatusCodes: []int{
 			http.StatusOK,
 		},
 		HttpMethod: http.MethodGet,
-		Pager:      &ListByCloudExadataInfrastructureCustomPager{},
+		Pager:      &ListByParentCustomPager{},
 		Path:       fmt.Sprintf("%s/dbServers", id.ID()),
 	}
 
@@ -74,16 +74,16 @@ func (c DbServersClient) ListByCloudExadataInfrastructure(ctx context.Context, i
 	return
 }
 
-// ListByCloudExadataInfrastructureComplete retrieves all the results into a single object
-func (c DbServersClient) ListByCloudExadataInfrastructureComplete(ctx context.Context, id CloudExadataInfrastructureId) (ListByCloudExadataInfrastructureCompleteResult, error) {
-	return c.ListByCloudExadataInfrastructureCompleteMatchingPredicate(ctx, id, DbServerOperationPredicate{})
+// ListByParentComplete retrieves all the results into a single object
+func (c DbServersClient) ListByParentComplete(ctx context.Context, id CloudExadataInfrastructureId) (ListByParentCompleteResult, error) {
+	return c.ListByParentCompleteMatchingPredicate(ctx, id, DbServerOperationPredicate{})
 }
 
-// ListByCloudExadataInfrastructureCompleteMatchingPredicate retrieves all the results and then applies the predicate
-func (c DbServersClient) ListByCloudExadataInfrastructureCompleteMatchingPredicate(ctx context.Context, id CloudExadataInfrastructureId, predicate DbServerOperationPredicate) (result ListByCloudExadataInfrastructureCompleteResult, err error) {
+// ListByParentCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c DbServersClient) ListByParentCompleteMatchingPredicate(ctx context.Context, id CloudExadataInfrastructureId, predicate DbServerOperationPredicate) (result ListByParentCompleteResult, err error) {
 	items := make([]DbServer, 0)
 
-	resp, err := c.ListByCloudExadataInfrastructure(ctx, id)
+	resp, err := c.ListByParent(ctx, id)
 	if err != nil {
 		result.LatestHttpResponse = resp.HttpResponse
 		err = fmt.Errorf("loading results: %+v", err)
@@ -97,7 +97,7 @@ func (c DbServersClient) ListByCloudExadataInfrastructureCompleteMatchingPredica
 		}
 	}
 
-	result = ListByCloudExadataInfrastructureCompleteResult{
+	result = ListByParentCompleteResult{
 		LatestHttpResponse: resp.HttpResponse,
 		Items:              items,
 	}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2024-06-01/virtualnetworkaddresses/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2024-06-01/virtualnetworkaddresses/README.md
@@ -65,14 +65,14 @@ if model := read.Model; model != nil {
 ```
 
 
-### Example Usage: `VirtualNetworkAddressesClient.ListByCloudVMCluster`
+### Example Usage: `VirtualNetworkAddressesClient.ListByParent`
 
 ```go
 ctx := context.TODO()
 id := virtualnetworkaddresses.NewCloudVMClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "cloudVmClusterName")
 
-// alternatively `client.ListByCloudVMCluster(ctx, id)` can be used to do batched pagination
-items, err := client.ListByCloudVMClusterComplete(ctx, id)
+// alternatively `client.ListByParent(ctx, id)` can be used to do batched pagination
+items, err := client.ListByParentComplete(ctx, id)
 if err != nil {
 	// handle the error
 }

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2024-06-01/virtualnetworkaddresses/method_listbyparent.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2024-06-01/virtualnetworkaddresses/method_listbyparent.go
@@ -12,22 +12,22 @@ import (
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See NOTICE.txt in the project root for license information.
 
-type ListByCloudVMClusterOperationResponse struct {
+type ListByParentOperationResponse struct {
 	HttpResponse *http.Response
 	OData        *odata.OData
 	Model        *[]VirtualNetworkAddress
 }
 
-type ListByCloudVMClusterCompleteResult struct {
+type ListByParentCompleteResult struct {
 	LatestHttpResponse *http.Response
 	Items              []VirtualNetworkAddress
 }
 
-type ListByCloudVMClusterCustomPager struct {
+type ListByParentCustomPager struct {
 	NextLink *odata.Link `json:"nextLink"`
 }
 
-func (p *ListByCloudVMClusterCustomPager) NextPageLink() *odata.Link {
+func (p *ListByParentCustomPager) NextPageLink() *odata.Link {
 	defer func() {
 		p.NextLink = nil
 	}()
@@ -35,15 +35,15 @@ func (p *ListByCloudVMClusterCustomPager) NextPageLink() *odata.Link {
 	return p.NextLink
 }
 
-// ListByCloudVMCluster ...
-func (c VirtualNetworkAddressesClient) ListByCloudVMCluster(ctx context.Context, id CloudVMClusterId) (result ListByCloudVMClusterOperationResponse, err error) {
+// ListByParent ...
+func (c VirtualNetworkAddressesClient) ListByParent(ctx context.Context, id CloudVMClusterId) (result ListByParentOperationResponse, err error) {
 	opts := client.RequestOptions{
 		ContentType: "application/json; charset=utf-8",
 		ExpectedStatusCodes: []int{
 			http.StatusOK,
 		},
 		HttpMethod: http.MethodGet,
-		Pager:      &ListByCloudVMClusterCustomPager{},
+		Pager:      &ListByParentCustomPager{},
 		Path:       fmt.Sprintf("%s/virtualNetworkAddresses", id.ID()),
 	}
 
@@ -74,16 +74,16 @@ func (c VirtualNetworkAddressesClient) ListByCloudVMCluster(ctx context.Context,
 	return
 }
 
-// ListByCloudVMClusterComplete retrieves all the results into a single object
-func (c VirtualNetworkAddressesClient) ListByCloudVMClusterComplete(ctx context.Context, id CloudVMClusterId) (ListByCloudVMClusterCompleteResult, error) {
-	return c.ListByCloudVMClusterCompleteMatchingPredicate(ctx, id, VirtualNetworkAddressOperationPredicate{})
+// ListByParentComplete retrieves all the results into a single object
+func (c VirtualNetworkAddressesClient) ListByParentComplete(ctx context.Context, id CloudVMClusterId) (ListByParentCompleteResult, error) {
+	return c.ListByParentCompleteMatchingPredicate(ctx, id, VirtualNetworkAddressOperationPredicate{})
 }
 
-// ListByCloudVMClusterCompleteMatchingPredicate retrieves all the results and then applies the predicate
-func (c VirtualNetworkAddressesClient) ListByCloudVMClusterCompleteMatchingPredicate(ctx context.Context, id CloudVMClusterId, predicate VirtualNetworkAddressOperationPredicate) (result ListByCloudVMClusterCompleteResult, err error) {
+// ListByParentCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c VirtualNetworkAddressesClient) ListByParentCompleteMatchingPredicate(ctx context.Context, id CloudVMClusterId, predicate VirtualNetworkAddressOperationPredicate) (result ListByParentCompleteResult, err error) {
 	items := make([]VirtualNetworkAddress, 0)
 
-	resp, err := c.ListByCloudVMCluster(ctx, id)
+	resp, err := c.ListByParent(ctx, id)
 	if err != nil {
 		result.LatestHttpResponse = resp.HttpResponse
 		err = fmt.Errorf("loading results: %+v", err)
@@ -97,7 +97,7 @@ func (c VirtualNetworkAddressesClient) ListByCloudVMClusterCompleteMatchingPredi
 		}
 	}
 
-	result = ListByCloudVMClusterCompleteResult{
+	result = ListByParentCompleteResult{
 		LatestHttpResponse: resp.HttpResponse,
 		Items:              items,
 	}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2023-02-01/protecteditems/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2023-02-01/protecteditems/README.md
@@ -31,12 +31,8 @@ payload := protecteditems.ProtectedItemResource{
 }
 
 
-read, err := client.CreateOrUpdate(ctx, id, payload)
-if err != nil {
+if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
 	// handle the error
-}
-if model := read.Model; model != nil {
-	// do something with the model/response object
 }
 ```
 
@@ -47,12 +43,8 @@ if model := read.Model; model != nil {
 ctx := context.TODO()
 id := protecteditems.NewProtectedItemID("12345678-1234-9876-4563-123456789012", "example-resource-group", "vaultName", "backupFabricName", "protectionContainerName", "protectedItemName")
 
-read, err := client.Delete(ctx, id)
-if err != nil {
+if err := client.DeleteThenPoll(ctx, id); err != nil {
 	// handle the error
-}
-if model := read.Model; model != nil {
-	// do something with the model/response object
 }
 ```
 

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2023-02-01/protecteditems/method_createorupdate_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2023-02-01/protecteditems/method_createorupdate_autorest.go
@@ -2,16 +2,19 @@ package protecteditems
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
 )
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See NOTICE.txt in the project root for license information.
 
 type CreateOrUpdateOperationResponse struct {
+	Poller       polling.LongRunningPoller
 	HttpResponse *http.Response
 	Model        *ProtectedItemResource
 }
@@ -24,19 +27,27 @@ func (c ProtectedItemsClient) CreateOrUpdate(ctx context.Context, id ProtectedIt
 		return
 	}
 
-	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	result, err = c.senderForCreateOrUpdate(ctx, req)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "protecteditems.ProtectedItemsClient", "CreateOrUpdate", result.HttpResponse, "Failure sending request")
 		return
 	}
 
-	result, err = c.responderForCreateOrUpdate(result.HttpResponse)
+	return
+}
+
+// CreateOrUpdateThenPoll performs CreateOrUpdate then polls until it's completed
+func (c ProtectedItemsClient) CreateOrUpdateThenPoll(ctx context.Context, id ProtectedItemId, input ProtectedItemResource) error {
+	result, err := c.CreateOrUpdate(ctx, id, input)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "protecteditems.ProtectedItemsClient", "CreateOrUpdate", result.HttpResponse, "Failure responding to request")
-		return
+		return fmt.Errorf("performing CreateOrUpdate: %+v", err)
 	}
 
-	return
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after CreateOrUpdate: %+v", err)
+	}
+
+	return nil
 }
 
 // preparerForCreateOrUpdate prepares the CreateOrUpdate request.
@@ -55,15 +66,15 @@ func (c ProtectedItemsClient) preparerForCreateOrUpdate(ctx context.Context, id 
 	return preparer.Prepare((&http.Request{}).WithContext(ctx))
 }
 
-// responderForCreateOrUpdate handles the response to the CreateOrUpdate request. The method always
-// closes the http.Response Body.
-func (c ProtectedItemsClient) responderForCreateOrUpdate(resp *http.Response) (result CreateOrUpdateOperationResponse, err error) {
-	err = autorest.Respond(
-		resp,
-		azure.WithErrorUnlessStatusCode(http.StatusAccepted, http.StatusOK),
-		autorest.ByUnmarshallingJSON(&result.Model),
-		autorest.ByClosing())
-	result.HttpResponse = resp
+// senderForCreateOrUpdate sends the CreateOrUpdate request. The method will close the
+// http.Response Body if it receives an error.
+func (c ProtectedItemsClient) senderForCreateOrUpdate(ctx context.Context, req *http.Request) (future CreateOrUpdateOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
 
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
 	return
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -143,7 +143,7 @@ github.com/hashicorp/go-azure-helpers/resourcemanager/tags
 github.com/hashicorp/go-azure-helpers/resourcemanager/zones
 github.com/hashicorp/go-azure-helpers/sender
 github.com/hashicorp/go-azure-helpers/storage
-# github.com/hashicorp/go-azure-sdk/resource-manager v0.20250409.1192141
+# github.com/hashicorp/go-azure-sdk/resource-manager v0.20250520.1180806
 ## explicit; go 1.22
 github.com/hashicorp/go-azure-sdk/resource-manager/aad/2021-05-01/domainservices
 github.com/hashicorp/go-azure-sdk/resource-manager/aadb2c/2021-04-01-preview
@@ -1168,7 +1168,7 @@ github.com/hashicorp/go-azure-sdk/resource-manager/workloads/2024-09-01/sapappli
 github.com/hashicorp/go-azure-sdk/resource-manager/workloads/2024-09-01/sapcentralserverinstances
 github.com/hashicorp/go-azure-sdk/resource-manager/workloads/2024-09-01/sapdatabaseinstances
 github.com/hashicorp/go-azure-sdk/resource-manager/workloads/2024-09-01/sapvirtualinstances
-# github.com/hashicorp/go-azure-sdk/sdk v0.20250409.1192141
+# github.com/hashicorp/go-azure-sdk/sdk v0.20250520.1180806
 ## explicit; go 1.22
 github.com/hashicorp/go-azure-sdk/sdk/auth
 github.com/hashicorp/go-azure-sdk/sdk/auth/autorest


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

- Update to latest version of `go-azure-sdk`
- Replace `ListByCloudVMCluster` and `ListByCloudExadataInfrastructure` with `ListByParent` method
- Update `azurerm_backup_protected_file_share`, `azurerm_backup_protected_vm`, and `protectedItemClient` to use LRO methods added with [Pandora workaround](https://github.com/hashicorp/pandora/pull/4767)

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
