### PR TITLE
`azurerm_mobile_network_slice` move `Snssai` block's props to top level

### DIFF
--- a/internal/services/mobilenetwork/mobile_network_slice_resource.go
+++ b/internal/services/mobilenetwork/mobile_network_slice_resource.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/mobilenetwork"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/slice"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -25,13 +26,15 @@ type SliceResourceModel struct {
 	MobileNetworkId                                  string                                                          `tfschema:"mobile_network_id"`
 	Description                                      string                                                          `tfschema:"description"`
 	Location                                         string                                                          `tfschema:"location"`
-	SingleNetworkSliceSelectionAssistanceInformation []SingleNetworkSliceSelectionAssistanceInformationResourceModel `tfschema:"single_network_slice_selection_assistance_information"`
+	SliceDifferentiator                              string                                                          `tfschema:"slice_differentiator"`
+	SliceServiceType                                 int64                                                           `tfschema:"slice_service_type"`
+	SingleNetworkSliceSelectionAssistanceInformation []SingleNetworkSliceSelectionAssistanceInformationResourceModel `tfschema:"single_network_slice_selection_assistance_information,removedInNextMajorVersion"`
 	Tags                                             map[string]string                                               `tfschema:"tags"`
 }
 
 type SingleNetworkSliceSelectionAssistanceInformationResourceModel struct {
-	SliceDifferentiator string `tfschema:"slice_differentiator"`
-	SliceServiceType    int64  `tfschema:"slice_service_type"`
+	SliceDifferentiator string `tfschema:"slice_differentiator,removedInNextMajorVersion"`
+	SliceServiceType    int64  `tfschema:"slice_service_type,removedInNextMajorVersion"`
 }
 
 type SliceResource struct{}
@@ -51,7 +54,7 @@ func (r SliceResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
 }
 
 func (r SliceResource) Arguments() map[string]*pluginsdk.Schema {
-	return map[string]*pluginsdk.Schema{
+	s := map[string]*pluginsdk.Schema{
 		"name": {
 			Type:         pluginsdk.TypeString,
 			Required:     true,
@@ -74,17 +77,57 @@ func (r SliceResource) Arguments() map[string]*pluginsdk.Schema {
 
 		"location": commonschema.Location(),
 
-		"single_network_slice_selection_assistance_information": {
-			Type:     pluginsdk.TypeList,
-			Required: true,
-			MaxItems: 1,
+		"slice_service_type": {
+			Type:         pluginsdk.TypeInt,
+			Required:     true,
+			ValidateFunc: validation.IntBetween(0, 255),
+		},
+
+		"slice_differentiator": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			ValidateFunc: validation.StringMatch(
+				regexp.MustCompile(`^[A-Fa-f0-9]{6}$`),
+				"Slice Differentiator must be a 6 digit hex string",
+			),
+		},
+
+		"tags": commonschema.Tags(),
+	}
+
+	if !features.FivePointOh() {
+		s["slice_service_type"] = &pluginsdk.Schema{
+			Type:          pluginsdk.TypeInt,
+			Optional:      true,
+			Computed:      true,
+			ValidateFunc:  validation.IntBetween(0, 255),
+			ConflictsWith: []string{"single_network_slice_selection_assistance_information"},
+		}
+
+		s["slice_differentiator"] = &pluginsdk.Schema{
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Computed: true,
+			ValidateFunc: validation.StringMatch(
+				regexp.MustCompile(`^[A-Fa-f0-9]{6}$`),
+				"Slice Differentiator must be a 6 digit hex string",
+			),
+			ConflictsWith: []string{"single_network_slice_selection_assistance_information"},
+		}
+
+		s["single_network_slice_selection_assistance_information"] = &pluginsdk.Schema{
+			Type:          pluginsdk.TypeList,
+			Optional:      true,
+			Computed:      true,
+			ConflictsWith: []string{"slice_service_type", "slice_differentiator"},
+			MaxItems:      1,
+			Deprecated:    "`single_network_slice_selection_assistance_information` has been deprecated and its properties, `slice_differentiator` and `slice_service_type` have been moved to the top level. The `single_network_slice_selection_assistance_information` block will be removed in v5.0 of the AzureRM Provider.",
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
-					// TODO: these fields can be moved to the top-level in 4.0
-
 					"slice_differentiator": {
-						Type:     pluginsdk.TypeString,
-						Optional: true,
+						Type:       pluginsdk.TypeString,
+						Optional:   true,
+						Deprecated: "`single_network_slice_selection_assistance_information` has been deprecated and its properties, `slice_differentiator` and `slice_service_type` have been moved to the top level. The `single_network_slice_selection_assistance_information` block will be removed in v5.0 of the AzureRM Provider.",
 						ValidateFunc: validation.StringMatch(
 							regexp.MustCompile(`^[A-Fa-f0-9]{6}$`),
 							"Slice Differentiator must be a 6 digit hex string",
@@ -94,14 +137,15 @@ func (r SliceResource) Arguments() map[string]*pluginsdk.Schema {
 					"slice_service_type": {
 						Type:         pluginsdk.TypeInt,
 						Required:     true,
+						Deprecated:   "`single_network_slice_selection_assistance_information` has been deprecated and its properties, `slice_differentiator` and `slice_service_type` have been moved to the top level. The `single_network_slice_selection_assistance_information` block will be removed in v5.0 of the AzureRM Provider.",
 						ValidateFunc: validation.IntBetween(0, 255),
 					},
 				},
 			},
-		},
-
-		"tags": commonschema.Tags(),
+		}
 	}
+
+	return s
 }
 
 func (r SliceResource) Attributes() map[string]*pluginsdk.Schema {
@@ -134,16 +178,26 @@ func (r SliceResource) Create() sdk.ResourceFunc {
 			}
 
 			properties := slice.Slice{
-				Location:   location.Normalize(model.Location),
-				Properties: slice.SlicePropertiesFormat{},
-				Tags:       &model.Tags,
+				Location: location.Normalize(model.Location),
+				Properties: slice.SlicePropertiesFormat{
+					Snssai: slice.Snssai{
+						Sst: model.SliceServiceType,
+					},
+				},
+				Tags: &model.Tags,
 			}
 
 			if model.Description != "" {
 				properties.Properties.Description = &model.Description
 			}
 
-			properties.Properties.Snssai = expandSingleNetworkSliceSelectionAssistanceInformationResourceModel(model.SingleNetworkSliceSelectionAssistanceInformation)
+			if model.SliceDifferentiator != "" {
+				properties.Properties.Snssai.Sd = &model.SliceDifferentiator
+			}
+
+			if !features.FivePointOh() {
+				properties.Properties.Snssai = expandSingleNetworkSliceSelectionAssistanceInformationResourceModel(model.SingleNetworkSliceSelectionAssistanceInformation)
+			}
 
 			if err := client.CreateOrUpdateThenPoll(ctx, id, properties); err != nil {
 				return fmt.Errorf("creating %s: %+v", id, err)
@@ -191,7 +245,15 @@ func (r SliceResource) Update() sdk.ResourceFunc {
 			}
 
 			if metadata.ResourceData.HasChange("snssai") {
-				updateModel.Properties.Snssai = expandSingleNetworkSliceSelectionAssistanceInformationResourceModel(model.SingleNetworkSliceSelectionAssistanceInformation)
+				if !features.FivePointOh() {
+					updateModel.Properties.Snssai = expandSingleNetworkSliceSelectionAssistanceInformationResourceModel(model.SingleNetworkSliceSelectionAssistanceInformation)
+				}
+				updateModel.Properties.Snssai = slice.Snssai{
+					Sst: model.SliceServiceType,
+				}
+				if model.SliceDifferentiator != "" {
+					updateModel.Properties.Snssai.Sd = &model.SliceDifferentiator
+				}
 			}
 
 			if metadata.ResourceData.HasChange("tags") {
@@ -238,7 +300,13 @@ func (r SliceResource) Read() sdk.ResourceFunc {
 					state.Description = *model.Properties.Description
 				}
 
-				state.SingleNetworkSliceSelectionAssistanceInformation = flattenSingleNetworkSliceSelectionAssistanceInformationResourceModel(model.Properties.Snssai)
+				if !features.FivePointOh() {
+					state.SingleNetworkSliceSelectionAssistanceInformation = flattenSingleNetworkSliceSelectionAssistanceInformationResourceModel(model.Properties.Snssai)
+				}
+				state.SliceServiceType = model.Properties.Snssai.Sst
+				if model.Properties.Snssai.Sd != nil {
+					state.SliceDifferentiator = *model.Properties.Snssai.Sd
+				}
 
 				if model.Tags != nil {
 					state.Tags = *model.Tags

--- a/internal/services/mobilenetwork/mobile_network_slice_resource_test.go
+++ b/internal/services/mobilenetwork/mobile_network_slice_resource_test.go
@@ -8,13 +8,14 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/slice"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type MobileNetworkSliceResource struct{}
@@ -92,16 +93,16 @@ func (r MobileNetworkSliceResource) Exists(ctx context.Context, clients *clients
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r MobileNetworkSliceResource) basic(data acceptance.TestData) string {
-	template := r.template(data)
-	return fmt.Sprintf(`
+	if !features.FivePointOh() {
+		return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
@@ -117,7 +118,22 @@ resource "azurerm_mobile_network_slice" "test" {
     slice_service_type = 1
   }
 }
-`, template, data.RandomInteger)
+`, r.template(data), data.RandomInteger)
+	}
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_mobile_network_slice" "test" {
+  name               = "acctest-mns-%d"
+  mobile_network_id  = azurerm_mobile_network.test.id
+  location           = azurerm_mobile_network.test.location
+  slice_service_type = 1
+}
+`, r.template(data), data.RandomInteger)
 }
 
 func (r MobileNetworkSliceResource) requiresImport(data acceptance.TestData) string {
@@ -126,13 +142,10 @@ func (r MobileNetworkSliceResource) requiresImport(data acceptance.TestData) str
 %s
 
 resource "azurerm_mobile_network_slice" "import" {
-  name              = azurerm_mobile_network_slice.test.name
-  mobile_network_id = azurerm_mobile_network_slice.test.mobile_network_id
-  location          = azurerm_mobile_network_slice.test.location
-
-  single_network_slice_selection_assistance_information {
-    slice_service_type = 1
-  }
+  name               = azurerm_mobile_network_slice.test.name
+  mobile_network_id  = azurerm_mobile_network_slice.test.mobile_network_id
+  location           = azurerm_mobile_network_slice.test.location
+  slice_service_type = 1
 }
 `, template)
 }
@@ -147,14 +160,11 @@ provider "azurerm" {
 %s
 
 resource "azurerm_mobile_network_slice" "test" {
-  name              = "acctest-mns-%d"
-  mobile_network_id = azurerm_mobile_network.test.id
-  location          = azurerm_mobile_network.test.location
-  description       = "my favorite slice"
-
-  single_network_slice_selection_assistance_information {
-    slice_service_type = 1
-  }
+  name               = "acctest-mns-%d"
+  mobile_network_id  = azurerm_mobile_network.test.id
+  location           = azurerm_mobile_network.test.location
+  description        = "my favorite slice"
+  slice_service_type = 1
 
   tags = {
     key = "value"
@@ -173,14 +183,11 @@ provider "azurerm" {
 %s
 
 resource "azurerm_mobile_network_slice" "test" {
-  name              = "acctest-mns-%d"
-  mobile_network_id = azurerm_mobile_network.test.id
-  location          = azurerm_mobile_network.test.location
-  description       = "my favorite slice2"
-
-  single_network_slice_selection_assistance_information {
-    slice_service_type = 1
-  }
+  name               = "acctest-mns-%d"
+  mobile_network_id  = azurerm_mobile_network.test.id
+  location           = azurerm_mobile_network.test.location
+  description        = "my favorite slice2"
+  slice_service_type = 1
 
   tags = {
     key = "value"

--- a/website/docs/5.0-upgrade-guide.html.markdown
+++ b/website/docs/5.0-upgrade-guide.html.markdown
@@ -231,6 +231,10 @@ Please follow the format in the example below for listing breaking changes in re
 * The `site_config.min_tls_version` property no longer accepts `1.0` or `1.1` as a value.
 * The `site_config.scm_min_tls_version` property no longer accepts `1.0` or `1.1` as a value.
 
+### `azurerm_mobile_network_slice`
+
+* The `single_network_slice_selection_assistance_information` has been removed and its properties, `slice_differentiator` and `slice_service_type` have been moved to the top level.
+
 ### `azurerm_monitor_aad_diagnostic_setting`
 
 * The deprecated `enabled_log.retention_policy` block has been removed.

--- a/website/docs/r/mobile_network_slice.html.markdown
+++ b/website/docs/r/mobile_network_slice.html.markdown
@@ -54,19 +54,13 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the Azure Region where the Mobile Network Slice should exist. Changing this forces a new Mobile Network Slice to be created.
 
-* `single_network_slice_selection_assistance_information` - (Required) A `single_network_slice_selection_assistance_information` block as defined below. Single-network slice selection assistance information (S-NSSAI). Unique at the scope of a mobile network.
+* `slice_differentiator` - (Optional) Slice differentiator (SD). Must be a 6 digit hex string. For single-network slice selection assistance information (S-NSSAI). Unique at the scope of a mobile network.
+
+* `slice_service_type` - (Required) Slice/service type (SST). Must be between `0` and `255`. For single-network slice selection assistance information (S-NSSAI). Unique at the scope of a mobile network.
 
 * `description` - (Optional) A description for this Mobile Network Slice.
 
 * `tags` - (Optional) A mapping of tags which should be assigned to the Mobile Network Slice.
-
----
-
-A `single_network_slice_selection_assistance_information` block supports the following:
-
-* `slice_differentiator` - (Optional) Slice differentiator (SD). Must be a 6 digit hex string.
-
-* `slice_service_type` - (Required) Slice/service type (SST). Must be between `0` and `255`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This PR move the properties of the `Snssai` block to the top level.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

* `azurerm_mobile_network_slice` move `Snssai` block's props to top level [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
