### PR TITLE
Oracle Exascale Feature

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,8 +17,8 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-azure-helpers v0.72.0
-	github.com/hashicorp/go-azure-sdk/resource-manager v0.20250520.1180806
-	github.com/hashicorp/go-azure-sdk/sdk v0.20250520.1180806
+	github.com/hashicorp/go-azure-sdk/resource-manager v0.20250526.1224007
+	github.com/hashicorp/go-azure-sdk/sdk v0.20250526.1224007
 	github.com/hashicorp/go-cty v1.4.1
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -92,10 +92,10 @@ github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-azure-helpers v0.72.0 h1:eOCpXBkDYYMESkOBC0LgPMNUdiLPtQxv7sCW/hHdUbw=
 github.com/hashicorp/go-azure-helpers v0.72.0/go.mod h1:Omirva2gGNrhN4pigurl5RN7u3BoaN0bco8ZSbdaNy8=
-github.com/hashicorp/go-azure-sdk/resource-manager v0.20250520.1180806 h1:MEENQuAsDwRwHSB6eGpnA6E/7NOpVjqvdS2VTyydWHA=
-github.com/hashicorp/go-azure-sdk/resource-manager v0.20250520.1180806/go.mod h1:ZeFAzmaxJEZrvJJB663ylkKmAjQOaLiZ1owVa0kghCo=
-github.com/hashicorp/go-azure-sdk/sdk v0.20250520.1180806 h1:nteX2b+diNtQ7dGZxCVvkEQ4QDnO4rFRmQPChvVWaaE=
-github.com/hashicorp/go-azure-sdk/sdk v0.20250520.1180806/go.mod h1:/LiVkre6Py4M8+xkSHgJieWkHWv03USdwg5x/zeX9Rc=
+github.com/hashicorp/go-azure-sdk/resource-manager v0.20250526.1224007 h1:f6lHHLKKpP9UvqBJgTj9KYc151pl4Hejn+JPJc3tBaw=
+github.com/hashicorp/go-azure-sdk/resource-manager v0.20250526.1224007/go.mod h1:ODGrAh7XT0ZdevtTJmR+vQ7AlYUzsxDjPMMgRXa6KYo=
+github.com/hashicorp/go-azure-sdk/sdk v0.20250526.1224007 h1:r12QJswIykg3Ofqby1WJi1NnR42Qmnaij6/1kBCLLEg=
+github.com/hashicorp/go-azure-sdk/sdk v0.20250526.1224007/go.mod h1:/LiVkre6Py4M8+xkSHgJieWkHWv03USdwg5x/zeX9Rc=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=
 github.com/hashicorp/go-checkpoint v0.5.0/go.mod h1:7nfLNL10NsxqO4iWuW6tWW0HjZuDrwkBuEQsVcpCOgg=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=

--- a/internal/services/oracle/client/client.go
+++ b/internal/services/oracle/client/client.go
@@ -6,12 +6,14 @@ import (
 	"fmt"
 
 	oracle "github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2024-06-01"
+	oracle25 "github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01"
 	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/common"
 )
 
 type Client struct {
-	OracleClient *oracle.Client
+	OracleClient   *oracle.Client
+	OracleClient25 *oracle25.Client
 }
 
 func NewClient(o *common.ClientOptions) (*Client, error) {
@@ -23,9 +25,16 @@ func NewClient(o *common.ClientOptions) (*Client, error) {
 		o.Configure(c, o.Authorizers.ResourceManager)
 	})
 	if err != nil {
-		return nil, fmt.Errorf("building Database client: %+v", err)
+		return nil, fmt.Errorf("building Oracle client: %+v", err)
+	}
+	oracleClient25, err := oracle25.NewClientWithBaseURI(o.Environment.ResourceManager, func(c *resourcemanager.Client) {
+		o.Configure(c, o.Authorizers.ResourceManager)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("building Database client v2025 : %+v", err)
 	}
 	return &Client{
-		OracleClient: oracleClient,
+		OracleClient:   oracleClient,
+		OracleClient25: oracleClient25,
 	}, nil
 }

--- a/internal/services/oracle/oracle_exadb_vm_cluster_data_source.go
+++ b/internal/services/oracle/oracle_exadb_vm_cluster_data_source.go
@@ -1,0 +1,612 @@
+// Copyright © 2025, Oracle and/or its affiliates. All rights reserved
+
+package oracle
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/zones"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exadbvmclusters"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/oracle/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type ExadbVmClusterDataSource struct{}
+
+type ExadbVmClusterDataModel struct {
+	Name              string            `tfschema:"name"`
+	ResourceGroupName string            `tfschema:"resource_group_name"`
+	Tags              map[string]string `tfschema:"tags"`
+	Zones             zones.Schema      `tfschema:"zones"`
+
+	// ExadbVMClusterProperties
+	BackupSubnetCidr          string                            `tfschema:"backup_subnet_cidr"`
+	ClusterName               string                            `tfschema:"cluster_name"`
+	DataCollectionOptions     []ExadbDataCollectionOptionsModel `tfschema:"data_collection_options"`
+	DisplayName               string                            `tfschema:"display_name"`
+	Domain                    string                            `tfschema:"domain"`
+	EnabledEcpuCount          int64                             `tfschema:"enabled_ecpu_count"`
+	ExascaleDbStorageVaultId  string                            `tfschema:"exascale_db_storage_vault_id"`
+	GiVersion                 string                            `tfschema:"gi_version"`
+	GridImageOcid             string                            `tfschema:"grid_image_ocid"`
+	GridImageType             string                            `tfschema:"grid_image_type"`
+	Hostname                  string                            `tfschema:"hostname"`
+	HostnameActual            string                            `tfschema:"hostname_actual"`
+	IormConfigCache           []IormConfigModel                 `tfschema:"iorm_config_cache"`
+	LicenseModel              string                            `tfschema:"license_model"`
+	LifecycleDetails          string                            `tfschema:"lifecycle_details"`
+	LifecycleState            string                            `tfschema:"lifecycle_state"`
+	ListenerPort              int64                             `tfschema:"listener_port"`
+	Location                  string                            `tfschema:"location"`
+	MemorySizeInGbs           int64                             `tfschema:"memory_size_in_gbs"`
+	NodeCount                 int64                             `tfschema:"node_count"`
+	NsgCidrs                  []NsgCidrModel                    `tfschema:"nsg_cidrs"`
+	NsgUrl                    string                            `tfschema:"nsg_url"`
+	OciUrl                    string                            `tfschema:"oci_url"`
+	Ocid                      string                            `tfschema:"ocid"`
+	PrivateZoneOcid           string                            `tfschema:"private_zone_ocid"`
+	ScanDnsName               string                            `tfschema:"scan_dns_name"`
+	ScanDnsRecordId           string                            `tfschema:"scan_dns_record_id"`
+	ScanIPIds                 []string                          `tfschema:"scan_ip_ids"`
+	ScanListenerPortTcp       int64                             `tfschema:"scan_listener_port_tcp"`
+	ScanListenerPortTcpSsl    int64                             `tfschema:"scan_listener_port_tcp_ssl"`
+	Shape                     string                            `tfschema:"shape"`
+	SnapshotFileSystemStorage []ExadbVmClusterStorageModel      `tfschema:"snapshot_file_system_storage"`
+	SshPublicKeys             []string                          `tfschema:"ssh_public_keys"`
+	SubnetId                  string                            `tfschema:"subnet_id"`
+	SubnetOcid                string                            `tfschema:"subnet_ocid"`
+	SystemVersion             string                            `tfschema:"system_version"`
+	TimeZone                  string                            `tfschema:"time_zone"`
+	TotalEcpuCount            int64                             `tfschema:"total_ecpu_count"`
+	TotalFileSystemStorage    []ExadbVmClusterStorageModel      `tfschema:"total_file_system_storage"`
+	VipIds                    []string                          `tfschema:"vip_ids"`
+	VmFileSystemStorage       []ExadbVmClusterStorageModel      `tfschema:"vm_file_system_storage"`
+	VnetId                    string                            `tfschema:"virtual_network_id"`
+	ZoneOcid                  string                            `tfschema:"zone_ocid"`
+}
+
+type ExadbDataCollectionOptionsModel struct {
+	IsDiagnosticsEventsEnabled bool `tfschema:"diagnostics_events_enabled"`
+	IsHealthMonitoringEnabled  bool `tfschema:"health_monitoring_enabled"`
+	IsIncidentLogsEnabled      bool `tfschema:"incident_logs_enabled"`
+}
+
+type IormConfigModel struct {
+	DbPlans          []ExadbDbIormConfigModel `tfschema:"db_plans"`
+	LifecycleDetails string                   `tfschema:"lifecycle_details"`
+	LifecycleState   string                   `tfschema:"lifecycle_state"`
+	Objective        string                   `tfschema:"objective"`
+}
+
+type ExadbDbIormConfigModel struct {
+	DbName          string `tfschema:"db_name"`
+	FlashCacheLimit string `tfschema:"flash_cache_limit"`
+	Share           int64  `tfschema:"share"`
+}
+
+type ExadbVmClusterStorageModel struct {
+	TotalSizeInGbs int64 `tfschema:"total_size_in_gbs"`
+}
+
+type NsgCidrModel struct {
+	DestinationPortRange []PortRangeModel `tfschema:"destination_port_range"`
+	Source               string           `tfschema:"source"`
+}
+
+type PortRangeModel struct {
+	Max int64 `tfschema:"max"`
+	Min int64 `tfschema:"min"`
+}
+
+func (d ExadbVmClusterDataSource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"resource_group_name": commonschema.ResourceGroupNameForDataSource(),
+		"zones":               commonschema.ZonesMultipleOptional(),
+
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: validate.ExadbVMClusterName,
+		},
+	}
+}
+
+func (d ExadbVmClusterDataSource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"location": commonschema.LocationComputed(),
+
+		// ExadbVMClusterProperties
+		"backup_subnet_cidr": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"cluster_name": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"data_collection_options": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"diagnostics_events_enabled": {
+						Type:     pluginsdk.TypeBool,
+						Computed: true,
+					},
+
+					"health_monitoring_enabled": {
+						Type:     pluginsdk.TypeBool,
+						Computed: true,
+					},
+
+					"incident_logs_enabled": {
+						Type:     pluginsdk.TypeBool,
+						Computed: true,
+					},
+				},
+			},
+		},
+
+		"display_name": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"domain": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"enabled_ecpu_count": {
+			Type:     pluginsdk.TypeInt,
+			Computed: true,
+		},
+
+		"exascale_db_storage_vault_id": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"gi_version": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"grid_image_ocid": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"grid_image_type": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"hostname": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"hostname_actual": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"iorm_config_cache": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"db_plans": {
+						Type:     pluginsdk.TypeList,
+						Computed: true,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"db_name": {
+									Type:     pluginsdk.TypeString,
+									Computed: true,
+								},
+
+								"flash_cache_limit": {
+									Type:     pluginsdk.TypeString,
+									Computed: true,
+								},
+
+								"share": {
+									Type:     pluginsdk.TypeInt,
+									Computed: true,
+								},
+							},
+						},
+					},
+
+					"lifecycle_details": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+
+					"lifecycle_state": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+
+					"objective": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+				},
+			},
+		},
+
+		"license_model": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"lifecycle_details": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"lifecycle_state": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"listener_port": {
+			Type:     pluginsdk.TypeInt,
+			Computed: true,
+		},
+
+		"memory_size_in_gbs": {
+			Type:     pluginsdk.TypeInt,
+			Computed: true,
+		},
+
+		"node_count": {
+			Type:     pluginsdk.TypeInt,
+			Computed: true,
+		},
+
+		"nsg_cidrs": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"destination_port_range": {
+						Type:     pluginsdk.TypeList,
+						Computed: true,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"max": {
+									Type:     pluginsdk.TypeInt,
+									Computed: true,
+								},
+
+								"min": {
+									Type:     pluginsdk.TypeInt,
+									Computed: true,
+								},
+							},
+						},
+					},
+
+					"source": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+				},
+			},
+		},
+
+		"nsg_url": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"oci_url": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"ocid": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"private_zone_ocid": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"scan_dns_name": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"scan_dns_record_id": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"scan_ip_ids": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+			},
+		},
+
+		"scan_listener_port_tcp": {
+			Type:     pluginsdk.TypeInt,
+			Computed: true,
+		},
+
+		"scan_listener_port_tcp_ssl": {
+			Type:     pluginsdk.TypeInt,
+			Computed: true,
+		},
+
+		"shape": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"snapshot_file_system_storage": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"total_size_in_gbs": {
+						Type:     pluginsdk.TypeInt,
+						Computed: true,
+					},
+				},
+			},
+		},
+
+		"ssh_public_keys": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+			},
+		},
+
+		"subnet_id": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"subnet_ocid": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"system_version": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"time_zone": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"total_ecpu_count": {
+			Type:     pluginsdk.TypeInt,
+			Computed: true,
+		},
+
+		"total_file_system_storage": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"total_size_in_gbs": {
+						Type:     pluginsdk.TypeInt,
+						Computed: true,
+					},
+				},
+			},
+		},
+
+		"vip_ids": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+			},
+		},
+
+		"vm_file_system_storage": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"total_size_in_gbs": {
+						Type:     pluginsdk.TypeInt,
+						Computed: true,
+					},
+				},
+			},
+		},
+
+		"virtual_network_id": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"zone_ocid": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"tags": commonschema.TagsDataSource(),
+	}
+}
+
+func (d ExadbVmClusterDataSource) ModelObject() interface{} {
+	return &ExadbVmClusterDataModel{}
+}
+
+func (d ExadbVmClusterDataSource) ResourceType() string {
+	return "azurerm_oracle_exa_db_vm_cluster"
+}
+
+func (d ExadbVmClusterDataSource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return exadbvmclusters.ValidateExadbVMClusterID
+}
+
+func (d ExadbVmClusterDataSource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Oracle.OracleClient25.ExadbVMClusters
+			subscriptionId := metadata.Client.Account.SubscriptionId
+
+			var state ExadbVmClusterDataModel
+			if err := metadata.Decode(&state); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			id := exadbvmclusters.NewExadbVMClusterID(subscriptionId, state.ResourceGroupName, state.Name)
+
+			resp, err := client.Get(ctx, id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return fmt.Errorf("%s was not found", id)
+				}
+				return fmt.Errorf("retrieving %s: %+v", id, err)
+			}
+
+			if model := resp.Model; model != nil {
+				state.Location = location.Normalize(model.Location)
+				state.Tags = pointer.From(model.Tags)
+				state.Zones = pointer.From(model.Zones)
+				if props := model.Properties; props != nil {
+					state.BackupSubnetCidr = pointer.From(props.BackupSubnetCidr)
+					state.ClusterName = pointer.From(props.ClusterName)
+					state.DataCollectionOptions = FlattenExadbDataCollectionOptions(props.DataCollectionOptions)
+					state.DisplayName = props.DisplayName
+					state.Domain = pointer.From(props.Domain)
+					state.EnabledEcpuCount = props.EnabledEcpuCount
+					state.ExascaleDbStorageVaultId = props.ExascaleDbStorageVaultId
+					state.GiVersion = pointer.From(props.GiVersion)
+					state.GridImageOcid = pointer.From(props.GridImageOcid)
+					state.GridImageType = string(pointer.From(props.GridImageType))
+					state.Hostname = removeHostnameSuffix(props.Hostname)
+					state.HostnameActual = props.Hostname
+					state.IormConfigCache = FlattenIormConfig(props.IormConfigCache)
+					state.LicenseModel = string(pointer.From(props.LicenseModel))
+					state.LifecycleDetails = pointer.From(props.LifecycleDetails)
+					state.LifecycleState = string(*props.LifecycleState)
+					state.ListenerPort = pointer.From(props.ListenerPort)
+					state.MemorySizeInGbs = pointer.From(props.MemorySizeInGbs)
+					state.NodeCount = props.NodeCount
+					state.NsgCidrs = FlattenNsgCidrs(props.NsgCidrs)
+					state.NsgUrl = pointer.From(props.NsgURL)
+					state.OciUrl = pointer.From(props.OciURL)
+					state.Ocid = pointer.From(props.Ocid)
+					state.PrivateZoneOcid = pointer.From(props.PrivateZoneOcid)
+					state.ScanDnsName = pointer.From(props.ScanDnsName)
+					state.ScanDnsRecordId = pointer.From(props.ScanDnsRecordId)
+					state.ScanIPIds = pointer.From(props.ScanIPIds)
+					state.ScanListenerPortTcp = pointer.From(props.ScanListenerPortTcp)
+					state.ScanListenerPortTcpSsl = pointer.From(props.ScanListenerPortTcpSsl)
+					state.Shape = props.Shape
+					state.SnapshotFileSystemStorage = FlattenExadbVmClusterStorage(props.SnapshotFileSystemStorage)
+					state.SshPublicKeys = props.SshPublicKeys
+					state.SubnetId = props.SubnetId
+					state.SubnetOcid = pointer.From(props.SubnetOcid)
+					state.SystemVersion = pointer.From(props.SystemVersion)
+					state.TimeZone = pointer.From(props.TimeZone)
+					state.TotalEcpuCount = props.TotalEcpuCount
+					state.TotalFileSystemStorage = FlattenExadbVmClusterStorage(props.TotalFileSystemStorage)
+					state.VipIds = *props.VipIds
+					state.VmFileSystemStorage = FlattenVMFileSystemStorage(props.VMFileSystemStorage)
+					state.VnetId = props.VnetId
+					state.ZoneOcid = pointer.From(props.ZoneOcid)
+				}
+			}
+
+			metadata.SetID(id)
+
+			return metadata.Encode(&state)
+		},
+	}
+}
+
+func FlattenIormConfig(input *exadbvmclusters.ExadataIormConfig) []IormConfigModel {
+	output := make([]IormConfigModel, 0)
+
+	if input != nil {
+		var dbIormConfigModel []ExadbDbIormConfigModel
+		if input.DbPlans != nil {
+			dbPlans := *input.DbPlans
+			for _, dbPlan := range dbPlans {
+				dbIormConfigModel = append(dbIormConfigModel, ExadbDbIormConfigModel{
+					DbName:          pointer.From(dbPlan.DbName),
+					FlashCacheLimit: pointer.From(dbPlan.FlashCacheLimit),
+					Share:           pointer.From(dbPlan.Share),
+				})
+			}
+		}
+		return append(output, IormConfigModel{
+			DbPlans:          dbIormConfigModel,
+			LifecycleDetails: pointer.From(input.LifecycleDetails),
+			LifecycleState:   string(pointer.From(input.LifecycleState)),
+			Objective:        string(pointer.From(input.Objective)),
+		})
+	}
+
+	return output
+}
+
+func FlattenExadbVmClusterStorage(input *exadbvmclusters.ExadbVMClusterStorageDetails) []ExadbVmClusterStorageModel {
+	output := make([]ExadbVmClusterStorageModel, 0)
+	if input != nil {
+		return append(output, ExadbVmClusterStorageModel{
+			TotalSizeInGbs: input.TotalSizeInGbs,
+		})
+	}
+	return output
+}
+
+func FlattenVMFileSystemStorage(input exadbvmclusters.ExadbVMClusterStorageDetails) []ExadbVmClusterStorageModel {
+	output := make([]ExadbVmClusterStorageModel, 0)
+	return append(output, ExadbVmClusterStorageModel{
+		TotalSizeInGbs: input.TotalSizeInGbs,
+	})
+}
+
+func FlattenNsgCidrs(input *[]exadbvmclusters.NsgCidr) []NsgCidrModel {
+	output := make([]NsgCidrModel, 0)
+
+	if input != nil {
+		for _, nsgCidr := range *input {
+			var portRangeModel []PortRangeModel
+			if nsgCidr.DestinationPortRange != nil {
+				portRangeModel = append(portRangeModel, PortRangeModel{
+					Max: nsgCidr.DestinationPortRange.Max,
+					Min: nsgCidr.DestinationPortRange.Min,
+				})
+			}
+			output = append(output, NsgCidrModel{
+				DestinationPortRange: portRangeModel,
+				Source:               nsgCidr.Source,
+			})
+		}
+	}
+
+	return output
+}

--- a/internal/services/oracle/oracle_exadb_vm_cluster_data_source_test.go
+++ b/internal/services/oracle/oracle_exadb_vm_cluster_data_source_test.go
@@ -1,0 +1,47 @@
+// Copyright © 2025, Oracle and/or its affiliates. All rights reserved
+
+package oracle_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/oracle"
+)
+
+type ExadbVmClusterDataSource struct{}
+
+func TestExadbVmClusterDataSource_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, oracle.ExadbVmClusterDataSource{}.ResourceType(), "test")
+	r := ExadbVmClusterDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("location").Exists(),
+				check.That(data.ResourceName).Key("name").Exists(),
+				check.That(data.ResourceName).Key("resource_group_name").Exists(),
+				check.That(data.ResourceName).Key("exascale_db_storage_vault_id").Exists(),
+				check.That(data.ResourceName).Key("display_name").Exists(),
+				check.That(data.ResourceName).Key("enabled_ecpu_count").Exists(),
+				check.That(data.ResourceName).Key("grid_image_ocid").Exists(),
+				check.That(data.ResourceName).Key("total_ecpu_count").Exists(),
+				check.That(data.ResourceName).Key("subnet_id").Exists(),
+			),
+		},
+	})
+}
+
+func (d ExadbVmClusterDataSource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_oracle_exa_db_vm_cluster" "test" {
+  name                = azurerm_oracle_exa_db_vm_cluster.test.name
+  resource_group_name = azurerm_oracle_exa_db_vm_cluster.test.resource_group_name
+}
+`, ExadbVmClusterResource{}.basic(data))
+}

--- a/internal/services/oracle/oracle_exadb_vm_cluster_resource.go
+++ b/internal/services/oracle/oracle_exadb_vm_cluster_resource.go
@@ -1,0 +1,613 @@
+// Copyright © 2025, Oracle and/or its affiliates. All rights reserved
+
+package oracle
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/zones"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbstoragevaults"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exadbvmclusters"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/oracle/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+var _ sdk.Resource = ExadbVmClusterResource{}
+
+type ExadbVmClusterResource struct{}
+
+type ExadbVmClusterResourceModel struct {
+	// Azure
+	Location          string            `tfschema:"location"`
+	Name              string            `tfschema:"name"`
+	ResourceGroupName string            `tfschema:"resource_group_name"`
+	Tags              map[string]string `tfschema:"tags"`
+	Zones             zones.Schema      `tfschema:"zones"`
+
+	// Required
+	DisplayName              string                       `tfschema:"display_name"`
+	EnabledEcpuCount         int64                        `tfschema:"enabled_ecpu_count"`
+	ExascaleDbStorageVaultId string                       `tfschema:"exascale_db_storage_vault_id"`
+	GridImageOcid            string                       `tfschema:"grid_image_ocid"`
+	Hostname                 string                       `tfschema:"hostname"`
+	NodeCount                int64                        `tfschema:"node_count"`
+	Shape                    string                       `tfschema:"shape"`
+	SshPublicKeys            []string                     `tfschema:"ssh_public_keys"`
+	SubnetId                 string                       `tfschema:"subnet_id"`
+	TotalEcpuCount           int64                        `tfschema:"total_ecpu_count"`
+	VmFileSystemStorage      []ExadbVmClusterStorageModel `tfschema:"vm_file_system_storage"`
+	VnetId                   string                       `tfschema:"virtual_network_id"`
+
+	// Optional
+	BackupSubnetCidr       string                            `tfschema:"backup_subnet_cidr"`
+	ClusterName            string                            `tfschema:"cluster_name"`
+	DataCollectionOptions  []ExadbDataCollectionOptionsModel `tfschema:"data_collection_options"`
+	Domain                 string                            `tfschema:"domain"`
+	LicenseModel           string                            `tfschema:"license_model"`
+	NsgCidrs               []NsgCidrModel                    `tfschema:"nsg_cidrs"`
+	Ocid                   string                            `tfschema:"ocid"`
+	PrivateZoneOcid        string                            `tfschema:"private_zone_ocid"`
+	ScanListenerPortTcp    int64                             `tfschema:"scan_listener_port_tcp"`
+	ScanListenerPortTcpSsl int64                             `tfschema:"scan_listener_port_tcp_ssl"`
+	SystemVersion          string                            `tfschema:"system_version"`
+	TimeZone               string                            `tfschema:"time_zone"`
+}
+
+func (ExadbVmClusterResource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"location": commonschema.Location(),
+
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: validate.ExadbVMClusterName,
+			ForceNew:     true,
+		},
+
+		"resource_group_name": commonschema.ResourceGroupName(),
+
+		// Required
+		"display_name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validate.ExadbVMClusterName,
+		},
+
+		"enabled_ecpu_count": {
+			Type:         pluginsdk.TypeInt,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validate.EcpuCount,
+		},
+
+		"exascale_db_storage_vault_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: exascaledbstoragevaults.ValidateExascaleDbStorageVaultID,
+		},
+
+		"grid_image_ocid": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"hostname": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"node_count": {
+			Type:         pluginsdk.TypeInt,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.IntBetween(2, 10),
+		},
+
+		"shape": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+		},
+
+		"ssh_public_keys": {
+			Type:     pluginsdk.TypeList,
+			Required: true,
+			ForceNew: true,
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+			},
+		},
+
+		"subnet_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: commonids.ValidateSubnetID,
+		},
+
+		"total_ecpu_count": {
+			Type:         pluginsdk.TypeInt,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validate.EcpuCount,
+		},
+
+		"vm_file_system_storage": {
+			Type:     pluginsdk.TypeList,
+			Required: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"total_size_in_gbs": {
+						Type:     pluginsdk.TypeInt,
+						Required: true,
+					},
+				},
+			},
+		},
+
+		"virtual_network_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: commonids.ValidateVirtualNetworkID,
+		},
+
+		// Optional
+		"backup_subnet_cidr": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.IsCIDR,
+		},
+
+		"cluster_name": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			Computed:     true,
+			ForceNew:     true,
+			ValidateFunc: validate.ClusterName,
+		},
+
+		"data_collection_options": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			Computed: true,
+			ForceNew: true,
+			MaxItems: 1,
+			MinItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"diagnostics_events_enabled": {
+						Type:     pluginsdk.TypeBool,
+						Optional: true,
+						Computed: true,
+						ForceNew: true,
+					},
+
+					"health_monitoring_enabled": {
+						Type:     pluginsdk.TypeBool,
+						Optional: true,
+						Computed: true,
+						ForceNew: true,
+					},
+
+					"incident_logs_enabled": {
+						Type:     pluginsdk.TypeBool,
+						Optional: true,
+						Computed: true,
+						ForceNew: true,
+					},
+				},
+			},
+		},
+
+		"domain": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+			ForceNew: true,
+		},
+
+		"license_model": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ForceNew:     true,
+			ValidateFunc: validate.ExadbLicenseModel,
+		},
+
+		"nsg_cidrs": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			Computed: true,
+			ForceNew: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"destination_port_range": {
+						Type:     pluginsdk.TypeList,
+						Computed: true,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"max": {
+									Type:     pluginsdk.TypeInt,
+									Optional: true,
+									Computed: true,
+									ForceNew: true,
+								},
+
+								"min": {
+									Type:     pluginsdk.TypeInt,
+									Optional: true,
+									Computed: true,
+									ForceNew: true,
+								},
+							},
+						},
+					},
+					"source": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						Computed: true,
+						ForceNew: true,
+					},
+				},
+			},
+		},
+
+		"private_zone_ocid": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+			ForceNew: true,
+		},
+
+		"scan_listener_port_tcp": {
+			Type:         pluginsdk.TypeInt,
+			Optional:     true,
+			Default:      1521,
+			ForceNew:     true,
+			ValidateFunc: validation.IntBetween(1024, 8999),
+		},
+
+		"scan_listener_port_tcp_ssl": {
+			Type:         pluginsdk.TypeInt,
+			Optional:     true,
+			Default:      2484,
+			ForceNew:     true,
+			ValidateFunc: validation.IntBetween(1024, 8999),
+		},
+
+		"system_version": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			Computed:     true,
+			ValidateFunc: validate.ExadbSystemVersion,
+		},
+
+		"time_zone": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Computed: true,
+			ForceNew: true,
+		},
+
+		"tags": commonschema.Tags(),
+
+		"zones": commonschema.ZonesMultipleRequiredForceNew(),
+	}
+}
+
+func (ExadbVmClusterResource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"hostname_actual": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"ocid": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+	}
+}
+
+func (ExadbVmClusterResource) ModelObject() interface{} {
+	return &ExadbVmClusterResource{}
+}
+
+func (ExadbVmClusterResource) ResourceType() string {
+	return "azurerm_oracle_exa_db_vm_cluster"
+}
+
+func (r ExadbVmClusterResource) Create() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 24 * time.Hour,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Oracle.OracleClient25.ExadbVMClusters
+			subscriptionId := metadata.Client.Account.SubscriptionId
+
+			var model ExadbVmClusterResourceModel
+			if err := metadata.Decode(&model); err != nil {
+				return err
+			}
+
+			id := exadbvmclusters.NewExadbVMClusterID(subscriptionId, model.ResourceGroupName, model.Name)
+
+			existing, err := client.Get(ctx, id)
+			if err != nil && !response.WasNotFound(existing.HttpResponse) {
+				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+			}
+			if !response.WasNotFound(existing.HttpResponse) {
+				return metadata.ResourceRequiresImport(r.ResourceType(), id)
+			}
+
+			param := exadbvmclusters.ExadbVMCluster{
+				// Azure
+				Name:     pointer.To(model.Name),
+				Location: model.Location,
+				Tags:     pointer.To(model.Tags),
+				Zones:    pointer.To(model.Zones),
+				Properties: &exadbvmclusters.ExadbVMClusterProperties{
+					// Required
+					DisplayName:              model.DisplayName,
+					EnabledEcpuCount:         model.EnabledEcpuCount,
+					ExascaleDbStorageVaultId: model.ExascaleDbStorageVaultId,
+					GridImageOcid:            pointer.To(model.GridImageOcid),
+					Hostname:                 model.Hostname,
+					NodeCount:                model.NodeCount,
+					Shape:                    model.Shape,
+					SshPublicKeys:            model.SshPublicKeys,
+					SubnetId:                 model.SubnetId,
+					TotalEcpuCount:           model.TotalEcpuCount,
+					VnetId:                   model.VnetId,
+				},
+			}
+
+			if len(model.VmFileSystemStorage) > 0 {
+				param.Properties.VMFileSystemStorage = exadbvmclusters.ExadbVMClusterStorageDetails{
+					TotalSizeInGbs: model.VmFileSystemStorage[0].TotalSizeInGbs,
+				}
+			}
+
+			if model.BackupSubnetCidr != "" {
+				param.Properties.BackupSubnetCidr = pointer.To(model.BackupSubnetCidr)
+			}
+			if model.ClusterName != "" {
+				param.Properties.ClusterName = pointer.To(model.ClusterName)
+			}
+			if len(model.DataCollectionOptions) > 0 {
+				param.Properties.DataCollectionOptions = &exadbvmclusters.DataCollectionOptions{
+					IsDiagnosticsEventsEnabled: pointer.To(model.DataCollectionOptions[0].IsDiagnosticsEventsEnabled),
+					IsHealthMonitoringEnabled:  pointer.To(model.DataCollectionOptions[0].IsHealthMonitoringEnabled),
+					IsIncidentLogsEnabled:      pointer.To(model.DataCollectionOptions[0].IsIncidentLogsEnabled),
+				}
+			}
+			if model.Domain != "" {
+				param.Properties.Domain = pointer.To(model.Domain)
+			}
+			if model.LicenseModel != "" {
+				param.Properties.LicenseModel = pointer.To(exadbvmclusters.LicenseModel(model.LicenseModel))
+			}
+			if len(model.NsgCidrs) > 0 {
+				param.Properties.NsgCidrs = pointer.To(ExpandNsgCidrs(model.NsgCidrs))
+			}
+			if model.PrivateZoneOcid != "" {
+				param.Properties.PrivateZoneOcid = pointer.To(model.PrivateZoneOcid)
+			}
+			if model.ScanListenerPortTcp >= 1024 && model.ScanListenerPortTcp <= 8999 {
+				param.Properties.ScanListenerPortTcp = pointer.To(model.ScanListenerPortTcp)
+			}
+			if model.ScanListenerPortTcpSsl >= 1024 && model.ScanListenerPortTcpSsl <= 8999 {
+				param.Properties.ScanListenerPortTcpSsl = pointer.To(model.ScanListenerPortTcpSsl)
+			}
+			if model.SystemVersion != "" {
+				param.Properties.SystemVersion = pointer.To(model.SystemVersion)
+			}
+			if model.TimeZone != "" {
+				param.Properties.TimeZone = pointer.To(model.TimeZone)
+			}
+
+			if err := client.CreateOrUpdateThenPoll(ctx, id, param); err != nil {
+				return fmt.Errorf("creating %s: %+v", id, err)
+			}
+
+			metadata.SetID(id)
+			return nil
+		},
+	}
+}
+
+func (r ExadbVmClusterResource) Update() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Oracle.OracleClient25.ExadbVMClusters
+			id, err := exadbvmclusters.ParseExadbVMClusterID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			var model ExadbVmClusterResourceModel
+			if err = metadata.Decode(&model); err != nil {
+				return fmt.Errorf("decoding err: %+v", err)
+			}
+
+			_, err = client.Get(ctx, *id)
+			if err != nil {
+				return fmt.Errorf("retrieving %s: %+v", *id, err)
+			}
+
+			update := &exadbvmclusters.ExadbVMClusterUpdate{
+				Properties: &exadbvmclusters.ExadbVMClusterUpdateProperties{},
+			}
+
+			if metadata.ResourceData.HasChange("node_count") {
+				update.Properties.NodeCount = pointer.To(model.NodeCount)
+			}
+
+			if metadata.ResourceData.HasChange("tags") {
+				update.Tags = pointer.To(model.Tags)
+			}
+
+			err = client.UpdateThenPoll(ctx, *id, *update)
+			if err != nil {
+				return fmt.Errorf("updating %s: %v", id, err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func (ExadbVmClusterResource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			id, err := exadbvmclusters.ParseExadbVMClusterID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			client := metadata.Client.Oracle.OracleClient25.ExadbVMClusters
+			resp, err := client.Get(ctx, *id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return metadata.MarkAsGone(id)
+				}
+				return fmt.Errorf("retrieving %s: %+v", id, err)
+			}
+
+			state := ExadbVmClusterResourceModel{
+				Name:              id.ExadbVmClusterName,
+				ResourceGroupName: id.ResourceGroupName,
+			}
+
+			// Azure
+			if model := resp.Model; model != nil {
+				state.Location = model.Location
+				state.Tags = pointer.From(model.Tags)
+				state.Zones = pointer.From(model.Zones)
+
+				if props := model.Properties; props != nil {
+					state.DisplayName = props.DisplayName
+					state.EnabledEcpuCount = props.EnabledEcpuCount
+					state.ExascaleDbStorageVaultId = props.ExascaleDbStorageVaultId
+					state.GridImageOcid = pointer.From(props.GridImageOcid)
+					state.Hostname = props.Hostname
+					state.NodeCount = props.NodeCount
+					state.Shape = props.Shape
+					state.SshPublicKeys = props.SshPublicKeys
+					tmp := make([]string, 0)
+					for _, key := range props.SshPublicKeys {
+						if key != "" {
+							tmp = append(tmp, key)
+						}
+					}
+					state.SshPublicKeys = tmp
+					state.SubnetId = props.SubnetId
+					state.TotalEcpuCount = props.TotalEcpuCount
+					state.VmFileSystemStorage = FlattenVMFileSystemStorage(props.VMFileSystemStorage)
+					state.VnetId = props.VnetId
+					state.Location = model.Location
+					state.Tags = pointer.From(model.Tags)
+					state.Zones = pointer.From(model.Zones)
+
+					// Optional
+					state.BackupSubnetCidr = pointer.From(props.BackupSubnetCidr)
+					state.ClusterName = pointer.From(props.ClusterName)
+					state.DataCollectionOptions = FlattenExadbDataCollectionOptionsInterface(metadata.ResourceData.Get("data_collection_options").([]interface{}))
+					state.Domain = pointer.From(props.Domain)
+					state.LicenseModel = string(pointer.From(props.LicenseModel))
+					state.NsgCidrs = FlattenNsgCidrs(props.NsgCidrs)
+					state.Ocid = pointer.From(props.Ocid)
+					state.PrivateZoneOcid = pointer.From(props.PrivateZoneOcid)
+					state.ScanListenerPortTcp = pointer.From(props.ScanListenerPortTcp)
+					state.ScanListenerPortTcpSsl = pointer.From(props.ScanListenerPortTcpSsl)
+					state.SystemVersion = metadata.ResourceData.Get("system_version").(string)
+					state.TimeZone = pointer.From(props.TimeZone)
+				}
+			}
+
+			return metadata.Encode(&state)
+		},
+	}
+}
+
+func (ExadbVmClusterResource) Delete() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Oracle.OracleClient25.ExadbVMClusters
+
+			id, err := exadbvmclusters.ParseExadbVMClusterID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			if err = client.DeleteThenPoll(ctx, *id); err != nil {
+				return fmt.Errorf("deleting %s: %+v", *id, err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func (ExadbVmClusterResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return exadbvmclusters.ValidateExadbVMClusterID
+}
+
+func FlattenExadbDataCollectionOptions(dataCollectionOptions *exadbvmclusters.DataCollectionOptions) []ExadbDataCollectionOptionsModel {
+	output := make([]ExadbDataCollectionOptionsModel, 0)
+	if dataCollectionOptions != nil {
+		return append(output, ExadbDataCollectionOptionsModel{
+			IsDiagnosticsEventsEnabled: pointer.From(dataCollectionOptions.IsDiagnosticsEventsEnabled),
+			IsHealthMonitoringEnabled:  pointer.From(dataCollectionOptions.IsHealthMonitoringEnabled),
+			IsIncidentLogsEnabled:      pointer.From(dataCollectionOptions.IsIncidentLogsEnabled),
+		})
+	}
+	return output
+}
+
+func FlattenExadbDataCollectionOptionsInterface(input []interface{}) []ExadbDataCollectionOptionsModel {
+	output := make([]ExadbDataCollectionOptionsModel, 0)
+	if len(input) == 0 || input[0] == nil {
+		return output
+	}
+	if m, ok := input[0].(map[string]interface{}); ok {
+		dataCollection := ExadbDataCollectionOptionsModel{
+			IsDiagnosticsEventsEnabled: m["diagnostics_events_enabled"].(bool),
+			IsHealthMonitoringEnabled:  m["health_monitoring_enabled"].(bool),
+			IsIncidentLogsEnabled:      m["incident_logs_enabled"].(bool),
+		}
+		output = append(output, dataCollection)
+	}
+	return output
+}
+
+func ExpandNsgCidrs(input []NsgCidrModel) []exadbvmclusters.NsgCidr {
+	output := make([]exadbvmclusters.NsgCidr, 0, len(input))
+
+	for _, nsgCidr := range input {
+		var portRangeValue = exadbvmclusters.PortRange{
+			Max: nsgCidr.DestinationPortRange[0].Max,
+			Min: nsgCidr.DestinationPortRange[0].Min,
+		}
+		output = append(output, exadbvmclusters.NsgCidr{
+			DestinationPortRange: pointer.To(portRangeValue),
+			Source:               nsgCidr.Source,
+		})
+	}
+	return output
+}

--- a/internal/services/oracle/oracle_exadb_vm_cluster_resource_test.go
+++ b/internal/services/oracle/oracle_exadb_vm_cluster_resource_test.go
@@ -1,0 +1,264 @@
+// Copyright © 2025, Oracle and/or its affiliates. All rights reserved
+
+package oracle_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exadbvmclusters"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/oracle"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type ExadbVmClusterResource struct{}
+
+func (a ExadbVmClusterResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := exadbvmclusters.ParseExadbVMClusterID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Oracle.OracleClient25.ExadbVMClusters.Get(ctx, *id)
+	if err != nil {
+		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+	return pointer.To(resp.Model != nil), nil
+}
+
+func TestExadbVmClusterResource_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, oracle.ExadbVmClusterResource{}.ResourceType(), "test")
+	r := ExadbVmClusterResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestExadbVmClusterResource_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, oracle.ExadbVmClusterResource{}.ResourceType(), "test")
+	r := ExadbVmClusterResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("data_collection_options", "system_version"),
+	})
+}
+
+func TestExadbVmClusterResource_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, oracle.ExadbVmClusterResource{}.ResourceType(), "test")
+	r := ExadbVmClusterResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func TestExadbVmClusterResource_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, oracle.ExadbVmClusterResource{}.ResourceType(), "test")
+	r := ExadbVmClusterResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.update(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("data_collection_options"),
+	})
+}
+
+func (a ExadbVmClusterResource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+  %s
+resource "azurerm_oracle_exa_db_vm_cluster" "test" {
+  location                        = "%[3]s"
+  name                            = "OFakeVmacctest%[2]d"
+  zones               			  = ["2"]
+  resource_group_name             = azurerm_resource_group.test.name
+  exascale_db_storage_vault_id	  = azurerm_oracle_exascale_db_storage_vault.test.id
+  display_name                    = "OFakeVmacctest%[2]d"
+  enabled_ecpu_count              = 16
+  grid_image_ocid				  = "ocid1.dbpatch.oc1.iad.anuwcljtt5t4sqqaoajnkveobp3ryw7zlfrrcf6tb2ndvygp54z2gbds2hxa"
+  hostname                        = "host"
+  node_count              		  = 2
+  shape                      	  = "EXADBXS"
+  ssh_public_keys                 = ["ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC+wWK73dCr+jgQOAxNsHAnNNNMEMWOHYEccp6wJm2gotpr9katuF/ZAdou5AaW1C61slRkHRkpRRX9FA9CYBiitZgvCCz+3nWNN7l/Up54Zps/pHWGZLHNJZRYyAB6j5yVLMVHIHriY49d/GZTZVNB8GoJv9Gakwc/fuEZYYl4YDFiGMBP///TzlI4jhiJzjKnEvqPFki5p2ZRJqcbCiF4pJrxUQR/RXqVFQdbRLZgYfJ8xGB878RENq3yQ39d8dVOkq4edbkzwcUmwwwkYVPIoDGsYLaRHnG+To7FvMeyO7xDVQkMKzopTQV8AuKpyvpqu0a9pWOMaiCyDytO7GGN you@me.com"]
+  subnet_id                       = azurerm_subnet.virtual_network_subnet.id
+  total_ecpu_count                = 32
+  vm_file_system_storage {
+    total_size_in_gbs = 440
+  }	
+  virtual_network_id              = azurerm_virtual_network.virtual_network.id
+}`, a.template(data), data.RandomInteger, data.Locations.Primary)
+}
+
+func (a ExadbVmClusterResource) complete(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+  %s
+resource "azurerm_oracle_exa_db_vm_cluster" "test" {
+  location                        = "%[3]s"
+  name                            = "OFakeVmacctest%[2]d"
+  zones               			   = ["2"]
+  resource_group_name             = azurerm_resource_group.test.name
+  exascale_db_storage_vault_id	  = azurerm_oracle_exascale_db_storage_vault.test.id
+  display_name                    = "OFakeVmacctest%[2]d"
+  enabled_ecpu_count              = 16
+  hostname                        = "host"
+  node_count              		  = 2
+  shape                      	  = "EXADBXS"
+  ssh_public_keys                 = ["ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC+wWK73dCr+jgQOAxNsHAnNNNMEMWOHYEccp6wJm2gotpr9katuF/ZAdou5AaW1C61slRkHRkpRRX9FA9CYBiitZgvCCz+3nWNN7l/Up54Zps/pHWGZLHNJZRYyAB6j5yVLMVHIHriY49d/GZTZVNB8GoJv9Gakwc/fuEZYYl4YDFiGMBP///TzlI4jhiJzjKnEvqPFki5p2ZRJqcbCiF4pJrxUQR/RXqVFQdbRLZgYfJ8xGB878RENq3yQ39d8dVOkq4edbkzwcUmwwwkYVPIoDGsYLaRHnG+To7FvMeyO7xDVQkMKzopTQV8AuKpyvpqu0a9pWOMaiCyDytO7GGN you@me.com"]
+  subnet_id                       = azurerm_subnet.virtual_network_subnet.id
+  total_ecpu_count                = 32
+  vm_file_system_storage {
+    total_size_in_gbs = 440
+  }	
+  virtual_network_id              = azurerm_virtual_network.virtual_network.id
+  backup_subnet_cidr              = "10.1.0.0/16"
+  cluster_name              	  = "clustername"
+  data_collection_options {
+    diagnostics_events_enabled = true
+    health_monitoring_enabled  = true
+    incident_logs_enabled      = true
+  }
+  domain                      = "ociactsubnet.ociactvnet.oraclevcn.com"
+  grid_image_ocid             = "ocid1.dbpatch.oc1.iad.anuwcljtt5t4sqqaoajnkveobp3ryw7zlfrrcf6tb2ndvygp54z2gbds2hxa"
+  license_model               = "BringYourOwnLicense"
+  private_zone_ocid     	  = "private_zoneocid"
+  scan_listener_port_tcp      = 1521
+  scan_listener_port_tcp_ssl  = 2484
+  system_version              = "23.1.23.0.0.250207"
+  time_zone        			  = "UTC"
+}`, a.template(data), data.RandomInteger, data.Locations.Primary)
+}
+
+func (a ExadbVmClusterResource) update(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+resource "azurerm_oracle_exa_db_vm_cluster" "test" {
+  location                        = "%[3]s"
+  name                            = "OFakeVmacctest%[2]d"
+  zones               			   = ["2"]
+  resource_group_name             = azurerm_resource_group.test.name
+  exascale_db_storage_vault_id	  = azurerm_oracle_exascale_db_storage_vault.test.id
+  display_name                    = "OFakeVmacctest%[2]d"
+  enabled_ecpu_count              = 16
+  grid_image_ocid                 = "ocid1.dbpatch.oc1.iad.anuwcljtt5t4sqqaoajnkveobp3ryw7zlfrrcf6tb2ndvygp54z2gbds2hxa"
+  hostname                        = "host"
+  node_count              		  = 4
+  shape                      	  = "EXADBXS"
+  ssh_public_keys                 = ["ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC+wWK73dCr+jgQOAxNsHAnNNNMEMWOHYEccp6wJm2gotpr9katuF/ZAdou5AaW1C61slRkHRkpRRX9FA9CYBiitZgvCCz+3nWNN7l/Up54Zps/pHWGZLHNJZRYyAB6j5yVLMVHIHriY49d/GZTZVNB8GoJv9Gakwc/fuEZYYl4YDFiGMBP///TzlI4jhiJzjKnEvqPFki5p2ZRJqcbCiF4pJrxUQR/RXqVFQdbRLZgYfJ8xGB878RENq3yQ39d8dVOkq4edbkzwcUmwwwkYVPIoDGsYLaRHnG+To7FvMeyO7xDVQkMKzopTQV8AuKpyvpqu0a9pWOMaiCyDytO7GGN you@me.com"]
+  subnet_id                       = azurerm_subnet.virtual_network_subnet.id
+  total_ecpu_count                = 64
+  vm_file_system_storage {
+    total_size_in_gbs = 440
+  }	
+  virtual_network_id              = azurerm_virtual_network.virtual_network.id
+}`, a.template(data), data.RandomInteger, data.Locations.Primary)
+}
+
+func (a ExadbVmClusterResource) requiresImport(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_oracle_exa_db_vm_cluster" "import" {
+  location                        = azurerm_oracle_exa_db_vm_cluster.test.location
+  name                            = azurerm_oracle_exa_db_vm_cluster.test.name
+  resource_group_name             = azurerm_oracle_exa_db_vm_cluster.test.resource_group_name
+  exascale_db_storage_vault_id    = azurerm_oracle_exa_db_vm_cluster.test.exascale_db_storage_vault_id
+  display_name                    = azurerm_oracle_exa_db_vm_cluster.test.display_name
+  enabled_ecpu_count      		  = azurerm_oracle_exa_db_vm_cluster.test.enabled_ecpu_count
+  grid_image_ocid                 = azurerm_oracle_exa_db_vm_cluster.test.grid_image_ocid
+  hostname   					  = azurerm_oracle_exa_db_vm_cluster.test.hostname
+  node_count                      = azurerm_oracle_exa_db_vm_cluster.test.node_count
+  shape		                      = azurerm_oracle_exa_db_vm_cluster.test.shape
+  ssh_public_keys                 = azurerm_oracle_exa_db_vm_cluster.test.ssh_public_keys
+  subnet_id                       = azurerm_oracle_exa_db_vm_cluster.test.subnet_id
+  total_ecpu_count                = azurerm_oracle_exa_db_vm_cluster.test.total_ecpu_count
+  vm_file_system_storage {
+    total_size_in_gbs = 440
+  }	  virtual_network_id              = azurerm_oracle_exa_db_vm_cluster.test.virtual_network_id
+  zones                                = azurerm_oracle_exascale_db_storage_vault.test.zones
+}
+`, a.basic(data))
+}
+
+func (a ExadbVmClusterResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_virtual_network" "virtual_network" {
+  name                = "actvnet"
+  address_space       = ["10.0.0.0/16"]
+  location            = "%[2]s"
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "virtual_network_subnet" {
+  name                 = "actsubnet"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.virtual_network.name
+  address_prefixes     = ["10.0.1.0/24"]
+
+  delegation {
+    name = "delegation"
+
+    service_delegation {
+      actions = [
+        "Microsoft.Network/networkinterfaces/*",
+        "Microsoft.Network/virtualNetworks/subnets/join/action",
+      ]
+      name = "Oracle.Database/networkAttachments"
+    }
+  }
+}
+
+resource "azurerm_oracle_exascale_db_storage_vault" "test" {
+  name                = "OFakeacctest%[1]d"
+  location            = "%[2]s"
+  resource_group_name = azurerm_resource_group.test.name
+  display_name        = "OFakeacctest%[1]d"
+  description         = "description"
+  high_capacity_database_storage_input {
+    total_size_in_gbs = 300
+  }
+  additional_flash_cache_in_percent = 100
+  zones               = ["2"]
+}
+
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}

--- a/internal/services/oracle/oracle_exascale_db_nodes_data_source.go
+++ b/internal/services/oracle/oracle_exascale_db_nodes_data_source.go
@@ -1,0 +1,198 @@
+// Copyright © 2025, Oracle and/or its affiliates. All rights reserved
+
+package oracle
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exadbvmclusters"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbnodes"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type ExascaleDbNodesDataSource struct{}
+
+type ExascaleDbNodesDataModel struct {
+	ExadbVmClusterId string                    `tfschema:"exa_db_vm_cluster_id"`
+	ExascaleDBNodes  []ExascaleDbNodeDataModel `tfschema:"exascale_db_nodes"`
+}
+
+type ExascaleDbNodeDataModel struct {
+	// ExascaleDbNodeProperties
+	AdditionalDetails          string `tfschema:"additional_details"`
+	CpuCoreCount               int64  `tfschema:"cpu_core_count"`
+	DbNodeStorageSizeInGbs     int64  `tfschema:"db_node_storage_size_in_gbs"`
+	FaultDomain                string `tfschema:"fault_domain"`
+	Hostname                   string `tfschema:"hostname"`
+	LifecycleState             string `tfschema:"lifecycle_state"`
+	MaintenanceType            string `tfschema:"maintenance_type"`
+	MemorySizeInGbs            int64  `tfschema:"memory_size_in_gbs"`
+	Ocid                       string `tfschema:"ocid"`
+	SoftwareStorageSizeInGb    int64  `tfschema:"software_storage_size_in_gbs"`
+	TimeMaintenanceWindowEnd   string `tfschema:"time_maintenance_window_end"`
+	TimeMaintenanceWindowStart string `tfschema:"time_maintenance_window_start"`
+	TotalCpuCoreCount          int64  `tfschema:"total_cpu_core_count"`
+}
+
+func (d ExascaleDbNodesDataSource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"exa_db_vm_cluster_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: exadbvmclusters.ValidateExadbVMClusterID,
+		},
+	}
+}
+
+func (d ExascaleDbNodesDataSource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"exascale_db_nodes": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					// ExascaleDbNodeProperties
+					"additional_details": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+
+					"cpu_core_count": {
+						Type:     pluginsdk.TypeInt,
+						Computed: true,
+					},
+
+					"db_node_storage_size_in_gbs": {
+						Type:     pluginsdk.TypeInt,
+						Computed: true,
+					},
+
+					"fault_domain": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+
+					"hostname": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+
+					"lifecycle_state": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+
+					"maintenance_type": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+
+					"memory_size_in_gbs": {
+						Type:     pluginsdk.TypeInt,
+						Computed: true,
+					},
+
+					"ocid": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+
+					"software_storage_size_in_gbs": {
+						Type:     pluginsdk.TypeInt,
+						Computed: true,
+					},
+
+					"time_maintenance_window_end": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+
+					"time_maintenance_window_start": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+
+					"total_cpu_core_count": {
+						Type:     pluginsdk.TypeInt,
+						Computed: true,
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d ExascaleDbNodesDataSource) ModelObject() interface{} {
+	return &ExascaleDbNodesDataModel{}
+}
+
+func (d ExascaleDbNodesDataSource) ResourceType() string {
+	return "azurerm_oracle_exascale_db_nodes"
+}
+
+func (d ExascaleDbNodesDataSource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return exascaledbnodes.ValidateExadbVMClusterDbNodeID
+}
+
+func (d ExascaleDbNodesDataSource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Oracle.OracleClient25.ExascaleDbNodes
+			subscriptionId := metadata.Client.Account.SubscriptionId
+
+			state := ExascaleDbNodesDataModel{
+				ExascaleDBNodes: make([]ExascaleDbNodeDataModel, 0),
+			}
+
+			if err := metadata.Decode(&state); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+			parsedExadbVmClusterId, err := exadbvmclusters.ParseExadbVMClusterID(state.ExadbVmClusterId)
+			if err != nil {
+				return fmt.Errorf("decoding id: %+v", err)
+			}
+			id := exascaledbnodes.NewExadbVMClusterID(subscriptionId, parsedExadbVmClusterId.ResourceGroupName, parsedExadbVmClusterId.ExadbVmClusterName)
+
+			resp, err := client.ListByParent(ctx, id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return fmt.Errorf("%s was not found", id)
+				}
+				return fmt.Errorf("retrieving %s: %+v", id, err)
+			}
+
+			if model := resp.Model; model != nil {
+				for _, element := range *model {
+					if props := element.Properties; props != nil {
+						dbNode := ExascaleDbNodeDataModel{
+							AdditionalDetails:          pointer.From(props.AdditionalDetails),
+							CpuCoreCount:               pointer.From(props.CpuCoreCount),
+							DbNodeStorageSizeInGbs:     pointer.From(props.DbNodeStorageSizeInGbs),
+							FaultDomain:                pointer.From(props.FaultDomain),
+							Hostname:                   pointer.From(props.Hostname),
+							LifecycleState:             string(*props.LifecycleState),
+							MaintenanceType:            pointer.From(props.MaintenanceType),
+							MemorySizeInGbs:            pointer.From(props.MemorySizeInGbs),
+							Ocid:                       props.Ocid,
+							SoftwareStorageSizeInGb:    pointer.From(props.SoftwareStorageSizeInGb),
+							TimeMaintenanceWindowEnd:   pointer.From(props.TimeMaintenanceWindowEnd),
+							TimeMaintenanceWindowStart: pointer.From(props.TimeMaintenanceWindowStart),
+							TotalCpuCoreCount:          pointer.From(props.TotalCPUCoreCount),
+						}
+						state.ExascaleDBNodes = append(state.ExascaleDBNodes, dbNode)
+					}
+				}
+			}
+
+			metadata.SetID(id)
+
+			return metadata.Encode(&state)
+		},
+	}
+}

--- a/internal/services/oracle/oracle_exascale_db_nodes_data_source_test.go
+++ b/internal/services/oracle/oracle_exascale_db_nodes_data_source_test.go
@@ -1,0 +1,37 @@
+// Copyright © 2025, Oracle and/or its affiliates. All rights reserved
+
+package oracle_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+)
+
+type ExascaleDBNodesDataSource struct{}
+
+func TestExascaleDBNodesDataSource_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_oracle_exascale_db_nodes", "test")
+	r := ExascaleDBNodesDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("exascale_db_nodes.0.cpu_core_count").Exists(),
+			),
+		},
+	})
+}
+
+func (d ExascaleDBNodesDataSource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_oracle_exascale_db_nodes" "test" {
+  exa_db_vm_cluster_id = azurerm_oracle_exa_db_vm_cluster.test.id
+}
+`, ExadbVmClusterResource{}.basic(data))
+}

--- a/internal/services/oracle/oracle_exascale_db_storage_vault_data_source.go
+++ b/internal/services/oracle/oracle_exascale_db_storage_vault_data_source.go
@@ -1,0 +1,203 @@
+// Copyright © 2025, Oracle and/or its affiliates. All rights reserved
+
+package oracle
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/zones"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbstoragevaults"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/oracle/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type ExascaleDbStorageVaultDataSource struct{}
+
+type ExascaleDbStorageVaultDataModel struct {
+	Location          string       `tfschema:"location"`
+	Name              string       `tfschema:"name"`
+	ResourceGroupName string       `tfschema:"resource_group_name"`
+	Zones             zones.Schema `tfschema:"zones"`
+
+	// ExascaleDbStorageVaultProperties
+	AdditionalFlashCacheInPercent int64                           `tfschema:"additional_flash_cache_in_percent"`
+	Description                   string                          `tfschema:"description"`
+	DisplayName                   string                          `tfschema:"display_name"`
+	HighCapacityDatabaseStorage   []ExascaleDbStorageDetailsModel `tfschema:"high_capacity_database_storage"`
+	LifecycleDetails              string                          `tfschema:"lifecycle_details"`
+	LifecycleState                string                          `tfschema:"lifecycle_state"`
+	Ocid                          string                          `tfschema:"ocid"`
+	OciUrl                        string                          `tfschema:"oci_url"`
+	TimeZone                      string                          `tfschema:"time_zone"`
+	VmClusterCount                int64                           `tfschema:"vm_cluster_count"`
+}
+
+type ExascaleDbStorageDetailsModel struct {
+	AvailableSizeInGbs int64 `tfschema:"available_size_in_gbs"`
+	TotalSizeInGbs     int64 `tfschema:"total_size_in_gbs"`
+}
+
+func (d ExascaleDbStorageVaultDataSource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"resource_group_name": commonschema.ResourceGroupNameForDataSource(),
+		"zones":               commonschema.ZonesMultipleOptional(),
+
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: validate.StorageVaultName,
+		},
+	}
+}
+
+func (d ExascaleDbStorageVaultDataSource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"location": commonschema.LocationComputed(),
+
+		// ExascaleDbStorageVaultProperties
+		"additional_flash_cache_in_percent": {
+			Type:     pluginsdk.TypeInt,
+			Computed: true,
+		},
+
+		"description": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"display_name": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"high_capacity_database_storage": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"available_size_in_gbs": {
+						Type:     pluginsdk.TypeInt,
+						Computed: true,
+					},
+					"total_size_in_gbs": {
+						Type:     pluginsdk.TypeInt,
+						Computed: true,
+					},
+				},
+			},
+		},
+
+		"time_zone": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"provisioning_state": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"lifecycle_state": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"lifecycle_details": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"vm_cluster_count": {
+			Type:     pluginsdk.TypeInt,
+			Computed: true,
+		},
+
+		"ocid": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"oci_url": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+	}
+}
+
+func (d ExascaleDbStorageVaultDataSource) ModelObject() interface{} {
+	return &ExascaleDbStorageVaultDataModel{}
+}
+
+func (d ExascaleDbStorageVaultDataSource) ResourceType() string {
+	return "azurerm_oracle_exascale_db_storage_vault"
+}
+
+func (d ExascaleDbStorageVaultDataSource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return exascaledbstoragevaults.ValidateExascaleDbStorageVaultID
+}
+
+func (d ExascaleDbStorageVaultDataSource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Oracle.OracleClient25.ExascaleDbStorageVaults
+			subscriptionId := metadata.Client.Account.SubscriptionId
+
+			var state ExascaleDbStorageVaultDataModel
+			if err := metadata.Decode(&state); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			id := exascaledbstoragevaults.NewExascaleDbStorageVaultID(subscriptionId, state.ResourceGroupName, state.Name)
+
+			resp, err := client.Get(ctx, id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return fmt.Errorf("%s was not found", id)
+				}
+				return fmt.Errorf("retrieving %s: %+v", id, err)
+			}
+
+			if model := resp.Model; model != nil {
+				state.Location = location.Normalize(model.Location)
+				state.Zones = pointer.From(model.Zones)
+				if props := model.Properties; props != nil {
+
+					state.AdditionalFlashCacheInPercent = pointer.From(props.AdditionalFlashCacheInPercent)
+					state.Description = pointer.From(props.Description)
+					state.DisplayName = props.DisplayName
+					state.HighCapacityDatabaseStorage = ExpandHighCapacityDatabaseStorage(props.HighCapacityDatabaseStorage)
+					state.TimeZone = pointer.From(props.TimeZone)
+					state.LifecycleState = string(*props.LifecycleState)
+					state.LifecycleDetails = pointer.From(props.LifecycleDetails)
+					state.VmClusterCount = pointer.From(props.VMClusterCount)
+					state.Ocid = pointer.From(props.Ocid)
+					state.OciUrl = pointer.From(props.OciURL)
+
+				}
+			}
+
+			metadata.SetID(id)
+
+			return metadata.Encode(&state)
+		},
+	}
+}
+
+func ExpandHighCapacityDatabaseStorage(input *exascaledbstoragevaults.ExascaleDbStorageDetails) []ExascaleDbStorageDetailsModel {
+	output := make([]ExascaleDbStorageDetailsModel, 0)
+	if input != nil {
+		return append(output, ExascaleDbStorageDetailsModel{
+			AvailableSizeInGbs: pointer.From(input.AvailableSizeInGbs),
+			TotalSizeInGbs:     pointer.From(input.TotalSizeInGbs),
+		})
+	}
+	return output
+}

--- a/internal/services/oracle/oracle_exascale_db_storage_vault_data_source_test.go
+++ b/internal/services/oracle/oracle_exascale_db_storage_vault_data_source_test.go
@@ -1,0 +1,44 @@
+// Copyright © 2025, Oracle and/or its affiliates. All rights reserved
+
+package oracle_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/oracle"
+)
+
+type ExascaleDbStorageVaultDataSource struct{}
+
+func TestDbStorageVaultDataSource_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, oracle.ExascaleDbStorageVaultDataSource{}.ResourceType(), "test")
+	r := ExascaleDbStorageVaultDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("location").Exists(),
+				check.That(data.ResourceName).Key("name").Exists(),
+				check.That(data.ResourceName).Key("resource_group_name").Exists(),
+				check.That(data.ResourceName).Key("display_name").Exists(),
+				check.That(data.ResourceName).Key("additional_flash_cache_in_percent").Exists(),
+				check.That(data.ResourceName).Key("description").Exists(),
+			),
+		},
+	})
+}
+
+func (d ExascaleDbStorageVaultDataSource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_oracle_exascale_db_storage_vault" "test" {
+  name                = azurerm_oracle_exascale_db_storage_vault.test.name
+  resource_group_name = azurerm_oracle_exascale_db_storage_vault.test.resource_group_name
+}
+`, ExascaleDbStorageVaultResource{}.basic(data))
+}

--- a/internal/services/oracle/oracle_exascale_db_storage_vault_resource.go
+++ b/internal/services/oracle/oracle_exascale_db_storage_vault_resource.go
@@ -1,0 +1,330 @@
+// Copyright © 2024, Oracle and/or its affiliates. All rights reserved
+
+package oracle
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/zones"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbstoragevaults"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/oracle/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+var _ sdk.Resource = ExascaleDbStorageVaultResource{}
+
+type ExascaleDbStorageVaultResource struct{}
+
+type ExascaleDbStorageVaultResourceModel struct {
+	Location          string            `tfschema:"location"`
+	Name              string            `tfschema:"name"`
+	ResourceGroupName string            `tfschema:"resource_group_name"`
+	Tags              map[string]string `tfschema:"tags"`
+	Zones             zones.Schema      `tfschema:"zones"`
+
+	// Required
+	AdditionalFlashCacheInPercent    int64                                `tfschema:"additional_flash_cache_in_percent"`
+	Description                      string                               `tfschema:"description"`
+	DisplayName                      string                               `tfschema:"display_name"`
+	HighCapacityDatabaseStorageInput []ExascaleDbStorageInputDetailsModel `tfschema:"high_capacity_database_storage_input"`
+
+	// Optional
+	HighCapacityDatabaseStorage []ExascaleDbStorageDetailsModel `tfschema:"high_capacity_database_storage"`
+	TimeZone                    string                          `tfschema:"time_zone"`
+}
+
+type ExascaleDbStorageInputDetailsModel struct {
+	TotalSizeInGbs int64 `tfschema:"total_size_in_gbs"`
+}
+
+func (ExascaleDbStorageVaultResource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"location": commonschema.Location(),
+
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: validate.StorageVaultName,
+			ForceNew:     true,
+		},
+
+		"resource_group_name": commonschema.ResourceGroupName(),
+
+		// Required
+		"additional_flash_cache_in_percent": {
+			Type:     pluginsdk.TypeInt,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"description": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"display_name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validate.StorageVaultName,
+		},
+
+		"high_capacity_database_storage_input": {
+			Type:     pluginsdk.TypeList,
+			Required: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"total_size_in_gbs": {
+						Type:     pluginsdk.TypeInt,
+						Required: true,
+					},
+				},
+			},
+		},
+
+		// Optional
+		"high_capacity_database_storage": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			Computed: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"available_size_in_gbs": {
+						Type:     pluginsdk.TypeInt,
+						Optional: true,
+						Computed: true,
+					},
+					"total_size_in_gbs": {
+						Type:     pluginsdk.TypeInt,
+						Optional: true,
+						Computed: true,
+					},
+				},
+			},
+		},
+
+		"time_zone": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Default:  "UTC",
+		},
+
+		"tags": commonschema.Tags(),
+
+		"zones": commonschema.ZonesMultipleRequiredForceNew(),
+	}
+}
+
+func (ExascaleDbStorageVaultResource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{}
+}
+
+func (ExascaleDbStorageVaultResource) ModelObject() interface{} {
+	return &ExascaleDbStorageVaultResource{}
+}
+
+func (ExascaleDbStorageVaultResource) ResourceType() string {
+	return "azurerm_oracle_exascale_db_storage_vault"
+}
+
+func (r ExascaleDbStorageVaultResource) Create() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 120 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Oracle.OracleClient25.ExascaleDbStorageVaults
+			subscriptionId := metadata.Client.Account.SubscriptionId
+
+			var model ExascaleDbStorageVaultResourceModel
+			if err := metadata.Decode(&model); err != nil {
+				return err
+			}
+
+			id := exascaledbstoragevaults.NewExascaleDbStorageVaultID(subscriptionId,
+				model.ResourceGroupName,
+				model.Name)
+
+			existing, err := client.Get(ctx, id)
+			if err != nil && !response.WasNotFound(existing.HttpResponse) {
+				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+			}
+			if !response.WasNotFound(existing.HttpResponse) {
+				return metadata.ResourceRequiresImport(r.ResourceType(), id)
+			}
+
+			param := exascaledbstoragevaults.ExascaleDbStorageVault{
+				Name:     pointer.To(model.Name),
+				Location: location.Normalize(model.Location),
+				Zones:    pointer.To(model.Zones),
+				Tags:     pointer.To(model.Tags),
+				Properties: &exascaledbstoragevaults.ExascaleDbStorageVaultProperties{
+					DisplayName:                   model.DisplayName,
+					AdditionalFlashCacheInPercent: pointer.To(model.AdditionalFlashCacheInPercent),
+					Description:                   pointer.To(model.Description),
+					TimeZone:                      pointer.To(model.TimeZone),
+				},
+			}
+
+			if len(model.HighCapacityDatabaseStorageInput) > 0 {
+				param.Properties.HighCapacityDatabaseStorageInput = exascaledbstoragevaults.ExascaleDbStorageInputDetails{
+					TotalSizeInGbs: model.HighCapacityDatabaseStorageInput[0].TotalSizeInGbs,
+				}
+			}
+
+			if len(model.HighCapacityDatabaseStorage) > 0 {
+				param.Properties.HighCapacityDatabaseStorage = &exascaledbstoragevaults.ExascaleDbStorageDetails{
+					AvailableSizeInGbs: pointer.To(model.HighCapacityDatabaseStorage[0].AvailableSizeInGbs),
+					TotalSizeInGbs:     pointer.To(model.HighCapacityDatabaseStorage[0].TotalSizeInGbs),
+				}
+			}
+
+			if err := client.CreateThenPoll(ctx, id, param); err != nil {
+				return fmt.Errorf("creating %s: %+v", id, err)
+			}
+
+			metadata.SetID(id)
+			return nil
+		},
+	}
+}
+
+func (r ExascaleDbStorageVaultResource) Update() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Oracle.OracleClient25.ExascaleDbStorageVaults
+			id, err := exascaledbstoragevaults.ParseExascaleDbStorageVaultID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			var model ExascaleDbStorageVaultResourceModel
+			if err = metadata.Decode(&model); err != nil {
+				return fmt.Errorf("decoding err: %+v", err)
+			}
+
+			_, err = client.Get(ctx, *id)
+			if err != nil {
+				return fmt.Errorf("retrieving %s: %+v", *id, err)
+			}
+
+			update := &exascaledbstoragevaults.ExascaleDbStorageVaultTagsUpdate{}
+
+			if metadata.ResourceData.HasChange("tags") {
+				update.Tags = pointer.To(model.Tags)
+			}
+
+			err = client.UpdateThenPoll(ctx, *id, *update)
+			if err != nil {
+				return fmt.Errorf("updating %s: %v", id, err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func (ExascaleDbStorageVaultResource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			id, err := exascaledbstoragevaults.ParseExascaleDbStorageVaultID(metadata.ResourceData.Id())
+			if err != nil {
+				return fmt.Errorf("retrieving %s: %+v", id, err)
+			}
+
+			client := metadata.Client.Oracle.OracleClient25.ExascaleDbStorageVaults
+			result, err := client.Get(ctx, *id)
+			if err != nil {
+				if response.WasNotFound(result.HttpResponse) {
+					return metadata.MarkAsGone(id)
+				}
+				return fmt.Errorf("retrieving %s: %+v", id, err)
+			}
+
+			state := ExascaleDbStorageVaultResourceModel{
+				Name:              id.ExascaleDbStorageVaultName,
+				ResourceGroupName: id.ResourceGroupName,
+			}
+
+			if model := result.Model; model != nil {
+				state.Location = location.Normalize(model.Location)
+				state.Tags = pointer.From(model.Tags)
+				state.Zones = pointer.From(model.Zones)
+				if props := model.Properties; props != nil {
+					state.Name = pointer.ToString(result.Model.Name)
+					state.Location = result.Model.Location
+					state.Tags = pointer.From(model.Tags)
+					state.Zones = pointer.From(result.Model.Zones)
+					state.DisplayName = props.DisplayName
+					state.AdditionalFlashCacheInPercent = pointer.From(props.AdditionalFlashCacheInPercent)
+					state.Description = pointer.From(props.Description)
+					state.HighCapacityDatabaseStorage = ExpandHighCapacityDatabaseStorageInterface(metadata.ResourceData.Get("high_capacity_database_storage").([]interface{}))
+					state.HighCapacityDatabaseStorageInput = ExpandHighCapacityDatabaseStorageInputInterface(metadata.ResourceData.Get("high_capacity_database_storage_input").([]interface{}))
+					state.TimeZone = pointer.From(props.TimeZone)
+				}
+			}
+			return metadata.Encode(&state)
+		},
+	}
+}
+
+func (ExascaleDbStorageVaultResource) Delete() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Oracle.OracleClient25.ExascaleDbStorageVaults
+
+			id, err := exascaledbstoragevaults.ParseExascaleDbStorageVaultID(metadata.ResourceData.Id())
+			if err != nil {
+				return fmt.Errorf("retrieving %s: %+v", id, err)
+			}
+
+			if err = client.DeleteThenPoll(ctx, *id); err != nil {
+				return fmt.Errorf("deleting %s: %+v", *id, err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func (ExascaleDbStorageVaultResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return exascaledbstoragevaults.ValidateExascaleDbStorageVaultID
+}
+
+func ExpandHighCapacityDatabaseStorageInputInterface(input []interface{}) []ExascaleDbStorageInputDetailsModel {
+	output := make([]ExascaleDbStorageInputDetailsModel, 0)
+	if len(input) == 0 || input[0] == nil {
+		return output
+	}
+	if m, ok := input[0].(map[string]interface{}); ok {
+		storageInput := ExascaleDbStorageInputDetailsModel{
+			TotalSizeInGbs: int64(m["total_size_in_gbs"].(int)),
+		}
+		output = append(output, storageInput)
+	}
+	return output
+}
+
+func ExpandHighCapacityDatabaseStorageInterface(input []interface{}) []ExascaleDbStorageDetailsModel {
+	output := make([]ExascaleDbStorageDetailsModel, 0)
+	if len(input) == 0 || input[0] == nil {
+		return output
+	}
+	if m, ok := input[0].(map[string]interface{}); ok {
+		storageInput := ExascaleDbStorageDetailsModel{
+			TotalSizeInGbs:     int64(m["total_size_in_gbs"].(int)),
+			AvailableSizeInGbs: int64(m["available_size_in_gbs"].(int)),
+		}
+		output = append(output, storageInput)
+	}
+	return output
+}

--- a/internal/services/oracle/oracle_exascale_db_storage_vault_resource_test.go
+++ b/internal/services/oracle/oracle_exascale_db_storage_vault_resource_test.go
@@ -1,0 +1,156 @@
+// Copyright © 2025, Oracle and/or its affiliates. All rights reserved
+
+package oracle_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbstoragevaults"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/oracle"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type ExascaleDbStorageVaultResource struct{}
+
+func (a ExascaleDbStorageVaultResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := exascaledbstoragevaults.ParseExascaleDbStorageVaultID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Oracle.OracleClient25.ExascaleDbStorageVaults.Get(ctx, *id)
+	if err != nil {
+		return nil, fmt.Errorf("retrieving db storage vault %s: %+v", id, err)
+	}
+	return pointer.To(resp.Model != nil), nil
+}
+
+func TestDbStorageVaultResource_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, oracle.ExascaleDbStorageVaultResource{}.ResourceType(), "test")
+	r := ExascaleDbStorageVaultResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("high_capacity_database_storage_input", "high_capacity_database_storage"),
+	})
+}
+
+func TestDbStorageVaultResource_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, oracle.ExascaleDbStorageVaultResource{}.ResourceType(), "test")
+	r := ExascaleDbStorageVaultResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("high_capacity_database_storage_input", "high_capacity_database_storage"),
+	})
+}
+
+func TestDbStorageVaultResource_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, oracle.ExascaleDbStorageVaultResource{}.ResourceType(), "test")
+	r := ExascaleDbStorageVaultResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func (a ExascaleDbStorageVaultResource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_oracle_exascale_db_storage_vault" "test" {
+  name                             = "OFake%[2]d"
+  resource_group_name              = azurerm_resource_group.test.name
+  location                         = "%[3]s"
+  zones               			   = ["2"]
+  display_name                     = "OFake%[2]d"
+  description                      = "description"
+  additional_flash_cache_in_percent = 100
+  high_capacity_database_storage_input {
+    total_size_in_gbs = 300
+  }
+  time_zone        			  = "UTC"
+}
+`, a.template(data), data.RandomInteger, data.Locations.Primary)
+}
+
+func (a ExascaleDbStorageVaultResource) complete(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+
+%s
+
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_oracle_exascale_db_storage_vault" "test" {
+  name                             = "OFake%[2]d"
+  resource_group_name              = azurerm_resource_group.test.name
+  location                         = "%[3]s"
+  zones                            = ["2"]
+  display_name                     = "OFake%[2]d"
+  high_capacity_database_storage_input {
+	total_size_in_gbs = 300
+  }
+  additional_flash_cache_in_percent = 100
+  description                    = "description"
+  high_capacity_database_storage {
+	total_size_in_gbs = 300
+	available_size_in_gbs = 60
+  }
+  time_zone        			  = "UTC"
+}
+`, a.template(data), data.RandomInteger, data.Locations.Primary)
+}
+
+func (a ExascaleDbStorageVaultResource) requiresImport(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_oracle_exascale_db_storage_vault" "import" {
+  name                          	   = azurerm_oracle_exascale_db_storage_vault.test.name
+  resource_group_name            	   = azurerm_oracle_exascale_db_storage_vault.test.resource_group_name
+  location                             = azurerm_oracle_exascale_db_storage_vault.test.location
+  display_name                         = azurerm_oracle_exascale_db_storage_vault.test.display_name
+  additional_flash_cache_in_percent	   = azurerm_oracle_exascale_db_storage_vault.test.additional_flash_cache_in_percent
+  description                      	   = azurerm_oracle_exascale_db_storage_vault.test.description
+  time_zone  					       = azurerm_oracle_exascale_db_storage_vault.test.time_zone
+  zones                                = azurerm_oracle_exascale_db_storage_vault.test.zones
+}
+`, a.basic(data))
+}
+
+func (a ExascaleDbStorageVaultResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}

--- a/internal/services/oracle/registration.go
+++ b/internal/services/oracle/registration.go
@@ -20,6 +20,9 @@ func (r Registration) DataSources() []sdk.DataSource {
 		DBServersDataSource{},
 		DbSystemShapesDataSource{},
 		ExadataInfraDataSource{},
+		ExadbVmClusterDataSource{},
+		ExascaleDbStorageVaultDataSource{},
+		ExascaleDbNodesDataSource{},
 		GiVersionsDataSource{},
 	}
 }
@@ -29,6 +32,8 @@ func (r Registration) Resources() []sdk.Resource {
 		AutonomousDatabaseRegularResource{},
 		CloudVmClusterResource{},
 		ExadataInfraResource{},
+		ExadbVmClusterResource{},
+		ExascaleDbStorageVaultResource{},
 	}
 }
 

--- a/internal/services/oracle/validate/exadb_vm_cluster.go
+++ b/internal/services/oracle/validate/exadb_vm_cluster.go
@@ -1,0 +1,119 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package validate
+
+import (
+	"fmt"
+	"regexp"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exadbvmclusters"
+)
+
+func ExadbVMClusterName(i interface{}, k string) (warnings []string, errors []error) {
+	v, ok := i.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected type of %s to be string", k))
+		return
+	}
+
+	if len(v) < 1 || len(v) > 255 {
+		errors = append(errors, fmt.Errorf("name must be %d to %d characters", 1, 255))
+		return
+	}
+
+	firstChar, _ := utf8.DecodeRuneInString(v)
+	if !unicode.IsLetter(firstChar) && firstChar != '_' {
+		errors = append(errors, fmt.Errorf("name must start with a letter or underscore (_)"))
+		return
+	}
+
+	re := regexp.MustCompile("--")
+	if re.MatchString(v) {
+		errors = append(errors, fmt.Errorf("name must not contain any consecutive hyphers (--)"))
+		return
+	}
+
+	return
+}
+
+func ClusterName(i interface{}, k string) (warnings []string, errors []error) {
+	v, ok := i.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected type of %s to be string", k))
+		return
+	}
+
+	if len(v) > 11 {
+		errors = append(errors, fmt.Errorf("name can be no longer than %d characters", 11))
+		return
+	}
+
+	firstChar, _ := utf8.DecodeRuneInString(v)
+	if !unicode.IsLetter(firstChar) {
+		errors = append(errors, fmt.Errorf("name must start with an alphabetic character"))
+		return
+	}
+
+	re := regexp.MustCompile("_")
+	if re.MatchString(v) {
+		errors = append(errors, fmt.Errorf("name must not contain any underscores (_)"))
+		return
+	}
+
+	return
+}
+
+func EcpuCount(i interface{}, k string) (warnings []string, errors []error) {
+	v, ok := i.(int)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected type of %s to be int", k))
+		return
+	}
+
+	if v < 8 || v > 200 {
+		errors = append(errors, fmt.Errorf("ecpu_count must be between %v and %v", 8, 200))
+		return
+	}
+
+	if v%4 != 0 {
+		errors = append(errors, fmt.Errorf("ecpu_count needs to be multiple of %v", 4))
+		return
+	}
+
+	return
+}
+
+func ExadbLicenseModel(i interface{}, k string) (warnings []string, errors []error) {
+	v, ok := i.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected type of %s to be string", k))
+		return
+	}
+
+	if v != string(exadbvmclusters.LicenseModelBringYourOwnLicense) && v != string(exadbvmclusters.LicenseModelLicenseIncluded) {
+		errors = append(errors, fmt.Errorf("%v must be %v or %v", k,
+			string(exadbvmclusters.LicenseModelBringYourOwnLicense), string(exadbvmclusters.LicenseModelLicenseIncluded)))
+		return
+	}
+
+	return
+}
+
+func ExadbSystemVersion(i interface{}, k string) (warnings []string, errors []error) {
+	v, ok := i.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected type of %s to be string", k))
+		return
+	}
+
+	pattern := "(?:19|22|23|24|25)\\.[0-9]+(\\.[0-9]+)*|[0-9]+(\\.[0-9]+)*"
+	re := regexp.MustCompile(pattern)
+	if !re.MatchString(v) {
+		errors = append(errors, fmt.Errorf("%s must match one of the following patterns: %v", k, pattern))
+	}
+
+	return
+}

--- a/internal/services/oracle/validate/exascale_db_storage_vault.go
+++ b/internal/services/oracle/validate/exascale_db_storage_vault.go
@@ -1,0 +1,38 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package validate
+
+import (
+	"fmt"
+	"regexp"
+	"unicode"
+	"unicode/utf8"
+)
+
+func StorageVaultName(i interface{}, k string) (warnings []string, errors []error) {
+	v, ok := i.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected type of %s to be string", k))
+		return
+	}
+
+	if len(v) < 1 || len(v) > 255 {
+		errors = append(errors, fmt.Errorf("name must be %d to %d characters", 1, 255))
+		return
+	}
+
+	firstChar, _ := utf8.DecodeRuneInString(v)
+	if !unicode.IsLetter(firstChar) && firstChar != '_' {
+		errors = append(errors, fmt.Errorf("name must start with a letter or underscore (_)"))
+		return
+	}
+
+	re := regexp.MustCompile("--")
+	if re.MatchString(v) {
+		errors = append(errors, fmt.Errorf("name must not contain any consecutive hyphers (--)"))
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasebackups/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasebackups/README.md
@@ -1,0 +1,99 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasebackups` Documentation
+
+The `autonomousdatabasebackups` SDK allows for interaction with Azure Resource Manager `oracledatabase` (API Version `2025-03-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasebackups"
+```
+
+
+### Client Initialization
+
+```go
+client := autonomousdatabasebackups.NewAutonomousDatabaseBackupsClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `AutonomousDatabaseBackupsClient.CreateOrUpdate`
+
+```go
+ctx := context.TODO()
+id := autonomousdatabasebackups.NewAutonomousDatabaseBackupID("12345678-1234-9876-4563-123456789012", "example-resource-group", "autonomousDatabaseName", "autonomousDatabaseBackupName")
+
+payload := autonomousdatabasebackups.AutonomousDatabaseBackup{
+	// ...
+}
+
+
+if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `AutonomousDatabaseBackupsClient.Delete`
+
+```go
+ctx := context.TODO()
+id := autonomousdatabasebackups.NewAutonomousDatabaseBackupID("12345678-1234-9876-4563-123456789012", "example-resource-group", "autonomousDatabaseName", "autonomousDatabaseBackupName")
+
+if err := client.DeleteThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `AutonomousDatabaseBackupsClient.Get`
+
+```go
+ctx := context.TODO()
+id := autonomousdatabasebackups.NewAutonomousDatabaseBackupID("12345678-1234-9876-4563-123456789012", "example-resource-group", "autonomousDatabaseName", "autonomousDatabaseBackupName")
+
+read, err := client.Get(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `AutonomousDatabaseBackupsClient.ListByParent`
+
+```go
+ctx := context.TODO()
+id := autonomousdatabasebackups.NewAutonomousDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "autonomousDatabaseName")
+
+// alternatively `client.ListByParent(ctx, id)` can be used to do batched pagination
+items, err := client.ListByParentComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `AutonomousDatabaseBackupsClient.Update`
+
+```go
+ctx := context.TODO()
+id := autonomousdatabasebackups.NewAutonomousDatabaseBackupID("12345678-1234-9876-4563-123456789012", "example-resource-group", "autonomousDatabaseName", "autonomousDatabaseBackupName")
+
+payload := autonomousdatabasebackups.AutonomousDatabaseBackupUpdate{
+	// ...
+}
+
+
+if err := client.UpdateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasebackups/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasebackups/client.go
@@ -1,0 +1,26 @@
+package autonomousdatabasebackups
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AutonomousDatabaseBackupsClient struct {
+	Client *resourcemanager.Client
+}
+
+func NewAutonomousDatabaseBackupsClientWithBaseURI(sdkApi sdkEnv.Api) (*AutonomousDatabaseBackupsClient, error) {
+	client, err := resourcemanager.NewClient(sdkApi, "autonomousdatabasebackups", defaultApiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating AutonomousDatabaseBackupsClient: %+v", err)
+	}
+
+	return &AutonomousDatabaseBackupsClient{
+		Client: client,
+	}, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasebackups/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasebackups/constants.go
@@ -1,0 +1,151 @@
+package autonomousdatabasebackups
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AutonomousDatabaseBackupLifecycleState string
+
+const (
+	AutonomousDatabaseBackupLifecycleStateActive   AutonomousDatabaseBackupLifecycleState = "Active"
+	AutonomousDatabaseBackupLifecycleStateCreating AutonomousDatabaseBackupLifecycleState = "Creating"
+	AutonomousDatabaseBackupLifecycleStateDeleting AutonomousDatabaseBackupLifecycleState = "Deleting"
+	AutonomousDatabaseBackupLifecycleStateFailed   AutonomousDatabaseBackupLifecycleState = "Failed"
+	AutonomousDatabaseBackupLifecycleStateUpdating AutonomousDatabaseBackupLifecycleState = "Updating"
+)
+
+func PossibleValuesForAutonomousDatabaseBackupLifecycleState() []string {
+	return []string{
+		string(AutonomousDatabaseBackupLifecycleStateActive),
+		string(AutonomousDatabaseBackupLifecycleStateCreating),
+		string(AutonomousDatabaseBackupLifecycleStateDeleting),
+		string(AutonomousDatabaseBackupLifecycleStateFailed),
+		string(AutonomousDatabaseBackupLifecycleStateUpdating),
+	}
+}
+
+func (s *AutonomousDatabaseBackupLifecycleState) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseAutonomousDatabaseBackupLifecycleState(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseAutonomousDatabaseBackupLifecycleState(input string) (*AutonomousDatabaseBackupLifecycleState, error) {
+	vals := map[string]AutonomousDatabaseBackupLifecycleState{
+		"active":   AutonomousDatabaseBackupLifecycleStateActive,
+		"creating": AutonomousDatabaseBackupLifecycleStateCreating,
+		"deleting": AutonomousDatabaseBackupLifecycleStateDeleting,
+		"failed":   AutonomousDatabaseBackupLifecycleStateFailed,
+		"updating": AutonomousDatabaseBackupLifecycleStateUpdating,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := AutonomousDatabaseBackupLifecycleState(input)
+	return &out, nil
+}
+
+type AutonomousDatabaseBackupType string
+
+const (
+	AutonomousDatabaseBackupTypeFull        AutonomousDatabaseBackupType = "Full"
+	AutonomousDatabaseBackupTypeIncremental AutonomousDatabaseBackupType = "Incremental"
+	AutonomousDatabaseBackupTypeLongTerm    AutonomousDatabaseBackupType = "LongTerm"
+)
+
+func PossibleValuesForAutonomousDatabaseBackupType() []string {
+	return []string{
+		string(AutonomousDatabaseBackupTypeFull),
+		string(AutonomousDatabaseBackupTypeIncremental),
+		string(AutonomousDatabaseBackupTypeLongTerm),
+	}
+}
+
+func (s *AutonomousDatabaseBackupType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseAutonomousDatabaseBackupType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseAutonomousDatabaseBackupType(input string) (*AutonomousDatabaseBackupType, error) {
+	vals := map[string]AutonomousDatabaseBackupType{
+		"full":        AutonomousDatabaseBackupTypeFull,
+		"incremental": AutonomousDatabaseBackupTypeIncremental,
+		"longterm":    AutonomousDatabaseBackupTypeLongTerm,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := AutonomousDatabaseBackupType(input)
+	return &out, nil
+}
+
+type AzureResourceProvisioningState string
+
+const (
+	AzureResourceProvisioningStateCanceled     AzureResourceProvisioningState = "Canceled"
+	AzureResourceProvisioningStateFailed       AzureResourceProvisioningState = "Failed"
+	AzureResourceProvisioningStateProvisioning AzureResourceProvisioningState = "Provisioning"
+	AzureResourceProvisioningStateSucceeded    AzureResourceProvisioningState = "Succeeded"
+)
+
+func PossibleValuesForAzureResourceProvisioningState() []string {
+	return []string{
+		string(AzureResourceProvisioningStateCanceled),
+		string(AzureResourceProvisioningStateFailed),
+		string(AzureResourceProvisioningStateProvisioning),
+		string(AzureResourceProvisioningStateSucceeded),
+	}
+}
+
+func (s *AzureResourceProvisioningState) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseAzureResourceProvisioningState(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseAzureResourceProvisioningState(input string) (*AzureResourceProvisioningState, error) {
+	vals := map[string]AzureResourceProvisioningState{
+		"canceled":     AzureResourceProvisioningStateCanceled,
+		"failed":       AzureResourceProvisioningStateFailed,
+		"provisioning": AzureResourceProvisioningStateProvisioning,
+		"succeeded":    AzureResourceProvisioningStateSucceeded,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := AzureResourceProvisioningState(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasebackups/id_autonomousdatabase.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasebackups/id_autonomousdatabase.go
@@ -1,0 +1,130 @@
+package autonomousdatabasebackups
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&AutonomousDatabaseId{})
+}
+
+var _ resourceids.ResourceId = &AutonomousDatabaseId{}
+
+// AutonomousDatabaseId is a struct representing the Resource ID for a Autonomous Database
+type AutonomousDatabaseId struct {
+	SubscriptionId         string
+	ResourceGroupName      string
+	AutonomousDatabaseName string
+}
+
+// NewAutonomousDatabaseID returns a new AutonomousDatabaseId struct
+func NewAutonomousDatabaseID(subscriptionId string, resourceGroupName string, autonomousDatabaseName string) AutonomousDatabaseId {
+	return AutonomousDatabaseId{
+		SubscriptionId:         subscriptionId,
+		ResourceGroupName:      resourceGroupName,
+		AutonomousDatabaseName: autonomousDatabaseName,
+	}
+}
+
+// ParseAutonomousDatabaseID parses 'input' into a AutonomousDatabaseId
+func ParseAutonomousDatabaseID(input string) (*AutonomousDatabaseId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&AutonomousDatabaseId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := AutonomousDatabaseId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseAutonomousDatabaseIDInsensitively parses 'input' case-insensitively into a AutonomousDatabaseId
+// note: this method should only be used for API response data and not user input
+func ParseAutonomousDatabaseIDInsensitively(input string) (*AutonomousDatabaseId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&AutonomousDatabaseId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := AutonomousDatabaseId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *AutonomousDatabaseId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.AutonomousDatabaseName, ok = input.Parsed["autonomousDatabaseName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "autonomousDatabaseName", input)
+	}
+
+	return nil
+}
+
+// ValidateAutonomousDatabaseID checks that 'input' can be parsed as a Autonomous Database ID
+func ValidateAutonomousDatabaseID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseAutonomousDatabaseID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Autonomous Database ID
+func (id AutonomousDatabaseId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Oracle.Database/autonomousDatabases/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.AutonomousDatabaseName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Autonomous Database ID
+func (id AutonomousDatabaseId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticOracleDatabase", "Oracle.Database", "Oracle.Database"),
+		resourceids.StaticSegment("staticAutonomousDatabases", "autonomousDatabases", "autonomousDatabases"),
+		resourceids.UserSpecifiedSegment("autonomousDatabaseName", "autonomousDatabaseName"),
+	}
+}
+
+// String returns a human-readable description of this Autonomous Database ID
+func (id AutonomousDatabaseId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Autonomous Database Name: %q", id.AutonomousDatabaseName),
+	}
+	return fmt.Sprintf("Autonomous Database (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasebackups/id_autonomousdatabasebackup.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasebackups/id_autonomousdatabasebackup.go
@@ -1,0 +1,139 @@
+package autonomousdatabasebackups
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&AutonomousDatabaseBackupId{})
+}
+
+var _ resourceids.ResourceId = &AutonomousDatabaseBackupId{}
+
+// AutonomousDatabaseBackupId is a struct representing the Resource ID for a Autonomous Database Backup
+type AutonomousDatabaseBackupId struct {
+	SubscriptionId               string
+	ResourceGroupName            string
+	AutonomousDatabaseName       string
+	AutonomousDatabaseBackupName string
+}
+
+// NewAutonomousDatabaseBackupID returns a new AutonomousDatabaseBackupId struct
+func NewAutonomousDatabaseBackupID(subscriptionId string, resourceGroupName string, autonomousDatabaseName string, autonomousDatabaseBackupName string) AutonomousDatabaseBackupId {
+	return AutonomousDatabaseBackupId{
+		SubscriptionId:               subscriptionId,
+		ResourceGroupName:            resourceGroupName,
+		AutonomousDatabaseName:       autonomousDatabaseName,
+		AutonomousDatabaseBackupName: autonomousDatabaseBackupName,
+	}
+}
+
+// ParseAutonomousDatabaseBackupID parses 'input' into a AutonomousDatabaseBackupId
+func ParseAutonomousDatabaseBackupID(input string) (*AutonomousDatabaseBackupId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&AutonomousDatabaseBackupId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := AutonomousDatabaseBackupId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseAutonomousDatabaseBackupIDInsensitively parses 'input' case-insensitively into a AutonomousDatabaseBackupId
+// note: this method should only be used for API response data and not user input
+func ParseAutonomousDatabaseBackupIDInsensitively(input string) (*AutonomousDatabaseBackupId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&AutonomousDatabaseBackupId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := AutonomousDatabaseBackupId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *AutonomousDatabaseBackupId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.AutonomousDatabaseName, ok = input.Parsed["autonomousDatabaseName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "autonomousDatabaseName", input)
+	}
+
+	if id.AutonomousDatabaseBackupName, ok = input.Parsed["autonomousDatabaseBackupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "autonomousDatabaseBackupName", input)
+	}
+
+	return nil
+}
+
+// ValidateAutonomousDatabaseBackupID checks that 'input' can be parsed as a Autonomous Database Backup ID
+func ValidateAutonomousDatabaseBackupID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseAutonomousDatabaseBackupID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Autonomous Database Backup ID
+func (id AutonomousDatabaseBackupId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Oracle.Database/autonomousDatabases/%s/autonomousDatabaseBackups/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.AutonomousDatabaseName, id.AutonomousDatabaseBackupName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Autonomous Database Backup ID
+func (id AutonomousDatabaseBackupId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticOracleDatabase", "Oracle.Database", "Oracle.Database"),
+		resourceids.StaticSegment("staticAutonomousDatabases", "autonomousDatabases", "autonomousDatabases"),
+		resourceids.UserSpecifiedSegment("autonomousDatabaseName", "autonomousDatabaseName"),
+		resourceids.StaticSegment("staticAutonomousDatabaseBackups", "autonomousDatabaseBackups", "autonomousDatabaseBackups"),
+		resourceids.UserSpecifiedSegment("autonomousDatabaseBackupName", "autonomousDatabaseBackupName"),
+	}
+}
+
+// String returns a human-readable description of this Autonomous Database Backup ID
+func (id AutonomousDatabaseBackupId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Autonomous Database Name: %q", id.AutonomousDatabaseName),
+		fmt.Sprintf("Autonomous Database Backup Name: %q", id.AutonomousDatabaseBackupName),
+	}
+	return fmt.Sprintf("Autonomous Database Backup (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasebackups/method_createorupdate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasebackups/method_createorupdate.go
@@ -1,0 +1,75 @@
+package autonomousdatabasebackups
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateOrUpdateOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *AutonomousDatabaseBackup
+}
+
+// CreateOrUpdate ...
+func (c AutonomousDatabaseBackupsClient) CreateOrUpdate(ctx context.Context, id AutonomousDatabaseBackupId, input AutonomousDatabaseBackup) (result CreateOrUpdateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPut,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// CreateOrUpdateThenPoll performs CreateOrUpdate then polls until it's completed
+func (c AutonomousDatabaseBackupsClient) CreateOrUpdateThenPoll(ctx context.Context, id AutonomousDatabaseBackupId, input AutonomousDatabaseBackup) error {
+	result, err := c.CreateOrUpdate(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing CreateOrUpdate: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after CreateOrUpdate: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasebackups/method_delete.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasebackups/method_delete.go
@@ -1,0 +1,70 @@
+package autonomousdatabasebackups
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeleteOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// Delete ...
+func (c AutonomousDatabaseBackupsClient) Delete(ctx context.Context, id AutonomousDatabaseBackupId) (result DeleteOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusNoContent,
+		},
+		HttpMethod: http.MethodDelete,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// DeleteThenPoll performs Delete then polls until it's completed
+func (c AutonomousDatabaseBackupsClient) DeleteThenPoll(ctx context.Context, id AutonomousDatabaseBackupId) error {
+	result, err := c.Delete(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing Delete: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Delete: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasebackups/method_get.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasebackups/method_get.go
@@ -1,0 +1,53 @@
+package autonomousdatabasebackups
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *AutonomousDatabaseBackup
+}
+
+// Get ...
+func (c AutonomousDatabaseBackupsClient) Get(ctx context.Context, id AutonomousDatabaseBackupId) (result GetOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model AutonomousDatabaseBackup
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasebackups/method_listbyparent.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasebackups/method_listbyparent.go
@@ -1,0 +1,105 @@
+package autonomousdatabasebackups
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListByParentOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]AutonomousDatabaseBackup
+}
+
+type ListByParentCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []AutonomousDatabaseBackup
+}
+
+type ListByParentCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *ListByParentCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// ListByParent ...
+func (c AutonomousDatabaseBackupsClient) ListByParent(ctx context.Context, id AutonomousDatabaseId) (result ListByParentOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Pager:      &ListByParentCustomPager{},
+		Path:       fmt.Sprintf("%s/autonomousDatabaseBackups", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]AutonomousDatabaseBackup `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListByParentComplete retrieves all the results into a single object
+func (c AutonomousDatabaseBackupsClient) ListByParentComplete(ctx context.Context, id AutonomousDatabaseId) (ListByParentCompleteResult, error) {
+	return c.ListByParentCompleteMatchingPredicate(ctx, id, AutonomousDatabaseBackupOperationPredicate{})
+}
+
+// ListByParentCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c AutonomousDatabaseBackupsClient) ListByParentCompleteMatchingPredicate(ctx context.Context, id AutonomousDatabaseId, predicate AutonomousDatabaseBackupOperationPredicate) (result ListByParentCompleteResult, err error) {
+	items := make([]AutonomousDatabaseBackup, 0)
+
+	resp, err := c.ListByParent(ctx, id)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListByParentCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasebackups/method_update.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasebackups/method_update.go
@@ -1,0 +1,75 @@
+package autonomousdatabasebackups
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpdateOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *AutonomousDatabaseBackup
+}
+
+// Update ...
+func (c AutonomousDatabaseBackupsClient) Update(ctx context.Context, id AutonomousDatabaseBackupId, input AutonomousDatabaseBackupUpdate) (result UpdateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPatch,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// UpdateThenPoll performs Update then polls until it's completed
+func (c AutonomousDatabaseBackupsClient) UpdateThenPoll(ctx context.Context, id AutonomousDatabaseBackupId, input AutonomousDatabaseBackupUpdate) error {
+	result, err := c.Update(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing Update: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Update: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasebackups/model_autonomousdatabasebackup.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasebackups/model_autonomousdatabasebackup.go
@@ -1,0 +1,16 @@
+package autonomousdatabasebackups
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/systemdata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AutonomousDatabaseBackup struct {
+	Id         *string                             `json:"id,omitempty"`
+	Name       *string                             `json:"name,omitempty"`
+	Properties *AutonomousDatabaseBackupProperties `json:"properties,omitempty"`
+	SystemData *systemdata.SystemData              `json:"systemData,omitempty"`
+	Type       *string                             `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasebackups/model_autonomousdatabasebackupproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasebackups/model_autonomousdatabasebackupproperties.go
@@ -1,0 +1,41 @@
+package autonomousdatabasebackups
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AutonomousDatabaseBackupProperties struct {
+	AutonomousDatabaseOcid *string                                 `json:"autonomousDatabaseOcid,omitempty"`
+	BackupType             *AutonomousDatabaseBackupType           `json:"backupType,omitempty"`
+	DatabaseSizeInTbs      *float64                                `json:"databaseSizeInTbs,omitempty"`
+	DbVersion              *string                                 `json:"dbVersion,omitempty"`
+	DisplayName            *string                                 `json:"displayName,omitempty"`
+	IsAutomatic            *bool                                   `json:"isAutomatic,omitempty"`
+	IsRestorable           *bool                                   `json:"isRestorable,omitempty"`
+	LifecycleDetails       *string                                 `json:"lifecycleDetails,omitempty"`
+	LifecycleState         *AutonomousDatabaseBackupLifecycleState `json:"lifecycleState,omitempty"`
+	Ocid                   *string                                 `json:"ocid,omitempty"`
+	ProvisioningState      *AzureResourceProvisioningState         `json:"provisioningState,omitempty"`
+	RetentionPeriodInDays  *int64                                  `json:"retentionPeriodInDays,omitempty"`
+	SizeInTbs              *float64                                `json:"sizeInTbs,omitempty"`
+	TimeAvailableTil       *string                                 `json:"timeAvailableTil,omitempty"`
+	TimeEnded              *string                                 `json:"timeEnded,omitempty"`
+	TimeStarted            *string                                 `json:"timeStarted,omitempty"`
+}
+
+func (o *AutonomousDatabaseBackupProperties) GetTimeAvailableTilAsTime() (*time.Time, error) {
+	if o.TimeAvailableTil == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.TimeAvailableTil, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *AutonomousDatabaseBackupProperties) SetTimeAvailableTilAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.TimeAvailableTil = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasebackups/model_autonomousdatabasebackupupdate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasebackups/model_autonomousdatabasebackupupdate.go
@@ -1,0 +1,16 @@
+package autonomousdatabasebackups
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/systemdata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AutonomousDatabaseBackupUpdate struct {
+	Id         *string                             `json:"id,omitempty"`
+	Name       *string                             `json:"name,omitempty"`
+	Properties *AutonomousDatabaseBackupProperties `json:"properties,omitempty"`
+	SystemData *systemdata.SystemData              `json:"systemData,omitempty"`
+	Type       *string                             `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasebackups/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasebackups/predicates.go
@@ -1,0 +1,27 @@
+package autonomousdatabasebackups
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AutonomousDatabaseBackupOperationPredicate struct {
+	Id   *string
+	Name *string
+	Type *string
+}
+
+func (p AutonomousDatabaseBackupOperationPredicate) Matches(input AutonomousDatabaseBackup) bool {
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasebackups/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasebackups/version.go
@@ -1,0 +1,10 @@
+package autonomousdatabasebackups
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2025-03-01"
+
+func userAgent() string {
+	return "hashicorp/go-azure-sdk/autonomousdatabasebackups/2025-03-01"
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasecharactersets/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasecharactersets/README.md
@@ -1,0 +1,53 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasecharactersets` Documentation
+
+The `autonomousdatabasecharactersets` SDK allows for interaction with Azure Resource Manager `oracledatabase` (API Version `2025-03-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasecharactersets"
+```
+
+
+### Client Initialization
+
+```go
+client := autonomousdatabasecharactersets.NewAutonomousDatabaseCharacterSetsClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `AutonomousDatabaseCharacterSetsClient.Get`
+
+```go
+ctx := context.TODO()
+id := autonomousdatabasecharactersets.NewAutonomousDatabaseCharacterSetID("12345678-1234-9876-4563-123456789012", "locationName", "autonomousDatabaseCharacterSetName")
+
+read, err := client.Get(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `AutonomousDatabaseCharacterSetsClient.ListByLocation`
+
+```go
+ctx := context.TODO()
+id := autonomousdatabasecharactersets.NewLocationID("12345678-1234-9876-4563-123456789012", "locationName")
+
+// alternatively `client.ListByLocation(ctx, id)` can be used to do batched pagination
+items, err := client.ListByLocationComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasecharactersets/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasecharactersets/client.go
@@ -1,0 +1,26 @@
+package autonomousdatabasecharactersets
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AutonomousDatabaseCharacterSetsClient struct {
+	Client *resourcemanager.Client
+}
+
+func NewAutonomousDatabaseCharacterSetsClientWithBaseURI(sdkApi sdkEnv.Api) (*AutonomousDatabaseCharacterSetsClient, error) {
+	client, err := resourcemanager.NewClient(sdkApi, "autonomousdatabasecharactersets", defaultApiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating AutonomousDatabaseCharacterSetsClient: %+v", err)
+	}
+
+	return &AutonomousDatabaseCharacterSetsClient{
+		Client: client,
+	}, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasecharactersets/id_autonomousdatabasecharacterset.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasecharactersets/id_autonomousdatabasecharacterset.go
@@ -1,0 +1,130 @@
+package autonomousdatabasecharactersets
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&AutonomousDatabaseCharacterSetId{})
+}
+
+var _ resourceids.ResourceId = &AutonomousDatabaseCharacterSetId{}
+
+// AutonomousDatabaseCharacterSetId is a struct representing the Resource ID for a Autonomous Database Character Set
+type AutonomousDatabaseCharacterSetId struct {
+	SubscriptionId                     string
+	LocationName                       string
+	AutonomousDatabaseCharacterSetName string
+}
+
+// NewAutonomousDatabaseCharacterSetID returns a new AutonomousDatabaseCharacterSetId struct
+func NewAutonomousDatabaseCharacterSetID(subscriptionId string, locationName string, autonomousDatabaseCharacterSetName string) AutonomousDatabaseCharacterSetId {
+	return AutonomousDatabaseCharacterSetId{
+		SubscriptionId:                     subscriptionId,
+		LocationName:                       locationName,
+		AutonomousDatabaseCharacterSetName: autonomousDatabaseCharacterSetName,
+	}
+}
+
+// ParseAutonomousDatabaseCharacterSetID parses 'input' into a AutonomousDatabaseCharacterSetId
+func ParseAutonomousDatabaseCharacterSetID(input string) (*AutonomousDatabaseCharacterSetId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&AutonomousDatabaseCharacterSetId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := AutonomousDatabaseCharacterSetId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseAutonomousDatabaseCharacterSetIDInsensitively parses 'input' case-insensitively into a AutonomousDatabaseCharacterSetId
+// note: this method should only be used for API response data and not user input
+func ParseAutonomousDatabaseCharacterSetIDInsensitively(input string) (*AutonomousDatabaseCharacterSetId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&AutonomousDatabaseCharacterSetId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := AutonomousDatabaseCharacterSetId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *AutonomousDatabaseCharacterSetId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.LocationName, ok = input.Parsed["locationName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "locationName", input)
+	}
+
+	if id.AutonomousDatabaseCharacterSetName, ok = input.Parsed["autonomousDatabaseCharacterSetName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "autonomousDatabaseCharacterSetName", input)
+	}
+
+	return nil
+}
+
+// ValidateAutonomousDatabaseCharacterSetID checks that 'input' can be parsed as a Autonomous Database Character Set ID
+func ValidateAutonomousDatabaseCharacterSetID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseAutonomousDatabaseCharacterSetID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Autonomous Database Character Set ID
+func (id AutonomousDatabaseCharacterSetId) ID() string {
+	fmtString := "/subscriptions/%s/providers/Oracle.Database/locations/%s/autonomousDatabaseCharacterSets/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.LocationName, id.AutonomousDatabaseCharacterSetName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Autonomous Database Character Set ID
+func (id AutonomousDatabaseCharacterSetId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticOracleDatabase", "Oracle.Database", "Oracle.Database"),
+		resourceids.StaticSegment("staticLocations", "locations", "locations"),
+		resourceids.UserSpecifiedSegment("locationName", "locationName"),
+		resourceids.StaticSegment("staticAutonomousDatabaseCharacterSets", "autonomousDatabaseCharacterSets", "autonomousDatabaseCharacterSets"),
+		resourceids.UserSpecifiedSegment("autonomousDatabaseCharacterSetName", "autonomousDatabaseCharacterSetName"),
+	}
+}
+
+// String returns a human-readable description of this Autonomous Database Character Set ID
+func (id AutonomousDatabaseCharacterSetId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Location Name: %q", id.LocationName),
+		fmt.Sprintf("Autonomous Database Character Set Name: %q", id.AutonomousDatabaseCharacterSetName),
+	}
+	return fmt.Sprintf("Autonomous Database Character Set (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasecharactersets/id_location.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasecharactersets/id_location.go
@@ -1,0 +1,121 @@
+package autonomousdatabasecharactersets
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&LocationId{})
+}
+
+var _ resourceids.ResourceId = &LocationId{}
+
+// LocationId is a struct representing the Resource ID for a Location
+type LocationId struct {
+	SubscriptionId string
+	LocationName   string
+}
+
+// NewLocationID returns a new LocationId struct
+func NewLocationID(subscriptionId string, locationName string) LocationId {
+	return LocationId{
+		SubscriptionId: subscriptionId,
+		LocationName:   locationName,
+	}
+}
+
+// ParseLocationID parses 'input' into a LocationId
+func ParseLocationID(input string) (*LocationId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&LocationId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := LocationId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseLocationIDInsensitively parses 'input' case-insensitively into a LocationId
+// note: this method should only be used for API response data and not user input
+func ParseLocationIDInsensitively(input string) (*LocationId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&LocationId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := LocationId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *LocationId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.LocationName, ok = input.Parsed["locationName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "locationName", input)
+	}
+
+	return nil
+}
+
+// ValidateLocationID checks that 'input' can be parsed as a Location ID
+func ValidateLocationID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseLocationID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Location ID
+func (id LocationId) ID() string {
+	fmtString := "/subscriptions/%s/providers/Oracle.Database/locations/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.LocationName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Location ID
+func (id LocationId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticOracleDatabase", "Oracle.Database", "Oracle.Database"),
+		resourceids.StaticSegment("staticLocations", "locations", "locations"),
+		resourceids.UserSpecifiedSegment("locationName", "locationName"),
+	}
+}
+
+// String returns a human-readable description of this Location ID
+func (id LocationId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Location Name: %q", id.LocationName),
+	}
+	return fmt.Sprintf("Location (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasecharactersets/method_get.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasecharactersets/method_get.go
@@ -1,0 +1,53 @@
+package autonomousdatabasecharactersets
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *AutonomousDatabaseCharacterSet
+}
+
+// Get ...
+func (c AutonomousDatabaseCharacterSetsClient) Get(ctx context.Context, id AutonomousDatabaseCharacterSetId) (result GetOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model AutonomousDatabaseCharacterSet
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasecharactersets/method_listbylocation.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasecharactersets/method_listbylocation.go
@@ -1,0 +1,105 @@
+package autonomousdatabasecharactersets
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListByLocationOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]AutonomousDatabaseCharacterSet
+}
+
+type ListByLocationCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []AutonomousDatabaseCharacterSet
+}
+
+type ListByLocationCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *ListByLocationCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// ListByLocation ...
+func (c AutonomousDatabaseCharacterSetsClient) ListByLocation(ctx context.Context, id LocationId) (result ListByLocationOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Pager:      &ListByLocationCustomPager{},
+		Path:       fmt.Sprintf("%s/autonomousDatabaseCharacterSets", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]AutonomousDatabaseCharacterSet `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListByLocationComplete retrieves all the results into a single object
+func (c AutonomousDatabaseCharacterSetsClient) ListByLocationComplete(ctx context.Context, id LocationId) (ListByLocationCompleteResult, error) {
+	return c.ListByLocationCompleteMatchingPredicate(ctx, id, AutonomousDatabaseCharacterSetOperationPredicate{})
+}
+
+// ListByLocationCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c AutonomousDatabaseCharacterSetsClient) ListByLocationCompleteMatchingPredicate(ctx context.Context, id LocationId, predicate AutonomousDatabaseCharacterSetOperationPredicate) (result ListByLocationCompleteResult, err error) {
+	items := make([]AutonomousDatabaseCharacterSet, 0)
+
+	resp, err := c.ListByLocation(ctx, id)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListByLocationCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasecharactersets/model_autonomousdatabasecharacterset.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasecharactersets/model_autonomousdatabasecharacterset.go
@@ -1,0 +1,16 @@
+package autonomousdatabasecharactersets
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/systemdata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AutonomousDatabaseCharacterSet struct {
+	Id         *string                                   `json:"id,omitempty"`
+	Name       *string                                   `json:"name,omitempty"`
+	Properties *AutonomousDatabaseCharacterSetProperties `json:"properties,omitempty"`
+	SystemData *systemdata.SystemData                    `json:"systemData,omitempty"`
+	Type       *string                                   `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasecharactersets/model_autonomousdatabasecharactersetproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasecharactersets/model_autonomousdatabasecharactersetproperties.go
@@ -1,0 +1,8 @@
+package autonomousdatabasecharactersets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AutonomousDatabaseCharacterSetProperties struct {
+	CharacterSet string `json:"characterSet"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasecharactersets/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasecharactersets/predicates.go
@@ -1,0 +1,27 @@
+package autonomousdatabasecharactersets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AutonomousDatabaseCharacterSetOperationPredicate struct {
+	Id   *string
+	Name *string
+	Type *string
+}
+
+func (p AutonomousDatabaseCharacterSetOperationPredicate) Matches(input AutonomousDatabaseCharacterSet) bool {
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasecharactersets/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasecharactersets/version.go
@@ -1,0 +1,10 @@
+package autonomousdatabasecharactersets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2025-03-01"
+
+func userAgent() string {
+	return "hashicorp/go-azure-sdk/autonomousdatabasecharactersets/2025-03-01"
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasenationalcharactersets/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasenationalcharactersets/README.md
@@ -1,0 +1,53 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasenationalcharactersets` Documentation
+
+The `autonomousdatabasenationalcharactersets` SDK allows for interaction with Azure Resource Manager `oracledatabase` (API Version `2025-03-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasenationalcharactersets"
+```
+
+
+### Client Initialization
+
+```go
+client := autonomousdatabasenationalcharactersets.NewAutonomousDatabaseNationalCharacterSetsClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `AutonomousDatabaseNationalCharacterSetsClient.Get`
+
+```go
+ctx := context.TODO()
+id := autonomousdatabasenationalcharactersets.NewAutonomousDatabaseNationalCharacterSetID("12345678-1234-9876-4563-123456789012", "locationName", "autonomousDatabaseNationalCharacterSetName")
+
+read, err := client.Get(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `AutonomousDatabaseNationalCharacterSetsClient.ListByLocation`
+
+```go
+ctx := context.TODO()
+id := autonomousdatabasenationalcharactersets.NewLocationID("12345678-1234-9876-4563-123456789012", "locationName")
+
+// alternatively `client.ListByLocation(ctx, id)` can be used to do batched pagination
+items, err := client.ListByLocationComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasenationalcharactersets/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasenationalcharactersets/client.go
@@ -1,0 +1,26 @@
+package autonomousdatabasenationalcharactersets
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AutonomousDatabaseNationalCharacterSetsClient struct {
+	Client *resourcemanager.Client
+}
+
+func NewAutonomousDatabaseNationalCharacterSetsClientWithBaseURI(sdkApi sdkEnv.Api) (*AutonomousDatabaseNationalCharacterSetsClient, error) {
+	client, err := resourcemanager.NewClient(sdkApi, "autonomousdatabasenationalcharactersets", defaultApiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating AutonomousDatabaseNationalCharacterSetsClient: %+v", err)
+	}
+
+	return &AutonomousDatabaseNationalCharacterSetsClient{
+		Client: client,
+	}, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasenationalcharactersets/id_autonomousdatabasenationalcharacterset.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasenationalcharactersets/id_autonomousdatabasenationalcharacterset.go
@@ -1,0 +1,130 @@
+package autonomousdatabasenationalcharactersets
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&AutonomousDatabaseNationalCharacterSetId{})
+}
+
+var _ resourceids.ResourceId = &AutonomousDatabaseNationalCharacterSetId{}
+
+// AutonomousDatabaseNationalCharacterSetId is a struct representing the Resource ID for a Autonomous Database National Character Set
+type AutonomousDatabaseNationalCharacterSetId struct {
+	SubscriptionId                             string
+	LocationName                               string
+	AutonomousDatabaseNationalCharacterSetName string
+}
+
+// NewAutonomousDatabaseNationalCharacterSetID returns a new AutonomousDatabaseNationalCharacterSetId struct
+func NewAutonomousDatabaseNationalCharacterSetID(subscriptionId string, locationName string, autonomousDatabaseNationalCharacterSetName string) AutonomousDatabaseNationalCharacterSetId {
+	return AutonomousDatabaseNationalCharacterSetId{
+		SubscriptionId: subscriptionId,
+		LocationName:   locationName,
+		AutonomousDatabaseNationalCharacterSetName: autonomousDatabaseNationalCharacterSetName,
+	}
+}
+
+// ParseAutonomousDatabaseNationalCharacterSetID parses 'input' into a AutonomousDatabaseNationalCharacterSetId
+func ParseAutonomousDatabaseNationalCharacterSetID(input string) (*AutonomousDatabaseNationalCharacterSetId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&AutonomousDatabaseNationalCharacterSetId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := AutonomousDatabaseNationalCharacterSetId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseAutonomousDatabaseNationalCharacterSetIDInsensitively parses 'input' case-insensitively into a AutonomousDatabaseNationalCharacterSetId
+// note: this method should only be used for API response data and not user input
+func ParseAutonomousDatabaseNationalCharacterSetIDInsensitively(input string) (*AutonomousDatabaseNationalCharacterSetId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&AutonomousDatabaseNationalCharacterSetId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := AutonomousDatabaseNationalCharacterSetId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *AutonomousDatabaseNationalCharacterSetId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.LocationName, ok = input.Parsed["locationName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "locationName", input)
+	}
+
+	if id.AutonomousDatabaseNationalCharacterSetName, ok = input.Parsed["autonomousDatabaseNationalCharacterSetName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "autonomousDatabaseNationalCharacterSetName", input)
+	}
+
+	return nil
+}
+
+// ValidateAutonomousDatabaseNationalCharacterSetID checks that 'input' can be parsed as a Autonomous Database National Character Set ID
+func ValidateAutonomousDatabaseNationalCharacterSetID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseAutonomousDatabaseNationalCharacterSetID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Autonomous Database National Character Set ID
+func (id AutonomousDatabaseNationalCharacterSetId) ID() string {
+	fmtString := "/subscriptions/%s/providers/Oracle.Database/locations/%s/autonomousDatabaseNationalCharacterSets/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.LocationName, id.AutonomousDatabaseNationalCharacterSetName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Autonomous Database National Character Set ID
+func (id AutonomousDatabaseNationalCharacterSetId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticOracleDatabase", "Oracle.Database", "Oracle.Database"),
+		resourceids.StaticSegment("staticLocations", "locations", "locations"),
+		resourceids.UserSpecifiedSegment("locationName", "locationName"),
+		resourceids.StaticSegment("staticAutonomousDatabaseNationalCharacterSets", "autonomousDatabaseNationalCharacterSets", "autonomousDatabaseNationalCharacterSets"),
+		resourceids.UserSpecifiedSegment("autonomousDatabaseNationalCharacterSetName", "autonomousDatabaseNationalCharacterSetName"),
+	}
+}
+
+// String returns a human-readable description of this Autonomous Database National Character Set ID
+func (id AutonomousDatabaseNationalCharacterSetId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Location Name: %q", id.LocationName),
+		fmt.Sprintf("Autonomous Database National Character Set Name: %q", id.AutonomousDatabaseNationalCharacterSetName),
+	}
+	return fmt.Sprintf("Autonomous Database National Character Set (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasenationalcharactersets/id_location.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasenationalcharactersets/id_location.go
@@ -1,0 +1,121 @@
+package autonomousdatabasenationalcharactersets
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&LocationId{})
+}
+
+var _ resourceids.ResourceId = &LocationId{}
+
+// LocationId is a struct representing the Resource ID for a Location
+type LocationId struct {
+	SubscriptionId string
+	LocationName   string
+}
+
+// NewLocationID returns a new LocationId struct
+func NewLocationID(subscriptionId string, locationName string) LocationId {
+	return LocationId{
+		SubscriptionId: subscriptionId,
+		LocationName:   locationName,
+	}
+}
+
+// ParseLocationID parses 'input' into a LocationId
+func ParseLocationID(input string) (*LocationId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&LocationId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := LocationId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseLocationIDInsensitively parses 'input' case-insensitively into a LocationId
+// note: this method should only be used for API response data and not user input
+func ParseLocationIDInsensitively(input string) (*LocationId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&LocationId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := LocationId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *LocationId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.LocationName, ok = input.Parsed["locationName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "locationName", input)
+	}
+
+	return nil
+}
+
+// ValidateLocationID checks that 'input' can be parsed as a Location ID
+func ValidateLocationID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseLocationID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Location ID
+func (id LocationId) ID() string {
+	fmtString := "/subscriptions/%s/providers/Oracle.Database/locations/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.LocationName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Location ID
+func (id LocationId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticOracleDatabase", "Oracle.Database", "Oracle.Database"),
+		resourceids.StaticSegment("staticLocations", "locations", "locations"),
+		resourceids.UserSpecifiedSegment("locationName", "locationName"),
+	}
+}
+
+// String returns a human-readable description of this Location ID
+func (id LocationId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Location Name: %q", id.LocationName),
+	}
+	return fmt.Sprintf("Location (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasenationalcharactersets/method_get.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasenationalcharactersets/method_get.go
@@ -1,0 +1,53 @@
+package autonomousdatabasenationalcharactersets
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *AutonomousDatabaseNationalCharacterSet
+}
+
+// Get ...
+func (c AutonomousDatabaseNationalCharacterSetsClient) Get(ctx context.Context, id AutonomousDatabaseNationalCharacterSetId) (result GetOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model AutonomousDatabaseNationalCharacterSet
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasenationalcharactersets/method_listbylocation.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasenationalcharactersets/method_listbylocation.go
@@ -1,0 +1,105 @@
+package autonomousdatabasenationalcharactersets
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListByLocationOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]AutonomousDatabaseNationalCharacterSet
+}
+
+type ListByLocationCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []AutonomousDatabaseNationalCharacterSet
+}
+
+type ListByLocationCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *ListByLocationCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// ListByLocation ...
+func (c AutonomousDatabaseNationalCharacterSetsClient) ListByLocation(ctx context.Context, id LocationId) (result ListByLocationOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Pager:      &ListByLocationCustomPager{},
+		Path:       fmt.Sprintf("%s/autonomousDatabaseNationalCharacterSets", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]AutonomousDatabaseNationalCharacterSet `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListByLocationComplete retrieves all the results into a single object
+func (c AutonomousDatabaseNationalCharacterSetsClient) ListByLocationComplete(ctx context.Context, id LocationId) (ListByLocationCompleteResult, error) {
+	return c.ListByLocationCompleteMatchingPredicate(ctx, id, AutonomousDatabaseNationalCharacterSetOperationPredicate{})
+}
+
+// ListByLocationCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c AutonomousDatabaseNationalCharacterSetsClient) ListByLocationCompleteMatchingPredicate(ctx context.Context, id LocationId, predicate AutonomousDatabaseNationalCharacterSetOperationPredicate) (result ListByLocationCompleteResult, err error) {
+	items := make([]AutonomousDatabaseNationalCharacterSet, 0)
+
+	resp, err := c.ListByLocation(ctx, id)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListByLocationCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasenationalcharactersets/model_autonomousdatabasenationalcharacterset.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasenationalcharactersets/model_autonomousdatabasenationalcharacterset.go
@@ -1,0 +1,16 @@
+package autonomousdatabasenationalcharactersets
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/systemdata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AutonomousDatabaseNationalCharacterSet struct {
+	Id         *string                                           `json:"id,omitempty"`
+	Name       *string                                           `json:"name,omitempty"`
+	Properties *AutonomousDatabaseNationalCharacterSetProperties `json:"properties,omitempty"`
+	SystemData *systemdata.SystemData                            `json:"systemData,omitempty"`
+	Type       *string                                           `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasenationalcharactersets/model_autonomousdatabasenationalcharactersetproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasenationalcharactersets/model_autonomousdatabasenationalcharactersetproperties.go
@@ -1,0 +1,8 @@
+package autonomousdatabasenationalcharactersets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AutonomousDatabaseNationalCharacterSetProperties struct {
+	CharacterSet string `json:"characterSet"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasenationalcharactersets/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasenationalcharactersets/predicates.go
@@ -1,0 +1,27 @@
+package autonomousdatabasenationalcharactersets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AutonomousDatabaseNationalCharacterSetOperationPredicate struct {
+	Id   *string
+	Name *string
+	Type *string
+}
+
+func (p AutonomousDatabaseNationalCharacterSetOperationPredicate) Matches(input AutonomousDatabaseNationalCharacterSet) bool {
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasenationalcharactersets/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasenationalcharactersets/version.go
@@ -1,0 +1,10 @@
+package autonomousdatabasenationalcharactersets
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2025-03-01"
+
+func userAgent() string {
+	return "hashicorp/go-azure-sdk/autonomousdatabasenationalcharactersets/2025-03-01"
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/README.md
@@ -1,0 +1,218 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases` Documentation
+
+The `autonomousdatabases` SDK allows for interaction with Azure Resource Manager `oracledatabase` (API Version `2025-03-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+import "github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases"
+```
+
+
+### Client Initialization
+
+```go
+client := autonomousdatabases.NewAutonomousDatabasesClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `AutonomousDatabasesClient.ChangeDisasterRecoveryConfiguration`
+
+```go
+ctx := context.TODO()
+id := autonomousdatabases.NewAutonomousDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "autonomousDatabaseName")
+
+payload := autonomousdatabases.DisasterRecoveryConfigurationDetails{
+	// ...
+}
+
+
+if err := client.ChangeDisasterRecoveryConfigurationThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `AutonomousDatabasesClient.CreateOrUpdate`
+
+```go
+ctx := context.TODO()
+id := autonomousdatabases.NewAutonomousDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "autonomousDatabaseName")
+
+payload := autonomousdatabases.AutonomousDatabase{
+	// ...
+}
+
+
+if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `AutonomousDatabasesClient.Delete`
+
+```go
+ctx := context.TODO()
+id := autonomousdatabases.NewAutonomousDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "autonomousDatabaseName")
+
+if err := client.DeleteThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `AutonomousDatabasesClient.Failover`
+
+```go
+ctx := context.TODO()
+id := autonomousdatabases.NewAutonomousDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "autonomousDatabaseName")
+
+payload := autonomousdatabases.PeerDbDetails{
+	// ...
+}
+
+
+if err := client.FailoverThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `AutonomousDatabasesClient.GenerateWallet`
+
+```go
+ctx := context.TODO()
+id := autonomousdatabases.NewAutonomousDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "autonomousDatabaseName")
+
+payload := autonomousdatabases.GenerateAutonomousDatabaseWalletDetails{
+	// ...
+}
+
+
+read, err := client.GenerateWallet(ctx, id, payload)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `AutonomousDatabasesClient.Get`
+
+```go
+ctx := context.TODO()
+id := autonomousdatabases.NewAutonomousDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "autonomousDatabaseName")
+
+read, err := client.Get(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `AutonomousDatabasesClient.ListByResourceGroup`
+
+```go
+ctx := context.TODO()
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+
+// alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
+items, err := client.ListByResourceGroupComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `AutonomousDatabasesClient.ListBySubscription`
+
+```go
+ctx := context.TODO()
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+
+// alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
+items, err := client.ListBySubscriptionComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `AutonomousDatabasesClient.Restore`
+
+```go
+ctx := context.TODO()
+id := autonomousdatabases.NewAutonomousDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "autonomousDatabaseName")
+
+payload := autonomousdatabases.RestoreAutonomousDatabaseDetails{
+	// ...
+}
+
+
+if err := client.RestoreThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `AutonomousDatabasesClient.Shrink`
+
+```go
+ctx := context.TODO()
+id := autonomousdatabases.NewAutonomousDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "autonomousDatabaseName")
+
+if err := client.ShrinkThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `AutonomousDatabasesClient.Switchover`
+
+```go
+ctx := context.TODO()
+id := autonomousdatabases.NewAutonomousDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "autonomousDatabaseName")
+
+payload := autonomousdatabases.PeerDbDetails{
+	// ...
+}
+
+
+if err := client.SwitchoverThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `AutonomousDatabasesClient.Update`
+
+```go
+ctx := context.TODO()
+id := autonomousdatabases.NewAutonomousDatabaseID("12345678-1234-9876-4563-123456789012", "example-resource-group", "autonomousDatabaseName")
+
+payload := autonomousdatabases.AutonomousDatabaseUpdate{
+	// ...
+}
+
+
+if err := client.UpdateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/client.go
@@ -1,0 +1,26 @@
+package autonomousdatabases
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AutonomousDatabasesClient struct {
+	Client *resourcemanager.Client
+}
+
+func NewAutonomousDatabasesClientWithBaseURI(sdkApi sdkEnv.Api) (*AutonomousDatabasesClient, error) {
+	client, err := resourcemanager.NewClient(sdkApi, "autonomousdatabases", defaultApiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating AutonomousDatabasesClient: %+v", err)
+	}
+
+	return &AutonomousDatabasesClient{
+		Client: client,
+	}, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/constants.go
@@ -1,0 +1,1311 @@
+package autonomousdatabases
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AutonomousDatabaseLifecycleState string
+
+const (
+	AutonomousDatabaseLifecycleStateAvailable               AutonomousDatabaseLifecycleState = "Available"
+	AutonomousDatabaseLifecycleStateAvailableNeedsAttention AutonomousDatabaseLifecycleState = "AvailableNeedsAttention"
+	AutonomousDatabaseLifecycleStateBackupInProgress        AutonomousDatabaseLifecycleState = "BackupInProgress"
+	AutonomousDatabaseLifecycleStateInaccessible            AutonomousDatabaseLifecycleState = "Inaccessible"
+	AutonomousDatabaseLifecycleStateMaintenanceInProgress   AutonomousDatabaseLifecycleState = "MaintenanceInProgress"
+	AutonomousDatabaseLifecycleStateProvisioning            AutonomousDatabaseLifecycleState = "Provisioning"
+	AutonomousDatabaseLifecycleStateRecreating              AutonomousDatabaseLifecycleState = "Recreating"
+	AutonomousDatabaseLifecycleStateRestarting              AutonomousDatabaseLifecycleState = "Restarting"
+	AutonomousDatabaseLifecycleStateRestoreFailed           AutonomousDatabaseLifecycleState = "RestoreFailed"
+	AutonomousDatabaseLifecycleStateRestoreInProgress       AutonomousDatabaseLifecycleState = "RestoreInProgress"
+	AutonomousDatabaseLifecycleStateRoleChangeInProgress    AutonomousDatabaseLifecycleState = "RoleChangeInProgress"
+	AutonomousDatabaseLifecycleStateScaleInProgress         AutonomousDatabaseLifecycleState = "ScaleInProgress"
+	AutonomousDatabaseLifecycleStateStandby                 AutonomousDatabaseLifecycleState = "Standby"
+	AutonomousDatabaseLifecycleStateStarting                AutonomousDatabaseLifecycleState = "Starting"
+	AutonomousDatabaseLifecycleStateStopped                 AutonomousDatabaseLifecycleState = "Stopped"
+	AutonomousDatabaseLifecycleStateStopping                AutonomousDatabaseLifecycleState = "Stopping"
+	AutonomousDatabaseLifecycleStateTerminated              AutonomousDatabaseLifecycleState = "Terminated"
+	AutonomousDatabaseLifecycleStateTerminating             AutonomousDatabaseLifecycleState = "Terminating"
+	AutonomousDatabaseLifecycleStateUnavailable             AutonomousDatabaseLifecycleState = "Unavailable"
+	AutonomousDatabaseLifecycleStateUpdating                AutonomousDatabaseLifecycleState = "Updating"
+	AutonomousDatabaseLifecycleStateUpgrading               AutonomousDatabaseLifecycleState = "Upgrading"
+)
+
+func PossibleValuesForAutonomousDatabaseLifecycleState() []string {
+	return []string{
+		string(AutonomousDatabaseLifecycleStateAvailable),
+		string(AutonomousDatabaseLifecycleStateAvailableNeedsAttention),
+		string(AutonomousDatabaseLifecycleStateBackupInProgress),
+		string(AutonomousDatabaseLifecycleStateInaccessible),
+		string(AutonomousDatabaseLifecycleStateMaintenanceInProgress),
+		string(AutonomousDatabaseLifecycleStateProvisioning),
+		string(AutonomousDatabaseLifecycleStateRecreating),
+		string(AutonomousDatabaseLifecycleStateRestarting),
+		string(AutonomousDatabaseLifecycleStateRestoreFailed),
+		string(AutonomousDatabaseLifecycleStateRestoreInProgress),
+		string(AutonomousDatabaseLifecycleStateRoleChangeInProgress),
+		string(AutonomousDatabaseLifecycleStateScaleInProgress),
+		string(AutonomousDatabaseLifecycleStateStandby),
+		string(AutonomousDatabaseLifecycleStateStarting),
+		string(AutonomousDatabaseLifecycleStateStopped),
+		string(AutonomousDatabaseLifecycleStateStopping),
+		string(AutonomousDatabaseLifecycleStateTerminated),
+		string(AutonomousDatabaseLifecycleStateTerminating),
+		string(AutonomousDatabaseLifecycleStateUnavailable),
+		string(AutonomousDatabaseLifecycleStateUpdating),
+		string(AutonomousDatabaseLifecycleStateUpgrading),
+	}
+}
+
+func (s *AutonomousDatabaseLifecycleState) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseAutonomousDatabaseLifecycleState(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseAutonomousDatabaseLifecycleState(input string) (*AutonomousDatabaseLifecycleState, error) {
+	vals := map[string]AutonomousDatabaseLifecycleState{
+		"available":               AutonomousDatabaseLifecycleStateAvailable,
+		"availableneedsattention": AutonomousDatabaseLifecycleStateAvailableNeedsAttention,
+		"backupinprogress":        AutonomousDatabaseLifecycleStateBackupInProgress,
+		"inaccessible":            AutonomousDatabaseLifecycleStateInaccessible,
+		"maintenanceinprogress":   AutonomousDatabaseLifecycleStateMaintenanceInProgress,
+		"provisioning":            AutonomousDatabaseLifecycleStateProvisioning,
+		"recreating":              AutonomousDatabaseLifecycleStateRecreating,
+		"restarting":              AutonomousDatabaseLifecycleStateRestarting,
+		"restorefailed":           AutonomousDatabaseLifecycleStateRestoreFailed,
+		"restoreinprogress":       AutonomousDatabaseLifecycleStateRestoreInProgress,
+		"rolechangeinprogress":    AutonomousDatabaseLifecycleStateRoleChangeInProgress,
+		"scaleinprogress":         AutonomousDatabaseLifecycleStateScaleInProgress,
+		"standby":                 AutonomousDatabaseLifecycleStateStandby,
+		"starting":                AutonomousDatabaseLifecycleStateStarting,
+		"stopped":                 AutonomousDatabaseLifecycleStateStopped,
+		"stopping":                AutonomousDatabaseLifecycleStateStopping,
+		"terminated":              AutonomousDatabaseLifecycleStateTerminated,
+		"terminating":             AutonomousDatabaseLifecycleStateTerminating,
+		"unavailable":             AutonomousDatabaseLifecycleStateUnavailable,
+		"updating":                AutonomousDatabaseLifecycleStateUpdating,
+		"upgrading":               AutonomousDatabaseLifecycleStateUpgrading,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := AutonomousDatabaseLifecycleState(input)
+	return &out, nil
+}
+
+type AutonomousMaintenanceScheduleType string
+
+const (
+	AutonomousMaintenanceScheduleTypeEarly   AutonomousMaintenanceScheduleType = "Early"
+	AutonomousMaintenanceScheduleTypeRegular AutonomousMaintenanceScheduleType = "Regular"
+)
+
+func PossibleValuesForAutonomousMaintenanceScheduleType() []string {
+	return []string{
+		string(AutonomousMaintenanceScheduleTypeEarly),
+		string(AutonomousMaintenanceScheduleTypeRegular),
+	}
+}
+
+func (s *AutonomousMaintenanceScheduleType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseAutonomousMaintenanceScheduleType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseAutonomousMaintenanceScheduleType(input string) (*AutonomousMaintenanceScheduleType, error) {
+	vals := map[string]AutonomousMaintenanceScheduleType{
+		"early":   AutonomousMaintenanceScheduleTypeEarly,
+		"regular": AutonomousMaintenanceScheduleTypeRegular,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := AutonomousMaintenanceScheduleType(input)
+	return &out, nil
+}
+
+type AzureResourceProvisioningState string
+
+const (
+	AzureResourceProvisioningStateCanceled     AzureResourceProvisioningState = "Canceled"
+	AzureResourceProvisioningStateFailed       AzureResourceProvisioningState = "Failed"
+	AzureResourceProvisioningStateProvisioning AzureResourceProvisioningState = "Provisioning"
+	AzureResourceProvisioningStateSucceeded    AzureResourceProvisioningState = "Succeeded"
+)
+
+func PossibleValuesForAzureResourceProvisioningState() []string {
+	return []string{
+		string(AzureResourceProvisioningStateCanceled),
+		string(AzureResourceProvisioningStateFailed),
+		string(AzureResourceProvisioningStateProvisioning),
+		string(AzureResourceProvisioningStateSucceeded),
+	}
+}
+
+func (s *AzureResourceProvisioningState) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseAzureResourceProvisioningState(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseAzureResourceProvisioningState(input string) (*AzureResourceProvisioningState, error) {
+	vals := map[string]AzureResourceProvisioningState{
+		"canceled":     AzureResourceProvisioningStateCanceled,
+		"failed":       AzureResourceProvisioningStateFailed,
+		"provisioning": AzureResourceProvisioningStateProvisioning,
+		"succeeded":    AzureResourceProvisioningStateSucceeded,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := AzureResourceProvisioningState(input)
+	return &out, nil
+}
+
+type CloneType string
+
+const (
+	CloneTypeFull     CloneType = "Full"
+	CloneTypeMetadata CloneType = "Metadata"
+)
+
+func PossibleValuesForCloneType() []string {
+	return []string{
+		string(CloneTypeFull),
+		string(CloneTypeMetadata),
+	}
+}
+
+func (s *CloneType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseCloneType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseCloneType(input string) (*CloneType, error) {
+	vals := map[string]CloneType{
+		"full":     CloneTypeFull,
+		"metadata": CloneTypeMetadata,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := CloneType(input)
+	return &out, nil
+}
+
+type ComputeModel string
+
+const (
+	ComputeModelECPU ComputeModel = "ECPU"
+	ComputeModelOCPU ComputeModel = "OCPU"
+)
+
+func PossibleValuesForComputeModel() []string {
+	return []string{
+		string(ComputeModelECPU),
+		string(ComputeModelOCPU),
+	}
+}
+
+func (s *ComputeModel) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseComputeModel(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseComputeModel(input string) (*ComputeModel, error) {
+	vals := map[string]ComputeModel{
+		"ecpu": ComputeModelECPU,
+		"ocpu": ComputeModelOCPU,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ComputeModel(input)
+	return &out, nil
+}
+
+type ConsumerGroup string
+
+const (
+	ConsumerGroupHigh     ConsumerGroup = "High"
+	ConsumerGroupLow      ConsumerGroup = "Low"
+	ConsumerGroupMedium   ConsumerGroup = "Medium"
+	ConsumerGroupTp       ConsumerGroup = "Tp"
+	ConsumerGroupTpurgent ConsumerGroup = "Tpurgent"
+)
+
+func PossibleValuesForConsumerGroup() []string {
+	return []string{
+		string(ConsumerGroupHigh),
+		string(ConsumerGroupLow),
+		string(ConsumerGroupMedium),
+		string(ConsumerGroupTp),
+		string(ConsumerGroupTpurgent),
+	}
+}
+
+func (s *ConsumerGroup) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseConsumerGroup(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseConsumerGroup(input string) (*ConsumerGroup, error) {
+	vals := map[string]ConsumerGroup{
+		"high":     ConsumerGroupHigh,
+		"low":      ConsumerGroupLow,
+		"medium":   ConsumerGroupMedium,
+		"tp":       ConsumerGroupTp,
+		"tpurgent": ConsumerGroupTpurgent,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ConsumerGroup(input)
+	return &out, nil
+}
+
+type DataBaseType string
+
+const (
+	DataBaseTypeClone                       DataBaseType = "Clone"
+	DataBaseTypeCloneFromBackupTimestamp    DataBaseType = "CloneFromBackupTimestamp"
+	DataBaseTypeCrossRegionDisasterRecovery DataBaseType = "CrossRegionDisasterRecovery"
+	DataBaseTypeRegular                     DataBaseType = "Regular"
+)
+
+func PossibleValuesForDataBaseType() []string {
+	return []string{
+		string(DataBaseTypeClone),
+		string(DataBaseTypeCloneFromBackupTimestamp),
+		string(DataBaseTypeCrossRegionDisasterRecovery),
+		string(DataBaseTypeRegular),
+	}
+}
+
+func (s *DataBaseType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseDataBaseType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseDataBaseType(input string) (*DataBaseType, error) {
+	vals := map[string]DataBaseType{
+		"clone":                       DataBaseTypeClone,
+		"clonefrombackuptimestamp":    DataBaseTypeCloneFromBackupTimestamp,
+		"crossregiondisasterrecovery": DataBaseTypeCrossRegionDisasterRecovery,
+		"regular":                     DataBaseTypeRegular,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := DataBaseType(input)
+	return &out, nil
+}
+
+type DataSafeStatusType string
+
+const (
+	DataSafeStatusTypeDeregistering DataSafeStatusType = "Deregistering"
+	DataSafeStatusTypeFailed        DataSafeStatusType = "Failed"
+	DataSafeStatusTypeNotRegistered DataSafeStatusType = "NotRegistered"
+	DataSafeStatusTypeRegistered    DataSafeStatusType = "Registered"
+	DataSafeStatusTypeRegistering   DataSafeStatusType = "Registering"
+)
+
+func PossibleValuesForDataSafeStatusType() []string {
+	return []string{
+		string(DataSafeStatusTypeDeregistering),
+		string(DataSafeStatusTypeFailed),
+		string(DataSafeStatusTypeNotRegistered),
+		string(DataSafeStatusTypeRegistered),
+		string(DataSafeStatusTypeRegistering),
+	}
+}
+
+func (s *DataSafeStatusType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseDataSafeStatusType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseDataSafeStatusType(input string) (*DataSafeStatusType, error) {
+	vals := map[string]DataSafeStatusType{
+		"deregistering": DataSafeStatusTypeDeregistering,
+		"failed":        DataSafeStatusTypeFailed,
+		"notregistered": DataSafeStatusTypeNotRegistered,
+		"registered":    DataSafeStatusTypeRegistered,
+		"registering":   DataSafeStatusTypeRegistering,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := DataSafeStatusType(input)
+	return &out, nil
+}
+
+type DatabaseEditionType string
+
+const (
+	DatabaseEditionTypeEnterpriseEdition DatabaseEditionType = "EnterpriseEdition"
+	DatabaseEditionTypeStandardEdition   DatabaseEditionType = "StandardEdition"
+)
+
+func PossibleValuesForDatabaseEditionType() []string {
+	return []string{
+		string(DatabaseEditionTypeEnterpriseEdition),
+		string(DatabaseEditionTypeStandardEdition),
+	}
+}
+
+func (s *DatabaseEditionType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseDatabaseEditionType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseDatabaseEditionType(input string) (*DatabaseEditionType, error) {
+	vals := map[string]DatabaseEditionType{
+		"enterpriseedition": DatabaseEditionTypeEnterpriseEdition,
+		"standardedition":   DatabaseEditionTypeStandardEdition,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := DatabaseEditionType(input)
+	return &out, nil
+}
+
+type DayOfWeekName string
+
+const (
+	DayOfWeekNameFriday    DayOfWeekName = "Friday"
+	DayOfWeekNameMonday    DayOfWeekName = "Monday"
+	DayOfWeekNameSaturday  DayOfWeekName = "Saturday"
+	DayOfWeekNameSunday    DayOfWeekName = "Sunday"
+	DayOfWeekNameThursday  DayOfWeekName = "Thursday"
+	DayOfWeekNameTuesday   DayOfWeekName = "Tuesday"
+	DayOfWeekNameWednesday DayOfWeekName = "Wednesday"
+)
+
+func PossibleValuesForDayOfWeekName() []string {
+	return []string{
+		string(DayOfWeekNameFriday),
+		string(DayOfWeekNameMonday),
+		string(DayOfWeekNameSaturday),
+		string(DayOfWeekNameSunday),
+		string(DayOfWeekNameThursday),
+		string(DayOfWeekNameTuesday),
+		string(DayOfWeekNameWednesday),
+	}
+}
+
+func (s *DayOfWeekName) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseDayOfWeekName(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseDayOfWeekName(input string) (*DayOfWeekName, error) {
+	vals := map[string]DayOfWeekName{
+		"friday":    DayOfWeekNameFriday,
+		"monday":    DayOfWeekNameMonday,
+		"saturday":  DayOfWeekNameSaturday,
+		"sunday":    DayOfWeekNameSunday,
+		"thursday":  DayOfWeekNameThursday,
+		"tuesday":   DayOfWeekNameTuesday,
+		"wednesday": DayOfWeekNameWednesday,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := DayOfWeekName(input)
+	return &out, nil
+}
+
+type DisasterRecoveryType string
+
+const (
+	DisasterRecoveryTypeAdg         DisasterRecoveryType = "Adg"
+	DisasterRecoveryTypeBackupBased DisasterRecoveryType = "BackupBased"
+)
+
+func PossibleValuesForDisasterRecoveryType() []string {
+	return []string{
+		string(DisasterRecoveryTypeAdg),
+		string(DisasterRecoveryTypeBackupBased),
+	}
+}
+
+func (s *DisasterRecoveryType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseDisasterRecoveryType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseDisasterRecoveryType(input string) (*DisasterRecoveryType, error) {
+	vals := map[string]DisasterRecoveryType{
+		"adg":         DisasterRecoveryTypeAdg,
+		"backupbased": DisasterRecoveryTypeBackupBased,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := DisasterRecoveryType(input)
+	return &out, nil
+}
+
+type GenerateType string
+
+const (
+	GenerateTypeAll    GenerateType = "All"
+	GenerateTypeSingle GenerateType = "Single"
+)
+
+func PossibleValuesForGenerateType() []string {
+	return []string{
+		string(GenerateTypeAll),
+		string(GenerateTypeSingle),
+	}
+}
+
+func (s *GenerateType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseGenerateType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseGenerateType(input string) (*GenerateType, error) {
+	vals := map[string]GenerateType{
+		"all":    GenerateTypeAll,
+		"single": GenerateTypeSingle,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := GenerateType(input)
+	return &out, nil
+}
+
+type HostFormatType string
+
+const (
+	HostFormatTypeFqdn HostFormatType = "Fqdn"
+	HostFormatTypeIP   HostFormatType = "Ip"
+)
+
+func PossibleValuesForHostFormatType() []string {
+	return []string{
+		string(HostFormatTypeFqdn),
+		string(HostFormatTypeIP),
+	}
+}
+
+func (s *HostFormatType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseHostFormatType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseHostFormatType(input string) (*HostFormatType, error) {
+	vals := map[string]HostFormatType{
+		"fqdn": HostFormatTypeFqdn,
+		"ip":   HostFormatTypeIP,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := HostFormatType(input)
+	return &out, nil
+}
+
+type LicenseModel string
+
+const (
+	LicenseModelBringYourOwnLicense LicenseModel = "BringYourOwnLicense"
+	LicenseModelLicenseIncluded     LicenseModel = "LicenseIncluded"
+)
+
+func PossibleValuesForLicenseModel() []string {
+	return []string{
+		string(LicenseModelBringYourOwnLicense),
+		string(LicenseModelLicenseIncluded),
+	}
+}
+
+func (s *LicenseModel) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseLicenseModel(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseLicenseModel(input string) (*LicenseModel, error) {
+	vals := map[string]LicenseModel{
+		"bringyourownlicense": LicenseModelBringYourOwnLicense,
+		"licenseincluded":     LicenseModelLicenseIncluded,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := LicenseModel(input)
+	return &out, nil
+}
+
+type OpenModeType string
+
+const (
+	OpenModeTypeReadOnly  OpenModeType = "ReadOnly"
+	OpenModeTypeReadWrite OpenModeType = "ReadWrite"
+)
+
+func PossibleValuesForOpenModeType() []string {
+	return []string{
+		string(OpenModeTypeReadOnly),
+		string(OpenModeTypeReadWrite),
+	}
+}
+
+func (s *OpenModeType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseOpenModeType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseOpenModeType(input string) (*OpenModeType, error) {
+	vals := map[string]OpenModeType{
+		"readonly":  OpenModeTypeReadOnly,
+		"readwrite": OpenModeTypeReadWrite,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := OpenModeType(input)
+	return &out, nil
+}
+
+type OperationsInsightsStatusType string
+
+const (
+	OperationsInsightsStatusTypeDisabling       OperationsInsightsStatusType = "Disabling"
+	OperationsInsightsStatusTypeEnabled         OperationsInsightsStatusType = "Enabled"
+	OperationsInsightsStatusTypeEnabling        OperationsInsightsStatusType = "Enabling"
+	OperationsInsightsStatusTypeFailedDisabling OperationsInsightsStatusType = "FailedDisabling"
+	OperationsInsightsStatusTypeFailedEnabling  OperationsInsightsStatusType = "FailedEnabling"
+	OperationsInsightsStatusTypeNotEnabled      OperationsInsightsStatusType = "NotEnabled"
+)
+
+func PossibleValuesForOperationsInsightsStatusType() []string {
+	return []string{
+		string(OperationsInsightsStatusTypeDisabling),
+		string(OperationsInsightsStatusTypeEnabled),
+		string(OperationsInsightsStatusTypeEnabling),
+		string(OperationsInsightsStatusTypeFailedDisabling),
+		string(OperationsInsightsStatusTypeFailedEnabling),
+		string(OperationsInsightsStatusTypeNotEnabled),
+	}
+}
+
+func (s *OperationsInsightsStatusType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseOperationsInsightsStatusType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseOperationsInsightsStatusType(input string) (*OperationsInsightsStatusType, error) {
+	vals := map[string]OperationsInsightsStatusType{
+		"disabling":       OperationsInsightsStatusTypeDisabling,
+		"enabled":         OperationsInsightsStatusTypeEnabled,
+		"enabling":        OperationsInsightsStatusTypeEnabling,
+		"faileddisabling": OperationsInsightsStatusTypeFailedDisabling,
+		"failedenabling":  OperationsInsightsStatusTypeFailedEnabling,
+		"notenabled":      OperationsInsightsStatusTypeNotEnabled,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := OperationsInsightsStatusType(input)
+	return &out, nil
+}
+
+type PermissionLevelType string
+
+const (
+	PermissionLevelTypeRestricted   PermissionLevelType = "Restricted"
+	PermissionLevelTypeUnrestricted PermissionLevelType = "Unrestricted"
+)
+
+func PossibleValuesForPermissionLevelType() []string {
+	return []string{
+		string(PermissionLevelTypeRestricted),
+		string(PermissionLevelTypeUnrestricted),
+	}
+}
+
+func (s *PermissionLevelType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parsePermissionLevelType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parsePermissionLevelType(input string) (*PermissionLevelType, error) {
+	vals := map[string]PermissionLevelType{
+		"restricted":   PermissionLevelTypeRestricted,
+		"unrestricted": PermissionLevelTypeUnrestricted,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := PermissionLevelType(input)
+	return &out, nil
+}
+
+type ProtocolType string
+
+const (
+	ProtocolTypeTCP  ProtocolType = "TCP"
+	ProtocolTypeTCPS ProtocolType = "TCPS"
+)
+
+func PossibleValuesForProtocolType() []string {
+	return []string{
+		string(ProtocolTypeTCP),
+		string(ProtocolTypeTCPS),
+	}
+}
+
+func (s *ProtocolType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseProtocolType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseProtocolType(input string) (*ProtocolType, error) {
+	vals := map[string]ProtocolType{
+		"tcp":  ProtocolTypeTCP,
+		"tcps": ProtocolTypeTCPS,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ProtocolType(input)
+	return &out, nil
+}
+
+type RefreshableModelType string
+
+const (
+	RefreshableModelTypeAutomatic RefreshableModelType = "Automatic"
+	RefreshableModelTypeManual    RefreshableModelType = "Manual"
+)
+
+func PossibleValuesForRefreshableModelType() []string {
+	return []string{
+		string(RefreshableModelTypeAutomatic),
+		string(RefreshableModelTypeManual),
+	}
+}
+
+func (s *RefreshableModelType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseRefreshableModelType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseRefreshableModelType(input string) (*RefreshableModelType, error) {
+	vals := map[string]RefreshableModelType{
+		"automatic": RefreshableModelTypeAutomatic,
+		"manual":    RefreshableModelTypeManual,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := RefreshableModelType(input)
+	return &out, nil
+}
+
+type RefreshableStatusType string
+
+const (
+	RefreshableStatusTypeNotRefreshing RefreshableStatusType = "NotRefreshing"
+	RefreshableStatusTypeRefreshing    RefreshableStatusType = "Refreshing"
+)
+
+func PossibleValuesForRefreshableStatusType() []string {
+	return []string{
+		string(RefreshableStatusTypeNotRefreshing),
+		string(RefreshableStatusTypeRefreshing),
+	}
+}
+
+func (s *RefreshableStatusType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseRefreshableStatusType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseRefreshableStatusType(input string) (*RefreshableStatusType, error) {
+	vals := map[string]RefreshableStatusType{
+		"notrefreshing": RefreshableStatusTypeNotRefreshing,
+		"refreshing":    RefreshableStatusTypeRefreshing,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := RefreshableStatusType(input)
+	return &out, nil
+}
+
+type RepeatCadenceType string
+
+const (
+	RepeatCadenceTypeMonthly RepeatCadenceType = "Monthly"
+	RepeatCadenceTypeOneTime RepeatCadenceType = "OneTime"
+	RepeatCadenceTypeWeekly  RepeatCadenceType = "Weekly"
+	RepeatCadenceTypeYearly  RepeatCadenceType = "Yearly"
+)
+
+func PossibleValuesForRepeatCadenceType() []string {
+	return []string{
+		string(RepeatCadenceTypeMonthly),
+		string(RepeatCadenceTypeOneTime),
+		string(RepeatCadenceTypeWeekly),
+		string(RepeatCadenceTypeYearly),
+	}
+}
+
+func (s *RepeatCadenceType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseRepeatCadenceType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseRepeatCadenceType(input string) (*RepeatCadenceType, error) {
+	vals := map[string]RepeatCadenceType{
+		"monthly": RepeatCadenceTypeMonthly,
+		"onetime": RepeatCadenceTypeOneTime,
+		"weekly":  RepeatCadenceTypeWeekly,
+		"yearly":  RepeatCadenceTypeYearly,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := RepeatCadenceType(input)
+	return &out, nil
+}
+
+type RoleType string
+
+const (
+	RoleTypeBackupCopy      RoleType = "BackupCopy"
+	RoleTypeDisabledStandby RoleType = "DisabledStandby"
+	RoleTypePrimary         RoleType = "Primary"
+	RoleTypeSnapshotStandby RoleType = "SnapshotStandby"
+	RoleTypeStandby         RoleType = "Standby"
+)
+
+func PossibleValuesForRoleType() []string {
+	return []string{
+		string(RoleTypeBackupCopy),
+		string(RoleTypeDisabledStandby),
+		string(RoleTypePrimary),
+		string(RoleTypeSnapshotStandby),
+		string(RoleTypeStandby),
+	}
+}
+
+func (s *RoleType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseRoleType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseRoleType(input string) (*RoleType, error) {
+	vals := map[string]RoleType{
+		"backupcopy":      RoleTypeBackupCopy,
+		"disabledstandby": RoleTypeDisabledStandby,
+		"primary":         RoleTypePrimary,
+		"snapshotstandby": RoleTypeSnapshotStandby,
+		"standby":         RoleTypeStandby,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := RoleType(input)
+	return &out, nil
+}
+
+type SessionModeType string
+
+const (
+	SessionModeTypeDirect   SessionModeType = "Direct"
+	SessionModeTypeRedirect SessionModeType = "Redirect"
+)
+
+func PossibleValuesForSessionModeType() []string {
+	return []string{
+		string(SessionModeTypeDirect),
+		string(SessionModeTypeRedirect),
+	}
+}
+
+func (s *SessionModeType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseSessionModeType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseSessionModeType(input string) (*SessionModeType, error) {
+	vals := map[string]SessionModeType{
+		"direct":   SessionModeTypeDirect,
+		"redirect": SessionModeTypeRedirect,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := SessionModeType(input)
+	return &out, nil
+}
+
+type Source string
+
+const (
+	SourceBackupFromTimestamp         Source = "BackupFromTimestamp"
+	SourceCrossRegionDisasterRecovery Source = "CrossRegionDisasterRecovery"
+)
+
+func PossibleValuesForSource() []string {
+	return []string{
+		string(SourceBackupFromTimestamp),
+		string(SourceCrossRegionDisasterRecovery),
+	}
+}
+
+func (s *Source) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseSource(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseSource(input string) (*Source, error) {
+	vals := map[string]Source{
+		"backupfromtimestamp":         SourceBackupFromTimestamp,
+		"crossregiondisasterrecovery": SourceCrossRegionDisasterRecovery,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := Source(input)
+	return &out, nil
+}
+
+type SourceType string
+
+const (
+	SourceTypeBackupFromId                SourceType = "BackupFromId"
+	SourceTypeBackupFromTimestamp         SourceType = "BackupFromTimestamp"
+	SourceTypeCloneToRefreshable          SourceType = "CloneToRefreshable"
+	SourceTypeCrossRegionDataguard        SourceType = "CrossRegionDataguard"
+	SourceTypeCrossRegionDisasterRecovery SourceType = "CrossRegionDisasterRecovery"
+	SourceTypeDatabase                    SourceType = "Database"
+	SourceTypeNone                        SourceType = "None"
+)
+
+func PossibleValuesForSourceType() []string {
+	return []string{
+		string(SourceTypeBackupFromId),
+		string(SourceTypeBackupFromTimestamp),
+		string(SourceTypeCloneToRefreshable),
+		string(SourceTypeCrossRegionDataguard),
+		string(SourceTypeCrossRegionDisasterRecovery),
+		string(SourceTypeDatabase),
+		string(SourceTypeNone),
+	}
+}
+
+func (s *SourceType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseSourceType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseSourceType(input string) (*SourceType, error) {
+	vals := map[string]SourceType{
+		"backupfromid":                SourceTypeBackupFromId,
+		"backupfromtimestamp":         SourceTypeBackupFromTimestamp,
+		"clonetorefreshable":          SourceTypeCloneToRefreshable,
+		"crossregiondataguard":        SourceTypeCrossRegionDataguard,
+		"crossregiondisasterrecovery": SourceTypeCrossRegionDisasterRecovery,
+		"database":                    SourceTypeDatabase,
+		"none":                        SourceTypeNone,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := SourceType(input)
+	return &out, nil
+}
+
+type SyntaxFormatType string
+
+const (
+	SyntaxFormatTypeEzconnect     SyntaxFormatType = "Ezconnect"
+	SyntaxFormatTypeEzconnectplus SyntaxFormatType = "Ezconnectplus"
+	SyntaxFormatTypeLong          SyntaxFormatType = "Long"
+)
+
+func PossibleValuesForSyntaxFormatType() []string {
+	return []string{
+		string(SyntaxFormatTypeEzconnect),
+		string(SyntaxFormatTypeEzconnectplus),
+		string(SyntaxFormatTypeLong),
+	}
+}
+
+func (s *SyntaxFormatType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseSyntaxFormatType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseSyntaxFormatType(input string) (*SyntaxFormatType, error) {
+	vals := map[string]SyntaxFormatType{
+		"ezconnect":     SyntaxFormatTypeEzconnect,
+		"ezconnectplus": SyntaxFormatTypeEzconnectplus,
+		"long":          SyntaxFormatTypeLong,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := SyntaxFormatType(input)
+	return &out, nil
+}
+
+type TlsAuthenticationType string
+
+const (
+	TlsAuthenticationTypeMutual TlsAuthenticationType = "Mutual"
+	TlsAuthenticationTypeServer TlsAuthenticationType = "Server"
+)
+
+func PossibleValuesForTlsAuthenticationType() []string {
+	return []string{
+		string(TlsAuthenticationTypeMutual),
+		string(TlsAuthenticationTypeServer),
+	}
+}
+
+func (s *TlsAuthenticationType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseTlsAuthenticationType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseTlsAuthenticationType(input string) (*TlsAuthenticationType, error) {
+	vals := map[string]TlsAuthenticationType{
+		"mutual": TlsAuthenticationTypeMutual,
+		"server": TlsAuthenticationTypeServer,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := TlsAuthenticationType(input)
+	return &out, nil
+}
+
+type WorkloadType string
+
+const (
+	WorkloadTypeAJD  WorkloadType = "AJD"
+	WorkloadTypeAPEX WorkloadType = "APEX"
+	WorkloadTypeDW   WorkloadType = "DW"
+	WorkloadTypeOLTP WorkloadType = "OLTP"
+)
+
+func PossibleValuesForWorkloadType() []string {
+	return []string{
+		string(WorkloadTypeAJD),
+		string(WorkloadTypeAPEX),
+		string(WorkloadTypeDW),
+		string(WorkloadTypeOLTP),
+	}
+}
+
+func (s *WorkloadType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseWorkloadType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseWorkloadType(input string) (*WorkloadType, error) {
+	vals := map[string]WorkloadType{
+		"ajd":  WorkloadTypeAJD,
+		"apex": WorkloadTypeAPEX,
+		"dw":   WorkloadTypeDW,
+		"oltp": WorkloadTypeOLTP,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := WorkloadType(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/id_autonomousdatabase.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/id_autonomousdatabase.go
@@ -1,0 +1,130 @@
+package autonomousdatabases
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&AutonomousDatabaseId{})
+}
+
+var _ resourceids.ResourceId = &AutonomousDatabaseId{}
+
+// AutonomousDatabaseId is a struct representing the Resource ID for a Autonomous Database
+type AutonomousDatabaseId struct {
+	SubscriptionId         string
+	ResourceGroupName      string
+	AutonomousDatabaseName string
+}
+
+// NewAutonomousDatabaseID returns a new AutonomousDatabaseId struct
+func NewAutonomousDatabaseID(subscriptionId string, resourceGroupName string, autonomousDatabaseName string) AutonomousDatabaseId {
+	return AutonomousDatabaseId{
+		SubscriptionId:         subscriptionId,
+		ResourceGroupName:      resourceGroupName,
+		AutonomousDatabaseName: autonomousDatabaseName,
+	}
+}
+
+// ParseAutonomousDatabaseID parses 'input' into a AutonomousDatabaseId
+func ParseAutonomousDatabaseID(input string) (*AutonomousDatabaseId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&AutonomousDatabaseId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := AutonomousDatabaseId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseAutonomousDatabaseIDInsensitively parses 'input' case-insensitively into a AutonomousDatabaseId
+// note: this method should only be used for API response data and not user input
+func ParseAutonomousDatabaseIDInsensitively(input string) (*AutonomousDatabaseId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&AutonomousDatabaseId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := AutonomousDatabaseId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *AutonomousDatabaseId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.AutonomousDatabaseName, ok = input.Parsed["autonomousDatabaseName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "autonomousDatabaseName", input)
+	}
+
+	return nil
+}
+
+// ValidateAutonomousDatabaseID checks that 'input' can be parsed as a Autonomous Database ID
+func ValidateAutonomousDatabaseID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseAutonomousDatabaseID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Autonomous Database ID
+func (id AutonomousDatabaseId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Oracle.Database/autonomousDatabases/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.AutonomousDatabaseName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Autonomous Database ID
+func (id AutonomousDatabaseId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticOracleDatabase", "Oracle.Database", "Oracle.Database"),
+		resourceids.StaticSegment("staticAutonomousDatabases", "autonomousDatabases", "autonomousDatabases"),
+		resourceids.UserSpecifiedSegment("autonomousDatabaseName", "autonomousDatabaseName"),
+	}
+}
+
+// String returns a human-readable description of this Autonomous Database ID
+func (id AutonomousDatabaseId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Autonomous Database Name: %q", id.AutonomousDatabaseName),
+	}
+	return fmt.Sprintf("Autonomous Database (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/method_changedisasterrecoveryconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/method_changedisasterrecoveryconfiguration.go
@@ -1,0 +1,75 @@
+package autonomousdatabases
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ChangeDisasterRecoveryConfigurationOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *AutonomousDatabase
+}
+
+// ChangeDisasterRecoveryConfiguration ...
+func (c AutonomousDatabasesClient) ChangeDisasterRecoveryConfiguration(ctx context.Context, id AutonomousDatabaseId, input DisasterRecoveryConfigurationDetails) (result ChangeDisasterRecoveryConfigurationOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/changeDisasterRecoveryConfiguration", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// ChangeDisasterRecoveryConfigurationThenPoll performs ChangeDisasterRecoveryConfiguration then polls until it's completed
+func (c AutonomousDatabasesClient) ChangeDisasterRecoveryConfigurationThenPoll(ctx context.Context, id AutonomousDatabaseId, input DisasterRecoveryConfigurationDetails) error {
+	result, err := c.ChangeDisasterRecoveryConfiguration(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing ChangeDisasterRecoveryConfiguration: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after ChangeDisasterRecoveryConfiguration: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/method_createorupdate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/method_createorupdate.go
@@ -1,0 +1,75 @@
+package autonomousdatabases
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateOrUpdateOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *AutonomousDatabase
+}
+
+// CreateOrUpdate ...
+func (c AutonomousDatabasesClient) CreateOrUpdate(ctx context.Context, id AutonomousDatabaseId, input AutonomousDatabase) (result CreateOrUpdateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPut,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// CreateOrUpdateThenPoll performs CreateOrUpdate then polls until it's completed
+func (c AutonomousDatabasesClient) CreateOrUpdateThenPoll(ctx context.Context, id AutonomousDatabaseId, input AutonomousDatabase) error {
+	result, err := c.CreateOrUpdate(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing CreateOrUpdate: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after CreateOrUpdate: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/method_delete.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/method_delete.go
@@ -1,0 +1,70 @@
+package autonomousdatabases
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeleteOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// Delete ...
+func (c AutonomousDatabasesClient) Delete(ctx context.Context, id AutonomousDatabaseId) (result DeleteOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusNoContent,
+		},
+		HttpMethod: http.MethodDelete,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// DeleteThenPoll performs Delete then polls until it's completed
+func (c AutonomousDatabasesClient) DeleteThenPoll(ctx context.Context, id AutonomousDatabaseId) error {
+	result, err := c.Delete(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing Delete: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Delete: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/method_failover.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/method_failover.go
@@ -1,0 +1,75 @@
+package autonomousdatabases
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type FailoverOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *AutonomousDatabase
+}
+
+// Failover ...
+func (c AutonomousDatabasesClient) Failover(ctx context.Context, id AutonomousDatabaseId, input PeerDbDetails) (result FailoverOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/failover", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// FailoverThenPoll performs Failover then polls until it's completed
+func (c AutonomousDatabasesClient) FailoverThenPoll(ctx context.Context, id AutonomousDatabaseId, input PeerDbDetails) error {
+	result, err := c.Failover(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing Failover: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Failover: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/method_generatewallet.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/method_generatewallet.go
@@ -1,0 +1,58 @@
+package autonomousdatabases
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GenerateWalletOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *AutonomousDatabaseWalletFile
+}
+
+// GenerateWallet ...
+func (c AutonomousDatabasesClient) GenerateWallet(ctx context.Context, id AutonomousDatabaseId, input GenerateAutonomousDatabaseWalletDetails) (result GenerateWalletOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/generateWallet", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model AutonomousDatabaseWalletFile
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/method_get.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/method_get.go
@@ -1,0 +1,53 @@
+package autonomousdatabases
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *AutonomousDatabase
+}
+
+// Get ...
+func (c AutonomousDatabasesClient) Get(ctx context.Context, id AutonomousDatabaseId) (result GetOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model AutonomousDatabase
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/method_listbyresourcegroup.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/method_listbyresourcegroup.go
@@ -1,0 +1,106 @@
+package autonomousdatabases
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListByResourceGroupOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]AutonomousDatabase
+}
+
+type ListByResourceGroupCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []AutonomousDatabase
+}
+
+type ListByResourceGroupCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *ListByResourceGroupCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// ListByResourceGroup ...
+func (c AutonomousDatabasesClient) ListByResourceGroup(ctx context.Context, id commonids.ResourceGroupId) (result ListByResourceGroupOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Pager:      &ListByResourceGroupCustomPager{},
+		Path:       fmt.Sprintf("%s/providers/Oracle.Database/autonomousDatabases", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]AutonomousDatabase `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListByResourceGroupComplete retrieves all the results into a single object
+func (c AutonomousDatabasesClient) ListByResourceGroupComplete(ctx context.Context, id commonids.ResourceGroupId) (ListByResourceGroupCompleteResult, error) {
+	return c.ListByResourceGroupCompleteMatchingPredicate(ctx, id, AutonomousDatabaseOperationPredicate{})
+}
+
+// ListByResourceGroupCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c AutonomousDatabasesClient) ListByResourceGroupCompleteMatchingPredicate(ctx context.Context, id commonids.ResourceGroupId, predicate AutonomousDatabaseOperationPredicate) (result ListByResourceGroupCompleteResult, err error) {
+	items := make([]AutonomousDatabase, 0)
+
+	resp, err := c.ListByResourceGroup(ctx, id)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListByResourceGroupCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/method_listbysubscription.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/method_listbysubscription.go
@@ -1,0 +1,106 @@
+package autonomousdatabases
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListBySubscriptionOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]AutonomousDatabase
+}
+
+type ListBySubscriptionCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []AutonomousDatabase
+}
+
+type ListBySubscriptionCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *ListBySubscriptionCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// ListBySubscription ...
+func (c AutonomousDatabasesClient) ListBySubscription(ctx context.Context, id commonids.SubscriptionId) (result ListBySubscriptionOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Pager:      &ListBySubscriptionCustomPager{},
+		Path:       fmt.Sprintf("%s/providers/Oracle.Database/autonomousDatabases", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]AutonomousDatabase `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListBySubscriptionComplete retrieves all the results into a single object
+func (c AutonomousDatabasesClient) ListBySubscriptionComplete(ctx context.Context, id commonids.SubscriptionId) (ListBySubscriptionCompleteResult, error) {
+	return c.ListBySubscriptionCompleteMatchingPredicate(ctx, id, AutonomousDatabaseOperationPredicate{})
+}
+
+// ListBySubscriptionCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c AutonomousDatabasesClient) ListBySubscriptionCompleteMatchingPredicate(ctx context.Context, id commonids.SubscriptionId, predicate AutonomousDatabaseOperationPredicate) (result ListBySubscriptionCompleteResult, err error) {
+	items := make([]AutonomousDatabase, 0)
+
+	resp, err := c.ListBySubscription(ctx, id)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListBySubscriptionCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/method_restore.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/method_restore.go
@@ -1,0 +1,75 @@
+package autonomousdatabases
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RestoreOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *AutonomousDatabase
+}
+
+// Restore ...
+func (c AutonomousDatabasesClient) Restore(ctx context.Context, id AutonomousDatabaseId, input RestoreAutonomousDatabaseDetails) (result RestoreOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/restore", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// RestoreThenPoll performs Restore then polls until it's completed
+func (c AutonomousDatabasesClient) RestoreThenPoll(ctx context.Context, id AutonomousDatabaseId, input RestoreAutonomousDatabaseDetails) error {
+	result, err := c.Restore(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing Restore: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Restore: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/method_shrink.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/method_shrink.go
@@ -1,0 +1,71 @@
+package autonomousdatabases
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ShrinkOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *AutonomousDatabase
+}
+
+// Shrink ...
+func (c AutonomousDatabasesClient) Shrink(ctx context.Context, id AutonomousDatabaseId) (result ShrinkOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/shrink", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// ShrinkThenPoll performs Shrink then polls until it's completed
+func (c AutonomousDatabasesClient) ShrinkThenPoll(ctx context.Context, id AutonomousDatabaseId) error {
+	result, err := c.Shrink(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing Shrink: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Shrink: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/method_switchover.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/method_switchover.go
@@ -1,0 +1,75 @@
+package autonomousdatabases
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SwitchoverOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *AutonomousDatabase
+}
+
+// Switchover ...
+func (c AutonomousDatabasesClient) Switchover(ctx context.Context, id AutonomousDatabaseId, input PeerDbDetails) (result SwitchoverOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/switchover", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// SwitchoverThenPoll performs Switchover then polls until it's completed
+func (c AutonomousDatabasesClient) SwitchoverThenPoll(ctx context.Context, id AutonomousDatabaseId, input PeerDbDetails) error {
+	result, err := c.Switchover(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing Switchover: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Switchover: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/method_update.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/method_update.go
@@ -1,0 +1,75 @@
+package autonomousdatabases
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpdateOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *AutonomousDatabase
+}
+
+// Update ...
+func (c AutonomousDatabasesClient) Update(ctx context.Context, id AutonomousDatabaseId, input AutonomousDatabaseUpdate) (result UpdateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPatch,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// UpdateThenPoll performs Update then polls until it's completed
+func (c AutonomousDatabasesClient) UpdateThenPoll(ctx context.Context, id AutonomousDatabaseId, input AutonomousDatabaseUpdate) error {
+	result, err := c.Update(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing Update: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Update: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/model_allconnectionstringtype.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/model_allconnectionstringtype.go
@@ -1,0 +1,10 @@
+package autonomousdatabases
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AllConnectionStringType struct {
+	High   *string `json:"high,omitempty"`
+	Low    *string `json:"low,omitempty"`
+	Medium *string `json:"medium,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/model_apexdetailstype.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/model_apexdetailstype.go
@@ -1,0 +1,9 @@
+package autonomousdatabases
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ApexDetailsType struct {
+	ApexVersion *string `json:"apexVersion,omitempty"`
+	OrdsVersion *string `json:"ordsVersion,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/model_autonomousdatabase.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/model_autonomousdatabase.go
@@ -1,0 +1,59 @@
+package autonomousdatabases
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/systemdata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AutonomousDatabase struct {
+	Id         *string                          `json:"id,omitempty"`
+	Location   string                           `json:"location"`
+	Name       *string                          `json:"name,omitempty"`
+	Properties AutonomousDatabaseBaseProperties `json:"properties"`
+	SystemData *systemdata.SystemData           `json:"systemData,omitempty"`
+	Tags       *map[string]string               `json:"tags,omitempty"`
+	Type       *string                          `json:"type,omitempty"`
+}
+
+var _ json.Unmarshaler = &AutonomousDatabase{}
+
+func (s *AutonomousDatabase) UnmarshalJSON(bytes []byte) error {
+	var decoded struct {
+		Id         *string                `json:"id,omitempty"`
+		Location   string                 `json:"location"`
+		Name       *string                `json:"name,omitempty"`
+		SystemData *systemdata.SystemData `json:"systemData,omitempty"`
+		Tags       *map[string]string     `json:"tags,omitempty"`
+		Type       *string                `json:"type,omitempty"`
+	}
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+
+	s.Id = decoded.Id
+	s.Location = decoded.Location
+	s.Name = decoded.Name
+	s.SystemData = decoded.SystemData
+	s.Tags = decoded.Tags
+	s.Type = decoded.Type
+
+	var temp map[string]json.RawMessage
+	if err := json.Unmarshal(bytes, &temp); err != nil {
+		return fmt.Errorf("unmarshaling AutonomousDatabase into map[string]json.RawMessage: %+v", err)
+	}
+
+	if v, ok := temp["properties"]; ok {
+		impl, err := UnmarshalAutonomousDatabaseBasePropertiesImplementation(v)
+		if err != nil {
+			return fmt.Errorf("unmarshaling field 'Properties' for 'AutonomousDatabase': %+v", err)
+		}
+		s.Properties = impl
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/model_autonomousdatabasebaseproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/model_autonomousdatabasebaseproperties.go
@@ -1,0 +1,175 @@
+package autonomousdatabases
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AutonomousDatabaseBaseProperties interface {
+	AutonomousDatabaseBaseProperties() BaseAutonomousDatabaseBasePropertiesImpl
+}
+
+var _ AutonomousDatabaseBaseProperties = BaseAutonomousDatabaseBasePropertiesImpl{}
+
+type BaseAutonomousDatabaseBasePropertiesImpl struct {
+	ActualUsedDataStorageSizeInTbs           *float64                              `json:"actualUsedDataStorageSizeInTbs,omitempty"`
+	AdminPassword                            *string                               `json:"adminPassword,omitempty"`
+	AllocatedStorageSizeInTbs                *float64                              `json:"allocatedStorageSizeInTbs,omitempty"`
+	ApexDetails                              *ApexDetailsType                      `json:"apexDetails,omitempty"`
+	AutonomousDatabaseId                     *string                               `json:"autonomousDatabaseId,omitempty"`
+	AutonomousMaintenanceScheduleType        *AutonomousMaintenanceScheduleType    `json:"autonomousMaintenanceScheduleType,omitempty"`
+	AvailableUpgradeVersions                 *[]string                             `json:"availableUpgradeVersions,omitempty"`
+	BackupRetentionPeriodInDays              *int64                                `json:"backupRetentionPeriodInDays,omitempty"`
+	CharacterSet                             *string                               `json:"characterSet,omitempty"`
+	ComputeCount                             *float64                              `json:"computeCount,omitempty"`
+	ComputeModel                             *ComputeModel                         `json:"computeModel,omitempty"`
+	ConnectionStrings                        *ConnectionStringType                 `json:"connectionStrings,omitempty"`
+	ConnectionURLs                           *ConnectionURLType                    `json:"connectionUrls,omitempty"`
+	CpuCoreCount                             *int64                                `json:"cpuCoreCount,omitempty"`
+	CustomerContacts                         *[]CustomerContact                    `json:"customerContacts,omitempty"`
+	DataBaseType                             DataBaseType                          `json:"dataBaseType"`
+	DataSafeStatus                           *DataSafeStatusType                   `json:"dataSafeStatus,omitempty"`
+	DataStorageSizeInGbs                     *int64                                `json:"dataStorageSizeInGbs,omitempty"`
+	DataStorageSizeInTbs                     *int64                                `json:"dataStorageSizeInTbs,omitempty"`
+	DatabaseEdition                          *DatabaseEditionType                  `json:"databaseEdition,omitempty"`
+	DbVersion                                *string                               `json:"dbVersion,omitempty"`
+	DbWorkload                               *WorkloadType                         `json:"dbWorkload,omitempty"`
+	DisplayName                              *string                               `json:"displayName,omitempty"`
+	FailedDataRecoveryInSeconds              *int64                                `json:"failedDataRecoveryInSeconds,omitempty"`
+	InMemoryAreaInGbs                        *int64                                `json:"inMemoryAreaInGbs,omitempty"`
+	IsAutoScalingEnabled                     *bool                                 `json:"isAutoScalingEnabled,omitempty"`
+	IsAutoScalingForStorageEnabled           *bool                                 `json:"isAutoScalingForStorageEnabled,omitempty"`
+	IsLocalDataGuardEnabled                  *bool                                 `json:"isLocalDataGuardEnabled,omitempty"`
+	IsMtlsConnectionRequired                 *bool                                 `json:"isMtlsConnectionRequired,omitempty"`
+	IsPreview                                *bool                                 `json:"isPreview,omitempty"`
+	IsPreviewVersionWithServiceTermsAccepted *bool                                 `json:"isPreviewVersionWithServiceTermsAccepted,omitempty"`
+	IsRemoteDataGuardEnabled                 *bool                                 `json:"isRemoteDataGuardEnabled,omitempty"`
+	LicenseModel                             *LicenseModel                         `json:"licenseModel,omitempty"`
+	LifecycleDetails                         *string                               `json:"lifecycleDetails,omitempty"`
+	LifecycleState                           *AutonomousDatabaseLifecycleState     `json:"lifecycleState,omitempty"`
+	LocalAdgAutoFailoverMaxDataLossLimit     *int64                                `json:"localAdgAutoFailoverMaxDataLossLimit,omitempty"`
+	LocalDisasterRecoveryType                *DisasterRecoveryType                 `json:"localDisasterRecoveryType,omitempty"`
+	LocalStandbyDb                           *AutonomousDatabaseStandbySummary     `json:"localStandbyDb,omitempty"`
+	LongTermBackupSchedule                   *LongTermBackUpScheduleDetails        `json:"longTermBackupSchedule,omitempty"`
+	MemoryPerOracleComputeUnitInGbs          *int64                                `json:"memoryPerOracleComputeUnitInGbs,omitempty"`
+	NcharacterSet                            *string                               `json:"ncharacterSet,omitempty"`
+	NextLongTermBackupTimeStamp              *string                               `json:"nextLongTermBackupTimeStamp,omitempty"`
+	OciURL                                   *string                               `json:"ociUrl,omitempty"`
+	Ocid                                     *string                               `json:"ocid,omitempty"`
+	OpenMode                                 *OpenModeType                         `json:"openMode,omitempty"`
+	OperationsInsightsStatus                 *OperationsInsightsStatusType         `json:"operationsInsightsStatus,omitempty"`
+	PeerDbId                                 *string                               `json:"peerDbId,omitempty"`
+	PeerDbIds                                *[]string                             `json:"peerDbIds,omitempty"`
+	PermissionLevel                          *PermissionLevelType                  `json:"permissionLevel,omitempty"`
+	PrivateEndpoint                          *string                               `json:"privateEndpoint,omitempty"`
+	PrivateEndpointIP                        *string                               `json:"privateEndpointIp,omitempty"`
+	PrivateEndpointLabel                     *string                               `json:"privateEndpointLabel,omitempty"`
+	ProvisionableCPUs                        *[]int64                              `json:"provisionableCpus,omitempty"`
+	ProvisioningState                        *AzureResourceProvisioningState       `json:"provisioningState,omitempty"`
+	RemoteDisasterRecoveryConfiguration      *DisasterRecoveryConfigurationDetails `json:"remoteDisasterRecoveryConfiguration,omitempty"`
+	Role                                     *RoleType                             `json:"role,omitempty"`
+	ScheduledOperations                      *ScheduledOperationsType              `json:"scheduledOperations,omitempty"`
+	ServiceConsoleURL                        *string                               `json:"serviceConsoleUrl,omitempty"`
+	SqlWebDeveloperURL                       *string                               `json:"sqlWebDeveloperUrl,omitempty"`
+	SubnetId                                 *string                               `json:"subnetId,omitempty"`
+	SupportedRegionsToCloneTo                *[]string                             `json:"supportedRegionsToCloneTo,omitempty"`
+	TimeCreated                              *string                               `json:"timeCreated,omitempty"`
+	TimeDataGuardRoleChanged                 *string                               `json:"timeDataGuardRoleChanged,omitempty"`
+	TimeDeletionOfFreeAutonomousDatabase     *string                               `json:"timeDeletionOfFreeAutonomousDatabase,omitempty"`
+	TimeDisasterRecoveryRoleChanged          *string                               `json:"timeDisasterRecoveryRoleChanged,omitempty"`
+	TimeLocalDataGuardEnabled                *string                               `json:"timeLocalDataGuardEnabled,omitempty"`
+	TimeMaintenanceBegin                     *string                               `json:"timeMaintenanceBegin,omitempty"`
+	TimeMaintenanceEnd                       *string                               `json:"timeMaintenanceEnd,omitempty"`
+	TimeOfLastFailover                       *string                               `json:"timeOfLastFailover,omitempty"`
+	TimeOfLastRefresh                        *string                               `json:"timeOfLastRefresh,omitempty"`
+	TimeOfLastRefreshPoint                   *string                               `json:"timeOfLastRefreshPoint,omitempty"`
+	TimeOfLastSwitchover                     *string                               `json:"timeOfLastSwitchover,omitempty"`
+	TimeReclamationOfFreeAutonomousDatabase  *string                               `json:"timeReclamationOfFreeAutonomousDatabase,omitempty"`
+	UsedDataStorageSizeInGbs                 *int64                                `json:"usedDataStorageSizeInGbs,omitempty"`
+	UsedDataStorageSizeInTbs                 *int64                                `json:"usedDataStorageSizeInTbs,omitempty"`
+	VnetId                                   *string                               `json:"vnetId,omitempty"`
+	WhitelistedIPs                           *[]string                             `json:"whitelistedIps,omitempty"`
+}
+
+func (s BaseAutonomousDatabaseBasePropertiesImpl) AutonomousDatabaseBaseProperties() BaseAutonomousDatabaseBasePropertiesImpl {
+	return s
+}
+
+var _ AutonomousDatabaseBaseProperties = RawAutonomousDatabaseBasePropertiesImpl{}
+
+// RawAutonomousDatabaseBasePropertiesImpl is returned when the Discriminated Value doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawAutonomousDatabaseBasePropertiesImpl struct {
+	autonomousDatabaseBaseProperties BaseAutonomousDatabaseBasePropertiesImpl
+	Type                             string
+	Values                           map[string]interface{}
+}
+
+func (s RawAutonomousDatabaseBasePropertiesImpl) AutonomousDatabaseBaseProperties() BaseAutonomousDatabaseBasePropertiesImpl {
+	return s.autonomousDatabaseBaseProperties
+}
+
+func UnmarshalAutonomousDatabaseBasePropertiesImplementation(input []byte) (AutonomousDatabaseBaseProperties, error) {
+	if input == nil {
+		return nil, nil
+	}
+
+	var temp map[string]interface{}
+	if err := json.Unmarshal(input, &temp); err != nil {
+		return nil, fmt.Errorf("unmarshaling AutonomousDatabaseBaseProperties into map[string]interface: %+v", err)
+	}
+
+	var value string
+	if v, ok := temp["dataBaseType"]; ok {
+		value = fmt.Sprintf("%v", v)
+	}
+
+	if strings.EqualFold(value, "Clone") {
+		var out AutonomousDatabaseCloneProperties
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into AutonomousDatabaseCloneProperties: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "CrossRegionDisasterRecovery") {
+		var out AutonomousDatabaseCrossRegionDisasterRecoveryProperties
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into AutonomousDatabaseCrossRegionDisasterRecoveryProperties: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "CloneFromBackupTimestamp") {
+		var out AutonomousDatabaseFromBackupTimestampProperties
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into AutonomousDatabaseFromBackupTimestampProperties: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "Regular") {
+		var out AutonomousDatabaseProperties
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into AutonomousDatabaseProperties: %+v", err)
+		}
+		return out, nil
+	}
+
+	var parent BaseAutonomousDatabaseBasePropertiesImpl
+	if err := json.Unmarshal(input, &parent); err != nil {
+		return nil, fmt.Errorf("unmarshaling into BaseAutonomousDatabaseBasePropertiesImpl: %+v", err)
+	}
+
+	return RawAutonomousDatabaseBasePropertiesImpl{
+		autonomousDatabaseBaseProperties: parent,
+		Type:                             value,
+		Values:                           temp,
+	}, nil
+
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/model_autonomousdatabasecloneproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/model_autonomousdatabasecloneproperties.go
@@ -1,0 +1,272 @@
+package autonomousdatabases
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ AutonomousDatabaseBaseProperties = AutonomousDatabaseCloneProperties{}
+
+type AutonomousDatabaseCloneProperties struct {
+	CloneType                      CloneType              `json:"cloneType"`
+	IsReconnectCloneEnabled        *bool                  `json:"isReconnectCloneEnabled,omitempty"`
+	IsRefreshableClone             *bool                  `json:"isRefreshableClone,omitempty"`
+	RefreshableModel               *RefreshableModelType  `json:"refreshableModel,omitempty"`
+	RefreshableStatus              *RefreshableStatusType `json:"refreshableStatus,omitempty"`
+	Source                         *SourceType            `json:"source,omitempty"`
+	SourceId                       string                 `json:"sourceId"`
+	TimeUntilReconnectCloneEnabled *string                `json:"timeUntilReconnectCloneEnabled,omitempty"`
+
+	// Fields inherited from AutonomousDatabaseBaseProperties
+
+	ActualUsedDataStorageSizeInTbs           *float64                              `json:"actualUsedDataStorageSizeInTbs,omitempty"`
+	AdminPassword                            *string                               `json:"adminPassword,omitempty"`
+	AllocatedStorageSizeInTbs                *float64                              `json:"allocatedStorageSizeInTbs,omitempty"`
+	ApexDetails                              *ApexDetailsType                      `json:"apexDetails,omitempty"`
+	AutonomousDatabaseId                     *string                               `json:"autonomousDatabaseId,omitempty"`
+	AutonomousMaintenanceScheduleType        *AutonomousMaintenanceScheduleType    `json:"autonomousMaintenanceScheduleType,omitempty"`
+	AvailableUpgradeVersions                 *[]string                             `json:"availableUpgradeVersions,omitempty"`
+	BackupRetentionPeriodInDays              *int64                                `json:"backupRetentionPeriodInDays,omitempty"`
+	CharacterSet                             *string                               `json:"characterSet,omitempty"`
+	ComputeCount                             *float64                              `json:"computeCount,omitempty"`
+	ComputeModel                             *ComputeModel                         `json:"computeModel,omitempty"`
+	ConnectionStrings                        *ConnectionStringType                 `json:"connectionStrings,omitempty"`
+	ConnectionURLs                           *ConnectionURLType                    `json:"connectionUrls,omitempty"`
+	CpuCoreCount                             *int64                                `json:"cpuCoreCount,omitempty"`
+	CustomerContacts                         *[]CustomerContact                    `json:"customerContacts,omitempty"`
+	DataBaseType                             DataBaseType                          `json:"dataBaseType"`
+	DataSafeStatus                           *DataSafeStatusType                   `json:"dataSafeStatus,omitempty"`
+	DataStorageSizeInGbs                     *int64                                `json:"dataStorageSizeInGbs,omitempty"`
+	DataStorageSizeInTbs                     *int64                                `json:"dataStorageSizeInTbs,omitempty"`
+	DatabaseEdition                          *DatabaseEditionType                  `json:"databaseEdition,omitempty"`
+	DbVersion                                *string                               `json:"dbVersion,omitempty"`
+	DbWorkload                               *WorkloadType                         `json:"dbWorkload,omitempty"`
+	DisplayName                              *string                               `json:"displayName,omitempty"`
+	FailedDataRecoveryInSeconds              *int64                                `json:"failedDataRecoveryInSeconds,omitempty"`
+	InMemoryAreaInGbs                        *int64                                `json:"inMemoryAreaInGbs,omitempty"`
+	IsAutoScalingEnabled                     *bool                                 `json:"isAutoScalingEnabled,omitempty"`
+	IsAutoScalingForStorageEnabled           *bool                                 `json:"isAutoScalingForStorageEnabled,omitempty"`
+	IsLocalDataGuardEnabled                  *bool                                 `json:"isLocalDataGuardEnabled,omitempty"`
+	IsMtlsConnectionRequired                 *bool                                 `json:"isMtlsConnectionRequired,omitempty"`
+	IsPreview                                *bool                                 `json:"isPreview,omitempty"`
+	IsPreviewVersionWithServiceTermsAccepted *bool                                 `json:"isPreviewVersionWithServiceTermsAccepted,omitempty"`
+	IsRemoteDataGuardEnabled                 *bool                                 `json:"isRemoteDataGuardEnabled,omitempty"`
+	LicenseModel                             *LicenseModel                         `json:"licenseModel,omitempty"`
+	LifecycleDetails                         *string                               `json:"lifecycleDetails,omitempty"`
+	LifecycleState                           *AutonomousDatabaseLifecycleState     `json:"lifecycleState,omitempty"`
+	LocalAdgAutoFailoverMaxDataLossLimit     *int64                                `json:"localAdgAutoFailoverMaxDataLossLimit,omitempty"`
+	LocalDisasterRecoveryType                *DisasterRecoveryType                 `json:"localDisasterRecoveryType,omitempty"`
+	LocalStandbyDb                           *AutonomousDatabaseStandbySummary     `json:"localStandbyDb,omitempty"`
+	LongTermBackupSchedule                   *LongTermBackUpScheduleDetails        `json:"longTermBackupSchedule,omitempty"`
+	MemoryPerOracleComputeUnitInGbs          *int64                                `json:"memoryPerOracleComputeUnitInGbs,omitempty"`
+	NcharacterSet                            *string                               `json:"ncharacterSet,omitempty"`
+	NextLongTermBackupTimeStamp              *string                               `json:"nextLongTermBackupTimeStamp,omitempty"`
+	OciURL                                   *string                               `json:"ociUrl,omitempty"`
+	Ocid                                     *string                               `json:"ocid,omitempty"`
+	OpenMode                                 *OpenModeType                         `json:"openMode,omitempty"`
+	OperationsInsightsStatus                 *OperationsInsightsStatusType         `json:"operationsInsightsStatus,omitempty"`
+	PeerDbId                                 *string                               `json:"peerDbId,omitempty"`
+	PeerDbIds                                *[]string                             `json:"peerDbIds,omitempty"`
+	PermissionLevel                          *PermissionLevelType                  `json:"permissionLevel,omitempty"`
+	PrivateEndpoint                          *string                               `json:"privateEndpoint,omitempty"`
+	PrivateEndpointIP                        *string                               `json:"privateEndpointIp,omitempty"`
+	PrivateEndpointLabel                     *string                               `json:"privateEndpointLabel,omitempty"`
+	ProvisionableCPUs                        *[]int64                              `json:"provisionableCpus,omitempty"`
+	ProvisioningState                        *AzureResourceProvisioningState       `json:"provisioningState,omitempty"`
+	RemoteDisasterRecoveryConfiguration      *DisasterRecoveryConfigurationDetails `json:"remoteDisasterRecoveryConfiguration,omitempty"`
+	Role                                     *RoleType                             `json:"role,omitempty"`
+	ScheduledOperations                      *ScheduledOperationsType              `json:"scheduledOperations,omitempty"`
+	ServiceConsoleURL                        *string                               `json:"serviceConsoleUrl,omitempty"`
+	SqlWebDeveloperURL                       *string                               `json:"sqlWebDeveloperUrl,omitempty"`
+	SubnetId                                 *string                               `json:"subnetId,omitempty"`
+	SupportedRegionsToCloneTo                *[]string                             `json:"supportedRegionsToCloneTo,omitempty"`
+	TimeCreated                              *string                               `json:"timeCreated,omitempty"`
+	TimeDataGuardRoleChanged                 *string                               `json:"timeDataGuardRoleChanged,omitempty"`
+	TimeDeletionOfFreeAutonomousDatabase     *string                               `json:"timeDeletionOfFreeAutonomousDatabase,omitempty"`
+	TimeDisasterRecoveryRoleChanged          *string                               `json:"timeDisasterRecoveryRoleChanged,omitempty"`
+	TimeLocalDataGuardEnabled                *string                               `json:"timeLocalDataGuardEnabled,omitempty"`
+	TimeMaintenanceBegin                     *string                               `json:"timeMaintenanceBegin,omitempty"`
+	TimeMaintenanceEnd                       *string                               `json:"timeMaintenanceEnd,omitempty"`
+	TimeOfLastFailover                       *string                               `json:"timeOfLastFailover,omitempty"`
+	TimeOfLastRefresh                        *string                               `json:"timeOfLastRefresh,omitempty"`
+	TimeOfLastRefreshPoint                   *string                               `json:"timeOfLastRefreshPoint,omitempty"`
+	TimeOfLastSwitchover                     *string                               `json:"timeOfLastSwitchover,omitempty"`
+	TimeReclamationOfFreeAutonomousDatabase  *string                               `json:"timeReclamationOfFreeAutonomousDatabase,omitempty"`
+	UsedDataStorageSizeInGbs                 *int64                                `json:"usedDataStorageSizeInGbs,omitempty"`
+	UsedDataStorageSizeInTbs                 *int64                                `json:"usedDataStorageSizeInTbs,omitempty"`
+	VnetId                                   *string                               `json:"vnetId,omitempty"`
+	WhitelistedIPs                           *[]string                             `json:"whitelistedIps,omitempty"`
+}
+
+func (s AutonomousDatabaseCloneProperties) AutonomousDatabaseBaseProperties() BaseAutonomousDatabaseBasePropertiesImpl {
+	return BaseAutonomousDatabaseBasePropertiesImpl{
+		ActualUsedDataStorageSizeInTbs:           s.ActualUsedDataStorageSizeInTbs,
+		AdminPassword:                            s.AdminPassword,
+		AllocatedStorageSizeInTbs:                s.AllocatedStorageSizeInTbs,
+		ApexDetails:                              s.ApexDetails,
+		AutonomousDatabaseId:                     s.AutonomousDatabaseId,
+		AutonomousMaintenanceScheduleType:        s.AutonomousMaintenanceScheduleType,
+		AvailableUpgradeVersions:                 s.AvailableUpgradeVersions,
+		BackupRetentionPeriodInDays:              s.BackupRetentionPeriodInDays,
+		CharacterSet:                             s.CharacterSet,
+		ComputeCount:                             s.ComputeCount,
+		ComputeModel:                             s.ComputeModel,
+		ConnectionStrings:                        s.ConnectionStrings,
+		ConnectionURLs:                           s.ConnectionURLs,
+		CpuCoreCount:                             s.CpuCoreCount,
+		CustomerContacts:                         s.CustomerContacts,
+		DataBaseType:                             s.DataBaseType,
+		DataSafeStatus:                           s.DataSafeStatus,
+		DataStorageSizeInGbs:                     s.DataStorageSizeInGbs,
+		DataStorageSizeInTbs:                     s.DataStorageSizeInTbs,
+		DatabaseEdition:                          s.DatabaseEdition,
+		DbVersion:                                s.DbVersion,
+		DbWorkload:                               s.DbWorkload,
+		DisplayName:                              s.DisplayName,
+		FailedDataRecoveryInSeconds:              s.FailedDataRecoveryInSeconds,
+		InMemoryAreaInGbs:                        s.InMemoryAreaInGbs,
+		IsAutoScalingEnabled:                     s.IsAutoScalingEnabled,
+		IsAutoScalingForStorageEnabled:           s.IsAutoScalingForStorageEnabled,
+		IsLocalDataGuardEnabled:                  s.IsLocalDataGuardEnabled,
+		IsMtlsConnectionRequired:                 s.IsMtlsConnectionRequired,
+		IsPreview:                                s.IsPreview,
+		IsPreviewVersionWithServiceTermsAccepted: s.IsPreviewVersionWithServiceTermsAccepted,
+		IsRemoteDataGuardEnabled:                 s.IsRemoteDataGuardEnabled,
+		LicenseModel:                             s.LicenseModel,
+		LifecycleDetails:                         s.LifecycleDetails,
+		LifecycleState:                           s.LifecycleState,
+		LocalAdgAutoFailoverMaxDataLossLimit:     s.LocalAdgAutoFailoverMaxDataLossLimit,
+		LocalDisasterRecoveryType:                s.LocalDisasterRecoveryType,
+		LocalStandbyDb:                           s.LocalStandbyDb,
+		LongTermBackupSchedule:                   s.LongTermBackupSchedule,
+		MemoryPerOracleComputeUnitInGbs:          s.MemoryPerOracleComputeUnitInGbs,
+		NcharacterSet:                            s.NcharacterSet,
+		NextLongTermBackupTimeStamp:              s.NextLongTermBackupTimeStamp,
+		OciURL:                                   s.OciURL,
+		Ocid:                                     s.Ocid,
+		OpenMode:                                 s.OpenMode,
+		OperationsInsightsStatus:                 s.OperationsInsightsStatus,
+		PeerDbId:                                 s.PeerDbId,
+		PeerDbIds:                                s.PeerDbIds,
+		PermissionLevel:                          s.PermissionLevel,
+		PrivateEndpoint:                          s.PrivateEndpoint,
+		PrivateEndpointIP:                        s.PrivateEndpointIP,
+		PrivateEndpointLabel:                     s.PrivateEndpointLabel,
+		ProvisionableCPUs:                        s.ProvisionableCPUs,
+		ProvisioningState:                        s.ProvisioningState,
+		RemoteDisasterRecoveryConfiguration:      s.RemoteDisasterRecoveryConfiguration,
+		Role:                                     s.Role,
+		ScheduledOperations:                      s.ScheduledOperations,
+		ServiceConsoleURL:                        s.ServiceConsoleURL,
+		SqlWebDeveloperURL:                       s.SqlWebDeveloperURL,
+		SubnetId:                                 s.SubnetId,
+		SupportedRegionsToCloneTo:                s.SupportedRegionsToCloneTo,
+		TimeCreated:                              s.TimeCreated,
+		TimeDataGuardRoleChanged:                 s.TimeDataGuardRoleChanged,
+		TimeDeletionOfFreeAutonomousDatabase:     s.TimeDeletionOfFreeAutonomousDatabase,
+		TimeDisasterRecoveryRoleChanged:          s.TimeDisasterRecoveryRoleChanged,
+		TimeLocalDataGuardEnabled:                s.TimeLocalDataGuardEnabled,
+		TimeMaintenanceBegin:                     s.TimeMaintenanceBegin,
+		TimeMaintenanceEnd:                       s.TimeMaintenanceEnd,
+		TimeOfLastFailover:                       s.TimeOfLastFailover,
+		TimeOfLastRefresh:                        s.TimeOfLastRefresh,
+		TimeOfLastRefreshPoint:                   s.TimeOfLastRefreshPoint,
+		TimeOfLastSwitchover:                     s.TimeOfLastSwitchover,
+		TimeReclamationOfFreeAutonomousDatabase:  s.TimeReclamationOfFreeAutonomousDatabase,
+		UsedDataStorageSizeInGbs:                 s.UsedDataStorageSizeInGbs,
+		UsedDataStorageSizeInTbs:                 s.UsedDataStorageSizeInTbs,
+		VnetId:                                   s.VnetId,
+		WhitelistedIPs:                           s.WhitelistedIPs,
+	}
+}
+
+func (o *AutonomousDatabaseCloneProperties) GetNextLongTermBackupTimeStampAsTime() (*time.Time, error) {
+	if o.NextLongTermBackupTimeStamp == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.NextLongTermBackupTimeStamp, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *AutonomousDatabaseCloneProperties) SetNextLongTermBackupTimeStampAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.NextLongTermBackupTimeStamp = &formatted
+}
+
+func (o *AutonomousDatabaseCloneProperties) GetTimeCreatedAsTime() (*time.Time, error) {
+	if o.TimeCreated == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.TimeCreated, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *AutonomousDatabaseCloneProperties) SetTimeCreatedAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.TimeCreated = &formatted
+}
+
+func (o *AutonomousDatabaseCloneProperties) GetTimeDisasterRecoveryRoleChangedAsTime() (*time.Time, error) {
+	if o.TimeDisasterRecoveryRoleChanged == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.TimeDisasterRecoveryRoleChanged, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *AutonomousDatabaseCloneProperties) SetTimeDisasterRecoveryRoleChangedAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.TimeDisasterRecoveryRoleChanged = &formatted
+}
+
+func (o *AutonomousDatabaseCloneProperties) GetTimeMaintenanceBeginAsTime() (*time.Time, error) {
+	if o.TimeMaintenanceBegin == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.TimeMaintenanceBegin, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *AutonomousDatabaseCloneProperties) SetTimeMaintenanceBeginAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.TimeMaintenanceBegin = &formatted
+}
+
+func (o *AutonomousDatabaseCloneProperties) GetTimeMaintenanceEndAsTime() (*time.Time, error) {
+	if o.TimeMaintenanceEnd == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.TimeMaintenanceEnd, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *AutonomousDatabaseCloneProperties) SetTimeMaintenanceEndAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.TimeMaintenanceEnd = &formatted
+}
+
+var _ json.Marshaler = AutonomousDatabaseCloneProperties{}
+
+func (s AutonomousDatabaseCloneProperties) MarshalJSON() ([]byte, error) {
+	type wrapper AutonomousDatabaseCloneProperties
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling AutonomousDatabaseCloneProperties: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling AutonomousDatabaseCloneProperties: %+v", err)
+	}
+
+	decoded["dataBaseType"] = "Clone"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling AutonomousDatabaseCloneProperties: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/model_autonomousdatabasecrossregiondisasterrecoveryproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/model_autonomousdatabasecrossregiondisasterrecoveryproperties.go
@@ -1,0 +1,270 @@
+package autonomousdatabases
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ AutonomousDatabaseBaseProperties = AutonomousDatabaseCrossRegionDisasterRecoveryProperties{}
+
+type AutonomousDatabaseCrossRegionDisasterRecoveryProperties struct {
+	IsReplicateAutomaticBackups *bool                `json:"isReplicateAutomaticBackups,omitempty"`
+	RemoteDisasterRecoveryType  DisasterRecoveryType `json:"remoteDisasterRecoveryType"`
+	Source                      Source               `json:"source"`
+	SourceId                    string               `json:"sourceId"`
+	SourceLocation              *string              `json:"sourceLocation,omitempty"`
+	SourceOcid                  *string              `json:"sourceOcid,omitempty"`
+
+	// Fields inherited from AutonomousDatabaseBaseProperties
+
+	ActualUsedDataStorageSizeInTbs           *float64                              `json:"actualUsedDataStorageSizeInTbs,omitempty"`
+	AdminPassword                            *string                               `json:"adminPassword,omitempty"`
+	AllocatedStorageSizeInTbs                *float64                              `json:"allocatedStorageSizeInTbs,omitempty"`
+	ApexDetails                              *ApexDetailsType                      `json:"apexDetails,omitempty"`
+	AutonomousDatabaseId                     *string                               `json:"autonomousDatabaseId,omitempty"`
+	AutonomousMaintenanceScheduleType        *AutonomousMaintenanceScheduleType    `json:"autonomousMaintenanceScheduleType,omitempty"`
+	AvailableUpgradeVersions                 *[]string                             `json:"availableUpgradeVersions,omitempty"`
+	BackupRetentionPeriodInDays              *int64                                `json:"backupRetentionPeriodInDays,omitempty"`
+	CharacterSet                             *string                               `json:"characterSet,omitempty"`
+	ComputeCount                             *float64                              `json:"computeCount,omitempty"`
+	ComputeModel                             *ComputeModel                         `json:"computeModel,omitempty"`
+	ConnectionStrings                        *ConnectionStringType                 `json:"connectionStrings,omitempty"`
+	ConnectionURLs                           *ConnectionURLType                    `json:"connectionUrls,omitempty"`
+	CpuCoreCount                             *int64                                `json:"cpuCoreCount,omitempty"`
+	CustomerContacts                         *[]CustomerContact                    `json:"customerContacts,omitempty"`
+	DataBaseType                             DataBaseType                          `json:"dataBaseType"`
+	DataSafeStatus                           *DataSafeStatusType                   `json:"dataSafeStatus,omitempty"`
+	DataStorageSizeInGbs                     *int64                                `json:"dataStorageSizeInGbs,omitempty"`
+	DataStorageSizeInTbs                     *int64                                `json:"dataStorageSizeInTbs,omitempty"`
+	DatabaseEdition                          *DatabaseEditionType                  `json:"databaseEdition,omitempty"`
+	DbVersion                                *string                               `json:"dbVersion,omitempty"`
+	DbWorkload                               *WorkloadType                         `json:"dbWorkload,omitempty"`
+	DisplayName                              *string                               `json:"displayName,omitempty"`
+	FailedDataRecoveryInSeconds              *int64                                `json:"failedDataRecoveryInSeconds,omitempty"`
+	InMemoryAreaInGbs                        *int64                                `json:"inMemoryAreaInGbs,omitempty"`
+	IsAutoScalingEnabled                     *bool                                 `json:"isAutoScalingEnabled,omitempty"`
+	IsAutoScalingForStorageEnabled           *bool                                 `json:"isAutoScalingForStorageEnabled,omitempty"`
+	IsLocalDataGuardEnabled                  *bool                                 `json:"isLocalDataGuardEnabled,omitempty"`
+	IsMtlsConnectionRequired                 *bool                                 `json:"isMtlsConnectionRequired,omitempty"`
+	IsPreview                                *bool                                 `json:"isPreview,omitempty"`
+	IsPreviewVersionWithServiceTermsAccepted *bool                                 `json:"isPreviewVersionWithServiceTermsAccepted,omitempty"`
+	IsRemoteDataGuardEnabled                 *bool                                 `json:"isRemoteDataGuardEnabled,omitempty"`
+	LicenseModel                             *LicenseModel                         `json:"licenseModel,omitempty"`
+	LifecycleDetails                         *string                               `json:"lifecycleDetails,omitempty"`
+	LifecycleState                           *AutonomousDatabaseLifecycleState     `json:"lifecycleState,omitempty"`
+	LocalAdgAutoFailoverMaxDataLossLimit     *int64                                `json:"localAdgAutoFailoverMaxDataLossLimit,omitempty"`
+	LocalDisasterRecoveryType                *DisasterRecoveryType                 `json:"localDisasterRecoveryType,omitempty"`
+	LocalStandbyDb                           *AutonomousDatabaseStandbySummary     `json:"localStandbyDb,omitempty"`
+	LongTermBackupSchedule                   *LongTermBackUpScheduleDetails        `json:"longTermBackupSchedule,omitempty"`
+	MemoryPerOracleComputeUnitInGbs          *int64                                `json:"memoryPerOracleComputeUnitInGbs,omitempty"`
+	NcharacterSet                            *string                               `json:"ncharacterSet,omitempty"`
+	NextLongTermBackupTimeStamp              *string                               `json:"nextLongTermBackupTimeStamp,omitempty"`
+	OciURL                                   *string                               `json:"ociUrl,omitempty"`
+	Ocid                                     *string                               `json:"ocid,omitempty"`
+	OpenMode                                 *OpenModeType                         `json:"openMode,omitempty"`
+	OperationsInsightsStatus                 *OperationsInsightsStatusType         `json:"operationsInsightsStatus,omitempty"`
+	PeerDbId                                 *string                               `json:"peerDbId,omitempty"`
+	PeerDbIds                                *[]string                             `json:"peerDbIds,omitempty"`
+	PermissionLevel                          *PermissionLevelType                  `json:"permissionLevel,omitempty"`
+	PrivateEndpoint                          *string                               `json:"privateEndpoint,omitempty"`
+	PrivateEndpointIP                        *string                               `json:"privateEndpointIp,omitempty"`
+	PrivateEndpointLabel                     *string                               `json:"privateEndpointLabel,omitempty"`
+	ProvisionableCPUs                        *[]int64                              `json:"provisionableCpus,omitempty"`
+	ProvisioningState                        *AzureResourceProvisioningState       `json:"provisioningState,omitempty"`
+	RemoteDisasterRecoveryConfiguration      *DisasterRecoveryConfigurationDetails `json:"remoteDisasterRecoveryConfiguration,omitempty"`
+	Role                                     *RoleType                             `json:"role,omitempty"`
+	ScheduledOperations                      *ScheduledOperationsType              `json:"scheduledOperations,omitempty"`
+	ServiceConsoleURL                        *string                               `json:"serviceConsoleUrl,omitempty"`
+	SqlWebDeveloperURL                       *string                               `json:"sqlWebDeveloperUrl,omitempty"`
+	SubnetId                                 *string                               `json:"subnetId,omitempty"`
+	SupportedRegionsToCloneTo                *[]string                             `json:"supportedRegionsToCloneTo,omitempty"`
+	TimeCreated                              *string                               `json:"timeCreated,omitempty"`
+	TimeDataGuardRoleChanged                 *string                               `json:"timeDataGuardRoleChanged,omitempty"`
+	TimeDeletionOfFreeAutonomousDatabase     *string                               `json:"timeDeletionOfFreeAutonomousDatabase,omitempty"`
+	TimeDisasterRecoveryRoleChanged          *string                               `json:"timeDisasterRecoveryRoleChanged,omitempty"`
+	TimeLocalDataGuardEnabled                *string                               `json:"timeLocalDataGuardEnabled,omitempty"`
+	TimeMaintenanceBegin                     *string                               `json:"timeMaintenanceBegin,omitempty"`
+	TimeMaintenanceEnd                       *string                               `json:"timeMaintenanceEnd,omitempty"`
+	TimeOfLastFailover                       *string                               `json:"timeOfLastFailover,omitempty"`
+	TimeOfLastRefresh                        *string                               `json:"timeOfLastRefresh,omitempty"`
+	TimeOfLastRefreshPoint                   *string                               `json:"timeOfLastRefreshPoint,omitempty"`
+	TimeOfLastSwitchover                     *string                               `json:"timeOfLastSwitchover,omitempty"`
+	TimeReclamationOfFreeAutonomousDatabase  *string                               `json:"timeReclamationOfFreeAutonomousDatabase,omitempty"`
+	UsedDataStorageSizeInGbs                 *int64                                `json:"usedDataStorageSizeInGbs,omitempty"`
+	UsedDataStorageSizeInTbs                 *int64                                `json:"usedDataStorageSizeInTbs,omitempty"`
+	VnetId                                   *string                               `json:"vnetId,omitempty"`
+	WhitelistedIPs                           *[]string                             `json:"whitelistedIps,omitempty"`
+}
+
+func (s AutonomousDatabaseCrossRegionDisasterRecoveryProperties) AutonomousDatabaseBaseProperties() BaseAutonomousDatabaseBasePropertiesImpl {
+	return BaseAutonomousDatabaseBasePropertiesImpl{
+		ActualUsedDataStorageSizeInTbs:           s.ActualUsedDataStorageSizeInTbs,
+		AdminPassword:                            s.AdminPassword,
+		AllocatedStorageSizeInTbs:                s.AllocatedStorageSizeInTbs,
+		ApexDetails:                              s.ApexDetails,
+		AutonomousDatabaseId:                     s.AutonomousDatabaseId,
+		AutonomousMaintenanceScheduleType:        s.AutonomousMaintenanceScheduleType,
+		AvailableUpgradeVersions:                 s.AvailableUpgradeVersions,
+		BackupRetentionPeriodInDays:              s.BackupRetentionPeriodInDays,
+		CharacterSet:                             s.CharacterSet,
+		ComputeCount:                             s.ComputeCount,
+		ComputeModel:                             s.ComputeModel,
+		ConnectionStrings:                        s.ConnectionStrings,
+		ConnectionURLs:                           s.ConnectionURLs,
+		CpuCoreCount:                             s.CpuCoreCount,
+		CustomerContacts:                         s.CustomerContacts,
+		DataBaseType:                             s.DataBaseType,
+		DataSafeStatus:                           s.DataSafeStatus,
+		DataStorageSizeInGbs:                     s.DataStorageSizeInGbs,
+		DataStorageSizeInTbs:                     s.DataStorageSizeInTbs,
+		DatabaseEdition:                          s.DatabaseEdition,
+		DbVersion:                                s.DbVersion,
+		DbWorkload:                               s.DbWorkload,
+		DisplayName:                              s.DisplayName,
+		FailedDataRecoveryInSeconds:              s.FailedDataRecoveryInSeconds,
+		InMemoryAreaInGbs:                        s.InMemoryAreaInGbs,
+		IsAutoScalingEnabled:                     s.IsAutoScalingEnabled,
+		IsAutoScalingForStorageEnabled:           s.IsAutoScalingForStorageEnabled,
+		IsLocalDataGuardEnabled:                  s.IsLocalDataGuardEnabled,
+		IsMtlsConnectionRequired:                 s.IsMtlsConnectionRequired,
+		IsPreview:                                s.IsPreview,
+		IsPreviewVersionWithServiceTermsAccepted: s.IsPreviewVersionWithServiceTermsAccepted,
+		IsRemoteDataGuardEnabled:                 s.IsRemoteDataGuardEnabled,
+		LicenseModel:                             s.LicenseModel,
+		LifecycleDetails:                         s.LifecycleDetails,
+		LifecycleState:                           s.LifecycleState,
+		LocalAdgAutoFailoverMaxDataLossLimit:     s.LocalAdgAutoFailoverMaxDataLossLimit,
+		LocalDisasterRecoveryType:                s.LocalDisasterRecoveryType,
+		LocalStandbyDb:                           s.LocalStandbyDb,
+		LongTermBackupSchedule:                   s.LongTermBackupSchedule,
+		MemoryPerOracleComputeUnitInGbs:          s.MemoryPerOracleComputeUnitInGbs,
+		NcharacterSet:                            s.NcharacterSet,
+		NextLongTermBackupTimeStamp:              s.NextLongTermBackupTimeStamp,
+		OciURL:                                   s.OciURL,
+		Ocid:                                     s.Ocid,
+		OpenMode:                                 s.OpenMode,
+		OperationsInsightsStatus:                 s.OperationsInsightsStatus,
+		PeerDbId:                                 s.PeerDbId,
+		PeerDbIds:                                s.PeerDbIds,
+		PermissionLevel:                          s.PermissionLevel,
+		PrivateEndpoint:                          s.PrivateEndpoint,
+		PrivateEndpointIP:                        s.PrivateEndpointIP,
+		PrivateEndpointLabel:                     s.PrivateEndpointLabel,
+		ProvisionableCPUs:                        s.ProvisionableCPUs,
+		ProvisioningState:                        s.ProvisioningState,
+		RemoteDisasterRecoveryConfiguration:      s.RemoteDisasterRecoveryConfiguration,
+		Role:                                     s.Role,
+		ScheduledOperations:                      s.ScheduledOperations,
+		ServiceConsoleURL:                        s.ServiceConsoleURL,
+		SqlWebDeveloperURL:                       s.SqlWebDeveloperURL,
+		SubnetId:                                 s.SubnetId,
+		SupportedRegionsToCloneTo:                s.SupportedRegionsToCloneTo,
+		TimeCreated:                              s.TimeCreated,
+		TimeDataGuardRoleChanged:                 s.TimeDataGuardRoleChanged,
+		TimeDeletionOfFreeAutonomousDatabase:     s.TimeDeletionOfFreeAutonomousDatabase,
+		TimeDisasterRecoveryRoleChanged:          s.TimeDisasterRecoveryRoleChanged,
+		TimeLocalDataGuardEnabled:                s.TimeLocalDataGuardEnabled,
+		TimeMaintenanceBegin:                     s.TimeMaintenanceBegin,
+		TimeMaintenanceEnd:                       s.TimeMaintenanceEnd,
+		TimeOfLastFailover:                       s.TimeOfLastFailover,
+		TimeOfLastRefresh:                        s.TimeOfLastRefresh,
+		TimeOfLastRefreshPoint:                   s.TimeOfLastRefreshPoint,
+		TimeOfLastSwitchover:                     s.TimeOfLastSwitchover,
+		TimeReclamationOfFreeAutonomousDatabase:  s.TimeReclamationOfFreeAutonomousDatabase,
+		UsedDataStorageSizeInGbs:                 s.UsedDataStorageSizeInGbs,
+		UsedDataStorageSizeInTbs:                 s.UsedDataStorageSizeInTbs,
+		VnetId:                                   s.VnetId,
+		WhitelistedIPs:                           s.WhitelistedIPs,
+	}
+}
+
+func (o *AutonomousDatabaseCrossRegionDisasterRecoveryProperties) GetNextLongTermBackupTimeStampAsTime() (*time.Time, error) {
+	if o.NextLongTermBackupTimeStamp == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.NextLongTermBackupTimeStamp, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *AutonomousDatabaseCrossRegionDisasterRecoveryProperties) SetNextLongTermBackupTimeStampAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.NextLongTermBackupTimeStamp = &formatted
+}
+
+func (o *AutonomousDatabaseCrossRegionDisasterRecoveryProperties) GetTimeCreatedAsTime() (*time.Time, error) {
+	if o.TimeCreated == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.TimeCreated, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *AutonomousDatabaseCrossRegionDisasterRecoveryProperties) SetTimeCreatedAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.TimeCreated = &formatted
+}
+
+func (o *AutonomousDatabaseCrossRegionDisasterRecoveryProperties) GetTimeDisasterRecoveryRoleChangedAsTime() (*time.Time, error) {
+	if o.TimeDisasterRecoveryRoleChanged == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.TimeDisasterRecoveryRoleChanged, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *AutonomousDatabaseCrossRegionDisasterRecoveryProperties) SetTimeDisasterRecoveryRoleChangedAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.TimeDisasterRecoveryRoleChanged = &formatted
+}
+
+func (o *AutonomousDatabaseCrossRegionDisasterRecoveryProperties) GetTimeMaintenanceBeginAsTime() (*time.Time, error) {
+	if o.TimeMaintenanceBegin == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.TimeMaintenanceBegin, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *AutonomousDatabaseCrossRegionDisasterRecoveryProperties) SetTimeMaintenanceBeginAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.TimeMaintenanceBegin = &formatted
+}
+
+func (o *AutonomousDatabaseCrossRegionDisasterRecoveryProperties) GetTimeMaintenanceEndAsTime() (*time.Time, error) {
+	if o.TimeMaintenanceEnd == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.TimeMaintenanceEnd, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *AutonomousDatabaseCrossRegionDisasterRecoveryProperties) SetTimeMaintenanceEndAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.TimeMaintenanceEnd = &formatted
+}
+
+var _ json.Marshaler = AutonomousDatabaseCrossRegionDisasterRecoveryProperties{}
+
+func (s AutonomousDatabaseCrossRegionDisasterRecoveryProperties) MarshalJSON() ([]byte, error) {
+	type wrapper AutonomousDatabaseCrossRegionDisasterRecoveryProperties
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling AutonomousDatabaseCrossRegionDisasterRecoveryProperties: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling AutonomousDatabaseCrossRegionDisasterRecoveryProperties: %+v", err)
+	}
+
+	decoded["dataBaseType"] = "CrossRegionDisasterRecovery"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling AutonomousDatabaseCrossRegionDisasterRecoveryProperties: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/model_autonomousdatabasefrombackuptimestampproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/model_autonomousdatabasefrombackuptimestampproperties.go
@@ -1,0 +1,269 @@
+package autonomousdatabases
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ AutonomousDatabaseBaseProperties = AutonomousDatabaseFromBackupTimestampProperties{}
+
+type AutonomousDatabaseFromBackupTimestampProperties struct {
+	CloneType                         CloneType `json:"cloneType"`
+	Source                            Source    `json:"source"`
+	SourceId                          string    `json:"sourceId"`
+	Timestamp                         *string   `json:"timestamp,omitempty"`
+	UseLatestAvailableBackupTimeStamp *bool     `json:"useLatestAvailableBackupTimeStamp,omitempty"`
+
+	// Fields inherited from AutonomousDatabaseBaseProperties
+
+	ActualUsedDataStorageSizeInTbs           *float64                              `json:"actualUsedDataStorageSizeInTbs,omitempty"`
+	AdminPassword                            *string                               `json:"adminPassword,omitempty"`
+	AllocatedStorageSizeInTbs                *float64                              `json:"allocatedStorageSizeInTbs,omitempty"`
+	ApexDetails                              *ApexDetailsType                      `json:"apexDetails,omitempty"`
+	AutonomousDatabaseId                     *string                               `json:"autonomousDatabaseId,omitempty"`
+	AutonomousMaintenanceScheduleType        *AutonomousMaintenanceScheduleType    `json:"autonomousMaintenanceScheduleType,omitempty"`
+	AvailableUpgradeVersions                 *[]string                             `json:"availableUpgradeVersions,omitempty"`
+	BackupRetentionPeriodInDays              *int64                                `json:"backupRetentionPeriodInDays,omitempty"`
+	CharacterSet                             *string                               `json:"characterSet,omitempty"`
+	ComputeCount                             *float64                              `json:"computeCount,omitempty"`
+	ComputeModel                             *ComputeModel                         `json:"computeModel,omitempty"`
+	ConnectionStrings                        *ConnectionStringType                 `json:"connectionStrings,omitempty"`
+	ConnectionURLs                           *ConnectionURLType                    `json:"connectionUrls,omitempty"`
+	CpuCoreCount                             *int64                                `json:"cpuCoreCount,omitempty"`
+	CustomerContacts                         *[]CustomerContact                    `json:"customerContacts,omitempty"`
+	DataBaseType                             DataBaseType                          `json:"dataBaseType"`
+	DataSafeStatus                           *DataSafeStatusType                   `json:"dataSafeStatus,omitempty"`
+	DataStorageSizeInGbs                     *int64                                `json:"dataStorageSizeInGbs,omitempty"`
+	DataStorageSizeInTbs                     *int64                                `json:"dataStorageSizeInTbs,omitempty"`
+	DatabaseEdition                          *DatabaseEditionType                  `json:"databaseEdition,omitempty"`
+	DbVersion                                *string                               `json:"dbVersion,omitempty"`
+	DbWorkload                               *WorkloadType                         `json:"dbWorkload,omitempty"`
+	DisplayName                              *string                               `json:"displayName,omitempty"`
+	FailedDataRecoveryInSeconds              *int64                                `json:"failedDataRecoveryInSeconds,omitempty"`
+	InMemoryAreaInGbs                        *int64                                `json:"inMemoryAreaInGbs,omitempty"`
+	IsAutoScalingEnabled                     *bool                                 `json:"isAutoScalingEnabled,omitempty"`
+	IsAutoScalingForStorageEnabled           *bool                                 `json:"isAutoScalingForStorageEnabled,omitempty"`
+	IsLocalDataGuardEnabled                  *bool                                 `json:"isLocalDataGuardEnabled,omitempty"`
+	IsMtlsConnectionRequired                 *bool                                 `json:"isMtlsConnectionRequired,omitempty"`
+	IsPreview                                *bool                                 `json:"isPreview,omitempty"`
+	IsPreviewVersionWithServiceTermsAccepted *bool                                 `json:"isPreviewVersionWithServiceTermsAccepted,omitempty"`
+	IsRemoteDataGuardEnabled                 *bool                                 `json:"isRemoteDataGuardEnabled,omitempty"`
+	LicenseModel                             *LicenseModel                         `json:"licenseModel,omitempty"`
+	LifecycleDetails                         *string                               `json:"lifecycleDetails,omitempty"`
+	LifecycleState                           *AutonomousDatabaseLifecycleState     `json:"lifecycleState,omitempty"`
+	LocalAdgAutoFailoverMaxDataLossLimit     *int64                                `json:"localAdgAutoFailoverMaxDataLossLimit,omitempty"`
+	LocalDisasterRecoveryType                *DisasterRecoveryType                 `json:"localDisasterRecoveryType,omitempty"`
+	LocalStandbyDb                           *AutonomousDatabaseStandbySummary     `json:"localStandbyDb,omitempty"`
+	LongTermBackupSchedule                   *LongTermBackUpScheduleDetails        `json:"longTermBackupSchedule,omitempty"`
+	MemoryPerOracleComputeUnitInGbs          *int64                                `json:"memoryPerOracleComputeUnitInGbs,omitempty"`
+	NcharacterSet                            *string                               `json:"ncharacterSet,omitempty"`
+	NextLongTermBackupTimeStamp              *string                               `json:"nextLongTermBackupTimeStamp,omitempty"`
+	OciURL                                   *string                               `json:"ociUrl,omitempty"`
+	Ocid                                     *string                               `json:"ocid,omitempty"`
+	OpenMode                                 *OpenModeType                         `json:"openMode,omitempty"`
+	OperationsInsightsStatus                 *OperationsInsightsStatusType         `json:"operationsInsightsStatus,omitempty"`
+	PeerDbId                                 *string                               `json:"peerDbId,omitempty"`
+	PeerDbIds                                *[]string                             `json:"peerDbIds,omitempty"`
+	PermissionLevel                          *PermissionLevelType                  `json:"permissionLevel,omitempty"`
+	PrivateEndpoint                          *string                               `json:"privateEndpoint,omitempty"`
+	PrivateEndpointIP                        *string                               `json:"privateEndpointIp,omitempty"`
+	PrivateEndpointLabel                     *string                               `json:"privateEndpointLabel,omitempty"`
+	ProvisionableCPUs                        *[]int64                              `json:"provisionableCpus,omitempty"`
+	ProvisioningState                        *AzureResourceProvisioningState       `json:"provisioningState,omitempty"`
+	RemoteDisasterRecoveryConfiguration      *DisasterRecoveryConfigurationDetails `json:"remoteDisasterRecoveryConfiguration,omitempty"`
+	Role                                     *RoleType                             `json:"role,omitempty"`
+	ScheduledOperations                      *ScheduledOperationsType              `json:"scheduledOperations,omitempty"`
+	ServiceConsoleURL                        *string                               `json:"serviceConsoleUrl,omitempty"`
+	SqlWebDeveloperURL                       *string                               `json:"sqlWebDeveloperUrl,omitempty"`
+	SubnetId                                 *string                               `json:"subnetId,omitempty"`
+	SupportedRegionsToCloneTo                *[]string                             `json:"supportedRegionsToCloneTo,omitempty"`
+	TimeCreated                              *string                               `json:"timeCreated,omitempty"`
+	TimeDataGuardRoleChanged                 *string                               `json:"timeDataGuardRoleChanged,omitempty"`
+	TimeDeletionOfFreeAutonomousDatabase     *string                               `json:"timeDeletionOfFreeAutonomousDatabase,omitempty"`
+	TimeDisasterRecoveryRoleChanged          *string                               `json:"timeDisasterRecoveryRoleChanged,omitempty"`
+	TimeLocalDataGuardEnabled                *string                               `json:"timeLocalDataGuardEnabled,omitempty"`
+	TimeMaintenanceBegin                     *string                               `json:"timeMaintenanceBegin,omitempty"`
+	TimeMaintenanceEnd                       *string                               `json:"timeMaintenanceEnd,omitempty"`
+	TimeOfLastFailover                       *string                               `json:"timeOfLastFailover,omitempty"`
+	TimeOfLastRefresh                        *string                               `json:"timeOfLastRefresh,omitempty"`
+	TimeOfLastRefreshPoint                   *string                               `json:"timeOfLastRefreshPoint,omitempty"`
+	TimeOfLastSwitchover                     *string                               `json:"timeOfLastSwitchover,omitempty"`
+	TimeReclamationOfFreeAutonomousDatabase  *string                               `json:"timeReclamationOfFreeAutonomousDatabase,omitempty"`
+	UsedDataStorageSizeInGbs                 *int64                                `json:"usedDataStorageSizeInGbs,omitempty"`
+	UsedDataStorageSizeInTbs                 *int64                                `json:"usedDataStorageSizeInTbs,omitempty"`
+	VnetId                                   *string                               `json:"vnetId,omitempty"`
+	WhitelistedIPs                           *[]string                             `json:"whitelistedIps,omitempty"`
+}
+
+func (s AutonomousDatabaseFromBackupTimestampProperties) AutonomousDatabaseBaseProperties() BaseAutonomousDatabaseBasePropertiesImpl {
+	return BaseAutonomousDatabaseBasePropertiesImpl{
+		ActualUsedDataStorageSizeInTbs:           s.ActualUsedDataStorageSizeInTbs,
+		AdminPassword:                            s.AdminPassword,
+		AllocatedStorageSizeInTbs:                s.AllocatedStorageSizeInTbs,
+		ApexDetails:                              s.ApexDetails,
+		AutonomousDatabaseId:                     s.AutonomousDatabaseId,
+		AutonomousMaintenanceScheduleType:        s.AutonomousMaintenanceScheduleType,
+		AvailableUpgradeVersions:                 s.AvailableUpgradeVersions,
+		BackupRetentionPeriodInDays:              s.BackupRetentionPeriodInDays,
+		CharacterSet:                             s.CharacterSet,
+		ComputeCount:                             s.ComputeCount,
+		ComputeModel:                             s.ComputeModel,
+		ConnectionStrings:                        s.ConnectionStrings,
+		ConnectionURLs:                           s.ConnectionURLs,
+		CpuCoreCount:                             s.CpuCoreCount,
+		CustomerContacts:                         s.CustomerContacts,
+		DataBaseType:                             s.DataBaseType,
+		DataSafeStatus:                           s.DataSafeStatus,
+		DataStorageSizeInGbs:                     s.DataStorageSizeInGbs,
+		DataStorageSizeInTbs:                     s.DataStorageSizeInTbs,
+		DatabaseEdition:                          s.DatabaseEdition,
+		DbVersion:                                s.DbVersion,
+		DbWorkload:                               s.DbWorkload,
+		DisplayName:                              s.DisplayName,
+		FailedDataRecoveryInSeconds:              s.FailedDataRecoveryInSeconds,
+		InMemoryAreaInGbs:                        s.InMemoryAreaInGbs,
+		IsAutoScalingEnabled:                     s.IsAutoScalingEnabled,
+		IsAutoScalingForStorageEnabled:           s.IsAutoScalingForStorageEnabled,
+		IsLocalDataGuardEnabled:                  s.IsLocalDataGuardEnabled,
+		IsMtlsConnectionRequired:                 s.IsMtlsConnectionRequired,
+		IsPreview:                                s.IsPreview,
+		IsPreviewVersionWithServiceTermsAccepted: s.IsPreviewVersionWithServiceTermsAccepted,
+		IsRemoteDataGuardEnabled:                 s.IsRemoteDataGuardEnabled,
+		LicenseModel:                             s.LicenseModel,
+		LifecycleDetails:                         s.LifecycleDetails,
+		LifecycleState:                           s.LifecycleState,
+		LocalAdgAutoFailoverMaxDataLossLimit:     s.LocalAdgAutoFailoverMaxDataLossLimit,
+		LocalDisasterRecoveryType:                s.LocalDisasterRecoveryType,
+		LocalStandbyDb:                           s.LocalStandbyDb,
+		LongTermBackupSchedule:                   s.LongTermBackupSchedule,
+		MemoryPerOracleComputeUnitInGbs:          s.MemoryPerOracleComputeUnitInGbs,
+		NcharacterSet:                            s.NcharacterSet,
+		NextLongTermBackupTimeStamp:              s.NextLongTermBackupTimeStamp,
+		OciURL:                                   s.OciURL,
+		Ocid:                                     s.Ocid,
+		OpenMode:                                 s.OpenMode,
+		OperationsInsightsStatus:                 s.OperationsInsightsStatus,
+		PeerDbId:                                 s.PeerDbId,
+		PeerDbIds:                                s.PeerDbIds,
+		PermissionLevel:                          s.PermissionLevel,
+		PrivateEndpoint:                          s.PrivateEndpoint,
+		PrivateEndpointIP:                        s.PrivateEndpointIP,
+		PrivateEndpointLabel:                     s.PrivateEndpointLabel,
+		ProvisionableCPUs:                        s.ProvisionableCPUs,
+		ProvisioningState:                        s.ProvisioningState,
+		RemoteDisasterRecoveryConfiguration:      s.RemoteDisasterRecoveryConfiguration,
+		Role:                                     s.Role,
+		ScheduledOperations:                      s.ScheduledOperations,
+		ServiceConsoleURL:                        s.ServiceConsoleURL,
+		SqlWebDeveloperURL:                       s.SqlWebDeveloperURL,
+		SubnetId:                                 s.SubnetId,
+		SupportedRegionsToCloneTo:                s.SupportedRegionsToCloneTo,
+		TimeCreated:                              s.TimeCreated,
+		TimeDataGuardRoleChanged:                 s.TimeDataGuardRoleChanged,
+		TimeDeletionOfFreeAutonomousDatabase:     s.TimeDeletionOfFreeAutonomousDatabase,
+		TimeDisasterRecoveryRoleChanged:          s.TimeDisasterRecoveryRoleChanged,
+		TimeLocalDataGuardEnabled:                s.TimeLocalDataGuardEnabled,
+		TimeMaintenanceBegin:                     s.TimeMaintenanceBegin,
+		TimeMaintenanceEnd:                       s.TimeMaintenanceEnd,
+		TimeOfLastFailover:                       s.TimeOfLastFailover,
+		TimeOfLastRefresh:                        s.TimeOfLastRefresh,
+		TimeOfLastRefreshPoint:                   s.TimeOfLastRefreshPoint,
+		TimeOfLastSwitchover:                     s.TimeOfLastSwitchover,
+		TimeReclamationOfFreeAutonomousDatabase:  s.TimeReclamationOfFreeAutonomousDatabase,
+		UsedDataStorageSizeInGbs:                 s.UsedDataStorageSizeInGbs,
+		UsedDataStorageSizeInTbs:                 s.UsedDataStorageSizeInTbs,
+		VnetId:                                   s.VnetId,
+		WhitelistedIPs:                           s.WhitelistedIPs,
+	}
+}
+
+func (o *AutonomousDatabaseFromBackupTimestampProperties) GetNextLongTermBackupTimeStampAsTime() (*time.Time, error) {
+	if o.NextLongTermBackupTimeStamp == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.NextLongTermBackupTimeStamp, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *AutonomousDatabaseFromBackupTimestampProperties) SetNextLongTermBackupTimeStampAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.NextLongTermBackupTimeStamp = &formatted
+}
+
+func (o *AutonomousDatabaseFromBackupTimestampProperties) GetTimeCreatedAsTime() (*time.Time, error) {
+	if o.TimeCreated == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.TimeCreated, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *AutonomousDatabaseFromBackupTimestampProperties) SetTimeCreatedAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.TimeCreated = &formatted
+}
+
+func (o *AutonomousDatabaseFromBackupTimestampProperties) GetTimeDisasterRecoveryRoleChangedAsTime() (*time.Time, error) {
+	if o.TimeDisasterRecoveryRoleChanged == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.TimeDisasterRecoveryRoleChanged, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *AutonomousDatabaseFromBackupTimestampProperties) SetTimeDisasterRecoveryRoleChangedAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.TimeDisasterRecoveryRoleChanged = &formatted
+}
+
+func (o *AutonomousDatabaseFromBackupTimestampProperties) GetTimeMaintenanceBeginAsTime() (*time.Time, error) {
+	if o.TimeMaintenanceBegin == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.TimeMaintenanceBegin, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *AutonomousDatabaseFromBackupTimestampProperties) SetTimeMaintenanceBeginAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.TimeMaintenanceBegin = &formatted
+}
+
+func (o *AutonomousDatabaseFromBackupTimestampProperties) GetTimeMaintenanceEndAsTime() (*time.Time, error) {
+	if o.TimeMaintenanceEnd == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.TimeMaintenanceEnd, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *AutonomousDatabaseFromBackupTimestampProperties) SetTimeMaintenanceEndAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.TimeMaintenanceEnd = &formatted
+}
+
+var _ json.Marshaler = AutonomousDatabaseFromBackupTimestampProperties{}
+
+func (s AutonomousDatabaseFromBackupTimestampProperties) MarshalJSON() ([]byte, error) {
+	type wrapper AutonomousDatabaseFromBackupTimestampProperties
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling AutonomousDatabaseFromBackupTimestampProperties: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling AutonomousDatabaseFromBackupTimestampProperties: %+v", err)
+	}
+
+	decoded["dataBaseType"] = "CloneFromBackupTimestamp"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling AutonomousDatabaseFromBackupTimestampProperties: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/model_autonomousdatabaseproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/model_autonomousdatabaseproperties.go
@@ -1,0 +1,264 @@
+package autonomousdatabases
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ AutonomousDatabaseBaseProperties = AutonomousDatabaseProperties{}
+
+type AutonomousDatabaseProperties struct {
+
+	// Fields inherited from AutonomousDatabaseBaseProperties
+
+	ActualUsedDataStorageSizeInTbs           *float64                              `json:"actualUsedDataStorageSizeInTbs,omitempty"`
+	AdminPassword                            *string                               `json:"adminPassword,omitempty"`
+	AllocatedStorageSizeInTbs                *float64                              `json:"allocatedStorageSizeInTbs,omitempty"`
+	ApexDetails                              *ApexDetailsType                      `json:"apexDetails,omitempty"`
+	AutonomousDatabaseId                     *string                               `json:"autonomousDatabaseId,omitempty"`
+	AutonomousMaintenanceScheduleType        *AutonomousMaintenanceScheduleType    `json:"autonomousMaintenanceScheduleType,omitempty"`
+	AvailableUpgradeVersions                 *[]string                             `json:"availableUpgradeVersions,omitempty"`
+	BackupRetentionPeriodInDays              *int64                                `json:"backupRetentionPeriodInDays,omitempty"`
+	CharacterSet                             *string                               `json:"characterSet,omitempty"`
+	ComputeCount                             *float64                              `json:"computeCount,omitempty"`
+	ComputeModel                             *ComputeModel                         `json:"computeModel,omitempty"`
+	ConnectionStrings                        *ConnectionStringType                 `json:"connectionStrings,omitempty"`
+	ConnectionURLs                           *ConnectionURLType                    `json:"connectionUrls,omitempty"`
+	CpuCoreCount                             *int64                                `json:"cpuCoreCount,omitempty"`
+	CustomerContacts                         *[]CustomerContact                    `json:"customerContacts,omitempty"`
+	DataBaseType                             DataBaseType                          `json:"dataBaseType"`
+	DataSafeStatus                           *DataSafeStatusType                   `json:"dataSafeStatus,omitempty"`
+	DataStorageSizeInGbs                     *int64                                `json:"dataStorageSizeInGbs,omitempty"`
+	DataStorageSizeInTbs                     *int64                                `json:"dataStorageSizeInTbs,omitempty"`
+	DatabaseEdition                          *DatabaseEditionType                  `json:"databaseEdition,omitempty"`
+	DbVersion                                *string                               `json:"dbVersion,omitempty"`
+	DbWorkload                               *WorkloadType                         `json:"dbWorkload,omitempty"`
+	DisplayName                              *string                               `json:"displayName,omitempty"`
+	FailedDataRecoveryInSeconds              *int64                                `json:"failedDataRecoveryInSeconds,omitempty"`
+	InMemoryAreaInGbs                        *int64                                `json:"inMemoryAreaInGbs,omitempty"`
+	IsAutoScalingEnabled                     *bool                                 `json:"isAutoScalingEnabled,omitempty"`
+	IsAutoScalingForStorageEnabled           *bool                                 `json:"isAutoScalingForStorageEnabled,omitempty"`
+	IsLocalDataGuardEnabled                  *bool                                 `json:"isLocalDataGuardEnabled,omitempty"`
+	IsMtlsConnectionRequired                 *bool                                 `json:"isMtlsConnectionRequired,omitempty"`
+	IsPreview                                *bool                                 `json:"isPreview,omitempty"`
+	IsPreviewVersionWithServiceTermsAccepted *bool                                 `json:"isPreviewVersionWithServiceTermsAccepted,omitempty"`
+	IsRemoteDataGuardEnabled                 *bool                                 `json:"isRemoteDataGuardEnabled,omitempty"`
+	LicenseModel                             *LicenseModel                         `json:"licenseModel,omitempty"`
+	LifecycleDetails                         *string                               `json:"lifecycleDetails,omitempty"`
+	LifecycleState                           *AutonomousDatabaseLifecycleState     `json:"lifecycleState,omitempty"`
+	LocalAdgAutoFailoverMaxDataLossLimit     *int64                                `json:"localAdgAutoFailoverMaxDataLossLimit,omitempty"`
+	LocalDisasterRecoveryType                *DisasterRecoveryType                 `json:"localDisasterRecoveryType,omitempty"`
+	LocalStandbyDb                           *AutonomousDatabaseStandbySummary     `json:"localStandbyDb,omitempty"`
+	LongTermBackupSchedule                   *LongTermBackUpScheduleDetails        `json:"longTermBackupSchedule,omitempty"`
+	MemoryPerOracleComputeUnitInGbs          *int64                                `json:"memoryPerOracleComputeUnitInGbs,omitempty"`
+	NcharacterSet                            *string                               `json:"ncharacterSet,omitempty"`
+	NextLongTermBackupTimeStamp              *string                               `json:"nextLongTermBackupTimeStamp,omitempty"`
+	OciURL                                   *string                               `json:"ociUrl,omitempty"`
+	Ocid                                     *string                               `json:"ocid,omitempty"`
+	OpenMode                                 *OpenModeType                         `json:"openMode,omitempty"`
+	OperationsInsightsStatus                 *OperationsInsightsStatusType         `json:"operationsInsightsStatus,omitempty"`
+	PeerDbId                                 *string                               `json:"peerDbId,omitempty"`
+	PeerDbIds                                *[]string                             `json:"peerDbIds,omitempty"`
+	PermissionLevel                          *PermissionLevelType                  `json:"permissionLevel,omitempty"`
+	PrivateEndpoint                          *string                               `json:"privateEndpoint,omitempty"`
+	PrivateEndpointIP                        *string                               `json:"privateEndpointIp,omitempty"`
+	PrivateEndpointLabel                     *string                               `json:"privateEndpointLabel,omitempty"`
+	ProvisionableCPUs                        *[]int64                              `json:"provisionableCpus,omitempty"`
+	ProvisioningState                        *AzureResourceProvisioningState       `json:"provisioningState,omitempty"`
+	RemoteDisasterRecoveryConfiguration      *DisasterRecoveryConfigurationDetails `json:"remoteDisasterRecoveryConfiguration,omitempty"`
+	Role                                     *RoleType                             `json:"role,omitempty"`
+	ScheduledOperations                      *ScheduledOperationsType              `json:"scheduledOperations,omitempty"`
+	ServiceConsoleURL                        *string                               `json:"serviceConsoleUrl,omitempty"`
+	SqlWebDeveloperURL                       *string                               `json:"sqlWebDeveloperUrl,omitempty"`
+	SubnetId                                 *string                               `json:"subnetId,omitempty"`
+	SupportedRegionsToCloneTo                *[]string                             `json:"supportedRegionsToCloneTo,omitempty"`
+	TimeCreated                              *string                               `json:"timeCreated,omitempty"`
+	TimeDataGuardRoleChanged                 *string                               `json:"timeDataGuardRoleChanged,omitempty"`
+	TimeDeletionOfFreeAutonomousDatabase     *string                               `json:"timeDeletionOfFreeAutonomousDatabase,omitempty"`
+	TimeDisasterRecoveryRoleChanged          *string                               `json:"timeDisasterRecoveryRoleChanged,omitempty"`
+	TimeLocalDataGuardEnabled                *string                               `json:"timeLocalDataGuardEnabled,omitempty"`
+	TimeMaintenanceBegin                     *string                               `json:"timeMaintenanceBegin,omitempty"`
+	TimeMaintenanceEnd                       *string                               `json:"timeMaintenanceEnd,omitempty"`
+	TimeOfLastFailover                       *string                               `json:"timeOfLastFailover,omitempty"`
+	TimeOfLastRefresh                        *string                               `json:"timeOfLastRefresh,omitempty"`
+	TimeOfLastRefreshPoint                   *string                               `json:"timeOfLastRefreshPoint,omitempty"`
+	TimeOfLastSwitchover                     *string                               `json:"timeOfLastSwitchover,omitempty"`
+	TimeReclamationOfFreeAutonomousDatabase  *string                               `json:"timeReclamationOfFreeAutonomousDatabase,omitempty"`
+	UsedDataStorageSizeInGbs                 *int64                                `json:"usedDataStorageSizeInGbs,omitempty"`
+	UsedDataStorageSizeInTbs                 *int64                                `json:"usedDataStorageSizeInTbs,omitempty"`
+	VnetId                                   *string                               `json:"vnetId,omitempty"`
+	WhitelistedIPs                           *[]string                             `json:"whitelistedIps,omitempty"`
+}
+
+func (s AutonomousDatabaseProperties) AutonomousDatabaseBaseProperties() BaseAutonomousDatabaseBasePropertiesImpl {
+	return BaseAutonomousDatabaseBasePropertiesImpl{
+		ActualUsedDataStorageSizeInTbs:           s.ActualUsedDataStorageSizeInTbs,
+		AdminPassword:                            s.AdminPassword,
+		AllocatedStorageSizeInTbs:                s.AllocatedStorageSizeInTbs,
+		ApexDetails:                              s.ApexDetails,
+		AutonomousDatabaseId:                     s.AutonomousDatabaseId,
+		AutonomousMaintenanceScheduleType:        s.AutonomousMaintenanceScheduleType,
+		AvailableUpgradeVersions:                 s.AvailableUpgradeVersions,
+		BackupRetentionPeriodInDays:              s.BackupRetentionPeriodInDays,
+		CharacterSet:                             s.CharacterSet,
+		ComputeCount:                             s.ComputeCount,
+		ComputeModel:                             s.ComputeModel,
+		ConnectionStrings:                        s.ConnectionStrings,
+		ConnectionURLs:                           s.ConnectionURLs,
+		CpuCoreCount:                             s.CpuCoreCount,
+		CustomerContacts:                         s.CustomerContacts,
+		DataBaseType:                             s.DataBaseType,
+		DataSafeStatus:                           s.DataSafeStatus,
+		DataStorageSizeInGbs:                     s.DataStorageSizeInGbs,
+		DataStorageSizeInTbs:                     s.DataStorageSizeInTbs,
+		DatabaseEdition:                          s.DatabaseEdition,
+		DbVersion:                                s.DbVersion,
+		DbWorkload:                               s.DbWorkload,
+		DisplayName:                              s.DisplayName,
+		FailedDataRecoveryInSeconds:              s.FailedDataRecoveryInSeconds,
+		InMemoryAreaInGbs:                        s.InMemoryAreaInGbs,
+		IsAutoScalingEnabled:                     s.IsAutoScalingEnabled,
+		IsAutoScalingForStorageEnabled:           s.IsAutoScalingForStorageEnabled,
+		IsLocalDataGuardEnabled:                  s.IsLocalDataGuardEnabled,
+		IsMtlsConnectionRequired:                 s.IsMtlsConnectionRequired,
+		IsPreview:                                s.IsPreview,
+		IsPreviewVersionWithServiceTermsAccepted: s.IsPreviewVersionWithServiceTermsAccepted,
+		IsRemoteDataGuardEnabled:                 s.IsRemoteDataGuardEnabled,
+		LicenseModel:                             s.LicenseModel,
+		LifecycleDetails:                         s.LifecycleDetails,
+		LifecycleState:                           s.LifecycleState,
+		LocalAdgAutoFailoverMaxDataLossLimit:     s.LocalAdgAutoFailoverMaxDataLossLimit,
+		LocalDisasterRecoveryType:                s.LocalDisasterRecoveryType,
+		LocalStandbyDb:                           s.LocalStandbyDb,
+		LongTermBackupSchedule:                   s.LongTermBackupSchedule,
+		MemoryPerOracleComputeUnitInGbs:          s.MemoryPerOracleComputeUnitInGbs,
+		NcharacterSet:                            s.NcharacterSet,
+		NextLongTermBackupTimeStamp:              s.NextLongTermBackupTimeStamp,
+		OciURL:                                   s.OciURL,
+		Ocid:                                     s.Ocid,
+		OpenMode:                                 s.OpenMode,
+		OperationsInsightsStatus:                 s.OperationsInsightsStatus,
+		PeerDbId:                                 s.PeerDbId,
+		PeerDbIds:                                s.PeerDbIds,
+		PermissionLevel:                          s.PermissionLevel,
+		PrivateEndpoint:                          s.PrivateEndpoint,
+		PrivateEndpointIP:                        s.PrivateEndpointIP,
+		PrivateEndpointLabel:                     s.PrivateEndpointLabel,
+		ProvisionableCPUs:                        s.ProvisionableCPUs,
+		ProvisioningState:                        s.ProvisioningState,
+		RemoteDisasterRecoveryConfiguration:      s.RemoteDisasterRecoveryConfiguration,
+		Role:                                     s.Role,
+		ScheduledOperations:                      s.ScheduledOperations,
+		ServiceConsoleURL:                        s.ServiceConsoleURL,
+		SqlWebDeveloperURL:                       s.SqlWebDeveloperURL,
+		SubnetId:                                 s.SubnetId,
+		SupportedRegionsToCloneTo:                s.SupportedRegionsToCloneTo,
+		TimeCreated:                              s.TimeCreated,
+		TimeDataGuardRoleChanged:                 s.TimeDataGuardRoleChanged,
+		TimeDeletionOfFreeAutonomousDatabase:     s.TimeDeletionOfFreeAutonomousDatabase,
+		TimeDisasterRecoveryRoleChanged:          s.TimeDisasterRecoveryRoleChanged,
+		TimeLocalDataGuardEnabled:                s.TimeLocalDataGuardEnabled,
+		TimeMaintenanceBegin:                     s.TimeMaintenanceBegin,
+		TimeMaintenanceEnd:                       s.TimeMaintenanceEnd,
+		TimeOfLastFailover:                       s.TimeOfLastFailover,
+		TimeOfLastRefresh:                        s.TimeOfLastRefresh,
+		TimeOfLastRefreshPoint:                   s.TimeOfLastRefreshPoint,
+		TimeOfLastSwitchover:                     s.TimeOfLastSwitchover,
+		TimeReclamationOfFreeAutonomousDatabase:  s.TimeReclamationOfFreeAutonomousDatabase,
+		UsedDataStorageSizeInGbs:                 s.UsedDataStorageSizeInGbs,
+		UsedDataStorageSizeInTbs:                 s.UsedDataStorageSizeInTbs,
+		VnetId:                                   s.VnetId,
+		WhitelistedIPs:                           s.WhitelistedIPs,
+	}
+}
+
+func (o *AutonomousDatabaseProperties) GetNextLongTermBackupTimeStampAsTime() (*time.Time, error) {
+	if o.NextLongTermBackupTimeStamp == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.NextLongTermBackupTimeStamp, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *AutonomousDatabaseProperties) SetNextLongTermBackupTimeStampAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.NextLongTermBackupTimeStamp = &formatted
+}
+
+func (o *AutonomousDatabaseProperties) GetTimeCreatedAsTime() (*time.Time, error) {
+	if o.TimeCreated == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.TimeCreated, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *AutonomousDatabaseProperties) SetTimeCreatedAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.TimeCreated = &formatted
+}
+
+func (o *AutonomousDatabaseProperties) GetTimeDisasterRecoveryRoleChangedAsTime() (*time.Time, error) {
+	if o.TimeDisasterRecoveryRoleChanged == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.TimeDisasterRecoveryRoleChanged, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *AutonomousDatabaseProperties) SetTimeDisasterRecoveryRoleChangedAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.TimeDisasterRecoveryRoleChanged = &formatted
+}
+
+func (o *AutonomousDatabaseProperties) GetTimeMaintenanceBeginAsTime() (*time.Time, error) {
+	if o.TimeMaintenanceBegin == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.TimeMaintenanceBegin, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *AutonomousDatabaseProperties) SetTimeMaintenanceBeginAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.TimeMaintenanceBegin = &formatted
+}
+
+func (o *AutonomousDatabaseProperties) GetTimeMaintenanceEndAsTime() (*time.Time, error) {
+	if o.TimeMaintenanceEnd == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.TimeMaintenanceEnd, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *AutonomousDatabaseProperties) SetTimeMaintenanceEndAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.TimeMaintenanceEnd = &formatted
+}
+
+var _ json.Marshaler = AutonomousDatabaseProperties{}
+
+func (s AutonomousDatabaseProperties) MarshalJSON() ([]byte, error) {
+	type wrapper AutonomousDatabaseProperties
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling AutonomousDatabaseProperties: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling AutonomousDatabaseProperties: %+v", err)
+	}
+
+	decoded["dataBaseType"] = "Regular"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling AutonomousDatabaseProperties: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/model_autonomousdatabasestandbysummary.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/model_autonomousdatabasestandbysummary.go
@@ -1,0 +1,12 @@
+package autonomousdatabases
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AutonomousDatabaseStandbySummary struct {
+	LagTimeInSeconds                *int64                            `json:"lagTimeInSeconds,omitempty"`
+	LifecycleDetails                *string                           `json:"lifecycleDetails,omitempty"`
+	LifecycleState                  *AutonomousDatabaseLifecycleState `json:"lifecycleState,omitempty"`
+	TimeDataGuardRoleChanged        *string                           `json:"timeDataGuardRoleChanged,omitempty"`
+	TimeDisasterRecoveryRoleChanged *string                           `json:"timeDisasterRecoveryRoleChanged,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/model_autonomousdatabaseupdate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/model_autonomousdatabaseupdate.go
@@ -1,0 +1,9 @@
+package autonomousdatabases
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AutonomousDatabaseUpdate struct {
+	Properties *AutonomousDatabaseUpdateProperties `json:"properties,omitempty"`
+	Tags       *map[string]string                  `json:"tags,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/model_autonomousdatabaseupdateproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/model_autonomousdatabaseupdateproperties.go
@@ -1,0 +1,30 @@
+package autonomousdatabases
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AutonomousDatabaseUpdateProperties struct {
+	AdminPassword                        *string                            `json:"adminPassword,omitempty"`
+	AutonomousMaintenanceScheduleType    *AutonomousMaintenanceScheduleType `json:"autonomousMaintenanceScheduleType,omitempty"`
+	BackupRetentionPeriodInDays          *int64                             `json:"backupRetentionPeriodInDays,omitempty"`
+	ComputeCount                         *float64                           `json:"computeCount,omitempty"`
+	CpuCoreCount                         *int64                             `json:"cpuCoreCount,omitempty"`
+	CustomerContacts                     *[]CustomerContact                 `json:"customerContacts,omitempty"`
+	DataStorageSizeInGbs                 *int64                             `json:"dataStorageSizeInGbs,omitempty"`
+	DataStorageSizeInTbs                 *int64                             `json:"dataStorageSizeInTbs,omitempty"`
+	DatabaseEdition                      *DatabaseEditionType               `json:"databaseEdition,omitempty"`
+	DisplayName                          *string                            `json:"displayName,omitempty"`
+	IsAutoScalingEnabled                 *bool                              `json:"isAutoScalingEnabled,omitempty"`
+	IsAutoScalingForStorageEnabled       *bool                              `json:"isAutoScalingForStorageEnabled,omitempty"`
+	IsLocalDataGuardEnabled              *bool                              `json:"isLocalDataGuardEnabled,omitempty"`
+	IsMtlsConnectionRequired             *bool                              `json:"isMtlsConnectionRequired,omitempty"`
+	LicenseModel                         *LicenseModel                      `json:"licenseModel,omitempty"`
+	LocalAdgAutoFailoverMaxDataLossLimit *int64                             `json:"localAdgAutoFailoverMaxDataLossLimit,omitempty"`
+	LongTermBackupSchedule               *LongTermBackUpScheduleDetails     `json:"longTermBackupSchedule,omitempty"`
+	OpenMode                             *OpenModeType                      `json:"openMode,omitempty"`
+	PeerDbId                             *string                            `json:"peerDbId,omitempty"`
+	PermissionLevel                      *PermissionLevelType               `json:"permissionLevel,omitempty"`
+	Role                                 *RoleType                          `json:"role,omitempty"`
+	ScheduledOperations                  *ScheduledOperationsTypeUpdate     `json:"scheduledOperations,omitempty"`
+	WhitelistedIPs                       *[]string                          `json:"whitelistedIps,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/model_autonomousdatabasewalletfile.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/model_autonomousdatabasewalletfile.go
@@ -1,0 +1,8 @@
+package autonomousdatabases
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AutonomousDatabaseWalletFile struct {
+	WalletFiles string `json:"walletFiles"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/model_connectionstringtype.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/model_connectionstringtype.go
@@ -1,0 +1,13 @@
+package autonomousdatabases
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ConnectionStringType struct {
+	AllConnectionStrings *AllConnectionStringType `json:"allConnectionStrings,omitempty"`
+	Dedicated            *string                  `json:"dedicated,omitempty"`
+	High                 *string                  `json:"high,omitempty"`
+	Low                  *string                  `json:"low,omitempty"`
+	Medium               *string                  `json:"medium,omitempty"`
+	Profiles             *[]ProfileType           `json:"profiles,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/model_connectionurltype.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/model_connectionurltype.go
@@ -1,0 +1,14 @@
+package autonomousdatabases
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ConnectionURLType struct {
+	ApexURL                    *string `json:"apexUrl,omitempty"`
+	DatabaseTransformsURL      *string `json:"databaseTransformsUrl,omitempty"`
+	GraphStudioURL             *string `json:"graphStudioUrl,omitempty"`
+	MachineLearningNotebookURL *string `json:"machineLearningNotebookUrl,omitempty"`
+	MongoDbURL                 *string `json:"mongoDbUrl,omitempty"`
+	OrdsURL                    *string `json:"ordsUrl,omitempty"`
+	SqlDevWebURL               *string `json:"sqlDevWebUrl,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/model_customercontact.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/model_customercontact.go
@@ -1,0 +1,8 @@
+package autonomousdatabases
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CustomerContact struct {
+	Email string `json:"email"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/model_dayofweek.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/model_dayofweek.go
@@ -1,0 +1,8 @@
+package autonomousdatabases
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DayOfWeek struct {
+	Name DayOfWeekName `json:"name"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/model_dayofweekupdate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/model_dayofweekupdate.go
@@ -1,0 +1,8 @@
+package autonomousdatabases
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DayOfWeekUpdate struct {
+	Name *DayOfWeekName `json:"name,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/model_disasterrecoveryconfigurationdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/model_disasterrecoveryconfigurationdetails.go
@@ -1,0 +1,29 @@
+package autonomousdatabases
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DisasterRecoveryConfigurationDetails struct {
+	DisasterRecoveryType           *DisasterRecoveryType `json:"disasterRecoveryType,omitempty"`
+	IsReplicateAutomaticBackups    *bool                 `json:"isReplicateAutomaticBackups,omitempty"`
+	IsSnapshotStandby              *bool                 `json:"isSnapshotStandby,omitempty"`
+	TimeSnapshotStandbyEnabledTill *string               `json:"timeSnapshotStandbyEnabledTill,omitempty"`
+}
+
+func (o *DisasterRecoveryConfigurationDetails) GetTimeSnapshotStandbyEnabledTillAsTime() (*time.Time, error) {
+	if o.TimeSnapshotStandbyEnabledTill == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.TimeSnapshotStandbyEnabledTill, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *DisasterRecoveryConfigurationDetails) SetTimeSnapshotStandbyEnabledTillAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.TimeSnapshotStandbyEnabledTill = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/model_generateautonomousdatabasewalletdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/model_generateautonomousdatabasewalletdetails.go
@@ -1,0 +1,10 @@
+package autonomousdatabases
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GenerateAutonomousDatabaseWalletDetails struct {
+	GenerateType *GenerateType `json:"generateType,omitempty"`
+	IsRegional   *bool         `json:"isRegional,omitempty"`
+	Password     string        `json:"password"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/model_longtermbackupscheduledetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/model_longtermbackupscheduledetails.go
@@ -1,0 +1,29 @@
+package autonomousdatabases
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type LongTermBackUpScheduleDetails struct {
+	IsDisabled            *bool              `json:"isDisabled,omitempty"`
+	RepeatCadence         *RepeatCadenceType `json:"repeatCadence,omitempty"`
+	RetentionPeriodInDays *int64             `json:"retentionPeriodInDays,omitempty"`
+	TimeOfBackup          *string            `json:"timeOfBackup,omitempty"`
+}
+
+func (o *LongTermBackUpScheduleDetails) GetTimeOfBackupAsTime() (*time.Time, error) {
+	if o.TimeOfBackup == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.TimeOfBackup, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *LongTermBackUpScheduleDetails) SetTimeOfBackupAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.TimeOfBackup = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/model_peerdbdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/model_peerdbdetails.go
@@ -1,0 +1,10 @@
+package autonomousdatabases
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PeerDbDetails struct {
+	PeerDbId       *string `json:"peerDbId,omitempty"`
+	PeerDbLocation *string `json:"peerDbLocation,omitempty"`
+	PeerDbOcid     *string `json:"peerDbOcid,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/model_profiletype.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/model_profiletype.go
@@ -1,0 +1,16 @@
+package autonomousdatabases
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ProfileType struct {
+	ConsumerGroup     *ConsumerGroup         `json:"consumerGroup,omitempty"`
+	DisplayName       string                 `json:"displayName"`
+	HostFormat        HostFormatType         `json:"hostFormat"`
+	IsRegional        *bool                  `json:"isRegional,omitempty"`
+	Protocol          ProtocolType           `json:"protocol"`
+	SessionMode       SessionModeType        `json:"sessionMode"`
+	SyntaxFormat      SyntaxFormatType       `json:"syntaxFormat"`
+	TlsAuthentication *TlsAuthenticationType `json:"tlsAuthentication,omitempty"`
+	Value             string                 `json:"value"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/model_restoreautonomousdatabasedetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/model_restoreautonomousdatabasedetails.go
@@ -1,0 +1,23 @@
+package autonomousdatabases
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RestoreAutonomousDatabaseDetails struct {
+	Timestamp string `json:"timestamp"`
+}
+
+func (o *RestoreAutonomousDatabaseDetails) GetTimestampAsTime() (*time.Time, error) {
+	return dates.ParseAsFormat(&o.Timestamp, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *RestoreAutonomousDatabaseDetails) SetTimestampAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.Timestamp = formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/model_scheduledoperationstype.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/model_scheduledoperationstype.go
@@ -1,0 +1,10 @@
+package autonomousdatabases
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ScheduledOperationsType struct {
+	DayOfWeek          DayOfWeek `json:"dayOfWeek"`
+	ScheduledStartTime *string   `json:"scheduledStartTime,omitempty"`
+	ScheduledStopTime  *string   `json:"scheduledStopTime,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/model_scheduledoperationstypeupdate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/model_scheduledoperationstypeupdate.go
@@ -1,0 +1,10 @@
+package autonomousdatabases
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ScheduledOperationsTypeUpdate struct {
+	DayOfWeek          *DayOfWeekUpdate `json:"dayOfWeek,omitempty"`
+	ScheduledStartTime *string          `json:"scheduledStartTime,omitempty"`
+	ScheduledStopTime  *string          `json:"scheduledStopTime,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/predicates.go
@@ -1,0 +1,32 @@
+package autonomousdatabases
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AutonomousDatabaseOperationPredicate struct {
+	Id       *string
+	Location *string
+	Name     *string
+	Type     *string
+}
+
+func (p AutonomousDatabaseOperationPredicate) Matches(input AutonomousDatabase) bool {
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Location != nil && *p.Location != input.Location {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases/version.go
@@ -1,0 +1,10 @@
+package autonomousdatabases
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2025-03-01"
+
+func userAgent() string {
+	return "hashicorp/go-azure-sdk/autonomousdatabases/2025-03-01"
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabaseversions/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabaseversions/README.md
@@ -1,0 +1,53 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabaseversions` Documentation
+
+The `autonomousdatabaseversions` SDK allows for interaction with Azure Resource Manager `oracledatabase` (API Version `2025-03-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabaseversions"
+```
+
+
+### Client Initialization
+
+```go
+client := autonomousdatabaseversions.NewAutonomousDatabaseVersionsClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `AutonomousDatabaseVersionsClient.Get`
+
+```go
+ctx := context.TODO()
+id := autonomousdatabaseversions.NewAutonomousDbVersionID("12345678-1234-9876-4563-123456789012", "locationName", "autonomousDbVersionName")
+
+read, err := client.Get(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `AutonomousDatabaseVersionsClient.ListByLocation`
+
+```go
+ctx := context.TODO()
+id := autonomousdatabaseversions.NewLocationID("12345678-1234-9876-4563-123456789012", "locationName")
+
+// alternatively `client.ListByLocation(ctx, id)` can be used to do batched pagination
+items, err := client.ListByLocationComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabaseversions/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabaseversions/client.go
@@ -1,0 +1,26 @@
+package autonomousdatabaseversions
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AutonomousDatabaseVersionsClient struct {
+	Client *resourcemanager.Client
+}
+
+func NewAutonomousDatabaseVersionsClientWithBaseURI(sdkApi sdkEnv.Api) (*AutonomousDatabaseVersionsClient, error) {
+	client, err := resourcemanager.NewClient(sdkApi, "autonomousdatabaseversions", defaultApiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating AutonomousDatabaseVersionsClient: %+v", err)
+	}
+
+	return &AutonomousDatabaseVersionsClient{
+		Client: client,
+	}, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabaseversions/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabaseversions/constants.go
@@ -1,0 +1,57 @@
+package autonomousdatabaseversions
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type WorkloadType string
+
+const (
+	WorkloadTypeAJD  WorkloadType = "AJD"
+	WorkloadTypeAPEX WorkloadType = "APEX"
+	WorkloadTypeDW   WorkloadType = "DW"
+	WorkloadTypeOLTP WorkloadType = "OLTP"
+)
+
+func PossibleValuesForWorkloadType() []string {
+	return []string{
+		string(WorkloadTypeAJD),
+		string(WorkloadTypeAPEX),
+		string(WorkloadTypeDW),
+		string(WorkloadTypeOLTP),
+	}
+}
+
+func (s *WorkloadType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseWorkloadType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseWorkloadType(input string) (*WorkloadType, error) {
+	vals := map[string]WorkloadType{
+		"ajd":  WorkloadTypeAJD,
+		"apex": WorkloadTypeAPEX,
+		"dw":   WorkloadTypeDW,
+		"oltp": WorkloadTypeOLTP,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := WorkloadType(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabaseversions/id_autonomousdbversion.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabaseversions/id_autonomousdbversion.go
@@ -1,0 +1,130 @@
+package autonomousdatabaseversions
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&AutonomousDbVersionId{})
+}
+
+var _ resourceids.ResourceId = &AutonomousDbVersionId{}
+
+// AutonomousDbVersionId is a struct representing the Resource ID for a Autonomous Db Version
+type AutonomousDbVersionId struct {
+	SubscriptionId          string
+	LocationName            string
+	AutonomousDbVersionName string
+}
+
+// NewAutonomousDbVersionID returns a new AutonomousDbVersionId struct
+func NewAutonomousDbVersionID(subscriptionId string, locationName string, autonomousDbVersionName string) AutonomousDbVersionId {
+	return AutonomousDbVersionId{
+		SubscriptionId:          subscriptionId,
+		LocationName:            locationName,
+		AutonomousDbVersionName: autonomousDbVersionName,
+	}
+}
+
+// ParseAutonomousDbVersionID parses 'input' into a AutonomousDbVersionId
+func ParseAutonomousDbVersionID(input string) (*AutonomousDbVersionId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&AutonomousDbVersionId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := AutonomousDbVersionId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseAutonomousDbVersionIDInsensitively parses 'input' case-insensitively into a AutonomousDbVersionId
+// note: this method should only be used for API response data and not user input
+func ParseAutonomousDbVersionIDInsensitively(input string) (*AutonomousDbVersionId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&AutonomousDbVersionId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := AutonomousDbVersionId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *AutonomousDbVersionId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.LocationName, ok = input.Parsed["locationName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "locationName", input)
+	}
+
+	if id.AutonomousDbVersionName, ok = input.Parsed["autonomousDbVersionName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "autonomousDbVersionName", input)
+	}
+
+	return nil
+}
+
+// ValidateAutonomousDbVersionID checks that 'input' can be parsed as a Autonomous Db Version ID
+func ValidateAutonomousDbVersionID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseAutonomousDbVersionID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Autonomous Db Version ID
+func (id AutonomousDbVersionId) ID() string {
+	fmtString := "/subscriptions/%s/providers/Oracle.Database/locations/%s/autonomousDbVersions/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.LocationName, id.AutonomousDbVersionName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Autonomous Db Version ID
+func (id AutonomousDbVersionId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticOracleDatabase", "Oracle.Database", "Oracle.Database"),
+		resourceids.StaticSegment("staticLocations", "locations", "locations"),
+		resourceids.UserSpecifiedSegment("locationName", "locationName"),
+		resourceids.StaticSegment("staticAutonomousDbVersions", "autonomousDbVersions", "autonomousDbVersions"),
+		resourceids.UserSpecifiedSegment("autonomousDbVersionName", "autonomousDbVersionName"),
+	}
+}
+
+// String returns a human-readable description of this Autonomous Db Version ID
+func (id AutonomousDbVersionId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Location Name: %q", id.LocationName),
+		fmt.Sprintf("Autonomous Db Version Name: %q", id.AutonomousDbVersionName),
+	}
+	return fmt.Sprintf("Autonomous Db Version (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabaseversions/id_location.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabaseversions/id_location.go
@@ -1,0 +1,121 @@
+package autonomousdatabaseversions
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&LocationId{})
+}
+
+var _ resourceids.ResourceId = &LocationId{}
+
+// LocationId is a struct representing the Resource ID for a Location
+type LocationId struct {
+	SubscriptionId string
+	LocationName   string
+}
+
+// NewLocationID returns a new LocationId struct
+func NewLocationID(subscriptionId string, locationName string) LocationId {
+	return LocationId{
+		SubscriptionId: subscriptionId,
+		LocationName:   locationName,
+	}
+}
+
+// ParseLocationID parses 'input' into a LocationId
+func ParseLocationID(input string) (*LocationId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&LocationId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := LocationId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseLocationIDInsensitively parses 'input' case-insensitively into a LocationId
+// note: this method should only be used for API response data and not user input
+func ParseLocationIDInsensitively(input string) (*LocationId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&LocationId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := LocationId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *LocationId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.LocationName, ok = input.Parsed["locationName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "locationName", input)
+	}
+
+	return nil
+}
+
+// ValidateLocationID checks that 'input' can be parsed as a Location ID
+func ValidateLocationID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseLocationID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Location ID
+func (id LocationId) ID() string {
+	fmtString := "/subscriptions/%s/providers/Oracle.Database/locations/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.LocationName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Location ID
+func (id LocationId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticOracleDatabase", "Oracle.Database", "Oracle.Database"),
+		resourceids.StaticSegment("staticLocations", "locations", "locations"),
+		resourceids.UserSpecifiedSegment("locationName", "locationName"),
+	}
+}
+
+// String returns a human-readable description of this Location ID
+func (id LocationId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Location Name: %q", id.LocationName),
+	}
+	return fmt.Sprintf("Location (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabaseversions/method_get.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabaseversions/method_get.go
@@ -1,0 +1,53 @@
+package autonomousdatabaseversions
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *AutonomousDbVersion
+}
+
+// Get ...
+func (c AutonomousDatabaseVersionsClient) Get(ctx context.Context, id AutonomousDbVersionId) (result GetOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model AutonomousDbVersion
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabaseversions/method_listbylocation.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabaseversions/method_listbylocation.go
@@ -1,0 +1,105 @@
+package autonomousdatabaseversions
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListByLocationOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]AutonomousDbVersion
+}
+
+type ListByLocationCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []AutonomousDbVersion
+}
+
+type ListByLocationCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *ListByLocationCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// ListByLocation ...
+func (c AutonomousDatabaseVersionsClient) ListByLocation(ctx context.Context, id LocationId) (result ListByLocationOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Pager:      &ListByLocationCustomPager{},
+		Path:       fmt.Sprintf("%s/autonomousDbVersions", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]AutonomousDbVersion `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListByLocationComplete retrieves all the results into a single object
+func (c AutonomousDatabaseVersionsClient) ListByLocationComplete(ctx context.Context, id LocationId) (ListByLocationCompleteResult, error) {
+	return c.ListByLocationCompleteMatchingPredicate(ctx, id, AutonomousDbVersionOperationPredicate{})
+}
+
+// ListByLocationCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c AutonomousDatabaseVersionsClient) ListByLocationCompleteMatchingPredicate(ctx context.Context, id LocationId, predicate AutonomousDbVersionOperationPredicate) (result ListByLocationCompleteResult, err error) {
+	items := make([]AutonomousDbVersion, 0)
+
+	resp, err := c.ListByLocation(ctx, id)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListByLocationCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabaseversions/model_autonomousdbversion.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabaseversions/model_autonomousdbversion.go
@@ -1,0 +1,16 @@
+package autonomousdatabaseversions
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/systemdata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AutonomousDbVersion struct {
+	Id         *string                        `json:"id,omitempty"`
+	Name       *string                        `json:"name,omitempty"`
+	Properties *AutonomousDbVersionProperties `json:"properties,omitempty"`
+	SystemData *systemdata.SystemData         `json:"systemData,omitempty"`
+	Type       *string                        `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabaseversions/model_autonomousdbversionproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabaseversions/model_autonomousdbversionproperties.go
@@ -1,0 +1,13 @@
+package autonomousdatabaseversions
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AutonomousDbVersionProperties struct {
+	DbWorkload        *WorkloadType `json:"dbWorkload,omitempty"`
+	IsDefaultForFree  *bool         `json:"isDefaultForFree,omitempty"`
+	IsDefaultForPaid  *bool         `json:"isDefaultForPaid,omitempty"`
+	IsFreeTierEnabled *bool         `json:"isFreeTierEnabled,omitempty"`
+	IsPaidEnabled     *bool         `json:"isPaidEnabled,omitempty"`
+	Version           string        `json:"version"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabaseversions/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabaseversions/predicates.go
@@ -1,0 +1,27 @@
+package autonomousdatabaseversions
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AutonomousDbVersionOperationPredicate struct {
+	Id   *string
+	Name *string
+	Type *string
+}
+
+func (p AutonomousDbVersionOperationPredicate) Matches(input AutonomousDbVersion) bool {
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabaseversions/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabaseversions/version.go
@@ -1,0 +1,10 @@
+package autonomousdatabaseversions
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2025-03-01"
+
+func userAgent() string {
+	return "hashicorp/go-azure-sdk/autonomousdatabaseversions/2025-03-01"
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/client.go
@@ -1,0 +1,208 @@
+package v2025_03_01
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasebackups"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasecharactersets"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasenationalcharactersets"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabaseversions"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudexadatainfrastructures"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbnodes"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbservers"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbsystemshapes"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dnsprivateviews"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dnsprivatezones"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exadbvmclusters"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbnodes"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbstoragevaults"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/flexcomponents"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/giminorversions"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/giversions"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/oraclesubscriptions"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/systemversions"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/virtualnetworkaddresses"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+type Client struct {
+	AutonomousDatabaseBackups               *autonomousdatabasebackups.AutonomousDatabaseBackupsClient
+	AutonomousDatabaseCharacterSets         *autonomousdatabasecharactersets.AutonomousDatabaseCharacterSetsClient
+	AutonomousDatabaseNationalCharacterSets *autonomousdatabasenationalcharactersets.AutonomousDatabaseNationalCharacterSetsClient
+	AutonomousDatabaseVersions              *autonomousdatabaseversions.AutonomousDatabaseVersionsClient
+	AutonomousDatabases                     *autonomousdatabases.AutonomousDatabasesClient
+	CloudExadataInfrastructures             *cloudexadatainfrastructures.CloudExadataInfrastructuresClient
+	CloudVMClusters                         *cloudvmclusters.CloudVMClustersClient
+	DbNodes                                 *dbnodes.DbNodesClient
+	DbServers                               *dbservers.DbServersClient
+	DbSystemShapes                          *dbsystemshapes.DbSystemShapesClient
+	DnsPrivateViews                         *dnsprivateviews.DnsPrivateViewsClient
+	DnsPrivateZones                         *dnsprivatezones.DnsPrivateZonesClient
+	ExadbVMClusters                         *exadbvmclusters.ExadbVMClustersClient
+	ExascaleDbNodes                         *exascaledbnodes.ExascaleDbNodesClient
+	ExascaleDbStorageVaults                 *exascaledbstoragevaults.ExascaleDbStorageVaultsClient
+	FlexComponents                          *flexcomponents.FlexComponentsClient
+	GiMinorVersions                         *giminorversions.GiMinorVersionsClient
+	GiVersions                              *giversions.GiVersionsClient
+	OracleSubscriptions                     *oraclesubscriptions.OracleSubscriptionsClient
+	SystemVersions                          *systemversions.SystemVersionsClient
+	VirtualNetworkAddresses                 *virtualnetworkaddresses.VirtualNetworkAddressesClient
+}
+
+func NewClientWithBaseURI(sdkApi sdkEnv.Api, configureFunc func(c *resourcemanager.Client)) (*Client, error) {
+	autonomousDatabaseBackupsClient, err := autonomousdatabasebackups.NewAutonomousDatabaseBackupsClientWithBaseURI(sdkApi)
+	if err != nil {
+		return nil, fmt.Errorf("building AutonomousDatabaseBackups client: %+v", err)
+	}
+	configureFunc(autonomousDatabaseBackupsClient.Client)
+
+	autonomousDatabaseCharacterSetsClient, err := autonomousdatabasecharactersets.NewAutonomousDatabaseCharacterSetsClientWithBaseURI(sdkApi)
+	if err != nil {
+		return nil, fmt.Errorf("building AutonomousDatabaseCharacterSets client: %+v", err)
+	}
+	configureFunc(autonomousDatabaseCharacterSetsClient.Client)
+
+	autonomousDatabaseNationalCharacterSetsClient, err := autonomousdatabasenationalcharactersets.NewAutonomousDatabaseNationalCharacterSetsClientWithBaseURI(sdkApi)
+	if err != nil {
+		return nil, fmt.Errorf("building AutonomousDatabaseNationalCharacterSets client: %+v", err)
+	}
+	configureFunc(autonomousDatabaseNationalCharacterSetsClient.Client)
+
+	autonomousDatabaseVersionsClient, err := autonomousdatabaseversions.NewAutonomousDatabaseVersionsClientWithBaseURI(sdkApi)
+	if err != nil {
+		return nil, fmt.Errorf("building AutonomousDatabaseVersions client: %+v", err)
+	}
+	configureFunc(autonomousDatabaseVersionsClient.Client)
+
+	autonomousDatabasesClient, err := autonomousdatabases.NewAutonomousDatabasesClientWithBaseURI(sdkApi)
+	if err != nil {
+		return nil, fmt.Errorf("building AutonomousDatabases client: %+v", err)
+	}
+	configureFunc(autonomousDatabasesClient.Client)
+
+	cloudExadataInfrastructuresClient, err := cloudexadatainfrastructures.NewCloudExadataInfrastructuresClientWithBaseURI(sdkApi)
+	if err != nil {
+		return nil, fmt.Errorf("building CloudExadataInfrastructures client: %+v", err)
+	}
+	configureFunc(cloudExadataInfrastructuresClient.Client)
+
+	cloudVMClustersClient, err := cloudvmclusters.NewCloudVMClustersClientWithBaseURI(sdkApi)
+	if err != nil {
+		return nil, fmt.Errorf("building CloudVMClusters client: %+v", err)
+	}
+	configureFunc(cloudVMClustersClient.Client)
+
+	dbNodesClient, err := dbnodes.NewDbNodesClientWithBaseURI(sdkApi)
+	if err != nil {
+		return nil, fmt.Errorf("building DbNodes client: %+v", err)
+	}
+	configureFunc(dbNodesClient.Client)
+
+	dbServersClient, err := dbservers.NewDbServersClientWithBaseURI(sdkApi)
+	if err != nil {
+		return nil, fmt.Errorf("building DbServers client: %+v", err)
+	}
+	configureFunc(dbServersClient.Client)
+
+	dbSystemShapesClient, err := dbsystemshapes.NewDbSystemShapesClientWithBaseURI(sdkApi)
+	if err != nil {
+		return nil, fmt.Errorf("building DbSystemShapes client: %+v", err)
+	}
+	configureFunc(dbSystemShapesClient.Client)
+
+	dnsPrivateViewsClient, err := dnsprivateviews.NewDnsPrivateViewsClientWithBaseURI(sdkApi)
+	if err != nil {
+		return nil, fmt.Errorf("building DnsPrivateViews client: %+v", err)
+	}
+	configureFunc(dnsPrivateViewsClient.Client)
+
+	dnsPrivateZonesClient, err := dnsprivatezones.NewDnsPrivateZonesClientWithBaseURI(sdkApi)
+	if err != nil {
+		return nil, fmt.Errorf("building DnsPrivateZones client: %+v", err)
+	}
+	configureFunc(dnsPrivateZonesClient.Client)
+
+	exadbVMClustersClient, err := exadbvmclusters.NewExadbVMClustersClientWithBaseURI(sdkApi)
+	if err != nil {
+		return nil, fmt.Errorf("building ExadbVMClusters client: %+v", err)
+	}
+	configureFunc(exadbVMClustersClient.Client)
+
+	exascaleDbNodesClient, err := exascaledbnodes.NewExascaleDbNodesClientWithBaseURI(sdkApi)
+	if err != nil {
+		return nil, fmt.Errorf("building ExascaleDbNodes client: %+v", err)
+	}
+	configureFunc(exascaleDbNodesClient.Client)
+
+	exascaleDbStorageVaultsClient, err := exascaledbstoragevaults.NewExascaleDbStorageVaultsClientWithBaseURI(sdkApi)
+	if err != nil {
+		return nil, fmt.Errorf("building ExascaleDbStorageVaults client: %+v", err)
+	}
+	configureFunc(exascaleDbStorageVaultsClient.Client)
+
+	flexComponentsClient, err := flexcomponents.NewFlexComponentsClientWithBaseURI(sdkApi)
+	if err != nil {
+		return nil, fmt.Errorf("building FlexComponents client: %+v", err)
+	}
+	configureFunc(flexComponentsClient.Client)
+
+	giMinorVersionsClient, err := giminorversions.NewGiMinorVersionsClientWithBaseURI(sdkApi)
+	if err != nil {
+		return nil, fmt.Errorf("building GiMinorVersions client: %+v", err)
+	}
+	configureFunc(giMinorVersionsClient.Client)
+
+	giVersionsClient, err := giversions.NewGiVersionsClientWithBaseURI(sdkApi)
+	if err != nil {
+		return nil, fmt.Errorf("building GiVersions client: %+v", err)
+	}
+	configureFunc(giVersionsClient.Client)
+
+	oracleSubscriptionsClient, err := oraclesubscriptions.NewOracleSubscriptionsClientWithBaseURI(sdkApi)
+	if err != nil {
+		return nil, fmt.Errorf("building OracleSubscriptions client: %+v", err)
+	}
+	configureFunc(oracleSubscriptionsClient.Client)
+
+	systemVersionsClient, err := systemversions.NewSystemVersionsClientWithBaseURI(sdkApi)
+	if err != nil {
+		return nil, fmt.Errorf("building SystemVersions client: %+v", err)
+	}
+	configureFunc(systemVersionsClient.Client)
+
+	virtualNetworkAddressesClient, err := virtualnetworkaddresses.NewVirtualNetworkAddressesClientWithBaseURI(sdkApi)
+	if err != nil {
+		return nil, fmt.Errorf("building VirtualNetworkAddresses client: %+v", err)
+	}
+	configureFunc(virtualNetworkAddressesClient.Client)
+
+	return &Client{
+		AutonomousDatabaseBackups:               autonomousDatabaseBackupsClient,
+		AutonomousDatabaseCharacterSets:         autonomousDatabaseCharacterSetsClient,
+		AutonomousDatabaseNationalCharacterSets: autonomousDatabaseNationalCharacterSetsClient,
+		AutonomousDatabaseVersions:              autonomousDatabaseVersionsClient,
+		AutonomousDatabases:                     autonomousDatabasesClient,
+		CloudExadataInfrastructures:             cloudExadataInfrastructuresClient,
+		CloudVMClusters:                         cloudVMClustersClient,
+		DbNodes:                                 dbNodesClient,
+		DbServers:                               dbServersClient,
+		DbSystemShapes:                          dbSystemShapesClient,
+		DnsPrivateViews:                         dnsPrivateViewsClient,
+		DnsPrivateZones:                         dnsPrivateZonesClient,
+		ExadbVMClusters:                         exadbVMClustersClient,
+		ExascaleDbNodes:                         exascaleDbNodesClient,
+		ExascaleDbStorageVaults:                 exascaleDbStorageVaultsClient,
+		FlexComponents:                          flexComponentsClient,
+		GiMinorVersions:                         giMinorVersionsClient,
+		GiVersions:                              giVersionsClient,
+		OracleSubscriptions:                     oracleSubscriptionsClient,
+		SystemVersions:                          systemVersionsClient,
+		VirtualNetworkAddresses:                 virtualNetworkAddressesClient,
+	}, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudexadatainfrastructures/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudexadatainfrastructures/README.md
@@ -1,0 +1,129 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudexadatainfrastructures` Documentation
+
+The `cloudexadatainfrastructures` SDK allows for interaction with Azure Resource Manager `oracledatabase` (API Version `2025-03-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+import "github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudexadatainfrastructures"
+```
+
+
+### Client Initialization
+
+```go
+client := cloudexadatainfrastructures.NewCloudExadataInfrastructuresClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `CloudExadataInfrastructuresClient.AddStorageCapacity`
+
+```go
+ctx := context.TODO()
+id := cloudexadatainfrastructures.NewCloudExadataInfrastructureID("12345678-1234-9876-4563-123456789012", "example-resource-group", "cloudExadataInfrastructureName")
+
+if err := client.AddStorageCapacityThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `CloudExadataInfrastructuresClient.CreateOrUpdate`
+
+```go
+ctx := context.TODO()
+id := cloudexadatainfrastructures.NewCloudExadataInfrastructureID("12345678-1234-9876-4563-123456789012", "example-resource-group", "cloudExadataInfrastructureName")
+
+payload := cloudexadatainfrastructures.CloudExadataInfrastructure{
+	// ...
+}
+
+
+if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `CloudExadataInfrastructuresClient.Delete`
+
+```go
+ctx := context.TODO()
+id := cloudexadatainfrastructures.NewCloudExadataInfrastructureID("12345678-1234-9876-4563-123456789012", "example-resource-group", "cloudExadataInfrastructureName")
+
+if err := client.DeleteThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `CloudExadataInfrastructuresClient.Get`
+
+```go
+ctx := context.TODO()
+id := cloudexadatainfrastructures.NewCloudExadataInfrastructureID("12345678-1234-9876-4563-123456789012", "example-resource-group", "cloudExadataInfrastructureName")
+
+read, err := client.Get(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `CloudExadataInfrastructuresClient.ListByResourceGroup`
+
+```go
+ctx := context.TODO()
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+
+// alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
+items, err := client.ListByResourceGroupComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `CloudExadataInfrastructuresClient.ListBySubscription`
+
+```go
+ctx := context.TODO()
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+
+// alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
+items, err := client.ListBySubscriptionComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `CloudExadataInfrastructuresClient.Update`
+
+```go
+ctx := context.TODO()
+id := cloudexadatainfrastructures.NewCloudExadataInfrastructureID("12345678-1234-9876-4563-123456789012", "example-resource-group", "cloudExadataInfrastructureName")
+
+payload := cloudexadatainfrastructures.CloudExadataInfrastructureUpdate{
+	// ...
+}
+
+
+if err := client.UpdateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudexadatainfrastructures/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudexadatainfrastructures/client.go
@@ -1,0 +1,26 @@
+package cloudexadatainfrastructures
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CloudExadataInfrastructuresClient struct {
+	Client *resourcemanager.Client
+}
+
+func NewCloudExadataInfrastructuresClientWithBaseURI(sdkApi sdkEnv.Api) (*CloudExadataInfrastructuresClient, error) {
+	client, err := resourcemanager.NewClient(sdkApi, "cloudexadatainfrastructures", defaultApiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating CloudExadataInfrastructuresClient: %+v", err)
+	}
+
+	return &CloudExadataInfrastructuresClient{
+		Client: client,
+	}, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudexadatainfrastructures/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudexadatainfrastructures/constants.go
@@ -1,0 +1,363 @@
+package cloudexadatainfrastructures
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AzureResourceProvisioningState string
+
+const (
+	AzureResourceProvisioningStateCanceled     AzureResourceProvisioningState = "Canceled"
+	AzureResourceProvisioningStateFailed       AzureResourceProvisioningState = "Failed"
+	AzureResourceProvisioningStateProvisioning AzureResourceProvisioningState = "Provisioning"
+	AzureResourceProvisioningStateSucceeded    AzureResourceProvisioningState = "Succeeded"
+)
+
+func PossibleValuesForAzureResourceProvisioningState() []string {
+	return []string{
+		string(AzureResourceProvisioningStateCanceled),
+		string(AzureResourceProvisioningStateFailed),
+		string(AzureResourceProvisioningStateProvisioning),
+		string(AzureResourceProvisioningStateSucceeded),
+	}
+}
+
+func (s *AzureResourceProvisioningState) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseAzureResourceProvisioningState(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseAzureResourceProvisioningState(input string) (*AzureResourceProvisioningState, error) {
+	vals := map[string]AzureResourceProvisioningState{
+		"canceled":     AzureResourceProvisioningStateCanceled,
+		"failed":       AzureResourceProvisioningStateFailed,
+		"provisioning": AzureResourceProvisioningStateProvisioning,
+		"succeeded":    AzureResourceProvisioningStateSucceeded,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := AzureResourceProvisioningState(input)
+	return &out, nil
+}
+
+type CloudExadataInfrastructureLifecycleState string
+
+const (
+	CloudExadataInfrastructureLifecycleStateAvailable             CloudExadataInfrastructureLifecycleState = "Available"
+	CloudExadataInfrastructureLifecycleStateFailed                CloudExadataInfrastructureLifecycleState = "Failed"
+	CloudExadataInfrastructureLifecycleStateMaintenanceInProgress CloudExadataInfrastructureLifecycleState = "MaintenanceInProgress"
+	CloudExadataInfrastructureLifecycleStateProvisioning          CloudExadataInfrastructureLifecycleState = "Provisioning"
+	CloudExadataInfrastructureLifecycleStateTerminated            CloudExadataInfrastructureLifecycleState = "Terminated"
+	CloudExadataInfrastructureLifecycleStateTerminating           CloudExadataInfrastructureLifecycleState = "Terminating"
+	CloudExadataInfrastructureLifecycleStateUpdating              CloudExadataInfrastructureLifecycleState = "Updating"
+)
+
+func PossibleValuesForCloudExadataInfrastructureLifecycleState() []string {
+	return []string{
+		string(CloudExadataInfrastructureLifecycleStateAvailable),
+		string(CloudExadataInfrastructureLifecycleStateFailed),
+		string(CloudExadataInfrastructureLifecycleStateMaintenanceInProgress),
+		string(CloudExadataInfrastructureLifecycleStateProvisioning),
+		string(CloudExadataInfrastructureLifecycleStateTerminated),
+		string(CloudExadataInfrastructureLifecycleStateTerminating),
+		string(CloudExadataInfrastructureLifecycleStateUpdating),
+	}
+}
+
+func (s *CloudExadataInfrastructureLifecycleState) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseCloudExadataInfrastructureLifecycleState(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseCloudExadataInfrastructureLifecycleState(input string) (*CloudExadataInfrastructureLifecycleState, error) {
+	vals := map[string]CloudExadataInfrastructureLifecycleState{
+		"available":             CloudExadataInfrastructureLifecycleStateAvailable,
+		"failed":                CloudExadataInfrastructureLifecycleStateFailed,
+		"maintenanceinprogress": CloudExadataInfrastructureLifecycleStateMaintenanceInProgress,
+		"provisioning":          CloudExadataInfrastructureLifecycleStateProvisioning,
+		"terminated":            CloudExadataInfrastructureLifecycleStateTerminated,
+		"terminating":           CloudExadataInfrastructureLifecycleStateTerminating,
+		"updating":              CloudExadataInfrastructureLifecycleStateUpdating,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := CloudExadataInfrastructureLifecycleState(input)
+	return &out, nil
+}
+
+type ComputeModel string
+
+const (
+	ComputeModelECPU ComputeModel = "ECPU"
+	ComputeModelOCPU ComputeModel = "OCPU"
+)
+
+func PossibleValuesForComputeModel() []string {
+	return []string{
+		string(ComputeModelECPU),
+		string(ComputeModelOCPU),
+	}
+}
+
+func (s *ComputeModel) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseComputeModel(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseComputeModel(input string) (*ComputeModel, error) {
+	vals := map[string]ComputeModel{
+		"ecpu": ComputeModelECPU,
+		"ocpu": ComputeModelOCPU,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ComputeModel(input)
+	return &out, nil
+}
+
+type DayOfWeekName string
+
+const (
+	DayOfWeekNameFriday    DayOfWeekName = "Friday"
+	DayOfWeekNameMonday    DayOfWeekName = "Monday"
+	DayOfWeekNameSaturday  DayOfWeekName = "Saturday"
+	DayOfWeekNameSunday    DayOfWeekName = "Sunday"
+	DayOfWeekNameThursday  DayOfWeekName = "Thursday"
+	DayOfWeekNameTuesday   DayOfWeekName = "Tuesday"
+	DayOfWeekNameWednesday DayOfWeekName = "Wednesday"
+)
+
+func PossibleValuesForDayOfWeekName() []string {
+	return []string{
+		string(DayOfWeekNameFriday),
+		string(DayOfWeekNameMonday),
+		string(DayOfWeekNameSaturday),
+		string(DayOfWeekNameSunday),
+		string(DayOfWeekNameThursday),
+		string(DayOfWeekNameTuesday),
+		string(DayOfWeekNameWednesday),
+	}
+}
+
+func (s *DayOfWeekName) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseDayOfWeekName(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseDayOfWeekName(input string) (*DayOfWeekName, error) {
+	vals := map[string]DayOfWeekName{
+		"friday":    DayOfWeekNameFriday,
+		"monday":    DayOfWeekNameMonday,
+		"saturday":  DayOfWeekNameSaturday,
+		"sunday":    DayOfWeekNameSunday,
+		"thursday":  DayOfWeekNameThursday,
+		"tuesday":   DayOfWeekNameTuesday,
+		"wednesday": DayOfWeekNameWednesday,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := DayOfWeekName(input)
+	return &out, nil
+}
+
+type MonthName string
+
+const (
+	MonthNameApril     MonthName = "April"
+	MonthNameAugust    MonthName = "August"
+	MonthNameDecember  MonthName = "December"
+	MonthNameFebruary  MonthName = "February"
+	MonthNameJanuary   MonthName = "January"
+	MonthNameJuly      MonthName = "July"
+	MonthNameJune      MonthName = "June"
+	MonthNameMarch     MonthName = "March"
+	MonthNameMay       MonthName = "May"
+	MonthNameNovember  MonthName = "November"
+	MonthNameOctober   MonthName = "October"
+	MonthNameSeptember MonthName = "September"
+)
+
+func PossibleValuesForMonthName() []string {
+	return []string{
+		string(MonthNameApril),
+		string(MonthNameAugust),
+		string(MonthNameDecember),
+		string(MonthNameFebruary),
+		string(MonthNameJanuary),
+		string(MonthNameJuly),
+		string(MonthNameJune),
+		string(MonthNameMarch),
+		string(MonthNameMay),
+		string(MonthNameNovember),
+		string(MonthNameOctober),
+		string(MonthNameSeptember),
+	}
+}
+
+func (s *MonthName) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseMonthName(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseMonthName(input string) (*MonthName, error) {
+	vals := map[string]MonthName{
+		"april":     MonthNameApril,
+		"august":    MonthNameAugust,
+		"december":  MonthNameDecember,
+		"february":  MonthNameFebruary,
+		"january":   MonthNameJanuary,
+		"july":      MonthNameJuly,
+		"june":      MonthNameJune,
+		"march":     MonthNameMarch,
+		"may":       MonthNameMay,
+		"november":  MonthNameNovember,
+		"october":   MonthNameOctober,
+		"september": MonthNameSeptember,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := MonthName(input)
+	return &out, nil
+}
+
+type PatchingMode string
+
+const (
+	PatchingModeNonRolling PatchingMode = "NonRolling"
+	PatchingModeRolling    PatchingMode = "Rolling"
+)
+
+func PossibleValuesForPatchingMode() []string {
+	return []string{
+		string(PatchingModeNonRolling),
+		string(PatchingModeRolling),
+	}
+}
+
+func (s *PatchingMode) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parsePatchingMode(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parsePatchingMode(input string) (*PatchingMode, error) {
+	vals := map[string]PatchingMode{
+		"nonrolling": PatchingModeNonRolling,
+		"rolling":    PatchingModeRolling,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := PatchingMode(input)
+	return &out, nil
+}
+
+type Preference string
+
+const (
+	PreferenceCustomPreference Preference = "CustomPreference"
+	PreferenceNoPreference     Preference = "NoPreference"
+)
+
+func PossibleValuesForPreference() []string {
+	return []string{
+		string(PreferenceCustomPreference),
+		string(PreferenceNoPreference),
+	}
+}
+
+func (s *Preference) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parsePreference(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parsePreference(input string) (*Preference, error) {
+	vals := map[string]Preference{
+		"custompreference": PreferenceCustomPreference,
+		"nopreference":     PreferenceNoPreference,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := Preference(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudexadatainfrastructures/id_cloudexadatainfrastructure.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudexadatainfrastructures/id_cloudexadatainfrastructure.go
@@ -1,0 +1,130 @@
+package cloudexadatainfrastructures
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&CloudExadataInfrastructureId{})
+}
+
+var _ resourceids.ResourceId = &CloudExadataInfrastructureId{}
+
+// CloudExadataInfrastructureId is a struct representing the Resource ID for a Cloud Exadata Infrastructure
+type CloudExadataInfrastructureId struct {
+	SubscriptionId                 string
+	ResourceGroupName              string
+	CloudExadataInfrastructureName string
+}
+
+// NewCloudExadataInfrastructureID returns a new CloudExadataInfrastructureId struct
+func NewCloudExadataInfrastructureID(subscriptionId string, resourceGroupName string, cloudExadataInfrastructureName string) CloudExadataInfrastructureId {
+	return CloudExadataInfrastructureId{
+		SubscriptionId:                 subscriptionId,
+		ResourceGroupName:              resourceGroupName,
+		CloudExadataInfrastructureName: cloudExadataInfrastructureName,
+	}
+}
+
+// ParseCloudExadataInfrastructureID parses 'input' into a CloudExadataInfrastructureId
+func ParseCloudExadataInfrastructureID(input string) (*CloudExadataInfrastructureId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&CloudExadataInfrastructureId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := CloudExadataInfrastructureId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseCloudExadataInfrastructureIDInsensitively parses 'input' case-insensitively into a CloudExadataInfrastructureId
+// note: this method should only be used for API response data and not user input
+func ParseCloudExadataInfrastructureIDInsensitively(input string) (*CloudExadataInfrastructureId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&CloudExadataInfrastructureId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := CloudExadataInfrastructureId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *CloudExadataInfrastructureId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.CloudExadataInfrastructureName, ok = input.Parsed["cloudExadataInfrastructureName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "cloudExadataInfrastructureName", input)
+	}
+
+	return nil
+}
+
+// ValidateCloudExadataInfrastructureID checks that 'input' can be parsed as a Cloud Exadata Infrastructure ID
+func ValidateCloudExadataInfrastructureID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseCloudExadataInfrastructureID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Cloud Exadata Infrastructure ID
+func (id CloudExadataInfrastructureId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Oracle.Database/cloudExadataInfrastructures/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.CloudExadataInfrastructureName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Cloud Exadata Infrastructure ID
+func (id CloudExadataInfrastructureId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticOracleDatabase", "Oracle.Database", "Oracle.Database"),
+		resourceids.StaticSegment("staticCloudExadataInfrastructures", "cloudExadataInfrastructures", "cloudExadataInfrastructures"),
+		resourceids.UserSpecifiedSegment("cloudExadataInfrastructureName", "cloudExadataInfrastructureName"),
+	}
+}
+
+// String returns a human-readable description of this Cloud Exadata Infrastructure ID
+func (id CloudExadataInfrastructureId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Cloud Exadata Infrastructure Name: %q", id.CloudExadataInfrastructureName),
+	}
+	return fmt.Sprintf("Cloud Exadata Infrastructure (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudexadatainfrastructures/method_addstoragecapacity.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudexadatainfrastructures/method_addstoragecapacity.go
@@ -1,0 +1,71 @@
+package cloudexadatainfrastructures
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AddStorageCapacityOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *CloudExadataInfrastructure
+}
+
+// AddStorageCapacity ...
+func (c CloudExadataInfrastructuresClient) AddStorageCapacity(ctx context.Context, id CloudExadataInfrastructureId) (result AddStorageCapacityOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/addStorageCapacity", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// AddStorageCapacityThenPoll performs AddStorageCapacity then polls until it's completed
+func (c CloudExadataInfrastructuresClient) AddStorageCapacityThenPoll(ctx context.Context, id CloudExadataInfrastructureId) error {
+	result, err := c.AddStorageCapacity(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing AddStorageCapacity: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after AddStorageCapacity: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudexadatainfrastructures/method_createorupdate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudexadatainfrastructures/method_createorupdate.go
@@ -1,0 +1,75 @@
+package cloudexadatainfrastructures
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateOrUpdateOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *CloudExadataInfrastructure
+}
+
+// CreateOrUpdate ...
+func (c CloudExadataInfrastructuresClient) CreateOrUpdate(ctx context.Context, id CloudExadataInfrastructureId, input CloudExadataInfrastructure) (result CreateOrUpdateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPut,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// CreateOrUpdateThenPoll performs CreateOrUpdate then polls until it's completed
+func (c CloudExadataInfrastructuresClient) CreateOrUpdateThenPoll(ctx context.Context, id CloudExadataInfrastructureId, input CloudExadataInfrastructure) error {
+	result, err := c.CreateOrUpdate(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing CreateOrUpdate: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after CreateOrUpdate: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudexadatainfrastructures/method_delete.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudexadatainfrastructures/method_delete.go
@@ -1,0 +1,70 @@
+package cloudexadatainfrastructures
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeleteOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// Delete ...
+func (c CloudExadataInfrastructuresClient) Delete(ctx context.Context, id CloudExadataInfrastructureId) (result DeleteOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusNoContent,
+		},
+		HttpMethod: http.MethodDelete,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// DeleteThenPoll performs Delete then polls until it's completed
+func (c CloudExadataInfrastructuresClient) DeleteThenPoll(ctx context.Context, id CloudExadataInfrastructureId) error {
+	result, err := c.Delete(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing Delete: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Delete: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudexadatainfrastructures/method_get.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudexadatainfrastructures/method_get.go
@@ -1,0 +1,53 @@
+package cloudexadatainfrastructures
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *CloudExadataInfrastructure
+}
+
+// Get ...
+func (c CloudExadataInfrastructuresClient) Get(ctx context.Context, id CloudExadataInfrastructureId) (result GetOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model CloudExadataInfrastructure
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudexadatainfrastructures/method_listbyresourcegroup.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudexadatainfrastructures/method_listbyresourcegroup.go
@@ -1,0 +1,106 @@
+package cloudexadatainfrastructures
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListByResourceGroupOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]CloudExadataInfrastructure
+}
+
+type ListByResourceGroupCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []CloudExadataInfrastructure
+}
+
+type ListByResourceGroupCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *ListByResourceGroupCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// ListByResourceGroup ...
+func (c CloudExadataInfrastructuresClient) ListByResourceGroup(ctx context.Context, id commonids.ResourceGroupId) (result ListByResourceGroupOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Pager:      &ListByResourceGroupCustomPager{},
+		Path:       fmt.Sprintf("%s/providers/Oracle.Database/cloudExadataInfrastructures", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]CloudExadataInfrastructure `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListByResourceGroupComplete retrieves all the results into a single object
+func (c CloudExadataInfrastructuresClient) ListByResourceGroupComplete(ctx context.Context, id commonids.ResourceGroupId) (ListByResourceGroupCompleteResult, error) {
+	return c.ListByResourceGroupCompleteMatchingPredicate(ctx, id, CloudExadataInfrastructureOperationPredicate{})
+}
+
+// ListByResourceGroupCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c CloudExadataInfrastructuresClient) ListByResourceGroupCompleteMatchingPredicate(ctx context.Context, id commonids.ResourceGroupId, predicate CloudExadataInfrastructureOperationPredicate) (result ListByResourceGroupCompleteResult, err error) {
+	items := make([]CloudExadataInfrastructure, 0)
+
+	resp, err := c.ListByResourceGroup(ctx, id)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListByResourceGroupCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudexadatainfrastructures/method_listbysubscription.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudexadatainfrastructures/method_listbysubscription.go
@@ -1,0 +1,106 @@
+package cloudexadatainfrastructures
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListBySubscriptionOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]CloudExadataInfrastructure
+}
+
+type ListBySubscriptionCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []CloudExadataInfrastructure
+}
+
+type ListBySubscriptionCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *ListBySubscriptionCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// ListBySubscription ...
+func (c CloudExadataInfrastructuresClient) ListBySubscription(ctx context.Context, id commonids.SubscriptionId) (result ListBySubscriptionOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Pager:      &ListBySubscriptionCustomPager{},
+		Path:       fmt.Sprintf("%s/providers/Oracle.Database/cloudExadataInfrastructures", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]CloudExadataInfrastructure `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListBySubscriptionComplete retrieves all the results into a single object
+func (c CloudExadataInfrastructuresClient) ListBySubscriptionComplete(ctx context.Context, id commonids.SubscriptionId) (ListBySubscriptionCompleteResult, error) {
+	return c.ListBySubscriptionCompleteMatchingPredicate(ctx, id, CloudExadataInfrastructureOperationPredicate{})
+}
+
+// ListBySubscriptionCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c CloudExadataInfrastructuresClient) ListBySubscriptionCompleteMatchingPredicate(ctx context.Context, id commonids.SubscriptionId, predicate CloudExadataInfrastructureOperationPredicate) (result ListBySubscriptionCompleteResult, err error) {
+	items := make([]CloudExadataInfrastructure, 0)
+
+	resp, err := c.ListBySubscription(ctx, id)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListBySubscriptionCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudexadatainfrastructures/method_update.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudexadatainfrastructures/method_update.go
@@ -1,0 +1,75 @@
+package cloudexadatainfrastructures
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpdateOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *CloudExadataInfrastructure
+}
+
+// Update ...
+func (c CloudExadataInfrastructuresClient) Update(ctx context.Context, id CloudExadataInfrastructureId, input CloudExadataInfrastructureUpdate) (result UpdateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPatch,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// UpdateThenPoll performs Update then polls until it's completed
+func (c CloudExadataInfrastructuresClient) UpdateThenPoll(ctx context.Context, id CloudExadataInfrastructureId, input CloudExadataInfrastructureUpdate) error {
+	result, err := c.Update(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing Update: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Update: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudexadatainfrastructures/model_cloudexadatainfrastructure.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudexadatainfrastructures/model_cloudexadatainfrastructure.go
@@ -1,0 +1,20 @@
+package cloudexadatainfrastructures
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/systemdata"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/zones"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CloudExadataInfrastructure struct {
+	Id         *string                               `json:"id,omitempty"`
+	Location   string                                `json:"location"`
+	Name       *string                               `json:"name,omitempty"`
+	Properties *CloudExadataInfrastructureProperties `json:"properties,omitempty"`
+	SystemData *systemdata.SystemData                `json:"systemData,omitempty"`
+	Tags       *map[string]string                    `json:"tags,omitempty"`
+	Type       *string                               `json:"type,omitempty"`
+	Zones      zones.Schema                          `json:"zones"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudexadatainfrastructures/model_cloudexadatainfrastructureproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudexadatainfrastructures/model_cloudexadatainfrastructureproperties.go
@@ -1,0 +1,42 @@
+package cloudexadatainfrastructures
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CloudExadataInfrastructureProperties struct {
+	ActivatedStorageCount          *int64                                    `json:"activatedStorageCount,omitempty"`
+	AdditionalStorageCount         *int64                                    `json:"additionalStorageCount,omitempty"`
+	AvailableStorageSizeInGbs      *int64                                    `json:"availableStorageSizeInGbs,omitempty"`
+	ComputeCount                   *int64                                    `json:"computeCount,omitempty"`
+	ComputeModel                   *ComputeModel                             `json:"computeModel,omitempty"`
+	CpuCount                       *int64                                    `json:"cpuCount,omitempty"`
+	CustomerContacts               *[]CustomerContact                        `json:"customerContacts,omitempty"`
+	DataStorageSizeInTbs           *float64                                  `json:"dataStorageSizeInTbs,omitempty"`
+	DatabaseServerType             *string                                   `json:"databaseServerType,omitempty"`
+	DbNodeStorageSizeInGbs         *int64                                    `json:"dbNodeStorageSizeInGbs,omitempty"`
+	DbServerVersion                *string                                   `json:"dbServerVersion,omitempty"`
+	DefinedFileSystemConfiguration *[]DefinedFileSystemConfiguration         `json:"definedFileSystemConfiguration,omitempty"`
+	DisplayName                    string                                    `json:"displayName"`
+	EstimatedPatchingTime          *EstimatedPatchingTime                    `json:"estimatedPatchingTime,omitempty"`
+	LastMaintenanceRunId           *string                                   `json:"lastMaintenanceRunId,omitempty"`
+	LifecycleDetails               *string                                   `json:"lifecycleDetails,omitempty"`
+	LifecycleState                 *CloudExadataInfrastructureLifecycleState `json:"lifecycleState,omitempty"`
+	MaintenanceWindow              *MaintenanceWindow                        `json:"maintenanceWindow,omitempty"`
+	MaxCPUCount                    *int64                                    `json:"maxCpuCount,omitempty"`
+	MaxDataStorageInTbs            *float64                                  `json:"maxDataStorageInTbs,omitempty"`
+	MaxDbNodeStorageSizeInGbs      *int64                                    `json:"maxDbNodeStorageSizeInGbs,omitempty"`
+	MaxMemoryInGbs                 *int64                                    `json:"maxMemoryInGbs,omitempty"`
+	MemorySizeInGbs                *int64                                    `json:"memorySizeInGbs,omitempty"`
+	MonthlyDbServerVersion         *string                                   `json:"monthlyDbServerVersion,omitempty"`
+	MonthlyStorageServerVersion    *string                                   `json:"monthlyStorageServerVersion,omitempty"`
+	NextMaintenanceRunId           *string                                   `json:"nextMaintenanceRunId,omitempty"`
+	OciURL                         *string                                   `json:"ociUrl,omitempty"`
+	Ocid                           *string                                   `json:"ocid,omitempty"`
+	ProvisioningState              *AzureResourceProvisioningState           `json:"provisioningState,omitempty"`
+	Shape                          string                                    `json:"shape"`
+	StorageCount                   *int64                                    `json:"storageCount,omitempty"`
+	StorageServerType              *string                                   `json:"storageServerType,omitempty"`
+	StorageServerVersion           *string                                   `json:"storageServerVersion,omitempty"`
+	TimeCreated                    *string                                   `json:"timeCreated,omitempty"`
+	TotalStorageSizeInGbs          *int64                                    `json:"totalStorageSizeInGbs,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudexadatainfrastructures/model_cloudexadatainfrastructureupdate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudexadatainfrastructures/model_cloudexadatainfrastructureupdate.go
@@ -1,0 +1,14 @@
+package cloudexadatainfrastructures
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/zones"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CloudExadataInfrastructureUpdate struct {
+	Properties *CloudExadataInfrastructureUpdateProperties `json:"properties,omitempty"`
+	Tags       *map[string]string                          `json:"tags,omitempty"`
+	Zones      *zones.Schema                               `json:"zones,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudexadatainfrastructures/model_cloudexadatainfrastructureupdateproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudexadatainfrastructures/model_cloudexadatainfrastructureupdateproperties.go
@@ -1,0 +1,12 @@
+package cloudexadatainfrastructures
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CloudExadataInfrastructureUpdateProperties struct {
+	ComputeCount      *int64             `json:"computeCount,omitempty"`
+	CustomerContacts  *[]CustomerContact `json:"customerContacts,omitempty"`
+	DisplayName       *string            `json:"displayName,omitempty"`
+	MaintenanceWindow *MaintenanceWindow `json:"maintenanceWindow,omitempty"`
+	StorageCount      *int64             `json:"storageCount,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudexadatainfrastructures/model_customercontact.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudexadatainfrastructures/model_customercontact.go
@@ -1,0 +1,8 @@
+package cloudexadatainfrastructures
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CustomerContact struct {
+	Email string `json:"email"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudexadatainfrastructures/model_dayofweek.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudexadatainfrastructures/model_dayofweek.go
@@ -1,0 +1,8 @@
+package cloudexadatainfrastructures
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DayOfWeek struct {
+	Name DayOfWeekName `json:"name"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudexadatainfrastructures/model_definedfilesystemconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudexadatainfrastructures/model_definedfilesystemconfiguration.go
@@ -1,0 +1,11 @@
+package cloudexadatainfrastructures
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DefinedFileSystemConfiguration struct {
+	IsBackupPartition *bool   `json:"isBackupPartition,omitempty"`
+	IsResizable       *bool   `json:"isResizable,omitempty"`
+	MinSizeGb         *int64  `json:"minSizeGb,omitempty"`
+	MountPoint        *string `json:"mountPoint,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudexadatainfrastructures/model_estimatedpatchingtime.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudexadatainfrastructures/model_estimatedpatchingtime.go
@@ -1,0 +1,11 @@
+package cloudexadatainfrastructures
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type EstimatedPatchingTime struct {
+	EstimatedDbServerPatchingTime        *int64 `json:"estimatedDbServerPatchingTime,omitempty"`
+	EstimatedNetworkSwitchesPatchingTime *int64 `json:"estimatedNetworkSwitchesPatchingTime,omitempty"`
+	EstimatedStorageServerPatchingTime   *int64 `json:"estimatedStorageServerPatchingTime,omitempty"`
+	TotalEstimatedPatchingTime           *int64 `json:"totalEstimatedPatchingTime,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudexadatainfrastructures/model_maintenancewindow.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudexadatainfrastructures/model_maintenancewindow.go
@@ -1,0 +1,17 @@
+package cloudexadatainfrastructures
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type MaintenanceWindow struct {
+	CustomActionTimeoutInMins    *int64        `json:"customActionTimeoutInMins,omitempty"`
+	DaysOfWeek                   *[]DayOfWeek  `json:"daysOfWeek,omitempty"`
+	HoursOfDay                   *[]int64      `json:"hoursOfDay,omitempty"`
+	IsCustomActionTimeoutEnabled *bool         `json:"isCustomActionTimeoutEnabled,omitempty"`
+	IsMonthlyPatchingEnabled     *bool         `json:"isMonthlyPatchingEnabled,omitempty"`
+	LeadTimeInWeeks              *int64        `json:"leadTimeInWeeks,omitempty"`
+	Months                       *[]Month      `json:"months,omitempty"`
+	PatchingMode                 *PatchingMode `json:"patchingMode,omitempty"`
+	Preference                   *Preference   `json:"preference,omitempty"`
+	WeeksOfMonth                 *[]int64      `json:"weeksOfMonth,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudexadatainfrastructures/model_month.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudexadatainfrastructures/model_month.go
@@ -1,0 +1,8 @@
+package cloudexadatainfrastructures
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type Month struct {
+	Name MonthName `json:"name"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudexadatainfrastructures/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudexadatainfrastructures/predicates.go
@@ -1,0 +1,32 @@
+package cloudexadatainfrastructures
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CloudExadataInfrastructureOperationPredicate struct {
+	Id       *string
+	Location *string
+	Name     *string
+	Type     *string
+}
+
+func (p CloudExadataInfrastructureOperationPredicate) Matches(input CloudExadataInfrastructure) bool {
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Location != nil && *p.Location != input.Location {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudexadatainfrastructures/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudexadatainfrastructures/version.go
@@ -1,0 +1,10 @@
+package cloudexadatainfrastructures
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2025-03-01"
+
+func userAgent() string {
+	return "hashicorp/go-azure-sdk/cloudexadatainfrastructures/2025-03-01"
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters/README.md
@@ -1,0 +1,172 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters` Documentation
+
+The `cloudvmclusters` SDK allows for interaction with Azure Resource Manager `oracledatabase` (API Version `2025-03-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+import "github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters"
+```
+
+
+### Client Initialization
+
+```go
+client := cloudvmclusters.NewCloudVMClustersClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `CloudVMClustersClient.AddVMs`
+
+```go
+ctx := context.TODO()
+id := cloudvmclusters.NewCloudVMClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "cloudVmClusterName")
+
+payload := cloudvmclusters.AddRemoveDbNode{
+	// ...
+}
+
+
+if err := client.AddVMsThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `CloudVMClustersClient.CreateOrUpdate`
+
+```go
+ctx := context.TODO()
+id := cloudvmclusters.NewCloudVMClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "cloudVmClusterName")
+
+payload := cloudvmclusters.CloudVMCluster{
+	// ...
+}
+
+
+if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `CloudVMClustersClient.Delete`
+
+```go
+ctx := context.TODO()
+id := cloudvmclusters.NewCloudVMClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "cloudVmClusterName")
+
+if err := client.DeleteThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `CloudVMClustersClient.Get`
+
+```go
+ctx := context.TODO()
+id := cloudvmclusters.NewCloudVMClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "cloudVmClusterName")
+
+read, err := client.Get(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `CloudVMClustersClient.ListByResourceGroup`
+
+```go
+ctx := context.TODO()
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+
+// alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
+items, err := client.ListByResourceGroupComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `CloudVMClustersClient.ListBySubscription`
+
+```go
+ctx := context.TODO()
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+
+// alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
+items, err := client.ListBySubscriptionComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `CloudVMClustersClient.ListPrivateIPAddresses`
+
+```go
+ctx := context.TODO()
+id := cloudvmclusters.NewCloudVMClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "cloudVmClusterName")
+
+payload := cloudvmclusters.PrivateIPAddressesFilter{
+	// ...
+}
+
+
+read, err := client.ListPrivateIPAddresses(ctx, id, payload)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `CloudVMClustersClient.RemoveVMs`
+
+```go
+ctx := context.TODO()
+id := cloudvmclusters.NewCloudVMClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "cloudVmClusterName")
+
+payload := cloudvmclusters.AddRemoveDbNode{
+	// ...
+}
+
+
+if err := client.RemoveVMsThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `CloudVMClustersClient.Update`
+
+```go
+ctx := context.TODO()
+id := cloudvmclusters.NewCloudVMClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "cloudVmClusterName")
+
+payload := cloudvmclusters.CloudVMClusterUpdate{
+	// ...
+}
+
+
+if err := client.UpdateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters/client.go
@@ -1,0 +1,26 @@
+package cloudvmclusters
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CloudVMClustersClient struct {
+	Client *resourcemanager.Client
+}
+
+func NewCloudVMClustersClientWithBaseURI(sdkApi sdkEnv.Api) (*CloudVMClustersClient, error) {
+	client, err := resourcemanager.NewClient(sdkApi, "cloudvmclusters", defaultApiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating CloudVMClustersClient: %+v", err)
+	}
+
+	return &CloudVMClustersClient{
+		Client: client,
+	}, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters/constants.go
@@ -1,0 +1,336 @@
+package cloudvmclusters
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AzureResourceProvisioningState string
+
+const (
+	AzureResourceProvisioningStateCanceled     AzureResourceProvisioningState = "Canceled"
+	AzureResourceProvisioningStateFailed       AzureResourceProvisioningState = "Failed"
+	AzureResourceProvisioningStateProvisioning AzureResourceProvisioningState = "Provisioning"
+	AzureResourceProvisioningStateSucceeded    AzureResourceProvisioningState = "Succeeded"
+)
+
+func PossibleValuesForAzureResourceProvisioningState() []string {
+	return []string{
+		string(AzureResourceProvisioningStateCanceled),
+		string(AzureResourceProvisioningStateFailed),
+		string(AzureResourceProvisioningStateProvisioning),
+		string(AzureResourceProvisioningStateSucceeded),
+	}
+}
+
+func (s *AzureResourceProvisioningState) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseAzureResourceProvisioningState(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseAzureResourceProvisioningState(input string) (*AzureResourceProvisioningState, error) {
+	vals := map[string]AzureResourceProvisioningState{
+		"canceled":     AzureResourceProvisioningStateCanceled,
+		"failed":       AzureResourceProvisioningStateFailed,
+		"provisioning": AzureResourceProvisioningStateProvisioning,
+		"succeeded":    AzureResourceProvisioningStateSucceeded,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := AzureResourceProvisioningState(input)
+	return &out, nil
+}
+
+type CloudVMClusterLifecycleState string
+
+const (
+	CloudVMClusterLifecycleStateAvailable             CloudVMClusterLifecycleState = "Available"
+	CloudVMClusterLifecycleStateFailed                CloudVMClusterLifecycleState = "Failed"
+	CloudVMClusterLifecycleStateMaintenanceInProgress CloudVMClusterLifecycleState = "MaintenanceInProgress"
+	CloudVMClusterLifecycleStateProvisioning          CloudVMClusterLifecycleState = "Provisioning"
+	CloudVMClusterLifecycleStateTerminated            CloudVMClusterLifecycleState = "Terminated"
+	CloudVMClusterLifecycleStateTerminating           CloudVMClusterLifecycleState = "Terminating"
+	CloudVMClusterLifecycleStateUpdating              CloudVMClusterLifecycleState = "Updating"
+)
+
+func PossibleValuesForCloudVMClusterLifecycleState() []string {
+	return []string{
+		string(CloudVMClusterLifecycleStateAvailable),
+		string(CloudVMClusterLifecycleStateFailed),
+		string(CloudVMClusterLifecycleStateMaintenanceInProgress),
+		string(CloudVMClusterLifecycleStateProvisioning),
+		string(CloudVMClusterLifecycleStateTerminated),
+		string(CloudVMClusterLifecycleStateTerminating),
+		string(CloudVMClusterLifecycleStateUpdating),
+	}
+}
+
+func (s *CloudVMClusterLifecycleState) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseCloudVMClusterLifecycleState(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseCloudVMClusterLifecycleState(input string) (*CloudVMClusterLifecycleState, error) {
+	vals := map[string]CloudVMClusterLifecycleState{
+		"available":             CloudVMClusterLifecycleStateAvailable,
+		"failed":                CloudVMClusterLifecycleStateFailed,
+		"maintenanceinprogress": CloudVMClusterLifecycleStateMaintenanceInProgress,
+		"provisioning":          CloudVMClusterLifecycleStateProvisioning,
+		"terminated":            CloudVMClusterLifecycleStateTerminated,
+		"terminating":           CloudVMClusterLifecycleStateTerminating,
+		"updating":              CloudVMClusterLifecycleStateUpdating,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := CloudVMClusterLifecycleState(input)
+	return &out, nil
+}
+
+type ComputeModel string
+
+const (
+	ComputeModelECPU ComputeModel = "ECPU"
+	ComputeModelOCPU ComputeModel = "OCPU"
+)
+
+func PossibleValuesForComputeModel() []string {
+	return []string{
+		string(ComputeModelECPU),
+		string(ComputeModelOCPU),
+	}
+}
+
+func (s *ComputeModel) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseComputeModel(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseComputeModel(input string) (*ComputeModel, error) {
+	vals := map[string]ComputeModel{
+		"ecpu": ComputeModelECPU,
+		"ocpu": ComputeModelOCPU,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ComputeModel(input)
+	return &out, nil
+}
+
+type DiskRedundancy string
+
+const (
+	DiskRedundancyHigh   DiskRedundancy = "High"
+	DiskRedundancyNormal DiskRedundancy = "Normal"
+)
+
+func PossibleValuesForDiskRedundancy() []string {
+	return []string{
+		string(DiskRedundancyHigh),
+		string(DiskRedundancyNormal),
+	}
+}
+
+func (s *DiskRedundancy) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseDiskRedundancy(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseDiskRedundancy(input string) (*DiskRedundancy, error) {
+	vals := map[string]DiskRedundancy{
+		"high":   DiskRedundancyHigh,
+		"normal": DiskRedundancyNormal,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := DiskRedundancy(input)
+	return &out, nil
+}
+
+type IormLifecycleState string
+
+const (
+	IormLifecycleStateBootStrapping IormLifecycleState = "BootStrapping"
+	IormLifecycleStateDisabled      IormLifecycleState = "Disabled"
+	IormLifecycleStateEnabled       IormLifecycleState = "Enabled"
+	IormLifecycleStateFailed        IormLifecycleState = "Failed"
+	IormLifecycleStateUpdating      IormLifecycleState = "Updating"
+)
+
+func PossibleValuesForIormLifecycleState() []string {
+	return []string{
+		string(IormLifecycleStateBootStrapping),
+		string(IormLifecycleStateDisabled),
+		string(IormLifecycleStateEnabled),
+		string(IormLifecycleStateFailed),
+		string(IormLifecycleStateUpdating),
+	}
+}
+
+func (s *IormLifecycleState) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseIormLifecycleState(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseIormLifecycleState(input string) (*IormLifecycleState, error) {
+	vals := map[string]IormLifecycleState{
+		"bootstrapping": IormLifecycleStateBootStrapping,
+		"disabled":      IormLifecycleStateDisabled,
+		"enabled":       IormLifecycleStateEnabled,
+		"failed":        IormLifecycleStateFailed,
+		"updating":      IormLifecycleStateUpdating,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := IormLifecycleState(input)
+	return &out, nil
+}
+
+type LicenseModel string
+
+const (
+	LicenseModelBringYourOwnLicense LicenseModel = "BringYourOwnLicense"
+	LicenseModelLicenseIncluded     LicenseModel = "LicenseIncluded"
+)
+
+func PossibleValuesForLicenseModel() []string {
+	return []string{
+		string(LicenseModelBringYourOwnLicense),
+		string(LicenseModelLicenseIncluded),
+	}
+}
+
+func (s *LicenseModel) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseLicenseModel(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseLicenseModel(input string) (*LicenseModel, error) {
+	vals := map[string]LicenseModel{
+		"bringyourownlicense": LicenseModelBringYourOwnLicense,
+		"licenseincluded":     LicenseModelLicenseIncluded,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := LicenseModel(input)
+	return &out, nil
+}
+
+type Objective string
+
+const (
+	ObjectiveAuto           Objective = "Auto"
+	ObjectiveBalanced       Objective = "Balanced"
+	ObjectiveBasic          Objective = "Basic"
+	ObjectiveHighThroughput Objective = "HighThroughput"
+	ObjectiveLowLatency     Objective = "LowLatency"
+)
+
+func PossibleValuesForObjective() []string {
+	return []string{
+		string(ObjectiveAuto),
+		string(ObjectiveBalanced),
+		string(ObjectiveBasic),
+		string(ObjectiveHighThroughput),
+		string(ObjectiveLowLatency),
+	}
+}
+
+func (s *Objective) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseObjective(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseObjective(input string) (*Objective, error) {
+	vals := map[string]Objective{
+		"auto":           ObjectiveAuto,
+		"balanced":       ObjectiveBalanced,
+		"basic":          ObjectiveBasic,
+		"highthroughput": ObjectiveHighThroughput,
+		"lowlatency":     ObjectiveLowLatency,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := Objective(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters/id_cloudvmcluster.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters/id_cloudvmcluster.go
@@ -1,0 +1,130 @@
+package cloudvmclusters
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&CloudVMClusterId{})
+}
+
+var _ resourceids.ResourceId = &CloudVMClusterId{}
+
+// CloudVMClusterId is a struct representing the Resource ID for a Cloud V M Cluster
+type CloudVMClusterId struct {
+	SubscriptionId     string
+	ResourceGroupName  string
+	CloudVmClusterName string
+}
+
+// NewCloudVMClusterID returns a new CloudVMClusterId struct
+func NewCloudVMClusterID(subscriptionId string, resourceGroupName string, cloudVmClusterName string) CloudVMClusterId {
+	return CloudVMClusterId{
+		SubscriptionId:     subscriptionId,
+		ResourceGroupName:  resourceGroupName,
+		CloudVmClusterName: cloudVmClusterName,
+	}
+}
+
+// ParseCloudVMClusterID parses 'input' into a CloudVMClusterId
+func ParseCloudVMClusterID(input string) (*CloudVMClusterId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&CloudVMClusterId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := CloudVMClusterId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseCloudVMClusterIDInsensitively parses 'input' case-insensitively into a CloudVMClusterId
+// note: this method should only be used for API response data and not user input
+func ParseCloudVMClusterIDInsensitively(input string) (*CloudVMClusterId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&CloudVMClusterId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := CloudVMClusterId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *CloudVMClusterId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.CloudVmClusterName, ok = input.Parsed["cloudVmClusterName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "cloudVmClusterName", input)
+	}
+
+	return nil
+}
+
+// ValidateCloudVMClusterID checks that 'input' can be parsed as a Cloud V M Cluster ID
+func ValidateCloudVMClusterID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseCloudVMClusterID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Cloud V M Cluster ID
+func (id CloudVMClusterId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Oracle.Database/cloudVmClusters/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.CloudVmClusterName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Cloud V M Cluster ID
+func (id CloudVMClusterId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticOracleDatabase", "Oracle.Database", "Oracle.Database"),
+		resourceids.StaticSegment("staticCloudVmClusters", "cloudVmClusters", "cloudVmClusters"),
+		resourceids.UserSpecifiedSegment("cloudVmClusterName", "cloudVmClusterName"),
+	}
+}
+
+// String returns a human-readable description of this Cloud V M Cluster ID
+func (id CloudVMClusterId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Cloud Vm Cluster Name: %q", id.CloudVmClusterName),
+	}
+	return fmt.Sprintf("Cloud V M Cluster (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters/method_addvms.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters/method_addvms.go
@@ -1,0 +1,75 @@
+package cloudvmclusters
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AddVMsOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *CloudVMCluster
+}
+
+// AddVMs ...
+func (c CloudVMClustersClient) AddVMs(ctx context.Context, id CloudVMClusterId, input AddRemoveDbNode) (result AddVMsOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/addVms", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// AddVMsThenPoll performs AddVMs then polls until it's completed
+func (c CloudVMClustersClient) AddVMsThenPoll(ctx context.Context, id CloudVMClusterId, input AddRemoveDbNode) error {
+	result, err := c.AddVMs(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing AddVMs: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after AddVMs: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters/method_createorupdate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters/method_createorupdate.go
@@ -1,0 +1,75 @@
+package cloudvmclusters
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateOrUpdateOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *CloudVMCluster
+}
+
+// CreateOrUpdate ...
+func (c CloudVMClustersClient) CreateOrUpdate(ctx context.Context, id CloudVMClusterId, input CloudVMCluster) (result CreateOrUpdateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPut,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// CreateOrUpdateThenPoll performs CreateOrUpdate then polls until it's completed
+func (c CloudVMClustersClient) CreateOrUpdateThenPoll(ctx context.Context, id CloudVMClusterId, input CloudVMCluster) error {
+	result, err := c.CreateOrUpdate(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing CreateOrUpdate: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after CreateOrUpdate: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters/method_delete.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters/method_delete.go
@@ -1,0 +1,70 @@
+package cloudvmclusters
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeleteOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// Delete ...
+func (c CloudVMClustersClient) Delete(ctx context.Context, id CloudVMClusterId) (result DeleteOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusNoContent,
+		},
+		HttpMethod: http.MethodDelete,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// DeleteThenPoll performs Delete then polls until it's completed
+func (c CloudVMClustersClient) DeleteThenPoll(ctx context.Context, id CloudVMClusterId) error {
+	result, err := c.Delete(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing Delete: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Delete: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters/method_get.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters/method_get.go
@@ -1,0 +1,53 @@
+package cloudvmclusters
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *CloudVMCluster
+}
+
+// Get ...
+func (c CloudVMClustersClient) Get(ctx context.Context, id CloudVMClusterId) (result GetOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model CloudVMCluster
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters/method_listbyresourcegroup.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters/method_listbyresourcegroup.go
@@ -1,0 +1,106 @@
+package cloudvmclusters
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListByResourceGroupOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]CloudVMCluster
+}
+
+type ListByResourceGroupCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []CloudVMCluster
+}
+
+type ListByResourceGroupCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *ListByResourceGroupCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// ListByResourceGroup ...
+func (c CloudVMClustersClient) ListByResourceGroup(ctx context.Context, id commonids.ResourceGroupId) (result ListByResourceGroupOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Pager:      &ListByResourceGroupCustomPager{},
+		Path:       fmt.Sprintf("%s/providers/Oracle.Database/cloudVmClusters", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]CloudVMCluster `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListByResourceGroupComplete retrieves all the results into a single object
+func (c CloudVMClustersClient) ListByResourceGroupComplete(ctx context.Context, id commonids.ResourceGroupId) (ListByResourceGroupCompleteResult, error) {
+	return c.ListByResourceGroupCompleteMatchingPredicate(ctx, id, CloudVMClusterOperationPredicate{})
+}
+
+// ListByResourceGroupCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c CloudVMClustersClient) ListByResourceGroupCompleteMatchingPredicate(ctx context.Context, id commonids.ResourceGroupId, predicate CloudVMClusterOperationPredicate) (result ListByResourceGroupCompleteResult, err error) {
+	items := make([]CloudVMCluster, 0)
+
+	resp, err := c.ListByResourceGroup(ctx, id)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListByResourceGroupCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters/method_listbysubscription.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters/method_listbysubscription.go
@@ -1,0 +1,106 @@
+package cloudvmclusters
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListBySubscriptionOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]CloudVMCluster
+}
+
+type ListBySubscriptionCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []CloudVMCluster
+}
+
+type ListBySubscriptionCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *ListBySubscriptionCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// ListBySubscription ...
+func (c CloudVMClustersClient) ListBySubscription(ctx context.Context, id commonids.SubscriptionId) (result ListBySubscriptionOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Pager:      &ListBySubscriptionCustomPager{},
+		Path:       fmt.Sprintf("%s/providers/Oracle.Database/cloudVmClusters", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]CloudVMCluster `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListBySubscriptionComplete retrieves all the results into a single object
+func (c CloudVMClustersClient) ListBySubscriptionComplete(ctx context.Context, id commonids.SubscriptionId) (ListBySubscriptionCompleteResult, error) {
+	return c.ListBySubscriptionCompleteMatchingPredicate(ctx, id, CloudVMClusterOperationPredicate{})
+}
+
+// ListBySubscriptionCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c CloudVMClustersClient) ListBySubscriptionCompleteMatchingPredicate(ctx context.Context, id commonids.SubscriptionId, predicate CloudVMClusterOperationPredicate) (result ListBySubscriptionCompleteResult, err error) {
+	items := make([]CloudVMCluster, 0)
+
+	resp, err := c.ListBySubscription(ctx, id)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListBySubscriptionCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters/method_listprivateipaddresses.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters/method_listprivateipaddresses.go
@@ -1,0 +1,58 @@
+package cloudvmclusters
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListPrivateIPAddressesOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]PrivateIPAddressProperties
+}
+
+// ListPrivateIPAddresses ...
+func (c CloudVMClustersClient) ListPrivateIPAddresses(ctx context.Context, id CloudVMClusterId, input PrivateIPAddressesFilter) (result ListPrivateIPAddressesOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/listPrivateIpAddresses", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model []PrivateIPAddressProperties
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters/method_removevms.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters/method_removevms.go
@@ -1,0 +1,75 @@
+package cloudvmclusters
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RemoveVMsOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *CloudVMCluster
+}
+
+// RemoveVMs ...
+func (c CloudVMClustersClient) RemoveVMs(ctx context.Context, id CloudVMClusterId, input AddRemoveDbNode) (result RemoveVMsOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/removeVms", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// RemoveVMsThenPoll performs RemoveVMs then polls until it's completed
+func (c CloudVMClustersClient) RemoveVMsThenPoll(ctx context.Context, id CloudVMClusterId, input AddRemoveDbNode) error {
+	result, err := c.RemoveVMs(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing RemoveVMs: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after RemoveVMs: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters/method_update.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters/method_update.go
@@ -1,0 +1,75 @@
+package cloudvmclusters
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpdateOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *CloudVMCluster
+}
+
+// Update ...
+func (c CloudVMClustersClient) Update(ctx context.Context, id CloudVMClusterId, input CloudVMClusterUpdate) (result UpdateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPatch,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// UpdateThenPoll performs Update then polls until it's completed
+func (c CloudVMClustersClient) UpdateThenPoll(ctx context.Context, id CloudVMClusterId, input CloudVMClusterUpdate) error {
+	result, err := c.Update(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing Update: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Update: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters/model_addremovedbnode.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters/model_addremovedbnode.go
@@ -1,0 +1,8 @@
+package cloudvmclusters
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AddRemoveDbNode struct {
+	DbServers []string `json:"dbServers"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters/model_cloudvmcluster.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters/model_cloudvmcluster.go
@@ -1,0 +1,18 @@
+package cloudvmclusters
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/systemdata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CloudVMCluster struct {
+	Id         *string                   `json:"id,omitempty"`
+	Location   string                    `json:"location"`
+	Name       *string                   `json:"name,omitempty"`
+	Properties *CloudVMClusterProperties `json:"properties,omitempty"`
+	SystemData *systemdata.SystemData    `json:"systemData,omitempty"`
+	Tags       *map[string]string        `json:"tags,omitempty"`
+	Type       *string                   `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters/model_cloudvmclusterproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters/model_cloudvmclusterproperties.go
@@ -1,0 +1,75 @@
+package cloudvmclusters
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CloudVMClusterProperties struct {
+	BackupSubnetCidr               *string                           `json:"backupSubnetCidr,omitempty"`
+	CloudExadataInfrastructureId   string                            `json:"cloudExadataInfrastructureId"`
+	ClusterName                    *string                           `json:"clusterName,omitempty"`
+	CompartmentId                  *string                           `json:"compartmentId,omitempty"`
+	ComputeModel                   *ComputeModel                     `json:"computeModel,omitempty"`
+	ComputeNodes                   *[]string                         `json:"computeNodes,omitempty"`
+	CpuCoreCount                   int64                             `json:"cpuCoreCount"`
+	DataCollectionOptions          *DataCollectionOptions            `json:"dataCollectionOptions,omitempty"`
+	DataStoragePercentage          *int64                            `json:"dataStoragePercentage,omitempty"`
+	DataStorageSizeInTbs           *float64                          `json:"dataStorageSizeInTbs,omitempty"`
+	DbNodeStorageSizeInGbs         *int64                            `json:"dbNodeStorageSizeInGbs,omitempty"`
+	DbServers                      *[]string                         `json:"dbServers,omitempty"`
+	DiskRedundancy                 *DiskRedundancy                   `json:"diskRedundancy,omitempty"`
+	DisplayName                    string                            `json:"displayName"`
+	Domain                         *string                           `json:"domain,omitempty"`
+	FileSystemConfigurationDetails *[]FileSystemConfigurationDetails `json:"fileSystemConfigurationDetails,omitempty"`
+	GiVersion                      string                            `json:"giVersion"`
+	Hostname                       string                            `json:"hostname"`
+	IormConfigCache                *ExadataIormConfig                `json:"iormConfigCache,omitempty"`
+	IsLocalBackupEnabled           *bool                             `json:"isLocalBackupEnabled,omitempty"`
+	IsSparseDiskgroupEnabled       *bool                             `json:"isSparseDiskgroupEnabled,omitempty"`
+	LastUpdateHistoryEntryId       *string                           `json:"lastUpdateHistoryEntryId,omitempty"`
+	LicenseModel                   *LicenseModel                     `json:"licenseModel,omitempty"`
+	LifecycleDetails               *string                           `json:"lifecycleDetails,omitempty"`
+	LifecycleState                 *CloudVMClusterLifecycleState     `json:"lifecycleState,omitempty"`
+	ListenerPort                   *int64                            `json:"listenerPort,omitempty"`
+	MemorySizeInGbs                *int64                            `json:"memorySizeInGbs,omitempty"`
+	NodeCount                      *int64                            `json:"nodeCount,omitempty"`
+	NsgCidrs                       *[]NsgCidr                        `json:"nsgCidrs,omitempty"`
+	NsgURL                         *string                           `json:"nsgUrl,omitempty"`
+	OciURL                         *string                           `json:"ociUrl,omitempty"`
+	Ocid                           *string                           `json:"ocid,omitempty"`
+	OcpuCount                      *float64                          `json:"ocpuCount,omitempty"`
+	ProvisioningState              *AzureResourceProvisioningState   `json:"provisioningState,omitempty"`
+	ScanDnsName                    *string                           `json:"scanDnsName,omitempty"`
+	ScanDnsRecordId                *string                           `json:"scanDnsRecordId,omitempty"`
+	ScanIPIds                      *[]string                         `json:"scanIpIds,omitempty"`
+	ScanListenerPortTcp            *int64                            `json:"scanListenerPortTcp,omitempty"`
+	ScanListenerPortTcpSsl         *int64                            `json:"scanListenerPortTcpSsl,omitempty"`
+	Shape                          *string                           `json:"shape,omitempty"`
+	SshPublicKeys                  []string                          `json:"sshPublicKeys"`
+	StorageSizeInGbs               *int64                            `json:"storageSizeInGbs,omitempty"`
+	SubnetId                       string                            `json:"subnetId"`
+	SubnetOcid                     *string                           `json:"subnetOcid,omitempty"`
+	SystemVersion                  *string                           `json:"systemVersion,omitempty"`
+	TimeCreated                    *string                           `json:"timeCreated,omitempty"`
+	TimeZone                       *string                           `json:"timeZone,omitempty"`
+	VipIds                         *[]string                         `json:"vipIds,omitempty"`
+	VnetId                         string                            `json:"vnetId"`
+	ZoneId                         *string                           `json:"zoneId,omitempty"`
+}
+
+func (o *CloudVMClusterProperties) GetTimeCreatedAsTime() (*time.Time, error) {
+	if o.TimeCreated == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.TimeCreated, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *CloudVMClusterProperties) SetTimeCreatedAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.TimeCreated = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters/model_cloudvmclusterupdate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters/model_cloudvmclusterupdate.go
@@ -1,0 +1,9 @@
+package cloudvmclusters
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CloudVMClusterUpdate struct {
+	Properties *CloudVMClusterUpdateProperties `json:"properties,omitempty"`
+	Tags       *map[string]string              `json:"tags,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters/model_cloudvmclusterupdateproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters/model_cloudvmclusterupdateproperties.go
@@ -1,0 +1,19 @@
+package cloudvmclusters
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CloudVMClusterUpdateProperties struct {
+	ComputeNodes                   *[]string                         `json:"computeNodes,omitempty"`
+	CpuCoreCount                   *int64                            `json:"cpuCoreCount,omitempty"`
+	DataCollectionOptions          *DataCollectionOptions            `json:"dataCollectionOptions,omitempty"`
+	DataStorageSizeInTbs           *float64                          `json:"dataStorageSizeInTbs,omitempty"`
+	DbNodeStorageSizeInGbs         *int64                            `json:"dbNodeStorageSizeInGbs,omitempty"`
+	DisplayName                    *string                           `json:"displayName,omitempty"`
+	FileSystemConfigurationDetails *[]FileSystemConfigurationDetails `json:"fileSystemConfigurationDetails,omitempty"`
+	LicenseModel                   *LicenseModel                     `json:"licenseModel,omitempty"`
+	MemorySizeInGbs                *int64                            `json:"memorySizeInGbs,omitempty"`
+	OcpuCount                      *float64                          `json:"ocpuCount,omitempty"`
+	SshPublicKeys                  *[]string                         `json:"sshPublicKeys,omitempty"`
+	StorageSizeInGbs               *int64                            `json:"storageSizeInGbs,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters/model_datacollectionoptions.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters/model_datacollectionoptions.go
@@ -1,0 +1,10 @@
+package cloudvmclusters
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DataCollectionOptions struct {
+	IsDiagnosticsEventsEnabled *bool `json:"isDiagnosticsEventsEnabled,omitempty"`
+	IsHealthMonitoringEnabled  *bool `json:"isHealthMonitoringEnabled,omitempty"`
+	IsIncidentLogsEnabled      *bool `json:"isIncidentLogsEnabled,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters/model_dbiormconfig.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters/model_dbiormconfig.go
@@ -1,0 +1,10 @@
+package cloudvmclusters
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DbIormConfig struct {
+	DbName          *string `json:"dbName,omitempty"`
+	FlashCacheLimit *string `json:"flashCacheLimit,omitempty"`
+	Share           *int64  `json:"share,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters/model_exadataiormconfig.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters/model_exadataiormconfig.go
@@ -1,0 +1,11 @@
+package cloudvmclusters
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ExadataIormConfig struct {
+	DbPlans          *[]DbIormConfig     `json:"dbPlans,omitempty"`
+	LifecycleDetails *string             `json:"lifecycleDetails,omitempty"`
+	LifecycleState   *IormLifecycleState `json:"lifecycleState,omitempty"`
+	Objective        *Objective          `json:"objective,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters/model_filesystemconfigurationdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters/model_filesystemconfigurationdetails.go
@@ -1,0 +1,9 @@
+package cloudvmclusters
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type FileSystemConfigurationDetails struct {
+	FileSystemSizeGb *int64  `json:"fileSystemSizeGb,omitempty"`
+	MountPoint       *string `json:"mountPoint,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters/model_nsgcidr.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters/model_nsgcidr.go
@@ -1,0 +1,9 @@
+package cloudvmclusters
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NsgCidr struct {
+	DestinationPortRange *PortRange `json:"destinationPortRange,omitempty"`
+	Source               string     `json:"source"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters/model_portrange.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters/model_portrange.go
@@ -1,0 +1,9 @@
+package cloudvmclusters
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PortRange struct {
+	Max int64 `json:"max"`
+	Min int64 `json:"min"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters/model_privateipaddressesfilter.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters/model_privateipaddressesfilter.go
@@ -1,0 +1,9 @@
+package cloudvmclusters
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateIPAddressesFilter struct {
+	SubnetId string `json:"subnetId"`
+	VnicId   string `json:"vnicId"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters/model_privateipaddressproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters/model_privateipaddressproperties.go
@@ -1,0 +1,12 @@
+package cloudvmclusters
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateIPAddressProperties struct {
+	DisplayName   string `json:"displayName"`
+	HostnameLabel string `json:"hostnameLabel"`
+	IPAddress     string `json:"ipAddress"`
+	Ocid          string `json:"ocid"`
+	SubnetId      string `json:"subnetId"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters/predicates.go
@@ -1,0 +1,32 @@
+package cloudvmclusters
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CloudVMClusterOperationPredicate struct {
+	Id       *string
+	Location *string
+	Name     *string
+	Type     *string
+}
+
+func (p CloudVMClusterOperationPredicate) Matches(input CloudVMCluster) bool {
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Location != nil && *p.Location != input.Location {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters/version.go
@@ -1,0 +1,10 @@
+package cloudvmclusters
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2025-03-01"
+
+func userAgent() string {
+	return "hashicorp/go-azure-sdk/cloudvmclusters/2025-03-01"
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbnodes/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbnodes/README.md
@@ -1,0 +1,70 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbnodes` Documentation
+
+The `dbnodes` SDK allows for interaction with Azure Resource Manager `oracledatabase` (API Version `2025-03-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbnodes"
+```
+
+
+### Client Initialization
+
+```go
+client := dbnodes.NewDbNodesClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `DbNodesClient.Action`
+
+```go
+ctx := context.TODO()
+id := dbnodes.NewDbNodeID("12345678-1234-9876-4563-123456789012", "example-resource-group", "cloudVmClusterName", "dbNodeName")
+
+payload := dbnodes.DbNodeAction{
+	// ...
+}
+
+
+if err := client.ActionThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `DbNodesClient.Get`
+
+```go
+ctx := context.TODO()
+id := dbnodes.NewDbNodeID("12345678-1234-9876-4563-123456789012", "example-resource-group", "cloudVmClusterName", "dbNodeName")
+
+read, err := client.Get(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `DbNodesClient.ListByParent`
+
+```go
+ctx := context.TODO()
+id := dbnodes.NewCloudVMClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "cloudVmClusterName")
+
+// alternatively `client.ListByParent(ctx, id)` can be used to do batched pagination
+items, err := client.ListByParentComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbnodes/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbnodes/client.go
@@ -1,0 +1,26 @@
+package dbnodes
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DbNodesClient struct {
+	Client *resourcemanager.Client
+}
+
+func NewDbNodesClientWithBaseURI(sdkApi sdkEnv.Api) (*DbNodesClient, error) {
+	client, err := resourcemanager.NewClient(sdkApi, "dbnodes", defaultApiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating DbNodesClient: %+v", err)
+	}
+
+	return &DbNodesClient{
+		Client: client,
+	}, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbnodes/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbnodes/constants.go
@@ -1,0 +1,201 @@
+package dbnodes
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DbNodeActionEnum string
+
+const (
+	DbNodeActionEnumReset     DbNodeActionEnum = "Reset"
+	DbNodeActionEnumSoftReset DbNodeActionEnum = "SoftReset"
+	DbNodeActionEnumStart     DbNodeActionEnum = "Start"
+	DbNodeActionEnumStop      DbNodeActionEnum = "Stop"
+)
+
+func PossibleValuesForDbNodeActionEnum() []string {
+	return []string{
+		string(DbNodeActionEnumReset),
+		string(DbNodeActionEnumSoftReset),
+		string(DbNodeActionEnumStart),
+		string(DbNodeActionEnumStop),
+	}
+}
+
+func (s *DbNodeActionEnum) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseDbNodeActionEnum(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseDbNodeActionEnum(input string) (*DbNodeActionEnum, error) {
+	vals := map[string]DbNodeActionEnum{
+		"reset":     DbNodeActionEnumReset,
+		"softreset": DbNodeActionEnumSoftReset,
+		"start":     DbNodeActionEnumStart,
+		"stop":      DbNodeActionEnumStop,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := DbNodeActionEnum(input)
+	return &out, nil
+}
+
+type DbNodeMaintenanceType string
+
+const (
+	DbNodeMaintenanceTypeVMdbRebootMigration DbNodeMaintenanceType = "VmdbRebootMigration"
+)
+
+func PossibleValuesForDbNodeMaintenanceType() []string {
+	return []string{
+		string(DbNodeMaintenanceTypeVMdbRebootMigration),
+	}
+}
+
+func (s *DbNodeMaintenanceType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseDbNodeMaintenanceType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseDbNodeMaintenanceType(input string) (*DbNodeMaintenanceType, error) {
+	vals := map[string]DbNodeMaintenanceType{
+		"vmdbrebootmigration": DbNodeMaintenanceTypeVMdbRebootMigration,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := DbNodeMaintenanceType(input)
+	return &out, nil
+}
+
+type DbNodeProvisioningState string
+
+const (
+	DbNodeProvisioningStateAvailable    DbNodeProvisioningState = "Available"
+	DbNodeProvisioningStateFailed       DbNodeProvisioningState = "Failed"
+	DbNodeProvisioningStateProvisioning DbNodeProvisioningState = "Provisioning"
+	DbNodeProvisioningStateStarting     DbNodeProvisioningState = "Starting"
+	DbNodeProvisioningStateStopped      DbNodeProvisioningState = "Stopped"
+	DbNodeProvisioningStateStopping     DbNodeProvisioningState = "Stopping"
+	DbNodeProvisioningStateTerminated   DbNodeProvisioningState = "Terminated"
+	DbNodeProvisioningStateTerminating  DbNodeProvisioningState = "Terminating"
+	DbNodeProvisioningStateUpdating     DbNodeProvisioningState = "Updating"
+)
+
+func PossibleValuesForDbNodeProvisioningState() []string {
+	return []string{
+		string(DbNodeProvisioningStateAvailable),
+		string(DbNodeProvisioningStateFailed),
+		string(DbNodeProvisioningStateProvisioning),
+		string(DbNodeProvisioningStateStarting),
+		string(DbNodeProvisioningStateStopped),
+		string(DbNodeProvisioningStateStopping),
+		string(DbNodeProvisioningStateTerminated),
+		string(DbNodeProvisioningStateTerminating),
+		string(DbNodeProvisioningStateUpdating),
+	}
+}
+
+func (s *DbNodeProvisioningState) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseDbNodeProvisioningState(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseDbNodeProvisioningState(input string) (*DbNodeProvisioningState, error) {
+	vals := map[string]DbNodeProvisioningState{
+		"available":    DbNodeProvisioningStateAvailable,
+		"failed":       DbNodeProvisioningStateFailed,
+		"provisioning": DbNodeProvisioningStateProvisioning,
+		"starting":     DbNodeProvisioningStateStarting,
+		"stopped":      DbNodeProvisioningStateStopped,
+		"stopping":     DbNodeProvisioningStateStopping,
+		"terminated":   DbNodeProvisioningStateTerminated,
+		"terminating":  DbNodeProvisioningStateTerminating,
+		"updating":     DbNodeProvisioningStateUpdating,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := DbNodeProvisioningState(input)
+	return &out, nil
+}
+
+type ResourceProvisioningState string
+
+const (
+	ResourceProvisioningStateCanceled  ResourceProvisioningState = "Canceled"
+	ResourceProvisioningStateFailed    ResourceProvisioningState = "Failed"
+	ResourceProvisioningStateSucceeded ResourceProvisioningState = "Succeeded"
+)
+
+func PossibleValuesForResourceProvisioningState() []string {
+	return []string{
+		string(ResourceProvisioningStateCanceled),
+		string(ResourceProvisioningStateFailed),
+		string(ResourceProvisioningStateSucceeded),
+	}
+}
+
+func (s *ResourceProvisioningState) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseResourceProvisioningState(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseResourceProvisioningState(input string) (*ResourceProvisioningState, error) {
+	vals := map[string]ResourceProvisioningState{
+		"canceled":  ResourceProvisioningStateCanceled,
+		"failed":    ResourceProvisioningStateFailed,
+		"succeeded": ResourceProvisioningStateSucceeded,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ResourceProvisioningState(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbnodes/id_cloudvmcluster.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbnodes/id_cloudvmcluster.go
@@ -1,0 +1,130 @@
+package dbnodes
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&CloudVMClusterId{})
+}
+
+var _ resourceids.ResourceId = &CloudVMClusterId{}
+
+// CloudVMClusterId is a struct representing the Resource ID for a Cloud V M Cluster
+type CloudVMClusterId struct {
+	SubscriptionId     string
+	ResourceGroupName  string
+	CloudVmClusterName string
+}
+
+// NewCloudVMClusterID returns a new CloudVMClusterId struct
+func NewCloudVMClusterID(subscriptionId string, resourceGroupName string, cloudVmClusterName string) CloudVMClusterId {
+	return CloudVMClusterId{
+		SubscriptionId:     subscriptionId,
+		ResourceGroupName:  resourceGroupName,
+		CloudVmClusterName: cloudVmClusterName,
+	}
+}
+
+// ParseCloudVMClusterID parses 'input' into a CloudVMClusterId
+func ParseCloudVMClusterID(input string) (*CloudVMClusterId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&CloudVMClusterId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := CloudVMClusterId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseCloudVMClusterIDInsensitively parses 'input' case-insensitively into a CloudVMClusterId
+// note: this method should only be used for API response data and not user input
+func ParseCloudVMClusterIDInsensitively(input string) (*CloudVMClusterId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&CloudVMClusterId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := CloudVMClusterId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *CloudVMClusterId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.CloudVmClusterName, ok = input.Parsed["cloudVmClusterName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "cloudVmClusterName", input)
+	}
+
+	return nil
+}
+
+// ValidateCloudVMClusterID checks that 'input' can be parsed as a Cloud V M Cluster ID
+func ValidateCloudVMClusterID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseCloudVMClusterID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Cloud V M Cluster ID
+func (id CloudVMClusterId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Oracle.Database/cloudVmClusters/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.CloudVmClusterName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Cloud V M Cluster ID
+func (id CloudVMClusterId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticOracleDatabase", "Oracle.Database", "Oracle.Database"),
+		resourceids.StaticSegment("staticCloudVmClusters", "cloudVmClusters", "cloudVmClusters"),
+		resourceids.UserSpecifiedSegment("cloudVmClusterName", "cloudVmClusterName"),
+	}
+}
+
+// String returns a human-readable description of this Cloud V M Cluster ID
+func (id CloudVMClusterId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Cloud Vm Cluster Name: %q", id.CloudVmClusterName),
+	}
+	return fmt.Sprintf("Cloud V M Cluster (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbnodes/id_dbnode.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbnodes/id_dbnode.go
@@ -1,0 +1,139 @@
+package dbnodes
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&DbNodeId{})
+}
+
+var _ resourceids.ResourceId = &DbNodeId{}
+
+// DbNodeId is a struct representing the Resource ID for a Db Node
+type DbNodeId struct {
+	SubscriptionId     string
+	ResourceGroupName  string
+	CloudVmClusterName string
+	DbNodeName         string
+}
+
+// NewDbNodeID returns a new DbNodeId struct
+func NewDbNodeID(subscriptionId string, resourceGroupName string, cloudVmClusterName string, dbNodeName string) DbNodeId {
+	return DbNodeId{
+		SubscriptionId:     subscriptionId,
+		ResourceGroupName:  resourceGroupName,
+		CloudVmClusterName: cloudVmClusterName,
+		DbNodeName:         dbNodeName,
+	}
+}
+
+// ParseDbNodeID parses 'input' into a DbNodeId
+func ParseDbNodeID(input string) (*DbNodeId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&DbNodeId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := DbNodeId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseDbNodeIDInsensitively parses 'input' case-insensitively into a DbNodeId
+// note: this method should only be used for API response data and not user input
+func ParseDbNodeIDInsensitively(input string) (*DbNodeId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&DbNodeId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := DbNodeId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *DbNodeId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.CloudVmClusterName, ok = input.Parsed["cloudVmClusterName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "cloudVmClusterName", input)
+	}
+
+	if id.DbNodeName, ok = input.Parsed["dbNodeName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "dbNodeName", input)
+	}
+
+	return nil
+}
+
+// ValidateDbNodeID checks that 'input' can be parsed as a Db Node ID
+func ValidateDbNodeID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseDbNodeID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Db Node ID
+func (id DbNodeId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Oracle.Database/cloudVmClusters/%s/dbNodes/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.CloudVmClusterName, id.DbNodeName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Db Node ID
+func (id DbNodeId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticOracleDatabase", "Oracle.Database", "Oracle.Database"),
+		resourceids.StaticSegment("staticCloudVmClusters", "cloudVmClusters", "cloudVmClusters"),
+		resourceids.UserSpecifiedSegment("cloudVmClusterName", "cloudVmClusterName"),
+		resourceids.StaticSegment("staticDbNodes", "dbNodes", "dbNodes"),
+		resourceids.UserSpecifiedSegment("dbNodeName", "dbNodeName"),
+	}
+}
+
+// String returns a human-readable description of this Db Node ID
+func (id DbNodeId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Cloud Vm Cluster Name: %q", id.CloudVmClusterName),
+		fmt.Sprintf("Db Node Name: %q", id.DbNodeName),
+	}
+	return fmt.Sprintf("Db Node (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbnodes/method_action.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbnodes/method_action.go
@@ -1,0 +1,75 @@
+package dbnodes
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ActionOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *DbNode
+}
+
+// Action ...
+func (c DbNodesClient) Action(ctx context.Context, id DbNodeId, input DbNodeAction) (result ActionOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/action", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// ActionThenPoll performs Action then polls until it's completed
+func (c DbNodesClient) ActionThenPoll(ctx context.Context, id DbNodeId, input DbNodeAction) error {
+	result, err := c.Action(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing Action: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Action: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbnodes/method_get.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbnodes/method_get.go
@@ -1,0 +1,53 @@
+package dbnodes
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *DbNode
+}
+
+// Get ...
+func (c DbNodesClient) Get(ctx context.Context, id DbNodeId) (result GetOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model DbNode
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbnodes/method_listbyparent.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbnodes/method_listbyparent.go
@@ -1,0 +1,105 @@
+package dbnodes
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListByParentOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]DbNode
+}
+
+type ListByParentCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []DbNode
+}
+
+type ListByParentCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *ListByParentCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// ListByParent ...
+func (c DbNodesClient) ListByParent(ctx context.Context, id CloudVMClusterId) (result ListByParentOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Pager:      &ListByParentCustomPager{},
+		Path:       fmt.Sprintf("%s/dbNodes", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]DbNode `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListByParentComplete retrieves all the results into a single object
+func (c DbNodesClient) ListByParentComplete(ctx context.Context, id CloudVMClusterId) (ListByParentCompleteResult, error) {
+	return c.ListByParentCompleteMatchingPredicate(ctx, id, DbNodeOperationPredicate{})
+}
+
+// ListByParentCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c DbNodesClient) ListByParentCompleteMatchingPredicate(ctx context.Context, id CloudVMClusterId, predicate DbNodeOperationPredicate) (result ListByParentCompleteResult, err error) {
+	items := make([]DbNode, 0)
+
+	resp, err := c.ListByParent(ctx, id)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListByParentCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbnodes/model_dbnode.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbnodes/model_dbnode.go
@@ -1,0 +1,16 @@
+package dbnodes
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/systemdata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DbNode struct {
+	Id         *string                `json:"id,omitempty"`
+	Name       *string                `json:"name,omitempty"`
+	Properties *DbNodeProperties      `json:"properties,omitempty"`
+	SystemData *systemdata.SystemData `json:"systemData,omitempty"`
+	Type       *string                `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbnodes/model_dbnodeaction.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbnodes/model_dbnodeaction.go
@@ -1,0 +1,8 @@
+package dbnodes
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DbNodeAction struct {
+	Action DbNodeActionEnum `json:"action"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbnodes/model_dbnodeproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbnodes/model_dbnodeproperties.go
@@ -1,0 +1,69 @@
+package dbnodes
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DbNodeProperties struct {
+	AdditionalDetails          *string                    `json:"additionalDetails,omitempty"`
+	BackupIPId                 *string                    `json:"backupIpId,omitempty"`
+	BackupVnic2Id              *string                    `json:"backupVnic2Id,omitempty"`
+	BackupVnicId               *string                    `json:"backupVnicId,omitempty"`
+	CpuCoreCount               *int64                     `json:"cpuCoreCount,omitempty"`
+	DbNodeStorageSizeInGbs     *int64                     `json:"dbNodeStorageSizeInGbs,omitempty"`
+	DbServerId                 *string                    `json:"dbServerId,omitempty"`
+	DbSystemId                 string                     `json:"dbSystemId"`
+	FaultDomain                *string                    `json:"faultDomain,omitempty"`
+	HostIPId                   *string                    `json:"hostIpId,omitempty"`
+	Hostname                   *string                    `json:"hostname,omitempty"`
+	LifecycleDetails           *string                    `json:"lifecycleDetails,omitempty"`
+	LifecycleState             DbNodeProvisioningState    `json:"lifecycleState"`
+	MaintenanceType            *DbNodeMaintenanceType     `json:"maintenanceType,omitempty"`
+	MemorySizeInGbs            *int64                     `json:"memorySizeInGbs,omitempty"`
+	Ocid                       string                     `json:"ocid"`
+	ProvisioningState          *ResourceProvisioningState `json:"provisioningState,omitempty"`
+	SoftwareStorageSizeInGb    *int64                     `json:"softwareStorageSizeInGb,omitempty"`
+	TimeCreated                string                     `json:"timeCreated"`
+	TimeMaintenanceWindowEnd   *string                    `json:"timeMaintenanceWindowEnd,omitempty"`
+	TimeMaintenanceWindowStart *string                    `json:"timeMaintenanceWindowStart,omitempty"`
+	Vnic2Id                    *string                    `json:"vnic2Id,omitempty"`
+	VnicId                     string                     `json:"vnicId"`
+}
+
+func (o *DbNodeProperties) GetTimeCreatedAsTime() (*time.Time, error) {
+	return dates.ParseAsFormat(&o.TimeCreated, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *DbNodeProperties) SetTimeCreatedAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.TimeCreated = formatted
+}
+
+func (o *DbNodeProperties) GetTimeMaintenanceWindowEndAsTime() (*time.Time, error) {
+	if o.TimeMaintenanceWindowEnd == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.TimeMaintenanceWindowEnd, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *DbNodeProperties) SetTimeMaintenanceWindowEndAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.TimeMaintenanceWindowEnd = &formatted
+}
+
+func (o *DbNodeProperties) GetTimeMaintenanceWindowStartAsTime() (*time.Time, error) {
+	if o.TimeMaintenanceWindowStart == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.TimeMaintenanceWindowStart, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *DbNodeProperties) SetTimeMaintenanceWindowStartAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.TimeMaintenanceWindowStart = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbnodes/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbnodes/predicates.go
@@ -1,0 +1,27 @@
+package dbnodes
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DbNodeOperationPredicate struct {
+	Id   *string
+	Name *string
+	Type *string
+}
+
+func (p DbNodeOperationPredicate) Matches(input DbNode) bool {
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbnodes/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbnodes/version.go
@@ -1,0 +1,10 @@
+package dbnodes
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2025-03-01"
+
+func userAgent() string {
+	return "hashicorp/go-azure-sdk/dbnodes/2025-03-01"
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbservers/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbservers/README.md
@@ -1,0 +1,53 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbservers` Documentation
+
+The `dbservers` SDK allows for interaction with Azure Resource Manager `oracledatabase` (API Version `2025-03-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbservers"
+```
+
+
+### Client Initialization
+
+```go
+client := dbservers.NewDbServersClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `DbServersClient.Get`
+
+```go
+ctx := context.TODO()
+id := dbservers.NewDbServerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "cloudExadataInfrastructureName", "dbServerName")
+
+read, err := client.Get(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `DbServersClient.ListByParent`
+
+```go
+ctx := context.TODO()
+id := dbservers.NewCloudExadataInfrastructureID("12345678-1234-9876-4563-123456789012", "example-resource-group", "cloudExadataInfrastructureName")
+
+// alternatively `client.ListByParent(ctx, id)` can be used to do batched pagination
+items, err := client.ListByParentComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbservers/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbservers/client.go
@@ -1,0 +1,26 @@
+package dbservers
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DbServersClient struct {
+	Client *resourcemanager.Client
+}
+
+func NewDbServersClientWithBaseURI(sdkApi sdkEnv.Api) (*DbServersClient, error) {
+	client, err := resourcemanager.NewClient(sdkApi, "dbservers", defaultApiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating DbServersClient: %+v", err)
+	}
+
+	return &DbServersClient{
+		Client: client,
+	}, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbservers/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbservers/constants.go
@@ -1,0 +1,195 @@
+package dbservers
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ComputeModel string
+
+const (
+	ComputeModelECPU ComputeModel = "ECPU"
+	ComputeModelOCPU ComputeModel = "OCPU"
+)
+
+func PossibleValuesForComputeModel() []string {
+	return []string{
+		string(ComputeModelECPU),
+		string(ComputeModelOCPU),
+	}
+}
+
+func (s *ComputeModel) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseComputeModel(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseComputeModel(input string) (*ComputeModel, error) {
+	vals := map[string]ComputeModel{
+		"ecpu": ComputeModelECPU,
+		"ocpu": ComputeModelOCPU,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ComputeModel(input)
+	return &out, nil
+}
+
+type DbServerPatchingStatus string
+
+const (
+	DbServerPatchingStatusComplete              DbServerPatchingStatus = "Complete"
+	DbServerPatchingStatusFailed                DbServerPatchingStatus = "Failed"
+	DbServerPatchingStatusMaintenanceInProgress DbServerPatchingStatus = "MaintenanceInProgress"
+	DbServerPatchingStatusScheduled             DbServerPatchingStatus = "Scheduled"
+)
+
+func PossibleValuesForDbServerPatchingStatus() []string {
+	return []string{
+		string(DbServerPatchingStatusComplete),
+		string(DbServerPatchingStatusFailed),
+		string(DbServerPatchingStatusMaintenanceInProgress),
+		string(DbServerPatchingStatusScheduled),
+	}
+}
+
+func (s *DbServerPatchingStatus) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseDbServerPatchingStatus(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseDbServerPatchingStatus(input string) (*DbServerPatchingStatus, error) {
+	vals := map[string]DbServerPatchingStatus{
+		"complete":              DbServerPatchingStatusComplete,
+		"failed":                DbServerPatchingStatusFailed,
+		"maintenanceinprogress": DbServerPatchingStatusMaintenanceInProgress,
+		"scheduled":             DbServerPatchingStatusScheduled,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := DbServerPatchingStatus(input)
+	return &out, nil
+}
+
+type DbServerProvisioningState string
+
+const (
+	DbServerProvisioningStateAvailable             DbServerProvisioningState = "Available"
+	DbServerProvisioningStateCreating              DbServerProvisioningState = "Creating"
+	DbServerProvisioningStateDeleted               DbServerProvisioningState = "Deleted"
+	DbServerProvisioningStateDeleting              DbServerProvisioningState = "Deleting"
+	DbServerProvisioningStateMaintenanceInProgress DbServerProvisioningState = "MaintenanceInProgress"
+	DbServerProvisioningStateUnavailable           DbServerProvisioningState = "Unavailable"
+)
+
+func PossibleValuesForDbServerProvisioningState() []string {
+	return []string{
+		string(DbServerProvisioningStateAvailable),
+		string(DbServerProvisioningStateCreating),
+		string(DbServerProvisioningStateDeleted),
+		string(DbServerProvisioningStateDeleting),
+		string(DbServerProvisioningStateMaintenanceInProgress),
+		string(DbServerProvisioningStateUnavailable),
+	}
+}
+
+func (s *DbServerProvisioningState) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseDbServerProvisioningState(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseDbServerProvisioningState(input string) (*DbServerProvisioningState, error) {
+	vals := map[string]DbServerProvisioningState{
+		"available":             DbServerProvisioningStateAvailable,
+		"creating":              DbServerProvisioningStateCreating,
+		"deleted":               DbServerProvisioningStateDeleted,
+		"deleting":              DbServerProvisioningStateDeleting,
+		"maintenanceinprogress": DbServerProvisioningStateMaintenanceInProgress,
+		"unavailable":           DbServerProvisioningStateUnavailable,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := DbServerProvisioningState(input)
+	return &out, nil
+}
+
+type ResourceProvisioningState string
+
+const (
+	ResourceProvisioningStateCanceled  ResourceProvisioningState = "Canceled"
+	ResourceProvisioningStateFailed    ResourceProvisioningState = "Failed"
+	ResourceProvisioningStateSucceeded ResourceProvisioningState = "Succeeded"
+)
+
+func PossibleValuesForResourceProvisioningState() []string {
+	return []string{
+		string(ResourceProvisioningStateCanceled),
+		string(ResourceProvisioningStateFailed),
+		string(ResourceProvisioningStateSucceeded),
+	}
+}
+
+func (s *ResourceProvisioningState) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseResourceProvisioningState(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseResourceProvisioningState(input string) (*ResourceProvisioningState, error) {
+	vals := map[string]ResourceProvisioningState{
+		"canceled":  ResourceProvisioningStateCanceled,
+		"failed":    ResourceProvisioningStateFailed,
+		"succeeded": ResourceProvisioningStateSucceeded,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ResourceProvisioningState(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbservers/id_cloudexadatainfrastructure.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbservers/id_cloudexadatainfrastructure.go
@@ -1,0 +1,130 @@
+package dbservers
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&CloudExadataInfrastructureId{})
+}
+
+var _ resourceids.ResourceId = &CloudExadataInfrastructureId{}
+
+// CloudExadataInfrastructureId is a struct representing the Resource ID for a Cloud Exadata Infrastructure
+type CloudExadataInfrastructureId struct {
+	SubscriptionId                 string
+	ResourceGroupName              string
+	CloudExadataInfrastructureName string
+}
+
+// NewCloudExadataInfrastructureID returns a new CloudExadataInfrastructureId struct
+func NewCloudExadataInfrastructureID(subscriptionId string, resourceGroupName string, cloudExadataInfrastructureName string) CloudExadataInfrastructureId {
+	return CloudExadataInfrastructureId{
+		SubscriptionId:                 subscriptionId,
+		ResourceGroupName:              resourceGroupName,
+		CloudExadataInfrastructureName: cloudExadataInfrastructureName,
+	}
+}
+
+// ParseCloudExadataInfrastructureID parses 'input' into a CloudExadataInfrastructureId
+func ParseCloudExadataInfrastructureID(input string) (*CloudExadataInfrastructureId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&CloudExadataInfrastructureId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := CloudExadataInfrastructureId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseCloudExadataInfrastructureIDInsensitively parses 'input' case-insensitively into a CloudExadataInfrastructureId
+// note: this method should only be used for API response data and not user input
+func ParseCloudExadataInfrastructureIDInsensitively(input string) (*CloudExadataInfrastructureId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&CloudExadataInfrastructureId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := CloudExadataInfrastructureId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *CloudExadataInfrastructureId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.CloudExadataInfrastructureName, ok = input.Parsed["cloudExadataInfrastructureName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "cloudExadataInfrastructureName", input)
+	}
+
+	return nil
+}
+
+// ValidateCloudExadataInfrastructureID checks that 'input' can be parsed as a Cloud Exadata Infrastructure ID
+func ValidateCloudExadataInfrastructureID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseCloudExadataInfrastructureID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Cloud Exadata Infrastructure ID
+func (id CloudExadataInfrastructureId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Oracle.Database/cloudExadataInfrastructures/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.CloudExadataInfrastructureName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Cloud Exadata Infrastructure ID
+func (id CloudExadataInfrastructureId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticOracleDatabase", "Oracle.Database", "Oracle.Database"),
+		resourceids.StaticSegment("staticCloudExadataInfrastructures", "cloudExadataInfrastructures", "cloudExadataInfrastructures"),
+		resourceids.UserSpecifiedSegment("cloudExadataInfrastructureName", "cloudExadataInfrastructureName"),
+	}
+}
+
+// String returns a human-readable description of this Cloud Exadata Infrastructure ID
+func (id CloudExadataInfrastructureId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Cloud Exadata Infrastructure Name: %q", id.CloudExadataInfrastructureName),
+	}
+	return fmt.Sprintf("Cloud Exadata Infrastructure (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbservers/id_dbserver.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbservers/id_dbserver.go
@@ -1,0 +1,139 @@
+package dbservers
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&DbServerId{})
+}
+
+var _ resourceids.ResourceId = &DbServerId{}
+
+// DbServerId is a struct representing the Resource ID for a Db Server
+type DbServerId struct {
+	SubscriptionId                 string
+	ResourceGroupName              string
+	CloudExadataInfrastructureName string
+	DbServerName                   string
+}
+
+// NewDbServerID returns a new DbServerId struct
+func NewDbServerID(subscriptionId string, resourceGroupName string, cloudExadataInfrastructureName string, dbServerName string) DbServerId {
+	return DbServerId{
+		SubscriptionId:                 subscriptionId,
+		ResourceGroupName:              resourceGroupName,
+		CloudExadataInfrastructureName: cloudExadataInfrastructureName,
+		DbServerName:                   dbServerName,
+	}
+}
+
+// ParseDbServerID parses 'input' into a DbServerId
+func ParseDbServerID(input string) (*DbServerId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&DbServerId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := DbServerId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseDbServerIDInsensitively parses 'input' case-insensitively into a DbServerId
+// note: this method should only be used for API response data and not user input
+func ParseDbServerIDInsensitively(input string) (*DbServerId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&DbServerId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := DbServerId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *DbServerId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.CloudExadataInfrastructureName, ok = input.Parsed["cloudExadataInfrastructureName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "cloudExadataInfrastructureName", input)
+	}
+
+	if id.DbServerName, ok = input.Parsed["dbServerName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "dbServerName", input)
+	}
+
+	return nil
+}
+
+// ValidateDbServerID checks that 'input' can be parsed as a Db Server ID
+func ValidateDbServerID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseDbServerID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Db Server ID
+func (id DbServerId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Oracle.Database/cloudExadataInfrastructures/%s/dbServers/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.CloudExadataInfrastructureName, id.DbServerName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Db Server ID
+func (id DbServerId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticOracleDatabase", "Oracle.Database", "Oracle.Database"),
+		resourceids.StaticSegment("staticCloudExadataInfrastructures", "cloudExadataInfrastructures", "cloudExadataInfrastructures"),
+		resourceids.UserSpecifiedSegment("cloudExadataInfrastructureName", "cloudExadataInfrastructureName"),
+		resourceids.StaticSegment("staticDbServers", "dbServers", "dbServers"),
+		resourceids.UserSpecifiedSegment("dbServerName", "dbServerName"),
+	}
+}
+
+// String returns a human-readable description of this Db Server ID
+func (id DbServerId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Cloud Exadata Infrastructure Name: %q", id.CloudExadataInfrastructureName),
+		fmt.Sprintf("Db Server Name: %q", id.DbServerName),
+	}
+	return fmt.Sprintf("Db Server (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbservers/method_get.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbservers/method_get.go
@@ -1,0 +1,53 @@
+package dbservers
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *DbServer
+}
+
+// Get ...
+func (c DbServersClient) Get(ctx context.Context, id DbServerId) (result GetOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model DbServer
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbservers/method_listbyparent.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbservers/method_listbyparent.go
@@ -1,0 +1,105 @@
+package dbservers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListByParentOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]DbServer
+}
+
+type ListByParentCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []DbServer
+}
+
+type ListByParentCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *ListByParentCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// ListByParent ...
+func (c DbServersClient) ListByParent(ctx context.Context, id CloudExadataInfrastructureId) (result ListByParentOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Pager:      &ListByParentCustomPager{},
+		Path:       fmt.Sprintf("%s/dbServers", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]DbServer `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListByParentComplete retrieves all the results into a single object
+func (c DbServersClient) ListByParentComplete(ctx context.Context, id CloudExadataInfrastructureId) (ListByParentCompleteResult, error) {
+	return c.ListByParentCompleteMatchingPredicate(ctx, id, DbServerOperationPredicate{})
+}
+
+// ListByParentCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c DbServersClient) ListByParentCompleteMatchingPredicate(ctx context.Context, id CloudExadataInfrastructureId, predicate DbServerOperationPredicate) (result ListByParentCompleteResult, err error) {
+	items := make([]DbServer, 0)
+
+	resp, err := c.ListByParent(ctx, id)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListByParentCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbservers/model_dbserver.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbservers/model_dbserver.go
@@ -1,0 +1,16 @@
+package dbservers
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/systemdata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DbServer struct {
+	Id         *string                `json:"id,omitempty"`
+	Name       *string                `json:"name,omitempty"`
+	Properties *DbServerProperties    `json:"properties,omitempty"`
+	SystemData *systemdata.SystemData `json:"systemData,omitempty"`
+	Type       *string                `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbservers/model_dbserverpatchingdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbservers/model_dbserverpatchingdetails.go
@@ -1,0 +1,41 @@
+package dbservers
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DbServerPatchingDetails struct {
+	EstimatedPatchDuration *int64                  `json:"estimatedPatchDuration,omitempty"`
+	PatchingStatus         *DbServerPatchingStatus `json:"patchingStatus,omitempty"`
+	TimePatchingEnded      *string                 `json:"timePatchingEnded,omitempty"`
+	TimePatchingStarted    *string                 `json:"timePatchingStarted,omitempty"`
+}
+
+func (o *DbServerPatchingDetails) GetTimePatchingEndedAsTime() (*time.Time, error) {
+	if o.TimePatchingEnded == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.TimePatchingEnded, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *DbServerPatchingDetails) SetTimePatchingEndedAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.TimePatchingEnded = &formatted
+}
+
+func (o *DbServerPatchingDetails) GetTimePatchingStartedAsTime() (*time.Time, error) {
+	if o.TimePatchingStarted == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.TimePatchingStarted, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *DbServerPatchingDetails) SetTimePatchingStartedAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.TimePatchingStarted = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbservers/model_dbserverproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbservers/model_dbserverproperties.go
@@ -1,0 +1,46 @@
+package dbservers
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DbServerProperties struct {
+	AutonomousVMClusterIds      *[]string                  `json:"autonomousVmClusterIds,omitempty"`
+	AutonomousVirtualMachineIds *[]string                  `json:"autonomousVirtualMachineIds,omitempty"`
+	CompartmentId               *string                    `json:"compartmentId,omitempty"`
+	ComputeModel                *ComputeModel              `json:"computeModel,omitempty"`
+	CpuCoreCount                *int64                     `json:"cpuCoreCount,omitempty"`
+	DbNodeIds                   *[]string                  `json:"dbNodeIds,omitempty"`
+	DbNodeStorageSizeInGbs      *int64                     `json:"dbNodeStorageSizeInGbs,omitempty"`
+	DbServerPatchingDetails     *DbServerPatchingDetails   `json:"dbServerPatchingDetails,omitempty"`
+	DisplayName                 *string                    `json:"displayName,omitempty"`
+	ExadataInfrastructureId     *string                    `json:"exadataInfrastructureId,omitempty"`
+	LifecycleDetails            *string                    `json:"lifecycleDetails,omitempty"`
+	LifecycleState              *DbServerProvisioningState `json:"lifecycleState,omitempty"`
+	MaxCPUCount                 *int64                     `json:"maxCpuCount,omitempty"`
+	MaxDbNodeStorageInGbs       *int64                     `json:"maxDbNodeStorageInGbs,omitempty"`
+	MaxMemoryInGbs              *int64                     `json:"maxMemoryInGbs,omitempty"`
+	MemorySizeInGbs             *int64                     `json:"memorySizeInGbs,omitempty"`
+	Ocid                        *string                    `json:"ocid,omitempty"`
+	ProvisioningState           *ResourceProvisioningState `json:"provisioningState,omitempty"`
+	Shape                       *string                    `json:"shape,omitempty"`
+	TimeCreated                 *string                    `json:"timeCreated,omitempty"`
+	VMClusterIds                *[]string                  `json:"vmClusterIds,omitempty"`
+}
+
+func (o *DbServerProperties) GetTimeCreatedAsTime() (*time.Time, error) {
+	if o.TimeCreated == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.TimeCreated, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *DbServerProperties) SetTimeCreatedAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.TimeCreated = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbservers/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbservers/predicates.go
@@ -1,0 +1,27 @@
+package dbservers
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DbServerOperationPredicate struct {
+	Id   *string
+	Name *string
+	Type *string
+}
+
+func (p DbServerOperationPredicate) Matches(input DbServer) bool {
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbservers/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbservers/version.go
@@ -1,0 +1,10 @@
+package dbservers
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2025-03-01"
+
+func userAgent() string {
+	return "hashicorp/go-azure-sdk/dbservers/2025-03-01"
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbsystemshapes/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbsystemshapes/README.md
@@ -1,0 +1,53 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbsystemshapes` Documentation
+
+The `dbsystemshapes` SDK allows for interaction with Azure Resource Manager `oracledatabase` (API Version `2025-03-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbsystemshapes"
+```
+
+
+### Client Initialization
+
+```go
+client := dbsystemshapes.NewDbSystemShapesClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `DbSystemShapesClient.Get`
+
+```go
+ctx := context.TODO()
+id := dbsystemshapes.NewDbSystemShapeID("12345678-1234-9876-4563-123456789012", "locationName", "dbSystemShapeName")
+
+read, err := client.Get(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `DbSystemShapesClient.ListByLocation`
+
+```go
+ctx := context.TODO()
+id := dbsystemshapes.NewLocationID("12345678-1234-9876-4563-123456789012", "locationName")
+
+// alternatively `client.ListByLocation(ctx, id, dbsystemshapes.DefaultListByLocationOperationOptions())` can be used to do batched pagination
+items, err := client.ListByLocationComplete(ctx, id, dbsystemshapes.DefaultListByLocationOperationOptions())
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbsystemshapes/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbsystemshapes/client.go
@@ -1,0 +1,26 @@
+package dbsystemshapes
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DbSystemShapesClient struct {
+	Client *resourcemanager.Client
+}
+
+func NewDbSystemShapesClientWithBaseURI(sdkApi sdkEnv.Api) (*DbSystemShapesClient, error) {
+	client, err := resourcemanager.NewClient(sdkApi, "dbsystemshapes", defaultApiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating DbSystemShapesClient: %+v", err)
+	}
+
+	return &DbSystemShapesClient{
+		Client: client,
+	}, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbsystemshapes/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbsystemshapes/constants.go
@@ -1,0 +1,51 @@
+package dbsystemshapes
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ComputeModel string
+
+const (
+	ComputeModelECPU ComputeModel = "ECPU"
+	ComputeModelOCPU ComputeModel = "OCPU"
+)
+
+func PossibleValuesForComputeModel() []string {
+	return []string{
+		string(ComputeModelECPU),
+		string(ComputeModelOCPU),
+	}
+}
+
+func (s *ComputeModel) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseComputeModel(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseComputeModel(input string) (*ComputeModel, error) {
+	vals := map[string]ComputeModel{
+		"ecpu": ComputeModelECPU,
+		"ocpu": ComputeModelOCPU,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ComputeModel(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbsystemshapes/id_dbsystemshape.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbsystemshapes/id_dbsystemshape.go
@@ -1,0 +1,130 @@
+package dbsystemshapes
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&DbSystemShapeId{})
+}
+
+var _ resourceids.ResourceId = &DbSystemShapeId{}
+
+// DbSystemShapeId is a struct representing the Resource ID for a Db System Shape
+type DbSystemShapeId struct {
+	SubscriptionId    string
+	LocationName      string
+	DbSystemShapeName string
+}
+
+// NewDbSystemShapeID returns a new DbSystemShapeId struct
+func NewDbSystemShapeID(subscriptionId string, locationName string, dbSystemShapeName string) DbSystemShapeId {
+	return DbSystemShapeId{
+		SubscriptionId:    subscriptionId,
+		LocationName:      locationName,
+		DbSystemShapeName: dbSystemShapeName,
+	}
+}
+
+// ParseDbSystemShapeID parses 'input' into a DbSystemShapeId
+func ParseDbSystemShapeID(input string) (*DbSystemShapeId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&DbSystemShapeId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := DbSystemShapeId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseDbSystemShapeIDInsensitively parses 'input' case-insensitively into a DbSystemShapeId
+// note: this method should only be used for API response data and not user input
+func ParseDbSystemShapeIDInsensitively(input string) (*DbSystemShapeId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&DbSystemShapeId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := DbSystemShapeId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *DbSystemShapeId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.LocationName, ok = input.Parsed["locationName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "locationName", input)
+	}
+
+	if id.DbSystemShapeName, ok = input.Parsed["dbSystemShapeName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "dbSystemShapeName", input)
+	}
+
+	return nil
+}
+
+// ValidateDbSystemShapeID checks that 'input' can be parsed as a Db System Shape ID
+func ValidateDbSystemShapeID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseDbSystemShapeID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Db System Shape ID
+func (id DbSystemShapeId) ID() string {
+	fmtString := "/subscriptions/%s/providers/Oracle.Database/locations/%s/dbSystemShapes/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.LocationName, id.DbSystemShapeName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Db System Shape ID
+func (id DbSystemShapeId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticOracleDatabase", "Oracle.Database", "Oracle.Database"),
+		resourceids.StaticSegment("staticLocations", "locations", "locations"),
+		resourceids.UserSpecifiedSegment("locationName", "locationName"),
+		resourceids.StaticSegment("staticDbSystemShapes", "dbSystemShapes", "dbSystemShapes"),
+		resourceids.UserSpecifiedSegment("dbSystemShapeName", "dbSystemShapeName"),
+	}
+}
+
+// String returns a human-readable description of this Db System Shape ID
+func (id DbSystemShapeId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Location Name: %q", id.LocationName),
+		fmt.Sprintf("Db System Shape Name: %q", id.DbSystemShapeName),
+	}
+	return fmt.Sprintf("Db System Shape (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbsystemshapes/id_location.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbsystemshapes/id_location.go
@@ -1,0 +1,121 @@
+package dbsystemshapes
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&LocationId{})
+}
+
+var _ resourceids.ResourceId = &LocationId{}
+
+// LocationId is a struct representing the Resource ID for a Location
+type LocationId struct {
+	SubscriptionId string
+	LocationName   string
+}
+
+// NewLocationID returns a new LocationId struct
+func NewLocationID(subscriptionId string, locationName string) LocationId {
+	return LocationId{
+		SubscriptionId: subscriptionId,
+		LocationName:   locationName,
+	}
+}
+
+// ParseLocationID parses 'input' into a LocationId
+func ParseLocationID(input string) (*LocationId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&LocationId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := LocationId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseLocationIDInsensitively parses 'input' case-insensitively into a LocationId
+// note: this method should only be used for API response data and not user input
+func ParseLocationIDInsensitively(input string) (*LocationId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&LocationId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := LocationId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *LocationId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.LocationName, ok = input.Parsed["locationName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "locationName", input)
+	}
+
+	return nil
+}
+
+// ValidateLocationID checks that 'input' can be parsed as a Location ID
+func ValidateLocationID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseLocationID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Location ID
+func (id LocationId) ID() string {
+	fmtString := "/subscriptions/%s/providers/Oracle.Database/locations/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.LocationName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Location ID
+func (id LocationId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticOracleDatabase", "Oracle.Database", "Oracle.Database"),
+		resourceids.StaticSegment("staticLocations", "locations", "locations"),
+		resourceids.UserSpecifiedSegment("locationName", "locationName"),
+	}
+}
+
+// String returns a human-readable description of this Location ID
+func (id LocationId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Location Name: %q", id.LocationName),
+	}
+	return fmt.Sprintf("Location (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbsystemshapes/method_get.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbsystemshapes/method_get.go
@@ -1,0 +1,53 @@
+package dbsystemshapes
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *DbSystemShape
+}
+
+// Get ...
+func (c DbSystemShapesClient) Get(ctx context.Context, id DbSystemShapeId) (result GetOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model DbSystemShape
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbsystemshapes/method_listbylocation.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbsystemshapes/method_listbylocation.go
@@ -1,0 +1,134 @@
+package dbsystemshapes
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListByLocationOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]DbSystemShape
+}
+
+type ListByLocationCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []DbSystemShape
+}
+
+type ListByLocationOperationOptions struct {
+	Zone *string
+}
+
+func DefaultListByLocationOperationOptions() ListByLocationOperationOptions {
+	return ListByLocationOperationOptions{}
+}
+
+func (o ListByLocationOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+
+	return &out
+}
+
+func (o ListByLocationOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+
+	return &out
+}
+
+func (o ListByLocationOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+	if o.Zone != nil {
+		out.Append("zone", fmt.Sprintf("%v", *o.Zone))
+	}
+	return &out
+}
+
+type ListByLocationCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *ListByLocationCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// ListByLocation ...
+func (c DbSystemShapesClient) ListByLocation(ctx context.Context, id LocationId, options ListByLocationOperationOptions) (result ListByLocationOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodGet,
+		OptionsObject: options,
+		Pager:         &ListByLocationCustomPager{},
+		Path:          fmt.Sprintf("%s/dbSystemShapes", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]DbSystemShape `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListByLocationComplete retrieves all the results into a single object
+func (c DbSystemShapesClient) ListByLocationComplete(ctx context.Context, id LocationId, options ListByLocationOperationOptions) (ListByLocationCompleteResult, error) {
+	return c.ListByLocationCompleteMatchingPredicate(ctx, id, options, DbSystemShapeOperationPredicate{})
+}
+
+// ListByLocationCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c DbSystemShapesClient) ListByLocationCompleteMatchingPredicate(ctx context.Context, id LocationId, options ListByLocationOperationOptions, predicate DbSystemShapeOperationPredicate) (result ListByLocationCompleteResult, err error) {
+	items := make([]DbSystemShape, 0)
+
+	resp, err := c.ListByLocation(ctx, id, options)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListByLocationCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbsystemshapes/model_dbsystemshape.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbsystemshapes/model_dbsystemshape.go
@@ -1,0 +1,16 @@
+package dbsystemshapes
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/systemdata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DbSystemShape struct {
+	Id         *string                  `json:"id,omitempty"`
+	Name       *string                  `json:"name,omitempty"`
+	Properties *DbSystemShapeProperties `json:"properties,omitempty"`
+	SystemData *systemdata.SystemData   `json:"systemData,omitempty"`
+	Type       *string                  `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbsystemshapes/model_dbsystemshapeproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbsystemshapes/model_dbsystemshapeproperties.go
@@ -1,0 +1,31 @@
+package dbsystemshapes
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DbSystemShapeProperties struct {
+	AreServerTypesSupported            *bool         `json:"areServerTypesSupported,omitempty"`
+	AvailableCoreCount                 int64         `json:"availableCoreCount"`
+	AvailableCoreCountPerNode          *int64        `json:"availableCoreCountPerNode,omitempty"`
+	AvailableDataStorageInTbs          *int64        `json:"availableDataStorageInTbs,omitempty"`
+	AvailableDataStoragePerServerInTbs *float64      `json:"availableDataStoragePerServerInTbs,omitempty"`
+	AvailableDbNodePerNodeInGbs        *int64        `json:"availableDbNodePerNodeInGbs,omitempty"`
+	AvailableDbNodeStorageInGbs        *int64        `json:"availableDbNodeStorageInGbs,omitempty"`
+	AvailableMemoryInGbs               *int64        `json:"availableMemoryInGbs,omitempty"`
+	AvailableMemoryPerNodeInGbs        *int64        `json:"availableMemoryPerNodeInGbs,omitempty"`
+	ComputeModel                       *ComputeModel `json:"computeModel,omitempty"`
+	CoreCountIncrement                 *int64        `json:"coreCountIncrement,omitempty"`
+	DisplayName                        *string       `json:"displayName,omitempty"`
+	MaxStorageCount                    *int64        `json:"maxStorageCount,omitempty"`
+	MaximumNodeCount                   *int64        `json:"maximumNodeCount,omitempty"`
+	MinCoreCountPerNode                *int64        `json:"minCoreCountPerNode,omitempty"`
+	MinDataStorageInTbs                *int64        `json:"minDataStorageInTbs,omitempty"`
+	MinDbNodeStoragePerNodeInGbs       *int64        `json:"minDbNodeStoragePerNodeInGbs,omitempty"`
+	MinMemoryPerNodeInGbs              *int64        `json:"minMemoryPerNodeInGbs,omitempty"`
+	MinStorageCount                    *int64        `json:"minStorageCount,omitempty"`
+	MinimumCoreCount                   *int64        `json:"minimumCoreCount,omitempty"`
+	MinimumNodeCount                   *int64        `json:"minimumNodeCount,omitempty"`
+	RuntimeMinimumCoreCount            *int64        `json:"runtimeMinimumCoreCount,omitempty"`
+	ShapeFamily                        *string       `json:"shapeFamily,omitempty"`
+	ShapeName                          string        `json:"shapeName"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbsystemshapes/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbsystemshapes/predicates.go
@@ -1,0 +1,27 @@
+package dbsystemshapes
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DbSystemShapeOperationPredicate struct {
+	Id   *string
+	Name *string
+	Type *string
+}
+
+func (p DbSystemShapeOperationPredicate) Matches(input DbSystemShape) bool {
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbsystemshapes/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbsystemshapes/version.go
@@ -1,0 +1,10 @@
+package dbsystemshapes
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2025-03-01"
+
+func userAgent() string {
+	return "hashicorp/go-azure-sdk/dbsystemshapes/2025-03-01"
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dnsprivateviews/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dnsprivateviews/README.md
@@ -1,0 +1,53 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dnsprivateviews` Documentation
+
+The `dnsprivateviews` SDK allows for interaction with Azure Resource Manager `oracledatabase` (API Version `2025-03-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dnsprivateviews"
+```
+
+
+### Client Initialization
+
+```go
+client := dnsprivateviews.NewDnsPrivateViewsClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `DnsPrivateViewsClient.Get`
+
+```go
+ctx := context.TODO()
+id := dnsprivateviews.NewDnsPrivateViewID("12345678-1234-9876-4563-123456789012", "locationName", "dnsPrivateViewName")
+
+read, err := client.Get(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `DnsPrivateViewsClient.ListByLocation`
+
+```go
+ctx := context.TODO()
+id := dnsprivateviews.NewLocationID("12345678-1234-9876-4563-123456789012", "locationName")
+
+// alternatively `client.ListByLocation(ctx, id)` can be used to do batched pagination
+items, err := client.ListByLocationComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dnsprivateviews/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dnsprivateviews/client.go
@@ -1,0 +1,26 @@
+package dnsprivateviews
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DnsPrivateViewsClient struct {
+	Client *resourcemanager.Client
+}
+
+func NewDnsPrivateViewsClientWithBaseURI(sdkApi sdkEnv.Api) (*DnsPrivateViewsClient, error) {
+	client, err := resourcemanager.NewClient(sdkApi, "dnsprivateviews", defaultApiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating DnsPrivateViewsClient: %+v", err)
+	}
+
+	return &DnsPrivateViewsClient{
+		Client: client,
+	}, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dnsprivateviews/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dnsprivateviews/constants.go
@@ -1,0 +1,101 @@
+package dnsprivateviews
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DnsPrivateViewsLifecycleState string
+
+const (
+	DnsPrivateViewsLifecycleStateActive   DnsPrivateViewsLifecycleState = "Active"
+	DnsPrivateViewsLifecycleStateDeleted  DnsPrivateViewsLifecycleState = "Deleted"
+	DnsPrivateViewsLifecycleStateDeleting DnsPrivateViewsLifecycleState = "Deleting"
+	DnsPrivateViewsLifecycleStateUpdating DnsPrivateViewsLifecycleState = "Updating"
+)
+
+func PossibleValuesForDnsPrivateViewsLifecycleState() []string {
+	return []string{
+		string(DnsPrivateViewsLifecycleStateActive),
+		string(DnsPrivateViewsLifecycleStateDeleted),
+		string(DnsPrivateViewsLifecycleStateDeleting),
+		string(DnsPrivateViewsLifecycleStateUpdating),
+	}
+}
+
+func (s *DnsPrivateViewsLifecycleState) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseDnsPrivateViewsLifecycleState(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseDnsPrivateViewsLifecycleState(input string) (*DnsPrivateViewsLifecycleState, error) {
+	vals := map[string]DnsPrivateViewsLifecycleState{
+		"active":   DnsPrivateViewsLifecycleStateActive,
+		"deleted":  DnsPrivateViewsLifecycleStateDeleted,
+		"deleting": DnsPrivateViewsLifecycleStateDeleting,
+		"updating": DnsPrivateViewsLifecycleStateUpdating,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := DnsPrivateViewsLifecycleState(input)
+	return &out, nil
+}
+
+type ResourceProvisioningState string
+
+const (
+	ResourceProvisioningStateCanceled  ResourceProvisioningState = "Canceled"
+	ResourceProvisioningStateFailed    ResourceProvisioningState = "Failed"
+	ResourceProvisioningStateSucceeded ResourceProvisioningState = "Succeeded"
+)
+
+func PossibleValuesForResourceProvisioningState() []string {
+	return []string{
+		string(ResourceProvisioningStateCanceled),
+		string(ResourceProvisioningStateFailed),
+		string(ResourceProvisioningStateSucceeded),
+	}
+}
+
+func (s *ResourceProvisioningState) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseResourceProvisioningState(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseResourceProvisioningState(input string) (*ResourceProvisioningState, error) {
+	vals := map[string]ResourceProvisioningState{
+		"canceled":  ResourceProvisioningStateCanceled,
+		"failed":    ResourceProvisioningStateFailed,
+		"succeeded": ResourceProvisioningStateSucceeded,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ResourceProvisioningState(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dnsprivateviews/id_dnsprivateview.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dnsprivateviews/id_dnsprivateview.go
@@ -1,0 +1,130 @@
+package dnsprivateviews
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&DnsPrivateViewId{})
+}
+
+var _ resourceids.ResourceId = &DnsPrivateViewId{}
+
+// DnsPrivateViewId is a struct representing the Resource ID for a Dns Private View
+type DnsPrivateViewId struct {
+	SubscriptionId     string
+	LocationName       string
+	DnsPrivateViewName string
+}
+
+// NewDnsPrivateViewID returns a new DnsPrivateViewId struct
+func NewDnsPrivateViewID(subscriptionId string, locationName string, dnsPrivateViewName string) DnsPrivateViewId {
+	return DnsPrivateViewId{
+		SubscriptionId:     subscriptionId,
+		LocationName:       locationName,
+		DnsPrivateViewName: dnsPrivateViewName,
+	}
+}
+
+// ParseDnsPrivateViewID parses 'input' into a DnsPrivateViewId
+func ParseDnsPrivateViewID(input string) (*DnsPrivateViewId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&DnsPrivateViewId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := DnsPrivateViewId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseDnsPrivateViewIDInsensitively parses 'input' case-insensitively into a DnsPrivateViewId
+// note: this method should only be used for API response data and not user input
+func ParseDnsPrivateViewIDInsensitively(input string) (*DnsPrivateViewId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&DnsPrivateViewId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := DnsPrivateViewId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *DnsPrivateViewId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.LocationName, ok = input.Parsed["locationName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "locationName", input)
+	}
+
+	if id.DnsPrivateViewName, ok = input.Parsed["dnsPrivateViewName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "dnsPrivateViewName", input)
+	}
+
+	return nil
+}
+
+// ValidateDnsPrivateViewID checks that 'input' can be parsed as a Dns Private View ID
+func ValidateDnsPrivateViewID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseDnsPrivateViewID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Dns Private View ID
+func (id DnsPrivateViewId) ID() string {
+	fmtString := "/subscriptions/%s/providers/Oracle.Database/locations/%s/dnsPrivateViews/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.LocationName, id.DnsPrivateViewName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Dns Private View ID
+func (id DnsPrivateViewId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticOracleDatabase", "Oracle.Database", "Oracle.Database"),
+		resourceids.StaticSegment("staticLocations", "locations", "locations"),
+		resourceids.UserSpecifiedSegment("locationName", "locationName"),
+		resourceids.StaticSegment("staticDnsPrivateViews", "dnsPrivateViews", "dnsPrivateViews"),
+		resourceids.UserSpecifiedSegment("dnsPrivateViewName", "dnsPrivateViewName"),
+	}
+}
+
+// String returns a human-readable description of this Dns Private View ID
+func (id DnsPrivateViewId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Location Name: %q", id.LocationName),
+		fmt.Sprintf("Dns Private View Name: %q", id.DnsPrivateViewName),
+	}
+	return fmt.Sprintf("Dns Private View (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dnsprivateviews/id_location.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dnsprivateviews/id_location.go
@@ -1,0 +1,121 @@
+package dnsprivateviews
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&LocationId{})
+}
+
+var _ resourceids.ResourceId = &LocationId{}
+
+// LocationId is a struct representing the Resource ID for a Location
+type LocationId struct {
+	SubscriptionId string
+	LocationName   string
+}
+
+// NewLocationID returns a new LocationId struct
+func NewLocationID(subscriptionId string, locationName string) LocationId {
+	return LocationId{
+		SubscriptionId: subscriptionId,
+		LocationName:   locationName,
+	}
+}
+
+// ParseLocationID parses 'input' into a LocationId
+func ParseLocationID(input string) (*LocationId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&LocationId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := LocationId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseLocationIDInsensitively parses 'input' case-insensitively into a LocationId
+// note: this method should only be used for API response data and not user input
+func ParseLocationIDInsensitively(input string) (*LocationId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&LocationId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := LocationId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *LocationId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.LocationName, ok = input.Parsed["locationName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "locationName", input)
+	}
+
+	return nil
+}
+
+// ValidateLocationID checks that 'input' can be parsed as a Location ID
+func ValidateLocationID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseLocationID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Location ID
+func (id LocationId) ID() string {
+	fmtString := "/subscriptions/%s/providers/Oracle.Database/locations/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.LocationName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Location ID
+func (id LocationId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticOracleDatabase", "Oracle.Database", "Oracle.Database"),
+		resourceids.StaticSegment("staticLocations", "locations", "locations"),
+		resourceids.UserSpecifiedSegment("locationName", "locationName"),
+	}
+}
+
+// String returns a human-readable description of this Location ID
+func (id LocationId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Location Name: %q", id.LocationName),
+	}
+	return fmt.Sprintf("Location (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dnsprivateviews/method_get.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dnsprivateviews/method_get.go
@@ -1,0 +1,53 @@
+package dnsprivateviews
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *DnsPrivateView
+}
+
+// Get ...
+func (c DnsPrivateViewsClient) Get(ctx context.Context, id DnsPrivateViewId) (result GetOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model DnsPrivateView
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dnsprivateviews/method_listbylocation.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dnsprivateviews/method_listbylocation.go
@@ -1,0 +1,105 @@
+package dnsprivateviews
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListByLocationOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]DnsPrivateView
+}
+
+type ListByLocationCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []DnsPrivateView
+}
+
+type ListByLocationCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *ListByLocationCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// ListByLocation ...
+func (c DnsPrivateViewsClient) ListByLocation(ctx context.Context, id LocationId) (result ListByLocationOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Pager:      &ListByLocationCustomPager{},
+		Path:       fmt.Sprintf("%s/dnsPrivateViews", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]DnsPrivateView `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListByLocationComplete retrieves all the results into a single object
+func (c DnsPrivateViewsClient) ListByLocationComplete(ctx context.Context, id LocationId) (ListByLocationCompleteResult, error) {
+	return c.ListByLocationCompleteMatchingPredicate(ctx, id, DnsPrivateViewOperationPredicate{})
+}
+
+// ListByLocationCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c DnsPrivateViewsClient) ListByLocationCompleteMatchingPredicate(ctx context.Context, id LocationId, predicate DnsPrivateViewOperationPredicate) (result ListByLocationCompleteResult, err error) {
+	items := make([]DnsPrivateView, 0)
+
+	resp, err := c.ListByLocation(ctx, id)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListByLocationCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dnsprivateviews/model_dnsprivateview.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dnsprivateviews/model_dnsprivateview.go
@@ -1,0 +1,16 @@
+package dnsprivateviews
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/systemdata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DnsPrivateView struct {
+	Id         *string                   `json:"id,omitempty"`
+	Name       *string                   `json:"name,omitempty"`
+	Properties *DnsPrivateViewProperties `json:"properties,omitempty"`
+	SystemData *systemdata.SystemData    `json:"systemData,omitempty"`
+	Type       *string                   `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dnsprivateviews/model_dnsprivateviewproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dnsprivateviews/model_dnsprivateviewproperties.go
@@ -1,0 +1,39 @@
+package dnsprivateviews
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DnsPrivateViewProperties struct {
+	DisplayName       string                        `json:"displayName"`
+	IsProtected       bool                          `json:"isProtected"`
+	LifecycleState    DnsPrivateViewsLifecycleState `json:"lifecycleState"`
+	Ocid              string                        `json:"ocid"`
+	ProvisioningState *ResourceProvisioningState    `json:"provisioningState,omitempty"`
+	Self              string                        `json:"self"`
+	TimeCreated       string                        `json:"timeCreated"`
+	TimeUpdated       string                        `json:"timeUpdated"`
+}
+
+func (o *DnsPrivateViewProperties) GetTimeCreatedAsTime() (*time.Time, error) {
+	return dates.ParseAsFormat(&o.TimeCreated, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *DnsPrivateViewProperties) SetTimeCreatedAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.TimeCreated = formatted
+}
+
+func (o *DnsPrivateViewProperties) GetTimeUpdatedAsTime() (*time.Time, error) {
+	return dates.ParseAsFormat(&o.TimeUpdated, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *DnsPrivateViewProperties) SetTimeUpdatedAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.TimeUpdated = formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dnsprivateviews/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dnsprivateviews/predicates.go
@@ -1,0 +1,27 @@
+package dnsprivateviews
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DnsPrivateViewOperationPredicate struct {
+	Id   *string
+	Name *string
+	Type *string
+}
+
+func (p DnsPrivateViewOperationPredicate) Matches(input DnsPrivateView) bool {
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dnsprivateviews/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dnsprivateviews/version.go
@@ -1,0 +1,10 @@
+package dnsprivateviews
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2025-03-01"
+
+func userAgent() string {
+	return "hashicorp/go-azure-sdk/dnsprivateviews/2025-03-01"
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dnsprivatezones/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dnsprivatezones/README.md
@@ -1,0 +1,53 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dnsprivatezones` Documentation
+
+The `dnsprivatezones` SDK allows for interaction with Azure Resource Manager `oracledatabase` (API Version `2025-03-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dnsprivatezones"
+```
+
+
+### Client Initialization
+
+```go
+client := dnsprivatezones.NewDnsPrivateZonesClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `DnsPrivateZonesClient.Get`
+
+```go
+ctx := context.TODO()
+id := dnsprivatezones.NewDnsPrivateZoneID("12345678-1234-9876-4563-123456789012", "locationName", "dnsPrivateZoneName")
+
+read, err := client.Get(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `DnsPrivateZonesClient.ListByLocation`
+
+```go
+ctx := context.TODO()
+id := dnsprivatezones.NewLocationID("12345678-1234-9876-4563-123456789012", "locationName")
+
+// alternatively `client.ListByLocation(ctx, id)` can be used to do batched pagination
+items, err := client.ListByLocationComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dnsprivatezones/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dnsprivatezones/client.go
@@ -1,0 +1,26 @@
+package dnsprivatezones
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DnsPrivateZonesClient struct {
+	Client *resourcemanager.Client
+}
+
+func NewDnsPrivateZonesClientWithBaseURI(sdkApi sdkEnv.Api) (*DnsPrivateZonesClient, error) {
+	client, err := resourcemanager.NewClient(sdkApi, "dnsprivatezones", defaultApiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating DnsPrivateZonesClient: %+v", err)
+	}
+
+	return &DnsPrivateZonesClient{
+		Client: client,
+	}, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dnsprivatezones/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dnsprivatezones/constants.go
@@ -1,0 +1,145 @@
+package dnsprivatezones
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DnsPrivateZonesLifecycleState string
+
+const (
+	DnsPrivateZonesLifecycleStateActive   DnsPrivateZonesLifecycleState = "Active"
+	DnsPrivateZonesLifecycleStateCreating DnsPrivateZonesLifecycleState = "Creating"
+	DnsPrivateZonesLifecycleStateDeleted  DnsPrivateZonesLifecycleState = "Deleted"
+	DnsPrivateZonesLifecycleStateDeleting DnsPrivateZonesLifecycleState = "Deleting"
+	DnsPrivateZonesLifecycleStateUpdating DnsPrivateZonesLifecycleState = "Updating"
+)
+
+func PossibleValuesForDnsPrivateZonesLifecycleState() []string {
+	return []string{
+		string(DnsPrivateZonesLifecycleStateActive),
+		string(DnsPrivateZonesLifecycleStateCreating),
+		string(DnsPrivateZonesLifecycleStateDeleted),
+		string(DnsPrivateZonesLifecycleStateDeleting),
+		string(DnsPrivateZonesLifecycleStateUpdating),
+	}
+}
+
+func (s *DnsPrivateZonesLifecycleState) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseDnsPrivateZonesLifecycleState(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseDnsPrivateZonesLifecycleState(input string) (*DnsPrivateZonesLifecycleState, error) {
+	vals := map[string]DnsPrivateZonesLifecycleState{
+		"active":   DnsPrivateZonesLifecycleStateActive,
+		"creating": DnsPrivateZonesLifecycleStateCreating,
+		"deleted":  DnsPrivateZonesLifecycleStateDeleted,
+		"deleting": DnsPrivateZonesLifecycleStateDeleting,
+		"updating": DnsPrivateZonesLifecycleStateUpdating,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := DnsPrivateZonesLifecycleState(input)
+	return &out, nil
+}
+
+type ResourceProvisioningState string
+
+const (
+	ResourceProvisioningStateCanceled  ResourceProvisioningState = "Canceled"
+	ResourceProvisioningStateFailed    ResourceProvisioningState = "Failed"
+	ResourceProvisioningStateSucceeded ResourceProvisioningState = "Succeeded"
+)
+
+func PossibleValuesForResourceProvisioningState() []string {
+	return []string{
+		string(ResourceProvisioningStateCanceled),
+		string(ResourceProvisioningStateFailed),
+		string(ResourceProvisioningStateSucceeded),
+	}
+}
+
+func (s *ResourceProvisioningState) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseResourceProvisioningState(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseResourceProvisioningState(input string) (*ResourceProvisioningState, error) {
+	vals := map[string]ResourceProvisioningState{
+		"canceled":  ResourceProvisioningStateCanceled,
+		"failed":    ResourceProvisioningStateFailed,
+		"succeeded": ResourceProvisioningStateSucceeded,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ResourceProvisioningState(input)
+	return &out, nil
+}
+
+type ZoneType string
+
+const (
+	ZoneTypePrimary   ZoneType = "Primary"
+	ZoneTypeSecondary ZoneType = "Secondary"
+)
+
+func PossibleValuesForZoneType() []string {
+	return []string{
+		string(ZoneTypePrimary),
+		string(ZoneTypeSecondary),
+	}
+}
+
+func (s *ZoneType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseZoneType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseZoneType(input string) (*ZoneType, error) {
+	vals := map[string]ZoneType{
+		"primary":   ZoneTypePrimary,
+		"secondary": ZoneTypeSecondary,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ZoneType(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dnsprivatezones/id_dnsprivatezone.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dnsprivatezones/id_dnsprivatezone.go
@@ -1,0 +1,130 @@
+package dnsprivatezones
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&DnsPrivateZoneId{})
+}
+
+var _ resourceids.ResourceId = &DnsPrivateZoneId{}
+
+// DnsPrivateZoneId is a struct representing the Resource ID for a Dns Private Zone
+type DnsPrivateZoneId struct {
+	SubscriptionId     string
+	LocationName       string
+	DnsPrivateZoneName string
+}
+
+// NewDnsPrivateZoneID returns a new DnsPrivateZoneId struct
+func NewDnsPrivateZoneID(subscriptionId string, locationName string, dnsPrivateZoneName string) DnsPrivateZoneId {
+	return DnsPrivateZoneId{
+		SubscriptionId:     subscriptionId,
+		LocationName:       locationName,
+		DnsPrivateZoneName: dnsPrivateZoneName,
+	}
+}
+
+// ParseDnsPrivateZoneID parses 'input' into a DnsPrivateZoneId
+func ParseDnsPrivateZoneID(input string) (*DnsPrivateZoneId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&DnsPrivateZoneId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := DnsPrivateZoneId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseDnsPrivateZoneIDInsensitively parses 'input' case-insensitively into a DnsPrivateZoneId
+// note: this method should only be used for API response data and not user input
+func ParseDnsPrivateZoneIDInsensitively(input string) (*DnsPrivateZoneId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&DnsPrivateZoneId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := DnsPrivateZoneId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *DnsPrivateZoneId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.LocationName, ok = input.Parsed["locationName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "locationName", input)
+	}
+
+	if id.DnsPrivateZoneName, ok = input.Parsed["dnsPrivateZoneName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "dnsPrivateZoneName", input)
+	}
+
+	return nil
+}
+
+// ValidateDnsPrivateZoneID checks that 'input' can be parsed as a Dns Private Zone ID
+func ValidateDnsPrivateZoneID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseDnsPrivateZoneID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Dns Private Zone ID
+func (id DnsPrivateZoneId) ID() string {
+	fmtString := "/subscriptions/%s/providers/Oracle.Database/locations/%s/dnsPrivateZones/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.LocationName, id.DnsPrivateZoneName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Dns Private Zone ID
+func (id DnsPrivateZoneId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticOracleDatabase", "Oracle.Database", "Oracle.Database"),
+		resourceids.StaticSegment("staticLocations", "locations", "locations"),
+		resourceids.UserSpecifiedSegment("locationName", "locationName"),
+		resourceids.StaticSegment("staticDnsPrivateZones", "dnsPrivateZones", "dnsPrivateZones"),
+		resourceids.UserSpecifiedSegment("dnsPrivateZoneName", "dnsPrivateZoneName"),
+	}
+}
+
+// String returns a human-readable description of this Dns Private Zone ID
+func (id DnsPrivateZoneId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Location Name: %q", id.LocationName),
+		fmt.Sprintf("Dns Private Zone Name: %q", id.DnsPrivateZoneName),
+	}
+	return fmt.Sprintf("Dns Private Zone (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dnsprivatezones/id_location.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dnsprivatezones/id_location.go
@@ -1,0 +1,121 @@
+package dnsprivatezones
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&LocationId{})
+}
+
+var _ resourceids.ResourceId = &LocationId{}
+
+// LocationId is a struct representing the Resource ID for a Location
+type LocationId struct {
+	SubscriptionId string
+	LocationName   string
+}
+
+// NewLocationID returns a new LocationId struct
+func NewLocationID(subscriptionId string, locationName string) LocationId {
+	return LocationId{
+		SubscriptionId: subscriptionId,
+		LocationName:   locationName,
+	}
+}
+
+// ParseLocationID parses 'input' into a LocationId
+func ParseLocationID(input string) (*LocationId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&LocationId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := LocationId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseLocationIDInsensitively parses 'input' case-insensitively into a LocationId
+// note: this method should only be used for API response data and not user input
+func ParseLocationIDInsensitively(input string) (*LocationId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&LocationId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := LocationId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *LocationId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.LocationName, ok = input.Parsed["locationName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "locationName", input)
+	}
+
+	return nil
+}
+
+// ValidateLocationID checks that 'input' can be parsed as a Location ID
+func ValidateLocationID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseLocationID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Location ID
+func (id LocationId) ID() string {
+	fmtString := "/subscriptions/%s/providers/Oracle.Database/locations/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.LocationName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Location ID
+func (id LocationId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticOracleDatabase", "Oracle.Database", "Oracle.Database"),
+		resourceids.StaticSegment("staticLocations", "locations", "locations"),
+		resourceids.UserSpecifiedSegment("locationName", "locationName"),
+	}
+}
+
+// String returns a human-readable description of this Location ID
+func (id LocationId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Location Name: %q", id.LocationName),
+	}
+	return fmt.Sprintf("Location (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dnsprivatezones/method_get.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dnsprivatezones/method_get.go
@@ -1,0 +1,53 @@
+package dnsprivatezones
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *DnsPrivateZone
+}
+
+// Get ...
+func (c DnsPrivateZonesClient) Get(ctx context.Context, id DnsPrivateZoneId) (result GetOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model DnsPrivateZone
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dnsprivatezones/method_listbylocation.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dnsprivatezones/method_listbylocation.go
@@ -1,0 +1,105 @@
+package dnsprivatezones
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListByLocationOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]DnsPrivateZone
+}
+
+type ListByLocationCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []DnsPrivateZone
+}
+
+type ListByLocationCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *ListByLocationCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// ListByLocation ...
+func (c DnsPrivateZonesClient) ListByLocation(ctx context.Context, id LocationId) (result ListByLocationOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Pager:      &ListByLocationCustomPager{},
+		Path:       fmt.Sprintf("%s/dnsPrivateZones", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]DnsPrivateZone `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListByLocationComplete retrieves all the results into a single object
+func (c DnsPrivateZonesClient) ListByLocationComplete(ctx context.Context, id LocationId) (ListByLocationCompleteResult, error) {
+	return c.ListByLocationCompleteMatchingPredicate(ctx, id, DnsPrivateZoneOperationPredicate{})
+}
+
+// ListByLocationCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c DnsPrivateZonesClient) ListByLocationCompleteMatchingPredicate(ctx context.Context, id LocationId, predicate DnsPrivateZoneOperationPredicate) (result ListByLocationCompleteResult, err error) {
+	items := make([]DnsPrivateZone, 0)
+
+	resp, err := c.ListByLocation(ctx, id)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListByLocationCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dnsprivatezones/model_dnsprivatezone.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dnsprivatezones/model_dnsprivatezone.go
@@ -1,0 +1,16 @@
+package dnsprivatezones
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/systemdata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DnsPrivateZone struct {
+	Id         *string                   `json:"id,omitempty"`
+	Name       *string                   `json:"name,omitempty"`
+	Properties *DnsPrivateZoneProperties `json:"properties,omitempty"`
+	SystemData *systemdata.SystemData    `json:"systemData,omitempty"`
+	Type       *string                   `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dnsprivatezones/model_dnsprivatezoneproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dnsprivatezones/model_dnsprivatezoneproperties.go
@@ -1,0 +1,32 @@
+package dnsprivatezones
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DnsPrivateZoneProperties struct {
+	IsProtected       bool                          `json:"isProtected"`
+	LifecycleState    DnsPrivateZonesLifecycleState `json:"lifecycleState"`
+	Ocid              string                        `json:"ocid"`
+	ProvisioningState *ResourceProvisioningState    `json:"provisioningState,omitempty"`
+	Self              string                        `json:"self"`
+	Serial            int64                         `json:"serial"`
+	TimeCreated       string                        `json:"timeCreated"`
+	Version           string                        `json:"version"`
+	ViewId            *string                       `json:"viewId,omitempty"`
+	ZoneType          ZoneType                      `json:"zoneType"`
+}
+
+func (o *DnsPrivateZoneProperties) GetTimeCreatedAsTime() (*time.Time, error) {
+	return dates.ParseAsFormat(&o.TimeCreated, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *DnsPrivateZoneProperties) SetTimeCreatedAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.TimeCreated = formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dnsprivatezones/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dnsprivatezones/predicates.go
@@ -1,0 +1,27 @@
+package dnsprivatezones
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DnsPrivateZoneOperationPredicate struct {
+	Id   *string
+	Name *string
+	Type *string
+}
+
+func (p DnsPrivateZoneOperationPredicate) Matches(input DnsPrivateZone) bool {
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dnsprivatezones/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dnsprivatezones/version.go
@@ -1,0 +1,10 @@
+package dnsprivatezones
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2025-03-01"
+
+func userAgent() string {
+	return "hashicorp/go-azure-sdk/dnsprivatezones/2025-03-01"
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exadbvmclusters/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exadbvmclusters/README.md
@@ -1,0 +1,134 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exadbvmclusters` Documentation
+
+The `exadbvmclusters` SDK allows for interaction with Azure Resource Manager `oracledatabase` (API Version `2025-03-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+import "github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exadbvmclusters"
+```
+
+
+### Client Initialization
+
+```go
+client := exadbvmclusters.NewExadbVMClustersClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `ExadbVMClustersClient.CreateOrUpdate`
+
+```go
+ctx := context.TODO()
+id := exadbvmclusters.NewExadbVMClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "exadbVmClusterName")
+
+payload := exadbvmclusters.ExadbVMCluster{
+	// ...
+}
+
+
+if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `ExadbVMClustersClient.Delete`
+
+```go
+ctx := context.TODO()
+id := exadbvmclusters.NewExadbVMClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "exadbVmClusterName")
+
+if err := client.DeleteThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `ExadbVMClustersClient.Get`
+
+```go
+ctx := context.TODO()
+id := exadbvmclusters.NewExadbVMClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "exadbVmClusterName")
+
+read, err := client.Get(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `ExadbVMClustersClient.ListByResourceGroup`
+
+```go
+ctx := context.TODO()
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+
+// alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
+items, err := client.ListByResourceGroupComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `ExadbVMClustersClient.ListBySubscription`
+
+```go
+ctx := context.TODO()
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+
+// alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
+items, err := client.ListBySubscriptionComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `ExadbVMClustersClient.RemoveVMs`
+
+```go
+ctx := context.TODO()
+id := exadbvmclusters.NewExadbVMClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "exadbVmClusterName")
+
+payload := exadbvmclusters.RemoveVirtualMachineFromExadbVMClusterDetails{
+	// ...
+}
+
+
+if err := client.RemoveVMsThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `ExadbVMClustersClient.Update`
+
+```go
+ctx := context.TODO()
+id := exadbvmclusters.NewExadbVMClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "exadbVmClusterName")
+
+payload := exadbvmclusters.ExadbVMClusterUpdate{
+	// ...
+}
+
+
+if err := client.UpdateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exadbvmclusters/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exadbvmclusters/client.go
@@ -1,0 +1,26 @@
+package exadbvmclusters
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ExadbVMClustersClient struct {
+	Client *resourcemanager.Client
+}
+
+func NewExadbVMClustersClientWithBaseURI(sdkApi sdkEnv.Api) (*ExadbVMClustersClient, error) {
+	client, err := resourcemanager.NewClient(sdkApi, "exadbvmclusters", defaultApiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating ExadbVMClustersClient: %+v", err)
+	}
+
+	return &ExadbVMClustersClient{
+		Client: client,
+	}, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exadbvmclusters/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exadbvmclusters/constants.go
@@ -1,0 +1,295 @@
+package exadbvmclusters
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AzureResourceProvisioningState string
+
+const (
+	AzureResourceProvisioningStateCanceled     AzureResourceProvisioningState = "Canceled"
+	AzureResourceProvisioningStateFailed       AzureResourceProvisioningState = "Failed"
+	AzureResourceProvisioningStateProvisioning AzureResourceProvisioningState = "Provisioning"
+	AzureResourceProvisioningStateSucceeded    AzureResourceProvisioningState = "Succeeded"
+)
+
+func PossibleValuesForAzureResourceProvisioningState() []string {
+	return []string{
+		string(AzureResourceProvisioningStateCanceled),
+		string(AzureResourceProvisioningStateFailed),
+		string(AzureResourceProvisioningStateProvisioning),
+		string(AzureResourceProvisioningStateSucceeded),
+	}
+}
+
+func (s *AzureResourceProvisioningState) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseAzureResourceProvisioningState(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseAzureResourceProvisioningState(input string) (*AzureResourceProvisioningState, error) {
+	vals := map[string]AzureResourceProvisioningState{
+		"canceled":     AzureResourceProvisioningStateCanceled,
+		"failed":       AzureResourceProvisioningStateFailed,
+		"provisioning": AzureResourceProvisioningStateProvisioning,
+		"succeeded":    AzureResourceProvisioningStateSucceeded,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := AzureResourceProvisioningState(input)
+	return &out, nil
+}
+
+type ExadbVMClusterLifecycleState string
+
+const (
+	ExadbVMClusterLifecycleStateAvailable             ExadbVMClusterLifecycleState = "Available"
+	ExadbVMClusterLifecycleStateFailed                ExadbVMClusterLifecycleState = "Failed"
+	ExadbVMClusterLifecycleStateMaintenanceInProgress ExadbVMClusterLifecycleState = "MaintenanceInProgress"
+	ExadbVMClusterLifecycleStateProvisioning          ExadbVMClusterLifecycleState = "Provisioning"
+	ExadbVMClusterLifecycleStateTerminated            ExadbVMClusterLifecycleState = "Terminated"
+	ExadbVMClusterLifecycleStateTerminating           ExadbVMClusterLifecycleState = "Terminating"
+	ExadbVMClusterLifecycleStateUpdating              ExadbVMClusterLifecycleState = "Updating"
+)
+
+func PossibleValuesForExadbVMClusterLifecycleState() []string {
+	return []string{
+		string(ExadbVMClusterLifecycleStateAvailable),
+		string(ExadbVMClusterLifecycleStateFailed),
+		string(ExadbVMClusterLifecycleStateMaintenanceInProgress),
+		string(ExadbVMClusterLifecycleStateProvisioning),
+		string(ExadbVMClusterLifecycleStateTerminated),
+		string(ExadbVMClusterLifecycleStateTerminating),
+		string(ExadbVMClusterLifecycleStateUpdating),
+	}
+}
+
+func (s *ExadbVMClusterLifecycleState) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseExadbVMClusterLifecycleState(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseExadbVMClusterLifecycleState(input string) (*ExadbVMClusterLifecycleState, error) {
+	vals := map[string]ExadbVMClusterLifecycleState{
+		"available":             ExadbVMClusterLifecycleStateAvailable,
+		"failed":                ExadbVMClusterLifecycleStateFailed,
+		"maintenanceinprogress": ExadbVMClusterLifecycleStateMaintenanceInProgress,
+		"provisioning":          ExadbVMClusterLifecycleStateProvisioning,
+		"terminated":            ExadbVMClusterLifecycleStateTerminated,
+		"terminating":           ExadbVMClusterLifecycleStateTerminating,
+		"updating":              ExadbVMClusterLifecycleStateUpdating,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ExadbVMClusterLifecycleState(input)
+	return &out, nil
+}
+
+type GridImageType string
+
+const (
+	GridImageTypeCustomImage   GridImageType = "CustomImage"
+	GridImageTypeReleaseUpdate GridImageType = "ReleaseUpdate"
+)
+
+func PossibleValuesForGridImageType() []string {
+	return []string{
+		string(GridImageTypeCustomImage),
+		string(GridImageTypeReleaseUpdate),
+	}
+}
+
+func (s *GridImageType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseGridImageType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseGridImageType(input string) (*GridImageType, error) {
+	vals := map[string]GridImageType{
+		"customimage":   GridImageTypeCustomImage,
+		"releaseupdate": GridImageTypeReleaseUpdate,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := GridImageType(input)
+	return &out, nil
+}
+
+type IormLifecycleState string
+
+const (
+	IormLifecycleStateBootStrapping IormLifecycleState = "BootStrapping"
+	IormLifecycleStateDisabled      IormLifecycleState = "Disabled"
+	IormLifecycleStateEnabled       IormLifecycleState = "Enabled"
+	IormLifecycleStateFailed        IormLifecycleState = "Failed"
+	IormLifecycleStateUpdating      IormLifecycleState = "Updating"
+)
+
+func PossibleValuesForIormLifecycleState() []string {
+	return []string{
+		string(IormLifecycleStateBootStrapping),
+		string(IormLifecycleStateDisabled),
+		string(IormLifecycleStateEnabled),
+		string(IormLifecycleStateFailed),
+		string(IormLifecycleStateUpdating),
+	}
+}
+
+func (s *IormLifecycleState) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseIormLifecycleState(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseIormLifecycleState(input string) (*IormLifecycleState, error) {
+	vals := map[string]IormLifecycleState{
+		"bootstrapping": IormLifecycleStateBootStrapping,
+		"disabled":      IormLifecycleStateDisabled,
+		"enabled":       IormLifecycleStateEnabled,
+		"failed":        IormLifecycleStateFailed,
+		"updating":      IormLifecycleStateUpdating,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := IormLifecycleState(input)
+	return &out, nil
+}
+
+type LicenseModel string
+
+const (
+	LicenseModelBringYourOwnLicense LicenseModel = "BringYourOwnLicense"
+	LicenseModelLicenseIncluded     LicenseModel = "LicenseIncluded"
+)
+
+func PossibleValuesForLicenseModel() []string {
+	return []string{
+		string(LicenseModelBringYourOwnLicense),
+		string(LicenseModelLicenseIncluded),
+	}
+}
+
+func (s *LicenseModel) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseLicenseModel(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseLicenseModel(input string) (*LicenseModel, error) {
+	vals := map[string]LicenseModel{
+		"bringyourownlicense": LicenseModelBringYourOwnLicense,
+		"licenseincluded":     LicenseModelLicenseIncluded,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := LicenseModel(input)
+	return &out, nil
+}
+
+type Objective string
+
+const (
+	ObjectiveAuto           Objective = "Auto"
+	ObjectiveBalanced       Objective = "Balanced"
+	ObjectiveBasic          Objective = "Basic"
+	ObjectiveHighThroughput Objective = "HighThroughput"
+	ObjectiveLowLatency     Objective = "LowLatency"
+)
+
+func PossibleValuesForObjective() []string {
+	return []string{
+		string(ObjectiveAuto),
+		string(ObjectiveBalanced),
+		string(ObjectiveBasic),
+		string(ObjectiveHighThroughput),
+		string(ObjectiveLowLatency),
+	}
+}
+
+func (s *Objective) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseObjective(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseObjective(input string) (*Objective, error) {
+	vals := map[string]Objective{
+		"auto":           ObjectiveAuto,
+		"balanced":       ObjectiveBalanced,
+		"basic":          ObjectiveBasic,
+		"highthroughput": ObjectiveHighThroughput,
+		"lowlatency":     ObjectiveLowLatency,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := Objective(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exadbvmclusters/id_exadbvmcluster.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exadbvmclusters/id_exadbvmcluster.go
@@ -1,0 +1,130 @@
+package exadbvmclusters
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&ExadbVMClusterId{})
+}
+
+var _ resourceids.ResourceId = &ExadbVMClusterId{}
+
+// ExadbVMClusterId is a struct representing the Resource ID for a Exadb V M Cluster
+type ExadbVMClusterId struct {
+	SubscriptionId     string
+	ResourceGroupName  string
+	ExadbVmClusterName string
+}
+
+// NewExadbVMClusterID returns a new ExadbVMClusterId struct
+func NewExadbVMClusterID(subscriptionId string, resourceGroupName string, exadbVmClusterName string) ExadbVMClusterId {
+	return ExadbVMClusterId{
+		SubscriptionId:     subscriptionId,
+		ResourceGroupName:  resourceGroupName,
+		ExadbVmClusterName: exadbVmClusterName,
+	}
+}
+
+// ParseExadbVMClusterID parses 'input' into a ExadbVMClusterId
+func ParseExadbVMClusterID(input string) (*ExadbVMClusterId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&ExadbVMClusterId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := ExadbVMClusterId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseExadbVMClusterIDInsensitively parses 'input' case-insensitively into a ExadbVMClusterId
+// note: this method should only be used for API response data and not user input
+func ParseExadbVMClusterIDInsensitively(input string) (*ExadbVMClusterId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&ExadbVMClusterId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := ExadbVMClusterId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *ExadbVMClusterId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.ExadbVmClusterName, ok = input.Parsed["exadbVmClusterName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "exadbVmClusterName", input)
+	}
+
+	return nil
+}
+
+// ValidateExadbVMClusterID checks that 'input' can be parsed as a Exadb V M Cluster ID
+func ValidateExadbVMClusterID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseExadbVMClusterID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Exadb V M Cluster ID
+func (id ExadbVMClusterId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Oracle.Database/exadbVmClusters/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.ExadbVmClusterName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Exadb V M Cluster ID
+func (id ExadbVMClusterId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticOracleDatabase", "Oracle.Database", "Oracle.Database"),
+		resourceids.StaticSegment("staticExadbVmClusters", "exadbVmClusters", "exadbVmClusters"),
+		resourceids.UserSpecifiedSegment("exadbVmClusterName", "exadbVmClusterName"),
+	}
+}
+
+// String returns a human-readable description of this Exadb V M Cluster ID
+func (id ExadbVMClusterId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Exadb Vm Cluster Name: %q", id.ExadbVmClusterName),
+	}
+	return fmt.Sprintf("Exadb V M Cluster (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exadbvmclusters/method_createorupdate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exadbvmclusters/method_createorupdate.go
@@ -1,0 +1,75 @@
+package exadbvmclusters
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateOrUpdateOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *ExadbVMCluster
+}
+
+// CreateOrUpdate ...
+func (c ExadbVMClustersClient) CreateOrUpdate(ctx context.Context, id ExadbVMClusterId, input ExadbVMCluster) (result CreateOrUpdateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPut,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// CreateOrUpdateThenPoll performs CreateOrUpdate then polls until it's completed
+func (c ExadbVMClustersClient) CreateOrUpdateThenPoll(ctx context.Context, id ExadbVMClusterId, input ExadbVMCluster) error {
+	result, err := c.CreateOrUpdate(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing CreateOrUpdate: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after CreateOrUpdate: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exadbvmclusters/method_delete.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exadbvmclusters/method_delete.go
@@ -1,0 +1,70 @@
+package exadbvmclusters
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeleteOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// Delete ...
+func (c ExadbVMClustersClient) Delete(ctx context.Context, id ExadbVMClusterId) (result DeleteOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusNoContent,
+		},
+		HttpMethod: http.MethodDelete,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// DeleteThenPoll performs Delete then polls until it's completed
+func (c ExadbVMClustersClient) DeleteThenPoll(ctx context.Context, id ExadbVMClusterId) error {
+	result, err := c.Delete(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing Delete: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Delete: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exadbvmclusters/method_get.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exadbvmclusters/method_get.go
@@ -1,0 +1,53 @@
+package exadbvmclusters
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *ExadbVMCluster
+}
+
+// Get ...
+func (c ExadbVMClustersClient) Get(ctx context.Context, id ExadbVMClusterId) (result GetOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model ExadbVMCluster
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exadbvmclusters/method_listbyresourcegroup.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exadbvmclusters/method_listbyresourcegroup.go
@@ -1,0 +1,106 @@
+package exadbvmclusters
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListByResourceGroupOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]ExadbVMCluster
+}
+
+type ListByResourceGroupCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []ExadbVMCluster
+}
+
+type ListByResourceGroupCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *ListByResourceGroupCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// ListByResourceGroup ...
+func (c ExadbVMClustersClient) ListByResourceGroup(ctx context.Context, id commonids.ResourceGroupId) (result ListByResourceGroupOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Pager:      &ListByResourceGroupCustomPager{},
+		Path:       fmt.Sprintf("%s/providers/Oracle.Database/exadbVmClusters", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]ExadbVMCluster `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListByResourceGroupComplete retrieves all the results into a single object
+func (c ExadbVMClustersClient) ListByResourceGroupComplete(ctx context.Context, id commonids.ResourceGroupId) (ListByResourceGroupCompleteResult, error) {
+	return c.ListByResourceGroupCompleteMatchingPredicate(ctx, id, ExadbVMClusterOperationPredicate{})
+}
+
+// ListByResourceGroupCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c ExadbVMClustersClient) ListByResourceGroupCompleteMatchingPredicate(ctx context.Context, id commonids.ResourceGroupId, predicate ExadbVMClusterOperationPredicate) (result ListByResourceGroupCompleteResult, err error) {
+	items := make([]ExadbVMCluster, 0)
+
+	resp, err := c.ListByResourceGroup(ctx, id)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListByResourceGroupCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exadbvmclusters/method_listbysubscription.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exadbvmclusters/method_listbysubscription.go
@@ -1,0 +1,106 @@
+package exadbvmclusters
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListBySubscriptionOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]ExadbVMCluster
+}
+
+type ListBySubscriptionCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []ExadbVMCluster
+}
+
+type ListBySubscriptionCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *ListBySubscriptionCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// ListBySubscription ...
+func (c ExadbVMClustersClient) ListBySubscription(ctx context.Context, id commonids.SubscriptionId) (result ListBySubscriptionOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Pager:      &ListBySubscriptionCustomPager{},
+		Path:       fmt.Sprintf("%s/providers/Oracle.Database/exadbVmClusters", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]ExadbVMCluster `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListBySubscriptionComplete retrieves all the results into a single object
+func (c ExadbVMClustersClient) ListBySubscriptionComplete(ctx context.Context, id commonids.SubscriptionId) (ListBySubscriptionCompleteResult, error) {
+	return c.ListBySubscriptionCompleteMatchingPredicate(ctx, id, ExadbVMClusterOperationPredicate{})
+}
+
+// ListBySubscriptionCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c ExadbVMClustersClient) ListBySubscriptionCompleteMatchingPredicate(ctx context.Context, id commonids.SubscriptionId, predicate ExadbVMClusterOperationPredicate) (result ListBySubscriptionCompleteResult, err error) {
+	items := make([]ExadbVMCluster, 0)
+
+	resp, err := c.ListBySubscription(ctx, id)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListBySubscriptionCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exadbvmclusters/method_removevms.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exadbvmclusters/method_removevms.go
@@ -1,0 +1,75 @@
+package exadbvmclusters
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RemoveVMsOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *ExadbVMCluster
+}
+
+// RemoveVMs ...
+func (c ExadbVMClustersClient) RemoveVMs(ctx context.Context, id ExadbVMClusterId, input RemoveVirtualMachineFromExadbVMClusterDetails) (result RemoveVMsOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/removeVms", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// RemoveVMsThenPoll performs RemoveVMs then polls until it's completed
+func (c ExadbVMClustersClient) RemoveVMsThenPoll(ctx context.Context, id ExadbVMClusterId, input RemoveVirtualMachineFromExadbVMClusterDetails) error {
+	result, err := c.RemoveVMs(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing RemoveVMs: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after RemoveVMs: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exadbvmclusters/method_update.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exadbvmclusters/method_update.go
@@ -1,0 +1,75 @@
+package exadbvmclusters
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpdateOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *ExadbVMCluster
+}
+
+// Update ...
+func (c ExadbVMClustersClient) Update(ctx context.Context, id ExadbVMClusterId, input ExadbVMClusterUpdate) (result UpdateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPatch,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// UpdateThenPoll performs Update then polls until it's completed
+func (c ExadbVMClustersClient) UpdateThenPoll(ctx context.Context, id ExadbVMClusterId, input ExadbVMClusterUpdate) error {
+	result, err := c.Update(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing Update: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Update: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exadbvmclusters/model_datacollectionoptions.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exadbvmclusters/model_datacollectionoptions.go
@@ -1,0 +1,10 @@
+package exadbvmclusters
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DataCollectionOptions struct {
+	IsDiagnosticsEventsEnabled *bool `json:"isDiagnosticsEventsEnabled,omitempty"`
+	IsHealthMonitoringEnabled  *bool `json:"isHealthMonitoringEnabled,omitempty"`
+	IsIncidentLogsEnabled      *bool `json:"isIncidentLogsEnabled,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exadbvmclusters/model_dbiormconfig.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exadbvmclusters/model_dbiormconfig.go
@@ -1,0 +1,10 @@
+package exadbvmclusters
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DbIormConfig struct {
+	DbName          *string `json:"dbName,omitempty"`
+	FlashCacheLimit *string `json:"flashCacheLimit,omitempty"`
+	Share           *int64  `json:"share,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exadbvmclusters/model_dbnodedetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exadbvmclusters/model_dbnodedetails.go
@@ -1,0 +1,8 @@
+package exadbvmclusters
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DbNodeDetails struct {
+	DbNodeId string `json:"dbNodeId"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exadbvmclusters/model_exadataiormconfig.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exadbvmclusters/model_exadataiormconfig.go
@@ -1,0 +1,11 @@
+package exadbvmclusters
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ExadataIormConfig struct {
+	DbPlans          *[]DbIormConfig     `json:"dbPlans,omitempty"`
+	LifecycleDetails *string             `json:"lifecycleDetails,omitempty"`
+	LifecycleState   *IormLifecycleState `json:"lifecycleState,omitempty"`
+	Objective        *Objective          `json:"objective,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exadbvmclusters/model_exadbvmcluster.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exadbvmclusters/model_exadbvmcluster.go
@@ -1,0 +1,20 @@
+package exadbvmclusters
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/systemdata"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/zones"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ExadbVMCluster struct {
+	Id         *string                   `json:"id,omitempty"`
+	Location   string                    `json:"location"`
+	Name       *string                   `json:"name,omitempty"`
+	Properties *ExadbVMClusterProperties `json:"properties,omitempty"`
+	SystemData *systemdata.SystemData    `json:"systemData,omitempty"`
+	Tags       *map[string]string        `json:"tags,omitempty"`
+	Type       *string                   `json:"type,omitempty"`
+	Zones      *zones.Schema             `json:"zones,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exadbvmclusters/model_exadbvmclusterproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exadbvmclusters/model_exadbvmclusterproperties.go
@@ -1,0 +1,50 @@
+package exadbvmclusters
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ExadbVMClusterProperties struct {
+	BackupSubnetCidr          *string                         `json:"backupSubnetCidr,omitempty"`
+	BackupSubnetOcid          *string                         `json:"backupSubnetOcid,omitempty"`
+	ClusterName               *string                         `json:"clusterName,omitempty"`
+	DataCollectionOptions     *DataCollectionOptions          `json:"dataCollectionOptions,omitempty"`
+	DisplayName               string                          `json:"displayName"`
+	Domain                    *string                         `json:"domain,omitempty"`
+	EnabledEcpuCount          int64                           `json:"enabledEcpuCount"`
+	ExascaleDbStorageVaultId  string                          `json:"exascaleDbStorageVaultId"`
+	GiVersion                 *string                         `json:"giVersion,omitempty"`
+	GridImageOcid             *string                         `json:"gridImageOcid,omitempty"`
+	GridImageType             *GridImageType                  `json:"gridImageType,omitempty"`
+	Hostname                  string                          `json:"hostname"`
+	IormConfigCache           *ExadataIormConfig              `json:"iormConfigCache,omitempty"`
+	LicenseModel              *LicenseModel                   `json:"licenseModel,omitempty"`
+	LifecycleDetails          *string                         `json:"lifecycleDetails,omitempty"`
+	LifecycleState            *ExadbVMClusterLifecycleState   `json:"lifecycleState,omitempty"`
+	ListenerPort              *int64                          `json:"listenerPort,omitempty"`
+	MemorySizeInGbs           *int64                          `json:"memorySizeInGbs,omitempty"`
+	NodeCount                 int64                           `json:"nodeCount"`
+	NsgCidrs                  *[]NsgCidr                      `json:"nsgCidrs,omitempty"`
+	NsgURL                    *string                         `json:"nsgUrl,omitempty"`
+	OciURL                    *string                         `json:"ociUrl,omitempty"`
+	Ocid                      *string                         `json:"ocid,omitempty"`
+	PrivateZoneOcid           *string                         `json:"privateZoneOcid,omitempty"`
+	ProvisioningState         *AzureResourceProvisioningState `json:"provisioningState,omitempty"`
+	ScanDnsName               *string                         `json:"scanDnsName,omitempty"`
+	ScanDnsRecordId           *string                         `json:"scanDnsRecordId,omitempty"`
+	ScanIPIds                 *[]string                       `json:"scanIpIds,omitempty"`
+	ScanListenerPortTcp       *int64                          `json:"scanListenerPortTcp,omitempty"`
+	ScanListenerPortTcpSsl    *int64                          `json:"scanListenerPortTcpSsl,omitempty"`
+	Shape                     string                          `json:"shape"`
+	SnapshotFileSystemStorage *ExadbVMClusterStorageDetails   `json:"snapshotFileSystemStorage,omitempty"`
+	SshPublicKeys             []string                        `json:"sshPublicKeys"`
+	SubnetId                  string                          `json:"subnetId"`
+	SubnetOcid                *string                         `json:"subnetOcid,omitempty"`
+	SystemVersion             *string                         `json:"systemVersion,omitempty"`
+	TimeZone                  *string                         `json:"timeZone,omitempty"`
+	TotalEcpuCount            int64                           `json:"totalEcpuCount"`
+	TotalFileSystemStorage    *ExadbVMClusterStorageDetails   `json:"totalFileSystemStorage,omitempty"`
+	VMFileSystemStorage       ExadbVMClusterStorageDetails    `json:"vmFileSystemStorage"`
+	VipIds                    *[]string                       `json:"vipIds,omitempty"`
+	VnetId                    string                          `json:"vnetId"`
+	ZoneOcid                  *string                         `json:"zoneOcid,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exadbvmclusters/model_exadbvmclusterstoragedetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exadbvmclusters/model_exadbvmclusterstoragedetails.go
@@ -1,0 +1,8 @@
+package exadbvmclusters
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ExadbVMClusterStorageDetails struct {
+	TotalSizeInGbs int64 `json:"totalSizeInGbs"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exadbvmclusters/model_exadbvmclusterupdate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exadbvmclusters/model_exadbvmclusterupdate.go
@@ -1,0 +1,14 @@
+package exadbvmclusters
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/zones"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ExadbVMClusterUpdate struct {
+	Properties *ExadbVMClusterUpdateProperties `json:"properties,omitempty"`
+	Tags       *map[string]string              `json:"tags,omitempty"`
+	Zones      *zones.Schema                   `json:"zones,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exadbvmclusters/model_exadbvmclusterupdateproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exadbvmclusters/model_exadbvmclusterupdateproperties.go
@@ -1,0 +1,8 @@
+package exadbvmclusters
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ExadbVMClusterUpdateProperties struct {
+	NodeCount *int64 `json:"nodeCount,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exadbvmclusters/model_nsgcidr.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exadbvmclusters/model_nsgcidr.go
@@ -1,0 +1,9 @@
+package exadbvmclusters
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NsgCidr struct {
+	DestinationPortRange *PortRange `json:"destinationPortRange,omitempty"`
+	Source               string     `json:"source"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exadbvmclusters/model_portrange.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exadbvmclusters/model_portrange.go
@@ -1,0 +1,9 @@
+package exadbvmclusters
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PortRange struct {
+	Max int64 `json:"max"`
+	Min int64 `json:"min"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exadbvmclusters/model_removevirtualmachinefromexadbvmclusterdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exadbvmclusters/model_removevirtualmachinefromexadbvmclusterdetails.go
@@ -1,0 +1,8 @@
+package exadbvmclusters
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RemoveVirtualMachineFromExadbVMClusterDetails struct {
+	DbNodes []DbNodeDetails `json:"dbNodes"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exadbvmclusters/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exadbvmclusters/predicates.go
@@ -1,0 +1,32 @@
+package exadbvmclusters
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ExadbVMClusterOperationPredicate struct {
+	Id       *string
+	Location *string
+	Name     *string
+	Type     *string
+}
+
+func (p ExadbVMClusterOperationPredicate) Matches(input ExadbVMCluster) bool {
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Location != nil && *p.Location != input.Location {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exadbvmclusters/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exadbvmclusters/version.go
@@ -1,0 +1,10 @@
+package exadbvmclusters
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2025-03-01"
+
+func userAgent() string {
+	return "hashicorp/go-azure-sdk/exadbvmclusters/2025-03-01"
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbnodes/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbnodes/README.md
@@ -1,0 +1,70 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbnodes` Documentation
+
+The `exascaledbnodes` SDK allows for interaction with Azure Resource Manager `oracledatabase` (API Version `2025-03-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbnodes"
+```
+
+
+### Client Initialization
+
+```go
+client := exascaledbnodes.NewExascaleDbNodesClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `ExascaleDbNodesClient.Action`
+
+```go
+ctx := context.TODO()
+id := exascaledbnodes.NewExadbVMClusterDbNodeID("12345678-1234-9876-4563-123456789012", "example-resource-group", "exadbVmClusterName", "dbNodeName")
+
+payload := exascaledbnodes.DbNodeAction{
+	// ...
+}
+
+
+if err := client.ActionThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `ExascaleDbNodesClient.Get`
+
+```go
+ctx := context.TODO()
+id := exascaledbnodes.NewExadbVMClusterDbNodeID("12345678-1234-9876-4563-123456789012", "example-resource-group", "exadbVmClusterName", "dbNodeName")
+
+read, err := client.Get(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `ExascaleDbNodesClient.ListByParent`
+
+```go
+ctx := context.TODO()
+id := exascaledbnodes.NewExadbVMClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "exadbVmClusterName")
+
+// alternatively `client.ListByParent(ctx, id)` can be used to do batched pagination
+items, err := client.ListByParentComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbnodes/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbnodes/client.go
@@ -1,0 +1,26 @@
+package exascaledbnodes
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ExascaleDbNodesClient struct {
+	Client *resourcemanager.Client
+}
+
+func NewExascaleDbNodesClientWithBaseURI(sdkApi sdkEnv.Api) (*ExascaleDbNodesClient, error) {
+	client, err := resourcemanager.NewClient(sdkApi, "exascaledbnodes", defaultApiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating ExascaleDbNodesClient: %+v", err)
+	}
+
+	return &ExascaleDbNodesClient{
+		Client: client,
+	}, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbnodes/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbnodes/constants.go
@@ -1,0 +1,166 @@
+package exascaledbnodes
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AzureResourceProvisioningState string
+
+const (
+	AzureResourceProvisioningStateCanceled     AzureResourceProvisioningState = "Canceled"
+	AzureResourceProvisioningStateFailed       AzureResourceProvisioningState = "Failed"
+	AzureResourceProvisioningStateProvisioning AzureResourceProvisioningState = "Provisioning"
+	AzureResourceProvisioningStateSucceeded    AzureResourceProvisioningState = "Succeeded"
+)
+
+func PossibleValuesForAzureResourceProvisioningState() []string {
+	return []string{
+		string(AzureResourceProvisioningStateCanceled),
+		string(AzureResourceProvisioningStateFailed),
+		string(AzureResourceProvisioningStateProvisioning),
+		string(AzureResourceProvisioningStateSucceeded),
+	}
+}
+
+func (s *AzureResourceProvisioningState) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseAzureResourceProvisioningState(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseAzureResourceProvisioningState(input string) (*AzureResourceProvisioningState, error) {
+	vals := map[string]AzureResourceProvisioningState{
+		"canceled":     AzureResourceProvisioningStateCanceled,
+		"failed":       AzureResourceProvisioningStateFailed,
+		"provisioning": AzureResourceProvisioningStateProvisioning,
+		"succeeded":    AzureResourceProvisioningStateSucceeded,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := AzureResourceProvisioningState(input)
+	return &out, nil
+}
+
+type DbNodeActionEnum string
+
+const (
+	DbNodeActionEnumReset     DbNodeActionEnum = "Reset"
+	DbNodeActionEnumSoftReset DbNodeActionEnum = "SoftReset"
+	DbNodeActionEnumStart     DbNodeActionEnum = "Start"
+	DbNodeActionEnumStop      DbNodeActionEnum = "Stop"
+)
+
+func PossibleValuesForDbNodeActionEnum() []string {
+	return []string{
+		string(DbNodeActionEnumReset),
+		string(DbNodeActionEnumSoftReset),
+		string(DbNodeActionEnumStart),
+		string(DbNodeActionEnumStop),
+	}
+}
+
+func (s *DbNodeActionEnum) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseDbNodeActionEnum(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseDbNodeActionEnum(input string) (*DbNodeActionEnum, error) {
+	vals := map[string]DbNodeActionEnum{
+		"reset":     DbNodeActionEnumReset,
+		"softreset": DbNodeActionEnumSoftReset,
+		"start":     DbNodeActionEnumStart,
+		"stop":      DbNodeActionEnumStop,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := DbNodeActionEnum(input)
+	return &out, nil
+}
+
+type DbNodeProvisioningState string
+
+const (
+	DbNodeProvisioningStateAvailable    DbNodeProvisioningState = "Available"
+	DbNodeProvisioningStateFailed       DbNodeProvisioningState = "Failed"
+	DbNodeProvisioningStateProvisioning DbNodeProvisioningState = "Provisioning"
+	DbNodeProvisioningStateStarting     DbNodeProvisioningState = "Starting"
+	DbNodeProvisioningStateStopped      DbNodeProvisioningState = "Stopped"
+	DbNodeProvisioningStateStopping     DbNodeProvisioningState = "Stopping"
+	DbNodeProvisioningStateTerminated   DbNodeProvisioningState = "Terminated"
+	DbNodeProvisioningStateTerminating  DbNodeProvisioningState = "Terminating"
+	DbNodeProvisioningStateUpdating     DbNodeProvisioningState = "Updating"
+)
+
+func PossibleValuesForDbNodeProvisioningState() []string {
+	return []string{
+		string(DbNodeProvisioningStateAvailable),
+		string(DbNodeProvisioningStateFailed),
+		string(DbNodeProvisioningStateProvisioning),
+		string(DbNodeProvisioningStateStarting),
+		string(DbNodeProvisioningStateStopped),
+		string(DbNodeProvisioningStateStopping),
+		string(DbNodeProvisioningStateTerminated),
+		string(DbNodeProvisioningStateTerminating),
+		string(DbNodeProvisioningStateUpdating),
+	}
+}
+
+func (s *DbNodeProvisioningState) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseDbNodeProvisioningState(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseDbNodeProvisioningState(input string) (*DbNodeProvisioningState, error) {
+	vals := map[string]DbNodeProvisioningState{
+		"available":    DbNodeProvisioningStateAvailable,
+		"failed":       DbNodeProvisioningStateFailed,
+		"provisioning": DbNodeProvisioningStateProvisioning,
+		"starting":     DbNodeProvisioningStateStarting,
+		"stopped":      DbNodeProvisioningStateStopped,
+		"stopping":     DbNodeProvisioningStateStopping,
+		"terminated":   DbNodeProvisioningStateTerminated,
+		"terminating":  DbNodeProvisioningStateTerminating,
+		"updating":     DbNodeProvisioningStateUpdating,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := DbNodeProvisioningState(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbnodes/id_exadbvmcluster.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbnodes/id_exadbvmcluster.go
@@ -1,0 +1,130 @@
+package exascaledbnodes
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&ExadbVMClusterId{})
+}
+
+var _ resourceids.ResourceId = &ExadbVMClusterId{}
+
+// ExadbVMClusterId is a struct representing the Resource ID for a Exadb V M Cluster
+type ExadbVMClusterId struct {
+	SubscriptionId     string
+	ResourceGroupName  string
+	ExadbVmClusterName string
+}
+
+// NewExadbVMClusterID returns a new ExadbVMClusterId struct
+func NewExadbVMClusterID(subscriptionId string, resourceGroupName string, exadbVmClusterName string) ExadbVMClusterId {
+	return ExadbVMClusterId{
+		SubscriptionId:     subscriptionId,
+		ResourceGroupName:  resourceGroupName,
+		ExadbVmClusterName: exadbVmClusterName,
+	}
+}
+
+// ParseExadbVMClusterID parses 'input' into a ExadbVMClusterId
+func ParseExadbVMClusterID(input string) (*ExadbVMClusterId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&ExadbVMClusterId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := ExadbVMClusterId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseExadbVMClusterIDInsensitively parses 'input' case-insensitively into a ExadbVMClusterId
+// note: this method should only be used for API response data and not user input
+func ParseExadbVMClusterIDInsensitively(input string) (*ExadbVMClusterId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&ExadbVMClusterId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := ExadbVMClusterId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *ExadbVMClusterId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.ExadbVmClusterName, ok = input.Parsed["exadbVmClusterName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "exadbVmClusterName", input)
+	}
+
+	return nil
+}
+
+// ValidateExadbVMClusterID checks that 'input' can be parsed as a Exadb V M Cluster ID
+func ValidateExadbVMClusterID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseExadbVMClusterID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Exadb V M Cluster ID
+func (id ExadbVMClusterId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Oracle.Database/exadbVmClusters/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.ExadbVmClusterName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Exadb V M Cluster ID
+func (id ExadbVMClusterId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticOracleDatabase", "Oracle.Database", "Oracle.Database"),
+		resourceids.StaticSegment("staticExadbVmClusters", "exadbVmClusters", "exadbVmClusters"),
+		resourceids.UserSpecifiedSegment("exadbVmClusterName", "exadbVmClusterName"),
+	}
+}
+
+// String returns a human-readable description of this Exadb V M Cluster ID
+func (id ExadbVMClusterId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Exadb Vm Cluster Name: %q", id.ExadbVmClusterName),
+	}
+	return fmt.Sprintf("Exadb V M Cluster (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbnodes/id_exadbvmclusterdbnode.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbnodes/id_exadbvmclusterdbnode.go
@@ -1,0 +1,139 @@
+package exascaledbnodes
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&ExadbVMClusterDbNodeId{})
+}
+
+var _ resourceids.ResourceId = &ExadbVMClusterDbNodeId{}
+
+// ExadbVMClusterDbNodeId is a struct representing the Resource ID for a Exadb V M Cluster Db Node
+type ExadbVMClusterDbNodeId struct {
+	SubscriptionId     string
+	ResourceGroupName  string
+	ExadbVmClusterName string
+	DbNodeName         string
+}
+
+// NewExadbVMClusterDbNodeID returns a new ExadbVMClusterDbNodeId struct
+func NewExadbVMClusterDbNodeID(subscriptionId string, resourceGroupName string, exadbVmClusterName string, dbNodeName string) ExadbVMClusterDbNodeId {
+	return ExadbVMClusterDbNodeId{
+		SubscriptionId:     subscriptionId,
+		ResourceGroupName:  resourceGroupName,
+		ExadbVmClusterName: exadbVmClusterName,
+		DbNodeName:         dbNodeName,
+	}
+}
+
+// ParseExadbVMClusterDbNodeID parses 'input' into a ExadbVMClusterDbNodeId
+func ParseExadbVMClusterDbNodeID(input string) (*ExadbVMClusterDbNodeId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&ExadbVMClusterDbNodeId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := ExadbVMClusterDbNodeId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseExadbVMClusterDbNodeIDInsensitively parses 'input' case-insensitively into a ExadbVMClusterDbNodeId
+// note: this method should only be used for API response data and not user input
+func ParseExadbVMClusterDbNodeIDInsensitively(input string) (*ExadbVMClusterDbNodeId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&ExadbVMClusterDbNodeId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := ExadbVMClusterDbNodeId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *ExadbVMClusterDbNodeId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.ExadbVmClusterName, ok = input.Parsed["exadbVmClusterName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "exadbVmClusterName", input)
+	}
+
+	if id.DbNodeName, ok = input.Parsed["dbNodeName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "dbNodeName", input)
+	}
+
+	return nil
+}
+
+// ValidateExadbVMClusterDbNodeID checks that 'input' can be parsed as a Exadb V M Cluster Db Node ID
+func ValidateExadbVMClusterDbNodeID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseExadbVMClusterDbNodeID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Exadb V M Cluster Db Node ID
+func (id ExadbVMClusterDbNodeId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Oracle.Database/exadbVmClusters/%s/dbNodes/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.ExadbVmClusterName, id.DbNodeName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Exadb V M Cluster Db Node ID
+func (id ExadbVMClusterDbNodeId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticOracleDatabase", "Oracle.Database", "Oracle.Database"),
+		resourceids.StaticSegment("staticExadbVmClusters", "exadbVmClusters", "exadbVmClusters"),
+		resourceids.UserSpecifiedSegment("exadbVmClusterName", "exadbVmClusterName"),
+		resourceids.StaticSegment("staticDbNodes", "dbNodes", "dbNodes"),
+		resourceids.UserSpecifiedSegment("dbNodeName", "dbNodeName"),
+	}
+}
+
+// String returns a human-readable description of this Exadb V M Cluster Db Node ID
+func (id ExadbVMClusterDbNodeId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Exadb Vm Cluster Name: %q", id.ExadbVmClusterName),
+		fmt.Sprintf("Db Node Name: %q", id.DbNodeName),
+	}
+	return fmt.Sprintf("Exadb V M Cluster Db Node (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbnodes/method_action.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbnodes/method_action.go
@@ -1,0 +1,75 @@
+package exascaledbnodes
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ActionOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *DbActionResponse
+}
+
+// Action ...
+func (c ExascaleDbNodesClient) Action(ctx context.Context, id ExadbVMClusterDbNodeId, input DbNodeAction) (result ActionOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/action", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// ActionThenPoll performs Action then polls until it's completed
+func (c ExascaleDbNodesClient) ActionThenPoll(ctx context.Context, id ExadbVMClusterDbNodeId, input DbNodeAction) error {
+	result, err := c.Action(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing Action: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Action: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbnodes/method_get.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbnodes/method_get.go
@@ -1,0 +1,53 @@
+package exascaledbnodes
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *ExascaleDbNode
+}
+
+// Get ...
+func (c ExascaleDbNodesClient) Get(ctx context.Context, id ExadbVMClusterDbNodeId) (result GetOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model ExascaleDbNode
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbnodes/method_listbyparent.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbnodes/method_listbyparent.go
@@ -1,0 +1,105 @@
+package exascaledbnodes
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListByParentOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]ExascaleDbNode
+}
+
+type ListByParentCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []ExascaleDbNode
+}
+
+type ListByParentCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *ListByParentCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// ListByParent ...
+func (c ExascaleDbNodesClient) ListByParent(ctx context.Context, id ExadbVMClusterId) (result ListByParentOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Pager:      &ListByParentCustomPager{},
+		Path:       fmt.Sprintf("%s/dbNodes", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]ExascaleDbNode `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListByParentComplete retrieves all the results into a single object
+func (c ExascaleDbNodesClient) ListByParentComplete(ctx context.Context, id ExadbVMClusterId) (ListByParentCompleteResult, error) {
+	return c.ListByParentCompleteMatchingPredicate(ctx, id, ExascaleDbNodeOperationPredicate{})
+}
+
+// ListByParentCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c ExascaleDbNodesClient) ListByParentCompleteMatchingPredicate(ctx context.Context, id ExadbVMClusterId, predicate ExascaleDbNodeOperationPredicate) (result ListByParentCompleteResult, err error) {
+	items := make([]ExascaleDbNode, 0)
+
+	resp, err := c.ListByParent(ctx, id)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListByParentCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbnodes/model_dbactionresponse.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbnodes/model_dbactionresponse.go
@@ -1,0 +1,8 @@
+package exascaledbnodes
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DbActionResponse struct {
+	ProvisioningState *AzureResourceProvisioningState `json:"provisioningState,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbnodes/model_dbnodeaction.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbnodes/model_dbnodeaction.go
@@ -1,0 +1,8 @@
+package exascaledbnodes
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DbNodeAction struct {
+	Action DbNodeActionEnum `json:"action"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbnodes/model_exascaledbnode.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbnodes/model_exascaledbnode.go
@@ -1,0 +1,16 @@
+package exascaledbnodes
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/systemdata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ExascaleDbNode struct {
+	Id         *string                   `json:"id,omitempty"`
+	Name       *string                   `json:"name,omitempty"`
+	Properties *ExascaleDbNodeProperties `json:"properties,omitempty"`
+	SystemData *systemdata.SystemData    `json:"systemData,omitempty"`
+	Type       *string                   `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbnodes/model_exascaledbnodeproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbnodes/model_exascaledbnodeproperties.go
@@ -1,0 +1,50 @@
+package exascaledbnodes
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ExascaleDbNodeProperties struct {
+	AdditionalDetails          *string                  `json:"additionalDetails,omitempty"`
+	CpuCoreCount               *int64                   `json:"cpuCoreCount,omitempty"`
+	DbNodeStorageSizeInGbs     *int64                   `json:"dbNodeStorageSizeInGbs,omitempty"`
+	FaultDomain                *string                  `json:"faultDomain,omitempty"`
+	Hostname                   *string                  `json:"hostname,omitempty"`
+	LifecycleState             *DbNodeProvisioningState `json:"lifecycleState,omitempty"`
+	MaintenanceType            *string                  `json:"maintenanceType,omitempty"`
+	MemorySizeInGbs            *int64                   `json:"memorySizeInGbs,omitempty"`
+	Ocid                       string                   `json:"ocid"`
+	SoftwareStorageSizeInGb    *int64                   `json:"softwareStorageSizeInGb,omitempty"`
+	TimeMaintenanceWindowEnd   *string                  `json:"timeMaintenanceWindowEnd,omitempty"`
+	TimeMaintenanceWindowStart *string                  `json:"timeMaintenanceWindowStart,omitempty"`
+	TotalCPUCoreCount          *int64                   `json:"totalCpuCoreCount,omitempty"`
+}
+
+func (o *ExascaleDbNodeProperties) GetTimeMaintenanceWindowEndAsTime() (*time.Time, error) {
+	if o.TimeMaintenanceWindowEnd == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.TimeMaintenanceWindowEnd, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *ExascaleDbNodeProperties) SetTimeMaintenanceWindowEndAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.TimeMaintenanceWindowEnd = &formatted
+}
+
+func (o *ExascaleDbNodeProperties) GetTimeMaintenanceWindowStartAsTime() (*time.Time, error) {
+	if o.TimeMaintenanceWindowStart == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.TimeMaintenanceWindowStart, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *ExascaleDbNodeProperties) SetTimeMaintenanceWindowStartAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.TimeMaintenanceWindowStart = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbnodes/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbnodes/predicates.go
@@ -1,0 +1,27 @@
+package exascaledbnodes
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ExascaleDbNodeOperationPredicate struct {
+	Id   *string
+	Name *string
+	Type *string
+}
+
+func (p ExascaleDbNodeOperationPredicate) Matches(input ExascaleDbNode) bool {
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbnodes/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbnodes/version.go
@@ -1,0 +1,10 @@
+package exascaledbnodes
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2025-03-01"
+
+func userAgent() string {
+	return "hashicorp/go-azure-sdk/exascaledbnodes/2025-03-01"
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbstoragevaults/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbstoragevaults/README.md
@@ -1,0 +1,117 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbstoragevaults` Documentation
+
+The `exascaledbstoragevaults` SDK allows for interaction with Azure Resource Manager `oracledatabase` (API Version `2025-03-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+import "github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbstoragevaults"
+```
+
+
+### Client Initialization
+
+```go
+client := exascaledbstoragevaults.NewExascaleDbStorageVaultsClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `ExascaleDbStorageVaultsClient.Create`
+
+```go
+ctx := context.TODO()
+id := exascaledbstoragevaults.NewExascaleDbStorageVaultID("12345678-1234-9876-4563-123456789012", "example-resource-group", "exascaleDbStorageVaultName")
+
+payload := exascaledbstoragevaults.ExascaleDbStorageVault{
+	// ...
+}
+
+
+if err := client.CreateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `ExascaleDbStorageVaultsClient.Delete`
+
+```go
+ctx := context.TODO()
+id := exascaledbstoragevaults.NewExascaleDbStorageVaultID("12345678-1234-9876-4563-123456789012", "example-resource-group", "exascaleDbStorageVaultName")
+
+if err := client.DeleteThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `ExascaleDbStorageVaultsClient.Get`
+
+```go
+ctx := context.TODO()
+id := exascaledbstoragevaults.NewExascaleDbStorageVaultID("12345678-1234-9876-4563-123456789012", "example-resource-group", "exascaleDbStorageVaultName")
+
+read, err := client.Get(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `ExascaleDbStorageVaultsClient.ListByResourceGroup`
+
+```go
+ctx := context.TODO()
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+
+// alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
+items, err := client.ListByResourceGroupComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `ExascaleDbStorageVaultsClient.ListBySubscription`
+
+```go
+ctx := context.TODO()
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+
+// alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
+items, err := client.ListBySubscriptionComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `ExascaleDbStorageVaultsClient.Update`
+
+```go
+ctx := context.TODO()
+id := exascaledbstoragevaults.NewExascaleDbStorageVaultID("12345678-1234-9876-4563-123456789012", "example-resource-group", "exascaleDbStorageVaultName")
+
+payload := exascaledbstoragevaults.ExascaleDbStorageVaultTagsUpdate{
+	// ...
+}
+
+
+if err := client.UpdateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbstoragevaults/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbstoragevaults/client.go
@@ -1,0 +1,26 @@
+package exascaledbstoragevaults
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ExascaleDbStorageVaultsClient struct {
+	Client *resourcemanager.Client
+}
+
+func NewExascaleDbStorageVaultsClientWithBaseURI(sdkApi sdkEnv.Api) (*ExascaleDbStorageVaultsClient, error) {
+	client, err := resourcemanager.NewClient(sdkApi, "exascaledbstoragevaults", defaultApiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating ExascaleDbStorageVaultsClient: %+v", err)
+	}
+
+	return &ExascaleDbStorageVaultsClient{
+		Client: client,
+	}, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbstoragevaults/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbstoragevaults/constants.go
@@ -1,0 +1,110 @@
+package exascaledbstoragevaults
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AzureResourceProvisioningState string
+
+const (
+	AzureResourceProvisioningStateCanceled     AzureResourceProvisioningState = "Canceled"
+	AzureResourceProvisioningStateFailed       AzureResourceProvisioningState = "Failed"
+	AzureResourceProvisioningStateProvisioning AzureResourceProvisioningState = "Provisioning"
+	AzureResourceProvisioningStateSucceeded    AzureResourceProvisioningState = "Succeeded"
+)
+
+func PossibleValuesForAzureResourceProvisioningState() []string {
+	return []string{
+		string(AzureResourceProvisioningStateCanceled),
+		string(AzureResourceProvisioningStateFailed),
+		string(AzureResourceProvisioningStateProvisioning),
+		string(AzureResourceProvisioningStateSucceeded),
+	}
+}
+
+func (s *AzureResourceProvisioningState) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseAzureResourceProvisioningState(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseAzureResourceProvisioningState(input string) (*AzureResourceProvisioningState, error) {
+	vals := map[string]AzureResourceProvisioningState{
+		"canceled":     AzureResourceProvisioningStateCanceled,
+		"failed":       AzureResourceProvisioningStateFailed,
+		"provisioning": AzureResourceProvisioningStateProvisioning,
+		"succeeded":    AzureResourceProvisioningStateSucceeded,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := AzureResourceProvisioningState(input)
+	return &out, nil
+}
+
+type ExascaleDbStorageVaultLifecycleState string
+
+const (
+	ExascaleDbStorageVaultLifecycleStateAvailable    ExascaleDbStorageVaultLifecycleState = "Available"
+	ExascaleDbStorageVaultLifecycleStateFailed       ExascaleDbStorageVaultLifecycleState = "Failed"
+	ExascaleDbStorageVaultLifecycleStateProvisioning ExascaleDbStorageVaultLifecycleState = "Provisioning"
+	ExascaleDbStorageVaultLifecycleStateTerminated   ExascaleDbStorageVaultLifecycleState = "Terminated"
+	ExascaleDbStorageVaultLifecycleStateTerminating  ExascaleDbStorageVaultLifecycleState = "Terminating"
+	ExascaleDbStorageVaultLifecycleStateUpdating     ExascaleDbStorageVaultLifecycleState = "Updating"
+)
+
+func PossibleValuesForExascaleDbStorageVaultLifecycleState() []string {
+	return []string{
+		string(ExascaleDbStorageVaultLifecycleStateAvailable),
+		string(ExascaleDbStorageVaultLifecycleStateFailed),
+		string(ExascaleDbStorageVaultLifecycleStateProvisioning),
+		string(ExascaleDbStorageVaultLifecycleStateTerminated),
+		string(ExascaleDbStorageVaultLifecycleStateTerminating),
+		string(ExascaleDbStorageVaultLifecycleStateUpdating),
+	}
+}
+
+func (s *ExascaleDbStorageVaultLifecycleState) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseExascaleDbStorageVaultLifecycleState(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseExascaleDbStorageVaultLifecycleState(input string) (*ExascaleDbStorageVaultLifecycleState, error) {
+	vals := map[string]ExascaleDbStorageVaultLifecycleState{
+		"available":    ExascaleDbStorageVaultLifecycleStateAvailable,
+		"failed":       ExascaleDbStorageVaultLifecycleStateFailed,
+		"provisioning": ExascaleDbStorageVaultLifecycleStateProvisioning,
+		"terminated":   ExascaleDbStorageVaultLifecycleStateTerminated,
+		"terminating":  ExascaleDbStorageVaultLifecycleStateTerminating,
+		"updating":     ExascaleDbStorageVaultLifecycleStateUpdating,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ExascaleDbStorageVaultLifecycleState(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbstoragevaults/id_exascaledbstoragevault.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbstoragevaults/id_exascaledbstoragevault.go
@@ -1,0 +1,130 @@
+package exascaledbstoragevaults
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&ExascaleDbStorageVaultId{})
+}
+
+var _ resourceids.ResourceId = &ExascaleDbStorageVaultId{}
+
+// ExascaleDbStorageVaultId is a struct representing the Resource ID for a Exascale Db Storage Vault
+type ExascaleDbStorageVaultId struct {
+	SubscriptionId             string
+	ResourceGroupName          string
+	ExascaleDbStorageVaultName string
+}
+
+// NewExascaleDbStorageVaultID returns a new ExascaleDbStorageVaultId struct
+func NewExascaleDbStorageVaultID(subscriptionId string, resourceGroupName string, exascaleDbStorageVaultName string) ExascaleDbStorageVaultId {
+	return ExascaleDbStorageVaultId{
+		SubscriptionId:             subscriptionId,
+		ResourceGroupName:          resourceGroupName,
+		ExascaleDbStorageVaultName: exascaleDbStorageVaultName,
+	}
+}
+
+// ParseExascaleDbStorageVaultID parses 'input' into a ExascaleDbStorageVaultId
+func ParseExascaleDbStorageVaultID(input string) (*ExascaleDbStorageVaultId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&ExascaleDbStorageVaultId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := ExascaleDbStorageVaultId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseExascaleDbStorageVaultIDInsensitively parses 'input' case-insensitively into a ExascaleDbStorageVaultId
+// note: this method should only be used for API response data and not user input
+func ParseExascaleDbStorageVaultIDInsensitively(input string) (*ExascaleDbStorageVaultId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&ExascaleDbStorageVaultId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := ExascaleDbStorageVaultId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *ExascaleDbStorageVaultId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.ExascaleDbStorageVaultName, ok = input.Parsed["exascaleDbStorageVaultName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "exascaleDbStorageVaultName", input)
+	}
+
+	return nil
+}
+
+// ValidateExascaleDbStorageVaultID checks that 'input' can be parsed as a Exascale Db Storage Vault ID
+func ValidateExascaleDbStorageVaultID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseExascaleDbStorageVaultID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Exascale Db Storage Vault ID
+func (id ExascaleDbStorageVaultId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Oracle.Database/exascaleDbStorageVaults/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.ExascaleDbStorageVaultName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Exascale Db Storage Vault ID
+func (id ExascaleDbStorageVaultId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticOracleDatabase", "Oracle.Database", "Oracle.Database"),
+		resourceids.StaticSegment("staticExascaleDbStorageVaults", "exascaleDbStorageVaults", "exascaleDbStorageVaults"),
+		resourceids.UserSpecifiedSegment("exascaleDbStorageVaultName", "exascaleDbStorageVaultName"),
+	}
+}
+
+// String returns a human-readable description of this Exascale Db Storage Vault ID
+func (id ExascaleDbStorageVaultId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Exascale Db Storage Vault Name: %q", id.ExascaleDbStorageVaultName),
+	}
+	return fmt.Sprintf("Exascale Db Storage Vault (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbstoragevaults/method_create.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbstoragevaults/method_create.go
@@ -1,0 +1,75 @@
+package exascaledbstoragevaults
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *ExascaleDbStorageVault
+}
+
+// Create ...
+func (c ExascaleDbStorageVaultsClient) Create(ctx context.Context, id ExascaleDbStorageVaultId, input ExascaleDbStorageVault) (result CreateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPut,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// CreateThenPoll performs Create then polls until it's completed
+func (c ExascaleDbStorageVaultsClient) CreateThenPoll(ctx context.Context, id ExascaleDbStorageVaultId, input ExascaleDbStorageVault) error {
+	result, err := c.Create(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing Create: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Create: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbstoragevaults/method_delete.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbstoragevaults/method_delete.go
@@ -1,0 +1,70 @@
+package exascaledbstoragevaults
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeleteOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// Delete ...
+func (c ExascaleDbStorageVaultsClient) Delete(ctx context.Context, id ExascaleDbStorageVaultId) (result DeleteOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusNoContent,
+		},
+		HttpMethod: http.MethodDelete,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// DeleteThenPoll performs Delete then polls until it's completed
+func (c ExascaleDbStorageVaultsClient) DeleteThenPoll(ctx context.Context, id ExascaleDbStorageVaultId) error {
+	result, err := c.Delete(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing Delete: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Delete: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbstoragevaults/method_get.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbstoragevaults/method_get.go
@@ -1,0 +1,53 @@
+package exascaledbstoragevaults
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *ExascaleDbStorageVault
+}
+
+// Get ...
+func (c ExascaleDbStorageVaultsClient) Get(ctx context.Context, id ExascaleDbStorageVaultId) (result GetOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model ExascaleDbStorageVault
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbstoragevaults/method_listbyresourcegroup.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbstoragevaults/method_listbyresourcegroup.go
@@ -1,0 +1,106 @@
+package exascaledbstoragevaults
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListByResourceGroupOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]ExascaleDbStorageVault
+}
+
+type ListByResourceGroupCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []ExascaleDbStorageVault
+}
+
+type ListByResourceGroupCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *ListByResourceGroupCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// ListByResourceGroup ...
+func (c ExascaleDbStorageVaultsClient) ListByResourceGroup(ctx context.Context, id commonids.ResourceGroupId) (result ListByResourceGroupOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Pager:      &ListByResourceGroupCustomPager{},
+		Path:       fmt.Sprintf("%s/providers/Oracle.Database/exascaleDbStorageVaults", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]ExascaleDbStorageVault `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListByResourceGroupComplete retrieves all the results into a single object
+func (c ExascaleDbStorageVaultsClient) ListByResourceGroupComplete(ctx context.Context, id commonids.ResourceGroupId) (ListByResourceGroupCompleteResult, error) {
+	return c.ListByResourceGroupCompleteMatchingPredicate(ctx, id, ExascaleDbStorageVaultOperationPredicate{})
+}
+
+// ListByResourceGroupCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c ExascaleDbStorageVaultsClient) ListByResourceGroupCompleteMatchingPredicate(ctx context.Context, id commonids.ResourceGroupId, predicate ExascaleDbStorageVaultOperationPredicate) (result ListByResourceGroupCompleteResult, err error) {
+	items := make([]ExascaleDbStorageVault, 0)
+
+	resp, err := c.ListByResourceGroup(ctx, id)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListByResourceGroupCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbstoragevaults/method_listbysubscription.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbstoragevaults/method_listbysubscription.go
@@ -1,0 +1,106 @@
+package exascaledbstoragevaults
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListBySubscriptionOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]ExascaleDbStorageVault
+}
+
+type ListBySubscriptionCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []ExascaleDbStorageVault
+}
+
+type ListBySubscriptionCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *ListBySubscriptionCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// ListBySubscription ...
+func (c ExascaleDbStorageVaultsClient) ListBySubscription(ctx context.Context, id commonids.SubscriptionId) (result ListBySubscriptionOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Pager:      &ListBySubscriptionCustomPager{},
+		Path:       fmt.Sprintf("%s/providers/Oracle.Database/exascaleDbStorageVaults", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]ExascaleDbStorageVault `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListBySubscriptionComplete retrieves all the results into a single object
+func (c ExascaleDbStorageVaultsClient) ListBySubscriptionComplete(ctx context.Context, id commonids.SubscriptionId) (ListBySubscriptionCompleteResult, error) {
+	return c.ListBySubscriptionCompleteMatchingPredicate(ctx, id, ExascaleDbStorageVaultOperationPredicate{})
+}
+
+// ListBySubscriptionCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c ExascaleDbStorageVaultsClient) ListBySubscriptionCompleteMatchingPredicate(ctx context.Context, id commonids.SubscriptionId, predicate ExascaleDbStorageVaultOperationPredicate) (result ListBySubscriptionCompleteResult, err error) {
+	items := make([]ExascaleDbStorageVault, 0)
+
+	resp, err := c.ListBySubscription(ctx, id)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListBySubscriptionCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbstoragevaults/method_update.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbstoragevaults/method_update.go
@@ -1,0 +1,75 @@
+package exascaledbstoragevaults
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpdateOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *ExascaleDbStorageVault
+}
+
+// Update ...
+func (c ExascaleDbStorageVaultsClient) Update(ctx context.Context, id ExascaleDbStorageVaultId, input ExascaleDbStorageVaultTagsUpdate) (result UpdateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPatch,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// UpdateThenPoll performs Update then polls until it's completed
+func (c ExascaleDbStorageVaultsClient) UpdateThenPoll(ctx context.Context, id ExascaleDbStorageVaultId, input ExascaleDbStorageVaultTagsUpdate) error {
+	result, err := c.Update(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing Update: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Update: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbstoragevaults/model_exascaledbstoragedetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbstoragevaults/model_exascaledbstoragedetails.go
@@ -1,0 +1,9 @@
+package exascaledbstoragevaults
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ExascaleDbStorageDetails struct {
+	AvailableSizeInGbs *int64 `json:"availableSizeInGbs,omitempty"`
+	TotalSizeInGbs     *int64 `json:"totalSizeInGbs,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbstoragevaults/model_exascaledbstorageinputdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbstoragevaults/model_exascaledbstorageinputdetails.go
@@ -1,0 +1,8 @@
+package exascaledbstoragevaults
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ExascaleDbStorageInputDetails struct {
+	TotalSizeInGbs int64 `json:"totalSizeInGbs"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbstoragevaults/model_exascaledbstoragevault.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbstoragevaults/model_exascaledbstoragevault.go
@@ -1,0 +1,20 @@
+package exascaledbstoragevaults
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/systemdata"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/zones"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ExascaleDbStorageVault struct {
+	Id         *string                           `json:"id,omitempty"`
+	Location   string                            `json:"location"`
+	Name       *string                           `json:"name,omitempty"`
+	Properties *ExascaleDbStorageVaultProperties `json:"properties,omitempty"`
+	SystemData *systemdata.SystemData            `json:"systemData,omitempty"`
+	Tags       *map[string]string                `json:"tags,omitempty"`
+	Type       *string                           `json:"type,omitempty"`
+	Zones      *zones.Schema                     `json:"zones,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbstoragevaults/model_exascaledbstoragevaultproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbstoragevaults/model_exascaledbstoragevaultproperties.go
@@ -1,0 +1,19 @@
+package exascaledbstoragevaults
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ExascaleDbStorageVaultProperties struct {
+	AdditionalFlashCacheInPercent    *int64                                `json:"additionalFlashCacheInPercent,omitempty"`
+	Description                      *string                               `json:"description,omitempty"`
+	DisplayName                      string                                `json:"displayName"`
+	HighCapacityDatabaseStorage      *ExascaleDbStorageDetails             `json:"highCapacityDatabaseStorage,omitempty"`
+	HighCapacityDatabaseStorageInput ExascaleDbStorageInputDetails         `json:"highCapacityDatabaseStorageInput"`
+	LifecycleDetails                 *string                               `json:"lifecycleDetails,omitempty"`
+	LifecycleState                   *ExascaleDbStorageVaultLifecycleState `json:"lifecycleState,omitempty"`
+	OciURL                           *string                               `json:"ociUrl,omitempty"`
+	Ocid                             *string                               `json:"ocid,omitempty"`
+	ProvisioningState                *AzureResourceProvisioningState       `json:"provisioningState,omitempty"`
+	TimeZone                         *string                               `json:"timeZone,omitempty"`
+	VMClusterCount                   *int64                                `json:"vmClusterCount,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbstoragevaults/model_exascaledbstoragevaulttagsupdate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbstoragevaults/model_exascaledbstoragevaulttagsupdate.go
@@ -1,0 +1,8 @@
+package exascaledbstoragevaults
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ExascaleDbStorageVaultTagsUpdate struct {
+	Tags *map[string]string `json:"tags,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbstoragevaults/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbstoragevaults/predicates.go
@@ -1,0 +1,32 @@
+package exascaledbstoragevaults
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ExascaleDbStorageVaultOperationPredicate struct {
+	Id       *string
+	Location *string
+	Name     *string
+	Type     *string
+}
+
+func (p ExascaleDbStorageVaultOperationPredicate) Matches(input ExascaleDbStorageVault) bool {
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Location != nil && *p.Location != input.Location {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbstoragevaults/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbstoragevaults/version.go
@@ -1,0 +1,10 @@
+package exascaledbstoragevaults
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2025-03-01"
+
+func userAgent() string {
+	return "hashicorp/go-azure-sdk/exascaledbstoragevaults/2025-03-01"
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/flexcomponents/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/flexcomponents/README.md
@@ -1,0 +1,53 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/flexcomponents` Documentation
+
+The `flexcomponents` SDK allows for interaction with Azure Resource Manager `oracledatabase` (API Version `2025-03-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/flexcomponents"
+```
+
+
+### Client Initialization
+
+```go
+client := flexcomponents.NewFlexComponentsClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `FlexComponentsClient.Get`
+
+```go
+ctx := context.TODO()
+id := flexcomponents.NewFlexComponentID("12345678-1234-9876-4563-123456789012", "locationName", "flexComponentName")
+
+read, err := client.Get(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `FlexComponentsClient.ListByParent`
+
+```go
+ctx := context.TODO()
+id := flexcomponents.NewLocationID("12345678-1234-9876-4563-123456789012", "locationName")
+
+// alternatively `client.ListByParent(ctx, id, flexcomponents.DefaultListByParentOperationOptions())` can be used to do batched pagination
+items, err := client.ListByParentComplete(ctx, id, flexcomponents.DefaultListByParentOperationOptions())
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/flexcomponents/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/flexcomponents/client.go
@@ -1,0 +1,26 @@
+package flexcomponents
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type FlexComponentsClient struct {
+	Client *resourcemanager.Client
+}
+
+func NewFlexComponentsClientWithBaseURI(sdkApi sdkEnv.Api) (*FlexComponentsClient, error) {
+	client, err := resourcemanager.NewClient(sdkApi, "flexcomponents", defaultApiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating FlexComponentsClient: %+v", err)
+	}
+
+	return &FlexComponentsClient{
+		Client: client,
+	}, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/flexcomponents/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/flexcomponents/constants.go
@@ -1,0 +1,95 @@
+package flexcomponents
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type HardwareType string
+
+const (
+	HardwareTypeCELL    HardwareType = "CELL"
+	HardwareTypeCOMPUTE HardwareType = "COMPUTE"
+)
+
+func PossibleValuesForHardwareType() []string {
+	return []string{
+		string(HardwareTypeCELL),
+		string(HardwareTypeCOMPUTE),
+	}
+}
+
+func (s *HardwareType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseHardwareType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseHardwareType(input string) (*HardwareType, error) {
+	vals := map[string]HardwareType{
+		"cell":    HardwareTypeCELL,
+		"compute": HardwareTypeCOMPUTE,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := HardwareType(input)
+	return &out, nil
+}
+
+type SystemShapes string
+
+const (
+	SystemShapesExaDbXS              SystemShapes = "ExaDbXS"
+	SystemShapesExadataPointXNineM   SystemShapes = "Exadata.X9M"
+	SystemShapesExadataPointXOneOneM SystemShapes = "Exadata.X11M"
+)
+
+func PossibleValuesForSystemShapes() []string {
+	return []string{
+		string(SystemShapesExaDbXS),
+		string(SystemShapesExadataPointXNineM),
+		string(SystemShapesExadataPointXOneOneM),
+	}
+}
+
+func (s *SystemShapes) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseSystemShapes(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseSystemShapes(input string) (*SystemShapes, error) {
+	vals := map[string]SystemShapes{
+		"exadbxs":      SystemShapesExaDbXS,
+		"exadata.x9m":  SystemShapesExadataPointXNineM,
+		"exadata.x11m": SystemShapesExadataPointXOneOneM,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := SystemShapes(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/flexcomponents/id_flexcomponent.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/flexcomponents/id_flexcomponent.go
@@ -1,0 +1,130 @@
+package flexcomponents
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&FlexComponentId{})
+}
+
+var _ resourceids.ResourceId = &FlexComponentId{}
+
+// FlexComponentId is a struct representing the Resource ID for a Flex Component
+type FlexComponentId struct {
+	SubscriptionId    string
+	LocationName      string
+	FlexComponentName string
+}
+
+// NewFlexComponentID returns a new FlexComponentId struct
+func NewFlexComponentID(subscriptionId string, locationName string, flexComponentName string) FlexComponentId {
+	return FlexComponentId{
+		SubscriptionId:    subscriptionId,
+		LocationName:      locationName,
+		FlexComponentName: flexComponentName,
+	}
+}
+
+// ParseFlexComponentID parses 'input' into a FlexComponentId
+func ParseFlexComponentID(input string) (*FlexComponentId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&FlexComponentId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := FlexComponentId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseFlexComponentIDInsensitively parses 'input' case-insensitively into a FlexComponentId
+// note: this method should only be used for API response data and not user input
+func ParseFlexComponentIDInsensitively(input string) (*FlexComponentId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&FlexComponentId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := FlexComponentId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *FlexComponentId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.LocationName, ok = input.Parsed["locationName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "locationName", input)
+	}
+
+	if id.FlexComponentName, ok = input.Parsed["flexComponentName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "flexComponentName", input)
+	}
+
+	return nil
+}
+
+// ValidateFlexComponentID checks that 'input' can be parsed as a Flex Component ID
+func ValidateFlexComponentID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseFlexComponentID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Flex Component ID
+func (id FlexComponentId) ID() string {
+	fmtString := "/subscriptions/%s/providers/Oracle.Database/locations/%s/flexComponents/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.LocationName, id.FlexComponentName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Flex Component ID
+func (id FlexComponentId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticOracleDatabase", "Oracle.Database", "Oracle.Database"),
+		resourceids.StaticSegment("staticLocations", "locations", "locations"),
+		resourceids.UserSpecifiedSegment("locationName", "locationName"),
+		resourceids.StaticSegment("staticFlexComponents", "flexComponents", "flexComponents"),
+		resourceids.UserSpecifiedSegment("flexComponentName", "flexComponentName"),
+	}
+}
+
+// String returns a human-readable description of this Flex Component ID
+func (id FlexComponentId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Location Name: %q", id.LocationName),
+		fmt.Sprintf("Flex Component Name: %q", id.FlexComponentName),
+	}
+	return fmt.Sprintf("Flex Component (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/flexcomponents/id_location.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/flexcomponents/id_location.go
@@ -1,0 +1,121 @@
+package flexcomponents
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&LocationId{})
+}
+
+var _ resourceids.ResourceId = &LocationId{}
+
+// LocationId is a struct representing the Resource ID for a Location
+type LocationId struct {
+	SubscriptionId string
+	LocationName   string
+}
+
+// NewLocationID returns a new LocationId struct
+func NewLocationID(subscriptionId string, locationName string) LocationId {
+	return LocationId{
+		SubscriptionId: subscriptionId,
+		LocationName:   locationName,
+	}
+}
+
+// ParseLocationID parses 'input' into a LocationId
+func ParseLocationID(input string) (*LocationId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&LocationId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := LocationId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseLocationIDInsensitively parses 'input' case-insensitively into a LocationId
+// note: this method should only be used for API response data and not user input
+func ParseLocationIDInsensitively(input string) (*LocationId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&LocationId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := LocationId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *LocationId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.LocationName, ok = input.Parsed["locationName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "locationName", input)
+	}
+
+	return nil
+}
+
+// ValidateLocationID checks that 'input' can be parsed as a Location ID
+func ValidateLocationID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseLocationID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Location ID
+func (id LocationId) ID() string {
+	fmtString := "/subscriptions/%s/providers/Oracle.Database/locations/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.LocationName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Location ID
+func (id LocationId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticOracleDatabase", "Oracle.Database", "Oracle.Database"),
+		resourceids.StaticSegment("staticLocations", "locations", "locations"),
+		resourceids.UserSpecifiedSegment("locationName", "locationName"),
+	}
+}
+
+// String returns a human-readable description of this Location ID
+func (id LocationId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Location Name: %q", id.LocationName),
+	}
+	return fmt.Sprintf("Location (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/flexcomponents/method_get.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/flexcomponents/method_get.go
@@ -1,0 +1,53 @@
+package flexcomponents
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *FlexComponent
+}
+
+// Get ...
+func (c FlexComponentsClient) Get(ctx context.Context, id FlexComponentId) (result GetOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model FlexComponent
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/flexcomponents/method_listbyparent.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/flexcomponents/method_listbyparent.go
@@ -1,0 +1,134 @@
+package flexcomponents
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListByParentOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]FlexComponent
+}
+
+type ListByParentCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []FlexComponent
+}
+
+type ListByParentOperationOptions struct {
+	Shape *SystemShapes
+}
+
+func DefaultListByParentOperationOptions() ListByParentOperationOptions {
+	return ListByParentOperationOptions{}
+}
+
+func (o ListByParentOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+
+	return &out
+}
+
+func (o ListByParentOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+
+	return &out
+}
+
+func (o ListByParentOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+	if o.Shape != nil {
+		out.Append("shape", fmt.Sprintf("%v", *o.Shape))
+	}
+	return &out
+}
+
+type ListByParentCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *ListByParentCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// ListByParent ...
+func (c FlexComponentsClient) ListByParent(ctx context.Context, id LocationId, options ListByParentOperationOptions) (result ListByParentOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodGet,
+		OptionsObject: options,
+		Pager:         &ListByParentCustomPager{},
+		Path:          fmt.Sprintf("%s/flexComponents", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]FlexComponent `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListByParentComplete retrieves all the results into a single object
+func (c FlexComponentsClient) ListByParentComplete(ctx context.Context, id LocationId, options ListByParentOperationOptions) (ListByParentCompleteResult, error) {
+	return c.ListByParentCompleteMatchingPredicate(ctx, id, options, FlexComponentOperationPredicate{})
+}
+
+// ListByParentCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c FlexComponentsClient) ListByParentCompleteMatchingPredicate(ctx context.Context, id LocationId, options ListByParentOperationOptions, predicate FlexComponentOperationPredicate) (result ListByParentCompleteResult, err error) {
+	items := make([]FlexComponent, 0)
+
+	resp, err := c.ListByParent(ctx, id, options)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListByParentCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/flexcomponents/model_flexcomponent.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/flexcomponents/model_flexcomponent.go
@@ -1,0 +1,16 @@
+package flexcomponents
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/systemdata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type FlexComponent struct {
+	Id         *string                  `json:"id,omitempty"`
+	Name       *string                  `json:"name,omitempty"`
+	Properties *FlexComponentProperties `json:"properties,omitempty"`
+	SystemData *systemdata.SystemData   `json:"systemData,omitempty"`
+	Type       *string                  `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/flexcomponents/model_flexcomponentproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/flexcomponents/model_flexcomponentproperties.go
@@ -1,0 +1,17 @@
+package flexcomponents
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type FlexComponentProperties struct {
+	AvailableCoreCount         *int64        `json:"availableCoreCount,omitempty"`
+	AvailableDbStorageInGbs    *int64        `json:"availableDbStorageInGbs,omitempty"`
+	AvailableLocalStorageInGbs *int64        `json:"availableLocalStorageInGbs,omitempty"`
+	AvailableMemoryInGbs       *int64        `json:"availableMemoryInGbs,omitempty"`
+	ComputeModel               *string       `json:"computeModel,omitempty"`
+	DescriptionSummary         *string       `json:"descriptionSummary,omitempty"`
+	HardwareType               *HardwareType `json:"hardwareType,omitempty"`
+	MinimumCoreCount           *int64        `json:"minimumCoreCount,omitempty"`
+	RuntimeMinimumCoreCount    *int64        `json:"runtimeMinimumCoreCount,omitempty"`
+	Shape                      *string       `json:"shape,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/flexcomponents/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/flexcomponents/predicates.go
@@ -1,0 +1,27 @@
+package flexcomponents
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type FlexComponentOperationPredicate struct {
+	Id   *string
+	Name *string
+	Type *string
+}
+
+func (p FlexComponentOperationPredicate) Matches(input FlexComponent) bool {
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/flexcomponents/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/flexcomponents/version.go
@@ -1,0 +1,10 @@
+package flexcomponents
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2025-03-01"
+
+func userAgent() string {
+	return "hashicorp/go-azure-sdk/flexcomponents/2025-03-01"
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/giminorversions/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/giminorversions/README.md
@@ -1,0 +1,53 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/giminorversions` Documentation
+
+The `giminorversions` SDK allows for interaction with Azure Resource Manager `oracledatabase` (API Version `2025-03-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/giminorversions"
+```
+
+
+### Client Initialization
+
+```go
+client := giminorversions.NewGiMinorVersionsClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `GiMinorVersionsClient.Get`
+
+```go
+ctx := context.TODO()
+id := giminorversions.NewGiMinorVersionID("12345678-1234-9876-4563-123456789012", "locationName", "giVersionName", "giMinorVersionName")
+
+read, err := client.Get(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `GiMinorVersionsClient.ListByParent`
+
+```go
+ctx := context.TODO()
+id := giminorversions.NewGiVersionID("12345678-1234-9876-4563-123456789012", "locationName", "giVersionName")
+
+// alternatively `client.ListByParent(ctx, id, giminorversions.DefaultListByParentOperationOptions())` can be used to do batched pagination
+items, err := client.ListByParentComplete(ctx, id, giminorversions.DefaultListByParentOperationOptions())
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/giminorversions/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/giminorversions/client.go
@@ -1,0 +1,26 @@
+package giminorversions
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GiMinorVersionsClient struct {
+	Client *resourcemanager.Client
+}
+
+func NewGiMinorVersionsClientWithBaseURI(sdkApi sdkEnv.Api) (*GiMinorVersionsClient, error) {
+	client, err := resourcemanager.NewClient(sdkApi, "giminorversions", defaultApiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating GiMinorVersionsClient: %+v", err)
+	}
+
+	return &GiMinorVersionsClient{
+		Client: client,
+	}, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/giminorversions/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/giminorversions/constants.go
@@ -1,0 +1,51 @@
+package giminorversions
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ShapeFamily string
+
+const (
+	ShapeFamilyEXADATA ShapeFamily = "EXADATA"
+	ShapeFamilyEXADBXS ShapeFamily = "EXADB_XS"
+)
+
+func PossibleValuesForShapeFamily() []string {
+	return []string{
+		string(ShapeFamilyEXADATA),
+		string(ShapeFamilyEXADBXS),
+	}
+}
+
+func (s *ShapeFamily) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseShapeFamily(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseShapeFamily(input string) (*ShapeFamily, error) {
+	vals := map[string]ShapeFamily{
+		"exadata":  ShapeFamilyEXADATA,
+		"exadb_xs": ShapeFamilyEXADBXS,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ShapeFamily(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/giminorversions/id_giminorversion.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/giminorversions/id_giminorversion.go
@@ -1,0 +1,139 @@
+package giminorversions
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&GiMinorVersionId{})
+}
+
+var _ resourceids.ResourceId = &GiMinorVersionId{}
+
+// GiMinorVersionId is a struct representing the Resource ID for a Gi Minor Version
+type GiMinorVersionId struct {
+	SubscriptionId     string
+	LocationName       string
+	GiVersionName      string
+	GiMinorVersionName string
+}
+
+// NewGiMinorVersionID returns a new GiMinorVersionId struct
+func NewGiMinorVersionID(subscriptionId string, locationName string, giVersionName string, giMinorVersionName string) GiMinorVersionId {
+	return GiMinorVersionId{
+		SubscriptionId:     subscriptionId,
+		LocationName:       locationName,
+		GiVersionName:      giVersionName,
+		GiMinorVersionName: giMinorVersionName,
+	}
+}
+
+// ParseGiMinorVersionID parses 'input' into a GiMinorVersionId
+func ParseGiMinorVersionID(input string) (*GiMinorVersionId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&GiMinorVersionId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := GiMinorVersionId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseGiMinorVersionIDInsensitively parses 'input' case-insensitively into a GiMinorVersionId
+// note: this method should only be used for API response data and not user input
+func ParseGiMinorVersionIDInsensitively(input string) (*GiMinorVersionId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&GiMinorVersionId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := GiMinorVersionId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *GiMinorVersionId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.LocationName, ok = input.Parsed["locationName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "locationName", input)
+	}
+
+	if id.GiVersionName, ok = input.Parsed["giVersionName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "giVersionName", input)
+	}
+
+	if id.GiMinorVersionName, ok = input.Parsed["giMinorVersionName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "giMinorVersionName", input)
+	}
+
+	return nil
+}
+
+// ValidateGiMinorVersionID checks that 'input' can be parsed as a Gi Minor Version ID
+func ValidateGiMinorVersionID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseGiMinorVersionID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Gi Minor Version ID
+func (id GiMinorVersionId) ID() string {
+	fmtString := "/subscriptions/%s/providers/Oracle.Database/locations/%s/giVersions/%s/giMinorVersions/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.LocationName, id.GiVersionName, id.GiMinorVersionName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Gi Minor Version ID
+func (id GiMinorVersionId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticOracleDatabase", "Oracle.Database", "Oracle.Database"),
+		resourceids.StaticSegment("staticLocations", "locations", "locations"),
+		resourceids.UserSpecifiedSegment("locationName", "locationName"),
+		resourceids.StaticSegment("staticGiVersions", "giVersions", "giVersions"),
+		resourceids.UserSpecifiedSegment("giVersionName", "giVersionName"),
+		resourceids.StaticSegment("staticGiMinorVersions", "giMinorVersions", "giMinorVersions"),
+		resourceids.UserSpecifiedSegment("giMinorVersionName", "giMinorVersionName"),
+	}
+}
+
+// String returns a human-readable description of this Gi Minor Version ID
+func (id GiMinorVersionId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Location Name: %q", id.LocationName),
+		fmt.Sprintf("Gi Version Name: %q", id.GiVersionName),
+		fmt.Sprintf("Gi Minor Version Name: %q", id.GiMinorVersionName),
+	}
+	return fmt.Sprintf("Gi Minor Version (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/giminorversions/id_giversion.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/giminorversions/id_giversion.go
@@ -1,0 +1,130 @@
+package giminorversions
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&GiVersionId{})
+}
+
+var _ resourceids.ResourceId = &GiVersionId{}
+
+// GiVersionId is a struct representing the Resource ID for a Gi Version
+type GiVersionId struct {
+	SubscriptionId string
+	LocationName   string
+	GiVersionName  string
+}
+
+// NewGiVersionID returns a new GiVersionId struct
+func NewGiVersionID(subscriptionId string, locationName string, giVersionName string) GiVersionId {
+	return GiVersionId{
+		SubscriptionId: subscriptionId,
+		LocationName:   locationName,
+		GiVersionName:  giVersionName,
+	}
+}
+
+// ParseGiVersionID parses 'input' into a GiVersionId
+func ParseGiVersionID(input string) (*GiVersionId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&GiVersionId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := GiVersionId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseGiVersionIDInsensitively parses 'input' case-insensitively into a GiVersionId
+// note: this method should only be used for API response data and not user input
+func ParseGiVersionIDInsensitively(input string) (*GiVersionId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&GiVersionId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := GiVersionId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *GiVersionId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.LocationName, ok = input.Parsed["locationName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "locationName", input)
+	}
+
+	if id.GiVersionName, ok = input.Parsed["giVersionName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "giVersionName", input)
+	}
+
+	return nil
+}
+
+// ValidateGiVersionID checks that 'input' can be parsed as a Gi Version ID
+func ValidateGiVersionID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseGiVersionID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Gi Version ID
+func (id GiVersionId) ID() string {
+	fmtString := "/subscriptions/%s/providers/Oracle.Database/locations/%s/giVersions/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.LocationName, id.GiVersionName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Gi Version ID
+func (id GiVersionId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticOracleDatabase", "Oracle.Database", "Oracle.Database"),
+		resourceids.StaticSegment("staticLocations", "locations", "locations"),
+		resourceids.UserSpecifiedSegment("locationName", "locationName"),
+		resourceids.StaticSegment("staticGiVersions", "giVersions", "giVersions"),
+		resourceids.UserSpecifiedSegment("giVersionName", "giVersionName"),
+	}
+}
+
+// String returns a human-readable description of this Gi Version ID
+func (id GiVersionId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Location Name: %q", id.LocationName),
+		fmt.Sprintf("Gi Version Name: %q", id.GiVersionName),
+	}
+	return fmt.Sprintf("Gi Version (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/giminorversions/method_get.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/giminorversions/method_get.go
@@ -1,0 +1,53 @@
+package giminorversions
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *GiMinorVersion
+}
+
+// Get ...
+func (c GiMinorVersionsClient) Get(ctx context.Context, id GiMinorVersionId) (result GetOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model GiMinorVersion
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/giminorversions/method_listbyparent.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/giminorversions/method_listbyparent.go
@@ -1,0 +1,138 @@
+package giminorversions
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListByParentOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]GiMinorVersion
+}
+
+type ListByParentCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []GiMinorVersion
+}
+
+type ListByParentOperationOptions struct {
+	ShapeFamily *ShapeFamily
+	Zone        *string
+}
+
+func DefaultListByParentOperationOptions() ListByParentOperationOptions {
+	return ListByParentOperationOptions{}
+}
+
+func (o ListByParentOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+
+	return &out
+}
+
+func (o ListByParentOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+
+	return &out
+}
+
+func (o ListByParentOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+	if o.ShapeFamily != nil {
+		out.Append("shapeFamily", fmt.Sprintf("%v", *o.ShapeFamily))
+	}
+	if o.Zone != nil {
+		out.Append("zone", fmt.Sprintf("%v", *o.Zone))
+	}
+	return &out
+}
+
+type ListByParentCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *ListByParentCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// ListByParent ...
+func (c GiMinorVersionsClient) ListByParent(ctx context.Context, id GiVersionId, options ListByParentOperationOptions) (result ListByParentOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodGet,
+		OptionsObject: options,
+		Pager:         &ListByParentCustomPager{},
+		Path:          fmt.Sprintf("%s/giMinorVersions", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]GiMinorVersion `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListByParentComplete retrieves all the results into a single object
+func (c GiMinorVersionsClient) ListByParentComplete(ctx context.Context, id GiVersionId, options ListByParentOperationOptions) (ListByParentCompleteResult, error) {
+	return c.ListByParentCompleteMatchingPredicate(ctx, id, options, GiMinorVersionOperationPredicate{})
+}
+
+// ListByParentCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c GiMinorVersionsClient) ListByParentCompleteMatchingPredicate(ctx context.Context, id GiVersionId, options ListByParentOperationOptions, predicate GiMinorVersionOperationPredicate) (result ListByParentCompleteResult, err error) {
+	items := make([]GiMinorVersion, 0)
+
+	resp, err := c.ListByParent(ctx, id, options)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListByParentCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/giminorversions/model_giminorversion.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/giminorversions/model_giminorversion.go
@@ -1,0 +1,16 @@
+package giminorversions
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/systemdata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GiMinorVersion struct {
+	Id         *string                   `json:"id,omitempty"`
+	Name       *string                   `json:"name,omitempty"`
+	Properties *GiMinorVersionProperties `json:"properties,omitempty"`
+	SystemData *systemdata.SystemData    `json:"systemData,omitempty"`
+	Type       *string                   `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/giminorversions/model_giminorversionproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/giminorversions/model_giminorversionproperties.go
@@ -1,0 +1,9 @@
+package giminorversions
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GiMinorVersionProperties struct {
+	GridImageOcid *string `json:"gridImageOcid,omitempty"`
+	Version       string  `json:"version"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/giminorversions/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/giminorversions/predicates.go
@@ -1,0 +1,27 @@
+package giminorversions
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GiMinorVersionOperationPredicate struct {
+	Id   *string
+	Name *string
+	Type *string
+}
+
+func (p GiMinorVersionOperationPredicate) Matches(input GiMinorVersion) bool {
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/giminorversions/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/giminorversions/version.go
@@ -1,0 +1,10 @@
+package giminorversions
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2025-03-01"
+
+func userAgent() string {
+	return "hashicorp/go-azure-sdk/giminorversions/2025-03-01"
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/giversions/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/giversions/README.md
@@ -1,0 +1,53 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/giversions` Documentation
+
+The `giversions` SDK allows for interaction with Azure Resource Manager `oracledatabase` (API Version `2025-03-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/giversions"
+```
+
+
+### Client Initialization
+
+```go
+client := giversions.NewGiVersionsClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `GiVersionsClient.Get`
+
+```go
+ctx := context.TODO()
+id := giversions.NewGiVersionID("12345678-1234-9876-4563-123456789012", "locationName", "giVersionName")
+
+read, err := client.Get(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `GiVersionsClient.ListByLocation`
+
+```go
+ctx := context.TODO()
+id := giversions.NewLocationID("12345678-1234-9876-4563-123456789012", "locationName")
+
+// alternatively `client.ListByLocation(ctx, id, giversions.DefaultListByLocationOperationOptions())` can be used to do batched pagination
+items, err := client.ListByLocationComplete(ctx, id, giversions.DefaultListByLocationOperationOptions())
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/giversions/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/giversions/client.go
@@ -1,0 +1,26 @@
+package giversions
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GiVersionsClient struct {
+	Client *resourcemanager.Client
+}
+
+func NewGiVersionsClientWithBaseURI(sdkApi sdkEnv.Api) (*GiVersionsClient, error) {
+	client, err := resourcemanager.NewClient(sdkApi, "giversions", defaultApiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating GiVersionsClient: %+v", err)
+	}
+
+	return &GiVersionsClient{
+		Client: client,
+	}, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/giversions/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/giversions/constants.go
@@ -1,0 +1,54 @@
+package giversions
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SystemShapes string
+
+const (
+	SystemShapesExaDbXS              SystemShapes = "ExaDbXS"
+	SystemShapesExadataPointXNineM   SystemShapes = "Exadata.X9M"
+	SystemShapesExadataPointXOneOneM SystemShapes = "Exadata.X11M"
+)
+
+func PossibleValuesForSystemShapes() []string {
+	return []string{
+		string(SystemShapesExaDbXS),
+		string(SystemShapesExadataPointXNineM),
+		string(SystemShapesExadataPointXOneOneM),
+	}
+}
+
+func (s *SystemShapes) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseSystemShapes(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseSystemShapes(input string) (*SystemShapes, error) {
+	vals := map[string]SystemShapes{
+		"exadbxs":      SystemShapesExaDbXS,
+		"exadata.x9m":  SystemShapesExadataPointXNineM,
+		"exadata.x11m": SystemShapesExadataPointXOneOneM,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := SystemShapes(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/giversions/id_giversion.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/giversions/id_giversion.go
@@ -1,0 +1,130 @@
+package giversions
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&GiVersionId{})
+}
+
+var _ resourceids.ResourceId = &GiVersionId{}
+
+// GiVersionId is a struct representing the Resource ID for a Gi Version
+type GiVersionId struct {
+	SubscriptionId string
+	LocationName   string
+	GiVersionName  string
+}
+
+// NewGiVersionID returns a new GiVersionId struct
+func NewGiVersionID(subscriptionId string, locationName string, giVersionName string) GiVersionId {
+	return GiVersionId{
+		SubscriptionId: subscriptionId,
+		LocationName:   locationName,
+		GiVersionName:  giVersionName,
+	}
+}
+
+// ParseGiVersionID parses 'input' into a GiVersionId
+func ParseGiVersionID(input string) (*GiVersionId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&GiVersionId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := GiVersionId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseGiVersionIDInsensitively parses 'input' case-insensitively into a GiVersionId
+// note: this method should only be used for API response data and not user input
+func ParseGiVersionIDInsensitively(input string) (*GiVersionId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&GiVersionId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := GiVersionId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *GiVersionId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.LocationName, ok = input.Parsed["locationName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "locationName", input)
+	}
+
+	if id.GiVersionName, ok = input.Parsed["giVersionName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "giVersionName", input)
+	}
+
+	return nil
+}
+
+// ValidateGiVersionID checks that 'input' can be parsed as a Gi Version ID
+func ValidateGiVersionID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseGiVersionID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Gi Version ID
+func (id GiVersionId) ID() string {
+	fmtString := "/subscriptions/%s/providers/Oracle.Database/locations/%s/giVersions/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.LocationName, id.GiVersionName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Gi Version ID
+func (id GiVersionId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticOracleDatabase", "Oracle.Database", "Oracle.Database"),
+		resourceids.StaticSegment("staticLocations", "locations", "locations"),
+		resourceids.UserSpecifiedSegment("locationName", "locationName"),
+		resourceids.StaticSegment("staticGiVersions", "giVersions", "giVersions"),
+		resourceids.UserSpecifiedSegment("giVersionName", "giVersionName"),
+	}
+}
+
+// String returns a human-readable description of this Gi Version ID
+func (id GiVersionId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Location Name: %q", id.LocationName),
+		fmt.Sprintf("Gi Version Name: %q", id.GiVersionName),
+	}
+	return fmt.Sprintf("Gi Version (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/giversions/id_location.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/giversions/id_location.go
@@ -1,0 +1,121 @@
+package giversions
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&LocationId{})
+}
+
+var _ resourceids.ResourceId = &LocationId{}
+
+// LocationId is a struct representing the Resource ID for a Location
+type LocationId struct {
+	SubscriptionId string
+	LocationName   string
+}
+
+// NewLocationID returns a new LocationId struct
+func NewLocationID(subscriptionId string, locationName string) LocationId {
+	return LocationId{
+		SubscriptionId: subscriptionId,
+		LocationName:   locationName,
+	}
+}
+
+// ParseLocationID parses 'input' into a LocationId
+func ParseLocationID(input string) (*LocationId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&LocationId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := LocationId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseLocationIDInsensitively parses 'input' case-insensitively into a LocationId
+// note: this method should only be used for API response data and not user input
+func ParseLocationIDInsensitively(input string) (*LocationId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&LocationId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := LocationId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *LocationId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.LocationName, ok = input.Parsed["locationName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "locationName", input)
+	}
+
+	return nil
+}
+
+// ValidateLocationID checks that 'input' can be parsed as a Location ID
+func ValidateLocationID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseLocationID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Location ID
+func (id LocationId) ID() string {
+	fmtString := "/subscriptions/%s/providers/Oracle.Database/locations/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.LocationName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Location ID
+func (id LocationId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticOracleDatabase", "Oracle.Database", "Oracle.Database"),
+		resourceids.StaticSegment("staticLocations", "locations", "locations"),
+		resourceids.UserSpecifiedSegment("locationName", "locationName"),
+	}
+}
+
+// String returns a human-readable description of this Location ID
+func (id LocationId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Location Name: %q", id.LocationName),
+	}
+	return fmt.Sprintf("Location (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/giversions/method_get.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/giversions/method_get.go
@@ -1,0 +1,53 @@
+package giversions
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *GiVersion
+}
+
+// Get ...
+func (c GiVersionsClient) Get(ctx context.Context, id GiVersionId) (result GetOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model GiVersion
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/giversions/method_listbylocation.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/giversions/method_listbylocation.go
@@ -1,0 +1,138 @@
+package giversions
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListByLocationOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]GiVersion
+}
+
+type ListByLocationCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []GiVersion
+}
+
+type ListByLocationOperationOptions struct {
+	Shape *SystemShapes
+	Zone  *string
+}
+
+func DefaultListByLocationOperationOptions() ListByLocationOperationOptions {
+	return ListByLocationOperationOptions{}
+}
+
+func (o ListByLocationOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+
+	return &out
+}
+
+func (o ListByLocationOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+
+	return &out
+}
+
+func (o ListByLocationOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+	if o.Shape != nil {
+		out.Append("shape", fmt.Sprintf("%v", *o.Shape))
+	}
+	if o.Zone != nil {
+		out.Append("zone", fmt.Sprintf("%v", *o.Zone))
+	}
+	return &out
+}
+
+type ListByLocationCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *ListByLocationCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// ListByLocation ...
+func (c GiVersionsClient) ListByLocation(ctx context.Context, id LocationId, options ListByLocationOperationOptions) (result ListByLocationOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodGet,
+		OptionsObject: options,
+		Pager:         &ListByLocationCustomPager{},
+		Path:          fmt.Sprintf("%s/giVersions", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]GiVersion `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListByLocationComplete retrieves all the results into a single object
+func (c GiVersionsClient) ListByLocationComplete(ctx context.Context, id LocationId, options ListByLocationOperationOptions) (ListByLocationCompleteResult, error) {
+	return c.ListByLocationCompleteMatchingPredicate(ctx, id, options, GiVersionOperationPredicate{})
+}
+
+// ListByLocationCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c GiVersionsClient) ListByLocationCompleteMatchingPredicate(ctx context.Context, id LocationId, options ListByLocationOperationOptions, predicate GiVersionOperationPredicate) (result ListByLocationCompleteResult, err error) {
+	items := make([]GiVersion, 0)
+
+	resp, err := c.ListByLocation(ctx, id, options)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListByLocationCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/giversions/model_giversion.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/giversions/model_giversion.go
@@ -1,0 +1,16 @@
+package giversions
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/systemdata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GiVersion struct {
+	Id         *string                `json:"id,omitempty"`
+	Name       *string                `json:"name,omitempty"`
+	Properties *GiVersionProperties   `json:"properties,omitempty"`
+	SystemData *systemdata.SystemData `json:"systemData,omitempty"`
+	Type       *string                `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/giversions/model_giversionproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/giversions/model_giversionproperties.go
@@ -1,0 +1,8 @@
+package giversions
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GiVersionProperties struct {
+	Version string `json:"version"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/giversions/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/giversions/predicates.go
@@ -1,0 +1,27 @@
+package giversions
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GiVersionOperationPredicate struct {
+	Id   *string
+	Name *string
+	Type *string
+}
+
+func (p GiVersionOperationPredicate) Matches(input GiVersion) bool {
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/giversions/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/giversions/version.go
@@ -1,0 +1,10 @@
+package giversions
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2025-03-01"
+
+func userAgent() string {
+	return "hashicorp/go-azure-sdk/giversions/2025-03-01"
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/oraclesubscriptions/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/oraclesubscriptions/README.md
@@ -1,0 +1,153 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/oraclesubscriptions` Documentation
+
+The `oraclesubscriptions` SDK allows for interaction with Azure Resource Manager `oracledatabase` (API Version `2025-03-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+import "github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/oraclesubscriptions"
+```
+
+
+### Client Initialization
+
+```go
+client := oraclesubscriptions.NewOracleSubscriptionsClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `OracleSubscriptionsClient.AddAzureSubscriptions`
+
+```go
+ctx := context.TODO()
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+
+payload := oraclesubscriptions.AzureSubscriptions{
+	// ...
+}
+
+
+if err := client.AddAzureSubscriptionsThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `OracleSubscriptionsClient.CreateOrUpdate`
+
+```go
+ctx := context.TODO()
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+
+payload := oraclesubscriptions.OracleSubscription{
+	// ...
+}
+
+
+if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `OracleSubscriptionsClient.Delete`
+
+```go
+ctx := context.TODO()
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+
+if err := client.DeleteThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `OracleSubscriptionsClient.Get`
+
+```go
+ctx := context.TODO()
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+
+read, err := client.Get(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `OracleSubscriptionsClient.ListActivationLinks`
+
+```go
+ctx := context.TODO()
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+
+if err := client.ListActivationLinksThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `OracleSubscriptionsClient.ListBySubscription`
+
+```go
+ctx := context.TODO()
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+
+// alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
+items, err := client.ListBySubscriptionComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `OracleSubscriptionsClient.ListCloudAccountDetails`
+
+```go
+ctx := context.TODO()
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+
+if err := client.ListCloudAccountDetailsThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `OracleSubscriptionsClient.ListSaasSubscriptionDetails`
+
+```go
+ctx := context.TODO()
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+
+if err := client.ListSaasSubscriptionDetailsThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `OracleSubscriptionsClient.Update`
+
+```go
+ctx := context.TODO()
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+
+payload := oraclesubscriptions.OracleSubscriptionUpdate{
+	// ...
+}
+
+
+if err := client.UpdateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/oraclesubscriptions/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/oraclesubscriptions/client.go
@@ -1,0 +1,26 @@
+package oraclesubscriptions
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type OracleSubscriptionsClient struct {
+	Client *resourcemanager.Client
+}
+
+func NewOracleSubscriptionsClientWithBaseURI(sdkApi sdkEnv.Api) (*OracleSubscriptionsClient, error) {
+	client, err := resourcemanager.NewClient(sdkApi, "oraclesubscriptions", defaultApiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating OracleSubscriptionsClient: %+v", err)
+	}
+
+	return &OracleSubscriptionsClient{
+		Client: client,
+	}, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/oraclesubscriptions/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/oraclesubscriptions/constants.go
@@ -1,0 +1,183 @@
+package oraclesubscriptions
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AddSubscriptionOperationState string
+
+const (
+	AddSubscriptionOperationStateFailed    AddSubscriptionOperationState = "Failed"
+	AddSubscriptionOperationStateSucceeded AddSubscriptionOperationState = "Succeeded"
+	AddSubscriptionOperationStateUpdating  AddSubscriptionOperationState = "Updating"
+)
+
+func PossibleValuesForAddSubscriptionOperationState() []string {
+	return []string{
+		string(AddSubscriptionOperationStateFailed),
+		string(AddSubscriptionOperationStateSucceeded),
+		string(AddSubscriptionOperationStateUpdating),
+	}
+}
+
+func (s *AddSubscriptionOperationState) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseAddSubscriptionOperationState(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseAddSubscriptionOperationState(input string) (*AddSubscriptionOperationState, error) {
+	vals := map[string]AddSubscriptionOperationState{
+		"failed":    AddSubscriptionOperationStateFailed,
+		"succeeded": AddSubscriptionOperationStateSucceeded,
+		"updating":  AddSubscriptionOperationStateUpdating,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := AddSubscriptionOperationState(input)
+	return &out, nil
+}
+
+type CloudAccountProvisioningState string
+
+const (
+	CloudAccountProvisioningStateAvailable    CloudAccountProvisioningState = "Available"
+	CloudAccountProvisioningStatePending      CloudAccountProvisioningState = "Pending"
+	CloudAccountProvisioningStateProvisioning CloudAccountProvisioningState = "Provisioning"
+)
+
+func PossibleValuesForCloudAccountProvisioningState() []string {
+	return []string{
+		string(CloudAccountProvisioningStateAvailable),
+		string(CloudAccountProvisioningStatePending),
+		string(CloudAccountProvisioningStateProvisioning),
+	}
+}
+
+func (s *CloudAccountProvisioningState) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseCloudAccountProvisioningState(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseCloudAccountProvisioningState(input string) (*CloudAccountProvisioningState, error) {
+	vals := map[string]CloudAccountProvisioningState{
+		"available":    CloudAccountProvisioningStateAvailable,
+		"pending":      CloudAccountProvisioningStatePending,
+		"provisioning": CloudAccountProvisioningStateProvisioning,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := CloudAccountProvisioningState(input)
+	return &out, nil
+}
+
+type Intent string
+
+const (
+	IntentReset  Intent = "Reset"
+	IntentRetain Intent = "Retain"
+)
+
+func PossibleValuesForIntent() []string {
+	return []string{
+		string(IntentReset),
+		string(IntentRetain),
+	}
+}
+
+func (s *Intent) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseIntent(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseIntent(input string) (*Intent, error) {
+	vals := map[string]Intent{
+		"reset":  IntentReset,
+		"retain": IntentRetain,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := Intent(input)
+	return &out, nil
+}
+
+type OracleSubscriptionProvisioningState string
+
+const (
+	OracleSubscriptionProvisioningStateCanceled  OracleSubscriptionProvisioningState = "Canceled"
+	OracleSubscriptionProvisioningStateFailed    OracleSubscriptionProvisioningState = "Failed"
+	OracleSubscriptionProvisioningStateSucceeded OracleSubscriptionProvisioningState = "Succeeded"
+)
+
+func PossibleValuesForOracleSubscriptionProvisioningState() []string {
+	return []string{
+		string(OracleSubscriptionProvisioningStateCanceled),
+		string(OracleSubscriptionProvisioningStateFailed),
+		string(OracleSubscriptionProvisioningStateSucceeded),
+	}
+}
+
+func (s *OracleSubscriptionProvisioningState) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseOracleSubscriptionProvisioningState(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseOracleSubscriptionProvisioningState(input string) (*OracleSubscriptionProvisioningState, error) {
+	vals := map[string]OracleSubscriptionProvisioningState{
+		"canceled":  OracleSubscriptionProvisioningStateCanceled,
+		"failed":    OracleSubscriptionProvisioningStateFailed,
+		"succeeded": OracleSubscriptionProvisioningStateSucceeded,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := OracleSubscriptionProvisioningState(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/oraclesubscriptions/method_addazuresubscriptions.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/oraclesubscriptions/method_addazuresubscriptions.go
@@ -1,0 +1,74 @@
+package oraclesubscriptions
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AddAzureSubscriptionsOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// AddAzureSubscriptions ...
+func (c OracleSubscriptionsClient) AddAzureSubscriptions(ctx context.Context, id commonids.SubscriptionId, input AzureSubscriptions) (result AddAzureSubscriptionsOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/providers/Oracle.Database/oracleSubscriptions/default/addAzureSubscriptions", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// AddAzureSubscriptionsThenPoll performs AddAzureSubscriptions then polls until it's completed
+func (c OracleSubscriptionsClient) AddAzureSubscriptionsThenPoll(ctx context.Context, id commonids.SubscriptionId, input AzureSubscriptions) error {
+	result, err := c.AddAzureSubscriptions(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing AddAzureSubscriptions: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after AddAzureSubscriptions: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/oraclesubscriptions/method_createorupdate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/oraclesubscriptions/method_createorupdate.go
@@ -1,0 +1,76 @@
+package oraclesubscriptions
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateOrUpdateOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *OracleSubscription
+}
+
+// CreateOrUpdate ...
+func (c OracleSubscriptionsClient) CreateOrUpdate(ctx context.Context, id commonids.SubscriptionId, input OracleSubscription) (result CreateOrUpdateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPut,
+		Path:       fmt.Sprintf("%s/providers/Oracle.Database/oracleSubscriptions/default", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// CreateOrUpdateThenPoll performs CreateOrUpdate then polls until it's completed
+func (c OracleSubscriptionsClient) CreateOrUpdateThenPoll(ctx context.Context, id commonids.SubscriptionId, input OracleSubscription) error {
+	result, err := c.CreateOrUpdate(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing CreateOrUpdate: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after CreateOrUpdate: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/oraclesubscriptions/method_delete.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/oraclesubscriptions/method_delete.go
@@ -1,0 +1,71 @@
+package oraclesubscriptions
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeleteOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// Delete ...
+func (c OracleSubscriptionsClient) Delete(ctx context.Context, id commonids.SubscriptionId) (result DeleteOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusNoContent,
+		},
+		HttpMethod: http.MethodDelete,
+		Path:       fmt.Sprintf("%s/providers/Oracle.Database/oracleSubscriptions/default", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// DeleteThenPoll performs Delete then polls until it's completed
+func (c OracleSubscriptionsClient) DeleteThenPoll(ctx context.Context, id commonids.SubscriptionId) error {
+	result, err := c.Delete(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing Delete: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Delete: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/oraclesubscriptions/method_get.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/oraclesubscriptions/method_get.go
@@ -1,0 +1,55 @@
+package oraclesubscriptions
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *OracleSubscription
+}
+
+// Get ...
+func (c OracleSubscriptionsClient) Get(ctx context.Context, id commonids.SubscriptionId) (result GetOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       fmt.Sprintf("%s/providers/Oracle.Database/oracleSubscriptions/default", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model OracleSubscription
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/oraclesubscriptions/method_listactivationlinks.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/oraclesubscriptions/method_listactivationlinks.go
@@ -1,0 +1,72 @@
+package oraclesubscriptions
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListActivationLinksOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *ActivationLinks
+}
+
+// ListActivationLinks ...
+func (c OracleSubscriptionsClient) ListActivationLinks(ctx context.Context, id commonids.SubscriptionId) (result ListActivationLinksOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/providers/Oracle.Database/oracleSubscriptions/default/listActivationLinks", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// ListActivationLinksThenPoll performs ListActivationLinks then polls until it's completed
+func (c OracleSubscriptionsClient) ListActivationLinksThenPoll(ctx context.Context, id commonids.SubscriptionId) error {
+	result, err := c.ListActivationLinks(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing ListActivationLinks: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after ListActivationLinks: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/oraclesubscriptions/method_listbysubscription.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/oraclesubscriptions/method_listbysubscription.go
@@ -1,0 +1,106 @@
+package oraclesubscriptions
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListBySubscriptionOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]OracleSubscription
+}
+
+type ListBySubscriptionCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []OracleSubscription
+}
+
+type ListBySubscriptionCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *ListBySubscriptionCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// ListBySubscription ...
+func (c OracleSubscriptionsClient) ListBySubscription(ctx context.Context, id commonids.SubscriptionId) (result ListBySubscriptionOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Pager:      &ListBySubscriptionCustomPager{},
+		Path:       fmt.Sprintf("%s/providers/Oracle.Database/oracleSubscriptions", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]OracleSubscription `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListBySubscriptionComplete retrieves all the results into a single object
+func (c OracleSubscriptionsClient) ListBySubscriptionComplete(ctx context.Context, id commonids.SubscriptionId) (ListBySubscriptionCompleteResult, error) {
+	return c.ListBySubscriptionCompleteMatchingPredicate(ctx, id, OracleSubscriptionOperationPredicate{})
+}
+
+// ListBySubscriptionCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c OracleSubscriptionsClient) ListBySubscriptionCompleteMatchingPredicate(ctx context.Context, id commonids.SubscriptionId, predicate OracleSubscriptionOperationPredicate) (result ListBySubscriptionCompleteResult, err error) {
+	items := make([]OracleSubscription, 0)
+
+	resp, err := c.ListBySubscription(ctx, id)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListBySubscriptionCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/oraclesubscriptions/method_listcloudaccountdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/oraclesubscriptions/method_listcloudaccountdetails.go
@@ -1,0 +1,72 @@
+package oraclesubscriptions
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListCloudAccountDetailsOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *CloudAccountDetails
+}
+
+// ListCloudAccountDetails ...
+func (c OracleSubscriptionsClient) ListCloudAccountDetails(ctx context.Context, id commonids.SubscriptionId) (result ListCloudAccountDetailsOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/providers/Oracle.Database/oracleSubscriptions/default/listCloudAccountDetails", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// ListCloudAccountDetailsThenPoll performs ListCloudAccountDetails then polls until it's completed
+func (c OracleSubscriptionsClient) ListCloudAccountDetailsThenPoll(ctx context.Context, id commonids.SubscriptionId) error {
+	result, err := c.ListCloudAccountDetails(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing ListCloudAccountDetails: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after ListCloudAccountDetails: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/oraclesubscriptions/method_listsaassubscriptiondetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/oraclesubscriptions/method_listsaassubscriptiondetails.go
@@ -1,0 +1,72 @@
+package oraclesubscriptions
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListSaasSubscriptionDetailsOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *SaasSubscriptionDetails
+}
+
+// ListSaasSubscriptionDetails ...
+func (c OracleSubscriptionsClient) ListSaasSubscriptionDetails(ctx context.Context, id commonids.SubscriptionId) (result ListSaasSubscriptionDetailsOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/providers/Oracle.Database/oracleSubscriptions/default/listSaasSubscriptionDetails", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// ListSaasSubscriptionDetailsThenPoll performs ListSaasSubscriptionDetails then polls until it's completed
+func (c OracleSubscriptionsClient) ListSaasSubscriptionDetailsThenPoll(ctx context.Context, id commonids.SubscriptionId) error {
+	result, err := c.ListSaasSubscriptionDetails(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing ListSaasSubscriptionDetails: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after ListSaasSubscriptionDetails: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/oraclesubscriptions/method_update.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/oraclesubscriptions/method_update.go
@@ -1,0 +1,76 @@
+package oraclesubscriptions
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpdateOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *OracleSubscription
+}
+
+// Update ...
+func (c OracleSubscriptionsClient) Update(ctx context.Context, id commonids.SubscriptionId, input OracleSubscriptionUpdate) (result UpdateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPatch,
+		Path:       fmt.Sprintf("%s/providers/Oracle.Database/oracleSubscriptions/default", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// UpdateThenPoll performs Update then polls until it's completed
+func (c OracleSubscriptionsClient) UpdateThenPoll(ctx context.Context, id commonids.SubscriptionId, input OracleSubscriptionUpdate) error {
+	result, err := c.Update(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing Update: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Update: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/oraclesubscriptions/model_activationlinks.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/oraclesubscriptions/model_activationlinks.go
@@ -1,0 +1,9 @@
+package oraclesubscriptions
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ActivationLinks struct {
+	ExistingCloudAccountActivationLink *string `json:"existingCloudAccountActivationLink,omitempty"`
+	NewCloudAccountActivationLink      *string `json:"newCloudAccountActivationLink,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/oraclesubscriptions/model_azuresubscriptions.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/oraclesubscriptions/model_azuresubscriptions.go
@@ -1,0 +1,8 @@
+package oraclesubscriptions
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AzureSubscriptions struct {
+	AzureSubscriptionIds []string `json:"azureSubscriptionIds"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/oraclesubscriptions/model_cloudaccountdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/oraclesubscriptions/model_cloudaccountdetails.go
@@ -1,0 +1,9 @@
+package oraclesubscriptions
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CloudAccountDetails struct {
+	CloudAccountHomeRegion *string `json:"cloudAccountHomeRegion,omitempty"`
+	CloudAccountName       *string `json:"cloudAccountName,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/oraclesubscriptions/model_oraclesubscription.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/oraclesubscriptions/model_oraclesubscription.go
@@ -1,0 +1,17 @@
+package oraclesubscriptions
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/systemdata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type OracleSubscription struct {
+	Id         *string                       `json:"id,omitempty"`
+	Name       *string                       `json:"name,omitempty"`
+	Plan       *Plan                         `json:"plan,omitempty"`
+	Properties *OracleSubscriptionProperties `json:"properties,omitempty"`
+	SystemData *systemdata.SystemData        `json:"systemData,omitempty"`
+	Type       *string                       `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/oraclesubscriptions/model_oraclesubscriptionproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/oraclesubscriptions/model_oraclesubscriptionproperties.go
@@ -1,0 +1,17 @@
+package oraclesubscriptions
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type OracleSubscriptionProperties struct {
+	AddSubscriptionOperationState *AddSubscriptionOperationState       `json:"addSubscriptionOperationState,omitempty"`
+	AzureSubscriptionIds          *[]string                            `json:"azureSubscriptionIds,omitempty"`
+	CloudAccountId                *string                              `json:"cloudAccountId,omitempty"`
+	CloudAccountState             *CloudAccountProvisioningState       `json:"cloudAccountState,omitempty"`
+	Intent                        *Intent                              `json:"intent,omitempty"`
+	LastOperationStatusDetail     *string                              `json:"lastOperationStatusDetail,omitempty"`
+	ProductCode                   *string                              `json:"productCode,omitempty"`
+	ProvisioningState             *OracleSubscriptionProvisioningState `json:"provisioningState,omitempty"`
+	SaasSubscriptionId            *string                              `json:"saasSubscriptionId,omitempty"`
+	TermUnit                      *string                              `json:"termUnit,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/oraclesubscriptions/model_oraclesubscriptionupdate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/oraclesubscriptions/model_oraclesubscriptionupdate.go
@@ -1,0 +1,9 @@
+package oraclesubscriptions
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type OracleSubscriptionUpdate struct {
+	Plan       *PlanUpdate                         `json:"plan,omitempty"`
+	Properties *OracleSubscriptionUpdateProperties `json:"properties,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/oraclesubscriptions/model_oraclesubscriptionupdateproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/oraclesubscriptions/model_oraclesubscriptionupdateproperties.go
@@ -1,0 +1,9 @@
+package oraclesubscriptions
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type OracleSubscriptionUpdateProperties struct {
+	Intent      *Intent `json:"intent,omitempty"`
+	ProductCode *string `json:"productCode,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/oraclesubscriptions/model_plan.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/oraclesubscriptions/model_plan.go
@@ -1,0 +1,12 @@
+package oraclesubscriptions
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type Plan struct {
+	Name          string  `json:"name"`
+	Product       string  `json:"product"`
+	PromotionCode *string `json:"promotionCode,omitempty"`
+	Publisher     string  `json:"publisher"`
+	Version       *string `json:"version,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/oraclesubscriptions/model_planupdate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/oraclesubscriptions/model_planupdate.go
@@ -1,0 +1,12 @@
+package oraclesubscriptions
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PlanUpdate struct {
+	Name          *string `json:"name,omitempty"`
+	Product       *string `json:"product,omitempty"`
+	PromotionCode *string `json:"promotionCode,omitempty"`
+	Publisher     *string `json:"publisher,omitempty"`
+	Version       *string `json:"version,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/oraclesubscriptions/model_saassubscriptiondetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/oraclesubscriptions/model_saassubscriptiondetails.go
@@ -1,0 +1,37 @@
+package oraclesubscriptions
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SaasSubscriptionDetails struct {
+	Id                     *string `json:"id,omitempty"`
+	IsAutoRenew            *bool   `json:"isAutoRenew,omitempty"`
+	IsFreeTrial            *bool   `json:"isFreeTrial,omitempty"`
+	OfferId                *string `json:"offerId,omitempty"`
+	PlanId                 *string `json:"planId,omitempty"`
+	PublisherId            *string `json:"publisherId,omitempty"`
+	PurchaserEmailId       *string `json:"purchaserEmailId,omitempty"`
+	PurchaserTenantId      *string `json:"purchaserTenantId,omitempty"`
+	SaasSubscriptionStatus *string `json:"saasSubscriptionStatus,omitempty"`
+	SubscriptionName       *string `json:"subscriptionName,omitempty"`
+	TermUnit               *string `json:"termUnit,omitempty"`
+	TimeCreated            *string `json:"timeCreated,omitempty"`
+}
+
+func (o *SaasSubscriptionDetails) GetTimeCreatedAsTime() (*time.Time, error) {
+	if o.TimeCreated == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.TimeCreated, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *SaasSubscriptionDetails) SetTimeCreatedAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.TimeCreated = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/oraclesubscriptions/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/oraclesubscriptions/predicates.go
@@ -1,0 +1,27 @@
+package oraclesubscriptions
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type OracleSubscriptionOperationPredicate struct {
+	Id   *string
+	Name *string
+	Type *string
+}
+
+func (p OracleSubscriptionOperationPredicate) Matches(input OracleSubscription) bool {
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/oraclesubscriptions/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/oraclesubscriptions/version.go
@@ -1,0 +1,10 @@
+package oraclesubscriptions
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2025-03-01"
+
+func userAgent() string {
+	return "hashicorp/go-azure-sdk/oraclesubscriptions/2025-03-01"
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/systemversions/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/systemversions/README.md
@@ -1,0 +1,53 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/systemversions` Documentation
+
+The `systemversions` SDK allows for interaction with Azure Resource Manager `oracledatabase` (API Version `2025-03-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/systemversions"
+```
+
+
+### Client Initialization
+
+```go
+client := systemversions.NewSystemVersionsClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `SystemVersionsClient.Get`
+
+```go
+ctx := context.TODO()
+id := systemversions.NewSystemVersionID("12345678-1234-9876-4563-123456789012", "locationName", "systemVersionName")
+
+read, err := client.Get(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `SystemVersionsClient.ListByLocation`
+
+```go
+ctx := context.TODO()
+id := systemversions.NewLocationID("12345678-1234-9876-4563-123456789012", "locationName")
+
+// alternatively `client.ListByLocation(ctx, id)` can be used to do batched pagination
+items, err := client.ListByLocationComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/systemversions/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/systemversions/client.go
@@ -1,0 +1,26 @@
+package systemversions
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SystemVersionsClient struct {
+	Client *resourcemanager.Client
+}
+
+func NewSystemVersionsClientWithBaseURI(sdkApi sdkEnv.Api) (*SystemVersionsClient, error) {
+	client, err := resourcemanager.NewClient(sdkApi, "systemversions", defaultApiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating SystemVersionsClient: %+v", err)
+	}
+
+	return &SystemVersionsClient{
+		Client: client,
+	}, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/systemversions/id_location.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/systemversions/id_location.go
@@ -1,0 +1,121 @@
+package systemversions
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&LocationId{})
+}
+
+var _ resourceids.ResourceId = &LocationId{}
+
+// LocationId is a struct representing the Resource ID for a Location
+type LocationId struct {
+	SubscriptionId string
+	LocationName   string
+}
+
+// NewLocationID returns a new LocationId struct
+func NewLocationID(subscriptionId string, locationName string) LocationId {
+	return LocationId{
+		SubscriptionId: subscriptionId,
+		LocationName:   locationName,
+	}
+}
+
+// ParseLocationID parses 'input' into a LocationId
+func ParseLocationID(input string) (*LocationId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&LocationId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := LocationId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseLocationIDInsensitively parses 'input' case-insensitively into a LocationId
+// note: this method should only be used for API response data and not user input
+func ParseLocationIDInsensitively(input string) (*LocationId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&LocationId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := LocationId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *LocationId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.LocationName, ok = input.Parsed["locationName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "locationName", input)
+	}
+
+	return nil
+}
+
+// ValidateLocationID checks that 'input' can be parsed as a Location ID
+func ValidateLocationID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseLocationID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Location ID
+func (id LocationId) ID() string {
+	fmtString := "/subscriptions/%s/providers/Oracle.Database/locations/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.LocationName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Location ID
+func (id LocationId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticOracleDatabase", "Oracle.Database", "Oracle.Database"),
+		resourceids.StaticSegment("staticLocations", "locations", "locations"),
+		resourceids.UserSpecifiedSegment("locationName", "locationName"),
+	}
+}
+
+// String returns a human-readable description of this Location ID
+func (id LocationId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Location Name: %q", id.LocationName),
+	}
+	return fmt.Sprintf("Location (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/systemversions/id_systemversion.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/systemversions/id_systemversion.go
@@ -1,0 +1,130 @@
+package systemversions
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&SystemVersionId{})
+}
+
+var _ resourceids.ResourceId = &SystemVersionId{}
+
+// SystemVersionId is a struct representing the Resource ID for a System Version
+type SystemVersionId struct {
+	SubscriptionId    string
+	LocationName      string
+	SystemVersionName string
+}
+
+// NewSystemVersionID returns a new SystemVersionId struct
+func NewSystemVersionID(subscriptionId string, locationName string, systemVersionName string) SystemVersionId {
+	return SystemVersionId{
+		SubscriptionId:    subscriptionId,
+		LocationName:      locationName,
+		SystemVersionName: systemVersionName,
+	}
+}
+
+// ParseSystemVersionID parses 'input' into a SystemVersionId
+func ParseSystemVersionID(input string) (*SystemVersionId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&SystemVersionId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := SystemVersionId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseSystemVersionIDInsensitively parses 'input' case-insensitively into a SystemVersionId
+// note: this method should only be used for API response data and not user input
+func ParseSystemVersionIDInsensitively(input string) (*SystemVersionId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&SystemVersionId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := SystemVersionId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *SystemVersionId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.LocationName, ok = input.Parsed["locationName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "locationName", input)
+	}
+
+	if id.SystemVersionName, ok = input.Parsed["systemVersionName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "systemVersionName", input)
+	}
+
+	return nil
+}
+
+// ValidateSystemVersionID checks that 'input' can be parsed as a System Version ID
+func ValidateSystemVersionID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseSystemVersionID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted System Version ID
+func (id SystemVersionId) ID() string {
+	fmtString := "/subscriptions/%s/providers/Oracle.Database/locations/%s/systemVersions/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.LocationName, id.SystemVersionName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this System Version ID
+func (id SystemVersionId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticOracleDatabase", "Oracle.Database", "Oracle.Database"),
+		resourceids.StaticSegment("staticLocations", "locations", "locations"),
+		resourceids.UserSpecifiedSegment("locationName", "locationName"),
+		resourceids.StaticSegment("staticSystemVersions", "systemVersions", "systemVersions"),
+		resourceids.UserSpecifiedSegment("systemVersionName", "systemVersionName"),
+	}
+}
+
+// String returns a human-readable description of this System Version ID
+func (id SystemVersionId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Location Name: %q", id.LocationName),
+		fmt.Sprintf("System Version Name: %q", id.SystemVersionName),
+	}
+	return fmt.Sprintf("System Version (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/systemversions/method_get.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/systemversions/method_get.go
@@ -1,0 +1,53 @@
+package systemversions
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *SystemVersion
+}
+
+// Get ...
+func (c SystemVersionsClient) Get(ctx context.Context, id SystemVersionId) (result GetOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model SystemVersion
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/systemversions/method_listbylocation.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/systemversions/method_listbylocation.go
@@ -1,0 +1,105 @@
+package systemversions
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListByLocationOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]SystemVersion
+}
+
+type ListByLocationCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []SystemVersion
+}
+
+type ListByLocationCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *ListByLocationCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// ListByLocation ...
+func (c SystemVersionsClient) ListByLocation(ctx context.Context, id LocationId) (result ListByLocationOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Pager:      &ListByLocationCustomPager{},
+		Path:       fmt.Sprintf("%s/systemVersions", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]SystemVersion `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListByLocationComplete retrieves all the results into a single object
+func (c SystemVersionsClient) ListByLocationComplete(ctx context.Context, id LocationId) (ListByLocationCompleteResult, error) {
+	return c.ListByLocationCompleteMatchingPredicate(ctx, id, SystemVersionOperationPredicate{})
+}
+
+// ListByLocationCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c SystemVersionsClient) ListByLocationCompleteMatchingPredicate(ctx context.Context, id LocationId, predicate SystemVersionOperationPredicate) (result ListByLocationCompleteResult, err error) {
+	items := make([]SystemVersion, 0)
+
+	resp, err := c.ListByLocation(ctx, id)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListByLocationCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/systemversions/model_systemversion.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/systemversions/model_systemversion.go
@@ -1,0 +1,16 @@
+package systemversions
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/systemdata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SystemVersion struct {
+	Id         *string                  `json:"id,omitempty"`
+	Name       *string                  `json:"name,omitempty"`
+	Properties *SystemVersionProperties `json:"properties,omitempty"`
+	SystemData *systemdata.SystemData   `json:"systemData,omitempty"`
+	Type       *string                  `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/systemversions/model_systemversionproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/systemversions/model_systemversionproperties.go
@@ -1,0 +1,8 @@
+package systemversions
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SystemVersionProperties struct {
+	SystemVersion string `json:"systemVersion"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/systemversions/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/systemversions/predicates.go
@@ -1,0 +1,27 @@
+package systemversions
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SystemVersionOperationPredicate struct {
+	Id   *string
+	Name *string
+	Type *string
+}
+
+func (p SystemVersionOperationPredicate) Matches(input SystemVersion) bool {
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/systemversions/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/systemversions/version.go
@@ -1,0 +1,10 @@
+package systemversions
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2025-03-01"
+
+func userAgent() string {
+	return "hashicorp/go-azure-sdk/systemversions/2025-03-01"
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/virtualnetworkaddresses/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/virtualnetworkaddresses/README.md
@@ -1,0 +1,82 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/virtualnetworkaddresses` Documentation
+
+The `virtualnetworkaddresses` SDK allows for interaction with Azure Resource Manager `oracledatabase` (API Version `2025-03-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/virtualnetworkaddresses"
+```
+
+
+### Client Initialization
+
+```go
+client := virtualnetworkaddresses.NewVirtualNetworkAddressesClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `VirtualNetworkAddressesClient.CreateOrUpdate`
+
+```go
+ctx := context.TODO()
+id := virtualnetworkaddresses.NewVirtualNetworkAddressID("12345678-1234-9876-4563-123456789012", "example-resource-group", "cloudVmClusterName", "virtualNetworkAddressName")
+
+payload := virtualnetworkaddresses.VirtualNetworkAddress{
+	// ...
+}
+
+
+if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `VirtualNetworkAddressesClient.Delete`
+
+```go
+ctx := context.TODO()
+id := virtualnetworkaddresses.NewVirtualNetworkAddressID("12345678-1234-9876-4563-123456789012", "example-resource-group", "cloudVmClusterName", "virtualNetworkAddressName")
+
+if err := client.DeleteThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `VirtualNetworkAddressesClient.Get`
+
+```go
+ctx := context.TODO()
+id := virtualnetworkaddresses.NewVirtualNetworkAddressID("12345678-1234-9876-4563-123456789012", "example-resource-group", "cloudVmClusterName", "virtualNetworkAddressName")
+
+read, err := client.Get(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `VirtualNetworkAddressesClient.ListByParent`
+
+```go
+ctx := context.TODO()
+id := virtualnetworkaddresses.NewCloudVMClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "cloudVmClusterName")
+
+// alternatively `client.ListByParent(ctx, id)` can be used to do batched pagination
+items, err := client.ListByParentComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/virtualnetworkaddresses/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/virtualnetworkaddresses/client.go
@@ -1,0 +1,26 @@
+package virtualnetworkaddresses
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualNetworkAddressesClient struct {
+	Client *resourcemanager.Client
+}
+
+func NewVirtualNetworkAddressesClientWithBaseURI(sdkApi sdkEnv.Api) (*VirtualNetworkAddressesClient, error) {
+	client, err := resourcemanager.NewClient(sdkApi, "virtualnetworkaddresses", defaultApiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating VirtualNetworkAddressesClient: %+v", err)
+	}
+
+	return &VirtualNetworkAddressesClient{
+		Client: client,
+	}, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/virtualnetworkaddresses/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/virtualnetworkaddresses/constants.go
@@ -1,0 +1,107 @@
+package virtualnetworkaddresses
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AzureResourceProvisioningState string
+
+const (
+	AzureResourceProvisioningStateCanceled     AzureResourceProvisioningState = "Canceled"
+	AzureResourceProvisioningStateFailed       AzureResourceProvisioningState = "Failed"
+	AzureResourceProvisioningStateProvisioning AzureResourceProvisioningState = "Provisioning"
+	AzureResourceProvisioningStateSucceeded    AzureResourceProvisioningState = "Succeeded"
+)
+
+func PossibleValuesForAzureResourceProvisioningState() []string {
+	return []string{
+		string(AzureResourceProvisioningStateCanceled),
+		string(AzureResourceProvisioningStateFailed),
+		string(AzureResourceProvisioningStateProvisioning),
+		string(AzureResourceProvisioningStateSucceeded),
+	}
+}
+
+func (s *AzureResourceProvisioningState) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseAzureResourceProvisioningState(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseAzureResourceProvisioningState(input string) (*AzureResourceProvisioningState, error) {
+	vals := map[string]AzureResourceProvisioningState{
+		"canceled":     AzureResourceProvisioningStateCanceled,
+		"failed":       AzureResourceProvisioningStateFailed,
+		"provisioning": AzureResourceProvisioningStateProvisioning,
+		"succeeded":    AzureResourceProvisioningStateSucceeded,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := AzureResourceProvisioningState(input)
+	return &out, nil
+}
+
+type VirtualNetworkAddressLifecycleState string
+
+const (
+	VirtualNetworkAddressLifecycleStateAvailable    VirtualNetworkAddressLifecycleState = "Available"
+	VirtualNetworkAddressLifecycleStateFailed       VirtualNetworkAddressLifecycleState = "Failed"
+	VirtualNetworkAddressLifecycleStateProvisioning VirtualNetworkAddressLifecycleState = "Provisioning"
+	VirtualNetworkAddressLifecycleStateTerminated   VirtualNetworkAddressLifecycleState = "Terminated"
+	VirtualNetworkAddressLifecycleStateTerminating  VirtualNetworkAddressLifecycleState = "Terminating"
+)
+
+func PossibleValuesForVirtualNetworkAddressLifecycleState() []string {
+	return []string{
+		string(VirtualNetworkAddressLifecycleStateAvailable),
+		string(VirtualNetworkAddressLifecycleStateFailed),
+		string(VirtualNetworkAddressLifecycleStateProvisioning),
+		string(VirtualNetworkAddressLifecycleStateTerminated),
+		string(VirtualNetworkAddressLifecycleStateTerminating),
+	}
+}
+
+func (s *VirtualNetworkAddressLifecycleState) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseVirtualNetworkAddressLifecycleState(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseVirtualNetworkAddressLifecycleState(input string) (*VirtualNetworkAddressLifecycleState, error) {
+	vals := map[string]VirtualNetworkAddressLifecycleState{
+		"available":    VirtualNetworkAddressLifecycleStateAvailable,
+		"failed":       VirtualNetworkAddressLifecycleStateFailed,
+		"provisioning": VirtualNetworkAddressLifecycleStateProvisioning,
+		"terminated":   VirtualNetworkAddressLifecycleStateTerminated,
+		"terminating":  VirtualNetworkAddressLifecycleStateTerminating,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := VirtualNetworkAddressLifecycleState(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/virtualnetworkaddresses/id_cloudvmcluster.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/virtualnetworkaddresses/id_cloudvmcluster.go
@@ -1,0 +1,130 @@
+package virtualnetworkaddresses
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&CloudVMClusterId{})
+}
+
+var _ resourceids.ResourceId = &CloudVMClusterId{}
+
+// CloudVMClusterId is a struct representing the Resource ID for a Cloud V M Cluster
+type CloudVMClusterId struct {
+	SubscriptionId     string
+	ResourceGroupName  string
+	CloudVmClusterName string
+}
+
+// NewCloudVMClusterID returns a new CloudVMClusterId struct
+func NewCloudVMClusterID(subscriptionId string, resourceGroupName string, cloudVmClusterName string) CloudVMClusterId {
+	return CloudVMClusterId{
+		SubscriptionId:     subscriptionId,
+		ResourceGroupName:  resourceGroupName,
+		CloudVmClusterName: cloudVmClusterName,
+	}
+}
+
+// ParseCloudVMClusterID parses 'input' into a CloudVMClusterId
+func ParseCloudVMClusterID(input string) (*CloudVMClusterId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&CloudVMClusterId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := CloudVMClusterId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseCloudVMClusterIDInsensitively parses 'input' case-insensitively into a CloudVMClusterId
+// note: this method should only be used for API response data and not user input
+func ParseCloudVMClusterIDInsensitively(input string) (*CloudVMClusterId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&CloudVMClusterId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := CloudVMClusterId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *CloudVMClusterId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.CloudVmClusterName, ok = input.Parsed["cloudVmClusterName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "cloudVmClusterName", input)
+	}
+
+	return nil
+}
+
+// ValidateCloudVMClusterID checks that 'input' can be parsed as a Cloud V M Cluster ID
+func ValidateCloudVMClusterID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseCloudVMClusterID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Cloud V M Cluster ID
+func (id CloudVMClusterId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Oracle.Database/cloudVmClusters/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.CloudVmClusterName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Cloud V M Cluster ID
+func (id CloudVMClusterId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticOracleDatabase", "Oracle.Database", "Oracle.Database"),
+		resourceids.StaticSegment("staticCloudVmClusters", "cloudVmClusters", "cloudVmClusters"),
+		resourceids.UserSpecifiedSegment("cloudVmClusterName", "cloudVmClusterName"),
+	}
+}
+
+// String returns a human-readable description of this Cloud V M Cluster ID
+func (id CloudVMClusterId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Cloud Vm Cluster Name: %q", id.CloudVmClusterName),
+	}
+	return fmt.Sprintf("Cloud V M Cluster (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/virtualnetworkaddresses/id_virtualnetworkaddress.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/virtualnetworkaddresses/id_virtualnetworkaddress.go
@@ -1,0 +1,139 @@
+package virtualnetworkaddresses
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&VirtualNetworkAddressId{})
+}
+
+var _ resourceids.ResourceId = &VirtualNetworkAddressId{}
+
+// VirtualNetworkAddressId is a struct representing the Resource ID for a Virtual Network Address
+type VirtualNetworkAddressId struct {
+	SubscriptionId            string
+	ResourceGroupName         string
+	CloudVmClusterName        string
+	VirtualNetworkAddressName string
+}
+
+// NewVirtualNetworkAddressID returns a new VirtualNetworkAddressId struct
+func NewVirtualNetworkAddressID(subscriptionId string, resourceGroupName string, cloudVmClusterName string, virtualNetworkAddressName string) VirtualNetworkAddressId {
+	return VirtualNetworkAddressId{
+		SubscriptionId:            subscriptionId,
+		ResourceGroupName:         resourceGroupName,
+		CloudVmClusterName:        cloudVmClusterName,
+		VirtualNetworkAddressName: virtualNetworkAddressName,
+	}
+}
+
+// ParseVirtualNetworkAddressID parses 'input' into a VirtualNetworkAddressId
+func ParseVirtualNetworkAddressID(input string) (*VirtualNetworkAddressId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&VirtualNetworkAddressId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := VirtualNetworkAddressId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseVirtualNetworkAddressIDInsensitively parses 'input' case-insensitively into a VirtualNetworkAddressId
+// note: this method should only be used for API response data and not user input
+func ParseVirtualNetworkAddressIDInsensitively(input string) (*VirtualNetworkAddressId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&VirtualNetworkAddressId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := VirtualNetworkAddressId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *VirtualNetworkAddressId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.CloudVmClusterName, ok = input.Parsed["cloudVmClusterName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "cloudVmClusterName", input)
+	}
+
+	if id.VirtualNetworkAddressName, ok = input.Parsed["virtualNetworkAddressName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "virtualNetworkAddressName", input)
+	}
+
+	return nil
+}
+
+// ValidateVirtualNetworkAddressID checks that 'input' can be parsed as a Virtual Network Address ID
+func ValidateVirtualNetworkAddressID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseVirtualNetworkAddressID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Virtual Network Address ID
+func (id VirtualNetworkAddressId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Oracle.Database/cloudVmClusters/%s/virtualNetworkAddresses/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.CloudVmClusterName, id.VirtualNetworkAddressName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Virtual Network Address ID
+func (id VirtualNetworkAddressId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticOracleDatabase", "Oracle.Database", "Oracle.Database"),
+		resourceids.StaticSegment("staticCloudVmClusters", "cloudVmClusters", "cloudVmClusters"),
+		resourceids.UserSpecifiedSegment("cloudVmClusterName", "cloudVmClusterName"),
+		resourceids.StaticSegment("staticVirtualNetworkAddresses", "virtualNetworkAddresses", "virtualNetworkAddresses"),
+		resourceids.UserSpecifiedSegment("virtualNetworkAddressName", "virtualNetworkAddressName"),
+	}
+}
+
+// String returns a human-readable description of this Virtual Network Address ID
+func (id VirtualNetworkAddressId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Cloud Vm Cluster Name: %q", id.CloudVmClusterName),
+		fmt.Sprintf("Virtual Network Address Name: %q", id.VirtualNetworkAddressName),
+	}
+	return fmt.Sprintf("Virtual Network Address (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/virtualnetworkaddresses/method_createorupdate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/virtualnetworkaddresses/method_createorupdate.go
@@ -1,0 +1,75 @@
+package virtualnetworkaddresses
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateOrUpdateOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *VirtualNetworkAddress
+}
+
+// CreateOrUpdate ...
+func (c VirtualNetworkAddressesClient) CreateOrUpdate(ctx context.Context, id VirtualNetworkAddressId, input VirtualNetworkAddress) (result CreateOrUpdateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPut,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// CreateOrUpdateThenPoll performs CreateOrUpdate then polls until it's completed
+func (c VirtualNetworkAddressesClient) CreateOrUpdateThenPoll(ctx context.Context, id VirtualNetworkAddressId, input VirtualNetworkAddress) error {
+	result, err := c.CreateOrUpdate(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing CreateOrUpdate: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after CreateOrUpdate: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/virtualnetworkaddresses/method_delete.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/virtualnetworkaddresses/method_delete.go
@@ -1,0 +1,70 @@
+package virtualnetworkaddresses
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeleteOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// Delete ...
+func (c VirtualNetworkAddressesClient) Delete(ctx context.Context, id VirtualNetworkAddressId) (result DeleteOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusNoContent,
+		},
+		HttpMethod: http.MethodDelete,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// DeleteThenPoll performs Delete then polls until it's completed
+func (c VirtualNetworkAddressesClient) DeleteThenPoll(ctx context.Context, id VirtualNetworkAddressId) error {
+	result, err := c.Delete(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing Delete: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Delete: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/virtualnetworkaddresses/method_get.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/virtualnetworkaddresses/method_get.go
@@ -1,0 +1,53 @@
+package virtualnetworkaddresses
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *VirtualNetworkAddress
+}
+
+// Get ...
+func (c VirtualNetworkAddressesClient) Get(ctx context.Context, id VirtualNetworkAddressId) (result GetOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model VirtualNetworkAddress
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/virtualnetworkaddresses/method_listbyparent.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/virtualnetworkaddresses/method_listbyparent.go
@@ -1,0 +1,105 @@
+package virtualnetworkaddresses
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListByParentOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]VirtualNetworkAddress
+}
+
+type ListByParentCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []VirtualNetworkAddress
+}
+
+type ListByParentCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *ListByParentCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// ListByParent ...
+func (c VirtualNetworkAddressesClient) ListByParent(ctx context.Context, id CloudVMClusterId) (result ListByParentOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Pager:      &ListByParentCustomPager{},
+		Path:       fmt.Sprintf("%s/virtualNetworkAddresses", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]VirtualNetworkAddress `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListByParentComplete retrieves all the results into a single object
+func (c VirtualNetworkAddressesClient) ListByParentComplete(ctx context.Context, id CloudVMClusterId) (ListByParentCompleteResult, error) {
+	return c.ListByParentCompleteMatchingPredicate(ctx, id, VirtualNetworkAddressOperationPredicate{})
+}
+
+// ListByParentCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c VirtualNetworkAddressesClient) ListByParentCompleteMatchingPredicate(ctx context.Context, id CloudVMClusterId, predicate VirtualNetworkAddressOperationPredicate) (result ListByParentCompleteResult, err error) {
+	items := make([]VirtualNetworkAddress, 0)
+
+	resp, err := c.ListByParent(ctx, id)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListByParentCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/virtualnetworkaddresses/model_virtualnetworkaddress.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/virtualnetworkaddresses/model_virtualnetworkaddress.go
@@ -1,0 +1,16 @@
+package virtualnetworkaddresses
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/systemdata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualNetworkAddress struct {
+	Id         *string                          `json:"id,omitempty"`
+	Name       *string                          `json:"name,omitempty"`
+	Properties *VirtualNetworkAddressProperties `json:"properties,omitempty"`
+	SystemData *systemdata.SystemData           `json:"systemData,omitempty"`
+	Type       *string                          `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/virtualnetworkaddresses/model_virtualnetworkaddressproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/virtualnetworkaddresses/model_virtualnetworkaddressproperties.go
@@ -1,0 +1,33 @@
+package virtualnetworkaddresses
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualNetworkAddressProperties struct {
+	Domain            *string                              `json:"domain,omitempty"`
+	IPAddress         *string                              `json:"ipAddress,omitempty"`
+	LifecycleDetails  *string                              `json:"lifecycleDetails,omitempty"`
+	LifecycleState    *VirtualNetworkAddressLifecycleState `json:"lifecycleState,omitempty"`
+	Ocid              *string                              `json:"ocid,omitempty"`
+	ProvisioningState *AzureResourceProvisioningState      `json:"provisioningState,omitempty"`
+	TimeAssigned      *string                              `json:"timeAssigned,omitempty"`
+	VMOcid            *string                              `json:"vmOcid,omitempty"`
+}
+
+func (o *VirtualNetworkAddressProperties) GetTimeAssignedAsTime() (*time.Time, error) {
+	if o.TimeAssigned == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.TimeAssigned, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *VirtualNetworkAddressProperties) SetTimeAssignedAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.TimeAssigned = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/virtualnetworkaddresses/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/virtualnetworkaddresses/predicates.go
@@ -1,0 +1,27 @@
+package virtualnetworkaddresses
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualNetworkAddressOperationPredicate struct {
+	Id   *string
+	Name *string
+	Type *string
+}
+
+func (p VirtualNetworkAddressOperationPredicate) Matches(input VirtualNetworkAddress) bool {
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/virtualnetworkaddresses/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/virtualnetworkaddresses/version.go
@@ -1,0 +1,10 @@
+package virtualnetworkaddresses
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2025-03-01"
+
+func userAgent() string {
+	return "hashicorp/go-azure-sdk/virtualnetworkaddresses/2025-03-01"
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -143,7 +143,7 @@ github.com/hashicorp/go-azure-helpers/resourcemanager/tags
 github.com/hashicorp/go-azure-helpers/resourcemanager/zones
 github.com/hashicorp/go-azure-helpers/sender
 github.com/hashicorp/go-azure-helpers/storage
-# github.com/hashicorp/go-azure-sdk/resource-manager v0.20250520.1180806
+# github.com/hashicorp/go-azure-sdk/resource-manager v0.20250526.1224007
 ## explicit; go 1.22
 github.com/hashicorp/go-azure-sdk/resource-manager/aad/2021-05-01/domainservices
 github.com/hashicorp/go-azure-sdk/resource-manager/aadb2c/2021-04-01-preview
@@ -901,6 +901,28 @@ github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2024-06-01/giv
 github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2024-06-01/oraclesubscriptions
 github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2024-06-01/systemversions
 github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2024-06-01/virtualnetworkaddresses
+github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01
+github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasebackups
+github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasecharactersets
+github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabasenationalcharactersets
+github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabases
+github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/autonomousdatabaseversions
+github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudexadatainfrastructures
+github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/cloudvmclusters
+github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbnodes
+github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbservers
+github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dbsystemshapes
+github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dnsprivateviews
+github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/dnsprivatezones
+github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exadbvmclusters
+github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbnodes
+github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/exascaledbstoragevaults
+github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/flexcomponents
+github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/giminorversions
+github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/giversions
+github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/oraclesubscriptions
+github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/systemversions
+github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-03-01/virtualnetworkaddresses
 github.com/hashicorp/go-azure-sdk/resource-manager/orbital/2022-11-01/contact
 github.com/hashicorp/go-azure-sdk/resource-manager/orbital/2022-11-01/contactprofile
 github.com/hashicorp/go-azure-sdk/resource-manager/orbital/2022-11-01/groundstation
@@ -1178,7 +1200,7 @@ github.com/hashicorp/go-azure-sdk/resource-manager/workloads/2024-09-01/sapappli
 github.com/hashicorp/go-azure-sdk/resource-manager/workloads/2024-09-01/sapcentralserverinstances
 github.com/hashicorp/go-azure-sdk/resource-manager/workloads/2024-09-01/sapdatabaseinstances
 github.com/hashicorp/go-azure-sdk/resource-manager/workloads/2024-09-01/sapvirtualinstances
-# github.com/hashicorp/go-azure-sdk/sdk v0.20250520.1180806
+# github.com/hashicorp/go-azure-sdk/sdk v0.20250526.1224007
 ## explicit; go 1.22
 github.com/hashicorp/go-azure-sdk/sdk/auth
 github.com/hashicorp/go-azure-sdk/sdk/auth/autorest

--- a/website/docs/d/oracle_exadb_vm_cluster.html.markdown
+++ b/website/docs/d/oracle_exadb_vm_cluster.html.markdown
@@ -1,0 +1,176 @@
+---
+subcategory: "Oracle"
+layout: "azurerm"
+page_title: "Azure Resource Manager: Data Source: azurerm_oracle_exa_db_vm_cluster"
+description: |-
+  Gets information about an existing Exadata VM Cluster.
+---
+
+# Data Source: azurerm_oracle_exa_db_vm_cluster
+
+Use this data source to access information about an existing Exadata VM Cluster.
+
+## Example Usage
+
+```hcl
+data "azurerm_oracle_exa_db_vm_cluster" "example" {
+  name                = "existing"
+  resource_group_name = "existing"
+}
+
+output "id" {
+  value = data.azurerm_oracle_exa_db_vm_cluster.example.id
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of this Exadata VM Cluster.
+
+* `resource_group_name` - (Required) The name of the Resource Group where the Exadata VM Cluster exists.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported: 
+
+* `id` - The ID of the Exadata VM Cluster.
+
+* `backup_subnet_cidr` - Client OCI backup subnet CIDR, default is `192.168.252.0/22`.
+
+* `cluster_name` - The cluster name for Exadata VM Cluster.
+
+* `data_collection_options` - A `data_collection_options` block as defined below.
+
+* `display_name` - The user-friendly name for the Exadata VM Cluster. The name does not need to be unique.
+
+* `domain` - The domain name for the Exadata VM Cluster.
+
+* `enabled_ecpu_count` - The number of ECPUs to enable for an Exadata VM cluster on Exascale Infrastructure.
+
+* `exascale_db_storage_vault_id` - The OCID of the Exadata Database Storage Vault.
+
+* `gi_version` - A valid Oracle Grid Infrastructure (GI) software version.
+
+* `grid_image_ocid` - Grid Setup will be done using this grid image id.
+
+* `grid_image_type` - The type of Grid Image
+
+* `hostname` - The hostname for the Exadata VM Cluster without suffix.
+
+* `hostname_actual` - The hostname for the Exadata VM Cluster with suffix.
+
+* `iorm_config_cache` - A `iorm_config_cache` block as defined below.
+
+* `license_model` - The Oracle license model that applies to the Exadata VM Cluster.
+
+* `lifecycle_details` - Additional information about the current lifecycle state.
+
+* `lifecycle_state` - Exadata VM Cluster lifecycle state enum.
+
+* `listener_port` - The port number configured for the listener on the Exadata VM Cluster.
+
+* `location` - The Azure Region where the Exadata VM Cluster exists.
+
+* `memory_size_in_gbs` - The memory to be allocated in GBs.
+
+* `node_count` - The number of nodes in the Exadata VM Cluster.
+
+* `nsg_cidrs` - CIDR blocks for additional NSG ingress rules. The VNET CIDRs used to provision the VM Cluster will be added by default.
+
+* `nsg_url` - The list of [OCIDs](https://docs.oracle.com/en-us/iaas/Content/General/Concepts/identifiers.htm) for the network security groups (NSGs) to which this resource belongs. Setting this to an empty list removes all resources from all NSGs. For more information about NSGs, see [Security Rules](https://docs.oracle.com/en-us/iaas/Content/Network/Concepts/securityrules.htm). NsgIds restrictions:
+
+* `oci_url` - The URL of the resource in the OCI console.
+
+* `ocid` - The [OCID](https://docs.oracle.com/en-us/iaas/Content/General/Concepts/identifiers.htm) of the Exadata VM Cluster.
+
+* `private_zone_ocid` - The private zone ID in which you want DNS records to be created.
+
+* `scan_dns_name` - The FQDN of the DNS record for the SCAN IP addresses that are associated with the Exadata VM Cluster.
+
+* `scan_dns_record_id` - The [OCID](https://docs.oracle.com/en-us/iaas/Content/General/Concepts/identifiers.htm) of the DNS record for the SCAN IP addresses that are associated with the Exadata VM Cluster.
+
+* `scan_ip_ids` - A `scan_ip_ids` block as defined below.
+
+* `scan_listener_port_tcp` -  The TCP Single Client Access Name (SCAN) port. The default port is 1521.
+
+* `scan_listener_port_tcp_ssl` - The TCPS Single Client Access Name (SCAN) port. The default port is 2484.
+
+* `shape` - The model name of the Exadata hardware running the Exadata VM Cluster.
+
+* `snapshot_file_system_storage` - A `file_system_storage_details` block as defined below.
+
+* `ssh_public_keys` - The public key portion of one or more key pairs used for SSH access to the Exadata VM Cluster.
+
+* `subnet_id` - The ID of the Azure Resource Manager subnet resource.
+
+* `subnet_ocid` - The [OCID](https://docs.oracle.com/en-us/iaas/Content/General/Concepts/identifiers.htm) of the subnet associated with the Exadata VM Cluster.
+
+* `system_version` - Operating system version of the image.
+
+* `tags` - A mapping of tags assigned to the Exadata VM Cluster.
+
+* `time_zone` - The time zone of the Exadata VM Cluster. For details, see [Exadata Infrastructure Time Zones](https://docs.oracle.com/en-us/iaas/base-database/doc/manage-time-zone.html).
+
+* `total_ecpu_count` - The number of Total ECPUs for an Exadata VM cluster on Exascale Infrastructure.
+
+* `total_file_system_storage` - A `file_system_storage_details` block as defined below.
+
+* `vip_ids` - The [OCID](https://docs.oracle.com/en-us/iaas/Content/General/Concepts/identifiers.htm) of the virtual IP (VIP) addresses associated with the Exadata VM Cluster. The Cluster Ready Services (CRS) creates and maintains one VIP address for each node in the Exadata Cloud Service instance to enable failover. If one node fails, the VIP is reassigned to another active node in the Cluster. 
+
+* `vm_file_system_storage` - A `file_system_storage_details` block as defined below.
+
+* `virtual_network_id` - The ID to an Azure Resource Manager Virtual Network resource.
+
+* `zone_ocid` - The [OCID](https://docs.oracle.com/en-us/iaas/Content/General/Concepts/identifiers.htm) of the zone the Exadata VM Cluster is associated with.
+
+---
+
+A `data_collection_options` block exports the following:
+
+* `diagnostics_events_enabled` - Indicates whether diagnostic collection is enabled for the VM Cluster/Exadata VM Cluster/VMBM DBCS. Enabling diagnostic collection allows you to receive Events service notifications for guest VM issues. Diagnostic collection also allows Oracle to provide enhanced service and proactive support for your Exadata system. You can enable diagnostic collection during VM Cluster/Exadata VM Cluster provisioning. You can also disable or enable it at any time using the `UpdateVmCluster` or `updateExadataVmCluster` API.
+
+* `health_monitoring_enabled` -  Indicates whether health monitoring is enabled for the VM Cluster / Exadata VM Cluster / VMBM DBCS. Enabling health monitoring allows Oracle to collect diagnostic data and share it with its operations and support personnel. You may also receive notifications for some events. Collecting health diagnostics enables Oracle to provide proactive support and enhanced service for your system. Optionally enable health monitoring while provisioning a system. You can also disable or enable health monitoring anytime using the `UpdateVmCluster`, `UpdateExadataVmCluster` or `updateDbsystem` API.
+
+* `incident_logs_enabled` - Indicates whether incident logs and trace collection are enabled for the VM Cluster / Exadata VM Cluster / VMBM DBCS. Enabling incident logs collection allows Oracle to receive Events service notifications for guest VM issues, collect incident logs and traces, and use them to diagnose issues and resolve them. Optionally enable incident logs collection while provisioning a system. You can also disable or enable incident logs collection anytime using the `UpdateVmCluster`, `updateExadataVmCluster` or `updateDbsystem` API.
+
+---
+
+A `db_plans` block exports the following:
+
+* `db_name` - The database name. For the default `DbPlan`, the `dbName` is `default`.
+
+* `flash_cache_limit` - The flash cache limit for this database. This value is internally configured based on the share value assigned to the database.
+
+* `share` - The relative priority of this database.
+
+---
+
+A `iorm_config_cache` block exports the following:
+
+* `db_plans` - A `db_plans` block as defined above.
+
+* `lifecycle_details` - Additional information about the current `lifecycleState`.
+
+* `lifecycle_state` - The current state of IORM configuration for the Exadata DB system.
+
+* `objective` - The current value for the IORM objective. The default is `AUTO`.
+
+---
+
+A `file_system_storage_details` block exports the following:
+
+* `total_size_in_gbs` - Total Capacity 
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Exadata VM Cluster.
+
+## API Providers
+<!-- This section is generated, changes will be overwritten -->
+This data source uses the following Azure API Providers:
+
+* `Oracle.Database`: 2025-03-01

--- a/website/docs/d/oracle_exascale_db_nodes.html.markdown
+++ b/website/docs/d/oracle_exascale_db_nodes.html.markdown
@@ -1,0 +1,77 @@
+---
+subcategory: "Oracle"
+layout: "azurerm"
+page_title: "Azure Resource Manager: Data Source: azurerm_oracle_db_nodes"
+description: |-
+  This data source provides the list of DB Nodes.
+---
+
+# Data Source: azurerm_oracle_exascale_db_nodes
+
+Lists the database nodes for the specified Exadb VM Cluster.
+
+## Example Usage
+
+```hcl
+data "azurerm_oracle_exascale_db_nodes" "example" {
+  exadb_vm_cluster_id = "existing"
+}
+
+output "example" {
+  value = data.azurerm_oracle_exascale_db_nodes.example
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `exa_db_vm_cluster_id` - (Required) The id of the Exadb VM cluster.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported: 
+
+* `exascale_db_nodes` - A `exascale_db_nodes` block as defined below.
+
+---
+
+A `exascale_db_nodes` block exports the following:
+
+* `additional_details` - Additional information about the planned maintenance.
+
+* `cpu_core_count` - The number of CPU cores enabled on the exascale DB node.
+
+* `db_node_storage_size_in_gbs` - The allocated local node storage in GBs on the exascale DB node.
+
+* `fault_domain` - The name of the Fault Domain the instance is contained in.
+
+* `hostname` - The hostname for the exascale db node.
+
+* `lifecycle_state` - Information about the current lifecycle state.
+
+* `maintenance_type` - The type of database node maintenance.
+
+* `memory_size_in_gbs` - The allocated memory in GBs on the DB Node.
+
+* `ocid` - The [OCID](https://docs.oracle.com/en-us/iaas/Content/General/Concepts/identifiers.htm) of the Exascale DB node.
+
+* `software_storage_size_in_gb` - The size (in GB) of the block storage volume allocation for the DB system. This attribute applies only for virtual machine DB systems.
+
+* `time_maintenance_window_end` - End date and time of maintenance window.
+
+* `time_maintenance_window_start` - Start date and time of maintenance window.
+
+* `total_cpu_core_count` - The total number of CPU cores reserved on the Db node.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the DB Node.
+
+## API Providers
+<!-- This section is generated, changes will be overwritten -->
+This data source uses the following Azure API Providers:
+
+* `Oracle.Database`: 2025-03-01

--- a/website/docs/d/oracle_exascale_db_storage_vault.html.markdown
+++ b/website/docs/d/oracle_exascale_db_storage_vault.html.markdown
@@ -1,0 +1,82 @@
+---
+subcategory: "Oracle"
+layout: "azurerm"
+page_title: "Azure Resource Manager: Data Source: azurerm_oracle_exascale_db_storage_vault"
+description: |-
+  Gets information about an existing Exadata Database Storage Vault.
+---
+
+# Data Source: azurerm_oracle_exascale_db_storage_vault
+
+Use this data source to access information about an existing Exadata Database Storage Vault
+
+## Example Usage
+
+```hcl
+data "azurerm_oracle_exascale_db_storage_vault" "example" {
+  name                = "existing"
+  resource_group_name = "existing"
+}
+
+output "id" {
+  value = data.azurerm_oracle_exascale_db_storage_vault.example.id
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of this EExadata Database Storage Vault.
+
+* `resource_group_name` - (Required) The name of the Resource Group where the Exadata Database Storage Vault exists.
+
+* `zones` - The Exadata Database Storage Vault Azure zones.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported: 
+
+* `id` - The ID of the Exadata Database Storage Vault.
+
+* `additional_flash_cache_in_percent` - The size of additional Flash Cache in percentage of High Capacity database storage.
+
+* `description` - Exadata Database Storage Vault description.
+
+* `display_name` - The user-friendly name for the Exadata Database Storage Vault. The name does not need to be unique.
+
+* `high_capacity_database_storage` - A `high_capacity_database_storage` block as defined below.
+
+* `lifecycle_details` - Additional information about the current lifecycle state.
+
+* `lifecycle_state` - Exadata Database Storage Vault lifecycle state enum.
+
+* `location` - The Azure Region where the Exadata Database Storage Vault should exist.
+
+* `oci_url` - The URL of the resource in the OCI console.
+
+* `ocid` - The [OCID](https://docs.oracle.com/en-us/iaas/Content/General/Concepts/identifiers.htm) of the Exadata Database Storage Vault.
+
+* `time_zone` - The time zone that you want to use for the Exadata Database Storage Vault.
+
+* `vm_cluster_count` - The number of Exadata VM clusters used the Exadata Database Storage Vault.
+
+---
+
+A `high_capacity_database_storage` block exports the following:
+
+* `available_size_in_gbs` - Available Capacity
+
+* `total_size_in_gbs` - Total Capacity
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Exadata Database Storage Vault.
+
+## API Providers
+<!-- This section is generated, changes will be overwritten -->
+This data source uses the following Azure API Providers:
+
+* `Oracle.Database`: 2025-03-01

--- a/website/docs/r/oracle_exadb_vm_cluster.html.markdown
+++ b/website/docs/r/oracle_exadb_vm_cluster.html.markdown
@@ -1,0 +1,187 @@
+---
+subcategory: "Oracle"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_oracle_exa_db_vm_cluster"
+description: |-
+  Manages a Exadata VM Cluster.
+---
+
+# azurerm_oracle_exa_db_vm_cluster
+
+Manages a Exadata VM Cluster on Exascale Infrastructure.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_oracle_exascale_db_storage_vault" "example" {
+  name                = "example-exascale-db-storage-vault"
+  display_name        = "example-exascale-db-storage-vault"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  description         = "description"
+  high_capacity_database_storage_input {
+    total_size_in_gbs = 300
+  }
+  additional_flash_cache_in_percent = 100
+  zones               = ["3"]
+}
+
+resource "azurerm_virtual_network" "example" {
+  name                = "example-virtual-network"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+}
+
+resource "azurerm_subnet" "example" {
+  name                 = "example-subnet"
+  resource_group_name  = azurerm_resource_group.example.name
+  virtual_network_name = azurerm_virtual_network.example.name
+  address_prefixes     = ["10.0.1.0/24"]
+
+  delegation {
+    name = "delegation"
+
+    service_delegation {
+      actions = [
+        "Microsoft.Network/networkinterfaces/*",
+        "Microsoft.Network/virtualNetworks/subnets/join/action",
+      ]
+      name = "Oracle.Database/networkAttachments"
+    }
+  }
+}
+
+resource "azurerm_oracle_exa_db_vm_cluster" "example" {
+  name                            = "example-exadb-vm-cluster"
+  resource_group_name             = azurerm_resource_group.example.name
+  location                        = azurerm_resource_group.example.location
+  exascale_db_storage_vault_id    = azurerm_oracle_exascale_db_storage_vault.example.id
+  display_name                    = "example-exadb-vm-cluster"
+  enabled_ecpu_count              = 4
+  hostname                        = "hostname"
+  node_count              		  = 2
+  shape                      	  = "ExaDbXS"
+  ssh_public_keys                 = [file("~/.ssh/id_rsa.pub")]
+  subnet_id                       = azurerm_subnet.example.id
+  total_ecpu_count                = 10
+  vm_file_system_storage {
+    total_size_in_gbs 	= 120
+  }
+  virtual_network_id              = azurerm_virtual_network.example.id
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `display_name` - (Required) The user-friendly name for the Exadata VM Cluster. Changing this forces a new Exadata VM Cluster to be created. The name does not need to be unique.
+
+* `enabled_ecpu_count` - (Required) The number of ECPUs to enable for an Exadata VM cluster on Exascale Infrastructure.
+
+* `exascale_db_storage_vault_id` - (Required) The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the Exadata Database Storage Vault. Changing this forces a new Exadata VM Cluster to be created.
+
+* `hostname` - (Required) The hostname for the Exadata VM Cluster on Exascale Infrastructure. Changing this forces a new Exadata VM Cluster to be created.
+
+* `location` - (Required) The Azure Region where the Exadata VM Cluster should exist. Changing this forces a new Exadata VM Cluster to be created.
+
+* `name` - (Required) The name which should be used for this Exadata VM Cluster. Changing this forces a new Exadata VM Cluster to be created.
+
+* `node_count` - (Required) The number of nodes in the Exadata VM cluster on Exascale Infrastructure.
+
+* `resource_group_name` - (Required) The name of the Resource Group where the Exadata VM Cluster should exist. Changing this forces a new Exadata VM Cluster to be created.
+
+* `shape` - (Required) The shape of the Exadata VM cluster on Exascale Infrastructure resource.
+
+* `ssh_public_keys` - (Required) The public key portion of one or more key pairs used for SSH access to the Exadata VM Cluster. Changing this forces a new Exadata VM Cluster to be created.
+
+* `subnet_id` - (Required) The ID of the subnet associated with the Exadata VM Cluster. Changing this forces a new Exadata VM Cluster to be created.
+
+* `total_ecpu_count` - (Required) The number of Total ECPUs for an Exadata VM cluster on Exascale Infrastructure.
+
+* `vm_file_system_storage` - (Required) A `vm_file_system_storage` block as defined below. Changing this forces a new Exadata VM Cluster to be created.
+
+* `virtual_network_id` - (Required) The ID of the Virtual Network associated with the Exadata VM Cluster. Changing this forces a new Exadata VM Cluster to be created.
+
+---
+
+A `vm_file_system_storage` block supports the following:
+
+* `total_size_in_gbs` - (Required) Total Capacity. Changing this forces a new Exadata VM Cluster to be created.
+
+---
+
+* `backup_subnet_cidr` - (Optional) The backup subnet CIDR of the Virtual Network associated with the Exadata VM Cluster. Changing this forces a new Exadata VM Cluster to be created.
+
+* `cluster_name` - (Optional) The cluster name for Exadata VM Cluster. Changing this forces a new Exadata VM Cluster to be created.
+
+* `data_collection_options` - (Optional) A `data_collection_options` block as defined below. Changing this forces a new Exadata VM Cluster to be created.
+
+* `domain` - (Optional) The name of the OCI Private DNS Zone to be associated with the Exadata VM Cluster. This is required for specifying your own private domain name. Changing this forces a new Exadata VM Cluster to be created.
+
+* `grid_image_ocid` - (Optional) Grid Setup will be done using this grid image ocid.
+
+* `license_model` - (Optional) The Oracle license model that applies to the Exadata VM Cluster, either `BringYourOwnLicense` or `LicenseIncluded`. Changing this forces a new Exadata VM Cluster to be created.
+
+* `nsg_cidrs` - (Optional) CIDR blocks for additional NSG ingress rules. The VNET CIDRs used to provision the VM Cluster will be added by default. Changing this forces a new Exadata VM Cluster to be created.
+
+* `private_zone_ocid` - (Optional) The private zone ID in which you want DNS records to be created. Changing this forces a new Exadata VM Cluster to be created.
+
+* `scan_listener_port_tcp` - (Optional) The TCP Single Client Access Name (SCAN) port. The default port to 1521. Changing this forces a new Exadata VM Cluster to be created.
+
+* `scan_listener_port_tcp_ssl` - (Optional) The TCPS Single Client Access Name (SCAN) port. The default port to 2484. Changing this forces a new Exadata VM Cluster to be created.
+
+* `system_version` - (Optional) Operating system version of the Exadata image. System version must be <= Db server major version (the first two parts of the DB server version eg 23.1.X.X.XXXX). Accepted Values for Grid Infrastructure (GI) version 19.0.0.0 are 22.1.30.0.0.241204, 22.1.32.0.0.250205, 22.1.31.0.0.250110, 23.1.20.0.0.241112, 23.1.21.0.0.241204, 23.1.22.0.0.250119, 23.1.23.0.0.250207. For Grid Infrastructure (GI) version 23.0.0.0 allowed system versions are 23.1.19.0.0.241015, 23.1.20.0.0.241112, 23.1.22.0.0.250119, 23.1.21.0.0.241204, 23.1.23.0.0.250207.
+
+* `tags` - (Optional) A mapping of tags which should be assigned to the Exadata VM Cluster.
+
+* `time_zone` - (Optional) The time zone of the Exadata VM Cluster. For details, see [Exadata Infrastructure Time Zones](https://docs.cloud.oracle.com/iaas/Content/Database/References/timezones.htm). Changing this forces a new Exadata VM Cluster to be created.
+
+---
+
+A `data_collection_options` block supports the following:
+
+* `diagnostics_events_enabled` - (Optional) Indicates whether diagnostic collection is enabled for the VM Cluster/Exadata VM Cluster/VMBM DBCS. Enabling diagnostic collection allows you to receive Events service notifications for guest VM issues. Diagnostic collection also allows Oracle to provide enhanced service and proactive support for your Exadata system. You can enable diagnostic collection during VM Cluster/Exadata VM Cluster provisioning. You can also disable or enable it at any time using the `UpdateVmCluster` or `updateExadbVmCluster` API. Changing this forces a new Exadata VM Cluster to be created.
+
+* `health_monitoring_enabled` - (Optional) Indicates whether health monitoring is enabled for the VM Cluster / Exadata VM Cluster / VMBM DBCS. Enabling health monitoring allows Oracle to collect diagnostic data and share it with its operations and support personnel. You may also receive notifications for some events. Collecting health diagnostics enables Oracle to provide proactive support and enhanced service for your system. Optionally enable health monitoring while provisioning a system. You can also disable or enable health monitoring anytime using the `UpdateVmCluster`, `UpdateExadbVmCluster` or `updateDbsystem` API. Changing this forces a new Exadata VM Cluster to be created.
+
+* `incident_logs_enabled` - (Optional) Indicates whether incident logs and trace collection are enabled for the VM Cluster / Exadata VM Cluster / VMBM DBCS. Enabling incident logs collection allows Oracle to receive Events service notifications for guest VM issues, collect incident logs and traces, and use them to diagnose issues and resolve them. Optionally enable incident logs collection while provisioning a system. You can also disable or enable incident logs collection anytime using the `UpdateVmCluster`, `updateExadbVmCluster` or `updateDbsystem` API. Changing this forces a new Exadata VM Cluster to be created.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported: 
+
+* `id` - The ID of the Exadata VM Cluster.
+
+* `hostname_actual` - The hostname for the Exadata VM Cluster with suffix.
+
+* `ocid` - The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the Exadata VM Cluster.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 24 hours) Used when creating the Exadata VM Cluster.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Exadata VM Cluster.
+* `update` - (Defaults to 30 minutes) Used when updating the Exadata VM Cluster.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Exadata VM Cluster.
+
+## Import
+
+Exadata VM Clusters can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_oracle_exa_db_vm_cluster.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Oracle.Database/exadbVmClusters/exadbVmClusters1
+```
+
+## API Providers
+<!-- This section is generated, changes will be overwritten -->
+This resource uses the following Azure API Providers:
+
+* `Oracle.Database`: 2025-03-01

--- a/website/docs/r/oracle_exascale_db_storage_vault.html.markdown
+++ b/website/docs/r/oracle_exascale_db_storage_vault.html.markdown
@@ -1,0 +1,104 @@
+---
+subcategory: "Oracle"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_oracle_exascale_db_storage_vault"
+description: |-
+  Manages a Exadata Database Storage Vault.
+---
+
+# azurerm_oracle_exascale_db_storage_vault
+
+Manages a Exadata Database Storage Vault.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_oracle_exascale_db_storage_vault" "example" {
+  name                = "example-exascale-db-storage-vault"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  zones               = ["1"]
+  display_name        = "example-exascale-db-storage-vault"
+  description                      = "description"
+  additional_flash_cache_in_percent = 100
+  high_capacity_database_storage_input {
+    total_size_in_gbs = 300
+  }
+  time_zone        			  = "UTC"
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `location` - (Required) The Azure Region where the Exadata Database Storage Vault should exist. Changing this forces a new Exadata Database Storage Vault to be created.
+
+* `name` - (Required) The name which should be used for this Exadata Database Storage Vault. Changing this forces a new Exadata Database Storage Vault to be created.
+
+* `resource_group_name` - (Required) The name of the Resource Group where the ODB@A Infrastructure should exist. Changing this forces a new Exadata Database Storage Vault to be created.
+
+* `additional_flash_cache_in_percent` - (Required) The size of additional Flash Cache in percentage of High Capacity database storage. Changing this forces a new Exadata Database Storage Vault to be created.
+
+* `description` - (Required) Exadata Database Storage Vault description. Changing this forces a new Exadata Database Storage Vault to be created.
+
+* `display_name` - (Required) The user-friendly name for the Exadata Database Storage Vault resource. The name does not need to be unique. Changing this forces a new Exadata Database Storage Vault to be created.
+
+* `high_capacity_database_storage_input` - (Required) A `high_capacity_database_storage_input` block as defined below. Changing this forces a new Exadata Database Storage Vault to be created.
+
+* `zones` - (Required) Exadata Database Storage Vault zones. Changing this forces a new Exadata Database Storage Vault to be created.
+
+* `high_capacity_database_storage` - (Optional) A `high_capacity_database_storage` block as defined below.
+
+* `time_zone` - (Optional) The time zone that you want to use for the Exadata Database Storage Vault.
+
+* `tags` - (Optional) A mapping of tags which should be assigned to the Exadata Database Storage Vault.
+
+---
+
+A `high_capacity_database_storage_input` block supports the following:
+
+* `total_size_in_gbs` - (Required) Total Capacity
+
+---
+
+A `high_capacity_database_storage` block supports the following:
+
+* `available_size_in_gbs` - (Optional) Available Capacity
+
+* `total_size_in_gbs` - (Optional) Total Capacity
+
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the Exadata Database Storage Vault.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 2 hours) Used when creating the Exadata Database Storage Vault.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Exadata Database Storage Vault.
+* `update` - (Defaults to 30 minutes) Used when updating the Exadata Database Storage Vault.
+* `delete` - (Defaults to 1 hour) Used when deleting the Exadata Database Storage Vault.
+
+## Import
+
+Exadata Database Storage Vaults can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_oracle_exascale_db_storage_vault.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Oracle.Database/exascaleDbStorageVaults/exascaleDbStorageVaults1
+```
+
+## API Providers
+<!-- This section is generated, changes will be overwritten -->
+This resource uses the following Azure API Providers:
+
+* `Oracle.Database`: 2025-03-01


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

The following changes have been made to the Oracle provider to support a new feature - Oracle Exascale Infrastructure: Exadata VM cluster and Exadata Database Storage Vault.

### oracle_exascale_db_storage_vault_resource, oracle_exascale_db_storage_vault_data_source
Added new resource and data source

### oracle_exadb_vm_cluster_resource, oracle_exadb_vm_cluster_data_source
Added new resource and data source

### oracle_exascale_db_nodes_data_source
Added new data source

## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”

## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

![Screenshot 2025-06-09 at 3 11 04 PM](https://github.com/user-attachments/assets/d0577aba-0092-41d7-9ed1-d32233ddebc1)

![Screenshot 2025-06-10 at 11 07 53 AM](https://github.com/user-attachments/assets/a4468a27-cef7-4275-8a36-70cdd23047eb)

![Screenshot 2025-06-10 at 11 33 00 AM](https://github.com/user-attachments/assets/f0eb73dd-9fc7-470a-9730-e4681d9d475e)

![Screenshot 2025-06-10 at 12 04 05 PM](https://github.com/user-attachments/assets/651d9ce2-3534-4a32-b28e-0eda6569be78)


For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [X] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #29801

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
