### PR TITLE
[Bug:] `azurerm_orchestrated_virtual_machine_scale_set` - fix `nil` pointer dereferences and unsafe type assertions

### DIFF
--- a/internal/services/compute/orchestrated_virtual_machine_scale_set.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set.go
@@ -1104,7 +1104,7 @@ func expandOrchestratedVirtualMachineScaleSetIPConfiguration(raw map[string]inte
 	}
 
 	publicIPConfigsRaw := raw["public_ip_address"].([]interface{})
-	if len(publicIPConfigsRaw) > 0 {
+	if len(publicIPConfigsRaw) > 0 && publicIPConfigsRaw[0] != nil {
 		publicIPConfigRaw := publicIPConfigsRaw[0].(map[string]interface{})
 		publicIPAddressConfig := expandOrchestratedVirtualMachineScaleSetPublicIPAddress(publicIPConfigRaw)
 		ipConfiguration.Properties.PublicIPAddressConfiguration = publicIPAddressConfig
@@ -1241,7 +1241,7 @@ func expandOrchestratedVirtualMachineScaleSetIPConfigurationUpdate(raw map[strin
 	}
 
 	publicIPConfigsRaw := raw["public_ip_address"].([]interface{})
-	if len(publicIPConfigsRaw) > 0 {
+	if len(publicIPConfigsRaw) > 0 && publicIPConfigsRaw[0] != nil {
 		publicIPConfigRaw := publicIPConfigsRaw[0].(map[string]interface{})
 		publicIPAddressConfig := expandOrchestratedVirtualMachineScaleSetPublicIPAddressUpdate(publicIPConfigRaw)
 		ipConfiguration.Properties.PublicIPAddressConfiguration = publicIPAddressConfig
@@ -1358,7 +1358,7 @@ func ExpandOrchestratedVirtualMachineScaleSetOSDisk(input []interface{}, osType 
 		disk.DiskSizeGB = pointer.To(int64(osDiskSize))
 	}
 
-	if diffDiskSettingsRaw := raw["diff_disk_settings"].([]interface{}); len(diffDiskSettingsRaw) > 0 {
+	if diffDiskSettingsRaw := raw["diff_disk_settings"].([]interface{}); len(diffDiskSettingsRaw) > 0 && diffDiskSettingsRaw[0] != nil {
 		diffDiskRaw := diffDiskSettingsRaw[0].(map[string]interface{})
 		disk.DiffDiskSettings = &virtualmachinescalesets.DiffDiskSettings{
 			Option:    pointer.To(virtualmachinescalesets.DiffDiskOptions(diffDiskRaw["option"].(string))),
@@ -1707,7 +1707,7 @@ func flattenOrchestratedVirtualMachineScaleSetWindowsConfiguration(input *virtua
 
 	if v := d.Get("os_profile").([]interface{}); len(v) > 0 {
 		osProfile := v[0].(map[string]interface{})
-		if winConfigRaw := osProfile["windows_configuration"].([]interface{}); len(winConfigRaw) > 0 {
+		if winConfigRaw := osProfile["windows_configuration"].([]interface{}); len(winConfigRaw) > 0 && winConfigRaw[0] != nil {
 			winCfg := winConfigRaw[0].(map[string]interface{})
 			output["admin_password"] = winCfg["admin_password"].(string)
 		}
@@ -1771,7 +1771,7 @@ func flattenOrchestratedVirtualMachineScaleSetLinuxConfiguration(input *virtualm
 
 	if v := d.Get("os_profile").([]interface{}); len(v) > 0 {
 		osProfile := v[0].(map[string]interface{})
-		if linConfigRaw := osProfile["linux_configuration"].([]interface{}); len(linConfigRaw) > 0 {
+		if linConfigRaw := osProfile["linux_configuration"].([]interface{}); len(linConfigRaw) > 0 && linConfigRaw[0] != nil {
 			linCfg := linConfigRaw[0].(map[string]interface{})
 			output["admin_password"] = linCfg["admin_password"].(string)
 		}

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
@@ -517,7 +517,7 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 	extensionOperationsEnabled := d.Get("extension_operations_enabled").(bool)
 	osProfileRaw := d.Get("os_profile").([]interface{})
 
-	if len(osProfileRaw) > 0 {
+	if len(osProfileRaw) > 0 && osProfileRaw[0] != nil {
 		osProfile := osProfileRaw[0].(map[string]interface{})
 		winConfigRaw = osProfile["windows_configuration"].([]interface{})
 		linConfigRaw = osProfile["linux_configuration"].([]interface{})
@@ -857,7 +857,7 @@ func resourceOrchestratedVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData,
 		windowsConfig.PatchSettings = &virtualmachinescalesets.PatchSettings{}
 		linuxConfig := virtualmachinescalesets.LinuxConfiguration{}
 
-		if len(osProfileRaw) > 0 {
+		if len(osProfileRaw) > 0 && osProfileRaw[0] != nil {
 			osProfile := osProfileRaw[0].(map[string]interface{})
 			winConfigRaw := osProfile["windows_configuration"].([]interface{})
 			linConfigRaw := osProfile["linux_configuration"].([]interface{})
@@ -870,7 +870,7 @@ func resourceOrchestratedVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData,
 				vmssOsProfile.CustomData = pointer.To(osProfile["custom_data"].(string))
 			}
 
-			if len(winConfigRaw) > 0 {
+			if len(winConfigRaw) > 0 && winConfigRaw[0] != nil {
 				winConfig := winConfigRaw[0].(map[string]interface{})
 				provisionVMAgent := winConfig["provision_vm_agent"].(bool)
 				patchAssessmentMode := winConfig["patch_assessment_mode"].(string)
@@ -948,7 +948,7 @@ func resourceOrchestratedVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData,
 				vmssOsProfile.WindowsConfiguration = &windowsConfig
 			}
 
-			if len(linConfigRaw) > 0 {
+			if len(linConfigRaw) > 0 && linConfigRaw[0] != nil {
 				osType = virtualmachinescalesets.OperatingSystemTypesLinux
 				linConfig := linConfigRaw[0].(map[string]interface{})
 				provisionVMAgent := linConfig["provision_vm_agent"].(bool)

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
@@ -528,7 +528,7 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 			customData = v.(string)
 		}
 
-		if len(winConfigRaw) > 0 {
+		if len(winConfigRaw) > 0 && winConfigRaw[0] != nil {
 			winConfig := winConfigRaw[0].(map[string]interface{})
 			provisionVMAgent := winConfig["provision_vm_agent"].(bool)
 			patchAssessmentMode := winConfig["patch_assessment_mode"].(string)
@@ -592,7 +592,7 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 			}
 		}
 
-		if len(linConfigRaw) > 0 {
+		if len(linConfigRaw) > 0 && linConfigRaw[0] != nil {
 			osType = virtualmachinescalesets.OperatingSystemTypesLinux
 			linConfig := linConfigRaw[0].(map[string]interface{})
 			provisionVMAgent := linConfig["provision_vm_agent"].(bool)
@@ -1483,7 +1483,7 @@ func resourceOrchestratedVirtualMachineScaleSetDelete(d *pluginsdk.ResourceData,
 	// Original Error: Code="InUseSubnetCannotBeDeleted" Message="Subnet internal is in use by
 	// /{nicResourceID}/|providers|Microsoft.Compute|virtualMachineScaleSets|acctestvmss-190923101253410278|virtualMachines|0|networkInterfaces|example/ipConfigurations/internal and cannot be deleted.
 	// In order to delete the subnet, delete all the resources within the subnet. See aka.ms/deletesubnet.
-	if resp.Model.Sku != nil {
+	if resp.Model != nil && resp.Model.Sku != nil {
 		resp.Model.Sku.Capacity = utils.Int64(int64(0))
 
 		log.Printf("[DEBUG] Scaling instances to 0 prior to deletion - this helps avoids networking issues within Azure")

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
@@ -340,11 +340,11 @@ func resourceOrchestratedVirtualMachineScaleSet() *pluginsdk.Resource {
 
 				if hasSkuProfile {
 					if !hasSkuName || skuName != SkuNameMix {
-						return fmt.Errorf("`sku_profile` can only be set when `sku_name` is set to `Mix`")
+						return fmt.Errorf("'sku_profile' can only be configured when 'sku_name' is set to 'Mix'")
 					}
 				} else {
 					if hasSkuName && skuName == SkuNameMix {
-						return fmt.Errorf("`sku_profile` must be set when `sku_name` is set to `Mix`")
+						return fmt.Errorf("'sku_profile' must be configured when 'sku_name' is set to 'Mix'")
 					}
 				}
 
@@ -352,11 +352,11 @@ func resourceOrchestratedVirtualMachineScaleSet() *pluginsdk.Resource {
 				rollingUpgradePolicyRaw := diff.Get("rolling_upgrade_policy").([]interface{})
 
 				if upgradeMode == virtualmachinescalesets.UpgradeModeManual && len(rollingUpgradePolicyRaw) > 0 {
-					return fmt.Errorf("a `rolling_upgrade_policy` block cannot be specified when `upgrade_mode` is set to `%s`", string(upgradeMode))
+					return fmt.Errorf("'rolling_upgrade_policy' cannot be specified when 'upgrade_mode' is set to %q", string(upgradeMode))
 				}
 
 				if upgradeMode == virtualmachinescalesets.UpgradeModeRolling && len(rollingUpgradePolicyRaw) == 0 {
-					return fmt.Errorf("a `rolling_upgrade_policy` block must be specified when `upgrade_mode` is set to `%s`", string(upgradeMode))
+					return fmt.Errorf("'rolling_upgrade_policy' is required when 'upgrade_mode' is set to %q", string(upgradeMode))
 				}
 
 				return nil
@@ -461,7 +461,7 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 
 	if v, ok := d.GetOk("capacity_reservation_group_id"); ok {
 		if d.Get("single_placement_group").(bool) {
-			return fmt.Errorf("`single_placement_group` must be set to `false` when `capacity_reservation_group_id` is specified")
+			return fmt.Errorf("'single_placement_group' must be set to 'false' when 'capacity_reservation_group_id' is specified")
 		}
 
 		virtualMachineProfile.CapacityReservation = &virtualmachinescalesets.CapacityReservationProfile{
@@ -489,7 +489,7 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 
 	// Virtual Machine Scale Set with Flexible Orchestration Mode and 'Rolling' upgradeMode must have Health Extension Present
 	if upgradeMode == virtualmachinescalesets.UpgradeModeRolling && !hasHealthExtension {
-		return fmt.Errorf("a health extension must be specified when `upgrade_mode` is set to `Rolling`")
+		return fmt.Errorf("a health extension is required when 'upgrade_mode' is set to %q", string(upgradeMode))
 	}
 
 	if v, ok := d.GetOk("extensions_time_budget"); ok {
@@ -545,11 +545,11 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 			}
 
 			if extensionOperationsEnabled && !provisionVMAgent {
-				return fmt.Errorf("`extension_operations_enabled` cannot be set to `true` when `provision_vm_agent` is set to `false`")
+				return fmt.Errorf("'extension_operations_enabled' cannot be set to 'true' when 'provision_vm_agent' is set to 'false'")
 			}
 
 			if patchAssessmentMode == string(virtualmachinescalesets.WindowsPatchAssessmentModeAutomaticByPlatform) && !provisionVMAgent {
-				return fmt.Errorf("when the 'patch_assessment_mode' field is set to %q the 'provision_vm_agent' must always be set to 'true'", virtualmachinescalesets.WindowsPatchAssessmentModeAutomaticByPlatform)
+				return fmt.Errorf("when 'patch_assessment_mode' is set to %q, 'provision_vm_agent' must be set to 'true'", virtualmachinescalesets.WindowsPatchAssessmentModeAutomaticByPlatform)
 			}
 
 			// Validate patch mode and hotpatching configuration
@@ -560,34 +560,34 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 			if isHotpatchEnabledImage {
 				// it is a hotpatching enabled image, validate hotpatching enabled settings
 				if patchMode != string(virtualmachinescalesets.WindowsVMGuestPatchModeAutomaticByPlatform) {
-					return fmt.Errorf("when referencing a hotpatching enabled image the 'patch_mode' field must always be set to %q", virtualmachinescalesets.WindowsVMGuestPatchModeAutomaticByPlatform)
+					return fmt.Errorf("when using a hotpatching enabled image, 'patch_mode' must be set to %q", virtualmachinescalesets.WindowsVMGuestPatchModeAutomaticByPlatform)
 				}
 
 				if !provisionVMAgent {
-					return fmt.Errorf("when referencing a hotpatching enabled image the 'provision_vm_agent' field must always be set to 'true'")
+					return fmt.Errorf("when using a hotpatching enabled image, 'provision_vm_agent' must be set to 'true'")
 				}
 
 				if !hasHealthExtension {
-					return fmt.Errorf("when referencing a hotpatching enabled image the 'extension' field must always contain a 'application health extension'")
+					return fmt.Errorf("when using a hotpatching enabled image, an application health extension must be configured")
 				}
 
 				if !hotpatchingEnabled {
-					return fmt.Errorf("when referencing a hotpatching enabled image the 'hotpatching_enabled' field must always be set to 'true'")
+					return fmt.Errorf("when using a hotpatching enabled image, 'hotpatching_enabled' must be set to 'true'")
 				}
 			} else {
 				// not a hotpatching enabled image verify Automatic VM Guest Patching settings
 				if patchMode == string(virtualmachinescalesets.WindowsVMGuestPatchModeAutomaticByPlatform) {
 					if !provisionVMAgent {
-						return fmt.Errorf("when 'patch_mode' is set to %q then 'provision_vm_agent' must be set to 'true'", patchMode)
+						return fmt.Errorf("when 'patch_mode' is set to %q, 'provision_vm_agent' must be set to 'true'", patchMode)
 					}
 
 					if !hasHealthExtension {
-						return fmt.Errorf("when 'patch_mode' is set to %q then the 'extension' field must always contain a 'application health extension'", patchMode)
+						return fmt.Errorf("when 'patch_mode' is set to %q, an application health extension must be configured", patchMode)
 					}
 				}
 
 				if hotpatchingEnabled {
-					return fmt.Errorf("'hotpatching_enabled' field is not supported unless you are using one of the following hotpatching enable images, '2022-datacenter-azure-edition', '2022-datacenter-azure-edition-core-smalldisk', '2022-datacenter-azure-edition-hotpatch', '2022-datacenter-azure-edition-hotpatch-smalldisk', '2025-datacenter-azure-edition', '2025-datacenter-azure-edition-smalldisk', '2025-datacenter-azure-edition-core' or '2025-datacenter-azure-edition-core-smalldisk'")
+					return fmt.Errorf("'hotpatching_enabled' can only be used with supported Windows Server images: '2022-datacenter-azure-edition', '2022-datacenter-azure-edition-core-smalldisk', '2022-datacenter-azure-edition-hotpatch', '2022-datacenter-azure-edition-hotpatch-smalldisk', '2025-datacenter-azure-edition', '2025-datacenter-azure-edition-smalldisk', '2025-datacenter-azure-edition-core', or '2025-datacenter-azure-edition-core-smalldisk'")
 				}
 			}
 		}
@@ -611,11 +611,11 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 			}
 
 			if extensionOperationsEnabled && !provisionVMAgent {
-				return fmt.Errorf("`extension_operations_enabled` cannot be set to `true` when `provision_vm_agent` is set to `false`")
+				return fmt.Errorf("'extension_operations_enabled' cannot be set to true when 'provision_vm_agent' is set to false")
 			}
 
 			if patchAssessmentMode == string(virtualmachinescalesets.LinuxPatchAssessmentModeAutomaticByPlatform) && !provisionVMAgent {
-				return fmt.Errorf("when the 'patch_assessment_mode' field is set to %q the 'provision_vm_agent' must always be set to 'true'", virtualmachinescalesets.LinuxPatchAssessmentModeAutomaticByPlatform)
+				return fmt.Errorf("when 'patch_assessment_mode' is set to %q, 'provision_vm_agent' must be set to 'true'", virtualmachinescalesets.LinuxPatchAssessmentModeAutomaticByPlatform)
 			}
 
 			// Validate Automatic VM Guest Patching Settings
@@ -623,11 +623,11 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 
 			if patchMode == string(virtualmachinescalesets.LinuxVMGuestPatchModeAutomaticByPlatform) {
 				if !provisionVMAgent {
-					return fmt.Errorf("when the 'patch_mode' field is set to %q the 'provision_vm_agent' field must always be set to 'true', got %q", patchMode, strconv.FormatBool(provisionVMAgent))
+					return fmt.Errorf("when 'patch_mode' is set to %q, 'provision_vm_agent' must be set to 'true', got %q", patchMode, strconv.FormatBool(provisionVMAgent))
 				}
 
 				if !hasHealthExtension {
-					return fmt.Errorf("when the 'patch_mode' field is set to %q the 'extension' field must contain at least one 'application health extension', got 0", patchMode)
+					return fmt.Errorf("when 'patch_mode' is set to %q, at least one application health extension must be configured, got 0", patchMode)
 				}
 			}
 		}
@@ -677,7 +677,7 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 
 	if v, ok := d.Get("max_bid_price").(float64); ok && v > 0 {
 		if *virtualMachineProfile.Priority != virtualmachinescalesets.VirtualMachinePriorityTypesSpot {
-			return fmt.Errorf("`max_bid_price` can only be configured when `priority` is set to `Spot`")
+			return fmt.Errorf("'max_bid_price' can only be configured when 'priority' is set to %q", string(virtualmachinescalesets.VirtualMachinePriorityTypesSpot))
 		}
 
 		virtualMachineProfile.BillingProfile = &virtualmachinescalesets.BillingProfile{
@@ -693,11 +693,11 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 
 	if v, ok := d.GetOk("eviction_policy"); ok {
 		if *virtualMachineProfile.Priority != virtualmachinescalesets.VirtualMachinePriorityTypesSpot {
-			return fmt.Errorf("an `eviction_policy` can only be specified when `priority` is set to `Spot`")
+			return fmt.Errorf("'eviction_policy' can only be specified when 'priority' is set to %q", string(virtualmachinescalesets.VirtualMachinePriorityTypesSpot))
 		}
 		virtualMachineProfile.EvictionPolicy = pointer.To(virtualmachinescalesets.VirtualMachineEvictionPolicyTypes(v.(string)))
 	} else if *virtualMachineProfile.Priority == virtualmachinescalesets.VirtualMachinePriorityTypesSpot {
-		return fmt.Errorf("an `eviction_policy` must be specified when `priority` is set to `Spot`")
+		return fmt.Errorf("'eviction_policy' is required when 'priority' is set to %q", string(virtualmachinescalesets.VirtualMachinePriorityTypesSpot))
 	}
 
 	if v, ok := d.GetOk("license_type"); ok {
@@ -724,7 +724,7 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 
 		if v, ok := d.GetOk("automatic_instance_repair"); ok {
 			if !hasHealthExtension {
-				return fmt.Errorf("`automatic_instance_repair` can only be set if there is an application Health extension defined")
+				return fmt.Errorf("'automatic_instance_repair' can only be enabled when an application health extension is configured")
 			}
 
 			props.Properties.AutomaticRepairsPolicy = ExpandVirtualMachineScaleSetAutomaticRepairsPolicy(v.([]interface{}))
@@ -732,7 +732,7 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 
 		if v, ok := d.GetOk("zone_balance"); ok && v.(bool) {
 			if props.Zones == nil || len(*props.Zones) == 0 {
-				return fmt.Errorf("`zone_balance` can only be set to `true` when zones are specified")
+				return fmt.Errorf("'zone_balance' can only be set to 'true' when availability zones are specified")
 			}
 
 			props.Properties.ZoneBalance = pointer.To(v.(bool))
@@ -740,7 +740,7 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 
 		if v, ok := d.GetOk("priority_mix"); ok {
 			if *virtualMachineProfile.Priority != virtualmachinescalesets.VirtualMachinePriorityTypesSpot {
-				return fmt.Errorf("a `priority_mix` can only be specified when `priority` is set to `Spot`")
+				return fmt.Errorf("'priority_mix' can only be specified when 'priority' is set to %q", string(virtualmachinescalesets.VirtualMachinePriorityTypesSpot))
 			}
 			props.Properties.PriorityMixPolicy = ExpandOrchestratedVirtualMachineScaleSetPriorityMixPolicy(v.([]interface{}))
 		}
@@ -830,7 +830,7 @@ func resourceOrchestratedVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData,
 			if !pluginsdk.IsExplicitlyNullInConfig(d, "single_placement_group") {
 				singlePlacementGroup := d.Get("single_placement_group").(bool)
 				if singlePlacementGroup {
-					return fmt.Errorf("'single_placement_group' can not be set to 'true' once it has been set to 'false'")
+					return fmt.Errorf("'single_placement_group' cannot be changed from 'false' to 'true'")
 				}
 				updateProps.SinglePlacementGroup = pointer.To(singlePlacementGroup)
 			}
@@ -843,7 +843,7 @@ func resourceOrchestratedVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData,
 
 		if d.HasChange("max_bid_price") {
 			if priority != virtualmachinescalesets.VirtualMachinePriorityTypesSpot {
-				return fmt.Errorf("`max_bid_price` can only be configured when `priority` is set to `Spot`")
+				return fmt.Errorf("'max_bid_price' can only be configured when 'priority' is set to %q", string(virtualmachinescalesets.VirtualMachinePriorityTypesSpot))
 			}
 
 			updateProps.VirtualMachineProfile.BillingProfile = &virtualmachinescalesets.BillingProfile{
@@ -903,21 +903,21 @@ func resourceOrchestratedVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData,
 
 				if d.HasChange("os_profile.0.windows_configuration.0.provision_vm_agent") {
 					if isHotpatchEnabledImage && !provisionVMAgent {
-						return fmt.Errorf("when referencing a hotpatching enabled image the 'provision_vm_agent' field must always be set to 'true', got %q", strconv.FormatBool(provisionVMAgent))
+						return fmt.Errorf("when using a hotpatching enabled image, 'provision_vm_agent' must be set to 'true', got %q", strconv.FormatBool(provisionVMAgent))
 					}
 					windowsConfig.ProvisionVMAgent = pointer.To(provisionVMAgent)
 				}
 
 				if d.HasChange("os_profile.0.windows_configuration.0.patch_assessment_mode") {
 					if !provisionVMAgent && (patchAssessmentMode == string(virtualmachinescalesets.WindowsPatchAssessmentModeAutomaticByPlatform)) {
-						return fmt.Errorf("when the 'patch_assessment_mode' field is set to %q the 'provision_vm_agent' must always be set to 'true'", virtualmachinescalesets.WindowsPatchAssessmentModeAutomaticByPlatform)
+						return fmt.Errorf("when 'patch_assessment_mode' is set to %q, 'provision_vm_agent' must be set to 'true'", virtualmachinescalesets.WindowsPatchAssessmentModeAutomaticByPlatform)
 					}
 					windowsConfig.PatchSettings.AssessmentMode = pointer.To(virtualmachinescalesets.WindowsPatchAssessmentMode(patchAssessmentMode))
 				}
 
 				if d.HasChange("os_profile.0.windows_configuration.0.patch_mode") {
 					if isHotpatchEnabledImage && (patchMode != string(virtualmachinescalesets.WindowsVMGuestPatchModeAutomaticByPlatform)) {
-						return fmt.Errorf("when referencing a hotpatching enabled image the 'patch_mode' field must always be set to %q, got %q", virtualmachinescalesets.WindowsVMGuestPatchModeAutomaticByPlatform, patchMode)
+						return fmt.Errorf("when using a hotpatching enabled image, 'patch_mode' must be set to %q, got %q", virtualmachinescalesets.WindowsVMGuestPatchModeAutomaticByPlatform, patchMode)
 					}
 					windowsConfig.PatchSettings.PatchMode = pointer.To(virtualmachinescalesets.WindowsVMGuestPatchMode(patchMode))
 				}
@@ -927,7 +927,7 @@ func resourceOrchestratedVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData,
 				// support hotpatching to always be enabled and cannot be set to false, ever.
 				if d.HasChange("os_profile.0.windows_configuration.0.hotpatching_enabled") {
 					if isHotpatchEnabledImage && !hotpatchingEnabled {
-						return fmt.Errorf("when referencing a hotpatching enabled image the 'hotpatching_enabled' field must always be set to 'true', got %q", strconv.FormatBool(hotpatchingEnabled))
+						return fmt.Errorf("when using a hotpatching enabled image, 'hotpatching_enabled' must be set to 'true', got %q", strconv.FormatBool(hotpatchingEnabled))
 					}
 					windowsConfig.PatchSettings.EnableHotpatching = pointer.To(hotpatchingEnabled)
 				}
@@ -1112,7 +1112,7 @@ func resourceOrchestratedVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData,
 				}
 
 				if !hasHealthExtension {
-					return fmt.Errorf("`automatic_instance_repair` can only be set if there is an application Health extension defined")
+					return fmt.Errorf("'automatic_instance_repair' can only be enabled when an application health extension is configured")
 				}
 			}
 			updateProps.AutomaticRepairsPolicy = automaticRepairsPolicy
@@ -1169,11 +1169,11 @@ func resourceOrchestratedVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData,
 			}
 
 			if isHotpatchEnabledImage && !hasHealthExtension {
-				return fmt.Errorf("when referencing a hotpatching enabled image the 'extension' field must always contain a 'application health extension'")
+				return fmt.Errorf("when using a hotpatching enabled image, an application health extension must be configured")
 			}
 
 			if linuxAutomaticVMGuestPatchingEnabled && !hasHealthExtension {
-				return fmt.Errorf("when the 'patch_mode' field is set to %q the 'extension' field must contain at least one 'application health extension', got 0", virtualmachinescalesets.LinuxPatchAssessmentModeAutomaticByPlatform)
+				return fmt.Errorf("when 'patch_mode' is set to %q, at least one application health extension must be configured, got 0", virtualmachinescalesets.LinuxPatchAssessmentModeAutomaticByPlatform)
 			}
 
 			updateProps.VirtualMachineProfile.ExtensionProfile = extensionProfile

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
@@ -615,7 +615,7 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 			}
 
 			if extensionOperationsEnabled && !provisionVMAgent {
-				return fmt.Errorf("`extension_operations_enabled` cannot be set to true when `provision_vm_agent` is set to `false`")
+				return fmt.Errorf("`extension_operations_enabled` cannot be set to `true` when `provision_vm_agent` is set to `false`")
 			}
 
 			if patchAssessmentMode == string(virtualmachinescalesets.LinuxPatchAssessmentModeAutomaticByPlatform) && !provisionVMAgent {
@@ -1312,7 +1312,7 @@ func resourceOrchestratedVirtualMachineScaleSetRead(d *pluginsdk.ResourceData, m
 
 		if props := model.Properties; props != nil {
 			if err := d.Set("additional_capabilities", FlattenOrchestratedVirtualMachineScaleSetAdditionalCapabilities(props.AdditionalCapabilities)); err != nil {
-				return fmt.Errorf("setting `additional_capabilities`: %w", props.AdditionalCapabilities)
+				return fmt.Errorf("setting `additional_capabilities`: %+v", props.AdditionalCapabilities)
 			}
 
 			if err := d.Set("automatic_instance_repair", FlattenVirtualMachineScaleSetAutomaticRepairsPolicy(props.AutomaticRepairsPolicy)); err != nil {

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
@@ -340,11 +340,11 @@ func resourceOrchestratedVirtualMachineScaleSet() *pluginsdk.Resource {
 
 				if hasSkuProfile {
 					if !hasSkuName || skuName != SkuNameMix {
-						return fmt.Errorf("'sku_profile' can only be configured when 'sku_name' is set to 'Mix'")
+						return fmt.Errorf("`sku_profile` can only be configured when `sku_name` is set to `Mix`")
 					}
 				} else {
 					if hasSkuName && skuName == SkuNameMix {
-						return fmt.Errorf("'sku_profile' must be configured when 'sku_name' is set to 'Mix'")
+						return fmt.Errorf("`sku_profile` must be configured when `sku_name` is set to `Mix`")
 					}
 				}
 
@@ -352,11 +352,11 @@ func resourceOrchestratedVirtualMachineScaleSet() *pluginsdk.Resource {
 				rollingUpgradePolicyRaw := diff.Get("rolling_upgrade_policy").([]interface{})
 
 				if upgradeMode == virtualmachinescalesets.UpgradeModeManual && len(rollingUpgradePolicyRaw) > 0 {
-					return fmt.Errorf("'rolling_upgrade_policy' cannot be specified when 'upgrade_mode' is set to %q", string(upgradeMode))
+					return fmt.Errorf("`rolling_upgrade_policy` cannot be specified when `upgrade_mode` is set to `%s`", string(upgradeMode))
 				}
 
 				if upgradeMode == virtualmachinescalesets.UpgradeModeRolling && len(rollingUpgradePolicyRaw) == 0 {
-					return fmt.Errorf("'rolling_upgrade_policy' is required when 'upgrade_mode' is set to %q", string(upgradeMode))
+					return fmt.Errorf("`rolling_upgrade_policy` is required when `upgrade_mode` is set to `%s`", string(upgradeMode))
 				}
 
 				return nil
@@ -379,7 +379,7 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 		existing, err := client.Get(ctx, id, virtualmachinescalesets.DefaultGetOperationOptions())
 		if err != nil {
 			if !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for existing %s: %+v", id, err)
+				return fmt.Errorf("checking for existing %s: %w", id, err)
 			}
 		}
 
@@ -418,7 +418,7 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 	upgradeMode := virtualmachinescalesets.UpgradeMode(d.Get("upgrade_mode").(string))
 	rollingUpgradePolicy, err := ExpandVirtualMachineScaleSetRollingUpgradePolicy(d.Get("rolling_upgrade_policy").([]interface{}), len(zones) > 0, false)
 	if err != nil {
-		return fmt.Errorf("expanding `rolling_upgrade_policy`: %+v", err)
+		return fmt.Errorf("expanding `rolling_upgrade_policy`: %w", err)
 	}
 
 	props.Properties.UpgradePolicy = &virtualmachinescalesets.UpgradePolicy{
@@ -450,7 +450,7 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 		isLegacy = false
 		sku, err := expandOrchestratedVirtualMachineScaleSetSku(v.(string), instances)
 		if err != nil {
-			return fmt.Errorf("expanding 'sku_name': %+v", err)
+			return fmt.Errorf("expanding `sku_name`: %w", err)
 		}
 		props.Sku = sku
 	}
@@ -461,7 +461,7 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 
 	if v, ok := d.GetOk("capacity_reservation_group_id"); ok {
 		if d.Get("single_placement_group").(bool) {
-			return fmt.Errorf("'single_placement_group' must be set to 'false' when 'capacity_reservation_group_id' is specified")
+			return fmt.Errorf("`single_placement_group` must be set to `false` when `capacity_reservation_group_id` is specified")
 		}
 
 		virtualMachineProfile.CapacityReservation = &virtualmachinescalesets.CapacityReservationProfile{
@@ -489,7 +489,7 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 
 	// Virtual Machine Scale Set with Flexible Orchestration Mode and 'Rolling' upgradeMode must have Health Extension Present
 	if upgradeMode == virtualmachinescalesets.UpgradeModeRolling && !hasHealthExtension {
-		return fmt.Errorf("a health extension is required when 'upgrade_mode' is set to %q", string(upgradeMode))
+		return fmt.Errorf("health extension is required when `upgrade_mode` is set to `%s`", string(upgradeMode))
 	}
 
 	if v, ok := d.GetOk("extensions_time_budget"); ok {
@@ -539,17 +539,17 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 				// validate that the computer name is a valid Computer Prefix Name
 				_, errs := computeValidate.WindowsComputerNamePrefix(id.VirtualMachineScaleSetName, "computer_name_prefix")
 				if len(errs) > 0 {
-					return fmt.Errorf("unable to assume default computer name prefix %s. Please adjust the 'name', or specify an explicit 'computer_name_prefix'", errs[0])
+					return fmt.Errorf("unable to assume default computer name prefix %s. Please adjust the `name`, or specify an explicit `computer_name_prefix`", errs[0])
 				}
 				vmssOsProfile.ComputerNamePrefix = pointer.To(id.VirtualMachineScaleSetName)
 			}
 
 			if extensionOperationsEnabled && !provisionVMAgent {
-				return fmt.Errorf("'extension_operations_enabled' cannot be set to 'true' when 'provision_vm_agent' is set to 'false'")
+				return fmt.Errorf("`extension_operations_enabled` cannot be set to `true` when `provision_vm_agent` is set to `false`")
 			}
 
 			if patchAssessmentMode == string(virtualmachinescalesets.WindowsPatchAssessmentModeAutomaticByPlatform) && !provisionVMAgent {
-				return fmt.Errorf("when 'patch_assessment_mode' is set to %q, 'provision_vm_agent' must be set to 'true'", virtualmachinescalesets.WindowsPatchAssessmentModeAutomaticByPlatform)
+				return fmt.Errorf("when `patch_assessment_mode` is set to `%s`, `provision_vm_agent` must be set to `true`", virtualmachinescalesets.WindowsPatchAssessmentModeAutomaticByPlatform)
 			}
 
 			// Validate patch mode and hotpatching configuration
@@ -560,11 +560,11 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 			if isHotpatchEnabledImage {
 				// it is a hotpatching enabled image, validate hotpatching enabled settings
 				if patchMode != string(virtualmachinescalesets.WindowsVMGuestPatchModeAutomaticByPlatform) {
-					return fmt.Errorf("when using a hotpatching enabled image, 'patch_mode' must be set to %q", virtualmachinescalesets.WindowsVMGuestPatchModeAutomaticByPlatform)
+					return fmt.Errorf("when using a hotpatching enabled image, `patch_mode` must be set to `%s`", virtualmachinescalesets.WindowsVMGuestPatchModeAutomaticByPlatform)
 				}
 
 				if !provisionVMAgent {
-					return fmt.Errorf("when using a hotpatching enabled image, 'provision_vm_agent' must be set to 'true'")
+					return fmt.Errorf("when using a hotpatching enabled image, `provision_vm_agent` must be set to `true`")
 				}
 
 				if !hasHealthExtension {
@@ -572,22 +572,22 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 				}
 
 				if !hotpatchingEnabled {
-					return fmt.Errorf("when using a hotpatching enabled image, 'hotpatching_enabled' must be set to 'true'")
+					return fmt.Errorf("when using a hotpatching enabled image, `hotpatching_enabled` must be set to `true`")
 				}
 			} else {
 				// not a hotpatching enabled image verify Automatic VM Guest Patching settings
 				if patchMode == string(virtualmachinescalesets.WindowsVMGuestPatchModeAutomaticByPlatform) {
 					if !provisionVMAgent {
-						return fmt.Errorf("when 'patch_mode' is set to %q, 'provision_vm_agent' must be set to 'true'", patchMode)
+						return fmt.Errorf("when `patch_mode` is set to `%s`, `provision_vm_agent` must be set to `true`", patchMode)
 					}
 
 					if !hasHealthExtension {
-						return fmt.Errorf("when 'patch_mode' is set to %q, an application health extension must be configured", patchMode)
+						return fmt.Errorf("when `patch_mode` is set to `%s`, an application health extension must be configured", patchMode)
 					}
 				}
 
 				if hotpatchingEnabled {
-					return fmt.Errorf("'hotpatching_enabled' can only be used with supported Windows Server images: '2022-datacenter-azure-edition', '2022-datacenter-azure-edition-core-smalldisk', '2022-datacenter-azure-edition-hotpatch', '2022-datacenter-azure-edition-hotpatch-smalldisk', '2025-datacenter-azure-edition', '2025-datacenter-azure-edition-smalldisk', '2025-datacenter-azure-edition-core', or '2025-datacenter-azure-edition-core-smalldisk'")
+					return fmt.Errorf("`hotpatching_enabled` can only be used with supported Windows Server images: '2022-datacenter-azure-edition', '2022-datacenter-azure-edition-core-smalldisk', '2022-datacenter-azure-edition-hotpatch', '2022-datacenter-azure-edition-hotpatch-smalldisk', '2025-datacenter-azure-edition', '2025-datacenter-azure-edition-smalldisk', '2025-datacenter-azure-edition-core', or '2025-datacenter-azure-edition-core-smalldisk'")
 				}
 			}
 		}
@@ -604,18 +604,22 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 				// validate that the computer name is a valid Computer Prefix Name
 				_, errs := computeValidate.LinuxComputerNamePrefix(id.VirtualMachineScaleSetName, "computer_name_prefix")
 				if len(errs) > 0 {
-					return fmt.Errorf("unable to assume default computer name prefix %s. Please adjust the 'name', or specify an explicit 'computer_name_prefix'", errs[0])
+					if errs[0] != nil {
+						return fmt.Errorf("unable to assume default computer name prefix `%s`. Please adjust the `name`, or specify an explicit `computer_name_prefix`", errs[0])
+					}
+
+					return fmt.Errorf("unable to assume default computer name prefix. Please adjust the `name`, or specify an explicit `computer_name_prefix`")
 				}
 
 				vmssOsProfile.ComputerNamePrefix = pointer.To(id.VirtualMachineScaleSetName)
 			}
 
 			if extensionOperationsEnabled && !provisionVMAgent {
-				return fmt.Errorf("'extension_operations_enabled' cannot be set to true when 'provision_vm_agent' is set to false")
+				return fmt.Errorf("`extension_operations_enabled` cannot be set to true when `provision_vm_agent` is set to `false`")
 			}
 
 			if patchAssessmentMode == string(virtualmachinescalesets.LinuxPatchAssessmentModeAutomaticByPlatform) && !provisionVMAgent {
-				return fmt.Errorf("when 'patch_assessment_mode' is set to %q, 'provision_vm_agent' must be set to 'true'", virtualmachinescalesets.LinuxPatchAssessmentModeAutomaticByPlatform)
+				return fmt.Errorf("when `patch_assessment_mode` is set to `%s`, `provision_vm_agent` must be set to `true`", virtualmachinescalesets.LinuxPatchAssessmentModeAutomaticByPlatform)
 			}
 
 			// Validate Automatic VM Guest Patching Settings
@@ -623,11 +627,11 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 
 			if patchMode == string(virtualmachinescalesets.LinuxVMGuestPatchModeAutomaticByPlatform) {
 				if !provisionVMAgent {
-					return fmt.Errorf("when 'patch_mode' is set to %q, 'provision_vm_agent' must be set to 'true', got %q", patchMode, strconv.FormatBool(provisionVMAgent))
+					return fmt.Errorf("when `patch_mode` is set to `%s`, `provision_vm_agent` must be set to `true`, got `%s`", patchMode, strconv.FormatBool(provisionVMAgent))
 				}
 
 				if !hasHealthExtension {
-					return fmt.Errorf("when 'patch_mode' is set to %q, at least one application health extension must be configured, got 0", patchMode)
+					return fmt.Errorf("when `patch_mode` is set to `%s`, at least one application health extension must be configured, got 0", patchMode)
 				}
 			}
 		}
@@ -660,7 +664,7 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 		ultraSSDEnabled := d.Get("additional_capabilities.0.ultra_ssd_enabled").(bool)
 		dataDisks, err := ExpandOrchestratedVirtualMachineScaleSetDataDisk(v.([]interface{}), ultraSSDEnabled)
 		if err != nil {
-			return fmt.Errorf("expanding `data_disk`: %+v", err)
+			return fmt.Errorf("expanding `data_disk`: %w", err)
 		}
 		virtualMachineProfile.StorageProfile.DataDisks = dataDisks
 	}
@@ -668,7 +672,7 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 	if v, ok := d.GetOk("network_interface"); ok {
 		networkInterfaces, err := ExpandOrchestratedVirtualMachineScaleSetNetworkInterface(v.([]interface{}))
 		if err != nil {
-			return fmt.Errorf("expanding `network_interface`: %+v", err)
+			return fmt.Errorf("expanding `network_interface`: %w", err)
 		}
 
 		networkProfile.NetworkInterfaceConfigurations = networkInterfaces
@@ -677,7 +681,7 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 
 	if v, ok := d.Get("max_bid_price").(float64); ok && v > 0 {
 		if *virtualMachineProfile.Priority != virtualmachinescalesets.VirtualMachinePriorityTypesSpot {
-			return fmt.Errorf("'max_bid_price' can only be configured when 'priority' is set to %q", string(virtualmachinescalesets.VirtualMachinePriorityTypesSpot))
+			return fmt.Errorf("`max_bid_price` can only be configured when `priority` is set to `%s`", string(virtualmachinescalesets.VirtualMachinePriorityTypesSpot))
 		}
 
 		virtualMachineProfile.BillingProfile = &virtualmachinescalesets.BillingProfile{
@@ -693,11 +697,11 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 
 	if v, ok := d.GetOk("eviction_policy"); ok {
 		if *virtualMachineProfile.Priority != virtualmachinescalesets.VirtualMachinePriorityTypesSpot {
-			return fmt.Errorf("'eviction_policy' can only be specified when 'priority' is set to %q", string(virtualmachinescalesets.VirtualMachinePriorityTypesSpot))
+			return fmt.Errorf("`eviction_policy` can only be specified when `priority` is set to `%s`", string(virtualmachinescalesets.VirtualMachinePriorityTypesSpot))
 		}
 		virtualMachineProfile.EvictionPolicy = pointer.To(virtualmachinescalesets.VirtualMachineEvictionPolicyTypes(v.(string)))
 	} else if *virtualMachineProfile.Priority == virtualmachinescalesets.VirtualMachinePriorityTypesSpot {
-		return fmt.Errorf("'eviction_policy' is required when 'priority' is set to %q", string(virtualmachinescalesets.VirtualMachinePriorityTypesSpot))
+		return fmt.Errorf("`eviction_policy` is required when `priority` is set to `%s`", string(virtualmachinescalesets.VirtualMachinePriorityTypesSpot))
 	}
 
 	if v, ok := d.GetOk("license_type"); ok {
@@ -717,14 +721,14 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 		if v, ok := d.GetOk("identity"); ok {
 			identityExpanded, err := identity.ExpandSystemAndUserAssignedMap(v.([]interface{}))
 			if err != nil {
-				return fmt.Errorf("expanding `identity`: %+v", err)
+				return fmt.Errorf("expanding `identity`: %w", err)
 			}
 			props.Identity = identityExpanded
 		}
 
 		if v, ok := d.GetOk("automatic_instance_repair"); ok {
 			if !hasHealthExtension {
-				return fmt.Errorf("'automatic_instance_repair' can only be enabled when an application health extension is configured")
+				return fmt.Errorf("`automatic_instance_repair` can only be enabled when an application health extension is configured")
 			}
 
 			props.Properties.AutomaticRepairsPolicy = ExpandVirtualMachineScaleSetAutomaticRepairsPolicy(v.([]interface{}))
@@ -732,7 +736,7 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 
 		if v, ok := d.GetOk("zone_balance"); ok && v.(bool) {
 			if props.Zones == nil || len(*props.Zones) == 0 {
-				return fmt.Errorf("'zone_balance' can only be set to 'true' when availability zones are specified")
+				return fmt.Errorf("`zone_balance` can only be set to `true` when availability zones are specified")
 			}
 
 			props.Properties.ZoneBalance = pointer.To(v.(bool))
@@ -740,7 +744,7 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 
 		if v, ok := d.GetOk("priority_mix"); ok {
 			if *virtualMachineProfile.Priority != virtualmachinescalesets.VirtualMachinePriorityTypesSpot {
-				return fmt.Errorf("'priority_mix' can only be specified when 'priority' is set to %q", string(virtualmachinescalesets.VirtualMachinePriorityTypesSpot))
+				return fmt.Errorf("`priority_mix` can only be specified when `priority` is set to `%s`", string(virtualmachinescalesets.VirtualMachinePriorityTypesSpot))
 			}
 			props.Properties.PriorityMixPolicy = ExpandOrchestratedVirtualMachineScaleSetPriorityMixPolicy(v.([]interface{}))
 		}
@@ -750,7 +754,7 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 
 	log.Printf("[DEBUG] Creating Orchestrated %s.", id)
 	if err := client.CreateOrUpdateThenPoll(ctx, id, props, virtualmachinescalesets.DefaultCreateOrUpdateOperationOptions()); err != nil {
-		return fmt.Errorf("creating Orchestrated %s: %+v", id, err)
+		return fmt.Errorf("creating Orchestrated %s: %w", id, err)
 	}
 
 	log.Printf("[DEBUG] Orchestrated %s was created", id)
@@ -780,7 +784,7 @@ func resourceOrchestratedVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData,
 	options.Expand = pointer.To(virtualmachinescalesets.ExpandTypesForGetVMScaleSetsUserData)
 	existing, err := client.Get(ctx, *id, options)
 	if err != nil {
-		return fmt.Errorf("retrieving Orchestrated %s: %+v", id, err)
+		return fmt.Errorf("retrieving Orchestrated %s: %w", id, err)
 	}
 	if existing.Model == nil {
 		return fmt.Errorf("retrieving Orchestrated %s: `model` was nil", id)
@@ -794,10 +798,10 @@ func resourceOrchestratedVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData,
 
 	if !isLegacy {
 		if existing.Model.Properties.VirtualMachineProfile == nil {
-			return fmt.Errorf("retrieving Orchestrated %s: `properties.virtualMachineProfile` was nil", id)
+			return fmt.Errorf("retrieving Orchestrated %s: `Properties.VirtualMachineProfile` was nil", id)
 		}
 		if existing.Model.Properties.VirtualMachineProfile.StorageProfile == nil {
-			return fmt.Errorf("retrieving Orchestrated %s: `properties.virtualMachineProfile,storageProfile` was nil", id)
+			return fmt.Errorf("retrieving Orchestrated %s: `Properties.VirtualMachineProfile.StorageProfile` was nil", id)
 		}
 	}
 
@@ -830,7 +834,7 @@ func resourceOrchestratedVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData,
 			if !pluginsdk.IsExplicitlyNullInConfig(d, "single_placement_group") {
 				singlePlacementGroup := d.Get("single_placement_group").(bool)
 				if singlePlacementGroup {
-					return fmt.Errorf("'single_placement_group' cannot be changed from 'false' to 'true'")
+					return fmt.Errorf("`single_placement_group` cannot be changed from `false` to `true`")
 				}
 				updateProps.SinglePlacementGroup = pointer.To(singlePlacementGroup)
 			}
@@ -843,7 +847,7 @@ func resourceOrchestratedVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData,
 
 		if d.HasChange("max_bid_price") {
 			if priority != virtualmachinescalesets.VirtualMachinePriorityTypesSpot {
-				return fmt.Errorf("'max_bid_price' can only be configured when 'priority' is set to %q", string(virtualmachinescalesets.VirtualMachinePriorityTypesSpot))
+				return fmt.Errorf("`max_bid_price` can only be configured when `priority` is set to `%s`", string(virtualmachinescalesets.VirtualMachinePriorityTypesSpot))
 			}
 
 			updateProps.VirtualMachineProfile.BillingProfile = &virtualmachinescalesets.BillingProfile{
@@ -903,21 +907,21 @@ func resourceOrchestratedVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData,
 
 				if d.HasChange("os_profile.0.windows_configuration.0.provision_vm_agent") {
 					if isHotpatchEnabledImage && !provisionVMAgent {
-						return fmt.Errorf("when using a hotpatching enabled image, 'provision_vm_agent' must be set to 'true', got %q", strconv.FormatBool(provisionVMAgent))
+						return fmt.Errorf("when using a hotpatching enabled image, `provision_vm_agent` must be set to `true`, got `%s`", strconv.FormatBool(provisionVMAgent))
 					}
 					windowsConfig.ProvisionVMAgent = pointer.To(provisionVMAgent)
 				}
 
 				if d.HasChange("os_profile.0.windows_configuration.0.patch_assessment_mode") {
 					if !provisionVMAgent && (patchAssessmentMode == string(virtualmachinescalesets.WindowsPatchAssessmentModeAutomaticByPlatform)) {
-						return fmt.Errorf("when 'patch_assessment_mode' is set to %q, 'provision_vm_agent' must be set to 'true'", virtualmachinescalesets.WindowsPatchAssessmentModeAutomaticByPlatform)
+						return fmt.Errorf("when `patch_assessment_mode` is set to `%s`, `provision_vm_agent` must be set to `true`", virtualmachinescalesets.WindowsPatchAssessmentModeAutomaticByPlatform)
 					}
 					windowsConfig.PatchSettings.AssessmentMode = pointer.To(virtualmachinescalesets.WindowsPatchAssessmentMode(patchAssessmentMode))
 				}
 
 				if d.HasChange("os_profile.0.windows_configuration.0.patch_mode") {
 					if isHotpatchEnabledImage && (patchMode != string(virtualmachinescalesets.WindowsVMGuestPatchModeAutomaticByPlatform)) {
-						return fmt.Errorf("when using a hotpatching enabled image, 'patch_mode' must be set to %q, got %q", virtualmachinescalesets.WindowsVMGuestPatchModeAutomaticByPlatform, patchMode)
+						return fmt.Errorf("when using a hotpatching enabled image, `patch_mode` must be set to `%s`, got `%s`", virtualmachinescalesets.WindowsVMGuestPatchModeAutomaticByPlatform, patchMode)
 					}
 					windowsConfig.PatchSettings.PatchMode = pointer.To(virtualmachinescalesets.WindowsVMGuestPatchMode(patchMode))
 				}
@@ -927,7 +931,7 @@ func resourceOrchestratedVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData,
 				// support hotpatching to always be enabled and cannot be set to false, ever.
 				if d.HasChange("os_profile.0.windows_configuration.0.hotpatching_enabled") {
 					if isHotpatchEnabledImage && !hotpatchingEnabled {
-						return fmt.Errorf("when using a hotpatching enabled image, 'hotpatching_enabled' must be set to 'true', got %q", strconv.FormatBool(hotpatchingEnabled))
+						return fmt.Errorf("when using a hotpatching enabled image, `hotpatching_enabled` must be set to `true`, got `%s`", strconv.FormatBool(hotpatchingEnabled))
 					}
 					windowsConfig.PatchSettings.EnableHotpatching = pointer.To(hotpatchingEnabled)
 				}
@@ -979,7 +983,7 @@ func resourceOrchestratedVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData,
 
 				if d.HasChange("os_profile.0.linux_configuration.0.patch_assessment_mode") {
 					if !provisionVMAgent && (patchAssessmentMode == string(virtualmachinescalesets.LinuxPatchAssessmentModeAutomaticByPlatform)) {
-						return fmt.Errorf("when the 'patch_assessment_mode' field is set to %q the 'provision_vm_agent' must always be set to 'true'", virtualmachinescalesets.LinuxPatchAssessmentModeAutomaticByPlatform)
+						return fmt.Errorf("when the `patch_assessment_mode` field is set to `%s` the `provision_vm_agent` must always be set to `true`", virtualmachinescalesets.LinuxPatchAssessmentModeAutomaticByPlatform)
 					}
 
 					if linuxConfig.PatchSettings == nil {
@@ -991,7 +995,7 @@ func resourceOrchestratedVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData,
 				if d.HasChange("os_profile.0.linux_configuration.0.patch_mode") {
 					if patchMode == string(virtualmachinescalesets.LinuxPatchAssessmentModeAutomaticByPlatform) {
 						if !provisionVMAgent {
-							return fmt.Errorf("when the 'patch_mode' field is set to %q the 'provision_vm_agent' field must always be set to 'true', got %q", patchMode, strconv.FormatBool(provisionVMAgent))
+							return fmt.Errorf("when the `patch_mode` field is set to `%s` the `provision_vm_agent` field must always be set to `true`, got `%s`", patchMode, strconv.FormatBool(provisionVMAgent))
 						}
 
 						linuxAutomaticVMGuestPatchingEnabled = true
@@ -1020,7 +1024,7 @@ func resourceOrchestratedVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData,
 				ultraSSDEnabled := false // Currently not supported in orchestrated vmss
 				dataDisks, err := ExpandOrchestratedVirtualMachineScaleSetDataDisk(d.Get("data_disk").([]interface{}), ultraSSDEnabled)
 				if err != nil {
-					return fmt.Errorf("expanding `data_disk`: %+v", err)
+					return fmt.Errorf("expanding `data_disk`: %w", err)
 				}
 				updateProps.VirtualMachineProfile.StorageProfile.DataDisks = dataDisks
 			}
@@ -1056,7 +1060,7 @@ func resourceOrchestratedVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData,
 			networkInterfacesRaw := d.Get("network_interface").([]interface{})
 			networkInterfaces, err := ExpandOrchestratedVirtualMachineScaleSetNetworkInterfaceUpdate(networkInterfacesRaw)
 			if err != nil {
-				return fmt.Errorf("expanding `network_interface`: %+v", err)
+				return fmt.Errorf("expanding `network_interface`: %w", err)
 			}
 
 			updateProps.VirtualMachineProfile.NetworkProfile = &virtualmachinescalesets.VirtualMachineScaleSetUpdateNetworkProfile{
@@ -1112,7 +1116,7 @@ func resourceOrchestratedVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData,
 				}
 
 				if !hasHealthExtension {
-					return fmt.Errorf("'automatic_instance_repair' can only be enabled when an application health extension is configured")
+					return fmt.Errorf("`automatic_instance_repair` can only be enabled when an application health extension is configured")
 				}
 			}
 			updateProps.AutomaticRepairsPolicy = automaticRepairsPolicy
@@ -1121,7 +1125,7 @@ func resourceOrchestratedVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData,
 		if d.HasChange("identity") {
 			identityExpanded, err := identity.ExpandSystemAndUserAssignedMap(d.Get("identity").([]interface{}))
 			if err != nil {
-				return fmt.Errorf("expanding `identity`: %+v", err)
+				return fmt.Errorf("expanding `identity`: %w", err)
 			}
 
 			update.Identity = identityExpanded
@@ -1173,7 +1177,7 @@ func resourceOrchestratedVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData,
 			}
 
 			if linuxAutomaticVMGuestPatchingEnabled && !hasHealthExtension {
-				return fmt.Errorf("when 'patch_mode' is set to %q, at least one application health extension must be configured, got 0", virtualmachinescalesets.LinuxPatchAssessmentModeAutomaticByPlatform)
+				return fmt.Errorf("when `patch_mode` is set to `%s`, at least one application health extension must be configured, got 0", virtualmachinescalesets.LinuxPatchAssessmentModeAutomaticByPlatform)
 			}
 
 			updateProps.VirtualMachineProfile.ExtensionProfile = extensionProfile
@@ -1197,7 +1201,7 @@ func resourceOrchestratedVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData,
 		rollingRaw := d.Get("rolling_upgrade_policy").([]interface{})
 		rollingUpgradePolicy, err := ExpandVirtualMachineScaleSetRollingUpgradePolicy(rollingRaw, len(zones.ExpandUntyped(d.Get("zones").(*schema.Set).List())) > 0, false)
 		if err != nil {
-			return fmt.Errorf("expanding `rolling_upgrade_policy`: %+v", err)
+			return fmt.Errorf("expanding `rolling_upgrade_policy`: %w", err)
 		}
 
 		upgradePolicy.RollingUpgradePolicy = rollingUpgradePolicy
@@ -1268,7 +1272,7 @@ func resourceOrchestratedVirtualMachineScaleSetRead(d *pluginsdk.ResourceData, m
 			return nil
 		}
 
-		return fmt.Errorf("retrieving Orchestrated %s: %+v", id, err)
+		return fmt.Errorf("retrieving Orchestrated %s: %w", id, err)
 	}
 
 	d.Set("name", id.VirtualMachineScaleSetName)
@@ -1283,7 +1287,7 @@ func resourceOrchestratedVirtualMachineScaleSetRead(d *pluginsdk.ResourceData, m
 		if model.Sku != nil {
 			skuName, err = flattenOrchestratedVirtualMachineScaleSetSku(model.Sku)
 			if err != nil || skuName == nil {
-				return fmt.Errorf("setting `sku_name`: %+v", err)
+				return fmt.Errorf("setting `sku_name`: %w", err)
 			}
 
 			if resp.Model.Sku.Capacity != nil {
@@ -1296,23 +1300,23 @@ func resourceOrchestratedVirtualMachineScaleSetRead(d *pluginsdk.ResourceData, m
 
 		identityFlattened, err := flattenOrchestratedVirtualMachineScaleSetIdentity(model.Identity)
 		if err != nil {
-			return fmt.Errorf("flattening `identity`: %+v", err)
+			return fmt.Errorf("flattening `identity`: %w", err)
 		}
 		if err := d.Set("identity", identityFlattened); err != nil {
-			return fmt.Errorf("setting `identity`: %+v", err)
+			return fmt.Errorf("setting `identity`: %w", err)
 		}
 
 		if err := d.Set("plan", flattenPlanVMSS(model.Plan)); err != nil {
-			return fmt.Errorf("setting `plan`: %+v", err)
+			return fmt.Errorf("setting `plan`: %w", err)
 		}
 
 		if props := model.Properties; props != nil {
 			if err := d.Set("additional_capabilities", FlattenOrchestratedVirtualMachineScaleSetAdditionalCapabilities(props.AdditionalCapabilities)); err != nil {
-				return fmt.Errorf("setting `additional_capabilities`: %+v", props.AdditionalCapabilities)
+				return fmt.Errorf("setting `additional_capabilities`: %w", props.AdditionalCapabilities)
 			}
 
 			if err := d.Set("automatic_instance_repair", FlattenVirtualMachineScaleSetAutomaticRepairsPolicy(props.AutomaticRepairsPolicy)); err != nil {
-				return fmt.Errorf("setting `automatic_instance_repair`: %+v", err)
+				return fmt.Errorf("setting `automatic_instance_repair`: %w", err)
 			}
 
 			d.Set("platform_fault_domain_count", props.PlatformFaultDomainCount)
@@ -1328,7 +1332,7 @@ func resourceOrchestratedVirtualMachineScaleSetRead(d *pluginsdk.ResourceData, m
 			}
 
 			if err := d.Set("sku_profile", flattenOrchestratedVirtualMachineScaleSetSkuProfile(props.SkuProfile)); err != nil {
-				return fmt.Errorf("setting `sku_profile`: %+v", err)
+				return fmt.Errorf("setting `sku_profile`: %w", err)
 			}
 
 			d.Set("unique_id", props.UniqueId)
@@ -1339,7 +1343,7 @@ func resourceOrchestratedVirtualMachineScaleSetRead(d *pluginsdk.ResourceData, m
 			upgradeMode := string(virtualmachinescalesets.UpgradeModeManual)
 			if profile := props.VirtualMachineProfile; profile != nil {
 				if err := d.Set("boot_diagnostics", flattenBootDiagnosticsVMSS(profile.DiagnosticsProfile)); err != nil {
-					return fmt.Errorf("setting `boot_diagnostics`: %+v", err)
+					return fmt.Errorf("setting `boot_diagnostics`: %w", err)
 				}
 
 				capacityReservationGroupId := ""
@@ -1368,11 +1372,11 @@ func resourceOrchestratedVirtualMachineScaleSetRead(d *pluginsdk.ResourceData, m
 
 				if storageProfile := profile.StorageProfile; storageProfile != nil {
 					if err := d.Set("os_disk", FlattenOrchestratedVirtualMachineScaleSetOSDisk(storageProfile.OsDisk)); err != nil {
-						return fmt.Errorf("setting `os_disk`: %+v", err)
+						return fmt.Errorf("setting `os_disk`: %w", err)
 					}
 
 					if err := d.Set("data_disk", FlattenOrchestratedVirtualMachineScaleSetDataDisk(storageProfile.DataDisks)); err != nil {
-						return fmt.Errorf("setting `data_disk`: %+v", err)
+						return fmt.Errorf("setting `data_disk`: %w", err)
 					}
 
 					var storageImageId string
@@ -1388,13 +1392,13 @@ func resourceOrchestratedVirtualMachineScaleSetRead(d *pluginsdk.ResourceData, m
 					d.Set("source_image_id", storageImageId)
 
 					if err := d.Set("source_image_reference", flattenSourceImageReferenceVMSS(storageProfile.ImageReference, storageImageId != "")); err != nil {
-						return fmt.Errorf("setting `source_image_reference`: %+v", err)
+						return fmt.Errorf("setting `source_image_reference`: %w", err)
 					}
 				}
 
 				if osProfile := profile.OsProfile; osProfile != nil {
 					if err := d.Set("os_profile", FlattenOrchestratedVirtualMachineScaleSetOSProfile(osProfile, d)); err != nil {
-						return fmt.Errorf("setting `os_profile`: %+v", err)
+						return fmt.Errorf("setting `os_profile`: %w", err)
 					}
 
 					if osProfile.AllowExtensionOperations != nil {
@@ -1405,19 +1409,19 @@ func resourceOrchestratedVirtualMachineScaleSetRead(d *pluginsdk.ResourceData, m
 				if nwProfile := profile.NetworkProfile; nwProfile != nil {
 					flattenedNics := FlattenOrchestratedVirtualMachineScaleSetNetworkInterface(nwProfile.NetworkInterfaceConfigurations)
 					if err := d.Set("network_interface", flattenedNics); err != nil {
-						return fmt.Errorf("setting `network_interface`: %+v", err)
+						return fmt.Errorf("setting `network_interface`: %w", err)
 					}
 				}
 
 				if scheduleProfile := profile.ScheduledEventsProfile; scheduleProfile != nil {
 					if err := d.Set("termination_notification", FlattenOrchestratedVirtualMachineScaleSetScheduledEventsProfile(scheduleProfile)); err != nil {
-						return fmt.Errorf("setting `termination_notification`: %+v", err)
+						return fmt.Errorf("setting `termination_notification`: %w", err)
 					}
 				}
 
 				extensionProfile, err := flattenOrchestratedVirtualMachineScaleSetExtensions(profile.ExtensionProfile, d)
 				if err != nil {
-					return fmt.Errorf("failed flattening `extension`: %+v", err)
+					return fmt.Errorf("failed flattening `extension`: %w", err)
 				}
 				d.Set("extension", extensionProfile)
 
@@ -1438,14 +1442,14 @@ func resourceOrchestratedVirtualMachineScaleSetRead(d *pluginsdk.ResourceData, m
 					upgradeMode = string(pointer.From(policy.Mode))
 					flattenedRolling := FlattenVirtualMachineScaleSetRollingUpgradePolicy(policy.RollingUpgradePolicy)
 					if err := d.Set("rolling_upgrade_policy", flattenedRolling); err != nil {
-						return fmt.Errorf("setting `rolling_upgrade_policy`: %+v", err)
+						return fmt.Errorf("setting `rolling_upgrade_policy`: %w", err)
 					}
 				}
 			}
 
 			if priorityMixPolicy := props.PriorityMixPolicy; priorityMixPolicy != nil {
 				if err := d.Set("priority_mix", FlattenOrchestratedVirtualMachineScaleSetPriorityMixPolicy(priorityMixPolicy)); err != nil {
-					return fmt.Errorf("setting `priority_mix`: %+v", err)
+					return fmt.Errorf("setting `priority_mix`: %w", err)
 				}
 			}
 
@@ -1474,7 +1478,7 @@ func resourceOrchestratedVirtualMachineScaleSetDelete(d *pluginsdk.ResourceData,
 			return nil
 		}
 
-		return fmt.Errorf("retrieving Orchestrated %s: %+v", id, err)
+		return fmt.Errorf("retrieving Orchestrated %s: %w", id, err)
 	}
 
 	// Sometimes VMSS's aren't fully deleted when the `Delete` call returns - as such we'll try to scale the cluster
@@ -1491,7 +1495,7 @@ func resourceOrchestratedVirtualMachineScaleSetDelete(d *pluginsdk.ResourceData,
 			Sku: resp.Model.Sku,
 		}
 		if err := client.UpdateThenPoll(ctx, *id, update, virtualmachinescalesets.DefaultUpdateOperationOptions()); err != nil {
-			return fmt.Errorf("updating number of instances in Orchestrated %s to scale to 0: %+v", id, err)
+			return fmt.Errorf("updating number of instances in Orchestrated %s to scale to 0: %w", id, err)
 		}
 		log.Printf("[DEBUG] Scaled instances to 0 prior to deletion - this helps avoids networking issues within Azure")
 	} else {
@@ -1502,7 +1506,7 @@ func resourceOrchestratedVirtualMachineScaleSetDelete(d *pluginsdk.ResourceData,
 	// @ArcturusZhang (mimicking from windows_virtual_machine_pluginsdk.go): sending `nil` here omits this value from being sent
 	// which matches the previous behaviour - we're only splitting this out so it's clear why
 	if err = client.DeleteThenPoll(ctx, *id, virtualmachinescalesets.DefaultDeleteOperationOptions()); err != nil {
-		return fmt.Errorf("deleting Orchestrated %s: %+v", id, err)
+		return fmt.Errorf("deleting Orchestrated %s: %w", id, err)
 	}
 	log.Printf("[DEBUG] Deleted Orchestrated %s", id)
 
@@ -1553,7 +1557,7 @@ func expandOrchestratedVirtualMachineScaleSetSku(input string, capacity int) (*v
 	skuParts := strings.Split(input, "_")
 
 	if (input != SkuNameMix && len(skuParts) < 2) || strings.Contains(input, "__") || strings.Contains(input, " ") {
-		return nil, fmt.Errorf("'sku_name'(%q) is not formatted properly", input)
+		return nil, fmt.Errorf("`sku_name`(`%s`) is not formatted properly", input)
 	}
 
 	sku := &virtualmachinescalesets.Sku{
@@ -1580,7 +1584,7 @@ func flattenOrchestratedVirtualMachineScaleSetSku(input *virtualmachinescalesets
 		return &skuName, nil
 	}
 
-	return nil, fmt.Errorf("sku struct 'name' is nil")
+	return nil, fmt.Errorf("sku struct `name` is nil")
 }
 
 func expandOrchestratedVirtualMachineScaleSetPublicIPSku(input string) *virtualmachinescalesets.PublicIPAddressSku {

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_other_test.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_other_test.go
@@ -414,7 +414,7 @@ func TestAccOrchestratedVirtualMachineScaleSet_otherSinglePlacementGroupInvalid(
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config:      r.otherSinglePlacementGroup(data, "true"),
-			ExpectError: regexp.MustCompile("Virtual Machine Scale Sets with Flexible Orchestration Mode or Virtual Machines referencing such Virtual Machine Scale Sets cannot use VM Size"),
+			ExpectError: regexp.MustCompile("Virtual Machine Scale Sets with Flexible Orchestration Mode cannot be created with VM Size"),
 		},
 	})
 }

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_other_test.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_other_test.go
@@ -310,15 +310,15 @@ func TestAccOrchestratedVirtualMachineScaleSet_otherUpgradePolicyErrorValidation
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config:      r.otherRollingWithoutHealthExtension(data),
-			ExpectError: regexp.MustCompile("a health extension must be specified when `upgrade_mode` is set to `Rolling`"),
+			ExpectError: regexp.MustCompile("health extension is required when `upgrade_mode` is set"),
 		},
 		{
 			Config:      r.otherManualWithUpgradePolicy(data),
-			ExpectError: regexp.MustCompile("a `rolling_upgrade_policy` block cannot be specified"),
+			ExpectError: regexp.MustCompile("`rolling_upgrade_policy` cannot be specified when `upgrade_mode` is set"),
 		},
 		{
 			Config:      r.otherRollingWithoutUpgradePolicy(data),
-			ExpectError: regexp.MustCompile("a `rolling_upgrade_policy` block must be specified when `upgrade_mode` is set"),
+			ExpectError: regexp.MustCompile("`rolling_upgrade_policy` is required when `upgrade_mode` is set"),
 		},
 	})
 }

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_test.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_test.go
@@ -2155,8 +2155,8 @@ resource "azurerm_application_gateway" "test" {
   resource_group_name = azurerm_resource_group.test.name
 
   sku {
-    name     = "Standard_Medium"
-    tier     = "Standard"
+    name     = "Standard_v2"
+    tier     = "Standard_v2"
     capacity = 1
   }
 

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_test.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_test.go
@@ -424,15 +424,15 @@ func TestAccOrchestratedVirtualMachineScaleSet_skuProfileErrorConfiguration(t *t
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config:      r.skuProfileWithoutSkuName(data),
-			ExpectError: regexp.MustCompile("`sku_profile` can only be set when `sku_name` is set to `Mix`"),
+			ExpectError: regexp.MustCompile("'sku_profile' can only be configured when 'sku_name' is set to 'Mix'"),
 		},
 		{
 			Config:      r.skuProfileSkuNameIsNotMix(data),
-			ExpectError: regexp.MustCompile("`sku_profile` can only be set when `sku_name` is set to `Mix`"),
+			ExpectError: regexp.MustCompile("'sku_profile' can only be configured when 'sku_name' is set to 'Mix'"),
 		},
 		{
 			Config:      r.skuProfileNotExist(data),
-			ExpectError: regexp.MustCompile("`sku_profile` must be set when `sku_name` is set to `Mix`"),
+			ExpectError: regexp.MustCompile("'sku_profile' must be configured when 'sku_name' is set to 'Mix'"),
 		},
 	})
 }

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_test.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_test.go
@@ -2219,6 +2219,7 @@ resource "azurerm_application_gateway" "test" {
     http_listener_name         = "listener-1"
     backend_address_pool_name  = "pool-1"
     backend_http_settings_name = "backend-http-1"
+    priority                   = 10 # required field since API version 2021-08-01
   }
 
   tags = {

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_test.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_test.go
@@ -594,7 +594,6 @@ func TestAccOrchestratedVirtualMachineScaleSet_regression29748(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep(),
 	})
 }
 
@@ -2915,7 +2914,6 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "test" {
 }
 
 func (OrchestratedVirtualMachineScaleSetResource) osProfile_empty(data acceptance.TestData) string {
-	r := OrchestratedVirtualMachineScaleSetResource{}
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -2925,8 +2923,6 @@ resource "azurerm_resource_group" "test" {
   name     = "acctestRG-OVMSS-%[1]d"
   location = "%[2]s"
 }
-
-%[3]s
 
 resource "azurerm_orchestrated_virtual_machine_scale_set" "test" {
   name                = "acctestOVMSS-%[1]d"
@@ -2938,5 +2934,5 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "test" {
 
   os_profile {}
 }
-`, data.RandomInteger, data.Locations.Primary, r.natgateway_template(data))
+`, data.RandomInteger, data.Locations.Primary)
 }

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_test.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_test.go
@@ -424,15 +424,15 @@ func TestAccOrchestratedVirtualMachineScaleSet_skuProfileErrorConfiguration(t *t
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config:      r.skuProfileWithoutSkuName(data),
-			ExpectError: regexp.MustCompile("'sku_profile' can only be configured when 'sku_name' is set to 'Mix'"),
+			ExpectError: regexp.MustCompile("`sku_profile` can only be configured when `sku_name` is set"),
 		},
 		{
 			Config:      r.skuProfileSkuNameIsNotMix(data),
-			ExpectError: regexp.MustCompile("'sku_profile' can only be configured when 'sku_name' is set to 'Mix'"),
+			ExpectError: regexp.MustCompile("`sku_profile` can only be configured when `sku_name` is set"),
 		},
 		{
 			Config:      r.skuProfileNotExist(data),
-			ExpectError: regexp.MustCompile("'sku_profile' must be configured when 'sku_name' is set to 'Mix'"),
+			ExpectError: regexp.MustCompile("`sku_profile` must be configured when `sku_name` is set"),
 		},
 	})
 }


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

* Fix crashing bug where an empty `os_profile` block in the `azurerm_orchestrated_virtual_machine_scale_set` resource causes a panic
* Fix additional resource code where `nil` pointer dereferences and unsafe type assertions could also cause panics

### **Go Error Message Standards Compliance:**
* **Lowercase**: All error messages now start with lowercase letters (unless they begin with proper nouns like "VMSS")
* **No punctuation**: Removed periods and unnecessary punctuation from error messages
* **Error wrapping**: Used `%w` verb for proper error wrapping instead of `%+v` or `%v`
* **Error clarity**: Update error messages to be more end user friendly and actionable

## PR Checklist

- [X] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [X] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [X] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [X] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [X] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [X] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [X] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [X] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [X] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_orchestrated_virtual_machine_scale_set` - Fix crashing bug where an empty `os_profile` block causes a runtime panic [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [X] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #29748

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
