### PR TITLE
`azurerm_private_dns_zone_virtual_network_link` and `data.`azurerm_private_dns_zone_virtual_network_link` - supports `resolution_policy`

### DIFF
--- a/internal/services/privatedns/private_dns_zone_virtual_network_link_data_source.go
+++ b/internal/services/privatedns/private_dns_zone_virtual_network_link_data_source.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
@@ -48,6 +49,11 @@ func dataSourcePrivateDnsZoneVirtualNetworkLink() *pluginsdk.Resource {
 				Computed: true,
 			},
 
+			"resolution_policy": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
 			"tags": commonschema.TagsDataSource(),
 		},
 	}
@@ -78,6 +84,7 @@ func dataSourcePrivateDnsZoneVirtualNetworkLinkRead(d *pluginsdk.ResourceData, m
 	if model := resp.Model; model != nil {
 		if props := model.Properties; props != nil {
 			d.Set("registration_enabled", props.RegistrationEnabled)
+			d.Set("resolution_policy", pointer.From(props.ResolutionPolicy))
 
 			if network := props.VirtualNetwork; network != nil {
 				d.Set("virtual_network_id", network.Id)

--- a/internal/services/privatedns/private_dns_zone_virtual_network_link_data_source_test.go
+++ b/internal/services/privatedns/private_dns_zone_virtual_network_link_data_source_test.go
@@ -37,6 +37,31 @@ func TestAccDataSourcePrivateDnsZoneVirtualNetworkLink_basic(t *testing.T) {
 	})
 }
 
+func TestAccDataSourcePrivateDnsZoneVirtualNetworkLink_resolutionPolicy(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_private_dns_zone_virtual_network_link", "test")
+	r := PrivateDnsZoneVirtualNetworkLinkDataSource{}
+
+	resourceName := "azurerm_private_dns_zone_virtual_network_link.test"
+	zoneName := "azurerm_private_dns_zone.test"
+	vnetName := "azurerm_virtual_network.test"
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.resolutionPolicy(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("id").MatchesOtherKey(check.That(resourceName).Key("id")),
+				check.That(data.ResourceName).Key("name").MatchesOtherKey(check.That(resourceName).Key("name")),
+				check.That(data.ResourceName).Key("resource_group_name").MatchesOtherKey(check.That(resourceName).Key("resource_group_name")),
+				check.That(data.ResourceName).Key("virtual_network_id").MatchesOtherKey(check.That(vnetName).Key("id")),
+				check.That(data.ResourceName).Key("private_dns_zone_name").MatchesOtherKey(check.That(zoneName).Key("name")),
+				check.That(data.ResourceName).Key("registration_enabled").HasValue("false"),
+				check.That(data.ResourceName).Key("resolution_policy").HasValue("NxDomainRedirect"),
+				check.That(data.ResourceName).Key("tags.%").HasValue("0"),
+			),
+		},
+	})
+}
+
 func (PrivateDnsZoneVirtualNetworkLinkDataSource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
@@ -47,4 +72,16 @@ data "azurerm_private_dns_zone_virtual_network_link" "test" {
   private_dns_zone_name = azurerm_private_dns_zone.test.name
 }
 `, PrivateDnsZoneVirtualNetworkLinkResource{}.basic(data))
+}
+
+func (PrivateDnsZoneVirtualNetworkLinkDataSource) resolutionPolicy(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_private_dns_zone_virtual_network_link" "test" {
+  name                  = azurerm_private_dns_zone_virtual_network_link.test.name
+  resource_group_name   = azurerm_resource_group.test.name
+  private_dns_zone_name = azurerm_private_dns_zone.test.name
+}
+`, PrivateDnsZoneVirtualNetworkLinkResource{}.resolutionPolicy(data, "NxDomainRedirect"))
 }

--- a/internal/services/privatedns/private_dns_zone_virtual_network_link_resource.go
+++ b/internal/services/privatedns/private_dns_zone_virtual_network_link_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
@@ -75,6 +76,13 @@ func resourcePrivateDnsZoneVirtualNetworkLink() *pluginsdk.Resource {
 				Default:  false,
 			},
 
+			"resolution_policy": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				Default:      virtualnetworklinks.ResolutionPolicyDefault,
+				ValidateFunc: validation.StringInSlice(virtualnetworklinks.PossibleValuesForResolutionPolicy(), false),
+			},
+
 			"tags": commonschema.Tags(),
 		},
 	}
@@ -108,6 +116,7 @@ func resourcePrivateDnsZoneVirtualNetworkLinkCreateUpdate(d *pluginsdk.ResourceD
 				Id: utils.String(d.Get("virtual_network_id").(string)),
 			},
 			RegistrationEnabled: utils.Bool(d.Get("registration_enabled").(bool)),
+			ResolutionPolicy:    pointer.To(virtualnetworklinks.ResolutionPolicy(d.Get("resolution_policy").(string))),
 		},
 	}
 
@@ -150,6 +159,7 @@ func resourcePrivateDnsZoneVirtualNetworkLinkRead(d *pluginsdk.ResourceData, met
 	if model := resp.Model; model != nil {
 		if props := model.Properties; props != nil {
 			d.Set("registration_enabled", props.RegistrationEnabled)
+			d.Set("resolution_policy", pointer.From(props.ResolutionPolicy))
 
 			if network := props.VirtualNetwork; network != nil {
 				d.Set("virtual_network_id", network.Id)

--- a/website/docs/d/private_dns_zone_virtual_network_link.html.markdown
+++ b/website/docs/d/private_dns_zone_virtual_network_link.html.markdown
@@ -40,6 +40,8 @@ output "private_dns_a_record_id" {
 
 * `registration_enabled` - Whether the auto-registration of virtual machine records in the virtual network in the Private DNS zone is enabled or not.
 
+* `resolution_policy` - The resolution policy of the Private DNS Zone Virtual Network Link.
+
 * `tags` - A mapping of tags to assign to the resource.
 
 ## Timeouts

--- a/website/docs/r/private_dns_zone_virtual_network_link.html.markdown
+++ b/website/docs/r/private_dns_zone_virtual_network_link.html.markdown
@@ -52,6 +52,8 @@ The following arguments are supported:
 
 * `registration_enabled` - (Optional) Is auto-registration of virtual machine records in the virtual network in the Private DNS zone enabled? Defaults to `false`.
 
+* `resolution_policy` - (Optional) Specifies the resolution policy of the Private DNS Zone Virtual Network Link. Possible values are `Default` and `NxDomainRedirect`. Defaults to `Default`.
+
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ## Attributes Reference


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description
`resolution_policy` is used for private link, reference document: https://learn.microsoft.com/en-us/azure/dns/private-dns-fallback 
This PR is acutally doing the similar things to https://github.com/hashicorp/terraform-provider-azurerm/pull/28615 and https://github.com/hashicorp/terraform-provider-azurerm/pull/29628
But #28615 has been waiting for author's response for a long time, #29628 is naming the scheme in different way.

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

TC testing in progress

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_private_dns_zone_virtual_network_link` - supports `resolution_policy` [GH-00000]
*  `data.`azurerm_private_dns_zone_virtual_network_link` - supports `resolution_policy` [GH-00000]

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #29196
Fixes #28087

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
