### PR TITLE
`azurerm_linux_virtual_machine` - fix update for `identity` when VM has `VMExtensions` configured

### DIFF
--- a/internal/services/compute/linux_virtual_machine_resource.go
+++ b/internal/services/compute/linux_virtual_machine_resource.go
@@ -1128,13 +1128,18 @@ func resourceLinuxVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interface
 			return fmt.Errorf("updating identity for Linux %s: `model` was nil", id)
 		}
 
-		existing.Model.Identity = identityExpanded
+		identityUpdate := *existing.Model
+
+		identityUpdate.Identity = identityExpanded
+		identityUpdate.Resources = nil // Resources are subject to a validation error for some VM Extensions. Since we don't want to change these here, we send a nil to perform a no-op in the API
+
 		// Removing a user-assigned identity using PATCH requires setting it to `null` in the payload which
 		// 1. The go-azure-sdk for resource manager doesn't support at the moment
 		// 2. The expand identity function doesn't behave this way
 		// For the moment updating the identity with the PUT circumvents this API behaviour
 		// See https://github.com/hashicorp/terraform-provider-azurerm/issues/25058 for more details
-		if err := client.CreateOrUpdateThenPoll(ctx, *id, *existing.Model, virtualmachines.DefaultCreateOrUpdateOperationOptions()); err != nil {
+
+		if err := client.CreateOrUpdateThenPoll(ctx, *id, identityUpdate, virtualmachines.DefaultCreateOrUpdateOperationOptions()); err != nil {
 			return fmt.Errorf("updating identity for Linux %s: %+v", id, err)
 		}
 	}

--- a/internal/services/compute/linux_virtual_machine_resource_test.go
+++ b/internal/services/compute/linux_virtual_machine_resource_test.go
@@ -16,7 +16,7 @@ import (
 
 type LinuxVirtualMachineResource struct{}
 
-func (t LinuxVirtualMachineResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+func (r LinuxVirtualMachineResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := virtualmachines.ParseVirtualMachineID(state.ID)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
closes #29276