### PR TITLE
`encryption` block TODOs

### DIFF
--- a/internal/provider/provider_schema_test.go
+++ b/internal/provider/provider_schema_test.go
@@ -426,12 +426,12 @@ func TestResourcesWithAnEncryptionBlockBehaveConsistently(t *testing.T) {
 
 	// TODO: 4.0 - work through this list
 	resourcesWhichNeedToBeAddressed := map[string]struct{}{
-		"azurerm_automation_account":     {},
-		"azurerm_container_registry":     {},
-		"azurerm_managed_disk":           {},
-		"azurerm_media_services_account": {},
-		"azurerm_snapshot":               {},
-		"azurerm_load_test":              {},
+		"azurerm_automation_account":     {}, // deprecate key_source
+		"azurerm_container_registry":     {}, // make encryption block computed: false
+		"azurerm_managed_disk":           {}, // actually ok? has `encryption_settings`, computed false, but test says it's computed true
+		"azurerm_media_services_account": {}, // removed in 4.0
+		"azurerm_snapshot":               {}, // actually ok? actually ok? has `encryption_settings`, computed false, but test says it's computed true
+		"azurerm_load_test":              {}, // failing for an unknown reason????
 	}
 
 	for _, resourceName := range resourceNames {

--- a/internal/provider/provider_schema_test.go
+++ b/internal/provider/provider_schema_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
@@ -443,12 +444,11 @@ func TestResourcesWithAnEncryptionBlockBehaveConsistently(t *testing.T) {
 	sort.Strings(resourceNames)
 
 	// TODO: 4.0 - work through this list
-	resourcesWhichNeedToBeAddressed := map[string]struct{}{
-		"azurerm_automation_account":     {}, // deprecate key_source
-		"azurerm_container_registry":     {}, // make encryption block computed: false
-		"azurerm_managed_disk":           {}, // actually ok? has `encryption_settings`, computed false, but test says it's computed true
-		"azurerm_media_services_account": {}, // removed in 4.0
-		"azurerm_snapshot":               {}, // actually ok? actually ok? has `encryption_settings`, computed false, but test says it's computed true
+	resourcesWhichNeedToBeAddressed := map[string]struct{}{}
+
+	if !features.FivePointOh() {
+		resourcesWhichNeedToBeAddressed["azurerm_container_registry"] = struct{}{}
+		resourcesWhichNeedToBeAddressed["azurerm_automation_account"] = struct{}{}
 	}
 
 	for _, resourceName := range resourceNames {

--- a/internal/services/automation/automation_account_resource.go
+++ b/internal/services/automation/automation_account_resource.go
@@ -78,6 +78,7 @@ func resourceAutomationAccount() *pluginsdk.Resource {
 							ValidateFunc: commonids.ValidateUserAssignedIdentityID,
 						},
 
+						// TODO Properly deprecate with a !features.FivePointOh() block
 						"key_source": {
 							Type:       pluginsdk.TypeString,
 							Optional:   true,

--- a/internal/services/automation/automation_account_resource.go
+++ b/internal/services/automation/automation_account_resource.go
@@ -20,17 +20,17 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/automation/validate"
 	keyVaultParse "github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/parse"
 	keyVaultValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceAutomationAccount() *pluginsdk.Resource {
-	return &pluginsdk.Resource{
+	r := &pluginsdk.Resource{
 		Create: resourceAutomationAccountCreate,
 		Read:   resourceAutomationAccountRead,
 		Update: resourceAutomationAccountUpdate,
@@ -76,20 +76,6 @@ func resourceAutomationAccount() *pluginsdk.Resource {
 							Type:         pluginsdk.TypeString,
 							Optional:     true,
 							ValidateFunc: commonids.ValidateUserAssignedIdentityID,
-						},
-
-						// TODO Properly deprecate with a !features.FivePointOh() block
-						"key_source": {
-							Type:       pluginsdk.TypeString,
-							Optional:   true,
-							Deprecated: "This field is now ignored and will be removed in the next major version of the Azure Provider, the `encryption` block can be omitted to disable encryption",
-							ValidateFunc: validation.StringInSlice(
-								[]string{
-									string(automationaccount.EncryptionKeySourceTypeMicrosoftPointAutomation),
-									string(automationaccount.EncryptionKeySourceTypeMicrosoftPointKeyvault),
-								},
-								false,
-							),
 						},
 
 						"key_vault_key_id": {
@@ -156,6 +142,23 @@ func resourceAutomationAccount() *pluginsdk.Resource {
 			},
 		},
 	}
+
+	if !features.FivePointOh() {
+		r.Schema["encryption"].Elem.(*schema.Resource).Schema["key_source"] = &pluginsdk.Schema{
+			Type:       pluginsdk.TypeString,
+			Optional:   true,
+			Deprecated: "`encryption.key_source` has been deprecated and will be removed in v5.0 of the AzureRM Provider. To disable encryption, omit the `encryption` block",
+			ValidateFunc: validation.StringInSlice(
+				[]string{
+					string(automationaccount.EncryptionKeySourceTypeMicrosoftPointAutomation),
+					string(automationaccount.EncryptionKeySourceTypeMicrosoftPointKeyvault),
+				},
+				false,
+			),
+		}
+	}
+
+	return r
 }
 
 func resourceAutomationAccountCreate(d *pluginsdk.ResourceData, meta interface{}) error {
@@ -187,17 +190,17 @@ func resourceAutomationAccountCreate(d *pluginsdk.ResourceData, meta interface{}
 	}
 
 	parameters := automationaccount.AutomationAccountCreateOrUpdateParameters{
-		Location: utils.String(location.Normalize(d.Get("location").(string))),
+		Location: pointer.To(location.Normalize(d.Get("location").(string))),
 		Properties: &automationaccount.AutomationAccountCreateOrUpdateProperties{
 			Encryption: enc,
 			Sku: &automationaccount.Sku{
 				Name: automationaccount.SkuNameEnum(d.Get("sku_name").(string)),
 			},
-			PublicNetworkAccess: utils.Bool(d.Get("public_network_access_enabled").(bool)),
+			PublicNetworkAccess: pointer.To(d.Get("public_network_access_enabled").(bool)),
 		},
 	}
 
-	parameters.Properties.DisableLocalAuth = utils.Bool(!d.Get("local_authentication_enabled").(bool))
+	parameters.Properties.DisableLocalAuth = pointer.To(!d.Get("local_authentication_enabled").(bool))
 
 	// for create account do not set identity property (even TypeNone is not allowed), or api will response error
 	if identityVal.Type != identity.TypeNone {
@@ -236,19 +239,19 @@ func resourceAutomationAccountUpdate(d *pluginsdk.ResourceData, meta interface{}
 	}
 
 	parameters := automationaccount.AutomationAccountUpdateParameters{
-		Location: utils.String(location.Normalize(d.Get("location").(string))),
+		Location: pointer.To(location.Normalize(d.Get("location").(string))),
 		Identity: identity,
 		Properties: &automationaccount.AutomationAccountUpdateProperties{
 			Sku: &automationaccount.Sku{
 				Name: automationaccount.SkuNameEnum(d.Get("sku_name").(string)),
 			},
-			PublicNetworkAccess: utils.Bool(d.Get("public_network_access_enabled").(bool)),
+			PublicNetworkAccess: pointer.To(d.Get("public_network_access_enabled").(bool)),
 			Encryption:          enc,
 		},
 	}
 
 	if d.HasChange("local_authentication_enabled") {
-		parameters.Properties.DisableLocalAuth = utils.Bool(!d.Get("local_authentication_enabled").(bool))
+		parameters.Properties.DisableLocalAuth = pointer.To(!d.Get("local_authentication_enabled").(bool))
 	}
 
 	if tagsVal := tags.Expand(d.Get("tags").(map[string]interface{})); tagsVal != nil {
@@ -403,9 +406,9 @@ func expandEncryption(input []interface{}) (*automationaccount.EncryptionPropert
 			return nil, err
 		}
 		prop.KeyVaultProperties = &automationaccount.KeyVaultProperties{
-			KeyName:     utils.String(keyId.Name),
-			KeyVersion:  utils.String(keyId.Version),
-			KeyvaultUri: utils.String(keyId.KeyVaultBaseUrl),
+			KeyName:     pointer.To(keyId.Name),
+			KeyVersion:  pointer.To(keyId.Version),
+			KeyvaultUri: pointer.To(keyId.KeyVaultBaseUrl),
 		}
 	}
 	return prop, nil
@@ -440,7 +443,7 @@ func flattenEncryption(encryption *automationaccount.EncryptionProperties) []int
 			"key_vault_key_id":          keyVaultKeyId,
 			"user_assigned_identity_id": userAssignedIdentityId,
 
-			// TODO: remove this field in 4.x
+			// TODO: remove this field in 5.x
 			"key_source": "",
 		},
 	}

--- a/internal/services/containers/container_registry_resource.go
+++ b/internal/services/containers/container_registry_resource.go
@@ -25,6 +25,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/containers/migration"
 	containerValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/containers/validate"
 	keyVaultValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/validate"
@@ -34,7 +35,7 @@ import (
 )
 
 func resourceContainerRegistry() *pluginsdk.Resource {
-	return &pluginsdk.Resource{
+	r := &pluginsdk.Resource{
 		Create: resourceContainerRegistryCreate,
 		Read:   resourceContainerRegistryRead,
 		Update: resourceContainerRegistryUpdate,
@@ -139,7 +140,6 @@ func resourceContainerRegistry() *pluginsdk.Resource {
 			"encryption": {
 				Type:       pluginsdk.TypeList,
 				Optional:   true,
-				Computed:   true,
 				ConfigMode: pluginsdk.SchemaConfigModeAttr,
 				MaxItems:   1,
 				Elem: &pluginsdk.Resource{
@@ -334,6 +334,12 @@ func resourceContainerRegistry() *pluginsdk.Resource {
 			return nil
 		}),
 	}
+
+	if !features.FivePointOh() {
+		r.Schema["encryption"].Computed = true
+	}
+
+	return r
 }
 
 func resourceContainerRegistryCreate(d *pluginsdk.ResourceData, meta interface{}) error {


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Continuing through provider_schema_tests.go TODOs, this PR address the problems around `encryption` blocks throughout the provider, such as making them **not** `Computed`, removing problematic fields, etc.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

```
=== RUN   TestResourcesWithAnEncryptionBlockBehaveConsistently
--- PASS: TestResourcesWithAnEncryptionBlockBehaveConsistently (0.03s)
PASS

Process finished with the exit code 0
```


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `encryption` block improvements [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
