### PR TITLE
29766  - Function App Flex Consumption - support for storage attachment

### DIFF
--- a/internal/services/appservice/function_app_flex_consumption_resource_test.go
+++ b/internal/services/appservice/function_app_flex_consumption_resource_test.go
@@ -35,6 +35,21 @@ func TestAccFunctionAppFlexConsumption_basic(t *testing.T) {
 	})
 }
 
+func TestAccFunctionAppFlexConsumption_basicWithStorageAccount(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_function_app_flex_consumption", "test")
+	r := FunctionAppFlexConsumptionResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.withStorageAccount(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("site_credential.0.password"),
+	})
+}
+
 func TestAccFunctionAppFlexConsumption_connectionString(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_function_app_flex_consumption", "test")
 	r := FunctionAppFlexConsumptionResource{}
@@ -480,6 +495,43 @@ resource "azurerm_function_app_flex_consumption" "test" {
 `, r.template(data), data.RandomInteger)
 }
 
+func (r FunctionAppFlexConsumptionResource) withStorageAccount(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_function_app_flex_consumption" "test" {
+  name                = "acctest-LFA-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  service_plan_id     = azurerm_service_plan.test.id
+
+  storage_container_type      = "blobContainer"
+  storage_container_endpoint  = "${azurerm_storage_account.test.primary_blob_endpoint}${azurerm_storage_container.test.name}"
+  storage_authentication_type = "StorageAccountConnectionString"
+  storage_access_key          = azurerm_storage_account.test.primary_access_key
+  runtime_name                = "node"
+  runtime_version             = "20"
+  maximum_instance_count      = 100
+  instance_memory_in_mb       = 2048
+
+  site_config {}
+
+  storage_account {
+    name         = "files"
+    type         = "AzureFiles"
+    account_name = azurerm_storage_account.test.name
+    share_name   = azurerm_storage_share.test.name
+    access_key   = azurerm_storage_account.test.primary_access_key
+    mount_path   = "/files"
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
 func (r FunctionAppFlexConsumptionResource) connectionString(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -644,6 +696,15 @@ resource "azurerm_function_app_flex_consumption" "test" {
     name  = "Example"
     value = "some-postgresql-connection-string"
     type  = "PostgreSQL"
+  }
+
+  storage_account {
+    name         = azurerm_storage_account.test.name
+    share_name   = azurerm_storage_share.test.name
+    type         = "AzureFiles"
+    access_key   = azurerm_storage_account.test.primary_access_key
+    account_name = azurerm_storage_account.test.name
+    mount_path   = "/storage/files"
   }
 
   site_config {
@@ -1256,6 +1317,12 @@ resource "azurerm_storage_container" "test" {
   name                  = "acctestblobforfc"
   storage_account_name  = azurerm_storage_account.test.name
   container_access_type = "private"
+}
+
+resource "azurerm_storage_share" "test" {
+  name               = "test"
+  storage_account_id = azurerm_storage_account.test.id
+  quota              = 1
 }
 
 data "azurerm_storage_account_sas" "test" {

--- a/website/docs/r/function_app_flex_consumption.html.markdown
+++ b/website/docs/r/function_app_flex_consumption.html.markdown
@@ -77,6 +77,8 @@ The following arguments are supported:
 
 * `site_config` - (Required) A `site_config` block as defined below.
 
+* `storage_account` - (Optional) One or more `storage_account` blocks as defined below.
+
 * `storage_container_type` - (Required) The storage container type used for the Function App. The current supported type is `blobContainer`.
 
 * `storage_container_endpoint` - (Required) The backend storage container endpoint which will be used by this Function App.
@@ -670,6 +672,22 @@ A `sticky_settings` block supports the following:
 * `app_setting_names` - (Optional) A list of `app_setting` names that the Linux Function App will not swap between Slots when a swap operation is triggered.
 
 * `connection_string_names` - (Optional) A list of `connection_string` names that the Linux Function App will not swap between Slots when a swap operation is triggered.
+
+---
+
+A `storage_account` block supports the following:
+
+* `access_key` - (Required) The Access key for the storage account.
+
+* `account_name` - (Required) The Name of the Storage Account.
+
+* `name` - (Required) The name which should be used for this Storage Account.
+
+* `share_name` - (Required) The Name of the File Share or Container Name for Blob storage.
+
+* `type` - (Required) The Azure Storage Type. Possible values include `AzureFiles` and `AzureBlob`.
+
+* `mount_path` - (Optional) The path at which to mount the storage share.
 
 ---
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

Add `storage_account` block to attach storage for the `azurerm_function_app_flex_consumption` resource. 

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”

## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.

## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

```
make acctests SERVICE='appservice' TESTARGS='-run=TestAccFunctionAppFlexConsumption_basicWithStorageAccount' TESTTIMEOUT='15m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/appservice -run=TestAccFunctionAppFlexConsumption_basicWithStorageAccount -timeout 15m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccFunctionAppFlexConsumption_basicWithStorageAccount
=== PAUSE TestAccFunctionAppFlexConsumption_basicWithStorageAccount
=== CONT  TestAccFunctionAppFlexConsumption_basicWithStorageAccount
--- PASS: TestAccFunctionAppFlexConsumption_basicWithStorageAccount (283.06s)

make acctests SERVICE='appservice' TESTARGS='-run=TestAccFunctionAppFlexConsumption_complete' TESTTIMEOUT='15m'               
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/appservice -run=TestAccFunctionAppFlexConsumption_complete -timeout 15m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccFunctionAppFlexConsumption_complete
=== PAUSE TestAccFunctionAppFlexConsumption_complete
=== CONT  TestAccFunctionAppFlexConsumption_complete
--- PASS: TestAccFunctionAppFlexConsumption_complete (296.58s)

```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_function_app_flex_consumption` - support for the `storage_account` property [GH-29766]

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change

## Related Issue(s)
Fixes #29766

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
