### PR TITLE
`azurerm_kubernetes_flux_configuration` - Adds `provider` attribute to `git_repository` block

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,8 +17,8 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-azure-helpers v0.72.0
-	github.com/hashicorp/go-azure-sdk/resource-manager v0.20250526.1224007
-	github.com/hashicorp/go-azure-sdk/sdk v0.20250526.1224007
+	github.com/hashicorp/go-azure-sdk/resource-manager v0.20250606.1221725
+	github.com/hashicorp/go-azure-sdk/sdk v0.20250606.1221725
 	github.com/hashicorp/go-cty v1.4.1
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -92,10 +92,10 @@ github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-azure-helpers v0.72.0 h1:eOCpXBkDYYMESkOBC0LgPMNUdiLPtQxv7sCW/hHdUbw=
 github.com/hashicorp/go-azure-helpers v0.72.0/go.mod h1:Omirva2gGNrhN4pigurl5RN7u3BoaN0bco8ZSbdaNy8=
-github.com/hashicorp/go-azure-sdk/resource-manager v0.20250526.1224007 h1:f6lHHLKKpP9UvqBJgTj9KYc151pl4Hejn+JPJc3tBaw=
-github.com/hashicorp/go-azure-sdk/resource-manager v0.20250526.1224007/go.mod h1:ODGrAh7XT0ZdevtTJmR+vQ7AlYUzsxDjPMMgRXa6KYo=
-github.com/hashicorp/go-azure-sdk/sdk v0.20250526.1224007 h1:r12QJswIykg3Ofqby1WJi1NnR42Qmnaij6/1kBCLLEg=
-github.com/hashicorp/go-azure-sdk/sdk v0.20250526.1224007/go.mod h1:/LiVkre6Py4M8+xkSHgJieWkHWv03USdwg5x/zeX9Rc=
+github.com/hashicorp/go-azure-sdk/resource-manager v0.20250606.1221725 h1:BcIe0g0fM+wgeo4hoVHQn3Iy/pXAv3myyYHKTspwbaE=
+github.com/hashicorp/go-azure-sdk/resource-manager v0.20250606.1221725/go.mod h1:fYZRH7nsj6u+pE9R6tdxNpVOzKy/uNwt+jdnXAGIXoA=
+github.com/hashicorp/go-azure-sdk/sdk v0.20250606.1221725 h1:yJ1+SB8pLGF9XM1v6ccRc0n2nRH8Qmuqb/YKkCBpAQY=
+github.com/hashicorp/go-azure-sdk/sdk v0.20250606.1221725/go.mod h1:/LiVkre6Py4M8+xkSHgJieWkHWv03USdwg5x/zeX9Rc=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=
 github.com/hashicorp/go-checkpoint v0.5.0/go.mod h1:7nfLNL10NsxqO4iWuW6tWW0HjZuDrwkBuEQsVcpCOgg=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=

--- a/internal/services/containers/client/client.go
+++ b/internal/services/containers/client/client.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2024-09-01/snapshots"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2024-09-01/trustedaccess"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2022-11-01/extensions"
-	"github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2023-05-01/fluxconfiguration"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration"
 	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
 	"github.com/hashicorp/go-azure-sdk/sdk/environments"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/common"

--- a/internal/services/containers/kubernetes_flux_configuration_resource_test.go
+++ b/internal/services/containers/kubernetes_flux_configuration_resource_test.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
-	"github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2023-05-01/fluxconfiguration"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datafactory/2018-06-01/linkedservices/model_quickbookslinkedservicetypeproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datafactory/2018-06-01/linkedservices/model_quickbookslinkedservicetypeproperties.go
@@ -17,6 +17,7 @@ type QuickBooksLinkedServiceTypeProperties struct {
 	ConsumerSecret        SecretBase   `json:"consumerSecret"`
 	EncryptedCredential   *string      `json:"encryptedCredential,omitempty"`
 	Endpoint              *interface{} `json:"endpoint,omitempty"`
+	RefreshToken          SecretBase   `json:"refreshToken"`
 	UseEncryptedEndpoints *bool        `json:"useEncryptedEndpoints,omitempty"`
 }
 
@@ -69,6 +70,14 @@ func (s *QuickBooksLinkedServiceTypeProperties) UnmarshalJSON(bytes []byte) erro
 			return fmt.Errorf("unmarshaling field 'ConsumerSecret' for 'QuickBooksLinkedServiceTypeProperties': %+v", err)
 		}
 		s.ConsumerSecret = impl
+	}
+
+	if v, ok := temp["refreshToken"]; ok {
+		impl, err := UnmarshalSecretBaseImplementation(v)
+		if err != nil {
+			return fmt.Errorf("unmarshaling field 'RefreshToken' for 'QuickBooksLinkedServiceTypeProperties': %+v", err)
+		}
+		s.RefreshToken = impl
 	}
 
 	return nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datafactory/2018-06-01/pipelines/model_activity.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datafactory/2018-06-01/pipelines/model_activity.go
@@ -139,6 +139,14 @@ func UnmarshalActivityImplementation(input []byte) (Activity, error) {
 		return out, nil
 	}
 
+	if strings.EqualFold(value, "DatabricksJob") {
+		var out DatabricksJobActivity
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into DatabricksJobActivity: %+v", err)
+		}
+		return out, nil
+	}
+
 	if strings.EqualFold(value, "DatabricksNotebook") {
 		var out DatabricksNotebookActivity
 		if err := json.Unmarshal(input, &out); err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datafactory/2018-06-01/pipelines/model_databricksjobactivity.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datafactory/2018-06-01/pipelines/model_databricksjobactivity.go
@@ -1,0 +1,64 @@
+package pipelines
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ Activity = DatabricksJobActivity{}
+
+type DatabricksJobActivity struct {
+	LinkedServiceName *LinkedServiceReference             `json:"linkedServiceName,omitempty"`
+	Policy            *ActivityPolicy                     `json:"policy,omitempty"`
+	TypeProperties    DatabricksJobActivityTypeProperties `json:"typeProperties"`
+
+	// Fields inherited from Activity
+
+	DependsOn        *[]ActivityDependency     `json:"dependsOn,omitempty"`
+	Description      *string                   `json:"description,omitempty"`
+	Name             string                    `json:"name"`
+	OnInactiveMarkAs *ActivityOnInactiveMarkAs `json:"onInactiveMarkAs,omitempty"`
+	State            *ActivityState            `json:"state,omitempty"`
+	Type             string                    `json:"type"`
+	UserProperties   *[]UserProperty           `json:"userProperties,omitempty"`
+}
+
+func (s DatabricksJobActivity) Activity() BaseActivityImpl {
+	return BaseActivityImpl{
+		DependsOn:        s.DependsOn,
+		Description:      s.Description,
+		Name:             s.Name,
+		OnInactiveMarkAs: s.OnInactiveMarkAs,
+		State:            s.State,
+		Type:             s.Type,
+		UserProperties:   s.UserProperties,
+	}
+}
+
+var _ json.Marshaler = DatabricksJobActivity{}
+
+func (s DatabricksJobActivity) MarshalJSON() ([]byte, error) {
+	type wrapper DatabricksJobActivity
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling DatabricksJobActivity: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling DatabricksJobActivity: %+v", err)
+	}
+
+	decoded["type"] = "DatabricksJob"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling DatabricksJobActivity: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datafactory/2018-06-01/pipelines/model_databricksjobactivitytypeproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datafactory/2018-06-01/pipelines/model_databricksjobactivitytypeproperties.go
@@ -1,0 +1,9 @@
+package pipelines
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DatabricksJobActivityTypeProperties struct {
+	JobId         interface{}             `json:"jobId"`
+	JobParameters *map[string]interface{} `json:"jobParameters,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datafactory/2018-06-01/pipelines/model_expressionv2.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datafactory/2018-06-01/pipelines/model_expressionv2.go
@@ -7,5 +7,5 @@ type ExpressionV2 struct {
 	Operands  *[]ExpressionV2   `json:"operands,omitempty"`
 	Operators *[]string         `json:"operators,omitempty"`
 	Type      *ExpressionV2Type `json:"type,omitempty"`
-	Value     *string           `json:"value,omitempty"`
+	Value     *interface{}      `json:"value,omitempty"`
 }

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/README.md
@@ -1,0 +1,100 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration` Documentation
+
+The `fluxconfiguration` SDK allows for interaction with Azure Resource Manager `kubernetesconfiguration` (API Version `2024-11-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+import "github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration"
+```
+
+
+### Client Initialization
+
+```go
+client := fluxconfiguration.NewFluxConfigurationClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `FluxConfigurationClient.CreateOrUpdate`
+
+```go
+ctx := context.TODO()
+id := fluxconfiguration.NewScopedFluxConfigurationID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group", "fluxConfigurationName")
+
+payload := fluxconfiguration.FluxConfiguration{
+	// ...
+}
+
+
+if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `FluxConfigurationClient.Delete`
+
+```go
+ctx := context.TODO()
+id := fluxconfiguration.NewScopedFluxConfigurationID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group", "fluxConfigurationName")
+
+if err := client.DeleteThenPoll(ctx, id, fluxconfiguration.DefaultDeleteOperationOptions()); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `FluxConfigurationClient.Get`
+
+```go
+ctx := context.TODO()
+id := fluxconfiguration.NewScopedFluxConfigurationID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group", "fluxConfigurationName")
+
+read, err := client.Get(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `FluxConfigurationClient.List`
+
+```go
+ctx := context.TODO()
+id := commonids.NewScopeID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group")
+
+// alternatively `client.List(ctx, id)` can be used to do batched pagination
+items, err := client.ListComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `FluxConfigurationClient.Update`
+
+```go
+ctx := context.TODO()
+id := fluxconfiguration.NewScopedFluxConfigurationID("/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group", "fluxConfigurationName")
+
+payload := fluxconfiguration.FluxConfigurationPatch{
+	// ...
+}
+
+
+if err := client.UpdateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/client.go
@@ -1,0 +1,26 @@
+package fluxconfiguration
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type FluxConfigurationClient struct {
+	Client *resourcemanager.Client
+}
+
+func NewFluxConfigurationClientWithBaseURI(sdkApi sdkEnv.Api) (*FluxConfigurationClient, error) {
+	client, err := resourcemanager.NewClient(sdkApi, "fluxconfiguration", defaultApiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating FluxConfigurationClient: %+v", err)
+	}
+
+	return &FluxConfigurationClient{
+		Client: client,
+	}, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/constants.go
@@ -1,0 +1,283 @@
+package fluxconfiguration
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type FluxComplianceState string
+
+const (
+	FluxComplianceStateCompliant            FluxComplianceState = "Compliant"
+	FluxComplianceStateNonNegativeCompliant FluxComplianceState = "Non-Compliant"
+	FluxComplianceStatePending              FluxComplianceState = "Pending"
+	FluxComplianceStateSuspended            FluxComplianceState = "Suspended"
+	FluxComplianceStateUnknown              FluxComplianceState = "Unknown"
+)
+
+func PossibleValuesForFluxComplianceState() []string {
+	return []string{
+		string(FluxComplianceStateCompliant),
+		string(FluxComplianceStateNonNegativeCompliant),
+		string(FluxComplianceStatePending),
+		string(FluxComplianceStateSuspended),
+		string(FluxComplianceStateUnknown),
+	}
+}
+
+func (s *FluxComplianceState) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseFluxComplianceState(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseFluxComplianceState(input string) (*FluxComplianceState, error) {
+	vals := map[string]FluxComplianceState{
+		"compliant":     FluxComplianceStateCompliant,
+		"non-compliant": FluxComplianceStateNonNegativeCompliant,
+		"pending":       FluxComplianceStatePending,
+		"suspended":     FluxComplianceStateSuspended,
+		"unknown":       FluxComplianceStateUnknown,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := FluxComplianceState(input)
+	return &out, nil
+}
+
+type OperationType string
+
+const (
+	OperationTypeCopy    OperationType = "copy"
+	OperationTypeExtract OperationType = "extract"
+)
+
+func PossibleValuesForOperationType() []string {
+	return []string{
+		string(OperationTypeCopy),
+		string(OperationTypeExtract),
+	}
+}
+
+func (s *OperationType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseOperationType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseOperationType(input string) (*OperationType, error) {
+	vals := map[string]OperationType{
+		"copy":    OperationTypeCopy,
+		"extract": OperationTypeExtract,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := OperationType(input)
+	return &out, nil
+}
+
+type ProviderType string
+
+const (
+	ProviderTypeAzure   ProviderType = "Azure"
+	ProviderTypeGeneric ProviderType = "Generic"
+)
+
+func PossibleValuesForProviderType() []string {
+	return []string{
+		string(ProviderTypeAzure),
+		string(ProviderTypeGeneric),
+	}
+}
+
+func (s *ProviderType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseProviderType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseProviderType(input string) (*ProviderType, error) {
+	vals := map[string]ProviderType{
+		"azure":   ProviderTypeAzure,
+		"generic": ProviderTypeGeneric,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ProviderType(input)
+	return &out, nil
+}
+
+type ProvisioningState string
+
+const (
+	ProvisioningStateCanceled  ProvisioningState = "Canceled"
+	ProvisioningStateCreating  ProvisioningState = "Creating"
+	ProvisioningStateDeleting  ProvisioningState = "Deleting"
+	ProvisioningStateFailed    ProvisioningState = "Failed"
+	ProvisioningStateSucceeded ProvisioningState = "Succeeded"
+	ProvisioningStateUpdating  ProvisioningState = "Updating"
+)
+
+func PossibleValuesForProvisioningState() []string {
+	return []string{
+		string(ProvisioningStateCanceled),
+		string(ProvisioningStateCreating),
+		string(ProvisioningStateDeleting),
+		string(ProvisioningStateFailed),
+		string(ProvisioningStateSucceeded),
+		string(ProvisioningStateUpdating),
+	}
+}
+
+func (s *ProvisioningState) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseProvisioningState(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseProvisioningState(input string) (*ProvisioningState, error) {
+	vals := map[string]ProvisioningState{
+		"canceled":  ProvisioningStateCanceled,
+		"creating":  ProvisioningStateCreating,
+		"deleting":  ProvisioningStateDeleting,
+		"failed":    ProvisioningStateFailed,
+		"succeeded": ProvisioningStateSucceeded,
+		"updating":  ProvisioningStateUpdating,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ProvisioningState(input)
+	return &out, nil
+}
+
+type ScopeType string
+
+const (
+	ScopeTypeCluster   ScopeType = "cluster"
+	ScopeTypeNamespace ScopeType = "namespace"
+)
+
+func PossibleValuesForScopeType() []string {
+	return []string{
+		string(ScopeTypeCluster),
+		string(ScopeTypeNamespace),
+	}
+}
+
+func (s *ScopeType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseScopeType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseScopeType(input string) (*ScopeType, error) {
+	vals := map[string]ScopeType{
+		"cluster":   ScopeTypeCluster,
+		"namespace": ScopeTypeNamespace,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ScopeType(input)
+	return &out, nil
+}
+
+type SourceKindType string
+
+const (
+	SourceKindTypeAzureBlob     SourceKindType = "AzureBlob"
+	SourceKindTypeBucket        SourceKindType = "Bucket"
+	SourceKindTypeGitRepository SourceKindType = "GitRepository"
+	SourceKindTypeOCIRepository SourceKindType = "OCIRepository"
+)
+
+func PossibleValuesForSourceKindType() []string {
+	return []string{
+		string(SourceKindTypeAzureBlob),
+		string(SourceKindTypeBucket),
+		string(SourceKindTypeGitRepository),
+		string(SourceKindTypeOCIRepository),
+	}
+}
+
+func (s *SourceKindType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseSourceKindType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseSourceKindType(input string) (*SourceKindType, error) {
+	vals := map[string]SourceKindType{
+		"azureblob":     SourceKindTypeAzureBlob,
+		"bucket":        SourceKindTypeBucket,
+		"gitrepository": SourceKindTypeGitRepository,
+		"ocirepository": SourceKindTypeOCIRepository,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := SourceKindType(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/id_scopedfluxconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/id_scopedfluxconfiguration.go
@@ -1,0 +1,120 @@
+package fluxconfiguration
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&ScopedFluxConfigurationId{})
+}
+
+var _ resourceids.ResourceId = &ScopedFluxConfigurationId{}
+
+// ScopedFluxConfigurationId is a struct representing the Resource ID for a Scoped Flux Configuration
+type ScopedFluxConfigurationId struct {
+	Scope                 string
+	FluxConfigurationName string
+}
+
+// NewScopedFluxConfigurationID returns a new ScopedFluxConfigurationId struct
+func NewScopedFluxConfigurationID(scope string, fluxConfigurationName string) ScopedFluxConfigurationId {
+	return ScopedFluxConfigurationId{
+		Scope:                 scope,
+		FluxConfigurationName: fluxConfigurationName,
+	}
+}
+
+// ParseScopedFluxConfigurationID parses 'input' into a ScopedFluxConfigurationId
+func ParseScopedFluxConfigurationID(input string) (*ScopedFluxConfigurationId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&ScopedFluxConfigurationId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := ScopedFluxConfigurationId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseScopedFluxConfigurationIDInsensitively parses 'input' case-insensitively into a ScopedFluxConfigurationId
+// note: this method should only be used for API response data and not user input
+func ParseScopedFluxConfigurationIDInsensitively(input string) (*ScopedFluxConfigurationId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&ScopedFluxConfigurationId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := ScopedFluxConfigurationId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *ScopedFluxConfigurationId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.Scope, ok = input.Parsed["scope"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "scope", input)
+	}
+
+	if id.FluxConfigurationName, ok = input.Parsed["fluxConfigurationName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "fluxConfigurationName", input)
+	}
+
+	return nil
+}
+
+// ValidateScopedFluxConfigurationID checks that 'input' can be parsed as a Scoped Flux Configuration ID
+func ValidateScopedFluxConfigurationID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseScopedFluxConfigurationID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Scoped Flux Configuration ID
+func (id ScopedFluxConfigurationId) ID() string {
+	fmtString := "/%s/providers/Microsoft.KubernetesConfiguration/fluxConfigurations/%s"
+	return fmt.Sprintf(fmtString, strings.TrimPrefix(id.Scope, "/"), id.FluxConfigurationName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Scoped Flux Configuration ID
+func (id ScopedFluxConfigurationId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.ScopeSegment("scope", "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftKubernetesConfiguration", "Microsoft.KubernetesConfiguration", "Microsoft.KubernetesConfiguration"),
+		resourceids.StaticSegment("staticFluxConfigurations", "fluxConfigurations", "fluxConfigurations"),
+		resourceids.UserSpecifiedSegment("fluxConfigurationName", "fluxConfigurationName"),
+	}
+}
+
+// String returns a human-readable description of this Scoped Flux Configuration ID
+func (id ScopedFluxConfigurationId) String() string {
+	components := []string{
+		fmt.Sprintf("Scope: %q", id.Scope),
+		fmt.Sprintf("Flux Configuration Name: %q", id.FluxConfigurationName),
+	}
+	return fmt.Sprintf("Scoped Flux Configuration (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/method_createorupdate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/method_createorupdate.go
@@ -1,0 +1,75 @@
+package fluxconfiguration
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateOrUpdateOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *FluxConfiguration
+}
+
+// CreateOrUpdate ...
+func (c FluxConfigurationClient) CreateOrUpdate(ctx context.Context, id ScopedFluxConfigurationId, input FluxConfiguration) (result CreateOrUpdateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPut,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// CreateOrUpdateThenPoll performs CreateOrUpdate then polls until it's completed
+func (c FluxConfigurationClient) CreateOrUpdateThenPoll(ctx context.Context, id ScopedFluxConfigurationId, input FluxConfiguration) error {
+	result, err := c.CreateOrUpdate(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing CreateOrUpdate: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after CreateOrUpdate: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/method_delete.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/method_delete.go
@@ -1,0 +1,100 @@
+package fluxconfiguration
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeleteOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+type DeleteOperationOptions struct {
+	ForceDelete *bool
+}
+
+func DefaultDeleteOperationOptions() DeleteOperationOptions {
+	return DeleteOperationOptions{}
+}
+
+func (o DeleteOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+
+	return &out
+}
+
+func (o DeleteOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+
+	return &out
+}
+
+func (o DeleteOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+	if o.ForceDelete != nil {
+		out.Append("forceDelete", fmt.Sprintf("%v", *o.ForceDelete))
+	}
+	return &out
+}
+
+// Delete ...
+func (c FluxConfigurationClient) Delete(ctx context.Context, id ScopedFluxConfigurationId, options DeleteOperationOptions) (result DeleteOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusNoContent,
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodDelete,
+		OptionsObject: options,
+		Path:          id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// DeleteThenPoll performs Delete then polls until it's completed
+func (c FluxConfigurationClient) DeleteThenPoll(ctx context.Context, id ScopedFluxConfigurationId, options DeleteOperationOptions) error {
+	result, err := c.Delete(ctx, id, options)
+	if err != nil {
+		return fmt.Errorf("performing Delete: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Delete: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/method_get.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/method_get.go
@@ -1,0 +1,53 @@
+package fluxconfiguration
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *FluxConfiguration
+}
+
+// Get ...
+func (c FluxConfigurationClient) Get(ctx context.Context, id ScopedFluxConfigurationId) (result GetOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model FluxConfiguration
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/method_list.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/method_list.go
@@ -1,0 +1,106 @@
+package fluxconfiguration
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]FluxConfiguration
+}
+
+type ListCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []FluxConfiguration
+}
+
+type ListCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *ListCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// List ...
+func (c FluxConfigurationClient) List(ctx context.Context, id commonids.ScopeId) (result ListOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Pager:      &ListCustomPager{},
+		Path:       fmt.Sprintf("%s/providers/Microsoft.KubernetesConfiguration/fluxConfigurations", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]FluxConfiguration `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListComplete retrieves all the results into a single object
+func (c FluxConfigurationClient) ListComplete(ctx context.Context, id commonids.ScopeId) (ListCompleteResult, error) {
+	return c.ListCompleteMatchingPredicate(ctx, id, FluxConfigurationOperationPredicate{})
+}
+
+// ListCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c FluxConfigurationClient) ListCompleteMatchingPredicate(ctx context.Context, id commonids.ScopeId, predicate FluxConfigurationOperationPredicate) (result ListCompleteResult, err error) {
+	items := make([]FluxConfiguration, 0)
+
+	resp, err := c.List(ctx, id)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/method_update.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/method_update.go
@@ -1,0 +1,75 @@
+package fluxconfiguration
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpdateOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *FluxConfiguration
+}
+
+// Update ...
+func (c FluxConfigurationClient) Update(ctx context.Context, id ScopedFluxConfigurationId, input FluxConfigurationPatch) (result UpdateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPatch,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// UpdateThenPoll performs Update then polls until it's completed
+func (c FluxConfigurationClient) UpdateThenPoll(ctx context.Context, id ScopedFluxConfigurationId, input FluxConfigurationPatch) error {
+	result, err := c.Update(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing Update: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Update: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_azureblobdefinition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_azureblobdefinition.go
@@ -1,0 +1,16 @@
+package fluxconfiguration
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AzureBlobDefinition struct {
+	AccountKey            *string                     `json:"accountKey,omitempty"`
+	ContainerName         *string                     `json:"containerName,omitempty"`
+	LocalAuthRef          *string                     `json:"localAuthRef,omitempty"`
+	ManagedIdentity       *ManagedIdentityDefinition  `json:"managedIdentity,omitempty"`
+	SasToken              *string                     `json:"sasToken,omitempty"`
+	ServicePrincipal      *ServicePrincipalDefinition `json:"servicePrincipal,omitempty"`
+	SyncIntervalInSeconds *int64                      `json:"syncIntervalInSeconds,omitempty"`
+	TimeoutInSeconds      *int64                      `json:"timeoutInSeconds,omitempty"`
+	Url                   *string                     `json:"url,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_azureblobpatchdefinition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_azureblobpatchdefinition.go
@@ -1,0 +1,16 @@
+package fluxconfiguration
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AzureBlobPatchDefinition struct {
+	AccountKey            *string                          `json:"accountKey,omitempty"`
+	ContainerName         *string                          `json:"containerName,omitempty"`
+	LocalAuthRef          *string                          `json:"localAuthRef,omitempty"`
+	ManagedIdentity       *ManagedIdentityPatchDefinition  `json:"managedIdentity,omitempty"`
+	SasToken              *string                          `json:"sasToken,omitempty"`
+	ServicePrincipal      *ServicePrincipalPatchDefinition `json:"servicePrincipal,omitempty"`
+	SyncIntervalInSeconds *int64                           `json:"syncIntervalInSeconds,omitempty"`
+	TimeoutInSeconds      *int64                           `json:"timeoutInSeconds,omitempty"`
+	Url                   *string                          `json:"url,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_bucketdefinition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_bucketdefinition.go
@@ -1,0 +1,14 @@
+package fluxconfiguration
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type BucketDefinition struct {
+	AccessKey             *string `json:"accessKey,omitempty"`
+	BucketName            *string `json:"bucketName,omitempty"`
+	Insecure              *bool   `json:"insecure,omitempty"`
+	LocalAuthRef          *string `json:"localAuthRef,omitempty"`
+	SyncIntervalInSeconds *int64  `json:"syncIntervalInSeconds,omitempty"`
+	TimeoutInSeconds      *int64  `json:"timeoutInSeconds,omitempty"`
+	Url                   *string `json:"url,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_bucketpatchdefinition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_bucketpatchdefinition.go
@@ -1,0 +1,14 @@
+package fluxconfiguration
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type BucketPatchDefinition struct {
+	AccessKey             *string `json:"accessKey,omitempty"`
+	BucketName            *string `json:"bucketName,omitempty"`
+	Insecure              *bool   `json:"insecure,omitempty"`
+	LocalAuthRef          *string `json:"localAuthRef,omitempty"`
+	SyncIntervalInSeconds *int64  `json:"syncIntervalInSeconds,omitempty"`
+	TimeoutInSeconds      *int64  `json:"timeoutInSeconds,omitempty"`
+	Url                   *string `json:"url,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_fluxconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_fluxconfiguration.go
@@ -1,0 +1,16 @@
+package fluxconfiguration
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/systemdata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type FluxConfiguration struct {
+	Id         *string                      `json:"id,omitempty"`
+	Name       *string                      `json:"name,omitempty"`
+	Properties *FluxConfigurationProperties `json:"properties,omitempty"`
+	SystemData *systemdata.SystemData       `json:"systemData,omitempty"`
+	Type       *string                      `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_fluxconfigurationpatch.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_fluxconfigurationpatch.go
@@ -1,0 +1,8 @@
+package fluxconfiguration
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type FluxConfigurationPatch struct {
+	Properties *FluxConfigurationPatchProperties `json:"properties,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_fluxconfigurationpatchproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_fluxconfigurationpatchproperties.go
@@ -1,0 +1,15 @@
+package fluxconfiguration
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type FluxConfigurationPatchProperties struct {
+	AzureBlob                      *AzureBlobPatchDefinition                `json:"azureBlob,omitempty"`
+	Bucket                         *BucketPatchDefinition                   `json:"bucket,omitempty"`
+	ConfigurationProtectedSettings *map[string]string                       `json:"configurationProtectedSettings,omitempty"`
+	GitRepository                  *GitRepositoryPatchDefinition            `json:"gitRepository,omitempty"`
+	Kustomizations                 *map[string]KustomizationPatchDefinition `json:"kustomizations,omitempty"`
+	OciRepository                  *OCIRepositoryPatchDefinition            `json:"ociRepository,omitempty"`
+	SourceKind                     *SourceKindType                          `json:"sourceKind,omitempty"`
+	Suspend                        *bool                                    `json:"suspend,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_fluxconfigurationproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_fluxconfigurationproperties.go
@@ -1,0 +1,57 @@
+package fluxconfiguration
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type FluxConfigurationProperties struct {
+	AzureBlob                      *AzureBlobDefinition                `json:"azureBlob,omitempty"`
+	Bucket                         *BucketDefinition                   `json:"bucket,omitempty"`
+	ComplianceState                *FluxComplianceState                `json:"complianceState,omitempty"`
+	ConfigurationProtectedSettings *map[string]string                  `json:"configurationProtectedSettings,omitempty"`
+	ErrorMessage                   *string                             `json:"errorMessage,omitempty"`
+	GitRepository                  *GitRepositoryDefinition            `json:"gitRepository,omitempty"`
+	Kustomizations                 *map[string]KustomizationDefinition `json:"kustomizations,omitempty"`
+	Namespace                      *string                             `json:"namespace,omitempty"`
+	OciRepository                  *OCIRepositoryDefinition            `json:"ociRepository,omitempty"`
+	ProvisioningState              *ProvisioningState                  `json:"provisioningState,omitempty"`
+	ReconciliationWaitDuration     *string                             `json:"reconciliationWaitDuration,omitempty"`
+	RepositoryPublicKey            *string                             `json:"repositoryPublicKey,omitempty"`
+	Scope                          *ScopeType                          `json:"scope,omitempty"`
+	SourceKind                     *SourceKindType                     `json:"sourceKind,omitempty"`
+	SourceSyncedCommitId           *string                             `json:"sourceSyncedCommitId,omitempty"`
+	SourceUpdatedAt                *string                             `json:"sourceUpdatedAt,omitempty"`
+	StatusUpdatedAt                *string                             `json:"statusUpdatedAt,omitempty"`
+	Statuses                       *[]ObjectStatusDefinition           `json:"statuses,omitempty"`
+	Suspend                        *bool                               `json:"suspend,omitempty"`
+	WaitForReconciliation          *bool                               `json:"waitForReconciliation,omitempty"`
+}
+
+func (o *FluxConfigurationProperties) GetSourceUpdatedAtAsTime() (*time.Time, error) {
+	if o.SourceUpdatedAt == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.SourceUpdatedAt, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *FluxConfigurationProperties) SetSourceUpdatedAtAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.SourceUpdatedAt = &formatted
+}
+
+func (o *FluxConfigurationProperties) GetStatusUpdatedAtAsTime() (*time.Time, error) {
+	if o.StatusUpdatedAt == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.StatusUpdatedAt, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *FluxConfigurationProperties) SetStatusUpdatedAtAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.StatusUpdatedAt = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_gitrepositorydefinition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_gitrepositorydefinition.go
@@ -1,0 +1,16 @@
+package fluxconfiguration
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GitRepositoryDefinition struct {
+	HTTPSCACert           *string                  `json:"httpsCACert,omitempty"`
+	HTTPSUser             *string                  `json:"httpsUser,omitempty"`
+	LocalAuthRef          *string                  `json:"localAuthRef,omitempty"`
+	Provider              *ProviderType            `json:"provider,omitempty"`
+	RepositoryRef         *RepositoryRefDefinition `json:"repositoryRef,omitempty"`
+	SshKnownHosts         *string                  `json:"sshKnownHosts,omitempty"`
+	SyncIntervalInSeconds *int64                   `json:"syncIntervalInSeconds,omitempty"`
+	TimeoutInSeconds      *int64                   `json:"timeoutInSeconds,omitempty"`
+	Url                   *string                  `json:"url,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_gitrepositorypatchdefinition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_gitrepositorypatchdefinition.go
@@ -1,0 +1,16 @@
+package fluxconfiguration
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GitRepositoryPatchDefinition struct {
+	HTTPSCACert           *string                  `json:"httpsCACert,omitempty"`
+	HTTPSUser             *string                  `json:"httpsUser,omitempty"`
+	LocalAuthRef          *string                  `json:"localAuthRef,omitempty"`
+	Provider              *ProviderType            `json:"provider,omitempty"`
+	RepositoryRef         *RepositoryRefDefinition `json:"repositoryRef,omitempty"`
+	SshKnownHosts         *string                  `json:"sshKnownHosts,omitempty"`
+	SyncIntervalInSeconds *int64                   `json:"syncIntervalInSeconds,omitempty"`
+	TimeoutInSeconds      *int64                   `json:"timeoutInSeconds,omitempty"`
+	Url                   *string                  `json:"url,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_helmreleasepropertiesdefinition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_helmreleasepropertiesdefinition.go
@@ -1,0 +1,12 @@
+package fluxconfiguration
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type HelmReleasePropertiesDefinition struct {
+	FailureCount        *int64                     `json:"failureCount,omitempty"`
+	HelmChartRef        *ObjectReferenceDefinition `json:"helmChartRef,omitempty"`
+	InstallFailureCount *int64                     `json:"installFailureCount,omitempty"`
+	LastRevisionApplied *int64                     `json:"lastRevisionApplied,omitempty"`
+	UpgradeFailureCount *int64                     `json:"upgradeFailureCount,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_kustomizationdefinition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_kustomizationdefinition.go
@@ -1,0 +1,17 @@
+package fluxconfiguration
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type KustomizationDefinition struct {
+	DependsOn              *[]string            `json:"dependsOn,omitempty"`
+	Force                  *bool                `json:"force,omitempty"`
+	Name                   *string              `json:"name,omitempty"`
+	Path                   *string              `json:"path,omitempty"`
+	PostBuild              *PostBuildDefinition `json:"postBuild,omitempty"`
+	Prune                  *bool                `json:"prune,omitempty"`
+	RetryIntervalInSeconds *int64               `json:"retryIntervalInSeconds,omitempty"`
+	SyncIntervalInSeconds  *int64               `json:"syncIntervalInSeconds,omitempty"`
+	TimeoutInSeconds       *int64               `json:"timeoutInSeconds,omitempty"`
+	Wait                   *bool                `json:"wait,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_kustomizationpatchdefinition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_kustomizationpatchdefinition.go
@@ -1,0 +1,16 @@
+package fluxconfiguration
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type KustomizationPatchDefinition struct {
+	DependsOn              *[]string                 `json:"dependsOn,omitempty"`
+	Force                  *bool                     `json:"force,omitempty"`
+	Path                   *string                   `json:"path,omitempty"`
+	PostBuild              *PostBuildPatchDefinition `json:"postBuild,omitempty"`
+	Prune                  *bool                     `json:"prune,omitempty"`
+	RetryIntervalInSeconds *int64                    `json:"retryIntervalInSeconds,omitempty"`
+	SyncIntervalInSeconds  *int64                    `json:"syncIntervalInSeconds,omitempty"`
+	TimeoutInSeconds       *int64                    `json:"timeoutInSeconds,omitempty"`
+	Wait                   *bool                     `json:"wait,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_layerselectordefinition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_layerselectordefinition.go
@@ -1,0 +1,9 @@
+package fluxconfiguration
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type LayerSelectorDefinition struct {
+	MediaType *string        `json:"mediaType,omitempty"`
+	Operation *OperationType `json:"operation,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_layerselectorpatchdefinition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_layerselectorpatchdefinition.go
@@ -1,0 +1,9 @@
+package fluxconfiguration
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type LayerSelectorPatchDefinition struct {
+	MediaType *string        `json:"mediaType,omitempty"`
+	Operation *OperationType `json:"operation,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_managedidentitydefinition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_managedidentitydefinition.go
@@ -1,0 +1,8 @@
+package fluxconfiguration
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ManagedIdentityDefinition struct {
+	ClientId *string `json:"clientId,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_managedidentitypatchdefinition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_managedidentitypatchdefinition.go
@@ -1,0 +1,8 @@
+package fluxconfiguration
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ManagedIdentityPatchDefinition struct {
+	ClientId *string `json:"clientId,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_matchoidcidentitydefinition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_matchoidcidentitydefinition.go
@@ -1,0 +1,9 @@
+package fluxconfiguration
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type MatchOidcIdentityDefinition struct {
+	Issuer  *string `json:"issuer,omitempty"`
+	Subject *string `json:"subject,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_matchoidcidentitypatchdefinition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_matchoidcidentitypatchdefinition.go
@@ -1,0 +1,9 @@
+package fluxconfiguration
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type MatchOidcIdentityPatchDefinition struct {
+	Issuer  *string `json:"issuer,omitempty"`
+	Subject *string `json:"subject,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_objectreferencedefinition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_objectreferencedefinition.go
@@ -1,0 +1,9 @@
+package fluxconfiguration
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ObjectReferenceDefinition struct {
+	Name      *string `json:"name,omitempty"`
+	Namespace *string `json:"namespace,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_objectstatusconditiondefinition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_objectstatusconditiondefinition.go
@@ -1,0 +1,30 @@
+package fluxconfiguration
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ObjectStatusConditionDefinition struct {
+	LastTransitionTime *string `json:"lastTransitionTime,omitempty"`
+	Message            *string `json:"message,omitempty"`
+	Reason             *string `json:"reason,omitempty"`
+	Status             *string `json:"status,omitempty"`
+	Type               *string `json:"type,omitempty"`
+}
+
+func (o *ObjectStatusConditionDefinition) GetLastTransitionTimeAsTime() (*time.Time, error) {
+	if o.LastTransitionTime == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.LastTransitionTime, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *ObjectStatusConditionDefinition) SetLastTransitionTimeAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.LastTransitionTime = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_objectstatusdefinition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_objectstatusdefinition.go
@@ -1,0 +1,14 @@
+package fluxconfiguration
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ObjectStatusDefinition struct {
+	AppliedBy             *ObjectReferenceDefinition         `json:"appliedBy,omitempty"`
+	ComplianceState       *FluxComplianceState               `json:"complianceState,omitempty"`
+	HelmReleaseProperties *HelmReleasePropertiesDefinition   `json:"helmReleaseProperties,omitempty"`
+	Kind                  *string                            `json:"kind,omitempty"`
+	Name                  *string                            `json:"name,omitempty"`
+	Namespace             *string                            `json:"namespace,omitempty"`
+	StatusConditions      *[]ObjectStatusConditionDefinition `json:"statusConditions,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_ocirepositorydefinition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_ocirepositorydefinition.go
@@ -1,0 +1,18 @@
+package fluxconfiguration
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type OCIRepositoryDefinition struct {
+	Insecure              *bool                       `json:"insecure,omitempty"`
+	LayerSelector         *LayerSelectorDefinition    `json:"layerSelector,omitempty"`
+	LocalAuthRef          *string                     `json:"localAuthRef,omitempty"`
+	RepositoryRef         *OCIRepositoryRefDefinition `json:"repositoryRef,omitempty"`
+	ServiceAccountName    *string                     `json:"serviceAccountName,omitempty"`
+	SyncIntervalInSeconds *int64                      `json:"syncIntervalInSeconds,omitempty"`
+	TimeoutInSeconds      *int64                      `json:"timeoutInSeconds,omitempty"`
+	TlsConfig             *TlsConfigDefinition        `json:"tlsConfig,omitempty"`
+	Url                   *string                     `json:"url,omitempty"`
+	UseWorkloadIdentity   *bool                       `json:"useWorkloadIdentity,omitempty"`
+	Verify                *VerifyDefinition           `json:"verify,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_ocirepositorypatchdefinition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_ocirepositorypatchdefinition.go
@@ -1,0 +1,18 @@
+package fluxconfiguration
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type OCIRepositoryPatchDefinition struct {
+	Insecure              *bool                            `json:"insecure,omitempty"`
+	LayerSelector         *LayerSelectorPatchDefinition    `json:"layerSelector,omitempty"`
+	LocalAuthRef          *string                          `json:"localAuthRef,omitempty"`
+	RepositoryRef         *OCIRepositoryRefPatchDefinition `json:"repositoryRef,omitempty"`
+	ServiceAccountName    *string                          `json:"serviceAccountName,omitempty"`
+	SyncIntervalInSeconds *int64                           `json:"syncIntervalInSeconds,omitempty"`
+	TimeoutInSeconds      *int64                           `json:"timeoutInSeconds,omitempty"`
+	TlsConfig             *TlsConfigPatchDefinition        `json:"tlsConfig,omitempty"`
+	Url                   *string                          `json:"url,omitempty"`
+	UseWorkloadIdentity   *bool                            `json:"useWorkloadIdentity,omitempty"`
+	Verify                *VerifyPatchDefinition           `json:"verify,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_ocirepositoryrefdefinition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_ocirepositoryrefdefinition.go
@@ -1,0 +1,10 @@
+package fluxconfiguration
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type OCIRepositoryRefDefinition struct {
+	Digest *string `json:"digest,omitempty"`
+	Semver *string `json:"semver,omitempty"`
+	Tag    *string `json:"tag,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_ocirepositoryrefpatchdefinition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_ocirepositoryrefpatchdefinition.go
@@ -1,0 +1,10 @@
+package fluxconfiguration
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type OCIRepositoryRefPatchDefinition struct {
+	Digest *string `json:"digest,omitempty"`
+	Semver *string `json:"semver,omitempty"`
+	Tag    *string `json:"tag,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_postbuilddefinition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_postbuilddefinition.go
@@ -1,0 +1,9 @@
+package fluxconfiguration
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PostBuildDefinition struct {
+	Substitute     *map[string]string          `json:"substitute,omitempty"`
+	SubstituteFrom *[]SubstituteFromDefinition `json:"substituteFrom,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_postbuildpatchdefinition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_postbuildpatchdefinition.go
@@ -1,0 +1,9 @@
+package fluxconfiguration
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PostBuildPatchDefinition struct {
+	Substitute     *map[string]string               `json:"substitute,omitempty"`
+	SubstituteFrom *[]SubstituteFromPatchDefinition `json:"substituteFrom,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_repositoryrefdefinition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_repositoryrefdefinition.go
@@ -1,0 +1,11 @@
+package fluxconfiguration
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RepositoryRefDefinition struct {
+	Branch *string `json:"branch,omitempty"`
+	Commit *string `json:"commit,omitempty"`
+	Semver *string `json:"semver,omitempty"`
+	Tag    *string `json:"tag,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_serviceprincipaldefinition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_serviceprincipaldefinition.go
@@ -1,0 +1,13 @@
+package fluxconfiguration
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ServicePrincipalDefinition struct {
+	ClientCertificate          *string `json:"clientCertificate,omitempty"`
+	ClientCertificatePassword  *string `json:"clientCertificatePassword,omitempty"`
+	ClientCertificateSendChain *bool   `json:"clientCertificateSendChain,omitempty"`
+	ClientId                   *string `json:"clientId,omitempty"`
+	ClientSecret               *string `json:"clientSecret,omitempty"`
+	TenantId                   *string `json:"tenantId,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_serviceprincipalpatchdefinition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_serviceprincipalpatchdefinition.go
@@ -1,0 +1,13 @@
+package fluxconfiguration
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ServicePrincipalPatchDefinition struct {
+	ClientCertificate          *string `json:"clientCertificate,omitempty"`
+	ClientCertificatePassword  *string `json:"clientCertificatePassword,omitempty"`
+	ClientCertificateSendChain *bool   `json:"clientCertificateSendChain,omitempty"`
+	ClientId                   *string `json:"clientId,omitempty"`
+	ClientSecret               *string `json:"clientSecret,omitempty"`
+	TenantId                   *string `json:"tenantId,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_substitutefromdefinition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_substitutefromdefinition.go
@@ -1,0 +1,10 @@
+package fluxconfiguration
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SubstituteFromDefinition struct {
+	Kind     *string `json:"kind,omitempty"`
+	Name     *string `json:"name,omitempty"`
+	Optional *bool   `json:"optional,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_substitutefrompatchdefinition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_substitutefrompatchdefinition.go
@@ -1,0 +1,10 @@
+package fluxconfiguration
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SubstituteFromPatchDefinition struct {
+	Kind     *string `json:"kind,omitempty"`
+	Name     *string `json:"name,omitempty"`
+	Optional *bool   `json:"optional,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_tlsconfigdefinition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_tlsconfigdefinition.go
@@ -1,0 +1,10 @@
+package fluxconfiguration
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type TlsConfigDefinition struct {
+	CaCertificate     *string `json:"caCertificate,omitempty"`
+	ClientCertificate *string `json:"clientCertificate,omitempty"`
+	PrivateKey        *string `json:"privateKey,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_tlsconfigpatchdefinition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_tlsconfigpatchdefinition.go
@@ -1,0 +1,10 @@
+package fluxconfiguration
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type TlsConfigPatchDefinition struct {
+	CaCertificate     *string `json:"caCertificate,omitempty"`
+	ClientCertificate *string `json:"clientCertificate,omitempty"`
+	PrivateKey        *string `json:"privateKey,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_verifydefinition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_verifydefinition.go
@@ -1,0 +1,10 @@
+package fluxconfiguration
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VerifyDefinition struct {
+	MatchOidcIdentity  *[]MatchOidcIdentityDefinition `json:"matchOidcIdentity,omitempty"`
+	Provider           *string                        `json:"provider,omitempty"`
+	VerificationConfig *map[string]string             `json:"verificationConfig,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_verifypatchdefinition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/model_verifypatchdefinition.go
@@ -1,0 +1,10 @@
+package fluxconfiguration
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VerifyPatchDefinition struct {
+	MatchOidcIdentity  *[]MatchOidcIdentityPatchDefinition `json:"matchOidcIdentity,omitempty"`
+	Provider           *string                             `json:"provider,omitempty"`
+	VerificationConfig *map[string]string                  `json:"verificationConfig,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/predicates.go
@@ -1,0 +1,27 @@
+package fluxconfiguration
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type FluxConfigurationOperationPredicate struct {
+	Id   *string
+	Name *string
+	Type *string
+}
+
+func (p FluxConfigurationOperationPredicate) Matches(input FluxConfiguration) bool {
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration/version.go
@@ -1,0 +1,10 @@
+package fluxconfiguration
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2024-11-01"
+
+func userAgent() string {
+	return "hashicorp/go-azure-sdk/fluxconfiguration/2024-11-01"
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2024-05-01/networkmanageractiveconfigurations/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2024-05-01/networkmanageractiveconfigurations/constants.go
@@ -138,8 +138,6 @@ func parseGroupMemberType(input string) (*GroupMemberType, error) {
 type ProvisioningState string
 
 const (
-	ProvisioningStateCanceled  ProvisioningState = "Canceled"
-	ProvisioningStateCreating  ProvisioningState = "Creating"
 	ProvisioningStateDeleting  ProvisioningState = "Deleting"
 	ProvisioningStateFailed    ProvisioningState = "Failed"
 	ProvisioningStateSucceeded ProvisioningState = "Succeeded"
@@ -148,8 +146,6 @@ const (
 
 func PossibleValuesForProvisioningState() []string {
 	return []string{
-		string(ProvisioningStateCanceled),
-		string(ProvisioningStateCreating),
 		string(ProvisioningStateDeleting),
 		string(ProvisioningStateFailed),
 		string(ProvisioningStateSucceeded),
@@ -172,8 +168,6 @@ func (s *ProvisioningState) UnmarshalJSON(bytes []byte) error {
 
 func parseProvisioningState(input string) (*ProvisioningState, error) {
 	vals := map[string]ProvisioningState{
-		"canceled":  ProvisioningStateCanceled,
-		"creating":  ProvisioningStateCreating,
 		"deleting":  ProvisioningStateDeleting,
 		"failed":    ProvisioningStateFailed,
 		"succeeded": ProvisioningStateSucceeded,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2024-05-01/networkmanageractiveconnectivityconfigurations/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2024-05-01/networkmanageractiveconnectivityconfigurations/constants.go
@@ -217,8 +217,6 @@ func parseIsGlobal(input string) (*IsGlobal, error) {
 type ProvisioningState string
 
 const (
-	ProvisioningStateCanceled  ProvisioningState = "Canceled"
-	ProvisioningStateCreating  ProvisioningState = "Creating"
 	ProvisioningStateDeleting  ProvisioningState = "Deleting"
 	ProvisioningStateFailed    ProvisioningState = "Failed"
 	ProvisioningStateSucceeded ProvisioningState = "Succeeded"
@@ -227,8 +225,6 @@ const (
 
 func PossibleValuesForProvisioningState() []string {
 	return []string{
-		string(ProvisioningStateCanceled),
-		string(ProvisioningStateCreating),
 		string(ProvisioningStateDeleting),
 		string(ProvisioningStateFailed),
 		string(ProvisioningStateSucceeded),
@@ -251,8 +247,6 @@ func (s *ProvisioningState) UnmarshalJSON(bytes []byte) error {
 
 func parseProvisioningState(input string) (*ProvisioningState, error) {
 	vals := map[string]ProvisioningState{
-		"canceled":  ProvisioningStateCanceled,
-		"creating":  ProvisioningStateCreating,
 		"deleting":  ProvisioningStateDeleting,
 		"failed":    ProvisioningStateFailed,
 		"succeeded": ProvisioningStateSucceeded,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2024-06-01/autonomousdatabasebackups/model_autonomousdatabasebackupupdateproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2024-06-01/autonomousdatabasebackups/model_autonomousdatabasebackupupdateproperties.go
@@ -3,6 +3,6 @@ package autonomousdatabasebackups
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See NOTICE.txt in the project root for license information.
 
-type AutonomousDatabaseBackupUpdate struct {
-	Properties *AutonomousDatabaseBackupUpdateProperties `json:"properties,omitempty"`
+type AutonomousDatabaseBackupUpdateProperties struct {
+	RetentionPeriodInDays *int64 `json:"retentionPeriodInDays,omitempty"`
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -143,7 +143,7 @@ github.com/hashicorp/go-azure-helpers/resourcemanager/tags
 github.com/hashicorp/go-azure-helpers/resourcemanager/zones
 github.com/hashicorp/go-azure-helpers/sender
 github.com/hashicorp/go-azure-helpers/storage
-# github.com/hashicorp/go-azure-sdk/resource-manager v0.20250526.1224007
+# github.com/hashicorp/go-azure-sdk/resource-manager v0.20250606.1221725
 ## explicit; go 1.22
 github.com/hashicorp/go-azure-sdk/resource-manager/aad/2021-05-01/domainservices
 github.com/hashicorp/go-azure-sdk/resource-manager/aadb2c/2021-04-01-preview
@@ -610,6 +610,7 @@ github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/managedhs
 github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/vaults
 github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2022-11-01/extensions
 github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2023-05-01/fluxconfiguration
+github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration
 github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2024-04-13/attacheddatabaseconfigurations
 github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2024-04-13/clusterprincipalassignments
 github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2024-04-13/clusters
@@ -1181,7 +1182,7 @@ github.com/hashicorp/go-azure-sdk/resource-manager/workloads/2024-09-01/sapappli
 github.com/hashicorp/go-azure-sdk/resource-manager/workloads/2024-09-01/sapcentralserverinstances
 github.com/hashicorp/go-azure-sdk/resource-manager/workloads/2024-09-01/sapdatabaseinstances
 github.com/hashicorp/go-azure-sdk/resource-manager/workloads/2024-09-01/sapvirtualinstances
-# github.com/hashicorp/go-azure-sdk/sdk v0.20250526.1224007
+# github.com/hashicorp/go-azure-sdk/sdk v0.20250606.1221725
 ## explicit; go 1.22
 github.com/hashicorp/go-azure-sdk/sdk/auth
 github.com/hashicorp/go-azure-sdk/sdk/auth/autorest

--- a/website/docs/r/kubernetes_flux_configuration.html.markdown
+++ b/website/docs/r/kubernetes_flux_configuration.html.markdown
@@ -198,6 +198,8 @@ A `git_repository` block supports the following:
 
 * `local_auth_reference` - (Optional) Specifies the name of a local secret on the Kubernetes cluster to use as the authentication secret rather than the managed or user-provided configuration secrets. It must be between 1 and 63 characters. It can contain only lowercase letters, numbers, and hyphens (-). It must start and end with a lowercase letter or number.
 
+* `provider` - (Optional) Specifies the OIDC provider used for workload identity federation authentication against Azure DevOps git repositories. Possible values are `azure`, `generic`. Defaults to `generic` which indicates local secret based authentication used.
+
 * `ssh_private_key_base64` - (Optional) Specifies the Base64-encoded SSH private key in PEM format.
 
 * `ssh_known_hosts_base64` - (Optional) Specifies the Base64-encoded known_hosts value containing public SSH keys required to access private git repositories over SSH.


### PR DESCRIPTION
## Community Note
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description
* Minor change adds `provider` attribute to `git_repository` block within the `azurerm_kubernetes_flux_configuration` resource

## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 

## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.

## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

* Minor change adds `provider` attribute to `git_repository` block within the `azurerm_kubernetes_flux_configuration` resource

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [X] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #27821