### PR TITLE
`azurerm_postgresql_*` - deprecate PostgreSQL Single Server and its sub resources

### DIFF
--- a/internal/services/postgres/postgresql_server_data_source.go
+++ b/internal/services/postgres/postgresql_server_data_source.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2017-12-01/servers"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
@@ -26,6 +27,8 @@ func dataSourcePostgreSqlServer() *pluginsdk.Resource {
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Read: pluginsdk.DefaultTimeout(10 * time.Minute),
 		},
+
+		DeprecationMessage: features.DeprecatedInFivePointOh("Azure Database for PostgreSQL Single Server and its sub resources are scheduled for retirement by 2025-03-28 and will migrate to using Azure Database for PostgreSQL Flexible Server: https://techcommunity.microsoft.com/blog/adforpostgresql/retiring-azure-database-for-postgresql-single-server-in-2025/3783783. The `azurerm_postgresql_server` data source is deprecated and will be removed in v5.0 of the AzureRM Provider. Please use the `azurerm_postgresql_flexible_server` data source instead"),
 
 		Schema: map[string]*pluginsdk.Schema{
 			"name": {

--- a/internal/services/postgres/postgresql_server_data_source_test.go
+++ b/internal/services/postgres/postgresql_server_data_source_test.go
@@ -9,11 +9,16 @@ import (
 
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 )
 
 type PostgreSQLServerDataSource struct{}
 
 func TestAccDataSourcePostgreSqlServer_basic(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skipf("Skipping since `azurerm_postgresql_server` is deprecated and will be removed in 5.0")
+	}
+
 	data := acceptance.BuildTestData(t, "data.azurerm_postgresql_server", "test")
 	r := PostgreSQLServerDataSource{}
 	version := "9.5"

--- a/internal/services/postgres/postgresql_server_resource.go
+++ b/internal/services/postgres/postgresql_server_resource.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/postgres/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/postgres/validate"
@@ -109,6 +110,8 @@ func resourcePostgreSQLServer() *pluginsdk.Resource {
 			Update: pluginsdk.DefaultTimeout(60 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(60 * time.Minute),
 		},
+
+		DeprecationMessage: features.DeprecatedInFivePointOh("Azure Database for PostgreSQL Single Server and its sub resources are scheduled for retirement by 2025-03-28 and will migrate to using Azure Database for PostgreSQL Flexible Server: https://techcommunity.microsoft.com/blog/adforpostgresql/retiring-azure-database-for-postgresql-single-server-in-2025/3783783. The `azurerm_postgresql_server` resource is deprecated and will be removed in v5.0 of the AzureRM Provider. Please use the `azurerm_postgresql_flexible_server` resource instead"),
 
 		SchemaVersion: 1,
 		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{

--- a/internal/services/postgres/postgresql_server_resource_test.go
+++ b/internal/services/postgres/postgresql_server_resource_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
@@ -24,6 +25,10 @@ import (
 type PostgreSQLServerResource struct{}
 
 func TestAccPostgreSQLServer_basicNinePointFive(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skipf("Skipping since `azurerm_postgresql_server` is deprecated and will be removed in 5.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_postgresql_server", "test")
 	r := PostgreSQLServerResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -38,6 +43,10 @@ func TestAccPostgreSQLServer_basicNinePointFive(t *testing.T) {
 }
 
 func TestAccPostgreSQLServer_basicNinePointSix(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skipf("Skipping since `azurerm_postgresql_server` is deprecated and will be removed in 5.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_postgresql_server", "test")
 	r := PostgreSQLServerResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -52,6 +61,10 @@ func TestAccPostgreSQLServer_basicNinePointSix(t *testing.T) {
 }
 
 func TestAccPostgreSQLServer_basicTenPointZero(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skipf("Skipping since `azurerm_postgresql_server` is deprecated and will be removed in 5.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_postgresql_server", "test")
 	r := PostgreSQLServerResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -66,6 +79,10 @@ func TestAccPostgreSQLServer_basicTenPointZero(t *testing.T) {
 }
 
 func TestAccPostgreSQLServer_gpTenPointZero(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skipf("Skipping since `azurerm_postgresql_server` is deprecated and will be removed in 5.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_postgresql_server", "test")
 	r := PostgreSQLServerResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -80,6 +97,10 @@ func TestAccPostgreSQLServer_gpTenPointZero(t *testing.T) {
 }
 
 func TestAccPostgreSQLServer_moTenPointZero(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skipf("Skipping since `azurerm_postgresql_server` is deprecated and will be removed in 5.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_postgresql_server", "test")
 	r := PostgreSQLServerResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -94,6 +115,10 @@ func TestAccPostgreSQLServer_moTenPointZero(t *testing.T) {
 }
 
 func TestAccPostgreSQLServer_basicEleven(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skipf("Skipping since `azurerm_postgresql_server` is deprecated and will be removed in 5.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_postgresql_server", "test")
 	r := PostgreSQLServerResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -108,6 +133,10 @@ func TestAccPostgreSQLServer_basicEleven(t *testing.T) {
 }
 
 func TestAccPostgreSQLServer_basicWithIdentity(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skipf("Skipping since `azurerm_postgresql_server` is deprecated and will be removed in 5.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_postgresql_server", "test")
 	r := PostgreSQLServerResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -122,6 +151,10 @@ func TestAccPostgreSQLServer_basicWithIdentity(t *testing.T) {
 }
 
 func TestAccPostgreSQLServer_autogrowOnly(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skipf("Skipping since `azurerm_postgresql_server` is deprecated and will be removed in 5.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_postgresql_server", "test")
 	r := PostgreSQLServerResource{}
 
@@ -144,6 +177,10 @@ func TestAccPostgreSQLServer_autogrowOnly(t *testing.T) {
 }
 
 func TestAccPostgreSQLServer_requiresImport(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skipf("Skipping since `azurerm_postgresql_server` is deprecated and will be removed in 5.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_postgresql_server", "test")
 	r := PostgreSQLServerResource{}
 
@@ -159,6 +196,10 @@ func TestAccPostgreSQLServer_requiresImport(t *testing.T) {
 }
 
 func TestAccPostgreSQLServer_complete(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skipf("Skipping since `azurerm_postgresql_server` is deprecated and will be removed in 5.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_postgresql_server", "test")
 	r := PostgreSQLServerResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -173,6 +214,10 @@ func TestAccPostgreSQLServer_complete(t *testing.T) {
 }
 
 func TestAccPostgreSQLServer_updated(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skipf("Skipping since `azurerm_postgresql_server` is deprecated and will be removed in 5.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_postgresql_server", "test")
 	r := PostgreSQLServerResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -201,6 +246,10 @@ func TestAccPostgreSQLServer_updated(t *testing.T) {
 }
 
 func TestAccPostgreSQLServer_updateSKU(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skipf("Skipping since `azurerm_postgresql_server` is deprecated and will be removed in 5.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_postgresql_server", "test")
 	r := PostgreSQLServerResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -222,6 +271,10 @@ func TestAccPostgreSQLServer_updateSKU(t *testing.T) {
 }
 
 func TestAccPostgreSQLServer_createReplica(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skipf("Skipping since `azurerm_postgresql_server` is deprecated and will be removed in 5.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_postgresql_server", "test")
 	r := PostgreSQLServerResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -243,6 +296,10 @@ func TestAccPostgreSQLServer_createReplica(t *testing.T) {
 }
 
 func TestAccPostgreSQLServer_updateReplicaToDefault(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skipf("Skipping since `azurerm_postgresql_server` is deprecated and will be removed in 5.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_postgresql_server", "replica")
 	r := PostgreSQLServerResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -265,6 +322,10 @@ func TestAccPostgreSQLServer_updateReplicaToDefault(t *testing.T) {
 
 // Update Admin Password in a separate call when Replication is stopped: https://github.com/Azure/azure-rest-api-specs/issues/16898
 func TestAccPostgreSQLServer_updateReplicaToDefaultAndSetPassword(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skipf("Skipping since `azurerm_postgresql_server` is deprecated and will be removed in 5.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_postgresql_server", "replica")
 	r := PostgreSQLServerResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -286,6 +347,10 @@ func TestAccPostgreSQLServer_updateReplicaToDefaultAndSetPassword(t *testing.T) 
 }
 
 func TestAccPostgreSQLServer_scaleReplicas(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skipf("Skipping since `azurerm_postgresql_server` is deprecated and will be removed in 5.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_postgresql_server", "test")
 	r := PostgreSQLServerResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -329,6 +394,10 @@ func TestAccPostgreSQLServer_scaleReplicas(t *testing.T) {
 }
 
 func TestAccPostgreSQLServer_createPointInTimeRestore(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skipf("Skipping since `azurerm_postgresql_server` is deprecated and will be removed in 5.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_postgresql_server", "test")
 	r := PostgreSQLServerResource{}
 	restoreTime := time.Now().Add(1 * time.Hour)
@@ -353,6 +422,10 @@ func TestAccPostgreSQLServer_createPointInTimeRestore(t *testing.T) {
 }
 
 func TestAccPostgreSQLServer_threatDetectionEmptyAttrs(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skipf("Skipping since `azurerm_postgresql_server` is deprecated and will be removed in 5.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_postgresql_server", "test")
 	r := PostgreSQLServerResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -367,6 +440,10 @@ func TestAccPostgreSQLServer_threatDetectionEmptyAttrs(t *testing.T) {
 }
 
 func TestAccPostgreSQLServer_minTlsVersionOnServerUpdate(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skipf("Skipping since `azurerm_postgresql_server` is deprecated and will be removed in 5.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_postgresql_server", "test")
 	r := PostgreSQLServerResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -386,6 +463,10 @@ func TestAccPostgreSQLServer_minTlsVersionOnServerUpdate(t *testing.T) {
 }
 
 func TestAccPostgreSQLServer_writeOnlyPassword(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skipf("Skipping since `azurerm_postgresql_server` is deprecated and will be removed in 5.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_postgresql_server", "test")
 	r := PostgreSQLServerResource{}
 
@@ -410,6 +491,10 @@ func TestAccPostgreSQLServer_writeOnlyPassword(t *testing.T) {
 }
 
 func TestAccPostgreSQLServer_updateToWriteOnlyPassword(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skipf("Skipping since `azurerm_postgresql_server` is deprecated and will be removed in 5.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_postgresql_server", "test")
 	r := PostgreSQLServerResource{}
 

--- a/internal/services/postgres/registration.go
+++ b/internal/services/postgres/registration.go
@@ -4,6 +4,7 @@
 package postgres
 
 import (
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
@@ -33,19 +34,23 @@ func (r Registration) WebsiteCategories() []string {
 
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
-	return map[string]*pluginsdk.Resource{
-		"azurerm_postgresql_server":          dataSourcePostgreSqlServer(),
+	dataSources := map[string]*pluginsdk.Resource{
 		"azurerm_postgresql_flexible_server": dataSourcePostgresqlFlexibleServer(),
 	}
+
+	if !features.FivePointOh() {
+		dataSources["azurerm_postgresql_server"] = dataSourcePostgreSqlServer()
+	}
+
+	return dataSources
 }
 
 // SupportedResources returns the supported Resources supported by this Service
 func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
-	return map[string]*pluginsdk.Resource{
+	resources := map[string]*pluginsdk.Resource{
 		"azurerm_postgresql_configuration":                                  resourcePostgreSQLConfiguration(),
 		"azurerm_postgresql_database":                                       resourcePostgreSQLDatabase(),
 		"azurerm_postgresql_firewall_rule":                                  resourcePostgreSQLFirewallRule(),
-		"azurerm_postgresql_server":                                         resourcePostgreSQLServer(),
 		"azurerm_postgresql_server_key":                                     resourcePostgreSQLServerKey(),
 		"azurerm_postgresql_virtual_network_rule":                           resourcePostgreSQLVirtualNetworkRule(),
 		"azurerm_postgresql_active_directory_administrator":                 resourcePostgreSQLAdministrator(),
@@ -55,6 +60,12 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 		"azurerm_postgresql_flexible_server_database":                       resourcePostgresqlFlexibleServerDatabase(),
 		"azurerm_postgresql_flexible_server_active_directory_administrator": resourcePostgresqlFlexibleServerAdministrator(),
 	}
+
+	if !features.FivePointOh() {
+		resources["azurerm_postgresql_server"] = resourcePostgreSQLServer()
+	}
+
+	return resources
 }
 
 func (r Registration) Resources() []sdk.Resource {

--- a/website/docs/5.0-upgrade-guide.html.markdown
+++ b/website/docs/5.0-upgrade-guide.html.markdown
@@ -74,6 +74,10 @@ This deprecated resource has been superseded/retired and has been removed from t
 
 * This deprecated resource has been retired and has been removed from the Azure Provider.
 
+### `azurerm_postgresql_server`
+
+* This deprecated resource has been retired and has been removed from the Azure Provider.
+
 ### `azurerm_security_center_auto_provisioning`
 
 * This deprecated resource has been removed from the Azure Provider. Please see the [documentation for more details](https://learn.microsoft.com/en-us/azure/defender-for-cloud/prepare-deprecation-log-analytics-mma-agent#log-analytics-agent-autoprovisioning-experience---deprecation-plan).
@@ -96,6 +100,10 @@ This deprecated data source has been superseded/retired and has been removed fro
 ### `azurerm_logic_app_standard`
 
 * The deprecated `site_config.public_network_access_enabled` property has been removed and superseded by the `public_network_access` property.
+
+### `azurerm_postgresql_server`
+
+* This deprecated data source has been retired and has been removed from the Azure Provider.
 
 ### `azurerm_spatial_anchors_account`
 

--- a/website/docs/d/postgresql_server.html.markdown
+++ b/website/docs/d/postgresql_server.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Use this data source to access information about an existing PostgreSQL Azure Database Server.
 
+~> **Note:** Azure Database for PostgreSQL Single Server and its sub resources are scheduled for retirement by 2025-03-28 and will migrate to using Azure Database for PostgreSQL Flexible Server: https://techcommunity.microsoft.com/blog/adforpostgresql/retiring-azure-database-for-postgresql-single-server-in-2025/3783783. The `azurerm_postgresql_server` data source is deprecated and will be removed in v5.0 of the AzureRM Provider. Please use the `azurerm_postgresql_flexible_server` data source instead.
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/postgresql_server.html.markdown
+++ b/website/docs/r/postgresql_server.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Manages a PostgreSQL Server.
 
+~> **Note:** Azure Database for PostgreSQL Single Server and its sub resources are scheduled for retirement by 2025-03-28 and will migrate to using Azure Database for PostgreSQL Flexible Server: https://techcommunity.microsoft.com/blog/adforpostgresql/retiring-azure-database-for-postgresql-single-server-in-2025/3783783. The `azurerm_postgresql_server` resource is deprecated and will be removed in v5.0 of the AzureRM Provider. Please use the `azurerm_postgresql_flexible_server` resource instead.
+
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description
Recently we found test cases related with PostgreSQL Single Server failed on TeamCity Daily Run. The error message indicates that PostgrSQL Single Server has been deprecated and service team confirmed that PostgreSQL Single Server and its sub resources have been deprecated. See more details from https://techcommunity.microsoft.com/blog/adforpostgresql/retiring-azure-database-for-postgresql-single-server-in-2025/3783783.

Error Message:
```
performing Create: unexpected status 400 (400 Bad Request) with error: InvalidElasticServerType: The provided server type value 'Azure Database for PostgreSQL - Single Server' is invalid.
```

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
