### PR TITLE
`azurerm_api_management_api_diagnostic` - fix bug that rejected "azuremonitor" identifier

### DIFF
--- a/internal/services/apimanagement/api_management_api_diagnostic_resource.go
+++ b/internal/services/apimanagement/api_management_api_diagnostic_resource.go
@@ -126,10 +126,9 @@ func resourceApiManagementApiDiagnostic() *pluginsdk.Resource {
 		},
 
 		CustomizeDiff: func(ctx context.Context, d *pluginsdk.ResourceDiff, i interface{}) error {
-			if _, n := d.GetChange("operation_name_format"); n != "" {
-				if d.Get("identifier") != "applicationinsights" {
-					return fmt.Errorf("`operation_name_format` cannot be set when `identifier` is not `applicationinsights`")
-				}
+			format := d.GetRawConfig().GetAttr("operation_name_format")
+			if !format.IsNull() && d.Get("identifier") != "applicationinsights" {
+				return fmt.Errorf("`operation_name_format` cannot be set when `identifier` is not `applicationinsights`")
 			}
 
 			return nil


### PR DESCRIPTION

<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Previously, `CustomizeDiff` in `resourceApiManagementApiDiagnostic` always returned an error when the `identifier` was "azuremonitor" because the `operation_name_format` attribute has a default value. This regression was introduced in
https://github.com/hashicorp/terraform-provider-azurerm/pull/27630.
This PR fixes the issue by checking whether the value is explicitly set.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

```console
$ make acctests SERVICE="apimanagement" TESTARGS='-run=TestAccApiManagementApiDiagnostic_'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/apimanagement -run=TestAccApiManagementApiDiagnostic_ -timeout 180m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccApiManagementApiDiagnostic_basic
=== PAUSE TestAccApiManagementApiDiagnostic_basic
=== RUN   TestAccApiManagementApiDiagnostic_update
=== PAUSE TestAccApiManagementApiDiagnostic_update
=== RUN   TestAccApiManagementApiDiagnostic_requiresImport
=== PAUSE TestAccApiManagementApiDiagnostic_requiresImport
=== RUN   TestAccApiManagementApiDiagnostic_complete
=== PAUSE TestAccApiManagementApiDiagnostic_complete
=== RUN   TestAccApiManagementApiDiagnostic_completeUpdate
=== PAUSE TestAccApiManagementApiDiagnostic_completeUpdate
=== RUN   TestAccApiManagementApiDiagnostic_dataMasking
=== PAUSE TestAccApiManagementApiDiagnostic_dataMasking
=== RUN   TestAccApiManagementApiDiagnostic_azuremonitor
=== PAUSE TestAccApiManagementApiDiagnostic_azuremonitor
=== RUN   TestAccApiManagementApiDiagnostic_azuremonitorWithOperationNameFormat
=== PAUSE TestAccApiManagementApiDiagnostic_azuremonitorWithOperationNameFormat
=== CONT  TestAccApiManagementApiDiagnostic_basic
=== CONT  TestAccApiManagementApiDiagnostic_completeUpdate
=== CONT  TestAccApiManagementApiDiagnostic_requiresImport
=== CONT  TestAccApiManagementApiDiagnostic_update
=== CONT  TestAccApiManagementApiDiagnostic_complete
=== CONT  TestAccApiManagementApiDiagnostic_azuremonitor
=== CONT  TestAccApiManagementApiDiagnostic_dataMasking
=== CONT  TestAccApiManagementApiDiagnostic_azuremonitorWithOperationNameFormat
--- PASS: TestAccApiManagementApiDiagnostic_azuremonitorWithOperationNameFormat (28.37s)
--- PASS: TestAccApiManagementApiDiagnostic_requiresImport (306.54s)
--- PASS: TestAccApiManagementApiDiagnostic_basic (327.60s)
--- PASS: TestAccApiManagementApiDiagnostic_complete (354.25s)
--- PASS: TestAccApiManagementApiDiagnostic_dataMasking (398.76s)
--- PASS: TestAccApiManagementApiDiagnostic_completeUpdate (460.03s)
--- PASS: TestAccApiManagementApiDiagnostic_update (493.43s)
--- PASS: TestAccApiManagementApiDiagnostic_azuremonitor (3960.54s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/apimanagement 3961.945s
```


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_api_management_api_diagnostic` - fix bug that rejected "azuremonitor" identifier


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/28547


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
