### PR TITLE
`azurerm_backup_protected_vm` - add `BackupsSuspended` to `protection_state`, fix some issues

### DIFF
--- a/internal/services/recoveryservices/backup_protected_vm_resource.go
+++ b/internal/services/recoveryservices/backup_protected_vm_resource.go
@@ -508,12 +508,10 @@ func checkRecoveryServicesVaultIsImmutable(ctx context.Context, client *vaults.V
 		}
 	}
 
-	// Not a pretty condition, but required to check immutability ¯\_(ツ)_/¯
 	if existingVault.Model != nil &&
 		existingVault.Model.Properties != nil &&
 		existingVault.Model.Properties.SecuritySettings != nil &&
 		existingVault.Model.Properties.SecuritySettings.ImmutabilitySettings != nil {
-
 		immutabilityState := pointer.From(existingVault.Model.Properties.SecuritySettings.ImmutabilitySettings.State)
 		if immutabilityState == vaults.ImmutabilityStateDisabled {
 			return errors.New("`protection_state` cannot be set to `BackupsSuspended` while the Recovery Services Vault is not in an immutable (`Locked` / `Unlocked`) state")

--- a/internal/services/recoveryservices/backup_protected_vm_resource.go
+++ b/internal/services/recoveryservices/backup_protected_vm_resource.go
@@ -8,15 +8,17 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"strings"
+	"slices"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservices/2024-01-01/vaults"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2023-02-01/protecteditems"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectionpolicies"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -59,6 +61,7 @@ func resourceRecoveryServicesBackupProtectedVM() *pluginsdk.Resource {
 
 func resourceRecoveryServicesBackupProtectedVMCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).RecoveryServices.ProtectedItemsClient
+	vaultClient := meta.(*clients.Client).RecoveryServices.VaultsClient
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -133,23 +136,30 @@ func resourceRecoveryServicesBackupProtectedVMCreate(d *pluginsdk.ResourceData, 
 		},
 	}
 
-	protectionState, ok := d.GetOk("protection_state")
-	protectionStopped := strings.EqualFold(protectionState.(string), string(protecteditems.ProtectionStateProtectionStopped))
-	requireUpdateProtectionState := ok && protectionStopped
-
 	if err := client.CreateOrUpdateThenPoll(ctx, id, item); err != nil {
 		return fmt.Errorf("creating %s: %+v", id, err)
 	}
 
 	d.SetId(id.ID())
 
-	// the protection state will be updated in the additional update.
-	if requireUpdateProtectionState {
-		p := protecteditems.ProtectionState(protectionState.(string))
+	// the protection state cannot be set during initial creation.
+	protectionState := d.Get("protection_state").(string)
+	protectionStateUpdateRequired := slices.Contains([]string{
+		string(protecteditems.ProtectionStateProtectionStopped),
+		string(protecteditems.ProtectionStateBackupsSuspended),
+	}, protectionState)
+
+	if protectionStateUpdateRequired {
+		if protectionState == string(protecteditems.ProtectionStateBackupsSuspended) {
+			if err := checkRecoveryServicesVaultIsImmutable(ctx, vaultClient, vaults.NewVaultID(id.SubscriptionId, id.ResourceGroupName, id.VaultName)); err != nil {
+				return err
+			}
+		}
+
 		updateInput := protecteditems.ProtectedItemResource{
 			Properties: &protecteditems.AzureIaaSComputeVMProtectedItem{
-				ProtectionState:  &p,
-				SourceResourceId: utils.String(vmId),
+				ProtectionState:  pointer.To(protecteditems.ProtectionState(protectionState)),
+				SourceResourceId: pointer.To(vmId),
 			},
 		}
 
@@ -180,7 +190,7 @@ func resourceRecoveryServicesBackupProtectedVMRead(d *pluginsdk.ResourceData, me
 			return nil
 		}
 
-		return fmt.Errorf("making Read request on %s: %+v", id, err)
+		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
 	if model := resp.Model; model != nil {
@@ -227,6 +237,7 @@ func resourceRecoveryServicesBackupProtectedVMRead(d *pluginsdk.ResourceData, me
 
 func resourceRecoveryServicesBackupProtectedVMUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).RecoveryServices.ProtectedItemsClient
+	vaultClient := meta.(*clients.Client).RecoveryServices.VaultsClient
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -254,47 +265,28 @@ func resourceRecoveryServicesBackupProtectedVMUpdate(d *pluginsdk.ResourceData, 
 
 	model := *existing.Model
 	properties := existing.Model.Properties.(protecteditems.AzureIaaSComputeVMProtectedItem)
-	updateProtectedBackup := false
 
 	if d.HasChange("backup_policy_id") {
 		properties.PolicyId = pointer.To(d.Get("backup_policy_id").(string))
-		updateProtectedBackup = true
 	}
 
 	if d.HasChange("exclude_disk_luns") || d.HasChange("include_disk_luns") {
 		properties.ExtendedProperties = expandDiskExclusion(d)
-		updateProtectedBackup = true
 	}
 
+	if d.HasChange("protection_state") {
+		protectionState := d.Get("protection_state").(string)
+		if protectionState == string(protecteditems.ProtectionStateBackupsSuspended) {
+			if err := checkRecoveryServicesVaultIsImmutable(ctx, vaultClient, vaults.NewVaultID(id.SubscriptionId, id.ResourceGroupName, id.VaultName)); err != nil {
+				return err
+			}
+		}
+		properties.ProtectionState = pointer.To(protecteditems.ProtectionState(protectionState))
+	}
 	model.Properties = properties
 
-	if updateProtectedBackup {
-		if err := client.CreateOrUpdateThenPoll(ctx, *id, model); err != nil {
-			return fmt.Errorf("updating %s: %+v", id, err)
-		}
-	}
-
-	protectionState := string(pointer.From(properties.ProtectionState))
-	protectionStopped := false
-	if d.HasChange("protection_state") {
-		protectionState = d.Get("protection_state").(string)
-		protectionStopped = strings.EqualFold(protectionState, string(protecteditems.ProtectionStateProtectionStopped))
-	}
-
-	// the protection state will be updated in the additional update.
-	if protectionStopped {
-		p := protecteditems.ProtectionState(protectionState)
-		vmId := d.Get("source_vm_id").(string)
-		updateInput := protecteditems.ProtectedItemResource{
-			Properties: &protecteditems.AzureIaaSComputeVMProtectedItem{
-				ProtectionState:  &p,
-				SourceResourceId: utils.String(vmId),
-			},
-		}
-
-		if err := client.CreateOrUpdateThenPoll(ctx, *id, updateInput); err != nil {
-			return fmt.Errorf("updating %s: %+v", *id, err)
-		}
+	if err := client.CreateOrUpdateThenPoll(ctx, *id, model); err != nil {
+		return fmt.Errorf("updating %s: %+v", id, err)
 	}
 
 	return resourceRecoveryServicesBackupProtectedVMRead(d, meta)
@@ -322,7 +314,7 @@ func resourceRecoveryServicesBackupProtectedVMDelete(d *pluginsdk.ResourceData, 
 				return nil
 			}
 
-			return fmt.Errorf("making Read request on %s: %+v", id, err)
+			return fmt.Errorf("retrieving %s: %+v", *id, err)
 		}
 
 		desiredState := protecteditems.ProtectionStateProtectionStopped
@@ -341,7 +333,7 @@ func resourceRecoveryServicesBackupProtectedVMDelete(d *pluginsdk.ResourceData, 
 					}
 
 					if err := client.CreateOrUpdateThenPoll(ctx, *id, updateInput); err != nil {
-						return fmt.Errorf("setting protection to %s and retaining data for %s: %+v", desiredState, id, err)
+						return fmt.Errorf("setting protection to %s and retaining data for %s: %+v", desiredState, *id, err)
 					}
 
 					return nil
@@ -350,10 +342,10 @@ func resourceRecoveryServicesBackupProtectedVMDelete(d *pluginsdk.ResourceData, 
 		}
 	}
 
-	log.Printf("[DEBUG] Deleting %s", id)
+	log.Printf("[DEBUG] Deleting %s", *id)
 
 	if err := client.DeleteThenPoll(ctx, *id); err != nil {
-		return fmt.Errorf("deleting %s: %+v", id, err)
+		return fmt.Errorf("deleting %s: %+v", *id, err)
 	}
 
 	return nil
@@ -366,7 +358,7 @@ func expandDiskExclusion(d *pluginsdk.ResourceData) *protecteditems.ExtendedProp
 		return &protecteditems.ExtendedProperties{
 			DiskExclusionProperties: &protecteditems.DiskExclusionProperties{
 				DiskLunList:     utils.ExpandInt64Slice(diskLun),
-				IsInclusionList: utils.Bool(true),
+				IsInclusionList: pointer.To(true),
 			},
 		}
 	}
@@ -377,7 +369,7 @@ func expandDiskExclusion(d *pluginsdk.ResourceData) *protecteditems.ExtendedProp
 		return &protecteditems.ExtendedProperties{
 			DiskExclusionProperties: &protecteditems.DiskExclusionProperties{
 				DiskLunList:     utils.ExpandInt64Slice(diskLun),
-				IsInclusionList: utils.Bool(false),
+				IsInclusionList: pointer.To(false),
 			},
 		}
 	}
@@ -476,15 +468,57 @@ func resourceRecoveryServicesBackupProtectedVMSchema() map[string]*pluginsdk.Sch
 		"protection_state": {
 			Type:     pluginsdk.TypeString,
 			Optional: true,
+			// Note: O+C because `protection_state` is set by Azure and may not be a persistent value.
 			Computed: true,
 			ValidateFunc: validation.StringInSlice([]string{
-				string(protecteditems.ProtectedItemStateIRPending),
-				string(protecteditems.ProtectedItemStateProtected),
-				string(protecteditems.ProtectedItemStateProtectionError),
-				string(protecteditems.ProtectedItemStateProtectionStopped),
-				string(protecteditems.ProtectedItemStateProtectionPaused),
-				string(protecteditems.ProtectionStateInvalid),
+				// While not a persistent state, `Protected` is an option to allow a path from `BackupsSuspended`/`ProtectionStopped` to a protected state.
+				string(protecteditems.ProtectionStateProtected),
+				string(protecteditems.ProtectionStateBackupsSuspended),
+				string(protecteditems.ProtectionStateProtectionStopped),
 			}, false),
+			DiffSuppressFunc: func(_, old, new string, d *schema.ResourceData) bool {
+				// We suppress the diff if the only change is from "IRPending" or "ProtectionPaused" to "Protected".
+				// These states are not persistent and are set by Azure based on the current protection state.
+				// While `Invalid` and `ProtectionError` are also not configurable, we're opting to output this in the diff
+				// as these states should indicate to the user that there is an error with the backup protected VM resource requiring attention.
+				suppressStates := []string{
+					string(protecteditems.ProtectedItemStateIRPending),
+					string(protecteditems.ProtectedItemStateProtectionPaused),
+				}
+
+				if new == string(protecteditems.ProtectionStateProtected) && slices.Contains(suppressStates, old) {
+					return true
+				}
+
+				return false
+			},
 		},
 	}
+}
+
+func checkRecoveryServicesVaultIsImmutable(ctx context.Context, client *vaults.VaultsClient, vaultId vaults.VaultId) error {
+	// While not ideal, if `protection_state` = `BackupsSuspended`, we get the recovery vault so we can ensure it's in an immutable state
+	// We're doing this here because the error message provided by Azure if it is not in an immutable state is confusing.
+	// Relevant issue: https://github.com/Azure/azure-rest-api-specs/issues/32688
+
+	existingVault, err := client.Get(ctx, vaultId)
+	if err != nil {
+		if !response.WasNotFound(existingVault.HttpResponse) {
+			return fmt.Errorf("checking for presence of Recovery Services Vault %s: %+v", vaultId, err)
+		}
+	}
+
+	// Not a pretty condition, but required to check immutability ¯\_(ツ)_/¯
+	if existingVault.Model != nil &&
+		existingVault.Model.Properties != nil &&
+		existingVault.Model.Properties.SecuritySettings != nil &&
+		existingVault.Model.Properties.SecuritySettings.ImmutabilitySettings != nil {
+
+		immutabilityState := pointer.From(existingVault.Model.Properties.SecuritySettings.ImmutabilitySettings.State)
+		if immutabilityState == vaults.ImmutabilityStateDisabled {
+			return errors.New("`protection_state` cannot be set to `BackupsSuspended` while the Recovery Services Vault is not in an immutable (`Locked` / `Unlocked`) state")
+		}
+	}
+
+	return nil
 }

--- a/internal/services/recoveryservices/backup_protected_vm_resource_test.go
+++ b/internal/services/recoveryservices/backup_protected_vm_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2023-02-01/protecteditems"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type BackupProtectedVmResource struct{}
@@ -232,6 +232,32 @@ func TestAccBackupProtectedVm_protectionStopped(t *testing.T) {
 	})
 }
 
+func TestAccBackupProtectedVm_backupsSuspended(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_backup_protected_vm", "test")
+	r := BackupProtectedVmResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.backupsSuspended(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			// vault cannot be deleted unless we unregister all backups
+			Config: r.base(data),
+		},
+	})
+}
+
 func TestAccBackupProtectedVm_protectionStoppedOnDestroy(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_backup_protected_vm", "test")
 	r := BackupProtectedVmResource{}
@@ -305,7 +331,7 @@ func TestAccBackupProtectedVm_recoverSoftDeletedVM(t *testing.T) {
 	})
 }
 
-func (t BackupProtectedVmResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+func (r BackupProtectedVmResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := protecteditems.ParseProtectedItemID(state.ID)
 	if err != nil {
 		return nil, err
@@ -316,7 +342,7 @@ func (t BackupProtectedVmResource) Exists(ctx context.Context, clients *clients.
 		return nil, fmt.Errorf("reading Recovery Service Protected VM (%s): %+v", id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (BackupProtectedVmResource) base(data acceptance.TestData) string {
@@ -465,6 +491,156 @@ resource "azurerm_backup_policy_vm" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomString, data.RandomInteger, data.RandomInteger)
+}
+
+func (BackupProtectedVmResource) baseImmutableVault(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-backup-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "vnet"
+  location            = azurerm_resource_group.test.location
+  address_space       = ["10.0.0.0/16"]
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctest_subnet"
+  virtual_network_name = azurerm_virtual_network.test.name
+  resource_group_name  = azurerm_resource_group.test.name
+  address_prefixes     = ["10.0.10.0/24"]
+}
+
+resource "azurerm_network_interface" "test" {
+  name                = "acctest_nic"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  ip_configuration {
+    name                          = "acctestipconfig"
+    subnet_id                     = azurerm_subnet.test.id
+    private_ip_address_allocation = "Dynamic"
+    public_ip_address_id          = azurerm_public_ip.test.id
+  }
+}
+
+resource "azurerm_public_ip" "test" {
+  name                = "acctest-ip"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Basic"
+  allocation_method   = "Dynamic"
+  domain_name_label   = "acctestip%[1]d"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctest%[3]s"
+  location                 = azurerm_resource_group.test.location
+  resource_group_name      = azurerm_resource_group.test.name
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_managed_disk" "test" {
+  name                 = "acctest-datadisk"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  storage_account_type = "Standard_LRS"
+  create_option        = "Empty"
+  disk_size_gb         = "1023"
+}
+
+resource "azurerm_virtual_machine" "test" {
+  name                  = "acctestvm"
+  location              = azurerm_resource_group.test.location
+  resource_group_name   = azurerm_resource_group.test.name
+  vm_size               = "Standard_D1_v2"
+  network_interface_ids = [azurerm_network_interface.test.id]
+
+  delete_os_disk_on_termination    = true
+  delete_data_disks_on_termination = true
+
+  storage_image_reference {
+    publisher = "Canonical"
+    offer     = "0001-com-ubuntu-server-jammy"
+    sku       = "22_04-lts"
+    version   = "latest"
+  }
+
+  storage_os_disk {
+    name              = "acctest-osdisk"
+    managed_disk_type = "Standard_LRS"
+    caching           = "ReadWrite"
+    create_option     = "FromImage"
+  }
+
+  storage_data_disk {
+    name              = "acctest-datadisk"
+    managed_disk_id   = azurerm_managed_disk.test.id
+    managed_disk_type = "Standard_LRS"
+    disk_size_gb      = azurerm_managed_disk.test.disk_size_gb
+    create_option     = "Attach"
+    lun               = 0
+  }
+
+  storage_data_disk {
+    name              = "acctest-another-datadisk"
+    create_option     = "Empty"
+    disk_size_gb      = "1"
+    lun               = 1
+    managed_disk_type = "Standard_LRS"
+  }
+
+  os_profile {
+    computer_name  = "acctest"
+    admin_username = "vmadmin"
+    admin_password = "Password123!@#"
+  }
+
+  os_profile_linux_config {
+    disable_password_authentication = false
+  }
+
+  boot_diagnostics {
+    enabled     = true
+    storage_uri = azurerm_storage_account.test.primary_blob_endpoint
+  }
+
+}
+
+resource "azurerm_recovery_services_vault" "test" {
+  name                = "acctest-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Standard"
+
+  immutability = "Unlocked"
+
+  soft_delete_enabled = false
+}
+
+resource "azurerm_backup_policy_vm" "test" {
+  name                = "acctest-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  recovery_vault_name = azurerm_recovery_services_vault.test.name
+
+  backup {
+    frequency = "Daily"
+    time      = "23:00"
+  }
+
+  retention_daily {
+    count = 10
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }
 
 func (BackupProtectedVmResource) baseWithOutProvider(data acceptance.TestData) string {
@@ -1100,6 +1276,22 @@ resource "azurerm_backup_protected_vm" "test" {
   protection_state  = "ProtectionStopped"
 }
 `, r.base(data))
+}
+
+func (r BackupProtectedVmResource) backupsSuspended(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_backup_protected_vm" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  recovery_vault_name = azurerm_recovery_services_vault.test.name
+  source_vm_id        = azurerm_virtual_machine.test.id
+  backup_policy_id    = azurerm_backup_policy_vm.test.id
+
+  include_disk_luns = [0]
+  protection_state  = "BackupsSuspended"
+}
+`, r.baseImmutableVault(data))
 }
 
 func (r BackupProtectedVmResource) protectionStoppedOnDestroy(data acceptance.TestData) string {

--- a/website/docs/r/backup_protected_vm.html.markdown
+++ b/website/docs/r/backup_protected_vm.html.markdown
@@ -68,7 +68,7 @@ The following arguments are supported:
 
 ~> **Note:** `backup_policy_id` is required during initial creation of this resource.
 
-~> **Note:** When `protection_state` is set to `BackupsSuspended` or `ProtectionStopped`, the Azure API does not return `backup_policy_id`. To avoid a perpetual diff, use Terraform's [ignore_changes](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#ignore_changes) argument.
+~> **Note:** When `protection_state` is set to `BackupsSuspended` or `ProtectionStopped`, the Azure API may not return `backup_policy_id`. To avoid a perpetual diff, use Terraform's [ignore_changes](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#ignore_changes) argument.
 
 * `exclude_disk_luns` - (Optional) A list of Disks' Logical Unit Numbers (LUN) to be excluded for VM Protection.
 

--- a/website/docs/r/backup_protected_vm.html.markdown
+++ b/website/docs/r/backup_protected_vm.html.markdown
@@ -3,12 +3,12 @@ subcategory: "Recovery Services"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_backup_protected_vm"
 description: |-
-  Manages an Azure Backup Protected VM.
+  Manages an Azure Backup Protected Virtual Machine.
 ---
 
 # azurerm_backup_protected_vm
 
-Manages Azure Backup for an Azure VM
+Manages an Azure Backup Protected Virtual Machine.
 
 ## Example Usage
 
@@ -60,18 +60,23 @@ The following arguments are supported:
 
 * `recovery_vault_name` - (Required) Specifies the name of the Recovery Services Vault to use. Changing this forces a new resource to be created.
 
-* `source_vm_id` - (Optional) Specifies the ID of the VM to backup. Changing this forces a new resource to be created.
+* `source_vm_id` - (Optional) Specifies the ID of the virtual machine to back up. Changing this forces a new resource to be created.
 
-~> **Note:** After creation, the `source_vm_id` property can be removed without forcing a new resource to be created; however, setting it to a different ID will create a new resource.
-This allows the source vm to be deleted without having to remove the backup.
+~> **Note:** After creation, the `source_vm_id` property can be removed without forcing a new resource to be created; however, setting it to a different ID will create a new resource. This allows the source virtual machine to be deleted without having to remove the backup.
 
-* `backup_policy_id` - (Optional) Specifies the id of the backup policy to use. Required in creation or when `protection_stopped` is not specified.
+* `backup_policy_id` - (Optional) Specifies the ID of the backup policy to use.
 
-* `exclude_disk_luns` - (Optional) A list of Disks' Logical Unit Numbers(LUN) to be excluded for VM Protection.
+~> **Note:** `backup_policy_id` is required during initial creation of this resource.
 
-* `include_disk_luns` - (Optional) A list of Disks' Logical Unit Numbers(LUN) to be included for VM Protection.
+~> **Note:** When `protection_state` is set to `BackupsSuspended` or `ProtectionStopped`, the Azure API does not return `backup_policy_id`. To avoid a perpetual diff, use Terraform's [ignore_changes](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#ignore_changes) argument.
 
-* `protection_state` - (Optional) Specifies Protection state of the backup. Possible values are `Invalid`, `IRPending`, `Protected`, `ProtectionStopped`, `ProtectionError` and `ProtectionPaused`.
+* `exclude_disk_luns` - (Optional) A list of Disks' Logical Unit Numbers (LUN) to be excluded for VM Protection.
+
+* `include_disk_luns` - (Optional) A list of Disks' Logical Unit Numbers (LUN) to be included for VM Protection.
+
+* `protection_state` - (Optional) Specifies Protection state of the backup. Possible values are `Protected`, `BackupsSuspended`, and `ProtectionStopped`.
+
+~> **Note:** `protection_state` cannot be set to `BackupsSuspended` unless the `azurerm_recovery_services_vault` has `immutability` set to `Unlocked` or `Locked`.
 
 ## Attributes Reference
 
@@ -90,10 +95,8 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 
 ## Import
 
-Recovery Services Protected VMs can be imported using the `resource id`, e.g.
+Backup Protected Virtual Machines can be imported using the `resource id`, e.g.
 
 ```shell
 terraform import azurerm_backup_protected_vm.item1 "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.RecoveryServices/vaults/example-recovery-vault/backupFabrics/Azure/protectionContainers/iaasvmcontainer;iaasvmcontainerv2;group1;vm1/protectedItems/vm;iaasvmcontainerv2;group1;vm1"
 ```
-
-Note the ID requires quoting as there are semicolons


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

- Adds `BackupsSuspended` to `protection_state`
- Removes `protection_states` that aren't persistent or result in a bad request (`Invalid` state), I did not wrap these in a 5.0 flag since these values didn't do anything in the resource's current state. If preferred, I can add the 5.0 flag for these.
- Fixes an issue where `protection_state` wouldn't apply changes when going from `ProtectionStopped` to any other protection state (to re-enable protection)

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

Running...

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
