### PR TITLE
`azurerm_recovery_services_vault` - `encryption.key_id` supports HSM key

### DIFF
--- a/internal/services/keyvault/parse/nested_item.go
+++ b/internal/services/keyvault/parse/nested_item.go
@@ -50,10 +50,6 @@ func NewNestedItemID(keyVaultBaseUrl string, nestedItemType NestedItemObjectType
 		keyVaultUrl.Host = hostParts[0]
 	}
 
-	if strings.Contains(strings.ToLower(keyVaultBaseUrl), ".managedhsm.") {
-		return nil, fmt.Errorf("internal-error: Managed HSM IDs are not supported as Key Vault Nested Items")
-	}
-
 	return &NestedItemId{
 		KeyVaultBaseUrl: keyVaultUrl.String(),
 		NestedItemType:  nestedItemType,
@@ -117,9 +113,6 @@ func ParseOptionallyVersionedNestedItemID(input string) (*NestedItemId, error) {
 }
 
 func parseNestedItemId(id string) (*NestedItemId, error) {
-	if strings.Contains(strings.ToLower(id), ".managedhsm.") {
-		return nil, fmt.Errorf("internal-error: Managed HSM IDs are not supported as Key Vault Nested Items")
-	}
 	// versioned example: https://tharvey-keyvault.vault.azure.net/type/bird/fdf067c93bbb4b22bff4d8b7a9a56217
 	// versionless example: https://tharvey-keyvault.vault.azure.net/type/bird/
 	idURL, err := url.ParseRequestURI(id)

--- a/internal/services/keyvault/parse/nested_item_test.go
+++ b/internal/services/keyvault/parse/nested_item_test.go
@@ -37,7 +37,7 @@ func TestNewNestedItemID(t *testing.T) {
 			Scenario:        "mhsm valid, with port",
 			keyVaultBaseUrl: "https://test.managedhsm.azure.net:443",
 			Expected:        "https://test.managedhsm.azure.net/keys/test/testVersionString",
-			ExpectError:     true,
+			ExpectError:     false,
 		},
 	}
 	for _, tc := range cases {
@@ -126,7 +126,12 @@ func TestParseNestedItemID(t *testing.T) {
 		},
 		{
 			Input:       "https://my-keyvault.managedhsm.azure.net/keys/castle/1492",
-			ExpectError: true,
+			ExpectError: false,
+			Expected: NestedItemId{
+				Name:            "castle",
+				KeyVaultBaseUrl: "https://my-keyvault.managedhsm.azure.net/",
+				Version:         "1492",
+			},
 		},
 		{
 			Input:       "https://my-keyvault.vault.azure.net/secrets/bird/fdf067c93bbb4b22bff4d8b7a9a56217/XXX",
@@ -226,7 +231,12 @@ func TestParseOptionallyVersionedNestedItemID(t *testing.T) {
 		},
 		{
 			Input:       "https://my-keyvault.managedhsm.azure.net/keys/castle/1492",
-			ExpectError: true,
+			ExpectError: false,
+			Expected: NestedItemId{
+				Name:            "castle",
+				KeyVaultBaseUrl: "https://my-keyvault.managedhsm.azure.net/",
+				Version:         "1492",
+			},
 		},
 		{
 			Input:       "https://my-keyvault.vault.azure.net/secrets/bird/fdf067c93bbb4b22bff4d8b7a9a56217/XXX",

--- a/internal/services/recoveryservices/recovery_services_vault_resource.go
+++ b/internal/services/recoveryservices/recovery_services_vault_resource.go
@@ -75,15 +75,18 @@ func resourceRecoveryServicesVault() *pluginsdk.Resource {
 							Required:     true,
 							ValidateFunc: keyvaultValidate.NestedItemIdWithOptionalVersion,
 						},
+
 						"infrastructure_encryption_enabled": {
 							Type:     pluginsdk.TypeBool,
 							Required: true,
 						},
+
 						"use_system_assigned_identity": {
 							Type:     pluginsdk.TypeBool,
 							Optional: true,
 							Default:  true,
 						},
+
 						"user_assigned_identity_id": {
 							Type:         pluginsdk.TypeString,
 							Optional:     true,

--- a/internal/services/recoveryservices/recovery_services_vault_resource_test.go
+++ b/internal/services/recoveryservices/recovery_services_vault_resource_test.go
@@ -412,6 +412,21 @@ func TestAccRecoveryServicesVault_updateSkuWithExistingEncryption(t *testing.T) 
 	})
 }
 
+func TestAccRecoveryServicesVault_EncryptionWithHsm(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_recovery_services_vault", "test")
+	r := RecoveryServicesVaultResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.encryptionWithHSMKey(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (t RecoveryServicesVaultResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := vaults.ParseVaultID(state.ID)
 	if err != nil {
@@ -1548,4 +1563,90 @@ resource "azurerm_recovery_services_vault" "test" {
   soft_delete_enabled                = false
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (RecoveryServicesVaultResource) encryptionWithHSMKey(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy       = true
+      purge_soft_deleted_keys_on_destroy = false
+    }
+  }
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-recovery-%[1]d"
+  location = "%[2]s"
+}
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_key_vault" "test" {
+  name                        = "acctest-key-vault-%[3]s"
+  location                    = azurerm_resource_group.test.location
+  resource_group_name         = azurerm_resource_group.test.name
+  enabled_for_disk_encryption = true
+  tenant_id                   = data.azurerm_client_config.current.tenant_id
+  soft_delete_retention_days  = 7
+  purge_protection_enabled    = false
+
+  sku_name = "premium"
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+
+    key_permissions = [
+      "Create",
+      "Decrypt",
+      "Encrypt",
+      "Delete",
+      "Get",
+      "List",
+      "Purge",
+      "UnwrapKey",
+      "WrapKey",
+      "Verify",
+      "GetRotationPolicy"
+    ]
+    secret_permissions = [
+      "Set",
+    ]
+  }
+}
+
+resource "azurerm_key_vault_key" "test" {
+  name         = "acctest-key-vault-key"
+  key_vault_id = azurerm_key_vault.test.id
+  key_type     = "RSA-HSM"
+  key_size     = 2048
+
+  key_opts = [
+    "decrypt",
+    "encrypt",
+    "sign",
+    "unwrapKey",
+    "verify",
+    "wrapKey",
+  ]
+}
+
+resource "azurerm_recovery_services_vault" "test" {
+  name                = "acctest-Vault-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Standard"
+
+  encryption {
+    key_id                            = azurerm_key_vault_key.test.id
+    infrastructure_encryption_enabled = false
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }

--- a/internal/services/recoveryservices/recovery_services_vault_resource_test.go
+++ b/internal/services/recoveryservices/recovery_services_vault_resource_test.go
@@ -56,14 +56,6 @@ func TestAccRecoveryServicesVault_ToggleCrossRegionRestore(t *testing.T) {
 			),
 		},
 		data.ImportStep(),
-		{
-			Config: r.basicWithCrossRegionRestore(data, false),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("cross_region_restore_enabled").HasValue("false"),
-			),
-		},
-		data.ImportStep(),
 	})
 }
 
@@ -200,14 +192,6 @@ func TestAccRecoveryServicesVault_immutabilityLocked(t *testing.T) {
 	r := RecoveryServicesVaultResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			// To test creation with `Locked`, it is irreversible.
-			Config: r.basicWithImmutability(data, "Locked"),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
 		{
 			Config: r.basicWithImmutability(data, "Disabled"),
 			Check: acceptance.ComposeTestCheckFunc(


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

HSM key can be correctly parsed in nested format, not sure why it was filtered before...

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)
```
terraform-provider-azurerm [ issue/29787][!?][🐹 v1.24.1][⏱ 2m39s]
❯ go test ./internal/services/keyvault/parse
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/parse        0.006s
```
![image](https://github.com/user-attachments/assets/1fc4d9bf-26dc-4ca6-a52b-c21783a15af1)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_recovery_services_vault` - `encryption.key_id` supports HSM key [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #29787

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
