### PR TITLE
[Dependencies] `azurerm_cdn_frontdoor_firewall_policy` - upgrade `webapplicationfirewallpolicies` to `2025-03-01` API 

### DIFF
--- a/internal/services/cdn/client/client.go
+++ b/internal/services/cdn/client/client.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2024-02-01/rulesets"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2024-02-01/securitypolicies"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2024-09-01/rules"
-	waf "github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2024-02-01/webapplicationfirewallpolicies"
+	waf "github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/common"
 )
 

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/README.md
@@ -1,0 +1,117 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies` Documentation
+
+The `webapplicationfirewallpolicies` SDK allows for interaction with Azure Resource Manager `frontdoor` (API Version `2025-03-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+import "github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies"
+```
+
+
+### Client Initialization
+
+```go
+client := webapplicationfirewallpolicies.NewWebApplicationFirewallPoliciesClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `WebApplicationFirewallPoliciesClient.PoliciesCreateOrUpdate`
+
+```go
+ctx := context.TODO()
+id := webapplicationfirewallpolicies.NewFrontDoorWebApplicationFirewallPolicyID("12345678-1234-9876-4563-123456789012", "example-resource-group", "frontDoorWebApplicationFirewallPolicyName")
+
+payload := webapplicationfirewallpolicies.WebApplicationFirewallPolicy{
+	// ...
+}
+
+
+if err := client.PoliciesCreateOrUpdateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `WebApplicationFirewallPoliciesClient.PoliciesDelete`
+
+```go
+ctx := context.TODO()
+id := webapplicationfirewallpolicies.NewFrontDoorWebApplicationFirewallPolicyID("12345678-1234-9876-4563-123456789012", "example-resource-group", "frontDoorWebApplicationFirewallPolicyName")
+
+if err := client.PoliciesDeleteThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `WebApplicationFirewallPoliciesClient.PoliciesGet`
+
+```go
+ctx := context.TODO()
+id := webapplicationfirewallpolicies.NewFrontDoorWebApplicationFirewallPolicyID("12345678-1234-9876-4563-123456789012", "example-resource-group", "frontDoorWebApplicationFirewallPolicyName")
+
+read, err := client.PoliciesGet(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `WebApplicationFirewallPoliciesClient.PoliciesList`
+
+```go
+ctx := context.TODO()
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+
+// alternatively `client.PoliciesList(ctx, id)` can be used to do batched pagination
+items, err := client.PoliciesListComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `WebApplicationFirewallPoliciesClient.PoliciesListBySubscription`
+
+```go
+ctx := context.TODO()
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+
+// alternatively `client.PoliciesListBySubscription(ctx, id)` can be used to do batched pagination
+items, err := client.PoliciesListBySubscriptionComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `WebApplicationFirewallPoliciesClient.PoliciesUpdate`
+
+```go
+ctx := context.TODO()
+id := webapplicationfirewallpolicies.NewFrontDoorWebApplicationFirewallPolicyID("12345678-1234-9876-4563-123456789012", "example-resource-group", "frontDoorWebApplicationFirewallPolicyName")
+
+payload := webapplicationfirewallpolicies.TagsObject{
+	// ...
+}
+
+
+if err := client.PoliciesUpdateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/client.go
@@ -1,0 +1,18 @@
+package webapplicationfirewallpolicies
+
+import "github.com/Azure/go-autorest/autorest"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type WebApplicationFirewallPoliciesClient struct {
+	Client  autorest.Client
+	baseUri string
+}
+
+func NewWebApplicationFirewallPoliciesClientWithBaseURI(endpoint string) WebApplicationFirewallPoliciesClient {
+	return WebApplicationFirewallPoliciesClient{
+		Client:  autorest.NewClientWithUserAgent(userAgent()),
+		baseUri: endpoint,
+	}
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/constants.go
@@ -1,0 +1,700 @@
+package webapplicationfirewallpolicies
+
+import (
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ActionType string
+
+const (
+	ActionTypeAllow          ActionType = "Allow"
+	ActionTypeAnomalyScoring ActionType = "AnomalyScoring"
+	ActionTypeBlock          ActionType = "Block"
+	ActionTypeCAPTCHA        ActionType = "CAPTCHA"
+	ActionTypeJSChallenge    ActionType = "JSChallenge"
+	ActionTypeLog            ActionType = "Log"
+	ActionTypeRedirect       ActionType = "Redirect"
+)
+
+func PossibleValuesForActionType() []string {
+	return []string{
+		string(ActionTypeAllow),
+		string(ActionTypeAnomalyScoring),
+		string(ActionTypeBlock),
+		string(ActionTypeCAPTCHA),
+		string(ActionTypeJSChallenge),
+		string(ActionTypeLog),
+		string(ActionTypeRedirect),
+	}
+}
+
+func parseActionType(input string) (*ActionType, error) {
+	vals := map[string]ActionType{
+		"allow":          ActionTypeAllow,
+		"anomalyscoring": ActionTypeAnomalyScoring,
+		"block":          ActionTypeBlock,
+		"captcha":        ActionTypeCAPTCHA,
+		"jschallenge":    ActionTypeJSChallenge,
+		"log":            ActionTypeLog,
+		"redirect":       ActionTypeRedirect,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ActionType(input)
+	return &out, nil
+}
+
+type CustomRuleEnabledState string
+
+const (
+	CustomRuleEnabledStateDisabled CustomRuleEnabledState = "Disabled"
+	CustomRuleEnabledStateEnabled  CustomRuleEnabledState = "Enabled"
+)
+
+func PossibleValuesForCustomRuleEnabledState() []string {
+	return []string{
+		string(CustomRuleEnabledStateDisabled),
+		string(CustomRuleEnabledStateEnabled),
+	}
+}
+
+func parseCustomRuleEnabledState(input string) (*CustomRuleEnabledState, error) {
+	vals := map[string]CustomRuleEnabledState{
+		"disabled": CustomRuleEnabledStateDisabled,
+		"enabled":  CustomRuleEnabledStateEnabled,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := CustomRuleEnabledState(input)
+	return &out, nil
+}
+
+type ManagedRuleEnabledState string
+
+const (
+	ManagedRuleEnabledStateDisabled ManagedRuleEnabledState = "Disabled"
+	ManagedRuleEnabledStateEnabled  ManagedRuleEnabledState = "Enabled"
+)
+
+func PossibleValuesForManagedRuleEnabledState() []string {
+	return []string{
+		string(ManagedRuleEnabledStateDisabled),
+		string(ManagedRuleEnabledStateEnabled),
+	}
+}
+
+func parseManagedRuleEnabledState(input string) (*ManagedRuleEnabledState, error) {
+	vals := map[string]ManagedRuleEnabledState{
+		"disabled": ManagedRuleEnabledStateDisabled,
+		"enabled":  ManagedRuleEnabledStateEnabled,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ManagedRuleEnabledState(input)
+	return &out, nil
+}
+
+type ManagedRuleExclusionMatchVariable string
+
+const (
+	ManagedRuleExclusionMatchVariableQueryStringArgNames     ManagedRuleExclusionMatchVariable = "QueryStringArgNames"
+	ManagedRuleExclusionMatchVariableRequestBodyJsonArgNames ManagedRuleExclusionMatchVariable = "RequestBodyJsonArgNames"
+	ManagedRuleExclusionMatchVariableRequestBodyPostArgNames ManagedRuleExclusionMatchVariable = "RequestBodyPostArgNames"
+	ManagedRuleExclusionMatchVariableRequestCookieNames      ManagedRuleExclusionMatchVariable = "RequestCookieNames"
+	ManagedRuleExclusionMatchVariableRequestHeaderNames      ManagedRuleExclusionMatchVariable = "RequestHeaderNames"
+)
+
+func PossibleValuesForManagedRuleExclusionMatchVariable() []string {
+	return []string{
+		string(ManagedRuleExclusionMatchVariableQueryStringArgNames),
+		string(ManagedRuleExclusionMatchVariableRequestBodyJsonArgNames),
+		string(ManagedRuleExclusionMatchVariableRequestBodyPostArgNames),
+		string(ManagedRuleExclusionMatchVariableRequestCookieNames),
+		string(ManagedRuleExclusionMatchVariableRequestHeaderNames),
+	}
+}
+
+func parseManagedRuleExclusionMatchVariable(input string) (*ManagedRuleExclusionMatchVariable, error) {
+	vals := map[string]ManagedRuleExclusionMatchVariable{
+		"querystringargnames":     ManagedRuleExclusionMatchVariableQueryStringArgNames,
+		"requestbodyjsonargnames": ManagedRuleExclusionMatchVariableRequestBodyJsonArgNames,
+		"requestbodypostargnames": ManagedRuleExclusionMatchVariableRequestBodyPostArgNames,
+		"requestcookienames":      ManagedRuleExclusionMatchVariableRequestCookieNames,
+		"requestheadernames":      ManagedRuleExclusionMatchVariableRequestHeaderNames,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ManagedRuleExclusionMatchVariable(input)
+	return &out, nil
+}
+
+type ManagedRuleExclusionSelectorMatchOperator string
+
+const (
+	ManagedRuleExclusionSelectorMatchOperatorContains   ManagedRuleExclusionSelectorMatchOperator = "Contains"
+	ManagedRuleExclusionSelectorMatchOperatorEndsWith   ManagedRuleExclusionSelectorMatchOperator = "EndsWith"
+	ManagedRuleExclusionSelectorMatchOperatorEquals     ManagedRuleExclusionSelectorMatchOperator = "Equals"
+	ManagedRuleExclusionSelectorMatchOperatorEqualsAny  ManagedRuleExclusionSelectorMatchOperator = "EqualsAny"
+	ManagedRuleExclusionSelectorMatchOperatorStartsWith ManagedRuleExclusionSelectorMatchOperator = "StartsWith"
+)
+
+func PossibleValuesForManagedRuleExclusionSelectorMatchOperator() []string {
+	return []string{
+		string(ManagedRuleExclusionSelectorMatchOperatorContains),
+		string(ManagedRuleExclusionSelectorMatchOperatorEndsWith),
+		string(ManagedRuleExclusionSelectorMatchOperatorEquals),
+		string(ManagedRuleExclusionSelectorMatchOperatorEqualsAny),
+		string(ManagedRuleExclusionSelectorMatchOperatorStartsWith),
+	}
+}
+
+func parseManagedRuleExclusionSelectorMatchOperator(input string) (*ManagedRuleExclusionSelectorMatchOperator, error) {
+	vals := map[string]ManagedRuleExclusionSelectorMatchOperator{
+		"contains":   ManagedRuleExclusionSelectorMatchOperatorContains,
+		"endswith":   ManagedRuleExclusionSelectorMatchOperatorEndsWith,
+		"equals":     ManagedRuleExclusionSelectorMatchOperatorEquals,
+		"equalsany":  ManagedRuleExclusionSelectorMatchOperatorEqualsAny,
+		"startswith": ManagedRuleExclusionSelectorMatchOperatorStartsWith,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ManagedRuleExclusionSelectorMatchOperator(input)
+	return &out, nil
+}
+
+type ManagedRuleSetActionType string
+
+const (
+	ManagedRuleSetActionTypeBlock    ManagedRuleSetActionType = "Block"
+	ManagedRuleSetActionTypeLog      ManagedRuleSetActionType = "Log"
+	ManagedRuleSetActionTypeRedirect ManagedRuleSetActionType = "Redirect"
+)
+
+func PossibleValuesForManagedRuleSetActionType() []string {
+	return []string{
+		string(ManagedRuleSetActionTypeBlock),
+		string(ManagedRuleSetActionTypeLog),
+		string(ManagedRuleSetActionTypeRedirect),
+	}
+}
+
+func parseManagedRuleSetActionType(input string) (*ManagedRuleSetActionType, error) {
+	vals := map[string]ManagedRuleSetActionType{
+		"block":    ManagedRuleSetActionTypeBlock,
+		"log":      ManagedRuleSetActionTypeLog,
+		"redirect": ManagedRuleSetActionTypeRedirect,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ManagedRuleSetActionType(input)
+	return &out, nil
+}
+
+type MatchVariable string
+
+const (
+	MatchVariableCookies       MatchVariable = "Cookies"
+	MatchVariablePostArgs      MatchVariable = "PostArgs"
+	MatchVariableQueryString   MatchVariable = "QueryString"
+	MatchVariableRemoteAddr    MatchVariable = "RemoteAddr"
+	MatchVariableRequestBody   MatchVariable = "RequestBody"
+	MatchVariableRequestHeader MatchVariable = "RequestHeader"
+	MatchVariableRequestMethod MatchVariable = "RequestMethod"
+	MatchVariableRequestUri    MatchVariable = "RequestUri"
+	MatchVariableSocketAddr    MatchVariable = "SocketAddr"
+)
+
+func PossibleValuesForMatchVariable() []string {
+	return []string{
+		string(MatchVariableCookies),
+		string(MatchVariablePostArgs),
+		string(MatchVariableQueryString),
+		string(MatchVariableRemoteAddr),
+		string(MatchVariableRequestBody),
+		string(MatchVariableRequestHeader),
+		string(MatchVariableRequestMethod),
+		string(MatchVariableRequestUri),
+		string(MatchVariableSocketAddr),
+	}
+}
+
+func parseMatchVariable(input string) (*MatchVariable, error) {
+	vals := map[string]MatchVariable{
+		"cookies":       MatchVariableCookies,
+		"postargs":      MatchVariablePostArgs,
+		"querystring":   MatchVariableQueryString,
+		"remoteaddr":    MatchVariableRemoteAddr,
+		"requestbody":   MatchVariableRequestBody,
+		"requestheader": MatchVariableRequestHeader,
+		"requestmethod": MatchVariableRequestMethod,
+		"requesturi":    MatchVariableRequestUri,
+		"socketaddr":    MatchVariableSocketAddr,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := MatchVariable(input)
+	return &out, nil
+}
+
+type Operator string
+
+const (
+	OperatorAny                Operator = "Any"
+	OperatorBeginsWith         Operator = "BeginsWith"
+	OperatorContains           Operator = "Contains"
+	OperatorEndsWith           Operator = "EndsWith"
+	OperatorEqual              Operator = "Equal"
+	OperatorGeoMatch           Operator = "GeoMatch"
+	OperatorGreaterThan        Operator = "GreaterThan"
+	OperatorGreaterThanOrEqual Operator = "GreaterThanOrEqual"
+	OperatorIPMatch            Operator = "IPMatch"
+	OperatorLessThan           Operator = "LessThan"
+	OperatorLessThanOrEqual    Operator = "LessThanOrEqual"
+	OperatorRegEx              Operator = "RegEx"
+)
+
+func PossibleValuesForOperator() []string {
+	return []string{
+		string(OperatorAny),
+		string(OperatorBeginsWith),
+		string(OperatorContains),
+		string(OperatorEndsWith),
+		string(OperatorEqual),
+		string(OperatorGeoMatch),
+		string(OperatorGreaterThan),
+		string(OperatorGreaterThanOrEqual),
+		string(OperatorIPMatch),
+		string(OperatorLessThan),
+		string(OperatorLessThanOrEqual),
+		string(OperatorRegEx),
+	}
+}
+
+func parseOperator(input string) (*Operator, error) {
+	vals := map[string]Operator{
+		"any":                OperatorAny,
+		"beginswith":         OperatorBeginsWith,
+		"contains":           OperatorContains,
+		"endswith":           OperatorEndsWith,
+		"equal":              OperatorEqual,
+		"geomatch":           OperatorGeoMatch,
+		"greaterthan":        OperatorGreaterThan,
+		"greaterthanorequal": OperatorGreaterThanOrEqual,
+		"ipmatch":            OperatorIPMatch,
+		"lessthan":           OperatorLessThan,
+		"lessthanorequal":    OperatorLessThanOrEqual,
+		"regex":              OperatorRegEx,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := Operator(input)
+	return &out, nil
+}
+
+type PolicyEnabledState string
+
+const (
+	PolicyEnabledStateDisabled PolicyEnabledState = "Disabled"
+	PolicyEnabledStateEnabled  PolicyEnabledState = "Enabled"
+)
+
+func PossibleValuesForPolicyEnabledState() []string {
+	return []string{
+		string(PolicyEnabledStateDisabled),
+		string(PolicyEnabledStateEnabled),
+	}
+}
+
+func parsePolicyEnabledState(input string) (*PolicyEnabledState, error) {
+	vals := map[string]PolicyEnabledState{
+		"disabled": PolicyEnabledStateDisabled,
+		"enabled":  PolicyEnabledStateEnabled,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := PolicyEnabledState(input)
+	return &out, nil
+}
+
+type PolicyMode string
+
+const (
+	PolicyModeDetection  PolicyMode = "Detection"
+	PolicyModePrevention PolicyMode = "Prevention"
+)
+
+func PossibleValuesForPolicyMode() []string {
+	return []string{
+		string(PolicyModeDetection),
+		string(PolicyModePrevention),
+	}
+}
+
+func parsePolicyMode(input string) (*PolicyMode, error) {
+	vals := map[string]PolicyMode{
+		"detection":  PolicyModeDetection,
+		"prevention": PolicyModePrevention,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := PolicyMode(input)
+	return &out, nil
+}
+
+type PolicyRequestBodyCheck string
+
+const (
+	PolicyRequestBodyCheckDisabled PolicyRequestBodyCheck = "Disabled"
+	PolicyRequestBodyCheckEnabled  PolicyRequestBodyCheck = "Enabled"
+)
+
+func PossibleValuesForPolicyRequestBodyCheck() []string {
+	return []string{
+		string(PolicyRequestBodyCheckDisabled),
+		string(PolicyRequestBodyCheckEnabled),
+	}
+}
+
+func parsePolicyRequestBodyCheck(input string) (*PolicyRequestBodyCheck, error) {
+	vals := map[string]PolicyRequestBodyCheck{
+		"disabled": PolicyRequestBodyCheckDisabled,
+		"enabled":  PolicyRequestBodyCheckEnabled,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := PolicyRequestBodyCheck(input)
+	return &out, nil
+}
+
+type PolicyResourceState string
+
+const (
+	PolicyResourceStateCreating  PolicyResourceState = "Creating"
+	PolicyResourceStateDeleting  PolicyResourceState = "Deleting"
+	PolicyResourceStateDisabled  PolicyResourceState = "Disabled"
+	PolicyResourceStateDisabling PolicyResourceState = "Disabling"
+	PolicyResourceStateEnabled   PolicyResourceState = "Enabled"
+	PolicyResourceStateEnabling  PolicyResourceState = "Enabling"
+)
+
+func PossibleValuesForPolicyResourceState() []string {
+	return []string{
+		string(PolicyResourceStateCreating),
+		string(PolicyResourceStateDeleting),
+		string(PolicyResourceStateDisabled),
+		string(PolicyResourceStateDisabling),
+		string(PolicyResourceStateEnabled),
+		string(PolicyResourceStateEnabling),
+	}
+}
+
+func parsePolicyResourceState(input string) (*PolicyResourceState, error) {
+	vals := map[string]PolicyResourceState{
+		"creating":  PolicyResourceStateCreating,
+		"deleting":  PolicyResourceStateDeleting,
+		"disabled":  PolicyResourceStateDisabled,
+		"disabling": PolicyResourceStateDisabling,
+		"enabled":   PolicyResourceStateEnabled,
+		"enabling":  PolicyResourceStateEnabling,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := PolicyResourceState(input)
+	return &out, nil
+}
+
+type RuleType string
+
+const (
+	RuleTypeMatchRule     RuleType = "MatchRule"
+	RuleTypeRateLimitRule RuleType = "RateLimitRule"
+)
+
+func PossibleValuesForRuleType() []string {
+	return []string{
+		string(RuleTypeMatchRule),
+		string(RuleTypeRateLimitRule),
+	}
+}
+
+func parseRuleType(input string) (*RuleType, error) {
+	vals := map[string]RuleType{
+		"matchrule":     RuleTypeMatchRule,
+		"ratelimitrule": RuleTypeRateLimitRule,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := RuleType(input)
+	return &out, nil
+}
+
+type ScrubbingRuleEntryMatchOperator string
+
+const (
+	ScrubbingRuleEntryMatchOperatorEquals    ScrubbingRuleEntryMatchOperator = "Equals"
+	ScrubbingRuleEntryMatchOperatorEqualsAny ScrubbingRuleEntryMatchOperator = "EqualsAny"
+)
+
+func PossibleValuesForScrubbingRuleEntryMatchOperator() []string {
+	return []string{
+		string(ScrubbingRuleEntryMatchOperatorEquals),
+		string(ScrubbingRuleEntryMatchOperatorEqualsAny),
+	}
+}
+
+func parseScrubbingRuleEntryMatchOperator(input string) (*ScrubbingRuleEntryMatchOperator, error) {
+	vals := map[string]ScrubbingRuleEntryMatchOperator{
+		"equals":    ScrubbingRuleEntryMatchOperatorEquals,
+		"equalsany": ScrubbingRuleEntryMatchOperatorEqualsAny,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ScrubbingRuleEntryMatchOperator(input)
+	return &out, nil
+}
+
+type ScrubbingRuleEntryMatchVariable string
+
+const (
+	ScrubbingRuleEntryMatchVariableQueryStringArgNames     ScrubbingRuleEntryMatchVariable = "QueryStringArgNames"
+	ScrubbingRuleEntryMatchVariableRequestBodyJsonArgNames ScrubbingRuleEntryMatchVariable = "RequestBodyJsonArgNames"
+	ScrubbingRuleEntryMatchVariableRequestBodyPostArgNames ScrubbingRuleEntryMatchVariable = "RequestBodyPostArgNames"
+	ScrubbingRuleEntryMatchVariableRequestCookieNames      ScrubbingRuleEntryMatchVariable = "RequestCookieNames"
+	ScrubbingRuleEntryMatchVariableRequestHeaderNames      ScrubbingRuleEntryMatchVariable = "RequestHeaderNames"
+	ScrubbingRuleEntryMatchVariableRequestIPAddress        ScrubbingRuleEntryMatchVariable = "RequestIPAddress"
+	ScrubbingRuleEntryMatchVariableRequestUri              ScrubbingRuleEntryMatchVariable = "RequestUri"
+)
+
+func PossibleValuesForScrubbingRuleEntryMatchVariable() []string {
+	return []string{
+		string(ScrubbingRuleEntryMatchVariableQueryStringArgNames),
+		string(ScrubbingRuleEntryMatchVariableRequestBodyJsonArgNames),
+		string(ScrubbingRuleEntryMatchVariableRequestBodyPostArgNames),
+		string(ScrubbingRuleEntryMatchVariableRequestCookieNames),
+		string(ScrubbingRuleEntryMatchVariableRequestHeaderNames),
+		string(ScrubbingRuleEntryMatchVariableRequestIPAddress),
+		string(ScrubbingRuleEntryMatchVariableRequestUri),
+	}
+}
+
+func parseScrubbingRuleEntryMatchVariable(input string) (*ScrubbingRuleEntryMatchVariable, error) {
+	vals := map[string]ScrubbingRuleEntryMatchVariable{
+		"querystringargnames":     ScrubbingRuleEntryMatchVariableQueryStringArgNames,
+		"requestbodyjsonargnames": ScrubbingRuleEntryMatchVariableRequestBodyJsonArgNames,
+		"requestbodypostargnames": ScrubbingRuleEntryMatchVariableRequestBodyPostArgNames,
+		"requestcookienames":      ScrubbingRuleEntryMatchVariableRequestCookieNames,
+		"requestheadernames":      ScrubbingRuleEntryMatchVariableRequestHeaderNames,
+		"requestipaddress":        ScrubbingRuleEntryMatchVariableRequestIPAddress,
+		"requesturi":              ScrubbingRuleEntryMatchVariableRequestUri,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ScrubbingRuleEntryMatchVariable(input)
+	return &out, nil
+}
+
+type ScrubbingRuleEntryState string
+
+const (
+	ScrubbingRuleEntryStateDisabled ScrubbingRuleEntryState = "Disabled"
+	ScrubbingRuleEntryStateEnabled  ScrubbingRuleEntryState = "Enabled"
+)
+
+func PossibleValuesForScrubbingRuleEntryState() []string {
+	return []string{
+		string(ScrubbingRuleEntryStateDisabled),
+		string(ScrubbingRuleEntryStateEnabled),
+	}
+}
+
+func parseScrubbingRuleEntryState(input string) (*ScrubbingRuleEntryState, error) {
+	vals := map[string]ScrubbingRuleEntryState{
+		"disabled": ScrubbingRuleEntryStateDisabled,
+		"enabled":  ScrubbingRuleEntryStateEnabled,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ScrubbingRuleEntryState(input)
+	return &out, nil
+}
+
+type SkuName string
+
+const (
+	SkuNameClassicAzureFrontDoor  SkuName = "Classic_AzureFrontDoor"
+	SkuNamePremiumAzureFrontDoor  SkuName = "Premium_AzureFrontDoor"
+	SkuNameStandardAzureFrontDoor SkuName = "Standard_AzureFrontDoor"
+)
+
+func PossibleValuesForSkuName() []string {
+	return []string{
+		string(SkuNameClassicAzureFrontDoor),
+		string(SkuNamePremiumAzureFrontDoor),
+		string(SkuNameStandardAzureFrontDoor),
+	}
+}
+
+func parseSkuName(input string) (*SkuName, error) {
+	vals := map[string]SkuName{
+		"classic_azurefrontdoor":  SkuNameClassicAzureFrontDoor,
+		"premium_azurefrontdoor":  SkuNamePremiumAzureFrontDoor,
+		"standard_azurefrontdoor": SkuNameStandardAzureFrontDoor,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := SkuName(input)
+	return &out, nil
+}
+
+type TransformType string
+
+const (
+	TransformTypeLowercase   TransformType = "Lowercase"
+	TransformTypeRemoveNulls TransformType = "RemoveNulls"
+	TransformTypeTrim        TransformType = "Trim"
+	TransformTypeURLDecode   TransformType = "UrlDecode"
+	TransformTypeURLEncode   TransformType = "UrlEncode"
+	TransformTypeUppercase   TransformType = "Uppercase"
+)
+
+func PossibleValuesForTransformType() []string {
+	return []string{
+		string(TransformTypeLowercase),
+		string(TransformTypeRemoveNulls),
+		string(TransformTypeTrim),
+		string(TransformTypeURLDecode),
+		string(TransformTypeURLEncode),
+		string(TransformTypeUppercase),
+	}
+}
+
+func parseTransformType(input string) (*TransformType, error) {
+	vals := map[string]TransformType{
+		"lowercase":   TransformTypeLowercase,
+		"removenulls": TransformTypeRemoveNulls,
+		"trim":        TransformTypeTrim,
+		"urldecode":   TransformTypeURLDecode,
+		"urlencode":   TransformTypeURLEncode,
+		"uppercase":   TransformTypeUppercase,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := TransformType(input)
+	return &out, nil
+}
+
+type VariableName string
+
+const (
+	VariableNameGeoLocation VariableName = "GeoLocation"
+	VariableNameNone        VariableName = "None"
+	VariableNameSocketAddr  VariableName = "SocketAddr"
+)
+
+func PossibleValuesForVariableName() []string {
+	return []string{
+		string(VariableNameGeoLocation),
+		string(VariableNameNone),
+		string(VariableNameSocketAddr),
+	}
+}
+
+func parseVariableName(input string) (*VariableName, error) {
+	vals := map[string]VariableName{
+		"geolocation": VariableNameGeoLocation,
+		"none":        VariableNameNone,
+		"socketaddr":  VariableNameSocketAddr,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := VariableName(input)
+	return &out, nil
+}
+
+type WebApplicationFirewallScrubbingState string
+
+const (
+	WebApplicationFirewallScrubbingStateDisabled WebApplicationFirewallScrubbingState = "Disabled"
+	WebApplicationFirewallScrubbingStateEnabled  WebApplicationFirewallScrubbingState = "Enabled"
+)
+
+func PossibleValuesForWebApplicationFirewallScrubbingState() []string {
+	return []string{
+		string(WebApplicationFirewallScrubbingStateDisabled),
+		string(WebApplicationFirewallScrubbingStateEnabled),
+	}
+}
+
+func parseWebApplicationFirewallScrubbingState(input string) (*WebApplicationFirewallScrubbingState, error) {
+	vals := map[string]WebApplicationFirewallScrubbingState{
+		"disabled": WebApplicationFirewallScrubbingStateDisabled,
+		"enabled":  WebApplicationFirewallScrubbingStateEnabled,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := WebApplicationFirewallScrubbingState(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/id_frontdoorwebapplicationfirewallpolicy.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/id_frontdoorwebapplicationfirewallpolicy.go
@@ -1,0 +1,130 @@
+package webapplicationfirewallpolicies
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&FrontDoorWebApplicationFirewallPolicyId{})
+}
+
+var _ resourceids.ResourceId = &FrontDoorWebApplicationFirewallPolicyId{}
+
+// FrontDoorWebApplicationFirewallPolicyId is a struct representing the Resource ID for a Front Door Web Application Firewall Policy
+type FrontDoorWebApplicationFirewallPolicyId struct {
+	SubscriptionId                            string
+	ResourceGroupName                         string
+	FrontDoorWebApplicationFirewallPolicyName string
+}
+
+// NewFrontDoorWebApplicationFirewallPolicyID returns a new FrontDoorWebApplicationFirewallPolicyId struct
+func NewFrontDoorWebApplicationFirewallPolicyID(subscriptionId string, resourceGroupName string, frontDoorWebApplicationFirewallPolicyName string) FrontDoorWebApplicationFirewallPolicyId {
+	return FrontDoorWebApplicationFirewallPolicyId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		FrontDoorWebApplicationFirewallPolicyName: frontDoorWebApplicationFirewallPolicyName,
+	}
+}
+
+// ParseFrontDoorWebApplicationFirewallPolicyID parses 'input' into a FrontDoorWebApplicationFirewallPolicyId
+func ParseFrontDoorWebApplicationFirewallPolicyID(input string) (*FrontDoorWebApplicationFirewallPolicyId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&FrontDoorWebApplicationFirewallPolicyId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := FrontDoorWebApplicationFirewallPolicyId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseFrontDoorWebApplicationFirewallPolicyIDInsensitively parses 'input' case-insensitively into a FrontDoorWebApplicationFirewallPolicyId
+// note: this method should only be used for API response data and not user input
+func ParseFrontDoorWebApplicationFirewallPolicyIDInsensitively(input string) (*FrontDoorWebApplicationFirewallPolicyId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&FrontDoorWebApplicationFirewallPolicyId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := FrontDoorWebApplicationFirewallPolicyId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *FrontDoorWebApplicationFirewallPolicyId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.FrontDoorWebApplicationFirewallPolicyName, ok = input.Parsed["frontDoorWebApplicationFirewallPolicyName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "frontDoorWebApplicationFirewallPolicyName", input)
+	}
+
+	return nil
+}
+
+// ValidateFrontDoorWebApplicationFirewallPolicyID checks that 'input' can be parsed as a Front Door Web Application Firewall Policy ID
+func ValidateFrontDoorWebApplicationFirewallPolicyID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseFrontDoorWebApplicationFirewallPolicyID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Front Door Web Application Firewall Policy ID
+func (id FrontDoorWebApplicationFirewallPolicyId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/frontDoorWebApplicationFirewallPolicies/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.FrontDoorWebApplicationFirewallPolicyName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Front Door Web Application Firewall Policy ID
+func (id FrontDoorWebApplicationFirewallPolicyId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftNetwork", "Microsoft.Network", "Microsoft.Network"),
+		resourceids.StaticSegment("staticFrontDoorWebApplicationFirewallPolicies", "frontDoorWebApplicationFirewallPolicies", "frontDoorWebApplicationFirewallPolicies"),
+		resourceids.UserSpecifiedSegment("frontDoorWebApplicationFirewallPolicyName", "frontDoorWebApplicationFirewallPolicyName"),
+	}
+}
+
+// String returns a human-readable description of this Front Door Web Application Firewall Policy ID
+func (id FrontDoorWebApplicationFirewallPolicyId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Front Door Web Application Firewall Policy Name: %q", id.FrontDoorWebApplicationFirewallPolicyName),
+	}
+	return fmt.Sprintf("Front Door Web Application Firewall Policy (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/method_policiescreateorupdate_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/method_policiescreateorupdate_autorest.go
@@ -1,0 +1,80 @@
+package webapplicationfirewallpolicies
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PoliciesCreateOrUpdateOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+	Model        *WebApplicationFirewallPolicy
+}
+
+// PoliciesCreateOrUpdate ...
+func (c WebApplicationFirewallPoliciesClient) PoliciesCreateOrUpdate(ctx context.Context, id FrontDoorWebApplicationFirewallPolicyId, input WebApplicationFirewallPolicy) (result PoliciesCreateOrUpdateOperationResponse, err error) {
+	req, err := c.preparerForPoliciesCreateOrUpdate(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "webapplicationfirewallpolicies.WebApplicationFirewallPoliciesClient", "PoliciesCreateOrUpdate", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForPoliciesCreateOrUpdate(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "webapplicationfirewallpolicies.WebApplicationFirewallPoliciesClient", "PoliciesCreateOrUpdate", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// PoliciesCreateOrUpdateThenPoll performs PoliciesCreateOrUpdate then polls until it's completed
+func (c WebApplicationFirewallPoliciesClient) PoliciesCreateOrUpdateThenPoll(ctx context.Context, id FrontDoorWebApplicationFirewallPolicyId, input WebApplicationFirewallPolicy) error {
+	result, err := c.PoliciesCreateOrUpdate(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing PoliciesCreateOrUpdate: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after PoliciesCreateOrUpdate: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForPoliciesCreateOrUpdate prepares the PoliciesCreateOrUpdate request.
+func (c WebApplicationFirewallPoliciesClient) preparerForPoliciesCreateOrUpdate(ctx context.Context, id FrontDoorWebApplicationFirewallPolicyId, input WebApplicationFirewallPolicy) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPut(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForPoliciesCreateOrUpdate sends the PoliciesCreateOrUpdate request. The method will close the
+// http.Response Body if it receives an error.
+func (c WebApplicationFirewallPoliciesClient) senderForPoliciesCreateOrUpdate(ctx context.Context, req *http.Request) (future PoliciesCreateOrUpdateOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/method_policiesdelete_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/method_policiesdelete_autorest.go
@@ -1,0 +1,78 @@
+package webapplicationfirewallpolicies
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PoliciesDeleteOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// PoliciesDelete ...
+func (c WebApplicationFirewallPoliciesClient) PoliciesDelete(ctx context.Context, id FrontDoorWebApplicationFirewallPolicyId) (result PoliciesDeleteOperationResponse, err error) {
+	req, err := c.preparerForPoliciesDelete(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "webapplicationfirewallpolicies.WebApplicationFirewallPoliciesClient", "PoliciesDelete", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForPoliciesDelete(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "webapplicationfirewallpolicies.WebApplicationFirewallPoliciesClient", "PoliciesDelete", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// PoliciesDeleteThenPoll performs PoliciesDelete then polls until it's completed
+func (c WebApplicationFirewallPoliciesClient) PoliciesDeleteThenPoll(ctx context.Context, id FrontDoorWebApplicationFirewallPolicyId) error {
+	result, err := c.PoliciesDelete(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing PoliciesDelete: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after PoliciesDelete: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForPoliciesDelete prepares the PoliciesDelete request.
+func (c WebApplicationFirewallPoliciesClient) preparerForPoliciesDelete(ctx context.Context, id FrontDoorWebApplicationFirewallPolicyId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsDelete(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForPoliciesDelete sends the PoliciesDelete request. The method will close the
+// http.Response Body if it receives an error.
+func (c WebApplicationFirewallPoliciesClient) senderForPoliciesDelete(ctx context.Context, req *http.Request) (future PoliciesDeleteOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/method_policiesget_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/method_policiesget_autorest.go
@@ -1,0 +1,68 @@
+package webapplicationfirewallpolicies
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PoliciesGetOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *WebApplicationFirewallPolicy
+}
+
+// PoliciesGet ...
+func (c WebApplicationFirewallPoliciesClient) PoliciesGet(ctx context.Context, id FrontDoorWebApplicationFirewallPolicyId) (result PoliciesGetOperationResponse, err error) {
+	req, err := c.preparerForPoliciesGet(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "webapplicationfirewallpolicies.WebApplicationFirewallPoliciesClient", "PoliciesGet", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "webapplicationfirewallpolicies.WebApplicationFirewallPoliciesClient", "PoliciesGet", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForPoliciesGet(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "webapplicationfirewallpolicies.WebApplicationFirewallPoliciesClient", "PoliciesGet", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForPoliciesGet prepares the PoliciesGet request.
+func (c WebApplicationFirewallPoliciesClient) preparerForPoliciesGet(ctx context.Context, id FrontDoorWebApplicationFirewallPolicyId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForPoliciesGet handles the response to the PoliciesGet request. The method always
+// closes the http.Response Body.
+func (c WebApplicationFirewallPoliciesClient) responderForPoliciesGet(resp *http.Response) (result PoliciesGetOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/method_policieslist_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/method_policieslist_autorest.go
@@ -1,0 +1,187 @@
+package webapplicationfirewallpolicies
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PoliciesListOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *[]WebApplicationFirewallPolicy
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (PoliciesListOperationResponse, error)
+}
+
+type PoliciesListCompleteResult struct {
+	Items []WebApplicationFirewallPolicy
+}
+
+func (r PoliciesListOperationResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r PoliciesListOperationResponse) LoadMore(ctx context.Context) (resp PoliciesListOperationResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+// PoliciesList ...
+func (c WebApplicationFirewallPoliciesClient) PoliciesList(ctx context.Context, id commonids.ResourceGroupId) (resp PoliciesListOperationResponse, err error) {
+	req, err := c.preparerForPoliciesList(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "webapplicationfirewallpolicies.WebApplicationFirewallPoliciesClient", "PoliciesList", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "webapplicationfirewallpolicies.WebApplicationFirewallPoliciesClient", "PoliciesList", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForPoliciesList(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "webapplicationfirewallpolicies.WebApplicationFirewallPoliciesClient", "PoliciesList", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// preparerForPoliciesList prepares the PoliciesList request.
+func (c WebApplicationFirewallPoliciesClient) preparerForPoliciesList(ctx context.Context, id commonids.ResourceGroupId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/providers/Microsoft.Network/frontDoorWebApplicationFirewallPolicies", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForPoliciesListWithNextLink prepares the PoliciesList request with the given nextLink token.
+func (c WebApplicationFirewallPoliciesClient) preparerForPoliciesListWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForPoliciesList handles the response to the PoliciesList request. The method always
+// closes the http.Response Body.
+func (c WebApplicationFirewallPoliciesClient) responderForPoliciesList(resp *http.Response) (result PoliciesListOperationResponse, err error) {
+	type page struct {
+		Values   []WebApplicationFirewallPolicy `json:"value"`
+		NextLink *string                        `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result PoliciesListOperationResponse, err error) {
+			req, err := c.preparerForPoliciesListWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "webapplicationfirewallpolicies.WebApplicationFirewallPoliciesClient", "PoliciesList", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "webapplicationfirewallpolicies.WebApplicationFirewallPoliciesClient", "PoliciesList", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForPoliciesList(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "webapplicationfirewallpolicies.WebApplicationFirewallPoliciesClient", "PoliciesList", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}
+
+// PoliciesListComplete retrieves all of the results into a single object
+func (c WebApplicationFirewallPoliciesClient) PoliciesListComplete(ctx context.Context, id commonids.ResourceGroupId) (PoliciesListCompleteResult, error) {
+	return c.PoliciesListCompleteMatchingPredicate(ctx, id, WebApplicationFirewallPolicyOperationPredicate{})
+}
+
+// PoliciesListCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c WebApplicationFirewallPoliciesClient) PoliciesListCompleteMatchingPredicate(ctx context.Context, id commonids.ResourceGroupId, predicate WebApplicationFirewallPolicyOperationPredicate) (resp PoliciesListCompleteResult, err error) {
+	items := make([]WebApplicationFirewallPolicy, 0)
+
+	page, err := c.PoliciesList(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := PoliciesListCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/method_policieslistbysubscription_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/method_policieslistbysubscription_autorest.go
@@ -1,0 +1,187 @@
+package webapplicationfirewallpolicies
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PoliciesListBySubscriptionOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *[]WebApplicationFirewallPolicy
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (PoliciesListBySubscriptionOperationResponse, error)
+}
+
+type PoliciesListBySubscriptionCompleteResult struct {
+	Items []WebApplicationFirewallPolicy
+}
+
+func (r PoliciesListBySubscriptionOperationResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r PoliciesListBySubscriptionOperationResponse) LoadMore(ctx context.Context) (resp PoliciesListBySubscriptionOperationResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+// PoliciesListBySubscription ...
+func (c WebApplicationFirewallPoliciesClient) PoliciesListBySubscription(ctx context.Context, id commonids.SubscriptionId) (resp PoliciesListBySubscriptionOperationResponse, err error) {
+	req, err := c.preparerForPoliciesListBySubscription(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "webapplicationfirewallpolicies.WebApplicationFirewallPoliciesClient", "PoliciesListBySubscription", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "webapplicationfirewallpolicies.WebApplicationFirewallPoliciesClient", "PoliciesListBySubscription", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForPoliciesListBySubscription(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "webapplicationfirewallpolicies.WebApplicationFirewallPoliciesClient", "PoliciesListBySubscription", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// preparerForPoliciesListBySubscription prepares the PoliciesListBySubscription request.
+func (c WebApplicationFirewallPoliciesClient) preparerForPoliciesListBySubscription(ctx context.Context, id commonids.SubscriptionId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/providers/Microsoft.Network/frontDoorWebApplicationFirewallPolicies", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForPoliciesListBySubscriptionWithNextLink prepares the PoliciesListBySubscription request with the given nextLink token.
+func (c WebApplicationFirewallPoliciesClient) preparerForPoliciesListBySubscriptionWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForPoliciesListBySubscription handles the response to the PoliciesListBySubscription request. The method always
+// closes the http.Response Body.
+func (c WebApplicationFirewallPoliciesClient) responderForPoliciesListBySubscription(resp *http.Response) (result PoliciesListBySubscriptionOperationResponse, err error) {
+	type page struct {
+		Values   []WebApplicationFirewallPolicy `json:"value"`
+		NextLink *string                        `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result PoliciesListBySubscriptionOperationResponse, err error) {
+			req, err := c.preparerForPoliciesListBySubscriptionWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "webapplicationfirewallpolicies.WebApplicationFirewallPoliciesClient", "PoliciesListBySubscription", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "webapplicationfirewallpolicies.WebApplicationFirewallPoliciesClient", "PoliciesListBySubscription", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForPoliciesListBySubscription(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "webapplicationfirewallpolicies.WebApplicationFirewallPoliciesClient", "PoliciesListBySubscription", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}
+
+// PoliciesListBySubscriptionComplete retrieves all of the results into a single object
+func (c WebApplicationFirewallPoliciesClient) PoliciesListBySubscriptionComplete(ctx context.Context, id commonids.SubscriptionId) (PoliciesListBySubscriptionCompleteResult, error) {
+	return c.PoliciesListBySubscriptionCompleteMatchingPredicate(ctx, id, WebApplicationFirewallPolicyOperationPredicate{})
+}
+
+// PoliciesListBySubscriptionCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c WebApplicationFirewallPoliciesClient) PoliciesListBySubscriptionCompleteMatchingPredicate(ctx context.Context, id commonids.SubscriptionId, predicate WebApplicationFirewallPolicyOperationPredicate) (resp PoliciesListBySubscriptionCompleteResult, err error) {
+	items := make([]WebApplicationFirewallPolicy, 0)
+
+	page, err := c.PoliciesListBySubscription(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := PoliciesListBySubscriptionCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/method_policiesupdate_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/method_policiesupdate_autorest.go
@@ -1,0 +1,80 @@
+package webapplicationfirewallpolicies
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PoliciesUpdateOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+	Model        *WebApplicationFirewallPolicy
+}
+
+// PoliciesUpdate ...
+func (c WebApplicationFirewallPoliciesClient) PoliciesUpdate(ctx context.Context, id FrontDoorWebApplicationFirewallPolicyId, input TagsObject) (result PoliciesUpdateOperationResponse, err error) {
+	req, err := c.preparerForPoliciesUpdate(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "webapplicationfirewallpolicies.WebApplicationFirewallPoliciesClient", "PoliciesUpdate", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForPoliciesUpdate(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "webapplicationfirewallpolicies.WebApplicationFirewallPoliciesClient", "PoliciesUpdate", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// PoliciesUpdateThenPoll performs PoliciesUpdate then polls until it's completed
+func (c WebApplicationFirewallPoliciesClient) PoliciesUpdateThenPoll(ctx context.Context, id FrontDoorWebApplicationFirewallPolicyId, input TagsObject) error {
+	result, err := c.PoliciesUpdate(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing PoliciesUpdate: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after PoliciesUpdate: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForPoliciesUpdate prepares the PoliciesUpdate request.
+func (c WebApplicationFirewallPoliciesClient) preparerForPoliciesUpdate(ctx context.Context, id FrontDoorWebApplicationFirewallPolicyId, input TagsObject) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPatch(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForPoliciesUpdate sends the PoliciesUpdate request. The method will close the
+// http.Response Body if it receives an error.
+func (c WebApplicationFirewallPoliciesClient) senderForPoliciesUpdate(ctx context.Context, req *http.Request) (future PoliciesUpdateOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/model_customrule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/model_customrule.go
@@ -1,0 +1,16 @@
+package webapplicationfirewallpolicies
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CustomRule struct {
+	Action                     ActionType              `json:"action"`
+	EnabledState               *CustomRuleEnabledState `json:"enabledState,omitempty"`
+	GroupBy                    *[]GroupByVariable      `json:"groupBy,omitempty"`
+	MatchConditions            []MatchCondition        `json:"matchConditions"`
+	Name                       *string                 `json:"name,omitempty"`
+	Priority                   int64                   `json:"priority"`
+	RateLimitDurationInMinutes *int64                  `json:"rateLimitDurationInMinutes,omitempty"`
+	RateLimitThreshold         *int64                  `json:"rateLimitThreshold,omitempty"`
+	RuleType                   RuleType                `json:"ruleType"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/model_customrulelist.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/model_customrulelist.go
@@ -1,0 +1,8 @@
+package webapplicationfirewallpolicies
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CustomRuleList struct {
+	Rules *[]CustomRule `json:"rules,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/model_frontendendpointlink.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/model_frontendendpointlink.go
@@ -1,0 +1,8 @@
+package webapplicationfirewallpolicies
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type FrontendEndpointLink struct {
+	Id *string `json:"id,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/model_groupbyvariable.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/model_groupbyvariable.go
@@ -1,0 +1,8 @@
+package webapplicationfirewallpolicies
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GroupByVariable struct {
+	VariableName VariableName `json:"variableName"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/model_managedruleexclusion.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/model_managedruleexclusion.go
@@ -1,0 +1,10 @@
+package webapplicationfirewallpolicies
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ManagedRuleExclusion struct {
+	MatchVariable         ManagedRuleExclusionMatchVariable         `json:"matchVariable"`
+	Selector              string                                    `json:"selector"`
+	SelectorMatchOperator ManagedRuleExclusionSelectorMatchOperator `json:"selectorMatchOperator"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/model_managedrulegroupoverride.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/model_managedrulegroupoverride.go
@@ -1,0 +1,10 @@
+package webapplicationfirewallpolicies
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ManagedRuleGroupOverride struct {
+	Exclusions    *[]ManagedRuleExclusion `json:"exclusions,omitempty"`
+	RuleGroupName string                  `json:"ruleGroupName"`
+	Rules         *[]ManagedRuleOverride  `json:"rules,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/model_managedruleoverride.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/model_managedruleoverride.go
@@ -1,0 +1,11 @@
+package webapplicationfirewallpolicies
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ManagedRuleOverride struct {
+	Action       *ActionType              `json:"action,omitempty"`
+	EnabledState *ManagedRuleEnabledState `json:"enabledState,omitempty"`
+	Exclusions   *[]ManagedRuleExclusion  `json:"exclusions,omitempty"`
+	RuleId       string                   `json:"ruleId"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/model_managedruleset.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/model_managedruleset.go
@@ -1,0 +1,12 @@
+package webapplicationfirewallpolicies
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ManagedRuleSet struct {
+	Exclusions         *[]ManagedRuleExclusion     `json:"exclusions,omitempty"`
+	RuleGroupOverrides *[]ManagedRuleGroupOverride `json:"ruleGroupOverrides,omitempty"`
+	RuleSetAction      *ManagedRuleSetActionType   `json:"ruleSetAction,omitempty"`
+	RuleSetType        string                      `json:"ruleSetType"`
+	RuleSetVersion     string                      `json:"ruleSetVersion"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/model_managedrulesetlist.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/model_managedrulesetlist.go
@@ -1,0 +1,8 @@
+package webapplicationfirewallpolicies
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ManagedRuleSetList struct {
+	ManagedRuleSets *[]ManagedRuleSet `json:"managedRuleSets,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/model_matchcondition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/model_matchcondition.go
@@ -1,0 +1,13 @@
+package webapplicationfirewallpolicies
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type MatchCondition struct {
+	MatchValue      []string         `json:"matchValue"`
+	MatchVariable   MatchVariable    `json:"matchVariable"`
+	NegateCondition *bool            `json:"negateCondition,omitempty"`
+	Operator        Operator         `json:"operator"`
+	Selector        *string          `json:"selector,omitempty"`
+	Transforms      *[]TransformType `json:"transforms,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/model_policysettings.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/model_policysettings.go
@@ -1,0 +1,16 @@
+package webapplicationfirewallpolicies
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PolicySettings struct {
+	CaptchaExpirationInMinutes             *int64                      `json:"captchaExpirationInMinutes,omitempty"`
+	CustomBlockResponseBody                *string                     `json:"customBlockResponseBody,omitempty"`
+	CustomBlockResponseStatusCode          *int64                      `json:"customBlockResponseStatusCode,omitempty"`
+	EnabledState                           *PolicyEnabledState         `json:"enabledState,omitempty"`
+	JavascriptChallengeExpirationInMinutes *int64                      `json:"javascriptChallengeExpirationInMinutes,omitempty"`
+	LogScrubbing                           *PolicySettingsLogScrubbing `json:"logScrubbing,omitempty"`
+	Mode                                   *PolicyMode                 `json:"mode,omitempty"`
+	RedirectURL                            *string                     `json:"redirectUrl,omitempty"`
+	RequestBodyCheck                       *PolicyRequestBodyCheck     `json:"requestBodyCheck,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/model_policysettingslogscrubbing.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/model_policysettingslogscrubbing.go
@@ -1,0 +1,9 @@
+package webapplicationfirewallpolicies
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PolicySettingsLogScrubbing struct {
+	ScrubbingRules *[]WebApplicationFirewallScrubbingRules `json:"scrubbingRules,omitempty"`
+	State          *WebApplicationFirewallScrubbingState   `json:"state,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/model_routingrulelink.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/model_routingrulelink.go
@@ -1,0 +1,8 @@
+package webapplicationfirewallpolicies
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RoutingRuleLink struct {
+	Id *string `json:"id,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/model_securitypolicylink.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/model_securitypolicylink.go
@@ -1,0 +1,8 @@
+package webapplicationfirewallpolicies
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SecurityPolicyLink struct {
+	Id *string `json:"id,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/model_sku.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/model_sku.go
@@ -1,0 +1,8 @@
+package webapplicationfirewallpolicies
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type Sku struct {
+	Name *SkuName `json:"name,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/model_tagsobject.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/model_tagsobject.go
@@ -1,0 +1,8 @@
+package webapplicationfirewallpolicies
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type TagsObject struct {
+	Tags *map[string]string `json:"tags,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/model_webapplicationfirewallpolicy.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/model_webapplicationfirewallpolicy.go
@@ -1,0 +1,15 @@
+package webapplicationfirewallpolicies
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type WebApplicationFirewallPolicy struct {
+	Etag       *string                                 `json:"etag,omitempty"`
+	Id         *string                                 `json:"id,omitempty"`
+	Location   *string                                 `json:"location,omitempty"`
+	Name       *string                                 `json:"name,omitempty"`
+	Properties *WebApplicationFirewallPolicyProperties `json:"properties,omitempty"`
+	Sku        *Sku                                    `json:"sku,omitempty"`
+	Tags       *map[string]string                      `json:"tags,omitempty"`
+	Type       *string                                 `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/model_webapplicationfirewallpolicyproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/model_webapplicationfirewallpolicyproperties.go
@@ -1,0 +1,15 @@
+package webapplicationfirewallpolicies
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type WebApplicationFirewallPolicyProperties struct {
+	CustomRules           *CustomRuleList         `json:"customRules,omitempty"`
+	FrontendEndpointLinks *[]FrontendEndpointLink `json:"frontendEndpointLinks,omitempty"`
+	ManagedRules          *ManagedRuleSetList     `json:"managedRules,omitempty"`
+	PolicySettings        *PolicySettings         `json:"policySettings,omitempty"`
+	ProvisioningState     *string                 `json:"provisioningState,omitempty"`
+	ResourceState         *PolicyResourceState    `json:"resourceState,omitempty"`
+	RoutingRuleLinks      *[]RoutingRuleLink      `json:"routingRuleLinks,omitempty"`
+	SecurityPolicyLinks   *[]SecurityPolicyLink   `json:"securityPolicyLinks,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/model_webapplicationfirewallscrubbingrules.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/model_webapplicationfirewallscrubbingrules.go
@@ -1,0 +1,11 @@
+package webapplicationfirewallpolicies
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type WebApplicationFirewallScrubbingRules struct {
+	MatchVariable         ScrubbingRuleEntryMatchVariable `json:"matchVariable"`
+	Selector              *string                         `json:"selector,omitempty"`
+	SelectorMatchOperator ScrubbingRuleEntryMatchOperator `json:"selectorMatchOperator"`
+	State                 *ScrubbingRuleEntryState        `json:"state,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/predicates.go
@@ -1,0 +1,37 @@
+package webapplicationfirewallpolicies
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type WebApplicationFirewallPolicyOperationPredicate struct {
+	Etag     *string
+	Id       *string
+	Location *string
+	Name     *string
+	Type     *string
+}
+
+func (p WebApplicationFirewallPolicyOperationPredicate) Matches(input WebApplicationFirewallPolicy) bool {
+
+	if p.Etag != nil && (input.Etag == nil || *p.Etag != *input.Etag) {
+		return false
+	}
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Location != nil && (input.Location == nil || *p.Location != *input.Location) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies/version.go
@@ -1,0 +1,10 @@
+package webapplicationfirewallpolicies
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2025-03-01"
+
+func userAgent() string {
+	return "hashicorp/go-azure-sdk/webapplicationfirewallpolicies/2025-03-01"
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -546,6 +546,7 @@ github.com/hashicorp/go-azure-sdk/resource-manager/fluidrelay/2022-05-26/fluidre
 github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2020-04-01/webapplicationfirewallpolicies
 github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2020-05-01/frontdoors
 github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2024-02-01/webapplicationfirewallpolicies
+github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies
 github.com/hashicorp/go-azure-sdk/resource-manager/graphservices/2023-04-13
 github.com/hashicorp/go-azure-sdk/resource-manager/graphservices/2023-04-13/graphservicesprods
 github.com/hashicorp/go-azure-sdk/resource-manager/guestconfiguration/2020-06-25/guestconfigurationassignments


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
