### PR TITLE
`azurerm_network_security_rule` - update schema validation for ource and destination values

### DIFF
--- a/internal/services/network/network_security_rule_resource.go
+++ b/internal/services/network/network_security_rule_resource.go
@@ -101,49 +101,51 @@ func resourceNetworkSecurityRule() *pluginsdk.Resource {
 			},
 
 			"source_address_prefix": {
-				Type:          pluginsdk.TypeString,
-				Optional:      true,
-				ConflictsWith: []string{"source_address_prefixes"},
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ExactlyOneOf: []string{"source_address_prefix", "source_address_prefixes", "source_application_security_group_ids"},
 			},
 
 			"source_address_prefixes": {
-				Type:          pluginsdk.TypeSet,
-				Optional:      true,
-				Elem:          &pluginsdk.Schema{Type: pluginsdk.TypeString},
-				Set:           pluginsdk.HashString,
-				ConflictsWith: []string{"source_address_prefix"},
+				Type:         pluginsdk.TypeSet,
+				Optional:     true,
+				Elem:         &pluginsdk.Schema{Type: pluginsdk.TypeString},
+				Set:          pluginsdk.HashString,
+				ExactlyOneOf: []string{"source_address_prefix", "source_address_prefixes", "source_application_security_group_ids"},
 			},
 
 			"destination_address_prefix": {
-				Type:          pluginsdk.TypeString,
-				Optional:      true,
-				ConflictsWith: []string{"destination_address_prefixes"},
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ExactlyOneOf: []string{"destination_address_prefix", "destination_address_prefixes", "destination_application_security_group_ids"},
 			},
 
 			"destination_address_prefixes": {
-				Type:          pluginsdk.TypeSet,
-				Optional:      true,
-				Elem:          &pluginsdk.Schema{Type: pluginsdk.TypeString},
-				Set:           pluginsdk.HashString,
-				ConflictsWith: []string{"destination_address_prefix"},
+				Type:         pluginsdk.TypeSet,
+				Optional:     true,
+				Elem:         &pluginsdk.Schema{Type: pluginsdk.TypeString},
+				Set:          pluginsdk.HashString,
+				ExactlyOneOf: []string{"destination_address_prefix", "destination_address_prefixes", "destination_application_security_group_ids"},
 			},
 
 			// lintignore:S018
 			"source_application_security_group_ids": {
-				Type:     pluginsdk.TypeSet,
-				MaxItems: 10,
-				Optional: true,
-				Elem:     &pluginsdk.Schema{Type: pluginsdk.TypeString},
-				Set:      pluginsdk.HashString,
+				Type:         pluginsdk.TypeSet,
+				MaxItems:     10,
+				Optional:     true,
+				ExactlyOneOf: []string{"source_address_prefix", "source_address_prefixes", "source_application_security_group_ids"},
+				Elem:         &pluginsdk.Schema{Type: pluginsdk.TypeString},
+				Set:          pluginsdk.HashString,
 			},
 
 			// lintignore:S018
 			"destination_application_security_group_ids": {
-				Type:     pluginsdk.TypeSet,
-				MaxItems: 10,
-				Optional: true,
-				Elem:     &pluginsdk.Schema{Type: pluginsdk.TypeString},
-				Set:      pluginsdk.HashString,
+				Type:         pluginsdk.TypeSet,
+				MaxItems:     10,
+				Optional:     true,
+				ExactlyOneOf: []string{"destination_address_prefix", "destination_address_prefixes", "destination_application_security_group_ids"},
+				Elem:         &pluginsdk.Schema{Type: pluginsdk.TypeString},
+				Set:          pluginsdk.HashString,
 			},
 
 			"access": {

--- a/website/docs/r/network_security_rule.html.markdown
+++ b/website/docs/r/network_security_rule.html.markdown
@@ -66,17 +66,21 @@ The following arguments are supported:
 
 * `destination_port_ranges` - (Optional) List of destination ports or port ranges. This is required if `destination_port_range` is not specified.
 
-* `source_address_prefix` - (Optional) CIDR or source IP range or * to match any IP. Tags such as `VirtualNetwork`, `AzureLoadBalancer` and `Internet` can also be used. This is required if `source_address_prefixes` is not specified.
+* `source_address_prefix` - (Optional) CIDR or source IP range or * to match any IP. Tags such as `VirtualNetwork`, `AzureLoadBalancer` and `Internet` can also be used. 
 
 * `source_address_prefixes` - (Optional) List of source address prefixes. Tags may not be used. This is required if `source_address_prefix` is not specified.
 
 * `source_application_security_group_ids` - (Optional) A List of source Application Security Group IDs
 
-* `destination_address_prefix` - (Optional) CIDR or destination IP range or * to match any IP. Tags such as `VirtualNetwork`, `AzureLoadBalancer` and `Internet` can also be used. Besides, it also supports all available Service Tags like ‘Sql.WestEurope‘, ‘Storage.EastUS‘, etc. You can list the available service tags with the CLI: ```shell az network list-service-tags --location westcentralus```. For further information please see [Azure CLI - az network list-service-tags](https://docs.microsoft.com/cli/azure/network?view=azure-cli-latest#az-network-list-service-tags). This is required if `destination_address_prefixes` is not specified.
+-> **Note:** One of `source_address_prefix`, `source_address_prefixes` or `source_application_security_group_ids` must be specified.
+
+* `destination_address_prefix` - (Optional) CIDR or destination IP range or * to match any IP. Tags such as `VirtualNetwork`, `AzureLoadBalancer` and `Internet` can also be used. Besides, it also supports all available Service Tags like ‘Sql.WestEurope‘, ‘Storage.EastUS‘, etc. You can list the available service tags with the CLI: ```shell az network list-service-tags --location westcentralus```. For further information please see [Azure CLI - az network list-service-tags](https://docs.microsoft.com/cli/azure/network?view=azure-cli-latest#az-network-list-service-tags). 
 
 * `destination_address_prefixes` - (Optional) List of destination address prefixes. Tags may not be used. This is required if `destination_address_prefix` is not specified.
 
 * `destination_application_security_group_ids` - (Optional) A List of destination Application Security Group IDs
+
+-> **Note:** One of `destination_address_prefix`, `destination_address_prefixes` or `destination_application_security_group_ids` must be specified.
 
 * `access` - (Required) Specifies whether network traffic is allowed or denied. Possible values are `Allow` and `Deny`.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

thanks to https://github.com/hashicorp/terraform-provider-azurerm/issues/29619, to update the constraint rules

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->
```
❯ tftest network TestAccNetworkSecurityRule_
=== RUN   TestAccNetworkSecurityRule_basic
=== PAUSE TestAccNetworkSecurityRule_basic
=== RUN   TestAccNetworkSecurityRule_requiresImport
=== PAUSE TestAccNetworkSecurityRule_requiresImport
=== RUN   TestAccNetworkSecurityRule_disappears
=== PAUSE TestAccNetworkSecurityRule_disappears
=== RUN   TestAccNetworkSecurityRule_addingRules
=== PAUSE TestAccNetworkSecurityRule_addingRules
=== RUN   TestAccNetworkSecurityRule_augmented
=== PAUSE TestAccNetworkSecurityRule_augmented
=== RUN   TestAccNetworkSecurityRule_applicationSecurityGroups
=== PAUSE TestAccNetworkSecurityRule_applicationSecurityGroups
=== CONT  TestAccNetworkSecurityRule_basic
=== CONT  TestAccNetworkSecurityRule_addingRules
=== CONT  TestAccNetworkSecurityRule_disappears
=== CONT  TestAccNetworkSecurityRule_requiresImport
=== CONT  TestAccNetworkSecurityRule_applicationSecurityGroups
=== CONT  TestAccNetworkSecurityRule_augmented
--- PASS: TestAccNetworkSecurityRule_requiresImport (106.89s)
--- PASS: TestAccNetworkSecurityRule_basic (107.00s)
--- PASS: TestAccNetworkSecurityRule_disappears (118.30s)
--- PASS: TestAccNetworkSecurityRule_addingRules (124.01s)
--- PASS: TestAccNetworkSecurityRule_augmented (128.12s)
--- PASS: TestAccNetworkSecurityRule_applicationSecurityGroups (133.69s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/network       133.736s
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_network_security_rule` - update schema validation for ource and destination values [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #29619


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
