### PR TITLE
`azurerm_video_indexer_account` - support for the `public_network_access` property

### DIFF
--- a/internal/services/videoindexer/video_indexer_account_resource.go
+++ b/internal/services/videoindexer/video_indexer_account_resource.go
@@ -82,7 +82,7 @@ func (r AccountResource) Arguments() map[string]*pluginsdk.Schema {
 			Type:         pluginsdk.TypeString,
 			Optional:     true,
 			Default:      string(accounts.PublicNetworkAccessEnabled),
-			ValidateFunc: validation.StringInSlice(accounts.PossibleValuesForPublicNetworkAccess(), true),
+			ValidateFunc: validation.StringInSlice(accounts.PossibleValuesForPublicNetworkAccess(), false),
 		},
 
 		"tags": tags.Schema(),

--- a/internal/services/videoindexer/video_indexer_account_resource.go
+++ b/internal/services/videoindexer/video_indexer_account_resource.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appservice/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 )
 
 type AccountResource struct{}
@@ -27,12 +28,13 @@ type AccountResource struct{}
 var _ sdk.ResourceWithUpdate = AccountResource{}
 
 type AccountModel struct {
-	Name          string                                     `tfschema:"name"`
-	ResourceGroup string                                     `tfschema:"resource_group_name"`
-	Location      string                                     `tfschema:"location"`
-	Storage       []StorageModel                             `tfschema:"storage"`
-	Identity      []identity.ModelSystemAssignedUserAssigned `tfschema:"identity"`
-	Tags          map[string]string                          `tfschema:"tags"`
+	Name                string                                     `tfschema:"name"`
+	ResourceGroup       string                                     `tfschema:"resource_group_name"`
+	Location            string                                     `tfschema:"location"`
+	Storage             []StorageModel                             `tfschema:"storage"`
+	Identity            []identity.ModelSystemAssignedUserAssigned `tfschema:"identity"`
+	PublicNetworkAccess string                                     `tfschema:"public_network_access"`
+	Tags                map[string]string                          `tfschema:"tags"`
 }
 
 type StorageModel struct {
@@ -75,6 +77,13 @@ func (r AccountResource) Arguments() map[string]*pluginsdk.Schema {
 		},
 
 		"identity": commonschema.SystemAssignedUserAssignedIdentityRequired(),
+
+		"public_network_access": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			Default:      string(accounts.PublicNetworkAccessEnabled),
+			ValidateFunc: validation.StringInSlice(accounts.PossibleValuesForPublicNetworkAccess(), true),
+		},
 
 		"tags": tags.Schema(),
 	}
@@ -128,7 +137,8 @@ func (r AccountResource) Create() sdk.ResourceFunc {
 				Location: location.Normalize(account.Location),
 				Tags:     pointer.To(account.Tags),
 				Properties: &accounts.AccountPropertiesForPutRequest{
-					StorageServices: expandStorageForCreate(account.Storage),
+					PublicNetworkAccess: pointer.To(accounts.PublicNetworkAccess(account.PublicNetworkAccess)),
+					StorageServices:     expandStorageForCreate(account.Storage),
 				},
 			}
 
@@ -181,6 +191,8 @@ func (r AccountResource) Read() sdk.ResourceFunc {
 					if err != nil {
 						return fmt.Errorf("flattening `storage`: %+v", err)
 					}
+
+					state.PublicNetworkAccess = string(pointer.From(props.PublicNetworkAccess))
 				}
 			}
 
@@ -223,6 +235,13 @@ func (r AccountResource) Update() sdk.ResourceFunc {
 				payload.Properties = &accounts.AccountPropertiesForPatchRequest{
 					StorageServices: expandStorageForUpdate(account.Storage),
 				}
+			}
+
+			if metadata.ResourceData.HasChange("public_network_access") {
+				if payload.Properties == nil {
+					payload.Properties = &accounts.AccountPropertiesForPatchRequest{}
+				}
+				payload.Properties.PublicNetworkAccess = pointer.To(accounts.PublicNetworkAccess(account.PublicNetworkAccess))
 			}
 
 			if _, err := client.Update(ctx, *id, payload); err != nil {

--- a/internal/services/videoindexer/video_indexer_account_resource_test.go
+++ b/internal/services/videoindexer/video_indexer_account_resource_test.go
@@ -157,9 +157,10 @@ provider "azurerm" {
 %[1]s
 
 resource "azurerm_video_indexer_account" "test" {
-  name                = "acctestvi-%[2]s"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
+  name                  = "acctestvi-%[2]s"
+  resource_group_name   = azurerm_resource_group.test.name
+  location              = azurerm_resource_group.test.location
+  public_network_access = "Disabled"
 
   storage {
     storage_account_id = azurerm_storage_account.test.id

--- a/website/docs/r/video_indexer_account.html.markdown
+++ b/website/docs/r/video_indexer_account.html.markdown
@@ -59,6 +59,8 @@ The following arguments are supported:
 
 * `identity` - (Required) An `identity` block as defined below.
 
+* `public_network_access` - The public network access for the Video Indexer Account. Possible values are `Enabled` and `Disabled`. Defaults to `Enabled`.
+
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ---


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Support for the `public_network_access_enabled` property.

Swagger:https://github.com/Azure/azure-rest-api-specs/blob/c9c3e8b9ec547d82c487f36f1126228f9eef0e79/specification/vi/resource-manager/Microsoft.VideoIndexer/stable/2025-04-01/vi.json#L1049C10-L1049C29

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

![image](https://github.com/user-attachments/assets/d17fe3e7-285f-4840-968a-da577f45840f)

![image](https://github.com/user-attachments/assets/12e7603d-0a70-4e0e-b77c-0bfca2a10607)

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-29618]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #29618


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
