### PR TITLE
`netapp_volume_group_oracle_resource` - add support for `data_protection_replication ` including Cross-Region Replication (CRR) and Cross-Zone Replication (CZR)

### DIFF
--- a/examples/netapp/avg_oracle_crr/README.md
+++ b/examples/netapp/avg_oracle_crr/README.md
@@ -1,0 +1,62 @@
+# Oracle Volume Group Cross-Region Replication Example
+
+This example demonstrates how to create Oracle volume groups with Cross-Region Replication (CRR) using the `azurerm_netapp_volume_group_oracle` resource.
+
+## Features Demonstrated
+
+- Creating primary and secondary Oracle volume groups across different Azure regions
+- Configuring Cross-Region Replication for disaster recovery
+- Setting up Oracle-specific volume specifications (ora-data1, ora-log)
+- Network configuration with dedicated subnets and delegations
+- NetApp account and pool setup for both regions
+
+## Configuration
+
+The example creates:
+
+1. **Primary Region**: Oracle volume group with data and log volumes
+2. **Secondary Region**: Oracle volume group with CRR-enabled volumes pointing to primary
+3. **Networking**: Virtual networks and delegated subnets in both regions
+4. **Infrastructure**: NetApp accounts and pools in both regions
+
+## CRR Configuration
+
+Each volume in the secondary volume group includes a `data_protection_replication` block that:
+
+- Sets `endpoint_type` to "dst" (destination)
+- References the corresponding primary volume via `remote_volume_resource_id`
+- Configures replication frequency (10 minutes in this example)
+- Specifies the remote volume location
+
+## Usage
+
+1. Set your variables in a `terraform.tfvars` file:
+
+```hcl
+prefix       = "myoracle"
+location     = "West Europe"
+alt_location = "East US"
+```
+
+2. Initialize and apply:
+
+```bash
+terraform init
+terraform plan
+terraform apply
+```
+
+## Notes
+
+- The secondary volume group depends on the primary to ensure proper creation order
+- Replication frequency can be "10minutes", "hourly", or "daily"
+- Both regions require adequate NetApp capacity pool sizing
+- Ensure your Azure subscription has NetApp services enabled in both regions
+
+## Cleanup
+
+When destroying resources, the secondary volume group should be destroyed before the primary to properly handle the replication relationship.
+
+```bash
+terraform destroy
+```

--- a/examples/netapp/avg_oracle_crr/main.tf
+++ b/examples/netapp/avg_oracle_crr/main.tf
@@ -1,0 +1,241 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+provider "azurerm" {
+  features {
+    netapp {
+      prevent_volume_destruction = true
+    }
+  }
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "${var.prefix}-resources"
+  location = var.location
+
+  tags = {
+    "SkipNRMSNSG" = "true"
+  }
+}
+
+# Primary region networking
+resource "azurerm_virtual_network" "example_primary" {
+  name                = "${var.prefix}-vnet-primary"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  address_space       = ["10.47.0.0/16"]
+}
+
+resource "azurerm_subnet" "example_primary" {
+  name                 = "${var.prefix}-delegated-subnet-primary"
+  resource_group_name  = azurerm_resource_group.example.name
+  virtual_network_name = azurerm_virtual_network.example_primary.name
+  address_prefixes     = ["10.47.2.0/24"]
+
+  delegation {
+    name = "exampledelegation"
+
+    service_delegation {
+      name    = "Microsoft.Netapp/volumes"
+      actions = ["Microsoft.Network/networkinterfaces/*", "Microsoft.Network/virtualNetworks/subnets/join/action"]
+    }
+  }
+}
+
+# Secondary region networking
+resource "azurerm_virtual_network" "example_secondary" {
+  name                = "${var.prefix}-vnet-secondary"
+  location            = var.alt_location
+  resource_group_name = azurerm_resource_group.example.name
+  address_space       = ["10.48.0.0/16"]
+}
+
+resource "azurerm_subnet" "example_secondary" {
+  name                 = "${var.prefix}-delegated-subnet-secondary"
+  resource_group_name  = azurerm_resource_group.example.name
+  virtual_network_name = azurerm_virtual_network.example_secondary.name
+  address_prefixes     = ["10.48.2.0/24"]
+
+  delegation {
+    name = "exampledelegation"
+
+    service_delegation {
+      name    = "Microsoft.Netapp/volumes"
+      actions = ["Microsoft.Network/networkinterfaces/*", "Microsoft.Network/virtualNetworks/subnets/join/action"]
+    }
+  }
+}
+
+# Primary region NetApp infrastructure
+resource "azurerm_netapp_account" "example_primary" {
+  name                = "${var.prefix}-netapp-account-primary"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+
+  depends_on = [
+    azurerm_subnet.example_primary
+  ]
+}
+
+resource "azurerm_netapp_pool" "example_primary" {
+  name                = "${var.prefix}-netapp-pool-primary"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  account_name        = azurerm_netapp_account.example_primary.name
+  service_level       = "Standard"
+  size_in_tb          = 4
+  qos_type            = "Manual"
+}
+
+# Secondary region NetApp infrastructure
+resource "azurerm_netapp_account" "example_secondary" {
+  name                = "${var.prefix}-netapp-account-secondary"
+  location            = var.alt_location
+  resource_group_name = azurerm_resource_group.example.name
+
+  depends_on = [
+    azurerm_subnet.example_secondary
+  ]
+}
+
+resource "azurerm_netapp_pool" "example_secondary" {
+  name                = "${var.prefix}-netapp-pool-secondary"
+  location            = var.alt_location
+  resource_group_name = azurerm_resource_group.example.name
+  account_name        = azurerm_netapp_account.example_secondary.name
+  service_level       = "Standard"
+  size_in_tb          = 4
+  qos_type            = "Manual"
+}
+
+# Primary Oracle volume group
+resource "azurerm_netapp_volume_group_oracle" "example_primary" {
+  name                   = "${var.prefix}-NetAppVolumeGroupOracle-primary"
+  location               = azurerm_resource_group.example.location
+  resource_group_name    = azurerm_resource_group.example.name
+  account_name           = azurerm_netapp_account.example_primary.name
+  group_description      = "Primary Oracle volume group for CRR"
+  application_identifier = "TST"
+
+  volume {
+    name                       = "${var.prefix}-volume-ora1-primary"
+    volume_path                = "${var.prefix}-my-unique-file-ora-path-1-primary"
+    service_level              = "Standard"
+    capacity_pool_id           = azurerm_netapp_pool.example_primary.id
+    subnet_id                  = azurerm_subnet.example_primary.id
+    volume_spec_name           = "ora-data1"
+    storage_quota_in_gb        = 1024
+    throughput_in_mibps        = 24
+    protocols                  = ["NFSv4.1"]
+    security_style             = "unix"
+    snapshot_directory_visible = false
+
+    export_policy_rule {
+      rule_index          = 1
+      allowed_clients     = "0.0.0.0/0"
+      nfsv3_enabled       = false
+      nfsv41_enabled      = true
+      unix_read_only      = false
+      unix_read_write     = true
+      root_access_enabled = false
+    }
+  }
+
+  volume {
+    name                       = "${var.prefix}-volume-oraLog-primary"
+    volume_path                = "${var.prefix}-my-unique-file-oralog-path-primary"
+    service_level              = "Standard"
+    capacity_pool_id           = azurerm_netapp_pool.example_primary.id
+    subnet_id                  = azurerm_subnet.example_primary.id
+    volume_spec_name           = "ora-log"
+    storage_quota_in_gb        = 1024
+    throughput_in_mibps        = 24
+    protocols                  = ["NFSv4.1"]
+    security_style             = "unix"
+    snapshot_directory_visible = false
+
+    export_policy_rule {
+      rule_index          = 1
+      allowed_clients     = "0.0.0.0/0"
+      nfsv3_enabled       = false
+      nfsv41_enabled      = true
+      unix_read_only      = false
+      unix_read_write     = true
+      root_access_enabled = false
+    }
+  }
+}
+
+# Secondary Oracle volume group with CRR
+resource "azurerm_netapp_volume_group_oracle" "example_secondary" {
+  depends_on = [azurerm_netapp_volume_group_oracle.example_primary]
+
+  name                   = "${var.prefix}-NetAppVolumeGroupOracle-secondary"
+  location               = var.alt_location
+  resource_group_name    = azurerm_resource_group.example.name
+  account_name           = azurerm_netapp_account.example_secondary.name
+  group_description      = "Secondary Oracle volume group for CRR"
+  application_identifier = "TST"
+
+  volume {
+    name                       = "${var.prefix}-volume-ora1-secondary"
+    volume_path                = "${var.prefix}-my-unique-file-ora-path-1-secondary"
+    service_level              = "Standard"
+    capacity_pool_id           = azurerm_netapp_pool.example_secondary.id
+    subnet_id                  = azurerm_subnet.example_secondary.id
+    volume_spec_name           = "ora-data1"
+    storage_quota_in_gb        = 1024
+    throughput_in_mibps        = 24
+    protocols                  = ["NFSv4.1"]
+    security_style             = "unix"
+    snapshot_directory_visible = false
+
+    export_policy_rule {
+      rule_index          = 1
+      allowed_clients     = "0.0.0.0/0"
+      nfsv3_enabled       = false
+      nfsv41_enabled      = true
+      unix_read_only      = false
+      unix_read_write     = true
+      root_access_enabled = false
+    }
+
+    data_protection_replication {
+      endpoint_type             = "dst"
+      remote_volume_location    = azurerm_resource_group.example.location
+      remote_volume_resource_id = azurerm_netapp_volume_group_oracle.example_primary.volume[0].id
+      replication_frequency     = "10minutes"
+    }
+  }
+
+  volume {
+    name                       = "${var.prefix}-volume-oraLog-secondary"
+    volume_path                = "${var.prefix}-my-unique-file-oralog-path-secondary"
+    service_level              = "Standard"
+    capacity_pool_id           = azurerm_netapp_pool.example_secondary.id
+    subnet_id                  = azurerm_subnet.example_secondary.id
+    volume_spec_name           = "ora-log"
+    storage_quota_in_gb        = 1024
+    throughput_in_mibps        = 24
+    protocols                  = ["NFSv4.1"]
+    security_style             = "unix"
+    snapshot_directory_visible = false
+
+    export_policy_rule {
+      rule_index          = 1
+      allowed_clients     = "0.0.0.0/0"
+      nfsv3_enabled       = false
+      nfsv41_enabled      = true
+      unix_read_only      = false
+      unix_read_write     = true
+      root_access_enabled = false
+    }
+
+    data_protection_replication {
+      endpoint_type             = "dst"
+      remote_volume_location    = azurerm_resource_group.example.location
+      remote_volume_resource_id = azurerm_netapp_volume_group_oracle.example_primary.volume[1].id
+      replication_frequency     = "10minutes"
+    }
+  }
+}

--- a/examples/netapp/avg_oracle_crr/variables.tf
+++ b/examples/netapp/avg_oracle_crr/variables.tf
@@ -1,0 +1,20 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+variable "prefix" {
+  description = "The prefix which should be used for all resources in this example"
+  type        = string
+  default     = "testnaocrr"
+}
+
+variable "location" {
+  description = "The Azure Region in which all resources in this example should be created"
+  type        = string
+  default     = "West Europe"
+}
+
+variable "alt_location" {
+  description = "The alternative Azure Region for the secondary volume group"
+  type        = string
+  default     = "East US"
+}

--- a/internal/services/netapp/models/models.go
+++ b/internal/services/netapp/models/models.go
@@ -79,6 +79,7 @@ type NetAppVolumeGroupOracleVolume struct {
 	VolumeSpecName               string                         `tfschema:"volume_spec_name"`
 	ExportPolicy                 []ExportPolicyRule             `tfschema:"export_policy_rule"`
 	MountIpAddresses             []string                       `tfschema:"mount_ip_addresses"`
+	DataProtectionReplication    []DataProtectionReplication    `tfschema:"data_protection_replication"`
 	DataProtectionSnapshotPolicy []DataProtectionSnapshotPolicy `tfschema:"data_protection_snapshot_policy"`
 	Zone                         string                         `tfschema:"zone"`
 	EncryptionKeySource          string                         `tfschema:"encryption_key_source"`

--- a/internal/services/netapp/netapp_volume_group_oracle_resource.go
+++ b/internal/services/netapp/netapp_volume_group_oracle_resource.go
@@ -380,7 +380,7 @@ func (r NetAppVolumeGroupOracleResource) Create() sdk.ResourceFunc {
 			}
 
 			// CRR - Authorizing secondaries from primary volumes
-			if err := authorizeVolumeReplication(ctx, volumeList, replicationClient, subscriptionId, model.ResourceGroupName, model.AccountName, id); err != nil {
+			if err := authorizeVolumeReplication(ctx, volumeList, replicationClient, subscriptionId, model.ResourceGroupName, model.AccountName); err != nil {
 				return err
 			}
 
@@ -389,7 +389,6 @@ func (r NetAppVolumeGroupOracleResource) Create() sdk.ResourceFunc {
 				if volumeCrr.Properties.DataProtection != nil &&
 					volumeCrr.Properties.DataProtection.Replication != nil &&
 					strings.EqualFold(string(pointer.From(volumeCrr.Properties.DataProtection.Replication.EndpointType)), string(volumegroups.EndpointTypeDst)) {
-
 					// Getting primary resource id for waiting
 					primaryId, err := volumesreplication.ParseVolumeID(pointer.From(volumeCrr.Properties.DataProtection.Replication.RemoteVolumeResourceId))
 					if err != nil {

--- a/internal/services/netapp/netapp_volume_group_oracle_resource.go
+++ b/internal/services/netapp/netapp_volume_group_oracle_resource.go
@@ -6,7 +6,6 @@ package netapp
 import (
 	"context"
 	"fmt"
-	"log"
 	"strings"
 	"time"
 
@@ -18,7 +17,6 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/netapp/2025-01-01/capacitypools"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/netapp/2025-01-01/volumegroups"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/netapp/2025-01-01/volumes"
-	"github.com/hashicorp/go-azure-sdk/resource-manager/netapp/2025-01-01/volumesreplication"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	netAppModels "github.com/hashicorp/terraform-provider-azurerm/internal/services/netapp/models"
@@ -259,6 +257,7 @@ func (r NetAppVolumeGroupOracleResource) Arguments() map[string]*pluginsdk.Schem
 									Type:         pluginsdk.TypeString,
 									Optional:     true,
 									Default:      string(volumegroups.EndpointTypeDst),
+									ForceNew:     true,
 									ValidateFunc: validation.StringInSlice(volumegroups.PossibleValuesForEndpointType(), false),
 								},
 
@@ -267,12 +266,14 @@ func (r NetAppVolumeGroupOracleResource) Arguments() map[string]*pluginsdk.Schem
 								"remote_volume_resource_id": {
 									Type:         pluginsdk.TypeString,
 									Required:     true,
+									ForceNew:     true,
 									ValidateFunc: azure.ValidateResourceID,
 								},
 
 								"replication_frequency": {
 									Type:         pluginsdk.TypeString,
 									Required:     true,
+									ForceNew:     true,
 									ValidateFunc: validation.StringInSlice(netAppModels.PossibleValuesForReplicationSchedule(), false),
 								},
 							},
@@ -355,9 +356,6 @@ func (r NetAppVolumeGroupOracleResource) Create() sdk.ResourceFunc {
 				return fmt.Errorf("one or more issues found while performing deeper validations for %s:\n%+v", id, errorList)
 			}
 
-			// Parse volume list to set secondary volumes for CRR
-			setVolumeListSecondaryVolumesType(volumeList)
-
 			parameters := volumegroups.VolumeGroupDetails{
 				Location: utils.String(location.Normalize(model.Location)),
 				Properties: &volumegroups.VolumeGroupProperties{
@@ -382,25 +380,6 @@ func (r NetAppVolumeGroupOracleResource) Create() sdk.ResourceFunc {
 			// CRR - Authorizing secondaries from primary volumes
 			if err := authorizeVolumeReplication(ctx, volumeList, replicationClient, subscriptionId, model.ResourceGroupName, model.AccountName); err != nil {
 				return err
-			}
-
-			// Wait for volume replication authorization to complete for all volumes
-			for _, volumeCrr := range pointer.From(volumeList) {
-				if volumeCrr.Properties.DataProtection != nil &&
-					volumeCrr.Properties.DataProtection.Replication != nil &&
-					strings.EqualFold(string(pointer.From(volumeCrr.Properties.DataProtection.Replication.EndpointType)), string(volumegroups.EndpointTypeDst)) {
-					// Getting primary resource id for waiting
-					primaryId, err := volumesreplication.ParseVolumeID(pointer.From(volumeCrr.Properties.DataProtection.Replication.RemoteVolumeResourceId))
-					if err != nil {
-						return err
-					}
-
-					// Wait for volume replication authorization to complete
-					log.Printf("[DEBUG] Waiting for replication authorization on %s to complete", id)
-					if err := waitForReplAuthorization(ctx, replicationClient, pointer.From(primaryId)); err != nil {
-						return err
-					}
-				}
 			}
 
 			metadata.SetID(id)

--- a/internal/services/netapp/netapp_volume_group_oracle_resource_test.go
+++ b/internal/services/netapp/netapp_volume_group_oracle_resource_test.go
@@ -1761,7 +1761,7 @@ resource "azurerm_netapp_volume_group_oracle" "test_secondary" {
 }
 
 func (NetAppVolumeGroupOracleResource) crossZoneReplicationAZ(data acceptance.TestData) string {
-	template := NetAppVolumeGroupOracleResource{}.templateForCrossZoneReplicationOracleAZ(data)
+	template := NetAppVolumeGroupOracleResource{}.templateAvailabilityZoneOracle(data)
 	return fmt.Sprintf(`
 %[1]s
 
@@ -1920,12 +1920,5 @@ resource "azurerm_netapp_volume_group_oracle" "test_secondary" {
     azurerm_netapp_volume_group_oracle.test_primary
   ]
 }
-`, template, data.RandomInteger)
-}
-
-func (r NetAppVolumeGroupOracleResource) templateForCrossZoneReplicationOracleAZ(data acceptance.TestData) string {
-	template := NetAppVolumeGroupOracleResource{}.templateAvailabilityZoneOracle(data)
-	return fmt.Sprintf(`
-%[1]s
 `, template, data.RandomInteger)
 }

--- a/internal/services/netapp/netapp_volume_group_oracle_resource_test.go
+++ b/internal/services/netapp/netapp_volume_group_oracle_resource_test.go
@@ -145,6 +145,36 @@ func TestAccNetAppVolumeGroupOracle_volCustomerManagedKeyEncryption(t *testing.T
 	})
 }
 
+func TestAccNetAppVolumeGroupOracle_crossRegionReplication(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_netapp_volume_group_oracle", "test_secondary")
+	r := NetAppVolumeGroupOracleResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.crossRegionReplication(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccNetAppVolumeGroupOracle_crossRegionReplicationAZ(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_netapp_volume_group_oracle", "test_secondary")
+	r := NetAppVolumeGroupOracleResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.crossRegionReplicationAZ(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (t NetAppVolumeGroupOracleResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	id, err := volumegroups.ParseVolumeGroupID(state.ID)
 	if err != nil {
@@ -468,7 +498,7 @@ resource "azurerm_netapp_volume_group_oracle" "test" {
 
   volume {
     name                       = "acctest-NetAppVolume-OraLog-%[2]d"
-    volume_path                = "my-unique-file-ora-path-2-%[2]d"
+    volume_path                = "my-unique-file-oralog-path-2-%[2]d"
     service_level              = "Standard"
     capacity_pool_id           = azurerm_netapp_pool.test.id
     subnet_id                  = azurerm_subnet.test.id
@@ -572,7 +602,7 @@ resource "azurerm_netapp_volume_group_oracle" "test" {
 
   volume {
     name                       = "acctest-NetAppVolume-OraLog-%[2]d"
-    volume_path                = "my-unique-file-ora-path-2-%[2]d"
+    volume_path                = "my-unique-file-oralog-path-2-%[2]d"
     service_level              = "Standard"
     capacity_pool_id           = azurerm_netapp_pool.test.id
     subnet_id                  = azurerm_subnet.test.id
@@ -1141,6 +1171,174 @@ resource "azurerm_netapp_pool" "test" {
 `, data.RandomInteger, data.Locations.Primary)
 }
 
+func (r NetAppVolumeGroupOracleResource) templateForAvgCrossRegionReplicationOracle(data acceptance.TestData) string {
+	template := NetAppVolumeGroupOracleResource{}.templatePpgOracle(data)
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_resource_group" "test_secondary" {
+  name     = "acctestRG-netapp-secondary-%[2]d"
+  location = "%[3]s"
+
+  tags = {
+    "SkipNRMSNSG" = "true"
+  }
+}
+
+resource "azurerm_user_assigned_identity" "test_secondary" {
+  name                = "user-assigned-identity-secondary-%[2]d"
+  location            = azurerm_resource_group.test_secondary.location
+  resource_group_name = azurerm_resource_group.test_secondary.name
+
+  tags = {
+    "CreatedOnDate" = "2022-07-08T23:50:21Z"
+  }
+}
+
+resource "azurerm_virtual_network" "test_secondary" {
+  name                = "acctest-VirtualNetwork-secondary-%[2]d"
+  location            = azurerm_resource_group.test_secondary.location
+  resource_group_name = azurerm_resource_group.test_secondary.name
+  address_space       = ["10.1.0.0/16"]
+
+  tags = {
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
+    "SkipASMAzSecPack" = "true"
+  }
+}
+
+resource "azurerm_subnet" "test_secondary" {
+  name                 = "acctest-DelegatedSubnet-secondary-%[2]d"
+  resource_group_name  = azurerm_resource_group.test_secondary.name
+  virtual_network_name = azurerm_virtual_network.test_secondary.name
+  address_prefixes     = ["10.1.2.0/24"]
+
+  delegation {
+    name = "testdelegation"
+
+    service_delegation {
+      name    = "Microsoft.Netapp/volumes"
+      actions = ["Microsoft.Network/networkinterfaces/*", "Microsoft.Network/virtualNetworks/subnets/join/action"]
+    }
+  }
+}
+
+resource "azurerm_netapp_account" "test_secondary" {
+  name                = "acctest-NetAppAccount-secondary-%[2]d"
+  location            = azurerm_resource_group.test_secondary.location
+  resource_group_name = azurerm_resource_group.test_secondary.name
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.test_secondary.id]
+  }
+
+  tags = {
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
+    "SkipASMAzSecPack" = "true"
+  }
+}
+
+resource "azurerm_netapp_pool" "test_secondary" {
+  name                = "acctest-NetAppPool-secondary-%[2]d"
+  location            = azurerm_resource_group.test_secondary.location
+  resource_group_name = azurerm_resource_group.test_secondary.name
+  account_name        = azurerm_netapp_account.test_secondary.name
+  service_level       = "Standard"
+  size_in_tb          = 4
+  qos_type            = "Manual"
+
+  tags = {
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
+    "SkipASMAzSecPack" = "true"
+  }
+}
+`, template, data.RandomInteger, data.Locations.Secondary)
+}
+
+func (r NetAppVolumeGroupOracleResource) templateForAvgCrossRegionReplicationOracleAZ(data acceptance.TestData) string {
+	template := NetAppVolumeGroupOracleResource{}.templateAvailabilityZoneOracle(data)
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_resource_group" "test_secondary" {
+  name     = "acctestRG-netapp-secondary-%[2]d"
+  location = "%[3]s"
+
+  tags = {
+    "SkipNRMSNSG" = "true"
+  }
+}
+
+resource "azurerm_user_assigned_identity" "test_secondary" {
+  name                = "user-assigned-identity-secondary-%[2]d"
+  location            = azurerm_resource_group.test_secondary.location
+  resource_group_name = azurerm_resource_group.test_secondary.name
+
+  tags = {
+    "CreatedOnDate" = "2022-07-08T23:50:21Z"
+  }
+}
+
+resource "azurerm_virtual_network" "test_secondary" {
+  name                = "acctest-VirtualNetwork-secondary-%[2]d"
+  location            = azurerm_resource_group.test_secondary.location
+  resource_group_name = azurerm_resource_group.test_secondary.name
+  address_space       = ["10.1.0.0/16"]
+
+  tags = {
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
+    "SkipASMAzSecPack" = "true"
+  }
+}
+
+resource "azurerm_subnet" "test_secondary" {
+  name                 = "acctest-DelegatedSubnet-secondary-%[2]d"
+  resource_group_name  = azurerm_resource_group.test_secondary.name
+  virtual_network_name = azurerm_virtual_network.test_secondary.name
+  address_prefixes     = ["10.1.2.0/24"]
+
+  delegation {
+    name = "testdelegation"
+
+    service_delegation {
+      name    = "Microsoft.Netapp/volumes"
+      actions = ["Microsoft.Network/networkinterfaces/*", "Microsoft.Network/virtualNetworks/subnets/join/action"]
+    }
+  }
+}
+
+resource "azurerm_netapp_account" "test_secondary" {
+  name                = "acctest-NetAppAccount-secondary-%[2]d"
+  location            = azurerm_resource_group.test_secondary.location
+  resource_group_name = azurerm_resource_group.test_secondary.name
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.test_secondary.id]
+  }
+
+  tags = {
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
+    "SkipASMAzSecPack" = "true"
+  }
+}
+
+resource "azurerm_netapp_pool" "test_secondary" {
+  name                = "acctest-NetAppPool-secondary-%[2]d"
+  location            = azurerm_resource_group.test_secondary.location
+  resource_group_name = azurerm_resource_group.test_secondary.name
+  account_name        = azurerm_netapp_account.test_secondary.name
+  service_level       = "Standard"
+  size_in_tb          = 4
+  qos_type            = "Manual"
+
+  tags = {
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
+    "SkipASMAzSecPack" = "true"
+  }
+}
+`, template, data.RandomInteger, data.Locations.Secondary)
+}
+
 func (NetAppVolumeGroupOracleResource) templateAvailabilityZoneOracle(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -1154,6 +1352,11 @@ provider "azurerm" {
   }
 }
 
+locals {
+  admin_username = "testadmin%[1]d"
+  admin_password = "Password1234!%[1]d"
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-netapp-%[1]d"
   location = "%[2]s"
@@ -1163,11 +1366,37 @@ resource "azurerm_resource_group" "test" {
   }
 }
 
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "user-assigned-identity-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  tags = {
+    "CreatedOnDate" = "2022-07-08T23:50:21Z"
+  }
+}
+
+resource "azurerm_network_security_group" "test" {
+  name                = "acctest-NSG-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  tags = {
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
+    "SkipASMAzSecPack" = "true"
+  }
+}
+
 resource "azurerm_virtual_network" "test" {
   name                = "acctest-VirtualNetwork-%[1]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   address_space       = ["10.0.0.0/16"]
+
+  tags = {
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
+    "SkipASMAzSecPack" = "true"
+  }
 }
 
 resource "azurerm_subnet" "test" {
@@ -1186,14 +1415,32 @@ resource "azurerm_subnet" "test" {
   }
 }
 
+resource "azurerm_subnet" "test1" {
+  name                 = "acctest-HostsSubnet-%[1]d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.1.0/24"]
+}
+
+resource "azurerm_subnet_network_security_group_association" "public" {
+  subnet_id                 = azurerm_subnet.test.id
+  network_security_group_id = azurerm_network_security_group.test.id
+}
+
 resource "azurerm_netapp_account" "test" {
   name                = "acctest-NetAppAccount-%[1]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
 
   depends_on = [
-    azurerm_subnet.test
+    azurerm_subnet.test,
+    azurerm_subnet.test1
   ]
+
+  tags = {
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
+    "SkipASMAzSecPack" = "true"
+  }
 }
 
 resource "azurerm_netapp_pool" "test" {
@@ -1204,6 +1451,332 @@ resource "azurerm_netapp_pool" "test" {
   service_level       = "Standard"
   size_in_tb          = 4
   qos_type            = "Manual"
+
+  tags = {
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
+    "SkipASMAzSecPack" = "true"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary)
+}
+
+func (NetAppVolumeGroupOracleResource) crossRegionReplication(data acceptance.TestData) string {
+	template := NetAppVolumeGroupOracleResource{}.templateForAvgCrossRegionReplicationOracle(data)
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_netapp_volume_group_oracle" "test_primary" {
+  name                   = "acctest-NetAppVolumeGroup-Primary-%[2]d"
+  location               = azurerm_resource_group.test.location
+  resource_group_name    = azurerm_resource_group.test.name
+  account_name           = azurerm_netapp_account.test.name
+  group_description      = "Test Oracle volume group"
+  application_identifier = "TST"
+
+  volume {
+    name                         = "acctest-NetAppVolume-ora1-Primary-%[2]d"
+    volume_path                  = "my-unique-file-ora-path-1-Primary-%[2]d"
+    service_level                = "Standard"
+    capacity_pool_id             = azurerm_netapp_pool.test.id
+    subnet_id                    = azurerm_subnet.test.id
+    proximity_placement_group_id = azurerm_proximity_placement_group.test.id
+    volume_spec_name             = "ora-data1"
+    storage_quota_in_gb          = 1024
+    throughput_in_mibps          = 24
+    protocols                    = ["NFSv4.1"]
+    security_style               = "unix"
+    snapshot_directory_visible   = false
+
+    export_policy_rule {
+      rule_index          = 1
+      allowed_clients     = "0.0.0.0/0"
+      nfsv3_enabled       = false
+      nfsv41_enabled      = true
+      unix_read_only      = false
+      unix_read_write     = true
+      root_access_enabled = false
+    }
+
+    tags = {
+      "CreatedOnDate"    = "2022-07-08T23:50:21Z",
+      "SkipASMAzSecPack" = "true"
+    }
+  }
+
+  volume {
+    name                         = "acctest-NetAppVolume-oraLog-Primary-%[2]d"
+    volume_path                  = "my-unique-file-oralog-path-Primary-%[2]d"
+    service_level                = "Standard"
+    capacity_pool_id             = azurerm_netapp_pool.test.id
+    subnet_id                    = azurerm_subnet.test.id
+    proximity_placement_group_id = azurerm_proximity_placement_group.test.id
+    volume_spec_name             = "ora-log"
+    storage_quota_in_gb          = 1024
+    throughput_in_mibps          = 24
+    protocols                    = ["NFSv4.1"]
+    security_style               = "unix"
+    snapshot_directory_visible   = false
+
+    export_policy_rule {
+      rule_index          = 1
+      allowed_clients     = "0.0.0.0/0"
+      nfsv3_enabled       = false
+      nfsv41_enabled      = true
+      unix_read_only      = false
+      unix_read_write     = true
+      root_access_enabled = false
+    }
+
+    tags = {
+      "CreatedOnDate"    = "2022-07-08T23:50:21Z",
+      "SkipASMAzSecPack" = "true"
+    }
+  }
+
+  depends_on = [
+    azurerm_proximity_placement_group.test
+  ]
+}
+
+resource "azurerm_netapp_volume_group_oracle" "test_secondary" {
+  name                   = "acctest-NetAppVolumeGroup-Secondary-%[2]d"
+  location               = azurerm_resource_group.test_secondary.location
+  resource_group_name    = azurerm_resource_group.test_secondary.name
+  account_name           = azurerm_netapp_account.test_secondary.name
+  group_description      = "Test Oracle volume group secondary"
+  application_identifier = "TST"
+
+  volume {
+    name                       = "acctest-NetAppVolume-ora1-Secondary-%[2]d"
+    volume_path                = "my-unique-file-ora-path-1-Secondary-%[2]d"
+    service_level              = "Standard"
+    capacity_pool_id           = azurerm_netapp_pool.test_secondary.id
+    subnet_id                  = azurerm_subnet.test_secondary.id
+    volume_spec_name           = "ora-data1"
+    storage_quota_in_gb        = 1024
+    throughput_in_mibps        = 24
+    protocols                  = ["NFSv4.1"]
+    security_style             = "unix"
+    snapshot_directory_visible = false
+
+    export_policy_rule {
+      rule_index          = 1
+      allowed_clients     = "0.0.0.0/0"
+      nfsv3_enabled       = false
+      nfsv41_enabled      = true
+      unix_read_only      = false
+      unix_read_write     = true
+      root_access_enabled = false
+    }
+
+    data_protection_replication {
+      endpoint_type             = "dst"
+      remote_volume_location    = azurerm_netapp_volume_group_oracle.test_primary.location
+      remote_volume_resource_id = azurerm_netapp_volume_group_oracle.test_primary.volume[0].id
+      replication_frequency     = "10minutes"
+    }
+
+    tags = {
+      "CreatedOnDate"    = "2022-07-08T23:50:21Z",
+      "SkipASMAzSecPack" = "true"
+    }
+  }
+
+  volume {
+    name                       = "acctest-NetAppVolume-oraLog-Secondary-%[2]d"
+    volume_path                = "my-unique-file-oralog-path-Secondary-%[2]d"
+    service_level              = "Standard"
+    capacity_pool_id           = azurerm_netapp_pool.test_secondary.id
+    subnet_id                  = azurerm_subnet.test_secondary.id
+    volume_spec_name           = "ora-log"
+    storage_quota_in_gb        = 1024
+    throughput_in_mibps        = 24
+    protocols                  = ["NFSv4.1"]
+    security_style             = "unix"
+    snapshot_directory_visible = false
+
+    export_policy_rule {
+      rule_index          = 1
+      allowed_clients     = "0.0.0.0/0"
+      nfsv3_enabled       = false
+      nfsv41_enabled      = true
+      unix_read_only      = false
+      unix_read_write     = true
+      root_access_enabled = false
+    }
+
+    data_protection_replication {
+      endpoint_type             = "dst"
+      remote_volume_location    = azurerm_netapp_volume_group_oracle.test_primary.location
+      remote_volume_resource_id = azurerm_netapp_volume_group_oracle.test_primary.volume[1].id
+      replication_frequency     = "10minutes"
+    }
+
+    tags = {
+      "CreatedOnDate"    = "2022-07-08T23:50:21Z",
+      "SkipASMAzSecPack" = "true"
+    }
+  }
+
+  depends_on = [
+    azurerm_netapp_volume_group_oracle.test_primary
+  ]
+}
+`, template, data.RandomInteger)
+}
+
+func (NetAppVolumeGroupOracleResource) crossRegionReplicationAZ(data acceptance.TestData) string {
+	template := NetAppVolumeGroupOracleResource{}.templateForAvgCrossRegionReplicationOracleAZ(data)
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_netapp_volume_group_oracle" "test_primary" {
+  name                   = "acctest-NetAppVolumeGroup-Primary-%[2]d"
+  location               = azurerm_resource_group.test.location
+  resource_group_name    = azurerm_resource_group.test.name
+  account_name           = azurerm_netapp_account.test.name
+  group_description      = "Test Oracle volume group"
+  application_identifier = "TST"
+
+  volume {
+    name                       = "acctest-NetAppVolume-ora1-Primary-%[2]d"
+    volume_path                = "my-unique-file-ora-path-1-Primary-%[2]d"
+    service_level              = "Standard"
+    capacity_pool_id           = azurerm_netapp_pool.test.id
+    subnet_id                  = azurerm_subnet.test.id
+    zone                       = "1"
+    volume_spec_name           = "ora-data1"
+    storage_quota_in_gb        = 1024
+    throughput_in_mibps        = 24
+    protocols                  = ["NFSv4.1"]
+    security_style             = "unix"
+    snapshot_directory_visible = false
+
+    export_policy_rule {
+      rule_index          = 1
+      allowed_clients     = "0.0.0.0/0"
+      nfsv3_enabled       = false
+      nfsv41_enabled      = true
+      unix_read_only      = false
+      unix_read_write     = true
+      root_access_enabled = false
+    }
+
+    tags = {
+      "CreatedOnDate"    = "2022-07-08T23:50:21Z",
+      "SkipASMAzSecPack" = "true"
+    }
+  }
+
+  volume {
+    name                       = "acctest-NetAppVolume-oraLog-Primary-%[2]d"
+    volume_path                = "my-unique-file-oralog-path-Primary-%[2]d"
+    service_level              = "Standard"
+    capacity_pool_id           = azurerm_netapp_pool.test.id
+    subnet_id                  = azurerm_subnet.test.id
+    zone                       = "1"
+    volume_spec_name           = "ora-log"
+    storage_quota_in_gb        = 1024
+    throughput_in_mibps        = 24
+    protocols                  = ["NFSv4.1"]
+    security_style             = "unix"
+    snapshot_directory_visible = false
+
+    export_policy_rule {
+      rule_index          = 1
+      allowed_clients     = "0.0.0.0/0"
+      nfsv3_enabled       = false
+      nfsv41_enabled      = true
+      unix_read_only      = false
+      unix_read_write     = true
+      root_access_enabled = false
+    }
+
+    tags = {
+      "CreatedOnDate"    = "2022-07-08T23:50:21Z",
+      "SkipASMAzSecPack" = "true"
+    }
+  }
+}
+
+resource "azurerm_netapp_volume_group_oracle" "test_secondary" {
+  name                   = "acctest-NetAppVolumeGroup-Secondary-%[2]d"
+  location               = azurerm_resource_group.test_secondary.location
+  resource_group_name    = azurerm_resource_group.test_secondary.name
+  account_name           = azurerm_netapp_account.test_secondary.name
+  group_description      = "Test Oracle volume group secondary"
+  application_identifier = "TST"
+
+  volume {
+    name                       = "acctest-NetAppVolume-ora1-Secondary-%[2]d"
+    volume_path                = "my-unique-file-ora-path-1-Secondary-%[2]d"
+    service_level              = "Standard"
+    capacity_pool_id           = azurerm_netapp_pool.test_secondary.id
+    subnet_id                  = azurerm_subnet.test_secondary.id
+    zone                       = "1"
+    volume_spec_name           = "ora-data1"
+    storage_quota_in_gb        = 1024
+    throughput_in_mibps        = 24
+    protocols                  = ["NFSv4.1"]
+    security_style             = "unix"
+    snapshot_directory_visible = false
+
+    export_policy_rule {
+      rule_index          = 1
+      allowed_clients     = "0.0.0.0/0"
+      nfsv3_enabled       = false
+      nfsv41_enabled      = true
+      unix_read_only      = false
+      unix_read_write     = true
+      root_access_enabled = false
+    }
+
+    data_protection_replication {
+      endpoint_type             = "dst"
+      remote_volume_location    = azurerm_netapp_volume_group_oracle.test_primary.location
+      remote_volume_resource_id = azurerm_netapp_volume_group_oracle.test_primary.volume[0].id
+      replication_frequency     = "10minutes"
+    }
+
+    tags = {
+      "CreatedOnDate"    = "2022-07-08T23:50:21Z",
+      "SkipASMAzSecPack" = "true"
+    }
+  }
+
+  volume {
+    name                       = "acctest-NetAppVolume-oraLog-Secondary-%[2]d"
+    volume_path                = "my-unique-file-oralog-path-Secondary-%[2]d"
+    service_level              = "Standard"
+    capacity_pool_id           = azurerm_netapp_pool.test_secondary.id
+    subnet_id                  = azurerm_subnet.test_secondary.id
+    zone                       = "1"
+    volume_spec_name           = "ora-log"
+    storage_quota_in_gb        = 1024
+    throughput_in_mibps        = 24
+    protocols                  = ["NFSv4.1"]
+    security_style             = "unix"
+    snapshot_directory_visible = false
+
+    export_policy_rule {
+      rule_index          = 1
+      allowed_clients     = "0.0.0.0/0"
+      nfsv3_enabled       = false
+      nfsv41_enabled      = true
+      unix_read_only      = false
+      unix_read_write     = true
+      root_access_enabled = false
+    }
+
+    tags = {
+      "CreatedOnDate"    = "2022-07-08T23:50:21Z",
+      "SkipASMAzSecPack" = "true"
+    }
+  }
+
+  depends_on = [
+    azurerm_netapp_volume_group_oracle.test_primary
+  ]
+}
+`, template, data.RandomInteger)
 }

--- a/internal/services/netapp/netapp_volume_group_sap_hana_resource.go
+++ b/internal/services/netapp/netapp_volume_group_sap_hana_resource.go
@@ -357,7 +357,7 @@ func (r NetAppVolumeGroupSAPHanaResource) Create() sdk.ResourceFunc {
 			}
 
 			// CRR - Authorizing secondaries from primary volumes
-			if err := authorizeVolumeReplication(ctx, volumeList, replicationClient, subscriptionId, model.ResourceGroupName, model.AccountName, id); err != nil {
+			if err := authorizeVolumeReplication(ctx, volumeList, replicationClient, subscriptionId, model.ResourceGroupName, model.AccountName); err != nil {
 				return err
 			}
 
@@ -366,7 +366,6 @@ func (r NetAppVolumeGroupSAPHanaResource) Create() sdk.ResourceFunc {
 				if volumeCrr.Properties.DataProtection != nil &&
 					volumeCrr.Properties.DataProtection.Replication != nil &&
 					strings.EqualFold(string(pointer.From(volumeCrr.Properties.DataProtection.Replication.EndpointType)), string(volumegroups.EndpointTypeDst)) {
-
 					// Getting primary resource id for waiting
 					primaryId, err := volumesreplication.ParseVolumeID(pointer.From(volumeCrr.Properties.DataProtection.Replication.RemoteVolumeResourceId))
 					if err != nil {

--- a/internal/services/netapp/netapp_volume_group_sap_hana_resource.go
+++ b/internal/services/netapp/netapp_volume_group_sap_hana_resource.go
@@ -333,15 +333,7 @@ func (r NetAppVolumeGroupSAPHanaResource) Create() sdk.ResourceFunc {
 			}
 
 			// Parse volume list to set secondary volumes for CRR
-			for i, volumeCrr := range pointer.From(volumeList) {
-				if volumeCrr.Properties.DataProtection != nil &&
-					volumeCrr.Properties.DataProtection.Replication != nil &&
-					strings.EqualFold(string(pointer.From(volumeCrr.Properties.DataProtection.Replication.EndpointType)), string(volumegroups.EndpointTypeDst)) {
-					// Modify volumeType as data protection type on main volumeList
-					// so it gets created correctly as data protection volume
-					(pointer.From(volumeList))[i].Properties.VolumeType = utils.String("DataProtection")
-				}
-			}
+			setVolumeListSecondaryVolumesType(volumeList)
 
 			parameters := volumegroups.VolumeGroupDetails{
 				Location: utils.String(location.Normalize(model.Location)),
@@ -365,35 +357,20 @@ func (r NetAppVolumeGroupSAPHanaResource) Create() sdk.ResourceFunc {
 			}
 
 			// CRR - Authorizing secondaries from primary volumes
+			if err := authorizeVolumeReplication(ctx, volumeList, replicationClient, subscriptionId, model.ResourceGroupName, model.AccountName, id); err != nil {
+				return err
+			}
+
+			// Wait for volume replication authorization to complete for all volumes
 			for _, volumeCrr := range pointer.From(volumeList) {
 				if volumeCrr.Properties.DataProtection != nil &&
 					volumeCrr.Properties.DataProtection.Replication != nil &&
 					strings.EqualFold(string(pointer.From(volumeCrr.Properties.DataProtection.Replication.EndpointType)), string(volumegroups.EndpointTypeDst)) {
-					capacityPoolId, err := capacitypools.ParseCapacityPoolID(pointer.From(volumeCrr.Properties.CapacityPoolResourceId))
-					if err != nil {
-						return err
-					}
 
-					// Getting secondary volume resource id
-					secondaryId := volumes.NewVolumeID(subscriptionId,
-						model.ResourceGroupName,
-						model.AccountName,
-						capacityPoolId.CapacityPoolName,
-						getUserDefinedVolumeName(volumeCrr.Name),
-					)
-
-					// Getting primary resource id
+					// Getting primary resource id for waiting
 					primaryId, err := volumesreplication.ParseVolumeID(pointer.From(volumeCrr.Properties.DataProtection.Replication.RemoteVolumeResourceId))
 					if err != nil {
 						return err
-					}
-
-					// Authorizing
-					if err = replicationClient.VolumesAuthorizeReplicationThenPoll(ctx, pointer.From(primaryId), volumesreplication.AuthorizeRequest{
-						RemoteVolumeResourceId: utils.String(secondaryId.ID()),
-					},
-					); err != nil {
-						return fmt.Errorf("cannot authorize volume replication: %v", err)
 					}
 
 					// Wait for volume replication authorization to complete

--- a/internal/services/netapp/netapp_volume_helper.go
+++ b/internal/services/netapp/netapp_volume_helper.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/netapp/2025-01-01/backups"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/netapp/2025-01-01/capacitypools"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/netapp/2025-01-01/volumegroups"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/netapp/2025-01-01/volumes"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/netapp/2025-01-01/volumesreplication"
@@ -180,7 +181,8 @@ func expandNetAppVolumeGroupOracleVolumes(input []netAppModels.NetAppVolumeGroup
 				VolumeSpecName:           utils.String(item.VolumeSpecName),
 				NetworkFeatures:          pointer.To(volumegroups.NetworkFeatures(item.NetworkFeatures)),
 				DataProtection: &volumegroups.VolumePropertiesDataProtection{
-					Snapshot: expandNetAppVolumeGroupDataProtectionSnapshotPolicy(item.DataProtectionSnapshotPolicy).Snapshot,
+					Replication: expandNetAppVolumeGroupDataProtectionReplication(item.DataProtectionReplication).Replication,
+					Snapshot:    expandNetAppVolumeGroupDataProtectionSnapshotPolicy(item.DataProtectionSnapshotPolicy).Snapshot,
 				},
 			},
 			Tags: &item.Tags,
@@ -519,6 +521,10 @@ func flattenNetAppVolumeGroupOracleVolumes(ctx context.Context, input *[]volumeg
 		standaloneVol, err := volumeClient.Get(ctx, pointer.From(id))
 		if err != nil {
 			return []netAppModels.NetAppVolumeGroupOracleVolume{}, fmt.Errorf("retrieving %s: %v", id, err)
+		}
+
+		if standaloneVol.Model.Properties.DataProtection != nil && standaloneVol.Model.Properties.DataProtection.Replication != nil {
+			volumeGroupVolume.DataProtectionReplication = flattenNetAppVolumeGroupVolumesDPReplication(standaloneVol.Model.Properties.DataProtection.Replication)
 		}
 
 		if standaloneVol.Model.Properties.DataProtection != nil && standaloneVol.Model.Properties.DataProtection.Snapshot != nil {
@@ -1049,4 +1055,67 @@ func translateSDKSchedule(scheduleName string) string {
 	}
 
 	return scheduleName
+}
+
+// setVolumeListSecondaryVolumesType sets VolumeType to "DataProtection" for secondary volumes in CRR
+func setVolumeListSecondaryVolumesType(volumeList *[]volumegroups.VolumeGroupVolumeProperties) {
+	if volumeList == nil {
+		return
+	}
+
+	for i := range *volumeList {
+		volume := &(*volumeList)[i]
+		if volume.Properties.DataProtection != nil && volume.Properties.DataProtection.Replication != nil {
+			replication := volume.Properties.DataProtection.Replication
+			if replication.EndpointType != nil &&
+				strings.EqualFold(string(pointer.From(replication.EndpointType)), string(volumegroups.EndpointTypeDst)) {
+				volume.Properties.VolumeType = utils.String("DataProtection")
+			}
+		}
+	}
+}
+
+// authorizeVolumeReplication handles CRR authorization for secondary volumes from primary volumes
+func authorizeVolumeReplication(ctx context.Context, volumeList *[]volumegroups.VolumeGroupVolumeProperties, replicationClient *volumesreplication.VolumesReplicationClient, subscriptionId, resourceGroupName, accountName string, volumeGroupId volumegroups.VolumeGroupId) error {
+	if volumeList == nil || replicationClient == nil {
+		return nil
+	}
+
+	for _, volume := range *volumeList {
+		if volume.Properties.DataProtection != nil && volume.Properties.DataProtection.Replication != nil {
+			replication := volume.Properties.DataProtection.Replication
+			if replication.EndpointType != nil &&
+				strings.EqualFold(string(pointer.From(replication.EndpointType)), string(volumegroups.EndpointTypeDst)) {
+
+				// Get the capacity pool for this volume
+				capacityPoolId, err := capacitypools.ParseCapacityPoolID(*volume.Properties.CapacityPoolResourceId)
+				if err != nil {
+					return fmt.Errorf("parsing capacity pool ID %q: %+v", *volume.Properties.CapacityPoolResourceId, err)
+				}
+
+				// This is a secondary volume, create its ID
+				secondaryId := volumes.NewVolumeID(subscriptionId,
+					resourceGroupName,
+					accountName,
+					capacityPoolId.CapacityPoolName,
+					getUserDefinedVolumeName(volume.Name),
+				)
+
+				// Getting primary resource id
+				primaryId, err := volumesreplication.ParseVolumeID(pointer.From(replication.RemoteVolumeResourceId))
+				if err != nil {
+					return fmt.Errorf("parsing primary volume ID %q: %+v", pointer.From(replication.RemoteVolumeResourceId), err)
+				}
+
+				// Authorizing
+				if err := replicationClient.VolumesAuthorizeReplicationThenPoll(ctx, pointer.From(primaryId), volumesreplication.AuthorizeRequest{
+					RemoteVolumeResourceId: utils.String(secondaryId.ID()),
+				}); err != nil {
+					return fmt.Errorf("authorizing volume replication for volume %q: %+v", secondaryId.ID(), err)
+				}
+			}
+		}
+	}
+
+	return nil
 }

--- a/internal/services/netapp/netapp_volume_helper.go
+++ b/internal/services/netapp/netapp_volume_helper.go
@@ -123,6 +123,14 @@ func expandNetAppVolumeGroupSAPHanaVolumes(input []netAppModels.NetAppVolumeGrou
 		dataProtectionReplication := expandNetAppVolumeGroupDataProtectionReplication(item.DataProtectionReplication)
 		dataProtectionSnapshotPolicy := expandNetAppVolumeGroupDataProtectionSnapshotPolicy(item.DataProtectionSnapshotPolicy)
 
+		dataProtection := &volumegroups.VolumePropertiesDataProtection{}
+		if dataProtectionReplication != nil && dataProtectionReplication.Replication != nil {
+			dataProtection.Replication = dataProtectionReplication.Replication
+		}
+		if dataProtectionSnapshotPolicy != nil && dataProtectionSnapshotPolicy.Snapshot != nil {
+			dataProtection.Snapshot = dataProtectionSnapshotPolicy.Snapshot
+		}
+
 		volumeProperties := &volumegroups.VolumeGroupVolumeProperties{
 			Name: utils.String(name),
 			Properties: volumegroups.VolumeProperties{
@@ -137,10 +145,7 @@ func expandNetAppVolumeGroupSAPHanaVolumes(input []netAppModels.NetAppVolumeGrou
 				SnapshotDirectoryVisible: utils.Bool(snapshotDirectoryVisible),
 				ThroughputMibps:          utils.Float(item.ThroughputInMibps),
 				VolumeSpecName:           utils.String(item.VolumeSpecName),
-				DataProtection: &volumegroups.VolumePropertiesDataProtection{
-					Replication: dataProtectionReplication.Replication,
-					Snapshot:    dataProtectionSnapshotPolicy.Snapshot,
-				},
+				DataProtection:           dataProtection,
 			},
 			Tags: &item.Tags,
 		}
@@ -175,6 +180,14 @@ func expandNetAppVolumeGroupOracleVolumes(input []netAppModels.NetAppVolumeGroup
 		dataProtectionReplication := expandNetAppVolumeGroupDataProtectionReplication(item.DataProtectionReplication)
 		dataProtectionSnapshotPolicy := expandNetAppVolumeGroupDataProtectionSnapshotPolicy(item.DataProtectionSnapshotPolicy)
 
+		dataProtection := &volumegroups.VolumePropertiesDataProtection{}
+		if dataProtectionReplication != nil && dataProtectionReplication.Replication != nil {
+			dataProtection.Replication = dataProtectionReplication.Replication
+		}
+		if dataProtectionSnapshotPolicy != nil && dataProtectionSnapshotPolicy.Snapshot != nil {
+			dataProtection.Snapshot = dataProtectionSnapshotPolicy.Snapshot
+		}
+
 		volumeProperties := &volumegroups.VolumeGroupVolumeProperties{
 			Name: pointer.To(item.Name),
 			Properties: volumegroups.VolumeProperties{
@@ -190,10 +203,7 @@ func expandNetAppVolumeGroupOracleVolumes(input []netAppModels.NetAppVolumeGroup
 				ThroughputMibps:          utils.Float(item.ThroughputInMibps),
 				VolumeSpecName:           utils.String(item.VolumeSpecName),
 				NetworkFeatures:          pointer.To(volumegroups.NetworkFeatures(item.NetworkFeatures)),
-				DataProtection: &volumegroups.VolumePropertiesDataProtection{
-					Replication: dataProtectionReplication.Replication,
-					Snapshot:    dataProtectionSnapshotPolicy.Snapshot,
-				},
+				DataProtection:           dataProtection,
 			},
 			Tags: &item.Tags,
 		}

--- a/internal/services/netapp/netapp_volume_helper.go
+++ b/internal/services/netapp/netapp_volume_helper.go
@@ -1076,7 +1076,7 @@ func setVolumeListSecondaryVolumesType(volumeList *[]volumegroups.VolumeGroupVol
 }
 
 // authorizeVolumeReplication handles CRR authorization for secondary volumes from primary volumes
-func authorizeVolumeReplication(ctx context.Context, volumeList *[]volumegroups.VolumeGroupVolumeProperties, replicationClient *volumesreplication.VolumesReplicationClient, subscriptionId, resourceGroupName, accountName string, volumeGroupId volumegroups.VolumeGroupId) error {
+func authorizeVolumeReplication(ctx context.Context, volumeList *[]volumegroups.VolumeGroupVolumeProperties, replicationClient *volumesreplication.VolumesReplicationClient, subscriptionId, resourceGroupName, accountName string) error {
 	if volumeList == nil || replicationClient == nil {
 		return nil
 	}
@@ -1086,7 +1086,6 @@ func authorizeVolumeReplication(ctx context.Context, volumeList *[]volumegroups.
 			replication := volume.Properties.DataProtection.Replication
 			if replication.EndpointType != nil &&
 				strings.EqualFold(string(pointer.From(replication.EndpointType)), string(volumegroups.EndpointTypeDst)) {
-
 				// Get the capacity pool for this volume
 				capacityPoolId, err := capacitypools.ParseCapacityPoolID(*volume.Properties.CapacityPoolResourceId)
 				if err != nil {

--- a/internal/services/netapp/validate/volume_group_oracle_volumes_validation.go
+++ b/internal/services/netapp/validate/volume_group_oracle_volumes_validation.go
@@ -97,14 +97,6 @@ func ValidateNetAppVolumeGroupOracleVolumes(volumeList *[]volumegroups.VolumeGro
 			}
 		}
 
-		// // Checking CRR rule that log cannot be DataProtection type
-		// if strings.EqualFold(pointer.From(volume.Properties.VolumeSpecName), string(VolumeSpecNameOracleLog)) &&
-		// 	volume.Properties.DataProtection != nil &&
-		// 	volume.Properties.DataProtection.Replication != nil &&
-		// 	strings.EqualFold(string(pointer.From(volume.Properties.DataProtection.Replication.EndpointType)), string(volumegroups.EndpointTypeDst)) {
-		// 	errors = append(errors, fmt.Errorf("'log volume spec type cannot be DataProtection type for %v on volume %v'", applicationType, pointer.From(volume.Name)))
-		// }
-
 		// Validating that snapshot policies are not being created in a data protection volume
 		if volume.Properties.DataProtection != nil &&
 			volume.Properties.DataProtection.Snapshot != nil &&

--- a/internal/services/netapp/validate/volume_group_oracle_volumes_validation.go
+++ b/internal/services/netapp/validate/volume_group_oracle_volumes_validation.go
@@ -97,13 +97,13 @@ func ValidateNetAppVolumeGroupOracleVolumes(volumeList *[]volumegroups.VolumeGro
 			}
 		}
 
-		// Checking CRR rule that log cannot be DataProtection type
-		if strings.EqualFold(pointer.From(volume.Properties.VolumeSpecName), string(VolumeSpecNameOracleLog)) &&
-			volume.Properties.DataProtection != nil &&
-			volume.Properties.DataProtection.Replication != nil &&
-			strings.EqualFold(string(pointer.From(volume.Properties.DataProtection.Replication.EndpointType)), string(volumegroups.EndpointTypeDst)) {
-			errors = append(errors, fmt.Errorf("'log volume spec type cannot be DataProtection type for %v on volume %v'", applicationType, pointer.From(volume.Name)))
-		}
+		// // Checking CRR rule that log cannot be DataProtection type
+		// if strings.EqualFold(pointer.From(volume.Properties.VolumeSpecName), string(VolumeSpecNameOracleLog)) &&
+		// 	volume.Properties.DataProtection != nil &&
+		// 	volume.Properties.DataProtection.Replication != nil &&
+		// 	strings.EqualFold(string(pointer.From(volume.Properties.DataProtection.Replication.EndpointType)), string(volumegroups.EndpointTypeDst)) {
+		// 	errors = append(errors, fmt.Errorf("'log volume spec type cannot be DataProtection type for %v on volume %v'", applicationType, pointer.From(volume.Name)))
+		// }
 
 		// Validating that snapshot policies are not being created in a data protection volume
 		if volume.Properties.DataProtection != nil &&

--- a/internal/services/netapp/validate/volume_group_oracle_volumes_validation_test.go
+++ b/internal/services/netapp/validate/volume_group_oracle_volumes_validation_test.go
@@ -1228,35 +1228,6 @@ func TestValidateNetAppVolumeGroupOracleVolumes(t *testing.T) {
 			Errors: 1,
 		},
 		{
-			Name: "ValidateEndpointDstNotEnabledOnLogVolume",
-			VolumesData: []volumegroups.VolumeGroupVolumeProperties{
-				{ // data1
-					Name: pointer.To(fmt.Sprintf("volume-%v", string(VolumeSpecNameOracleData1))),
-					Properties: volumegroups.VolumeProperties{
-						ProtocolTypes:           pointer.To([]string{"NFSv4.1"}),
-						ProximityPlacementGroup: pointer.To("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Compute/proximityPlacementGroups/ppg1"),
-						SecurityStyle:           pointer.To(volumegroups.SecurityStyleUnix),
-						VolumeSpecName:          pointer.To(string(VolumeSpecNameOracleData1)),
-					},
-				},
-				{ // log
-					Name: pointer.To(fmt.Sprintf("volume-%v", string(VolumeSpecNameOracleLog))),
-					Properties: volumegroups.VolumeProperties{
-						ProtocolTypes:           pointer.To([]string{"NFSv4.1"}),
-						ProximityPlacementGroup: pointer.To("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Compute/proximityPlacementGroups/ppg1"),
-						SecurityStyle:           pointer.To(volumegroups.SecurityStyleUnix),
-						VolumeSpecName:          pointer.To(string(VolumeSpecNameOracleLog)),
-						DataProtection: &volumegroups.VolumePropertiesDataProtection{
-							Replication: &volumegroups.ReplicationObject{
-								EndpointType: pointer.To(volumegroups.EndpointTypeDst),
-							},
-						},
-					},
-				},
-			},
-			Errors: 1,
-		},
-		{
 			Name: "ValidateCustomerManagedKeyOptionsAreSetTogether",
 			VolumesData: []volumegroups.VolumeGroupVolumeProperties{
 				{ // data1

--- a/website/docs/r/netapp_volume_group_oracle.html.markdown
+++ b/website/docs/r/netapp_volume_group_oracle.html.markdown
@@ -393,13 +393,13 @@ A `data_protection_replication` block is used when enabling the Cross-Region Rep
 
 This block supports the following:
 
-* `remote_volume_location` - (Required) Location of the primary volume.
+* `remote_volume_location` - (Required) Location of the primary volume. Changing this forces a new Application Volume Group to be created and data will be lost.
 
-* `remote_volume_resource_id` - (Required) Resource ID of the primary volume.
+* `remote_volume_resource_id` - (Required) Resource ID of the primary volume. Changing this forces a new Application Volume Group to be created and data will be lost.
 
-* `replication_frequency` - (Required) Replication frequency. Possible values are `10minutes`, `daily` and `hourly`.
+* `replication_frequency` - (Required) Replication frequency. Possible values are `10minutes`, `daily` and `hourly`. Changing this forces a new Application Volume Group to be created and data will be lost.
 
-* `endpoint_type` - (Optional) The endpoint type. Possible values are `dst` and `src`. Defaults to `dst`.
+* `endpoint_type` - (Optional) The endpoint type. Possible values are `dst` and `src`. Defaults to `dst`. Changing this forces a new Application Volume Group to be created and data will be lost.
 
 ---
 

--- a/website/docs/r/netapp_volume_group_oracle.html.markdown
+++ b/website/docs/r/netapp_volume_group_oracle.html.markdown
@@ -136,6 +136,194 @@ resource "azurerm_netapp_volume_group_oracle" "example" {
 }
 ```
 
+## Example Usage - Cross-Region Replication
+
+```hcl
+provider "azurerm" {
+  features {
+    netapp {
+      prevent_volume_destruction = true
+    }
+  }
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "${var.prefix}-resources"
+  location = var.location
+
+  tags = {
+    "SkipNRMSNSG" = "true"
+  }
+}
+
+# Primary region networking
+resource "azurerm_virtual_network" "example_primary" {
+  name                = "${var.prefix}-vnet-primary"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  address_space       = ["10.47.0.0/16"]
+}
+
+resource "azurerm_subnet" "example_primary" {
+  name                 = "${var.prefix}-delegated-subnet-primary"
+  resource_group_name  = azurerm_resource_group.example.name
+  virtual_network_name = azurerm_virtual_network.example_primary.name
+  address_prefixes     = ["10.47.2.0/24"]
+
+  delegation {
+    name = "exampledelegation"
+
+    service_delegation {
+      name    = "Microsoft.Netapp/volumes"
+      actions = ["Microsoft.Network/networkinterfaces/*", "Microsoft.Network/virtualNetworks/subnets/join/action"]
+    }
+  }
+}
+
+# Secondary region networking
+resource "azurerm_virtual_network" "example_secondary" {
+  name                = "${var.prefix}-vnet-secondary"
+  location            = var.alt_location
+  resource_group_name = azurerm_resource_group.example.name
+  address_space       = ["10.48.0.0/16"]
+}
+
+resource "azurerm_subnet" "example_secondary" {
+  name                 = "${var.prefix}-delegated-subnet-secondary"
+  resource_group_name  = azurerm_resource_group.example.name
+  virtual_network_name = azurerm_virtual_network.example_secondary.name
+  address_prefixes     = ["10.48.2.0/24"]
+
+  delegation {
+    name = "exampledelegation"
+
+    service_delegation {
+      name    = "Microsoft.Netapp/volumes"
+      actions = ["Microsoft.Network/networkinterfaces/*", "Microsoft.Network/virtualNetworks/subnets/join/action"]
+    }
+  }
+}
+
+# Primary region NetApp infrastructure
+resource "azurerm_netapp_account" "example_primary" {
+  name                = "${var.prefix}-netapp-account-primary"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+
+  depends_on = [
+    azurerm_subnet.example_primary
+  ]
+}
+
+resource "azurerm_netapp_pool" "example_primary" {
+  name                = "${var.prefix}-netapp-pool-primary"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  account_name        = azurerm_netapp_account.example_primary.name
+  service_level       = "Standard"
+  size_in_tb          = 4
+  qos_type            = "Manual"
+}
+
+# Secondary region NetApp infrastructure
+resource "azurerm_netapp_account" "example_secondary" {
+  name                = "${var.prefix}-netapp-account-secondary"
+  location            = var.alt_location
+  resource_group_name = azurerm_resource_group.example.name
+
+  depends_on = [
+    azurerm_subnet.example_secondary
+  ]
+}
+
+resource "azurerm_netapp_pool" "example_secondary" {
+  name                = "${var.prefix}-netapp-pool-secondary"
+  location            = var.alt_location
+  resource_group_name = azurerm_resource_group.example.name
+  account_name        = azurerm_netapp_account.example_secondary.name
+  service_level       = "Standard"
+  size_in_tb          = 4
+  qos_type            = "Manual"
+}
+
+# Primary Oracle volume group
+resource "azurerm_netapp_volume_group_oracle" "example_primary" {
+  name                   = "${var.prefix}-NetAppVolumeGroupOracle-primary"
+  location               = azurerm_resource_group.example.location
+  resource_group_name    = azurerm_resource_group.example.name
+  account_name           = azurerm_netapp_account.example_primary.name
+  group_description      = "Primary Oracle volume group for CRR"
+  application_identifier = "TST"
+
+  volume {
+    name                       = "${var.prefix}-volume-ora1-primary"
+    volume_path                = "${var.prefix}-my-unique-file-ora-path-1-primary"
+    service_level              = "Standard"
+    capacity_pool_id           = azurerm_netapp_pool.example_primary.id
+    subnet_id                  = azurerm_subnet.example_primary.id
+    volume_spec_name           = "ora-data1"
+    storage_quota_in_gb        = 1024
+    throughput_in_mibps        = 24
+    protocols                  = ["NFSv4.1"]
+    security_style             = "unix"
+    snapshot_directory_visible = false
+
+    export_policy_rule {
+      rule_index          = 1
+      allowed_clients     = "0.0.0.0/0"
+      nfsv3_enabled       = false
+      nfsv41_enabled      = true
+      unix_read_only      = false
+      unix_read_write     = true
+      root_access_enabled = false
+    }
+  }
+}
+
+# Secondary Oracle volume group with CRR
+resource "azurerm_netapp_volume_group_oracle" "example_secondary" {
+  depends_on = [azurerm_netapp_volume_group_oracle.example_primary]
+
+  name                   = "${var.prefix}-NetAppVolumeGroupOracle-secondary"
+  location               = var.alt_location
+  resource_group_name    = azurerm_resource_group.example.name
+  account_name           = azurerm_netapp_account.example_secondary.name
+  group_description      = "Secondary Oracle volume group for CRR"
+  application_identifier = "TST"
+
+  volume {
+    name                       = "${var.prefix}-volume-ora1-secondary"
+    volume_path                = "${var.prefix}-my-unique-file-ora-path-1-secondary"
+    service_level              = "Standard"
+    capacity_pool_id           = azurerm_netapp_pool.example_secondary.id
+    subnet_id                  = azurerm_subnet.example_secondary.id
+    volume_spec_name           = "ora-data1"
+    storage_quota_in_gb        = 1024
+    throughput_in_mibps        = 24
+    protocols                  = ["NFSv4.1"]
+    security_style             = "unix"
+    snapshot_directory_visible = false
+
+    export_policy_rule {
+      rule_index          = 1
+      allowed_clients     = "0.0.0.0/0"
+      nfsv3_enabled       = false
+      nfsv41_enabled      = true
+      unix_read_only      = false
+      unix_read_write     = true
+      root_access_enabled = false
+    }
+
+    data_protection_replication {
+      endpoint_type             = "dst"
+      remote_volume_location    = azurerm_resource_group.example.location
+      remote_volume_resource_id = azurerm_netapp_volume_group_oracle.example_primary.volume[0].id
+      replication_frequency     = "10minutes"
+    }
+  }
+}
+```
+
 ## Arguments Reference
 
 The following arguments are supported:
@@ -198,7 +386,23 @@ A `volume` block supports the following:
 
 * `data_protection_snapshot_policy` - (Optional) A `data_protection_snapshot_policy` block as defined below.
 
+* `data_protection_replication` - (Optional) A `data_protection_replication` block as defined below. Changing this forces a new Application Volume Group to be created and data will be lost.
+
 ---
+A `data_protection_replication` block is used when enabling the Cross-Region Replication (CRR) data protection option by deploying two Azure NetApp Files Volumes, one to be a primary volume and the other one will be the secondary, the secondary will have this block and will reference the primary volume, not all volume spec types are supported, please refer to [Understand Azure NetApp Files application volume group for Oracle](https://learn.microsoft.com/en-us/azure/azure-netapp-files/application-volume-oracle-introduction) for details. Each volume must be in a supported [region pair](https://docs.microsoft.com/azure/azure-netapp-files/cross-region-replication-introduction#supported-region-pairs).
+
+This block supports the following:
+
+* `remote_volume_location` - (Required) Location of the primary volume.
+
+* `remote_volume_resource_id` - (Required) Resource ID of the primary volume.
+
+* `replication_frequency` - (Required) Replication frequency. Possible values are `10minutes`, `daily` and `hourly`.
+
+* `endpoint_type` - (Optional) The endpoint type. Possible values are `dst` and `src`. Defaults to `dst`.
+
+---
+
 A `data_protection_snapshot_policy` block supports the following:
 
 * `snapshot_policy_id` - (Required) Resource ID of the snapshot policy to apply to the volume.

--- a/website/docs/r/netapp_volume_group_sap_hana.html.markdown
+++ b/website/docs/r/netapp_volume_group_sap_hana.html.markdown
@@ -300,13 +300,13 @@ A `data_protection_replication` block is used when enabling the Cross-Region Rep
 
 This block supports the following:
 
-* `remote_volume_location` - (Required) Location of the primary volume.
+* `remote_volume_location` - (Required) Location of the primary volume. Changing this forces a new Application Volume Group to be created and data will be lost.
 
-* `remote_volume_resource_id` - (Required) Resource ID of the primary volume.
+* `remote_volume_resource_id` - (Required) Resource ID of the primary volume. Changing this forces a new Application Volume Group to be created and data will be lost.
 
-* `replication_frequency` - (Required) eplication frequency. Possible values are `10minutes`, `daily` and `hourly`.
+* `replication_frequency` - (Required) eplication frequency. Possible values are `10minutes`, `daily` and `hourly`. Changing this forces a new Application Volume Group to be created and data will be lost.
 
-* `endpoint_type` - (Optional) The endpoint type. Possible values are `dst` and `src`. Defaults to `dst`.
+* `endpoint_type` - (Optional) The endpoint type. Possible values are `dst` and `src`. Defaults to `dst`. Changing this forces a new Application Volume Group to be created and data will be lost.
 
 ---
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This PR adds CRR and CZR functionality to the `azurerm_netapp_volume_group_oracle` resource.


## PR Checklist

- [X] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [X] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [X] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [X] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [X] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [X] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [X] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [X] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.

## Testing 

- [X] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

```
pmarques [ ~/go/src/github.com/terraform-providers/terraform-provider-azurerm ]$ cd /home/pmarques/go/src/github.com/terraform-providers/terraform-provider-azurerm && make acctests SERVICE='netapp' TESTARGS=' -parallel 1 -run=TestAccNetAppVolumeGroupOracle_crossRegionReplicationAZ -count=1' TESTTIMEOUT='1200m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/netapp -parallel 1 -run=TestAccNetAppVolumeGroupOracle_crossRegionReplicationAZ -count=1 -timeout 1200m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccNetAppVolumeGroupOracle_crossRegionReplicationAZ
=== PAUSE TestAccNetAppVolumeGroupOracle_crossRegionReplicationAZ
=== CONT  TestAccNetAppVolumeGroupOracle_crossRegionReplicationAZ
--- PASS: TestAccNetAppVolumeGroupOracle_crossRegionReplicationAZ (2094.14s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/netapp        2094.178s

pmarques [ ~/go/src/github.com/terraform-providers/terraform-provider-azurerm ]$ cd /home/pmarques/go/src/github.com/terraform-providers/terraform-provider-azurerm && make acctests SERVICE='netapp' TESTARGS=' -parallel 1 -run=TestAccNetAppVolumeGroupOracle_crossZoneReplicationAZ -count=1' TESTTIMEOUT='1200m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/netapp -parallel 1 -run=TestAccNetAppVolumeGroupOracle_crossZoneReplicationAZ -count=1 -timeout 1200m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccNetAppVolumeGroupOracle_crossZoneReplicationAZ
=== PAUSE TestAccNetAppVolumeGroupOracle_crossZoneReplicationAZ
=== CONT  TestAccNetAppVolumeGroupOracle_crossZoneReplicationAZ
--- PASS: TestAccNetAppVolumeGroupOracle_crossZoneReplicationAZ (2103.49s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/netapp        2103.525s
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

* `azurerm_netapp_volume_group_oracle_resource ` - support for Cross-Region/Zone Replication on Application Volume Group for Oracle.


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [X] Enhancement
- [ ] Breaking Change
