### PR TITLE
New Data Source: `azurerm_dev_center_environment_type`

### DIFF
--- a/internal/services/devcenter/dev_center_environment_type_data_source.go
+++ b/internal/services/devcenter/dev_center_environment_type_data_source.go
@@ -1,0 +1,96 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package devcenter
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/devcenter/2025-02-01/devcenters"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/devcenter/2025-02-01/environmenttypes"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/devcenter/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+var _ sdk.DataSource = DevCenterEnvironmentTypeDataSource{}
+
+type DevCenterEnvironmentTypeDataSource struct{}
+
+type DevCenterEnvironmentTypeDataSourceModel struct {
+	Name        string            `tfschema:"name"`
+	DevCenterId string            `tfschema:"dev_center_id"`
+	Tags        map[string]string `tfschema:"tags"`
+}
+
+func (DevCenterEnvironmentTypeDataSource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: validate.DevCenterEnvironmentTypeName,
+		},
+
+		"dev_center_id": commonschema.ResourceIDReferenceRequired(&environmenttypes.DevCenterId{}),
+	}
+}
+
+func (DevCenterEnvironmentTypeDataSource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"tags": commonschema.TagsDataSource(),
+	}
+}
+
+func (DevCenterEnvironmentTypeDataSource) ModelObject() interface{} {
+	return &DevCenterEnvironmentTypeDataSourceModel{}
+}
+
+func (DevCenterEnvironmentTypeDataSource) ResourceType() string {
+	return "azurerm_dev_center_environment_type"
+}
+
+func (r DevCenterEnvironmentTypeDataSource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.DevCenter.V20250201.EnvironmentTypes
+			subscriptionId := metadata.Client.Account.SubscriptionId
+
+			var state DevCenterEnvironmentTypeDataSourceModel
+			if err := metadata.Decode(&state); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			devCenterId, err := devcenters.ParseDevCenterID(state.DevCenterId)
+			if err != nil {
+				return err
+			}
+
+			id := environmenttypes.NewDevCenterEnvironmentTypeID(subscriptionId, devCenterId.ResourceGroupName, devCenterId.DevCenterName, state.Name)
+
+			resp, err := client.EnvironmentTypesGet(ctx, id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return fmt.Errorf("%s was not found", id)
+				}
+
+				return fmt.Errorf("retrieving %s: %+v", id, err)
+			}
+
+			metadata.SetID(id)
+
+			if model := resp.Model; model != nil {
+				state.Name = id.EnvironmentTypeName
+				state.DevCenterId = environmenttypes.NewDevCenterID(id.SubscriptionId, id.ResourceGroupName, id.DevCenterName).ID()
+				state.Tags = pointer.From(model.Tags)
+			}
+
+			return metadata.Encode(&state)
+		},
+	}
+}

--- a/internal/services/devcenter/dev_center_environment_type_data_source_test.go
+++ b/internal/services/devcenter/dev_center_environment_type_data_source_test.go
@@ -1,0 +1,40 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package devcenter_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+)
+
+type DevCenterEnvironmentTypeDataSource struct{}
+
+func TestAccDevCenterEnvironmentTypeDataSource_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_dev_center_environment_type", "test")
+	r := DevCenterEnvironmentTypeDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("name").Exists(),
+				check.That(data.ResourceName).Key("dev_center_id").Exists(),
+			),
+		},
+	})
+}
+
+func (d DevCenterEnvironmentTypeDataSource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_dev_center_environment_type" "test" {
+  name          = azurerm_dev_center_environment_type.test.name
+  dev_center_id = azurerm_dev_center_environment_type.test.dev_center_id
+}
+`, DevCenterEnvironmentTypeTestResource{}.basic(data))
+}

--- a/internal/services/devcenter/registration.go
+++ b/internal/services/devcenter/registration.go
@@ -29,6 +29,7 @@ func (r Registration) DataSources() []sdk.DataSource {
 	return []sdk.DataSource{
 		DevCenterDataSource{},
 		DevCenterProjectDataSource{},
+		DevCenterEnvironmentTypeDataSource{},
 	}
 }
 

--- a/website/docs/d/dev_center_environment_type.html.markdown
+++ b/website/docs/d/dev_center_environment_type.html.markdown
@@ -1,0 +1,46 @@
+---
+subcategory: "Dev Center"
+layout: "azurerm"
+page_title: "Azure Resource Manager: Data Source: azurerm_dev_center_environment_type"
+description: |-
+  Gets information about an existing Dev Center Environment Type.
+---
+
+# Data Source: azurerm_dev_center_environment_type
+
+Use this data source to access information about an existing Dev Center Environment Type.
+
+## Example Usage
+
+```hcl
+data "azurerm_dev_center_environment_type" "example" {
+  name          = azurerm_dev_center_environment_type.example.name
+  dev_center_id = azurerm_dev_center_environment_type.example.dev_center_id
+}
+
+output "id" {
+  value = data.azurerm_dev_center_environment_type.example.id
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of this Dev Center Environment Type.
+
+* `dev_center_id` - (Required) The ID of the associated Dev Center.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the Dev Center Environment Type.
+
+* `tags` - A mapping of tags assigned to the Dev Center Environment Type.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Dev Center Environment Type.


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description
Added new data source azurerm_dev_center_environment_type for https://github.com/hashicorp/terraform-provider-azurerm/issues/29648
<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* New Data Source: `azurerm_dev_center_environment_type`


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
