### PR TITLE
azurerm_storage_account_static_website - fix incorrect example resource reference

### DIFF
--- a/website/docs/r/storage_account_static_website.html.markdown
+++ b/website/docs/r/storage_account_static_website.html.markdown
@@ -30,7 +30,7 @@ resource "azurerm_storage_account" "example" {
   }
 }
 
-resource "azurerm_storage_account_static_website" "test" {
+resource "azurerm_storage_account_static_website" "example" {
   storage_account_id = azurerm_storage_account.example.id
   error_404_document = "custom_not_found.html"
   index_document     = "custom_index.html"

--- a/website/docs/r/storage_account_static_website.html.markdown
+++ b/website/docs/r/storage_account_static_website.html.markdown
@@ -31,7 +31,7 @@ resource "azurerm_storage_account" "example" {
 }
 
 resource "azurerm_storage_account_static_website" "test" {
-  storage_account_id = azurerm_storage_account.test.id
+  storage_account_id = azurerm_storage_account.example.id
   error_404_document = "custom_not_found.html"
   index_document     = "custom_index.html"
 }


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This pull request fixes an incorrect resource reference in the example block of the azurerm_storage_account_static_website documentation.

Previously, the example used:
```hcl

storage_account_id = azurerm_storage_account.test.id

```

However, there is no `azurerm_storage_account` resource with the name `test` in the example. The actual defined resource is:

```hcl

resource "azurerm_storage_account" "example" { ... }

```

This PR updates the reference to:

```hcl

storage_account_id = azurerm_storage_account.example.id

```

### Purpose 
- Corrects a misleading example that could result in confusion or Terraform plan/apply errors.
- Ensures the documentation is consistent and usable without modification.

### Additional Notes
- No logic changes were made. Only the example usage block was updated.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_storage_account_static_website` - fixed incorrect resource reference in the example code block to prevent confusion for users 


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix (documentation)
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
