### PR TITLE
`azurerm_policy_set_definition` - migrate to `go-azure-sdk` and split into 2 resources

### DIFF
--- a/internal/services/policy/management_group_policy_set_definition_resource.go
+++ b/internal/services/policy/management_group_policy_set_definition_resource.go
@@ -1,0 +1,345 @@
+package policy
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/resources/2025-01-01/policysetdefinitions"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+type ManagementGroupPolicySetDefinitionResource struct{}
+
+type ManagementGroupPolicySetDefinitionResourceModel struct {
+	Name                      string                           `tfschema:"name"`
+	PolicyType                string                           `tfschema:"policy_type"`
+	ManagementGroupID         string                           `tfschema:"management_group_id"`
+	DisplayName               string                           `tfschema:"display_name"`
+	Description               string                           `tfschema:"description"`
+	Metadata                  string                           `tfschema:"metadata"`
+	Parameters                string                           `tfschema:"parameters"`
+	PolicyDefinitionReference []PolicyDefinitionReferenceModel `tfschema:"policy_definition_reference"`
+	PolicyDefinitionGroup     []PolicyDefinitionGroupModel     `tfschema:"policy_definition_group"`
+}
+
+var _ sdk.ResourceWithUpdate = ManagementGroupPolicySetDefinitionResource{}
+
+func (r ManagementGroupPolicySetDefinitionResource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"policy_type": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringInSlice(policysetdefinitions.PossibleValuesForPolicyType(), false),
+		},
+
+		"management_group_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: commonids.ValidateManagementGroupID,
+		},
+
+		"display_name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"description": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+		},
+
+		"metadata": {
+			Type:             pluginsdk.TypeString,
+			Optional:         true,
+			Computed:         true,
+			ValidateFunc:     validation.StringIsJSON,
+			DiffSuppressFunc: policySetDefinitionsMetadataDiffSuppressFunc,
+		},
+
+		"parameters": {
+			Type:             pluginsdk.TypeString,
+			Optional:         true,
+			ValidateFunc:     validation.StringIsJSON,
+			DiffSuppressFunc: pluginsdk.SuppressJsonDiff,
+		},
+
+		"policy_definition_reference": policyDefinitionReferenceSchema(),
+
+		"policy_definition_group": policyDefinitionGroupSchema(),
+	}
+}
+
+func (r ManagementGroupPolicySetDefinitionResource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{}
+}
+
+func (r ManagementGroupPolicySetDefinitionResource) ModelObject() interface{} {
+	return &ManagementGroupPolicySetDefinitionResourceModel{}
+}
+
+func (r ManagementGroupPolicySetDefinitionResource) ResourceType() string {
+	return "azurerm_management_group_policy_set_definition"
+}
+
+func (r ManagementGroupPolicySetDefinitionResource) Create() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Policy.PolicySetDefinitionsClient
+
+			var model ManagementGroupPolicySetDefinitionResourceModel
+			if err := metadata.Decode(&model); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			managementGroupID, err := commonids.ParseManagementGroupID(model.ManagementGroupID)
+			if err != nil {
+				return err
+			}
+
+			id := policysetdefinitions.NewProviders2PolicySetDefinitionID(managementGroupID.GroupId, model.Name)
+
+			existing, err := client.GetAtManagementGroup(ctx, id, policysetdefinitions.DefaultGetAtManagementGroupOperationOptions())
+			if err != nil && !response.WasNotFound(existing.HttpResponse) {
+				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+			}
+
+			if !response.WasNotFound(existing.HttpResponse) {
+				return metadata.ResourceRequiresImport(r.ResourceType(), id)
+			}
+
+			parameters := policysetdefinitions.PolicySetDefinition{
+				Name: pointer.To(model.Name),
+				Properties: &policysetdefinitions.PolicySetDefinitionProperties{
+					Description: pointer.To(model.Description),
+					DisplayName: pointer.To(model.DisplayName),
+					PolicyType:  pointer.To(policysetdefinitions.PolicyType(model.PolicyType)),
+				},
+			}
+			props := parameters.Properties
+
+			if model.Metadata != "" {
+				expandedMetadata, err := pluginsdk.ExpandJsonFromString(model.Metadata)
+				if err != nil {
+					return fmt.Errorf("expanding `metadata`: %+v", err)
+				}
+
+				var iMetadata interface{} = expandedMetadata
+
+				props.Metadata = &iMetadata
+			}
+
+			if model.Parameters != "" {
+				expandedParameters, err := expandParameterDefinitionsValue(model.Parameters)
+				if err != nil {
+					return fmt.Errorf("expanding `parameters`: %+v", err)
+				}
+				props.Parameters = expandedParameters
+			}
+
+			if len(model.PolicyDefinitionReference) > 0 {
+				expandedDefinitions, err := expandPolicyDefinitionReference(model.PolicyDefinitionReference)
+				if err != nil {
+					return fmt.Errorf("expanding `policy_definition_reference`: %+v", err)
+				}
+				props.PolicyDefinitions = expandedDefinitions
+			}
+
+			if len(model.PolicyDefinitionGroup) > 0 {
+				props.PolicyDefinitionGroups = expandPolicyDefinitionGroup(model.PolicyDefinitionGroup)
+			}
+
+			if _, err = client.CreateOrUpdateAtManagementGroup(ctx, id, parameters); err != nil {
+				return fmt.Errorf("creating %s: %+v", id, err)
+			}
+
+			metadata.SetID(id)
+			return nil
+		},
+	}
+}
+
+func (r ManagementGroupPolicySetDefinitionResource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Policy.PolicySetDefinitionsClient
+
+			id, err := policysetdefinitions.ParseProviders2PolicySetDefinitionID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.GetAtManagementGroup(ctx, *id, policysetdefinitions.DefaultGetAtManagementGroupOperationOptions())
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return metadata.MarkAsGone(id)
+				}
+
+				return fmt.Errorf("retrieving %s: %+v", *id, err)
+			}
+
+			state := ManagementGroupPolicySetDefinitionResourceModel{
+				Name:              id.PolicySetDefinitionName,
+				ManagementGroupID: commonids.NewManagementGroupID(id.ManagementGroupName).ID(),
+			}
+
+			if model := resp.Model; model != nil {
+				if props := model.Properties; props != nil {
+					state.Description = pointer.From(props.Description)
+					state.DisplayName = pointer.From(props.DisplayName)
+					state.PolicyType = string(pointer.From(props.PolicyType))
+
+					if v, ok := pointer.From(props.Metadata).(map[string]interface{}); ok {
+						flattenedMetadata, err := pluginsdk.FlattenJsonToString(v)
+						if err != nil {
+							return fmt.Errorf("flattening `metadata`: %+v", err)
+						}
+						state.Metadata = flattenedMetadata
+					}
+
+					flattenedParameters, err := flattenParameterDefinitionsValue(props.Parameters)
+					if err != nil {
+						return fmt.Errorf("flattening `parameters`: %+v", err)
+					}
+					state.Parameters = flattenedParameters
+
+					flattenedDefinitions, err := flattenPolicyDefinitionReference(props.PolicyDefinitions)
+					if err != nil {
+						return fmt.Errorf("flattening `policy_definition_reference`: %+v", err)
+					}
+					state.PolicyDefinitionReference = flattenedDefinitions
+
+					state.PolicyDefinitionGroup = flattenPolicyDefinitionGroup(props.PolicyDefinitionGroups)
+				}
+			}
+
+			return metadata.Encode(&state)
+		},
+	}
+}
+
+func (r ManagementGroupPolicySetDefinitionResource) Update() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Policy.PolicySetDefinitionsClient
+
+			id, err := policysetdefinitions.ParseProviders2PolicySetDefinitionID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			var config ManagementGroupPolicySetDefinitionResourceModel
+			if err := metadata.Decode(&config); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			existing, err := client.GetAtManagementGroup(ctx, *id, policysetdefinitions.DefaultGetAtManagementGroupOperationOptions())
+			if err != nil {
+				if response.WasNotFound(existing.HttpResponse) {
+					return metadata.MarkAsGone(id)
+				}
+
+				return fmt.Errorf("retrieving %s: %+v", *id, err)
+			}
+
+			if existing.Model == nil {
+				return fmt.Errorf("retrieving %s: `model` was nil", *id)
+			}
+
+			if existing.Model.Properties == nil {
+				return fmt.Errorf("retrieving %s: `properties` was nil", *id)
+			}
+			props := existing.Model.Properties
+
+			if metadata.ResourceData.HasChange("display_name") {
+				props.DisplayName = pointer.To(config.DisplayName)
+			}
+
+			if metadata.ResourceData.HasChange("description") {
+				props.Description = pointer.To(config.Description)
+			}
+
+			if metadata.ResourceData.HasChange("metadata") {
+				expandedMetadata, err := pluginsdk.ExpandJsonFromString(config.Metadata)
+				if err != nil {
+					return fmt.Errorf("expanding `metadata`: %+v", err)
+				}
+
+				var iMetadata interface{} = expandedMetadata
+
+				props.Metadata = &iMetadata
+			}
+
+			if metadata.ResourceData.HasChange("parameters") {
+				props.Parameters = nil
+				if config.Parameters != "" {
+					expandedParameters, err := expandParameterDefinitionsValue(config.Parameters)
+					if err != nil {
+						return fmt.Errorf("expanding `parameters`: %+v", err)
+					}
+					props.Parameters = expandedParameters
+				}
+			}
+
+			if metadata.ResourceData.HasChange("policy_definition_reference") {
+				expandedDefinitions, err := expandPolicyDefinitionReference(config.PolicyDefinitionReference)
+				if err != nil {
+					return fmt.Errorf("expanding `policy_definition_reference`: %+v", err)
+				}
+				props.PolicyDefinitions = expandedDefinitions
+			}
+
+			if metadata.ResourceData.HasChange("policy_definition_group") {
+				props.PolicyDefinitionGroups = expandPolicyDefinitionGroup(config.PolicyDefinitionGroup)
+			}
+
+			if _, err := client.CreateOrUpdateAtManagementGroup(ctx, *id, *existing.Model); err != nil {
+				return fmt.Errorf("updating %s: %+v", *id, err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func (r ManagementGroupPolicySetDefinitionResource) Delete() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Policy.PolicySetDefinitionsClient
+
+			id, err := policysetdefinitions.ParseProviders2PolicySetDefinitionID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			if _, err := client.DeleteAtManagementGroup(ctx, *id); err != nil {
+				return fmt.Errorf("deleting %s: %+v", *id, err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func (r ManagementGroupPolicySetDefinitionResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return policysetdefinitions.ValidateProviders2PolicySetDefinitionID
+}

--- a/internal/services/policy/management_group_policy_set_definition_resource_test.go
+++ b/internal/services/policy/management_group_policy_set_definition_resource_test.go
@@ -1,0 +1,240 @@
+package policy_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/resources/2025-01-01/policysetdefinitions"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type ManagementGroupPolicySetDefinitionResourceTest struct{}
+
+func TestAccManagementGroupPolicySetDefinition_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_management_group_policy_set_definition", "test")
+	r := ManagementGroupPolicySetDefinitionResourceTest{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccManagementGroupPolicySetDefinition_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_management_group_policy_set_definition", "test")
+	r := ManagementGroupPolicySetDefinitionResourceTest{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func TestAccManagementGroupPolicySetDefinition_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_management_group_policy_set_definition", "test")
+	r := ManagementGroupPolicySetDefinitionResourceTest{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (ManagementGroupPolicySetDefinitionResourceTest) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := policysetdefinitions.ParseProviders2PolicySetDefinitionID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.Policy.PolicySetDefinitionsClient.GetAtManagementGroup(ctx, *id, policysetdefinitions.DefaultGetAtManagementGroupOperationOptions())
+	if err != nil {
+		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
+	}
+
+	return pointer.To(resp.Model != nil), nil
+}
+
+func (r ManagementGroupPolicySetDefinitionResourceTest) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_management_group_policy_set_definition" "test" {
+  name                = "acctestpolset-%[2]d"
+  policy_type         = "Custom"
+  display_name        = "acctestpolset-%[2]d"
+  management_group_id = azurerm_management_group.test.id
+
+  parameters = <<PARAMETERS
+   {
+       "allowedLocations": {
+           "type": "Array",
+           "metadata": {
+               "description": "The list of allowed locations for resources.",
+               "displayName": "Allowed locations",
+               "strongType": "location"
+           }
+       }
+   }
+PARAMETERS
+
+  policy_definition_reference {
+    policy_definition_id = azurerm_policy_definition.test.id
+    parameter_values     = <<VALUES
+   {
+     "allowedLocations": {"value": "[parameters('allowedLocations')]"}
+   }
+VALUES
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r ManagementGroupPolicySetDefinitionResourceTest) requiresImport(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_management_group_policy_set_definition" "import" {
+  name                = azurerm_management_group_policy_set_definition.test.name
+  policy_type         = azurerm_management_group_policy_set_definition.test.policy_type
+  display_name        = azurerm_management_group_policy_set_definition.test.display_name
+  management_group_id = azurerm_management_group.test.id
+
+  parameters = azurerm_management_group_policy_set_definition.test.parameters
+
+  policy_definition_reference {
+    policy_definition_id = azurerm_management_group_policy_set_definition.test.policy_definition_reference.0.policy_definition_id
+    parameter_values     = azurerm_management_group_policy_set_definition.test.policy_definition_reference.0.parameter_values
+  }
+}`, r.basic(data))
+}
+
+func (r ManagementGroupPolicySetDefinitionResourceTest) complete(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_management_group_policy_set_definition" "test" {
+  name                = "acctestpolset-%[2]d"
+  display_name        = "acctestpolset-%[2]d"
+  management_group_id = azurerm_management_group.test.id
+  policy_type         = "Custom"
+
+  description = "A description for this policy set definition"
+  metadata    = <<METADATA
+    {
+        "foo": "bar"
+    }
+METADATA
+
+  policy_definition_group {
+    name         = "Group-1"
+    category     = "My Access Control"
+    description  = "Controls accesses"
+    display_name = "Group-Display-1"
+  }
+
+  parameters = <<PARAMETERS
+   {
+       "allowedLocations": {
+           "type": "Array",
+           "metadata": {
+               "description": "The list of allowed locations for resources.",
+               "displayName": "Allowed locations",
+               "strongType": "location"
+           }
+       }
+   }
+PARAMETERS
+
+  policy_definition_reference {
+    policy_definition_id = azurerm_policy_definition.test.id
+    parameter_values     = <<VALUES
+   {
+     "allowedLocations": {"value": "[parameters('allowedLocations')]"}
+   }
+VALUES
+    policy_group_names   = ["Group-1"]
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r ManagementGroupPolicySetDefinitionResourceTest) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_management_group" "test" {
+  display_name = "acctestmg-%d"
+}
+
+resource "azurerm_policy_definition" "test" {
+  name                = "acctestpol-%[1]d"
+  display_name        = "acctestpol-%[1]d"
+  management_group_id = azurerm_management_group.test.id
+  mode                = "All"
+  policy_type         = "Custom"
+
+  policy_rule = <<POLICY_RULE
+    {
+    "if": {
+      "not": {
+        "field": "location",
+        "in": "[parameters('allowedLocations')]"
+      }
+    },
+    "then": {
+      "effect": "audit"
+    }
+  }
+POLICY_RULE
+
+  parameters = <<PARAMETERS
+  {
+    "allowedLocations": {
+      "type": "Array",
+      "metadata": {
+        "description": "The list of allowed locations for resources.",
+        "displayName": "Allowed locations",
+        "strongType": "location"
+      }
+    }
+  }
+PARAMETERS
+}
+`, data.RandomInteger)
+}

--- a/internal/services/policy/migration/policy_set_definition_v0_to_v1.go
+++ b/internal/services/policy/migration/policy_set_definition_v0_to_v1.go
@@ -1,0 +1,134 @@
+package migration
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/resources/2025-01-01/policysetdefinitions"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type PolicySetDefinitionV0ToV1 struct{}
+
+var _ pluginsdk.StateUpgrade = PolicySetDefinitionV0ToV1{}
+
+func (p PolicySetDefinitionV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+		},
+
+		"policy_type": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+		},
+
+		"management_group_id": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+		},
+
+		"display_name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+		},
+
+		"description": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+		},
+
+		"metadata": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Computed: true,
+		},
+
+		"parameters": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+		},
+
+		"policy_definition_reference": {
+			Type:     pluginsdk.TypeList,
+			Required: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"policy_definition_id": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+					},
+
+					"parameter_values": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+					},
+
+					"reference_id": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						Computed: true,
+					},
+
+					"policy_group_names": {
+						Type:     pluginsdk.TypeSet,
+						Optional: true,
+						Elem: &pluginsdk.Schema{
+							Type: pluginsdk.TypeString,
+						},
+					},
+				},
+			},
+		},
+
+		"policy_definition_group": {
+			Type:     pluginsdk.TypeSet,
+			Optional: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"name": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+					},
+
+					"display_name": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+					},
+
+					"category": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+					},
+
+					"description": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+					},
+
+					"additional_metadata_resource_id": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+					},
+				},
+			},
+		},
+	}
+}
+
+func (p PolicySetDefinitionV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		oldId := rawState["id"].(string)
+		parsedId, err := policysetdefinitions.ParseProviderPolicySetDefinitionIDInsensitively(oldId)
+		if err != nil {
+			return nil, err
+		}
+
+		newId := parsedId.ID()
+		log.Printf("[DEBUG] Updating ID from `%s` to `%s`", oldId, newId)
+		rawState["id"] = newId
+
+		return rawState, nil
+	}
+}

--- a/internal/services/policy/policy.go
+++ b/internal/services/policy/policy.go
@@ -122,7 +122,7 @@ func getPolicySetDefinitionByDisplayName(ctx context.Context, client *policy.Set
 	return results[0], nil
 }
 
-func expandParameterDefinitionsValueFromString(jsonString string) (map[string]*policy.ParameterDefinitionsValue, error) {
+func expandParameterDefinitionsValueFromStringTrack1(jsonString string) (map[string]*policy.ParameterDefinitionsValue, error) {
 	var result map[string]*policy.ParameterDefinitionsValue
 
 	err := json.Unmarshal([]byte(jsonString), &result)
@@ -130,7 +130,7 @@ func expandParameterDefinitionsValueFromString(jsonString string) (map[string]*p
 	return result, err
 }
 
-func flattenParameterDefinitionsValueToString(input map[string]*policy.ParameterDefinitionsValue) (string, error) {
+func flattenParameterDefinitionsValueToStringTrack1(input map[string]*policy.ParameterDefinitionsValue) (string, error) {
 	if len(input) == 0 {
 		return "", nil
 	}
@@ -156,7 +156,7 @@ func expandParameterValuesValueFromString(jsonString string) (map[string]assignm
 	return result, err
 }
 
-func flattenParameterValuesValueToString(input map[string]*policy.ParameterValuesValue) (string, error) {
+func flattenParameterValuesValueToStringTrack1(input map[string]*policy.ParameterValuesValue) (string, error) {
 	if input == nil {
 		return "", nil
 	}

--- a/internal/services/policy/policy_definition_data_source.go
+++ b/internal/services/policy/policy_definition_data_source.go
@@ -154,7 +154,7 @@ func policyDefinitionReadFunc(builtInOnly bool) func(d *pluginsdk.ResourceData, 
 			d.Set("metadata", metadataStr)
 		}
 
-		if parametersStr, err := flattenParameterDefinitionsValueToString(policyDefinition.Parameters); err == nil {
+		if parametersStr, err := flattenParameterDefinitionsValueToStringTrack1(policyDefinition.Parameters); err == nil {
 			d.Set("parameters", parametersStr)
 		} else {
 			return fmt.Errorf("failed to flatten Policy Parameters %q: %+v", name, err)

--- a/internal/services/policy/policy_definition_resource.go
+++ b/internal/services/policy/policy_definition_resource.go
@@ -53,12 +53,12 @@ func resourceArmPolicyDefinition() *pluginsdk.Resource {
 						return d.ForceNew("parameters")
 					}
 
-					oldParameters, err := expandParameterDefinitionsValueFromString(oldParametersString)
+					oldParameters, err := expandParameterDefinitionsValueFromStringTrack1(oldParametersString)
 					if err != nil {
 						return fmt.Errorf("expanding JSON for `parameters`: %+v", err)
 					}
 
-					newParameters, err := expandParameterDefinitionsValueFromString(newParametersString)
+					newParameters, err := expandParameterDefinitionsValueFromStringTrack1(newParametersString)
 					if err != nil {
 						return fmt.Errorf("expanding JSON for `parameters`: %+v", err)
 					}
@@ -131,7 +131,7 @@ func resourceArmPolicyDefinitionCreateUpdate(d *pluginsdk.ResourceData, meta int
 	}
 
 	if parametersString := d.Get("parameters").(string); parametersString != "" {
-		parameters, err := expandParameterDefinitionsValueFromString(parametersString)
+		parameters, err := expandParameterDefinitionsValueFromStringTrack1(parametersString)
 		if err != nil {
 			return fmt.Errorf("expanding JSON for `parameters`: %+v", err)
 		}
@@ -245,7 +245,7 @@ func resourceArmPolicyDefinitionRead(d *pluginsdk.ResourceData, meta interface{}
 			d.Set("metadata", metadataStr)
 		}
 
-		if parametersStr, err := flattenParameterDefinitionsValueToString(props.Parameters); err == nil {
+		if parametersStr, err := flattenParameterDefinitionsValueToStringTrack1(props.Parameters); err == nil {
 			d.Set("parameters", parametersStr)
 		} else {
 			return fmt.Errorf("flattening policy definition parameters %+v", err)

--- a/internal/services/policy/policy_set_definition.go
+++ b/internal/services/policy/policy_set_definition.go
@@ -148,7 +148,6 @@ func expandPolicyDefinitionReference(input []PolicyDefinitionReferenceModel) ([]
 	result := make([]policysetdefinitions.PolicyDefinitionReference, 0)
 
 	for _, v := range input {
-
 		expandedParameters, err := expandPolicyDefinitionReferenceParameterValues(v.ParameterValues)
 		if err != nil {
 			return nil, fmt.Errorf("expanding `parameter_values`: %+v", err)

--- a/internal/services/policy/policy_set_definition.go
+++ b/internal/services/policy/policy_set_definition.go
@@ -1,0 +1,305 @@
+package policy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"reflect"
+	"strconv"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/resources/2025-01-01/policysetdefinitions"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/policy/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+type PolicyDefinitionReferenceModel struct {
+	PolicyDefinitionID string   `tfschema:"policy_definition_id"`
+	ParameterValues    string   `tfschema:"parameter_values"`
+	ReferenceID        string   `tfschema:"reference_id"`
+	PolicyGroupNames   []string `tfschema:"policy_group_names"`
+}
+
+type PolicyDefinitionGroupModel struct {
+	Name                         string `tfschema:"name"`
+	DisplayName                  string `tfschema:"display_name"`
+	Category                     string `tfschema:"category"`
+	Description                  string `tfschema:"description"`
+	AdditionalMetadataResourceID string `tfschema:"additional_metadata_resource_id"`
+}
+
+func policyDefinitionReferenceSchema() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Required: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"policy_definition_id": {
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ValidateFunc: validate.PolicyDefinitionID,
+				},
+
+				"parameter_values": {
+					Type:             pluginsdk.TypeString,
+					Optional:         true,
+					ValidateFunc:     validation.StringIsJSON,
+					DiffSuppressFunc: pluginsdk.SuppressJsonDiff,
+				},
+
+				"reference_id": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+
+				"policy_group_names": {
+					Type:     pluginsdk.TypeSet,
+					Optional: true,
+					Elem: &pluginsdk.Schema{
+						Type:         pluginsdk.TypeString,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+				},
+			},
+		},
+	}
+}
+
+func policyDefinitionGroupSchema() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeSet,
+		Optional: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"name": {
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+
+				"display_name": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+
+				"category": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+
+				"description": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+
+				"additional_metadata_resource_id": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+			},
+		},
+		Set: policySetDefinitionPolicyDefinitionGroupHash,
+	}
+}
+
+func policySetDefinitionPolicyDefinitionGroupHash(v interface{}) int {
+	var buf bytes.Buffer
+
+	if m, ok := v.(map[string]interface{}); ok {
+		buf.WriteString(m["name"].(string))
+	}
+
+	return pluginsdk.HashString(buf.String())
+}
+
+func policySetDefinitionsMetadataDiffSuppressFunc(_, old, new string, _ *pluginsdk.ResourceData) bool {
+	var oldPolicySetDefinitionsMetadata map[string]interface{}
+	errOld := json.Unmarshal([]byte(old), &oldPolicySetDefinitionsMetadata)
+	if errOld != nil {
+		return false
+	}
+
+	var newPolicySetDefinitionsMetadata map[string]interface{}
+	errNew := json.Unmarshal([]byte(new), &newPolicySetDefinitionsMetadata)
+	if errNew != nil {
+		return false
+	}
+
+	// Ignore the following keys if they're found in the metadata JSON
+	ignoreKeys := [4]string{"createdBy", "createdOn", "updatedBy", "updatedOn"}
+	for _, key := range ignoreKeys {
+		delete(oldPolicySetDefinitionsMetadata, key)
+		delete(newPolicySetDefinitionsMetadata, key)
+	}
+
+	return reflect.DeepEqual(oldPolicySetDefinitionsMetadata, newPolicySetDefinitionsMetadata)
+}
+
+func expandPolicyDefinitionReference(input []PolicyDefinitionReferenceModel) ([]policysetdefinitions.PolicyDefinitionReference, error) {
+	result := make([]policysetdefinitions.PolicyDefinitionReference, 0)
+
+	for _, v := range input {
+
+		expandedParameters, err := expandPolicyDefinitionReferenceParameterValues(v.ParameterValues)
+		if err != nil {
+			return nil, fmt.Errorf("expanding `parameter_values`: %+v", err)
+		}
+
+		result = append(result, policysetdefinitions.PolicyDefinitionReference{
+			GroupNames:                  pointer.To(v.PolicyGroupNames),
+			Parameters:                  expandedParameters,
+			PolicyDefinitionId:          v.PolicyDefinitionID,
+			PolicyDefinitionReferenceId: pointer.To(v.ReferenceID),
+		})
+	}
+
+	return result, nil
+}
+
+func flattenPolicyDefinitionReference(input []policysetdefinitions.PolicyDefinitionReference) ([]PolicyDefinitionReferenceModel, error) {
+	result := make([]PolicyDefinitionReferenceModel, 0)
+
+	for _, definition := range input {
+		parameterValues, err := flattenPolicyDefinitionReferenceParameterValues(definition.Parameters)
+		if err != nil {
+			return nil, fmt.Errorf("flattening `parameter_values`: %+v", err)
+		}
+
+		result = append(result, PolicyDefinitionReferenceModel{
+			PolicyDefinitionID: definition.PolicyDefinitionId,
+			ParameterValues:    parameterValues,
+			ReferenceID:        pointer.From(definition.PolicyDefinitionReferenceId),
+			PolicyGroupNames:   pointer.From(definition.GroupNames),
+		})
+	}
+
+	return result, nil
+}
+
+func expandPolicyDefinitionReferenceParameterValues(input string) (*map[string]policysetdefinitions.ParameterValuesValue, error) {
+	if input == "" {
+		return nil, nil
+	}
+
+	result := make(map[string]policysetdefinitions.ParameterValuesValue)
+	if err := json.Unmarshal([]byte(input), &result); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+func flattenPolicyDefinitionReferenceParameterValues(input *map[string]policysetdefinitions.ParameterValuesValue) (string, error) {
+	if input == nil {
+		return "", nil
+	}
+
+	result, err := json.Marshal(input)
+	if err != nil {
+		return "", err
+	}
+
+	return string(result), err
+}
+
+func expandPolicyDefinitionGroup(input []PolicyDefinitionGroupModel) *[]policysetdefinitions.PolicyDefinitionGroup {
+	result := make([]policysetdefinitions.PolicyDefinitionGroup, 0)
+
+	for _, v := range input {
+		group := policysetdefinitions.PolicyDefinitionGroup{
+			Category:    pointer.To(v.Category),
+			Description: pointer.To(v.Description),
+			DisplayName: pointer.To(v.DisplayName),
+			Name:        v.Name,
+		}
+
+		// The API returns an error if we send an empty string for `AdditionalMetadataResourceID`
+		if v.AdditionalMetadataResourceID != "" {
+			group.AdditionalMetadataId = pointer.To(v.AdditionalMetadataResourceID)
+		}
+
+		result = append(result, group)
+	}
+
+	return &result
+}
+
+func flattenPolicyDefinitionGroup(input *[]policysetdefinitions.PolicyDefinitionGroup) []PolicyDefinitionGroupModel {
+	result := make([]PolicyDefinitionGroupModel, 0)
+
+	if input == nil {
+		return result
+	}
+
+	for _, v := range *input {
+		result = append(result, PolicyDefinitionGroupModel{
+			AdditionalMetadataResourceID: pointer.From(v.AdditionalMetadataId),
+			Category:                     pointer.From(v.Category),
+			Description:                  pointer.From(v.Description),
+			DisplayName:                  pointer.From(v.DisplayName),
+			Name:                         v.Name,
+		})
+	}
+
+	return result
+}
+
+func flattenParameterDefinitionsValue(input *map[string]policysetdefinitions.ParameterDefinitionsValue) (string, error) {
+	if input == nil {
+		return "", nil
+	}
+
+	result, err := json.Marshal(input)
+	if err != nil {
+		return "", err
+	}
+
+	compactJson := bytes.Buffer{}
+	if err := json.Compact(&compactJson, result); err != nil {
+		return "", err
+	}
+
+	return compactJson.String(), nil
+}
+
+func expandParameterDefinitionsValue(input string) (*map[string]policysetdefinitions.ParameterDefinitionsValue, error) {
+	var result map[string]policysetdefinitions.ParameterDefinitionsValue
+
+	err := json.Unmarshal([]byte(input), &result)
+
+	return &result, err
+}
+
+func getPolicySetDefinitionByID(ctx context.Context, client *policysetdefinitions.PolicySetDefinitionsClient, id any) (*http.Response, *policysetdefinitions.PolicySetDefinition, error) {
+	// TODO: Remove post 5.0
+	switch id := id.(type) {
+	case policysetdefinitions.ProviderPolicySetDefinitionId:
+		return getPolicySetDefinition(ctx, client, id)
+	case policysetdefinitions.Providers2PolicySetDefinitionId:
+		resp, err := client.GetAtManagementGroup(ctx, id, policysetdefinitions.DefaultGetAtManagementGroupOperationOptions())
+		return resp.HttpResponse, resp.Model, err
+	default:
+		return nil, nil, fmt.Errorf("`id` was not one of the expected types: %T", id)
+	}
+}
+
+func policySetDefinitionRefreshFunc(ctx context.Context, client *policysetdefinitions.PolicySetDefinitionsClient, id any) pluginsdk.StateRefreshFunc {
+	// TODO: Remove post 5.0
+	return func() (interface{}, string, error) {
+		resp, _, err := getPolicySetDefinitionByID(ctx, client, id)
+		if err != nil && !response.WasNotFound(resp) {
+			return nil, strconv.Itoa(resp.StatusCode), fmt.Errorf("retrieving %s: %+v", id, err)
+		}
+
+		return resp, strconv.Itoa(resp.StatusCode), nil
+	}
+}

--- a/internal/services/policy/policy_set_definition_data_source_test.go
+++ b/internal/services/policy/policy_set_definition_data_source_test.go
@@ -83,7 +83,7 @@ data "azurerm_policy_set_definition" "test" {
 }
 
 func (d PolicySetDefinitionDataSource) customByName(data acceptance.TestData) string {
-	template := PolicySetDefinitionResource{}.custom(data)
+	template := PolicySetDefinitionResourceTest{}.custom(data)
 	return fmt.Sprintf(`
 %s
 
@@ -94,7 +94,7 @@ data "azurerm_policy_set_definition" "test" {
 }
 
 func (d PolicySetDefinitionDataSource) customByDisplayName(data acceptance.TestData) string {
-	template := PolicySetDefinitionResource{}.custom(data)
+	template := PolicySetDefinitionResourceTest{}.custom(data)
 	return fmt.Sprintf(`
 %s
 

--- a/internal/services/policy/policy_set_definition_resource.go
+++ b/internal/services/policy/policy_set_definition_resource.go
@@ -27,7 +27,8 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
-// BEGIN TODO: Remove post 5.0
+// BEGIN
+// TODO: Remove from here until the `END` comment on ln836 post 5.0
 func resourceArmPolicySetDefinition() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
 		Create: resourceArmPolicySetDefinitionCreate,

--- a/internal/services/policy/policy_set_definition_resource.go
+++ b/internal/services/policy/policy_set_definition_resource.go
@@ -717,7 +717,7 @@ func resourceArmPolicySetDefinitionDelete(d *pluginsdk.ResourceData, meta interf
 	}
 
 	if managementGroupName != "" {
-		return deleteForManagementGroup(ctx, client, d, meta, policysetdefinitions.NewProviders2PolicySetDefinitionID(managementGroupName, resourceId.Name).ID())
+		return deleteForManagementGroup(ctx, client, policysetdefinitions.NewProviders2PolicySetDefinitionID(managementGroupName, resourceId.Name).ID())
 	}
 
 	id := policysetdefinitions.NewProviderPolicySetDefinitionID(subscriptionId, resourceId.Name)
@@ -729,7 +729,7 @@ func resourceArmPolicySetDefinitionDelete(d *pluginsdk.ResourceData, meta interf
 	return nil
 }
 
-func deleteForManagementGroup(ctx context.Context, client *policysetdefinitions.PolicySetDefinitionsClient, d *pluginsdk.ResourceData, meta any, managementGroupIdString string) error {
+func deleteForManagementGroup(ctx context.Context, client *policysetdefinitions.PolicySetDefinitionsClient, managementGroupIdString string) error {
 	id, err := policysetdefinitions.ParseProviders2PolicySetDefinitionID(managementGroupIdString)
 	if err != nil {
 		return err
@@ -831,6 +831,7 @@ func flattenAzureRMPolicySetDefinitionPolicyGroups(input *[]policysetdefinitions
 
 	return result
 }
+
 // END TODO: Remove post 5.0
 
 type PolicySetDefinitionResource struct{}
@@ -1090,7 +1091,6 @@ func (r PolicySetDefinitionResource) Read() sdk.ResourceFunc {
 			}
 
 			if model != nil {
-
 				if props := model.Properties; props != nil {
 					state.Description = pointer.From(props.Description)
 					state.DisplayName = pointer.From(props.DisplayName)

--- a/internal/services/policy/policy_set_definition_resource.go
+++ b/internal/services/policy/policy_set_definition_resource.go
@@ -4,21 +4,21 @@
 package policy
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"log"
-	"reflect"
-	"strconv"
+	"net/http"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/preview/resources/mgmt/2021-06-01-preview/policy" // nolint: staticcheck
-	"github.com/Azure/go-autorest/autorest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/resources/2025-01-01/policysetdefinitions"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	mgmtGrpParse "github.com/hashicorp/terraform-provider-azurerm/internal/services/managementgroup/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/policy/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/policy/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/policy/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -27,6 +27,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
+// BEGIN TODO: Remove post 5.0
 func resourceArmPolicySetDefinition() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
 		Create: resourceArmPolicySetDefinitionCreate,
@@ -64,17 +65,18 @@ func resourcePolicySetDefinitionSchema() map[string]*pluginsdk.Schema {
 			Required: true,
 			ForceNew: true,
 			ValidateFunc: validation.StringInSlice([]string{
-				string(policy.TypeBuiltIn),
-				string(policy.TypeCustom),
-				string(policy.TypeNotSpecified),
-				string(policy.TypeStatic),
+				string(policysetdefinitions.PolicyTypeBuiltIn),
+				string(policysetdefinitions.PolicyTypeCustom),
+				string(policysetdefinitions.PolicyTypeNotSpecified),
+				string(policysetdefinitions.PolicyTypeStatic),
 			}, false),
 		},
 
 		"management_group_id": {
-			Type:     pluginsdk.TypeString,
-			Optional: true,
-			ForceNew: true,
+			Type:       pluginsdk.TypeString,
+			Optional:   true,
+			ForceNew:   true,
+			Deprecated: "`management_group_id` has been deprecated in favour of the `azurerm_management_group_policy_set_definition` resource and will be removed in v5.0 of the AzureRM Provider.",
 		},
 
 		"display_name": {
@@ -176,87 +178,60 @@ func resourcePolicySetDefinitionSchema() map[string]*pluginsdk.Schema {
 					},
 				},
 			},
-			Set: resourceARMPolicySetDefinitionPolicyDefinitionGroupHash,
+			Set: policySetDefinitionPolicyDefinitionGroupHash,
 		},
 	}
 }
 
-func policySetDefinitionsMetadataDiffSuppressFunc(_, old, new string, _ *pluginsdk.ResourceData) bool {
-	var oldPolicySetDefinitionsMetadata map[string]interface{}
-	errOld := json.Unmarshal([]byte(old), &oldPolicySetDefinitionsMetadata)
-	if errOld != nil {
-		return false
-	}
-
-	var newPolicySetDefinitionsMetadata map[string]interface{}
-	errNew := json.Unmarshal([]byte(new), &newPolicySetDefinitionsMetadata)
-	if errNew != nil {
-		return false
-	}
-
-	// Ignore the following keys if they're found in the metadata JSON
-	ignoreKeys := [4]string{"createdBy", "createdOn", "updatedBy", "updatedOn"}
-	for _, key := range ignoreKeys {
-		delete(oldPolicySetDefinitionsMetadata, key)
-		delete(newPolicySetDefinitionsMetadata, key)
-	}
-
-	return reflect.DeepEqual(oldPolicySetDefinitionsMetadata, newPolicySetDefinitionsMetadata)
-}
-
-type DefinitionReferenceInOldApiVersion struct {
-	// PolicyDefinitionID - The ID of the policy definition or policy set definition.
-	PolicyDefinitionID *string `json:"policyDefinitionId,omitempty"`
-	// Parameters - The parameter values for the referenced policy rule. The keys are the parameter names.
-	Parameters map[string]*policy.ParameterValuesValue `json:"parameters"`
-}
-
 func resourceArmPolicySetDefinitionCreate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Policy.SetDefinitionsClient
+	client := meta.(*clients.Client).Policy.PolicySetDefinitionsClient
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	name := d.Get("name").(string)
-	managementGroupName := ""
 	if v, ok := d.GetOk("management_group_id"); ok {
-		managementGroupID, err := mgmtGrpParse.ManagementGroupID(v.(string))
-		if err != nil {
-			return err
-		}
-		managementGroupName = managementGroupID.Name
+		return createForManagementGroup(ctx, client, d, meta, v.(string))
 	}
 
-	existing, err := getPolicySetDefinitionByName(ctx, client, name, managementGroupName)
+	id := policysetdefinitions.NewProviderPolicySetDefinitionID(subscriptionId, d.Get("name").(string))
+
+	resp, _, err := getPolicySetDefinitionByID(ctx, client, id)
 	if err != nil {
-		if !utils.ResponseWasNotFound(existing.Response) {
-			return fmt.Errorf("checking for presence of existing Policy Set Definition %q: %+v", name, err)
+		if !response.WasNotFound(resp) {
+			return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
 		}
 	}
 
-	if existing.ID != nil && *existing.ID != "" {
-		return tf.ImportAsExistsError("azurerm_policy_set_definition", *existing.ID)
+	if !response.WasNotFound(resp) {
+		return tf.ImportAsExistsError("azurerm_policy_set_definition", id.ID())
 	}
 
-	properties := policy.SetDefinitionProperties{
-		PolicyType:  policy.Type(d.Get("policy_type").(string)),
-		DisplayName: utils.String(d.Get("display_name").(string)),
-		Description: utils.String(d.Get("description").(string)),
+	parameters := policysetdefinitions.PolicySetDefinition{
+		Properties: &policysetdefinitions.PolicySetDefinitionProperties{
+			DisplayName: pointer.To(d.Get("display_name").(string)),
+			Description: pointer.To(d.Get("description").(string)),
+			PolicyType:  pointer.To(policysetdefinitions.PolicyType(d.Get("policy_type").(string))),
+		},
 	}
+	props := parameters.Properties
 
 	if metaDataString := d.Get("metadata").(string); metaDataString != "" {
 		metaData, err := pluginsdk.ExpandJsonFromString(metaDataString)
 		if err != nil {
-			return fmt.Errorf("expanding JSON for `metadata`: %+v", err)
+			return fmt.Errorf("expanding `metadata`: %+v", err)
 		}
-		properties.Metadata = &metaData
+
+		var iMetadata interface{} = metaData
+
+		props.Metadata = &iMetadata
 	}
 
 	if parametersString := d.Get("parameters").(string); parametersString != "" {
-		parameters, err := expandParameterDefinitionsValueFromString(parametersString)
+		params, err := expandParameterDefinitionsValue(parametersString)
 		if err != nil {
-			return fmt.Errorf("expanding JSON for `parameters`: %+v", err)
+			return fmt.Errorf("expanding `parameters`: %+v", err)
 		}
-		properties.Parameters = parameters
+		props.Parameters = params
 	}
 
 	if v, ok := d.GetOk("policy_definition_reference"); ok {
@@ -264,99 +239,179 @@ func resourceArmPolicySetDefinitionCreate(d *pluginsdk.ResourceData, meta interf
 		if err != nil {
 			return fmt.Errorf("expanding `policy_definition_reference`: %+v", err)
 		}
-		properties.PolicyDefinitions = definitions
+		props.PolicyDefinitions = definitions
 	}
 
 	if v, ok := d.GetOk("policy_definition_group"); ok {
-		properties.PolicyDefinitionGroups = expandAzureRMPolicySetDefinitionPolicyGroups(v.(*pluginsdk.Set).List())
+		props.PolicyDefinitionGroups = expandAzureRMPolicySetDefinitionPolicyGroups(v.(*pluginsdk.Set).List())
 	}
 
-	definition := policy.SetDefinition{
-		SetDefinitionProperties: &properties,
-	}
-
-	if managementGroupName == "" {
-		_, err = client.CreateOrUpdate(ctx, name, definition)
-	} else {
-		_, err = client.CreateOrUpdateAtManagementGroup(ctx, name, definition, managementGroupName)
-	}
-
-	if err != nil {
-		return fmt.Errorf("creating Policy Set Definition %q: %+v", name, err)
+	if _, err = client.CreateOrUpdate(ctx, id, parameters); err != nil {
+		return fmt.Errorf("creating %s: %+v", id, err)
 	}
 
 	// Policy Definitions are eventually consistent; wait for them to stabilize
-	log.Printf("[DEBUG] Waiting for Policy Set Definition %q to become available", name)
+	log.Printf("[DEBUG] Waiting for %s to become available", id)
 	stateConf := &pluginsdk.StateChangeConf{
 		Pending:                   []string{"404"},
 		Target:                    []string{"200"},
-		Refresh:                   policySetDefinitionRefreshFunc(ctx, client, name, managementGroupName),
+		Refresh:                   policySetDefinitionRefreshFunc(ctx, client, id),
+		MinTimeout:                10 * time.Second,
+		Timeout:                   d.Timeout(pluginsdk.TimeoutCreate),
+		ContinuousTargetOccurence: 10,
+	}
+
+	if _, err = stateConf.WaitForStateContext(ctx); err != nil {
+		return fmt.Errorf("waiting for %s to become available: %+v", id, err)
+	}
+
+	resourceId, err := parse.PolicySetDefinitionID(id.ID())
+	if err != nil {
+		return fmt.Errorf("parsing %s: %+v", id.ID(), err)
+	}
+
+	d.SetId(resourceId.Id)
+
+	return resourceArmPolicySetDefinitionRead(d, meta)
+}
+
+func createForManagementGroup(ctx context.Context, client *policysetdefinitions.PolicySetDefinitionsClient, d *pluginsdk.ResourceData, meta any, managementGroupIdString string) error {
+	managementGroupId, err := mgmtGrpParse.ManagementGroupID(managementGroupIdString)
+	if err != nil {
+		return err
+	}
+
+	id := policysetdefinitions.NewProviders2PolicySetDefinitionID(managementGroupId.Name, d.Get("name").(string))
+
+	resp, _, err := getPolicySetDefinitionByID(ctx, client, id)
+	if err != nil {
+		if !response.WasNotFound(resp) {
+			return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+		}
+	}
+
+	if !response.WasNotFound(resp) {
+		return tf.ImportAsExistsError("azurerm_policy_set_definition", id.ID())
+	}
+
+	parameters := policysetdefinitions.PolicySetDefinition{
+		Properties: &policysetdefinitions.PolicySetDefinitionProperties{
+			DisplayName: pointer.To(d.Get("display_name").(string)),
+			Description: pointer.To(d.Get("description").(string)),
+			PolicyType:  pointer.To(policysetdefinitions.PolicyType(d.Get("policy_type").(string))),
+		},
+	}
+	props := parameters.Properties
+
+	if metaDataString := d.Get("metadata").(string); metaDataString != "" {
+		metaData, err := pluginsdk.ExpandJsonFromString(metaDataString)
+		if err != nil {
+			return fmt.Errorf("expanding `metadata`: %+v", err)
+		}
+
+		var iMetadata interface{} = metaData
+
+		props.Metadata = &iMetadata
+	}
+
+	if parametersString := d.Get("parameters").(string); parametersString != "" {
+		params, err := expandParameterDefinitionsValue(parametersString)
+		if err != nil {
+			return fmt.Errorf("expanding `parameters`: %+v", err)
+		}
+		props.Parameters = params
+	}
+
+	if v, ok := d.GetOk("policy_definition_reference"); ok {
+		definitions, err := expandAzureRMPolicySetDefinitionPolicyDefinitions(v.([]interface{}))
+		if err != nil {
+			return fmt.Errorf("expanding `policy_definition_reference`: %+v", err)
+		}
+		props.PolicyDefinitions = definitions
+	}
+
+	if v, ok := d.GetOk("policy_definition_group"); ok {
+		props.PolicyDefinitionGroups = expandAzureRMPolicySetDefinitionPolicyGroups(v.(*pluginsdk.Set).List())
+	}
+
+	if _, err = client.CreateOrUpdateAtManagementGroup(ctx, id, parameters); err != nil {
+		return fmt.Errorf("creating %s: %+v", id, err)
+	}
+
+	// Policy Definitions are eventually consistent; wait for them to stabilize
+	log.Printf("[DEBUG] Waiting for %s to become available", id)
+	stateConf := &pluginsdk.StateChangeConf{
+		Pending:                   []string{"404"},
+		Target:                    []string{"200"},
+		Refresh:                   policySetDefinitionRefreshFunc(ctx, client, id),
 		MinTimeout:                10 * time.Second,
 		ContinuousTargetOccurence: 10,
 	}
 
-	if d.IsNewResource() {
-		stateConf.Timeout = d.Timeout(pluginsdk.TimeoutCreate)
-	} else {
-		stateConf.Timeout = d.Timeout(pluginsdk.TimeoutUpdate)
-	}
+	stateConf.Timeout = d.Timeout(pluginsdk.TimeoutCreate)
 
 	if _, err = stateConf.WaitForStateContext(ctx); err != nil {
-		return fmt.Errorf("waiting for Policy Set Definition %q to become available: %+v", name, err)
+		return fmt.Errorf("waiting for %s to become available: %+v", id, err)
 	}
 
-	var resp policy.SetDefinition
-	resp, err = getPolicySetDefinitionByName(ctx, client, name, managementGroupName)
+	resourceId, err := parse.PolicySetDefinitionID(id.ID())
 	if err != nil {
-		return fmt.Errorf("retrieving Policy Set Definition %q: %+v", name, err)
+		return fmt.Errorf("parsing %s: %+v", id.ID(), err)
 	}
 
-	id, err := parse.PolicySetDefinitionID(*resp.ID)
-	if err != nil {
-		return fmt.Errorf("parsing Policy Set Definition %q: %+v", *resp.ID, err)
-	}
-
-	d.SetId(id.Id)
+	d.SetId(resourceId.Id)
 
 	return resourceArmPolicySetDefinitionRead(d, meta)
 }
 
 func resourceArmPolicySetDefinitionUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Policy.SetDefinitionsClient
+	client := meta.(*clients.Client).Policy.PolicySetDefinitionsClient
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := parse.PolicySetDefinitionID(d.Id())
+	resourceId, err := parse.PolicySetDefinitionID(d.Id())
 	if err != nil {
 		return err
 	}
 
 	managementGroupName := ""
 	var managementGroupId mgmtGrpParse.ManagementGroupId
-	if scopeId, ok := id.PolicyScopeId.(parse.ScopeAtManagementGroup); ok {
-		managementGroupId = mgmtGrpParse.NewManagementGroupId(scopeId.ManagementGroupName)
+	if v, ok := resourceId.PolicyScopeId.(parse.ScopeAtManagementGroup); ok {
+		managementGroupId = mgmtGrpParse.NewManagementGroupId(v.ManagementGroupName)
 		managementGroupName = managementGroupId.Name
 	}
 
-	// retrieve
-	existing, err := getPolicySetDefinitionByName(ctx, client, id.Name, managementGroupName)
-	if err != nil {
-		return fmt.Errorf("retrieving Policy Set Definition %q (Scope %q): %+v", id.Name, id.ScopeId(), err)
-	}
-	if existing.SetDefinitionProperties == nil {
-		return fmt.Errorf("retrieving Policy Set Definition %q (Scope %q): `properties` was nil", id.Name, id.ScopeId())
+	if managementGroupName != "" {
+		return updateForManagementGroup(ctx, client, d, meta, managementGroupId.ID())
 	}
 
+	id := policysetdefinitions.NewProviderPolicySetDefinitionID(subscriptionId, resourceId.Name)
+
+	_, model, err := getPolicySetDefinitionByID(ctx, client, id)
+	if err != nil {
+		return fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	if model == nil {
+		return fmt.Errorf("retrieving %s: `model` was nil", id)
+	}
+
+	if model.Properties == nil {
+		return fmt.Errorf("retrieving %s: `properties` was nil", id)
+	}
+	props := model.Properties
+
 	if d.HasChange("policy_type") {
-		existing.SetDefinitionProperties.PolicyType = policy.Type(d.Get("policy_type").(string))
+		props.PolicyType = pointer.To(policysetdefinitions.PolicyType(d.Get("policy_type").(string)))
 	}
 
 	if d.HasChange("display_name") {
-		existing.SetDefinitionProperties.DisplayName = utils.String(d.Get("display_name").(string))
+		props.DisplayName = pointer.To(d.Get("display_name").(string))
 	}
 
 	if d.HasChange("description") {
-		existing.SetDefinitionProperties.Description = utils.String(d.Get("description").(string))
+		props.Description = pointer.To(d.Get("description").(string))
 	}
 
 	if d.HasChange("metadata") {
@@ -366,132 +421,277 @@ func resourceArmPolicySetDefinitionUpdate(d *pluginsdk.ResourceData, meta interf
 			if err != nil {
 				return fmt.Errorf("expanding JSON for `metadata`: %+v", err)
 			}
-			existing.SetDefinitionProperties.Metadata = metaData
+
+			var iMetadata interface{} = metaData
+
+			props.Metadata = &iMetadata
 		} else {
-			existing.SetDefinitionProperties.Metadata = nil
+			props.Metadata = nil
 		}
 	}
 
 	if d.HasChange("parameters") {
 		parametersString := d.Get("parameters").(string)
 		if parametersString != "" {
-			parameters, err := expandParameterDefinitionsValueFromString(parametersString)
+			parameters, err := expandParameterDefinitionsValue(parametersString)
 			if err != nil {
 				return fmt.Errorf("expanding JSON for `parameters`: %+v", err)
 			}
-			existing.SetDefinitionProperties.Parameters = parameters
+			props.Parameters = parameters
 		} else {
-			existing.SetDefinitionProperties.Parameters = nil
+			props.Parameters = nil
 		}
 	}
 
 	if d.HasChange("policy_definition_group") {
-		existing.SetDefinitionProperties.PolicyDefinitionGroups = expandAzureRMPolicySetDefinitionPolicyGroups(d.Get("policy_definition_group").(*pluginsdk.Set).List())
+		props.PolicyDefinitionGroups = expandAzureRMPolicySetDefinitionPolicyGroups(d.Get("policy_definition_group").(*pluginsdk.Set).List())
 	}
 
 	if d.HasChange("policy_definition_reference") {
-		definitions, err := expandAzureRMPolicySetDefinitionPolicyDefinitionsUpdate(d)
+		definitions, err := expandAzureRMPolicySetDefinitionPolicyDefinitions(d.Get("policy_definition_reference").([]interface{}))
 		if err != nil {
 			return fmt.Errorf("expanding `policy_definition_reference`: %+v", err)
 		}
-		existing.SetDefinitionProperties.PolicyDefinitions = definitions
+		props.PolicyDefinitions = definitions
 	}
 
-	if managementGroupName == "" {
-		_, err = client.CreateOrUpdate(ctx, id.Name, existing)
-	} else {
-		_, err = client.CreateOrUpdateAtManagementGroup(ctx, id.Name, existing, managementGroupName)
+	if _, err = client.CreateOrUpdate(ctx, id, *model); err != nil {
+		return fmt.Errorf("updating %s: %+v", id, err)
 	}
 
+	return resourceArmPolicySetDefinitionRead(d, meta)
+}
+
+func updateForManagementGroup(ctx context.Context, client *policysetdefinitions.PolicySetDefinitionsClient, d *pluginsdk.ResourceData, meta any, managementGroupIdString string) error {
+	resourceId, err := parse.PolicySetDefinitionID(d.Id())
 	if err != nil {
-		return fmt.Errorf("updating Policy Set Definition %q: %+v", id.Name, err)
+		return err
 	}
 
-	var resp policy.SetDefinition
-	resp, err = getPolicySetDefinitionByName(ctx, client, id.Name, managementGroupName)
+	managementGroupId, err := mgmtGrpParse.ManagementGroupID(managementGroupIdString)
 	if err != nil {
-		return fmt.Errorf("retrieving Policy Set Definition %q: %+v", id.Name, err)
+		return fmt.Errorf("parsing %s: %+v", managementGroupIdString, err)
 	}
 
-	id, err = parse.PolicySetDefinitionID(*resp.ID)
+	id := policysetdefinitions.NewProviders2PolicySetDefinitionID(managementGroupId.Name, resourceId.Name)
+
+	_, model, err := getPolicySetDefinitionByID(ctx, client, id)
 	if err != nil {
-		return fmt.Errorf("parsing Policy Set Definition %q: %+v", *resp.ID, err)
+		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	d.SetId(id.Id)
+	if model == nil {
+		return fmt.Errorf("retrieving %s: `model` was nil", id)
+	}
+
+	if model.Properties == nil {
+		return fmt.Errorf("retrieving %s: `properties` was nil", id)
+	}
+	props := model.Properties
+
+	if d.HasChange("policy_type") {
+		props.PolicyType = pointer.To(policysetdefinitions.PolicyType(d.Get("policy_type").(string)))
+	}
+
+	if d.HasChange("display_name") {
+		props.DisplayName = pointer.To(d.Get("display_name").(string))
+	}
+
+	if d.HasChange("description") {
+		props.Description = pointer.To(d.Get("description").(string))
+	}
+
+	if d.HasChange("metadata") {
+		metaDataString := d.Get("metadata").(string)
+		if metaDataString != "" {
+			metaData, err := pluginsdk.ExpandJsonFromString(metaDataString)
+			if err != nil {
+				return fmt.Errorf("expanding JSON for `metadata`: %+v", err)
+			}
+
+			var iMetadata interface{} = metaData
+
+			props.Metadata = &iMetadata
+		} else {
+			props.Metadata = nil
+		}
+	}
+
+	if d.HasChange("parameters") {
+		parametersString := d.Get("parameters").(string)
+		if parametersString != "" {
+			parameters, err := expandParameterDefinitionsValue(parametersString)
+			if err != nil {
+				return fmt.Errorf("expanding JSON for `parameters`: %+v", err)
+			}
+			props.Parameters = parameters
+		} else {
+			props.Parameters = nil
+		}
+	}
+
+	if d.HasChange("policy_definition_group") {
+		props.PolicyDefinitionGroups = expandAzureRMPolicySetDefinitionPolicyGroups(d.Get("policy_definition_group").(*pluginsdk.Set).List())
+	}
+
+	if d.HasChange("policy_definition_reference") {
+		definitions, err := expandAzureRMPolicySetDefinitionPolicyDefinitions(d.Get("policy_definition_reference").([]interface{}))
+		if err != nil {
+			return fmt.Errorf("expanding `policy_definition_reference`: %+v", err)
+		}
+		props.PolicyDefinitions = definitions
+	}
+
+	if _, err = client.CreateOrUpdateAtManagementGroup(ctx, id, *model); err != nil {
+		return fmt.Errorf("updating %s: %+v", id, err)
+	}
 
 	return resourceArmPolicySetDefinitionRead(d, meta)
 }
 
 func resourceArmPolicySetDefinitionRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Policy.SetDefinitionsClient
+	client := meta.(*clients.Client).Policy.PolicySetDefinitionsClient
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := parse.PolicySetDefinitionID(d.Id())
+	resourceId, err := parse.PolicySetDefinitionID(d.Id())
 	if err != nil {
 		return err
 	}
 
 	managementGroupName := ""
 	var managementGroupId mgmtGrpParse.ManagementGroupId
-	switch scopeId := id.PolicyScopeId.(type) { // nolint gocritic
-	case parse.ScopeAtManagementGroup:
+	if scopeId, ok := resourceId.PolicyScopeId.(parse.ScopeAtManagementGroup); ok {
 		managementGroupId = mgmtGrpParse.NewManagementGroupId(scopeId.ManagementGroupName)
 		managementGroupName = managementGroupId.Name
 	}
 
-	resp, err := getPolicySetDefinitionByName(ctx, client, id.Name, managementGroupName)
+	if managementGroupName != "" {
+		return readForManagementGroup(ctx, client, d, managementGroupId.ID())
+	}
+
+	id := policysetdefinitions.NewProviderPolicySetDefinitionID(subscriptionId, resourceId.Name)
+
+	resp, model, err := getPolicySetDefinitionByID(ctx, client, id)
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
+		if response.WasNotFound(resp) {
 			log.Printf("[INFO] Error reading Policy Set Definition %q - removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}
 
-		return fmt.Errorf("reading Policy Set Definition %+v", err)
+		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	d.Set("name", resp.Name)
-	d.Set("management_group_id", managementGroupName)
-	if managementGroupName != "" {
-		d.Set("management_group_id", managementGroupId.ID())
+	if model != nil {
+		d.Set("name", model.Name)
+
+		if props := model.Properties; props != nil {
+			d.Set("policy_type", string(pointer.From(props.PolicyType)))
+			d.Set("display_name", props.DisplayName)
+			d.Set("description", props.Description)
+
+			if iMetadata := props.Metadata; iMetadata != nil {
+				metadata := *iMetadata
+				if v, ok := metadata.(map[string]interface{}); ok {
+					metadataStr, err := pluginsdk.FlattenJsonToString(v)
+					if err != nil {
+						return fmt.Errorf("flattening `metadata`: %+v", err)
+					}
+					d.Set("metadata", metadataStr)
+				}
+			}
+
+			if parameters := props.Parameters; parameters != nil {
+				parametersStr, err := flattenParameterDefinitionsValue(parameters)
+				if err != nil {
+					return fmt.Errorf("flattening `parameters`: %+v", err)
+				}
+
+				d.Set("parameters", parametersStr)
+			}
+
+			references, err := flattenAzureRMPolicySetDefinitionPolicyDefinitions(props.PolicyDefinitions)
+			if err != nil {
+				return fmt.Errorf("flattening `policy_definition_reference`: %+v", err)
+			}
+			if err := d.Set("policy_definition_reference", references); err != nil {
+				return fmt.Errorf("setting `policy_definition_reference`: %+v", err)
+			}
+
+			if err := d.Set("policy_definition_group", flattenAzureRMPolicySetDefinitionPolicyGroups(props.PolicyDefinitionGroups)); err != nil {
+				return fmt.Errorf("setting `policy_definition_group`: %+v", err)
+			}
+		}
 	}
 
-	if props := resp.SetDefinitionProperties; props != nil {
-		d.Set("policy_type", string(props.PolicyType))
-		d.Set("display_name", props.DisplayName)
-		d.Set("description", props.Description)
+	return nil
+}
 
-		if metadata := props.Metadata; metadata != nil {
-			metadataVal := metadata.(map[string]interface{})
-			metadataStr, err := pluginsdk.FlattenJsonToString(metadataVal)
-			if err != nil {
-				return fmt.Errorf("flattening JSON for `metadata`: %+v", err)
+func readForManagementGroup(ctx context.Context, client *policysetdefinitions.PolicySetDefinitionsClient, d *pluginsdk.ResourceData, managementGroupIdString string) error {
+	resourceId, err := parse.PolicySetDefinitionID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	managementGroupId, err := mgmtGrpParse.ManagementGroupID(managementGroupIdString)
+	if err != nil {
+		return err
+	}
+
+	id := policysetdefinitions.NewProviders2PolicySetDefinitionID(managementGroupId.Name, resourceId.Name)
+
+	resp, model, err := getPolicySetDefinitionByID(ctx, client, id)
+	if err != nil {
+		if response.WasNotFound(resp) {
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	if model != nil {
+		d.Set("name", model.Name)
+		d.Set("management_group_id", managementGroupIdString)
+
+		if props := model.Properties; props != nil {
+			d.Set("policy_type", string(pointer.From(props.PolicyType)))
+			d.Set("display_name", props.DisplayName)
+			d.Set("description", props.Description)
+
+			if iMetadata := props.Metadata; iMetadata != nil {
+				metadata := *iMetadata
+				if v, ok := metadata.(map[string]interface{}); ok {
+					metadataStr, err := pluginsdk.FlattenJsonToString(v)
+					if err != nil {
+						return fmt.Errorf("flattening `metadata`: %+v", err)
+					}
+					d.Set("metadata", metadataStr)
+				}
 			}
 
-			d.Set("metadata", metadataStr)
-		}
+			if parameters := props.Parameters; parameters != nil {
+				parametersStr, err := flattenParameterDefinitionsValue(parameters)
+				if err != nil {
+					return fmt.Errorf("flattening `parameters`: %+v", err)
+				}
 
-		if parameters := props.Parameters; parameters != nil {
-			parametersStr, err := flattenParameterDefinitionsValueToString(parameters)
-			if err != nil {
-				return fmt.Errorf("flattening JSON for `parameters`: %+v", err)
+				d.Set("parameters", parametersStr)
 			}
 
-			d.Set("parameters", parametersStr)
-		}
+			references, err := flattenAzureRMPolicySetDefinitionPolicyDefinitions(props.PolicyDefinitions)
+			if err != nil {
+				return fmt.Errorf("flattening `policy_definition_reference`: %+v", err)
+			}
+			if err := d.Set("policy_definition_reference", references); err != nil {
+				return fmt.Errorf("setting `policy_definition_reference`: %+v", err)
+			}
 
-		references, err := flattenAzureRMPolicySetDefinitionPolicyDefinitions(props.PolicyDefinitions)
-		if err != nil {
-			return fmt.Errorf("flattening `policy_definition_reference`: %+v", err)
-		}
-		if err := d.Set("policy_definition_reference", references); err != nil {
-			return fmt.Errorf("setting `policy_definition_reference`: %+v", err)
-		}
-
-		if err := d.Set("policy_definition_group", flattenAzureRMPolicySetDefinitionPolicyGroups(props.PolicyDefinitionGroups)); err != nil {
-			return fmt.Errorf("setting `policy_definition_group`: %+v", err)
+			if err := d.Set("policy_definition_group", flattenAzureRMPolicySetDefinitionPolicyGroups(props.PolicyDefinitionGroups)); err != nil {
+				return fmt.Errorf("setting `policy_definition_group`: %+v", err)
+			}
 		}
 	}
 
@@ -499,184 +699,113 @@ func resourceArmPolicySetDefinitionRead(d *pluginsdk.ResourceData, meta interfac
 }
 
 func resourceArmPolicySetDefinitionDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Policy.SetDefinitionsClient
+	client := meta.(*clients.Client).Policy.PolicySetDefinitionsClient
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := parse.PolicySetDefinitionID(d.Id())
+	resourceId, err := parse.PolicySetDefinitionID(d.Id())
 	if err != nil {
 		return err
 	}
 
 	managementGroupName := ""
-	if scopeId, ok := id.PolicyScopeId.(parse.ScopeAtManagementGroup); ok {
-		managementGroupName = scopeId.ManagementGroupName
+	var managementGroupId mgmtGrpParse.ManagementGroupId
+	if scopeId, ok := resourceId.PolicyScopeId.(parse.ScopeAtManagementGroup); ok {
+		managementGroupId = mgmtGrpParse.NewManagementGroupId(scopeId.ManagementGroupName)
+		managementGroupName = managementGroupId.Name
 	}
 
-	var resp autorest.Response
-	if managementGroupName == "" {
-		resp, err = client.Delete(ctx, id.Name)
-	} else {
-		resp, err = client.DeleteAtManagementGroup(ctx, id.Name, managementGroupName)
+	if managementGroupName != "" {
+		return deleteForManagementGroup(ctx, client, d, meta, policysetdefinitions.NewProviders2PolicySetDefinitionID(managementGroupName, resourceId.Name).ID())
 	}
 
-	if err != nil {
-		if utils.ResponseWasNotFound(resp) {
-			return nil
-		}
+	id := policysetdefinitions.NewProviderPolicySetDefinitionID(subscriptionId, resourceId.Name)
 
-		return fmt.Errorf("deleting Policy Set Definition %q: %+v", id.Name, err)
+	if _, err := client.Delete(ctx, id); err != nil {
+		return fmt.Errorf("deleting %s: %+v", id, err)
 	}
 
 	return nil
 }
 
-func policySetDefinitionRefreshFunc(ctx context.Context, client *policy.SetDefinitionsClient, name, managementGroupId string) pluginsdk.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		res, err := getPolicySetDefinitionByName(ctx, client, name, managementGroupId)
-		if err != nil {
-			return nil, strconv.Itoa(res.StatusCode), fmt.Errorf("issuing read request in policySetDefinitionRefreshFunc for Policy Set Definition %q: %+v", name, err)
-		}
-
-		return res, strconv.Itoa(res.StatusCode), nil
-	}
-}
-
-func expandAzureRMPolicySetDefinitionPolicyDefinitionsUpdate(d *pluginsdk.ResourceData) (*[]policy.DefinitionReference, error) {
-	result := make([]policy.DefinitionReference, 0)
-	input := d.Get("policy_definition_reference").([]interface{})
-
-	for i := range input {
-		if d.HasChange(fmt.Sprintf("policy_definition_reference.%d.parameter_values", i)) && d.HasChange(fmt.Sprintf("policy_definition_reference.%d.parameters", i)) {
-			return nil, fmt.Errorf("cannot set both `parameters` and `parameter_values`")
-		}
-		parameters := make(map[string]*policy.ParameterValuesValue)
-		if d.HasChange(fmt.Sprintf("policy_definition_reference.%d.parameters", i)) {
-			// there is change in `parameters` - the user is will to use this attribute as parameter values
-			log.Printf("[DEBUG] updating %s", fmt.Sprintf("policy_definition_reference.%d.parameters", i))
-			p := d.Get(fmt.Sprintf("policy_definition_reference.%d.parameters", i)).(map[string]interface{})
-			for k, v := range p {
-				parameters[k] = &policy.ParameterValuesValue{
-					Value: v,
-				}
-			}
-		} else {
-			// in this case, it is either parameter_values updated or no update on both, we took the value in `parameter_values` as the final value
-			log.Printf("[DEBUG] updating %s", fmt.Sprintf("policy_definition_reference.%d.parameter_values", i))
-			if p, ok := d.Get(fmt.Sprintf("policy_definition_reference.%d.parameter_values", i)).(string); ok && p != "" {
-				if err := json.Unmarshal([]byte(p), &parameters); err != nil {
-					return nil, fmt.Errorf("unmarshalling `parameter_values`: %+v", err)
-				}
-			}
-		}
-
-		result = append(result, policy.DefinitionReference{
-			PolicyDefinitionID:          utils.String(d.Get(fmt.Sprintf("policy_definition_reference.%d.policy_definition_id", i)).(string)),
-			Parameters:                  parameters,
-			PolicyDefinitionReferenceID: utils.String(d.Get(fmt.Sprintf("policy_definition_reference.%d.reference_id", i)).(string)),
-			GroupNames:                  utils.ExpandStringSlice(d.Get(fmt.Sprintf("policy_definition_reference.%d.policy_group_names", i)).(*schema.Set).List()),
-		})
+func deleteForManagementGroup(ctx context.Context, client *policysetdefinitions.PolicySetDefinitionsClient, d *pluginsdk.ResourceData, meta any, managementGroupIdString string) error {
+	id, err := policysetdefinitions.ParseProviders2PolicySetDefinitionID(managementGroupIdString)
+	if err != nil {
+		return err
 	}
 
-	return &result, nil
+	if _, err = client.DeleteAtManagementGroup(ctx, *id); err != nil {
+		return fmt.Errorf("deleting %s: %+v", *id, err)
+	}
+
+	return nil
 }
 
-func expandAzureRMPolicySetDefinitionPolicyDefinitions(input []interface{}) (*[]policy.DefinitionReference, error) {
-	result := make([]policy.DefinitionReference, 0)
+func expandAzureRMPolicySetDefinitionPolicyDefinitions(input []interface{}) ([]policysetdefinitions.PolicyDefinitionReference, error) {
+	result := make([]policysetdefinitions.PolicyDefinitionReference, 0)
 
 	for _, item := range input {
 		v := item.(map[string]interface{})
 
-		var parameters map[string]*policy.ParameterValuesValue
+		var parameters map[string]policysetdefinitions.ParameterValuesValue
 		if p, ok := v["parameter_values"].(string); ok && p != "" {
-			parameters = make(map[string]*policy.ParameterValuesValue)
+			parameters = make(map[string]policysetdefinitions.ParameterValuesValue)
 			if err := json.Unmarshal([]byte(p), &parameters); err != nil {
 				return nil, fmt.Errorf("unmarshalling `parameter_values`: %+v", err)
 			}
 		}
-		if p, ok := v["parameters"].(map[string]interface{}); ok {
-			if len(parameters) > 0 && len(p) > 0 {
-				return nil, fmt.Errorf("cannot set both `parameters` and `parameter_values`")
-			}
-			parameters = make(map[string]*policy.ParameterValuesValue)
-			for k, value := range p {
-				parameters[k] = &policy.ParameterValuesValue{
-					Value: value,
-				}
-			}
-		}
 
-		result = append(result, policy.DefinitionReference{
-			PolicyDefinitionID:          utils.String(v["policy_definition_id"].(string)),
-			Parameters:                  parameters,
-			PolicyDefinitionReferenceID: utils.String(v["reference_id"].(string)),
+		result = append(result, policysetdefinitions.PolicyDefinitionReference{
+			PolicyDefinitionId:          v["policy_definition_id"].(string),
+			Parameters:                  pointer.To(parameters),
+			PolicyDefinitionReferenceId: pointer.To(v["reference_id"].(string)),
 			GroupNames:                  utils.ExpandStringSlice(v["policy_group_names"].(*pluginsdk.Set).List()),
 		})
 	}
 
-	return &result, nil
+	return result, nil
 }
 
-func flattenAzureRMPolicySetDefinitionPolicyDefinitions(input *[]policy.DefinitionReference) ([]interface{}, error) {
+func flattenAzureRMPolicySetDefinitionPolicyDefinitions(input []policysetdefinitions.PolicyDefinitionReference) ([]interface{}, error) {
 	result := make([]interface{}, 0)
-	if input == nil {
-		return result, nil
-	}
 
-	for _, definition := range *input {
-		policyDefinitionID := ""
-		if definition.PolicyDefinitionID != nil {
-			policyDefinitionID = *definition.PolicyDefinitionID
-		}
-
-		parametersMap := make(map[string]interface{})
-		for k, v := range definition.Parameters {
-			if v == nil {
-				continue
-			}
-			parametersMap[k] = fmt.Sprintf("%v", v.Value) // map in terraform only accepts string as its values, therefore we have to convert the value to string
-		}
-
-		parameterValues, err := flattenParameterValuesValueToString(definition.Parameters)
+	for _, definition := range input {
+		parameterValues, err := flattenPolicyDefinitionReferenceParameterValues(definition.Parameters)
 		if err != nil {
-			return nil, fmt.Errorf("serializing JSON from `parameter_values`: %+v", err)
-		}
-
-		policyDefinitionReference := ""
-		if definition.PolicyDefinitionReferenceID != nil {
-			policyDefinitionReference = *definition.PolicyDefinitionReferenceID
+			return nil, fmt.Errorf("flattening `parameter_values`: %+v", err)
 		}
 
 		result = append(result, map[string]interface{}{
-			"policy_definition_id": policyDefinitionID,
+			"policy_definition_id": definition.PolicyDefinitionId,
 			"parameter_values":     parameterValues,
-			"reference_id":         policyDefinitionReference,
+			"reference_id":         pointer.From(definition.PolicyDefinitionReferenceId),
 			"policy_group_names":   utils.FlattenStringSlice(definition.GroupNames),
 		})
 	}
 	return result, nil
 }
 
-func expandAzureRMPolicySetDefinitionPolicyGroups(input []interface{}) *[]policy.DefinitionGroup {
-	result := make([]policy.DefinitionGroup, 0)
+func expandAzureRMPolicySetDefinitionPolicyGroups(input []interface{}) *[]policysetdefinitions.PolicyDefinitionGroup {
+	result := make([]policysetdefinitions.PolicyDefinitionGroup, 0)
 
 	for _, item := range input {
 		v := item.(map[string]interface{})
-		group := policy.DefinitionGroup{}
+		group := policysetdefinitions.PolicyDefinitionGroup{}
 		if name := v["name"].(string); name != "" {
-			group.Name = utils.String(name)
+			group.Name = name
 		}
 		if displayName := v["display_name"].(string); displayName != "" {
-			group.DisplayName = utils.String(displayName)
+			group.DisplayName = pointer.To(displayName)
 		}
 		if category := v["category"].(string); category != "" {
-			group.Category = utils.String(category)
+			group.Category = pointer.To(category)
 		}
 		if description := v["description"].(string); description != "" {
-			group.Description = utils.String(description)
+			group.Description = pointer.To(description)
 		}
 		if metadataID := v["additional_metadata_resource_id"].(string); metadataID != "" {
-			group.AdditionalMetadataID = utils.String(metadataID)
+			group.AdditionalMetadataId = pointer.To(metadataID)
 		}
 		result = append(result, group)
 	}
@@ -684,52 +813,433 @@ func expandAzureRMPolicySetDefinitionPolicyGroups(input []interface{}) *[]policy
 	return &result
 }
 
-func flattenAzureRMPolicySetDefinitionPolicyGroups(input *[]policy.DefinitionGroup) []interface{} {
+func flattenAzureRMPolicySetDefinitionPolicyGroups(input *[]policysetdefinitions.PolicyDefinitionGroup) []interface{} {
 	result := make([]interface{}, 0)
 	if input == nil {
 		return result
 	}
 
 	for _, group := range *input {
-		name := ""
-		if group.Name != nil {
-			name = *group.Name
-		}
-		displayName := ""
-		if group.DisplayName != nil {
-			displayName = *group.DisplayName
-		}
-		category := ""
-		if group.Category != nil {
-			category = *group.Category
-		}
-		description := ""
-		if group.Description != nil {
-			description = *group.Description
-		}
-		metadataID := ""
-		if group.AdditionalMetadataID != nil {
-			metadataID = *group.AdditionalMetadataID
-		}
-
 		result = append(result, map[string]interface{}{
-			"name":                            name,
-			"display_name":                    displayName,
-			"category":                        category,
-			"description":                     description,
-			"additional_metadata_resource_id": metadataID,
+			"name":                            group.Name,
+			"display_name":                    pointer.From(group.DisplayName),
+			"category":                        pointer.From(group.Category),
+			"description":                     pointer.From(group.Description),
+			"additional_metadata_resource_id": pointer.From(group.AdditionalMetadataId),
 		})
 	}
 
 	return result
 }
+// END TODO: Remove post 5.0
 
-func resourceARMPolicySetDefinitionPolicyDefinitionGroupHash(v interface{}) int {
-	var buf bytes.Buffer
+type PolicySetDefinitionResource struct{}
 
-	if m, ok := v.(map[string]interface{}); ok {
-		buf.WriteString(m["name"].(string))
+type PolicySetDefinitionResourceModel struct {
+	Name                      string                           `tfschema:"name"`
+	PolicyType                string                           `tfschema:"policy_type"`
+	DisplayName               string                           `tfschema:"display_name"`
+	Description               string                           `tfschema:"description"`
+	Metadata                  string                           `tfschema:"metadata"`
+	Parameters                string                           `tfschema:"parameters"`
+	PolicyDefinitionReference []PolicyDefinitionReferenceModel `tfschema:"policy_definition_reference"`
+	PolicyDefinitionGroup     []PolicyDefinitionGroupModel     `tfschema:"policy_definition_group"`
+}
+
+var (
+	_ sdk.ResourceWithUpdate         = PolicySetDefinitionResource{}
+	_ sdk.ResourceWithStateMigration = PolicySetDefinitionResource{}
+)
+
+func (r PolicySetDefinitionResource) StateUpgraders() sdk.StateUpgradeData {
+	return sdk.StateUpgradeData{
+		SchemaVersion: 1,
+		Upgraders: map[int]pluginsdk.StateUpgrade{
+			0: migration.PolicySetDefinitionV0ToV1{},
+		},
+	}
+}
+
+func (r PolicySetDefinitionResource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"policy_type": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringInSlice(policysetdefinitions.PossibleValuesForPolicyType(), false),
+		},
+
+		"display_name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"description": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+		},
+
+		"metadata": {
+			Type:             pluginsdk.TypeString,
+			Optional:         true,
+			Computed:         true,
+			ValidateFunc:     validation.StringIsJSON,
+			DiffSuppressFunc: policySetDefinitionsMetadataDiffSuppressFunc,
+		},
+
+		"parameters": {
+			Type:             pluginsdk.TypeString,
+			Optional:         true,
+			ValidateFunc:     validation.StringIsJSON,
+			DiffSuppressFunc: pluginsdk.SuppressJsonDiff,
+		},
+
+		"policy_definition_reference": {
+			Type:     pluginsdk.TypeList,
+			Required: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"policy_definition_id": {
+						Type:         pluginsdk.TypeString,
+						Required:     true,
+						ValidateFunc: validate.PolicyDefinitionID,
+					},
+
+					"parameter_values": {
+						Type:             pluginsdk.TypeString,
+						Optional:         true,
+						ValidateFunc:     validation.StringIsJSON,
+						DiffSuppressFunc: pluginsdk.SuppressJsonDiff,
+					},
+
+					"reference_id": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						Computed: true,
+					},
+
+					"policy_group_names": {
+						Type:     pluginsdk.TypeSet,
+						Optional: true,
+						Elem: &pluginsdk.Schema{
+							Type:         pluginsdk.TypeString,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+					},
+				},
+			},
+		},
+
+		"policy_definition_group": {
+			Type:     pluginsdk.TypeSet,
+			Optional: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"name": {
+						Type:         pluginsdk.TypeString,
+						Required:     true,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+
+					"display_name": {
+						Type:         pluginsdk.TypeString,
+						Optional:     true,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+
+					"category": {
+						Type:         pluginsdk.TypeString,
+						Optional:     true,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+
+					"description": {
+						Type:         pluginsdk.TypeString,
+						Optional:     true,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+
+					"additional_metadata_resource_id": {
+						Type:         pluginsdk.TypeString,
+						Optional:     true,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+				},
+			},
+			Set: policySetDefinitionPolicyDefinitionGroupHash,
+		},
+	}
+}
+
+func (r PolicySetDefinitionResource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{}
+}
+
+func (r PolicySetDefinitionResource) ModelObject() interface{} {
+	return &PolicySetDefinitionResourceModel{}
+}
+
+func (r PolicySetDefinitionResource) ResourceType() string {
+	return "azurerm_policy_set_definition"
+}
+
+func (r PolicySetDefinitionResource) Create() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Policy.PolicySetDefinitionsClient
+			subscriptionId := metadata.Client.Account.SubscriptionId
+
+			var model PolicySetDefinitionResourceModel
+			if err := metadata.Decode(&model); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			id := policysetdefinitions.NewProviderPolicySetDefinitionID(subscriptionId, model.Name)
+
+			resp, _, err := getPolicySetDefinition(ctx, client, id)
+			if err != nil && !response.WasNotFound(resp) {
+				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+			}
+
+			if !response.WasNotFound(resp) {
+				return metadata.ResourceRequiresImport(r.ResourceType(), id)
+			}
+
+			parameters := policysetdefinitions.PolicySetDefinition{
+				Name: pointer.To(model.Name),
+				Properties: &policysetdefinitions.PolicySetDefinitionProperties{
+					Description: pointer.To(model.Description),
+					DisplayName: pointer.To(model.DisplayName),
+					PolicyType:  pointer.To(policysetdefinitions.PolicyType(model.PolicyType)),
+				},
+			}
+
+			props := parameters.Properties
+			if model.Metadata != "" {
+				expandedMetadata, err := pluginsdk.ExpandJsonFromString(model.Metadata)
+				if err != nil {
+					return fmt.Errorf("expanding `metadata`: %+v", err)
+				}
+
+				var iMetadata interface{} = expandedMetadata
+
+				props.Metadata = &iMetadata
+			}
+
+			if model.Parameters != "" {
+				expandedParameters, err := expandParameterDefinitionsValue(model.Parameters)
+				if err != nil {
+					return fmt.Errorf("expanding `parameters`: %+v", err)
+				}
+				props.Parameters = expandedParameters
+			}
+
+			if len(model.PolicyDefinitionReference) > 0 {
+				expandedDefinitions, err := expandPolicyDefinitionReference(model.PolicyDefinitionReference)
+				if err != nil {
+					return fmt.Errorf("expanding `policy_definition_reference`: %+v", err)
+				}
+				props.PolicyDefinitions = expandedDefinitions
+			}
+
+			if len(model.PolicyDefinitionGroup) > 0 {
+				props.PolicyDefinitionGroups = expandPolicyDefinitionGroup(model.PolicyDefinitionGroup)
+			}
+
+			if _, err = client.CreateOrUpdate(ctx, id, parameters); err != nil {
+				return fmt.Errorf("creating %s: %+v", id, err)
+			}
+
+			metadata.SetID(id)
+			return nil
+		},
+	}
+}
+
+func (r PolicySetDefinitionResource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Policy.PolicySetDefinitionsClient
+
+			id, err := policysetdefinitions.ParseProviderPolicySetDefinitionID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			resp, model, err := getPolicySetDefinition(ctx, client, *id)
+			if err != nil {
+				if response.WasNotFound(resp) {
+					return metadata.MarkAsGone(id)
+				}
+
+				return fmt.Errorf("retrieving %s: %+v", *id, err)
+			}
+
+			state := PolicySetDefinitionResourceModel{
+				Name: id.PolicySetDefinitionName,
+			}
+
+			if model != nil {
+
+				if props := model.Properties; props != nil {
+					state.Description = pointer.From(props.Description)
+					state.DisplayName = pointer.From(props.DisplayName)
+					state.PolicyType = string(pointer.From(props.PolicyType))
+
+					if v, ok := pointer.From(props.Metadata).(map[string]interface{}); ok {
+						flattenedMetadata, err := pluginsdk.FlattenJsonToString(v)
+						if err != nil {
+							return fmt.Errorf("flattening `metadata`: %+v", err)
+						}
+						state.Metadata = flattenedMetadata
+					}
+
+					flattenedParameters, err := flattenParameterDefinitionsValue(props.Parameters)
+					if err != nil {
+						return fmt.Errorf("flattening `parameters`: %+v", err)
+					}
+					state.Parameters = flattenedParameters
+
+					flattenedDefinitions, err := flattenPolicyDefinitionReference(props.PolicyDefinitions)
+					if err != nil {
+						return fmt.Errorf("flattening `policy_definition_reference`: %+v", err)
+					}
+					state.PolicyDefinitionReference = flattenedDefinitions
+
+					state.PolicyDefinitionGroup = flattenPolicyDefinitionGroup(props.PolicyDefinitionGroups)
+				}
+			}
+
+			return metadata.Encode(&state)
+		},
+	}
+}
+
+func (r PolicySetDefinitionResource) Update() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Policy.PolicySetDefinitionsClient
+
+			id, err := policysetdefinitions.ParseProviderPolicySetDefinitionID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			var config PolicySetDefinitionResourceModel
+			if err := metadata.Decode(&config); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			resp, model, err := getPolicySetDefinition(ctx, client, *id)
+			if err != nil {
+				if response.WasNotFound(resp) {
+					return metadata.MarkAsGone(id)
+				}
+
+				return fmt.Errorf("retrieving %s: %+v", *id, err)
+			}
+
+			if model == nil {
+				return fmt.Errorf("retrieving %s: `model` was nil", *id)
+			}
+
+			if model.Properties == nil {
+				return fmt.Errorf("retrieving %s: `properties` was nil", *id)
+			}
+			props := model.Properties
+
+			if metadata.ResourceData.HasChange("display_name") {
+				props.DisplayName = pointer.To(config.DisplayName)
+			}
+
+			if metadata.ResourceData.HasChange("description") {
+				props.Description = pointer.To(config.Description)
+			}
+
+			if metadata.ResourceData.HasChange("metadata") {
+				expandedMetadata, err := pluginsdk.ExpandJsonFromString(config.Metadata)
+				if err != nil {
+					return fmt.Errorf("expanding `metadata`: %+v", err)
+				}
+
+				var iMetadata interface{} = expandedMetadata
+
+				props.Metadata = &iMetadata
+			}
+
+			if metadata.ResourceData.HasChange("parameters") {
+				props.Parameters = nil
+				if config.Parameters != "" {
+					expandedParameters, err := expandParameterDefinitionsValue(config.Parameters)
+					if err != nil {
+						return fmt.Errorf("expanding `parameters`: %+v", err)
+					}
+					props.Parameters = expandedParameters
+				}
+			}
+
+			if metadata.ResourceData.HasChange("policy_definition_reference") {
+				expandedDefinitions, err := expandPolicyDefinitionReference(config.PolicyDefinitionReference)
+				if err != nil {
+					return fmt.Errorf("expanding `policy_definition_reference`: %+v", err)
+				}
+				props.PolicyDefinitions = expandedDefinitions
+			}
+
+			if metadata.ResourceData.HasChange("policy_definition_group") {
+				props.PolicyDefinitionGroups = expandPolicyDefinitionGroup(config.PolicyDefinitionGroup)
+			}
+
+			if _, err := client.CreateOrUpdate(ctx, *id, *model); err != nil {
+				return fmt.Errorf("updating %s: %+v", *id, err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func (r PolicySetDefinitionResource) Delete() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Policy.PolicySetDefinitionsClient
+
+			id, err := policysetdefinitions.ParseProviderPolicySetDefinitionID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			if _, err := client.Delete(ctx, *id); err != nil {
+				return fmt.Errorf("deleting %s: %+v", *id, err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func (r PolicySetDefinitionResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return policysetdefinitions.ValidateProviderPolicySetDefinitionID
+}
+
+func getPolicySetDefinition(ctx context.Context, client *policysetdefinitions.PolicySetDefinitionsClient, id policysetdefinitions.ProviderPolicySetDefinitionId) (*http.Response, *policysetdefinitions.PolicySetDefinition, error) {
+	resp, err := client.GetBuiltIn(ctx, policysetdefinitions.NewPolicySetDefinitionID(id.PolicySetDefinitionName), policysetdefinitions.DefaultGetBuiltInOperationOptions())
+	if response.WasNotFound(resp.HttpResponse) {
+		resp, err := client.Get(ctx, id, policysetdefinitions.DefaultGetOperationOptions())
+		return resp.HttpResponse, resp.Model, err
 	}
 
-	return pluginsdk.HashString(buf.String())
+	return resp.HttpResponse, resp.Model, err
 }

--- a/internal/services/policy/policy_set_definition_resource.go
+++ b/internal/services/policy/policy_set_definition_resource.go
@@ -903,80 +903,9 @@ func (r PolicySetDefinitionResource) Arguments() map[string]*pluginsdk.Schema {
 			DiffSuppressFunc: pluginsdk.SuppressJsonDiff,
 		},
 
-		"policy_definition_reference": {
-			Type:     pluginsdk.TypeList,
-			Required: true,
-			Elem: &pluginsdk.Resource{
-				Schema: map[string]*pluginsdk.Schema{
-					"policy_definition_id": {
-						Type:         pluginsdk.TypeString,
-						Required:     true,
-						ValidateFunc: validate.PolicyDefinitionID,
-					},
+		"policy_definition_reference": policyDefinitionReferenceSchema(),
 
-					"parameter_values": {
-						Type:             pluginsdk.TypeString,
-						Optional:         true,
-						ValidateFunc:     validation.StringIsJSON,
-						DiffSuppressFunc: pluginsdk.SuppressJsonDiff,
-					},
-
-					"reference_id": {
-						Type:     pluginsdk.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-
-					"policy_group_names": {
-						Type:     pluginsdk.TypeSet,
-						Optional: true,
-						Elem: &pluginsdk.Schema{
-							Type:         pluginsdk.TypeString,
-							ValidateFunc: validation.StringIsNotEmpty,
-						},
-					},
-				},
-			},
-		},
-
-		"policy_definition_group": {
-			Type:     pluginsdk.TypeSet,
-			Optional: true,
-			Elem: &pluginsdk.Resource{
-				Schema: map[string]*pluginsdk.Schema{
-					"name": {
-						Type:         pluginsdk.TypeString,
-						Required:     true,
-						ValidateFunc: validation.StringIsNotEmpty,
-					},
-
-					"display_name": {
-						Type:         pluginsdk.TypeString,
-						Optional:     true,
-						ValidateFunc: validation.StringIsNotEmpty,
-					},
-
-					"category": {
-						Type:         pluginsdk.TypeString,
-						Optional:     true,
-						ValidateFunc: validation.StringIsNotEmpty,
-					},
-
-					"description": {
-						Type:         pluginsdk.TypeString,
-						Optional:     true,
-						ValidateFunc: validation.StringIsNotEmpty,
-					},
-
-					"additional_metadata_resource_id": {
-						Type:         pluginsdk.TypeString,
-						Optional:     true,
-						ValidateFunc: validation.StringIsNotEmpty,
-					},
-				},
-			},
-			Set: policySetDefinitionPolicyDefinitionGroupHash,
-		},
+		"policy_definition_group": policyDefinitionGroupSchema(),
 	}
 }
 

--- a/internal/services/policy/policy_set_definition_resource_test.go
+++ b/internal/services/policy/policy_set_definition_resource_test.go
@@ -8,20 +8,21 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/services/preview/resources/mgmt/2021-06-01-preview/policy" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/resources/2025-01-01/policysetdefinitions"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/policy/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
-type PolicySetDefinitionResource struct{}
+type PolicySetDefinitionResourceTest struct{}
 
 func TestAccAzureRMPolicySetDefinition_builtIn(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_policy_set_definition", "test")
-	r := PolicySetDefinitionResource{}
+	r := PolicySetDefinitionResourceTest{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -36,7 +37,7 @@ func TestAccAzureRMPolicySetDefinition_builtIn(t *testing.T) {
 
 func TestAccAzureRMPolicySetDefinition_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_policy_set_definition", "test")
-	r := PolicySetDefinitionResource{}
+	r := PolicySetDefinitionResourceTest{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -51,7 +52,7 @@ func TestAccAzureRMPolicySetDefinition_requiresImport(t *testing.T) {
 
 func TestAccAzureRMPolicySetDefinition_custom(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_policy_set_definition", "test")
-	r := PolicySetDefinitionResource{}
+	r := PolicySetDefinitionResourceTest{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -66,7 +67,7 @@ func TestAccAzureRMPolicySetDefinition_custom(t *testing.T) {
 
 func TestAccAzureRMPolicySetDefinition_customNoParameter(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_policy_set_definition", "test")
-	r := PolicySetDefinitionResource{}
+	r := PolicySetDefinitionResourceTest{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -88,7 +89,7 @@ func TestAccAzureRMPolicySetDefinition_customNoParameter(t *testing.T) {
 
 func TestAccAzureRMPolicySetDefinition_customUpdateDisplayName(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_policy_set_definition", "test")
-	r := PolicySetDefinitionResource{}
+	r := PolicySetDefinitionResourceTest{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -110,7 +111,7 @@ func TestAccAzureRMPolicySetDefinition_customUpdateDisplayName(t *testing.T) {
 
 func TestAccAzureRMPolicySetDefinition_customUpdateParameters(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_policy_set_definition", "test")
-	r := PolicySetDefinitionResource{}
+	r := PolicySetDefinitionResourceTest{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -131,7 +132,7 @@ func TestAccAzureRMPolicySetDefinition_customUpdateParameters(t *testing.T) {
 
 func TestAccAzureRMPolicySetDefinition_customUpdateAddNewReference(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_policy_set_definition", "test")
-	r := PolicySetDefinitionResource{}
+	r := PolicySetDefinitionResourceTest{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -153,7 +154,7 @@ func TestAccAzureRMPolicySetDefinition_customUpdateAddNewReference(t *testing.T)
 
 func TestAccAzureRMPolicySetDefinition_customWithPolicyReferenceID(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_policy_set_definition", "test")
-	r := PolicySetDefinitionResource{}
+	r := PolicySetDefinitionResourceTest{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -168,7 +169,7 @@ func TestAccAzureRMPolicySetDefinition_customWithPolicyReferenceID(t *testing.T)
 
 func TestAccAzureRMPolicySetDefinition_customWithDefinitionGroups(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_policy_set_definition", "test")
-	r := PolicySetDefinitionResource{}
+	r := PolicySetDefinitionResourceTest{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -197,7 +198,7 @@ func TestAccAzureRMPolicySetDefinition_customWithDefinitionGroups(t *testing.T) 
 
 func TestAccAzureRMPolicySetDefinition_customWithGroupsInDefinitionReferenceUpdate(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_policy_set_definition", "test")
-	r := PolicySetDefinitionResource{}
+	r := PolicySetDefinitionResourceTest{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -231,8 +232,12 @@ func TestAccAzureRMPolicySetDefinition_customWithGroupsInDefinitionReferenceUpda
 }
 
 func TestAccAzureRMPolicySetDefinition_managementGroup(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("`skipping test as `management_group_id` has been removed from the `azurerm_policy_set_definition` resource")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_policy_set_definition", "test")
-	r := PolicySetDefinitionResource{}
+	r := PolicySetDefinitionResourceTest{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -247,7 +252,7 @@ func TestAccAzureRMPolicySetDefinition_managementGroup(t *testing.T) {
 
 func TestAccAzureRMPolicySetDefinition_metadata(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_policy_set_definition", "test")
-	r := PolicySetDefinitionResource{}
+	r := PolicySetDefinitionResourceTest{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -260,7 +265,7 @@ func TestAccAzureRMPolicySetDefinition_metadata(t *testing.T) {
 	})
 }
 
-func (r PolicySetDefinitionResource) builtIn(data acceptance.TestData) string {
+func (r PolicySetDefinitionResourceTest) builtIn(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -287,7 +292,7 @@ PARAMETERS
   policy_definition_reference {
     policy_definition_id = "/providers/Microsoft.Authorization/policyDefinitions/e765b5de-1225-4ba3-bd56-1ac6695af988"
     parameter_values     = <<VALUES
-	{
+    {
       "listOfAllowedLocations": {"value": "[parameters('allowedLocations')]"}
     }
 VALUES
@@ -296,8 +301,7 @@ VALUES
 `, data.RandomInteger, data.RandomInteger)
 }
 
-func (r PolicySetDefinitionResource) requiresImport(data acceptance.TestData) string {
-	template := r.builtIn(data)
+func (r PolicySetDefinitionResourceTest) requiresImport(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -310,24 +314,23 @@ resource "azurerm_policy_set_definition" "import" {
   policy_definition_reference {
     policy_definition_id = "/providers/Microsoft.Authorization/policyDefinitions/e765b5de-1225-4ba3-bd56-1ac6695af988"
     parameter_values     = <<VALUES
-	{
+    {
       "listOfAllowedLocations": {"value": "[parameters('allowedLocations')]"}
     }
 VALUES
   }
 }
-`, template)
+`, r.builtIn(data))
 }
 
-func (r PolicySetDefinitionResource) custom(data acceptance.TestData) string {
-	template := r.template(data)
+func (r PolicySetDefinitionResourceTest) custom(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
 resource "azurerm_policy_set_definition" "test" {
-  name         = "acctestPolSet-%d"
+  name         = "acctestPolSet-%[2]d"
   policy_type  = "Custom"
-  display_name = "acctestPolSet-display-%d"
+  display_name = "acctestPolSet-display-%[2]d"
 
   parameters = <<PARAMETERS
     {
@@ -345,24 +348,23 @@ PARAMETERS
   policy_definition_reference {
     policy_definition_id = azurerm_policy_definition.test.id
     parameter_values     = <<VALUES
-	{
+    {
       "allowedLocations": {"value": "[parameters('allowedLocations')]"}
     }
 VALUES
   }
 }
-`, template, data.RandomInteger, data.RandomInteger)
+`, r.template(data), data.RandomInteger)
 }
 
-func (r PolicySetDefinitionResource) customUpdateDisplayName(data acceptance.TestData) string {
-	template := r.template(data)
+func (r PolicySetDefinitionResourceTest) customUpdateDisplayName(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
 resource "azurerm_policy_set_definition" "test" {
-  name         = "acctestPolSet-%d"
+  name         = "acctestPolSet-%[2]d"
   policy_type  = "Custom"
-  display_name = "acctestPolSet-display-%d-updated"
+  display_name = "acctestPolSet-display-%[2]d-updated"
 
   parameters = <<PARAMETERS
     {
@@ -380,24 +382,23 @@ PARAMETERS
   policy_definition_reference {
     policy_definition_id = azurerm_policy_definition.test.id
     parameter_values     = <<VALUES
-	{
+    {
       "allowedLocations": {"value": "[parameters('allowedLocations')]"}
     }
 VALUES
   }
 }
-`, template, data.RandomInteger, data.RandomInteger)
+`, r.template(data), data.RandomInteger)
 }
 
-func (r PolicySetDefinitionResource) customUpdateParameters(data acceptance.TestData) string {
-	template := r.template(data)
+func (r PolicySetDefinitionResourceTest) customUpdateParameters(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
 resource "azurerm_policy_set_definition" "test" {
-  name         = "acctestPolSet-%d"
+  name         = "acctestPolSet-%[2]d"
   policy_type  = "Custom"
-  display_name = "acctestPolSet-display-%d-updated"
+  display_name = "acctestPolSet-display-%[2]d-updated"
 
   parameters = <<PARAMETERS
     {
@@ -415,17 +416,16 @@ PARAMETERS
   policy_definition_reference {
     policy_definition_id = azurerm_policy_definition.test.id
     parameter_values     = <<VALUES
-	{
+    {
       "allowedLocations": {"value": ["%s"]}
     }
 VALUES
   }
 }
-`, template, data.RandomInteger, data.RandomInteger, data.Locations.Primary)
+`, r.template(data), data.RandomInteger, data.Locations.Primary)
 }
 
-func (r PolicySetDefinitionResource) customUpdateAddNewReference(data acceptance.TestData) string {
-	template := r.template(data)
+func (r PolicySetDefinitionResourceTest) customUpdateAddNewReference(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -434,9 +434,9 @@ data "azurerm_policy_definition" "allowed_resource_types" {
 }
 
 resource "azurerm_policy_set_definition" "test" {
-  name         = "acctestPolSet-%d"
+  name         = "acctestPolSet-%[2]d"
   policy_type  = "Custom"
-  display_name = "acctestPolSet-display-%d"
+  display_name = "acctestPolSet-display-%[2]d"
 
   parameters = <<PARAMETERS
     {
@@ -454,7 +454,7 @@ PARAMETERS
   policy_definition_reference {
     policy_definition_id = azurerm_policy_definition.test.id
     parameter_values     = <<VALUES
-	{
+    {
       "allowedLocations": {"value": "[parameters('allowedLocations')]"}
     }
 VALUES
@@ -463,64 +463,62 @@ VALUES
   policy_definition_reference {
     policy_definition_id = data.azurerm_policy_definition.allowed_resource_types.id
     parameter_values     = <<VALUES
-	{
+    {
       "listOfResourceTypesAllowed": {"value": ["Microsoft.Compute/virtualMachines"]}
     }
 VALUES
   }
 }
-`, template, data.RandomInteger, data.RandomInteger)
+`, r.template(data), data.RandomInteger)
 }
 
-func (r PolicySetDefinitionResource) customNoParameter(data acceptance.TestData) string {
-	template := r.templateNoParameter(data)
+func (r PolicySetDefinitionResourceTest) customNoParameter(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
 resource "azurerm_policy_set_definition" "test" {
-  name         = "acctestPolSet-%d"
+  name         = "acctestPolSet-%[2]d"
   policy_type  = "Custom"
-  display_name = "acctestPolSet-display-%d"
+  display_name = "acctestPolSet-display-%[2]d"
 
   policy_definition_reference {
     policy_definition_id = azurerm_policy_definition.test.id
   }
 }
-`, template, data.RandomInteger, data.RandomInteger)
+`, r.templateNoParameter(data), data.RandomInteger)
 }
 
-func (r PolicySetDefinitionResource) customNoParameterUpdate(data acceptance.TestData) string {
-	template := r.templateNoParameter(data)
+func (r PolicySetDefinitionResourceTest) customNoParameterUpdate(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
 resource "azurerm_policy_set_definition" "test" {
-  name         = "acctestPolSet-%d"
+  name         = "acctestPolSet-%[2]d"
   policy_type  = "Custom"
-  display_name = "acctestPolSet-display-%d"
+  display_name = "acctestPolSet-display-%[2]d"
 
   policy_definition_reference {
     policy_definition_id = azurerm_policy_definition.test.id
     parameter_values     = "{}"
   }
 }
-`, template, data.RandomInteger, data.RandomInteger)
+`, r.templateNoParameter(data), data.RandomInteger)
 }
 
-func (r PolicySetDefinitionResource) managementGroup(data acceptance.TestData) string {
+func (r PolicySetDefinitionResourceTest) managementGroup(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
 resource "azurerm_management_group" "test" {
-  display_name = "acctestmg-%d"
+  display_name = "acctestmg-%[1]d"
 }
 
 resource "azurerm_policy_set_definition" "test" {
-  name                = "acctestpolset-%d"
+  name                = "acctestpolset-%[1]d"
   policy_type         = "Custom"
-  display_name        = "acctestpolset-%d"
+  display_name        = "acctestpolset-%[1]d"
   management_group_id = azurerm_management_group.test.id
 
   parameters = <<PARAMETERS
@@ -539,25 +537,25 @@ PARAMETERS
   policy_definition_reference {
     policy_definition_id = "/providers/Microsoft.Authorization/policyDefinitions/e765b5de-1225-4ba3-bd56-1ac6695af988"
     parameter_values     = <<VALUES
-	{
+    {
       "listOfAllowedLocations": {"value": "[parameters('allowedLocations')]"}
     }
 VALUES
   }
 }
-`, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger)
 }
 
-func (r PolicySetDefinitionResource) metadata(data acceptance.TestData) string {
+func (r PolicySetDefinitionResourceTest) metadata(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
 resource "azurerm_policy_set_definition" "test" {
-  name         = "acctestpolset-%d"
+  name         = "acctestpolset-%[1]d"
   policy_type  = "Custom"
-  display_name = "acctestpolset-%d"
+  display_name = "acctestpolset-%[1]d"
 
   parameters = <<PARAMETERS
     {
@@ -575,7 +573,7 @@ PARAMETERS
   policy_definition_reference {
     policy_definition_id = "/providers/Microsoft.Authorization/policyDefinitions/e765b5de-1225-4ba3-bd56-1ac6695af988"
     parameter_values     = <<VALUES
-	{
+    {
       "listOfAllowedLocations": {"value": "[parameters('allowedLocations')]"}
     }
 VALUES
@@ -587,18 +585,17 @@ VALUES
     }
 METADATA
 }
-`, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger)
 }
 
-func (r PolicySetDefinitionResource) customWithPolicyReferenceID(data acceptance.TestData) string {
-	template := r.template(data)
+func (r PolicySetDefinitionResourceTest) customWithPolicyReferenceID(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
 resource "azurerm_policy_set_definition" "test" {
-  name         = "acctestPolSet-%d"
+  name         = "acctestPolSet-%[2]d"
   policy_type  = "Custom"
-  display_name = "acctestPolSet-display-%d"
+  display_name = "acctestPolSet-display-%[2]d"
 
   parameters = <<PARAMETERS
     {
@@ -616,25 +613,24 @@ PARAMETERS
   policy_definition_reference {
     policy_definition_id = azurerm_policy_definition.test.id
     parameter_values     = <<VALUES
-	{
+    {
       "allowedLocations": {"value": "[parameters('allowedLocations')]"}
     }
 VALUES
     reference_id         = "TestRef"
   }
 }
-`, template, data.RandomInteger, data.RandomInteger)
+`, r.template(data), data.RandomInteger)
 }
 
-func (r PolicySetDefinitionResource) customWithDefinitionGroups(data acceptance.TestData) string {
-	template := r.template(data)
+func (r PolicySetDefinitionResourceTest) customWithDefinitionGroups(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
 resource "azurerm_policy_set_definition" "test" {
-  name         = "acctestPolSet-%d"
+  name         = "acctestPolSet-%[2]d"
   policy_type  = "Custom"
-  display_name = "acctestPolSet-display-%d"
+  display_name = "acctestPolSet-display-%[2]d"
 
   parameters = <<PARAMETERS
     {
@@ -652,7 +648,7 @@ PARAMETERS
   policy_definition_reference {
     policy_definition_id = azurerm_policy_definition.test.id
     parameter_values     = <<VALUES
-	{
+    {
       "allowedLocations": {"value": "[parameters('allowedLocations')]"}
     }
 VALUES
@@ -671,18 +667,17 @@ VALUES
     name = "group-2"
   }
 }
-`, template, data.RandomInteger, data.RandomInteger)
+`, r.template(data), data.RandomInteger)
 }
 
-func (r PolicySetDefinitionResource) customWithDefinitionGroupsUpdate(data acceptance.TestData) string {
-	template := r.template(data)
+func (r PolicySetDefinitionResourceTest) customWithDefinitionGroupsUpdate(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
 resource "azurerm_policy_set_definition" "test" {
-  name         = "acctestPolSet-%d"
+  name         = "acctestPolSet-%[2]d"
   policy_type  = "Custom"
-  display_name = "acctestPolSet-display-%d"
+  display_name = "acctestPolSet-display-%[2]d"
 
   parameters = <<PARAMETERS
     {
@@ -700,7 +695,7 @@ PARAMETERS
   policy_definition_reference {
     policy_definition_id = azurerm_policy_definition.test.id
     parameter_values     = <<VALUES
-	{
+    {
       "allowedLocations": {"value": "[parameters('allowedLocations')]"}
     }
 VALUES
@@ -725,19 +720,18 @@ VALUES
     description  = "Controls security"
   }
 }
-`, template, data.RandomInteger, data.RandomInteger)
+`, r.template(data), data.RandomInteger)
 }
 
 // test adding "group-3" to policy_definition_reference.policy_group_names
-func (r PolicySetDefinitionResource) customWithDefinitionGroupsUsedInPolicyReference(data acceptance.TestData) string {
-	template := r.template(data)
+func (r PolicySetDefinitionResourceTest) customWithDefinitionGroupsUsedInPolicyReference(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
 resource "azurerm_policy_set_definition" "test" {
-  name         = "acctestPolSet-%d"
+  name         = "acctestPolSet-%[2]d"
   policy_type  = "Custom"
-  display_name = "acctestPolSet-display-%d"
+  display_name = "acctestPolSet-display-%[2]d"
 
   parameters = <<PARAMETERS
     {
@@ -755,7 +749,7 @@ PARAMETERS
   policy_definition_reference {
     policy_definition_id = azurerm_policy_definition.test.id
     parameter_values     = <<VALUES
-	{
+    {
       "allowedLocations": {"value": "[parameters('allowedLocations')]"}
     }
 VALUES
@@ -787,19 +781,18 @@ VALUES
     description  = "Newly added group 3"
   }
 }
-`, template, data.RandomInteger, data.RandomInteger)
+`, r.template(data), data.RandomInteger, data.RandomInteger)
 }
 
 // test adding "group-3" to policy_definition_reference.policy_group_names
-func (r PolicySetDefinitionResource) customWithDefinitionGroupsNotUsedInPolicyReference(data acceptance.TestData) string {
-	template := r.template(data)
+func (r PolicySetDefinitionResourceTest) customWithDefinitionGroupsNotUsedInPolicyReference(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
 resource "azurerm_policy_set_definition" "test" {
-  name         = "acctestPolSet-%d"
+  name         = "acctestPolSet-%[2]d"
   policy_type  = "Custom"
-  display_name = "acctestPolSet-display-%d"
+  display_name = "acctestPolSet-display-%[2]d"
 
   parameters = <<PARAMETERS
     {
@@ -848,23 +841,23 @@ PARAMETERS
     description  = "Newly added group 3"
   }
 }
-`, template, data.RandomInteger, data.RandomInteger)
+`, r.template(data), data.RandomInteger)
 }
 
-func (r PolicySetDefinitionResource) template(data acceptance.TestData) string {
+func (r PolicySetDefinitionResourceTest) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
 resource "azurerm_policy_definition" "test" {
-  name         = "acctestpol-%d"
+  name         = "acctestpol-%[1]d"
   policy_type  = "Custom"
   mode         = "All"
-  display_name = "acctestpol-%d"
+  display_name = "acctestpol-%[1]d"
 
   policy_rule = <<POLICY_RULE
-	{
+    {
     "if": {
       "not": {
         "field": "location",
@@ -890,23 +883,23 @@ POLICY_RULE
   }
 PARAMETERS
 }
-`, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger)
 }
 
-func (r PolicySetDefinitionResource) templateNoParameter(data acceptance.TestData) string {
+func (r PolicySetDefinitionResourceTest) templateNoParameter(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
 resource "azurerm_policy_definition" "test" {
-  name         = "acctestpol-%d"
+  name         = "acctestpol-%[1]d"
   policy_type  = "Custom"
   mode         = "All"
-  display_name = "acctestpol-%d"
+  display_name = "acctestpol-%[1]d"
 
   policy_rule = <<POLICY_RULE
-	{
+    {
     "if": {
       "not": {
         "field": "location",
@@ -919,27 +912,46 @@ resource "azurerm_policy_definition" "test" {
   }
 POLICY_RULE
 }
-`, data.RandomInteger, data.RandomInteger, data.Locations.Primary)
+`, data.RandomInteger, data.Locations.Primary)
 }
 
-func (r PolicySetDefinitionResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
-	id, err := parse.PolicySetDefinitionID(state.ID)
+func (r PolicySetDefinitionResourceTest) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	if !features.FivePointOh() {
+		subscriptionId := client.Account.SubscriptionId
+
+		resourceId, err := parse.PolicySetDefinitionID(state.ID)
+		if err != nil {
+			return nil, err
+		}
+
+		if scopeId, ok := resourceId.PolicyScopeId.(parse.ScopeAtManagementGroup); ok {
+			id := policysetdefinitions.NewProviders2PolicySetDefinitionID(scopeId.ManagementGroupName, resourceId.Name)
+			resp, err := client.Policy.PolicySetDefinitionsClient.GetAtManagementGroup(ctx, id, policysetdefinitions.DefaultGetAtManagementGroupOperationOptions())
+			if err != nil {
+				return nil, fmt.Errorf("retrieving %s: %+v", id, err)
+			}
+
+			return pointer.To(resp.Model != nil), nil
+		}
+
+		id := policysetdefinitions.NewProviderPolicySetDefinitionID(subscriptionId, resourceId.Name)
+		resp, err := client.Policy.PolicySetDefinitionsClient.Get(ctx, id, policysetdefinitions.DefaultGetOperationOptions())
+		if err != nil {
+			return nil, fmt.Errorf("retrieving %s: %+v", id, err)
+		}
+
+		return pointer.To(resp.Model != nil), nil
+	}
+
+	id, err := policysetdefinitions.ParseProviderPolicySetDefinitionID(state.ID)
 	if err != nil {
 		return nil, err
 	}
 
-	var resp policy.SetDefinition
-	if mgmtGroupID, ok := id.PolicyScopeId.(parse.ScopeAtManagementGroup); ok {
-		resp, err = client.Policy.SetDefinitionsClient.GetAtManagementGroup(ctx, id.Name, mgmtGroupID.ManagementGroupName)
-	} else {
-		resp, err = client.Policy.SetDefinitionsClient.Get(ctx, id.Name)
-	}
+	resp, err := client.Policy.PolicySetDefinitionsClient.Get(ctx, *id, policysetdefinitions.DefaultGetOperationOptions())
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
-		}
-		return nil, fmt.Errorf("retrieving Policy Set Definition %q: %+v", id.Name, err)
+		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(resp.Model != nil), nil
 }

--- a/internal/services/policy/registration.go
+++ b/internal/services/policy/registration.go
@@ -4,6 +4,7 @@
 package policy
 
 import (
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
@@ -26,12 +27,19 @@ func (r Registration) DataSources() []sdk.DataSource {
 }
 
 func (r Registration) Resources() []sdk.Resource {
-	return []sdk.Resource{
+	resources := []sdk.Resource{
 		ManagementGroupAssignmentResource{},
+		ManagementGroupPolicySetDefinitionResource{},
 		ResourceAssignmentResource{},
 		ResourceGroupAssignmentResource{},
 		SubscriptionAssignmentResource{},
 	}
+
+	if features.FivePointOh() {
+		resources = append(resources, PolicySetDefinitionResource{})
+	}
+
+	return resources
 }
 
 // Name is the name of this Service
@@ -58,9 +66,8 @@ func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 
 // SupportedResources returns the supported Resources supported by this Service
 func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
-	return map[string]*pluginsdk.Resource{
+	resources := map[string]*pluginsdk.Resource{
 		"azurerm_policy_definition":                               resourceArmPolicyDefinition(),
-		"azurerm_policy_set_definition":                           resourceArmPolicySetDefinition(),
 		"azurerm_management_group_policy_remediation":             resourceArmManagementGroupPolicyRemediation(),
 		"azurerm_resource_policy_remediation":                     resourceArmResourcePolicyRemediation(),
 		"azurerm_management_group_policy_exemption":               resourceArmManagementGroupPolicyExemption(),
@@ -71,4 +78,11 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 		"azurerm_subscription_policy_remediation":                 resourceArmSubscriptionPolicyRemediation(),
 		"azurerm_policy_virtual_machine_configuration_assignment": resourcePolicyVirtualMachineConfigurationAssignment(),
 	}
+
+	if !features.FivePointOh() {
+		// When this is removed post 5.0, the untyped resource functions for `azurerm_policy_set_definition` should also be cleaned up
+		resources["azurerm_policy_set_definition"] = resourceArmPolicySetDefinition()
+	}
+
+	return resources
 }

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2025-01-01/policysetdefinitions/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2025-01-01/policysetdefinitions/README.md
@@ -1,0 +1,194 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/resources/2025-01-01/policysetdefinitions` Documentation
+
+The `policysetdefinitions` SDK allows for interaction with Azure Resource Manager `resources` (API Version `2025-01-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+import "github.com/hashicorp/go-azure-sdk/resource-manager/resources/2025-01-01/policysetdefinitions"
+```
+
+
+### Client Initialization
+
+```go
+client := policysetdefinitions.NewPolicySetDefinitionsClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `PolicySetDefinitionsClient.CreateOrUpdate`
+
+```go
+ctx := context.TODO()
+id := policysetdefinitions.NewProviderPolicySetDefinitionID("12345678-1234-9876-4563-123456789012", "policySetDefinitionName")
+
+payload := policysetdefinitions.PolicySetDefinition{
+	// ...
+}
+
+
+read, err := client.CreateOrUpdate(ctx, id, payload)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `PolicySetDefinitionsClient.CreateOrUpdateAtManagementGroup`
+
+```go
+ctx := context.TODO()
+id := policysetdefinitions.NewProviders2PolicySetDefinitionID("managementGroupName", "policySetDefinitionName")
+
+payload := policysetdefinitions.PolicySetDefinition{
+	// ...
+}
+
+
+read, err := client.CreateOrUpdateAtManagementGroup(ctx, id, payload)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `PolicySetDefinitionsClient.Delete`
+
+```go
+ctx := context.TODO()
+id := policysetdefinitions.NewProviderPolicySetDefinitionID("12345678-1234-9876-4563-123456789012", "policySetDefinitionName")
+
+read, err := client.Delete(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `PolicySetDefinitionsClient.DeleteAtManagementGroup`
+
+```go
+ctx := context.TODO()
+id := policysetdefinitions.NewProviders2PolicySetDefinitionID("managementGroupName", "policySetDefinitionName")
+
+read, err := client.DeleteAtManagementGroup(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `PolicySetDefinitionsClient.Get`
+
+```go
+ctx := context.TODO()
+id := policysetdefinitions.NewProviderPolicySetDefinitionID("12345678-1234-9876-4563-123456789012", "policySetDefinitionName")
+
+read, err := client.Get(ctx, id, policysetdefinitions.DefaultGetOperationOptions())
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `PolicySetDefinitionsClient.GetAtManagementGroup`
+
+```go
+ctx := context.TODO()
+id := policysetdefinitions.NewProviders2PolicySetDefinitionID("managementGroupName", "policySetDefinitionName")
+
+read, err := client.GetAtManagementGroup(ctx, id, policysetdefinitions.DefaultGetAtManagementGroupOperationOptions())
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `PolicySetDefinitionsClient.GetBuiltIn`
+
+```go
+ctx := context.TODO()
+id := policysetdefinitions.NewPolicySetDefinitionID("policySetDefinitionName")
+
+read, err := client.GetBuiltIn(ctx, id, policysetdefinitions.DefaultGetBuiltInOperationOptions())
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `PolicySetDefinitionsClient.List`
+
+```go
+ctx := context.TODO()
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+
+// alternatively `client.List(ctx, id, policysetdefinitions.DefaultListOperationOptions())` can be used to do batched pagination
+items, err := client.ListComplete(ctx, id, policysetdefinitions.DefaultListOperationOptions())
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `PolicySetDefinitionsClient.ListBuiltIn`
+
+```go
+ctx := context.TODO()
+
+
+// alternatively `client.ListBuiltIn(ctx, policysetdefinitions.DefaultListBuiltInOperationOptions())` can be used to do batched pagination
+items, err := client.ListBuiltInComplete(ctx, policysetdefinitions.DefaultListBuiltInOperationOptions())
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `PolicySetDefinitionsClient.ListByManagementGroup`
+
+```go
+ctx := context.TODO()
+id := commonids.NewManagementGroupID("groupId")
+
+// alternatively `client.ListByManagementGroup(ctx, id, policysetdefinitions.DefaultListByManagementGroupOperationOptions())` can be used to do batched pagination
+items, err := client.ListByManagementGroupComplete(ctx, id, policysetdefinitions.DefaultListByManagementGroupOperationOptions())
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2025-01-01/policysetdefinitions/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2025-01-01/policysetdefinitions/client.go
@@ -1,0 +1,26 @@
+package policysetdefinitions
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PolicySetDefinitionsClient struct {
+	Client *resourcemanager.Client
+}
+
+func NewPolicySetDefinitionsClientWithBaseURI(sdkApi sdkEnv.Api) (*PolicySetDefinitionsClient, error) {
+	client, err := resourcemanager.NewClient(sdkApi, "policysetdefinitions", defaultApiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating PolicySetDefinitionsClient: %+v", err)
+	}
+
+	return &PolicySetDefinitionsClient{
+		Client: client,
+	}, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2025-01-01/policysetdefinitions/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2025-01-01/policysetdefinitions/constants.go
@@ -1,0 +1,113 @@
+package policysetdefinitions
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ParameterType string
+
+const (
+	ParameterTypeArray    ParameterType = "Array"
+	ParameterTypeBoolean  ParameterType = "Boolean"
+	ParameterTypeDateTime ParameterType = "DateTime"
+	ParameterTypeFloat    ParameterType = "Float"
+	ParameterTypeInteger  ParameterType = "Integer"
+	ParameterTypeObject   ParameterType = "Object"
+	ParameterTypeString   ParameterType = "String"
+)
+
+func PossibleValuesForParameterType() []string {
+	return []string{
+		string(ParameterTypeArray),
+		string(ParameterTypeBoolean),
+		string(ParameterTypeDateTime),
+		string(ParameterTypeFloat),
+		string(ParameterTypeInteger),
+		string(ParameterTypeObject),
+		string(ParameterTypeString),
+	}
+}
+
+func (s *ParameterType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseParameterType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseParameterType(input string) (*ParameterType, error) {
+	vals := map[string]ParameterType{
+		"array":    ParameterTypeArray,
+		"boolean":  ParameterTypeBoolean,
+		"datetime": ParameterTypeDateTime,
+		"float":    ParameterTypeFloat,
+		"integer":  ParameterTypeInteger,
+		"object":   ParameterTypeObject,
+		"string":   ParameterTypeString,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ParameterType(input)
+	return &out, nil
+}
+
+type PolicyType string
+
+const (
+	PolicyTypeBuiltIn      PolicyType = "BuiltIn"
+	PolicyTypeCustom       PolicyType = "Custom"
+	PolicyTypeNotSpecified PolicyType = "NotSpecified"
+	PolicyTypeStatic       PolicyType = "Static"
+)
+
+func PossibleValuesForPolicyType() []string {
+	return []string{
+		string(PolicyTypeBuiltIn),
+		string(PolicyTypeCustom),
+		string(PolicyTypeNotSpecified),
+		string(PolicyTypeStatic),
+	}
+}
+
+func (s *PolicyType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parsePolicyType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parsePolicyType(input string) (*PolicyType, error) {
+	vals := map[string]PolicyType{
+		"builtin":      PolicyTypeBuiltIn,
+		"custom":       PolicyTypeCustom,
+		"notspecified": PolicyTypeNotSpecified,
+		"static":       PolicyTypeStatic,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := PolicyType(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2025-01-01/policysetdefinitions/id_policysetdefinition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2025-01-01/policysetdefinitions/id_policysetdefinition.go
@@ -1,0 +1,112 @@
+package policysetdefinitions
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&PolicySetDefinitionId{})
+}
+
+var _ resourceids.ResourceId = &PolicySetDefinitionId{}
+
+// PolicySetDefinitionId is a struct representing the Resource ID for a Policy Set Definition
+type PolicySetDefinitionId struct {
+	PolicySetDefinitionName string
+}
+
+// NewPolicySetDefinitionID returns a new PolicySetDefinitionId struct
+func NewPolicySetDefinitionID(policySetDefinitionName string) PolicySetDefinitionId {
+	return PolicySetDefinitionId{
+		PolicySetDefinitionName: policySetDefinitionName,
+	}
+}
+
+// ParsePolicySetDefinitionID parses 'input' into a PolicySetDefinitionId
+func ParsePolicySetDefinitionID(input string) (*PolicySetDefinitionId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&PolicySetDefinitionId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := PolicySetDefinitionId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParsePolicySetDefinitionIDInsensitively parses 'input' case-insensitively into a PolicySetDefinitionId
+// note: this method should only be used for API response data and not user input
+func ParsePolicySetDefinitionIDInsensitively(input string) (*PolicySetDefinitionId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&PolicySetDefinitionId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := PolicySetDefinitionId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *PolicySetDefinitionId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.PolicySetDefinitionName, ok = input.Parsed["policySetDefinitionName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "policySetDefinitionName", input)
+	}
+
+	return nil
+}
+
+// ValidatePolicySetDefinitionID checks that 'input' can be parsed as a Policy Set Definition ID
+func ValidatePolicySetDefinitionID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParsePolicySetDefinitionID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Policy Set Definition ID
+func (id PolicySetDefinitionId) ID() string {
+	fmtString := "/providers/Microsoft.Authorization/policySetDefinitions/%s"
+	return fmt.Sprintf(fmtString, id.PolicySetDefinitionName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Policy Set Definition ID
+func (id PolicySetDefinitionId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftAuthorization", "Microsoft.Authorization", "Microsoft.Authorization"),
+		resourceids.StaticSegment("staticPolicySetDefinitions", "policySetDefinitions", "policySetDefinitions"),
+		resourceids.UserSpecifiedSegment("policySetDefinitionName", "policySetDefinitionName"),
+	}
+}
+
+// String returns a human-readable description of this Policy Set Definition ID
+func (id PolicySetDefinitionId) String() string {
+	components := []string{
+		fmt.Sprintf("Policy Set Definition Name: %q", id.PolicySetDefinitionName),
+	}
+	return fmt.Sprintf("Policy Set Definition (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2025-01-01/policysetdefinitions/id_providerpolicysetdefinition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2025-01-01/policysetdefinitions/id_providerpolicysetdefinition.go
@@ -1,0 +1,121 @@
+package policysetdefinitions
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&ProviderPolicySetDefinitionId{})
+}
+
+var _ resourceids.ResourceId = &ProviderPolicySetDefinitionId{}
+
+// ProviderPolicySetDefinitionId is a struct representing the Resource ID for a Provider Policy Set Definition
+type ProviderPolicySetDefinitionId struct {
+	SubscriptionId          string
+	PolicySetDefinitionName string
+}
+
+// NewProviderPolicySetDefinitionID returns a new ProviderPolicySetDefinitionId struct
+func NewProviderPolicySetDefinitionID(subscriptionId string, policySetDefinitionName string) ProviderPolicySetDefinitionId {
+	return ProviderPolicySetDefinitionId{
+		SubscriptionId:          subscriptionId,
+		PolicySetDefinitionName: policySetDefinitionName,
+	}
+}
+
+// ParseProviderPolicySetDefinitionID parses 'input' into a ProviderPolicySetDefinitionId
+func ParseProviderPolicySetDefinitionID(input string) (*ProviderPolicySetDefinitionId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&ProviderPolicySetDefinitionId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := ProviderPolicySetDefinitionId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseProviderPolicySetDefinitionIDInsensitively parses 'input' case-insensitively into a ProviderPolicySetDefinitionId
+// note: this method should only be used for API response data and not user input
+func ParseProviderPolicySetDefinitionIDInsensitively(input string) (*ProviderPolicySetDefinitionId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&ProviderPolicySetDefinitionId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := ProviderPolicySetDefinitionId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *ProviderPolicySetDefinitionId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.PolicySetDefinitionName, ok = input.Parsed["policySetDefinitionName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "policySetDefinitionName", input)
+	}
+
+	return nil
+}
+
+// ValidateProviderPolicySetDefinitionID checks that 'input' can be parsed as a Provider Policy Set Definition ID
+func ValidateProviderPolicySetDefinitionID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseProviderPolicySetDefinitionID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Provider Policy Set Definition ID
+func (id ProviderPolicySetDefinitionId) ID() string {
+	fmtString := "/subscriptions/%s/providers/Microsoft.Authorization/policySetDefinitions/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.PolicySetDefinitionName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Provider Policy Set Definition ID
+func (id ProviderPolicySetDefinitionId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftAuthorization", "Microsoft.Authorization", "Microsoft.Authorization"),
+		resourceids.StaticSegment("staticPolicySetDefinitions", "policySetDefinitions", "policySetDefinitions"),
+		resourceids.UserSpecifiedSegment("policySetDefinitionName", "policySetDefinitionName"),
+	}
+}
+
+// String returns a human-readable description of this Provider Policy Set Definition ID
+func (id ProviderPolicySetDefinitionId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Policy Set Definition Name: %q", id.PolicySetDefinitionName),
+	}
+	return fmt.Sprintf("Provider Policy Set Definition (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2025-01-01/policysetdefinitions/id_providers2policysetdefinition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2025-01-01/policysetdefinitions/id_providers2policysetdefinition.go
@@ -1,0 +1,123 @@
+package policysetdefinitions
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&Providers2PolicySetDefinitionId{})
+}
+
+var _ resourceids.ResourceId = &Providers2PolicySetDefinitionId{}
+
+// Providers2PolicySetDefinitionId is a struct representing the Resource ID for a Providers 2 Policy Set Definition
+type Providers2PolicySetDefinitionId struct {
+	ManagementGroupName     string
+	PolicySetDefinitionName string
+}
+
+// NewProviders2PolicySetDefinitionID returns a new Providers2PolicySetDefinitionId struct
+func NewProviders2PolicySetDefinitionID(managementGroupName string, policySetDefinitionName string) Providers2PolicySetDefinitionId {
+	return Providers2PolicySetDefinitionId{
+		ManagementGroupName:     managementGroupName,
+		PolicySetDefinitionName: policySetDefinitionName,
+	}
+}
+
+// ParseProviders2PolicySetDefinitionID parses 'input' into a Providers2PolicySetDefinitionId
+func ParseProviders2PolicySetDefinitionID(input string) (*Providers2PolicySetDefinitionId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&Providers2PolicySetDefinitionId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := Providers2PolicySetDefinitionId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseProviders2PolicySetDefinitionIDInsensitively parses 'input' case-insensitively into a Providers2PolicySetDefinitionId
+// note: this method should only be used for API response data and not user input
+func ParseProviders2PolicySetDefinitionIDInsensitively(input string) (*Providers2PolicySetDefinitionId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&Providers2PolicySetDefinitionId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := Providers2PolicySetDefinitionId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *Providers2PolicySetDefinitionId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.ManagementGroupName, ok = input.Parsed["managementGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "managementGroupName", input)
+	}
+
+	if id.PolicySetDefinitionName, ok = input.Parsed["policySetDefinitionName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "policySetDefinitionName", input)
+	}
+
+	return nil
+}
+
+// ValidateProviders2PolicySetDefinitionID checks that 'input' can be parsed as a Providers 2 Policy Set Definition ID
+func ValidateProviders2PolicySetDefinitionID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseProviders2PolicySetDefinitionID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Providers 2 Policy Set Definition ID
+func (id Providers2PolicySetDefinitionId) ID() string {
+	fmtString := "/providers/Microsoft.Management/managementGroups/%s/providers/Microsoft.Authorization/policySetDefinitions/%s"
+	return fmt.Sprintf(fmtString, id.ManagementGroupName, id.PolicySetDefinitionName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Providers 2 Policy Set Definition ID
+func (id Providers2PolicySetDefinitionId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftManagement", "Microsoft.Management", "Microsoft.Management"),
+		resourceids.StaticSegment("staticManagementGroups", "managementGroups", "managementGroups"),
+		resourceids.UserSpecifiedSegment("managementGroupName", "managementGroupName"),
+		resourceids.StaticSegment("staticProviders2", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftAuthorization", "Microsoft.Authorization", "Microsoft.Authorization"),
+		resourceids.StaticSegment("staticPolicySetDefinitions", "policySetDefinitions", "policySetDefinitions"),
+		resourceids.UserSpecifiedSegment("policySetDefinitionName", "policySetDefinitionName"),
+	}
+}
+
+// String returns a human-readable description of this Providers 2 Policy Set Definition ID
+func (id Providers2PolicySetDefinitionId) String() string {
+	components := []string{
+		fmt.Sprintf("Management Group Name: %q", id.ManagementGroupName),
+		fmt.Sprintf("Policy Set Definition Name: %q", id.PolicySetDefinitionName),
+	}
+	return fmt.Sprintf("Providers 2 Policy Set Definition (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2025-01-01/policysetdefinitions/method_createorupdate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2025-01-01/policysetdefinitions/method_createorupdate.go
@@ -1,0 +1,58 @@
+package policysetdefinitions
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateOrUpdateOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *PolicySetDefinition
+}
+
+// CreateOrUpdate ...
+func (c PolicySetDefinitionsClient) CreateOrUpdate(ctx context.Context, id ProviderPolicySetDefinitionId, input PolicySetDefinition) (result CreateOrUpdateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPut,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model PolicySetDefinition
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2025-01-01/policysetdefinitions/method_createorupdateatmanagementgroup.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2025-01-01/policysetdefinitions/method_createorupdateatmanagementgroup.go
@@ -1,0 +1,58 @@
+package policysetdefinitions
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateOrUpdateAtManagementGroupOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *PolicySetDefinition
+}
+
+// CreateOrUpdateAtManagementGroup ...
+func (c PolicySetDefinitionsClient) CreateOrUpdateAtManagementGroup(ctx context.Context, id Providers2PolicySetDefinitionId, input PolicySetDefinition) (result CreateOrUpdateAtManagementGroupOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPut,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model PolicySetDefinition
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2025-01-01/policysetdefinitions/method_delete.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2025-01-01/policysetdefinitions/method_delete.go
@@ -1,0 +1,47 @@
+package policysetdefinitions
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeleteOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// Delete ...
+func (c PolicySetDefinitionsClient) Delete(ctx context.Context, id ProviderPolicySetDefinitionId) (result DeleteOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusNoContent,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodDelete,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2025-01-01/policysetdefinitions/method_deleteatmanagementgroup.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2025-01-01/policysetdefinitions/method_deleteatmanagementgroup.go
@@ -1,0 +1,47 @@
+package policysetdefinitions
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeleteAtManagementGroupOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// DeleteAtManagementGroup ...
+func (c PolicySetDefinitionsClient) DeleteAtManagementGroup(ctx context.Context, id Providers2PolicySetDefinitionId) (result DeleteAtManagementGroupOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusNoContent,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodDelete,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2025-01-01/policysetdefinitions/method_get.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2025-01-01/policysetdefinitions/method_get.go
@@ -1,0 +1,83 @@
+package policysetdefinitions
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *PolicySetDefinition
+}
+
+type GetOperationOptions struct {
+	Expand *string
+}
+
+func DefaultGetOperationOptions() GetOperationOptions {
+	return GetOperationOptions{}
+}
+
+func (o GetOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+
+	return &out
+}
+
+func (o GetOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+
+	return &out
+}
+
+func (o GetOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+	if o.Expand != nil {
+		out.Append("$expand", fmt.Sprintf("%v", *o.Expand))
+	}
+	return &out
+}
+
+// Get ...
+func (c PolicySetDefinitionsClient) Get(ctx context.Context, id ProviderPolicySetDefinitionId, options GetOperationOptions) (result GetOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodGet,
+		OptionsObject: options,
+		Path:          id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model PolicySetDefinition
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2025-01-01/policysetdefinitions/method_getatmanagementgroup.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2025-01-01/policysetdefinitions/method_getatmanagementgroup.go
@@ -1,0 +1,83 @@
+package policysetdefinitions
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetAtManagementGroupOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *PolicySetDefinition
+}
+
+type GetAtManagementGroupOperationOptions struct {
+	Expand *string
+}
+
+func DefaultGetAtManagementGroupOperationOptions() GetAtManagementGroupOperationOptions {
+	return GetAtManagementGroupOperationOptions{}
+}
+
+func (o GetAtManagementGroupOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+
+	return &out
+}
+
+func (o GetAtManagementGroupOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+
+	return &out
+}
+
+func (o GetAtManagementGroupOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+	if o.Expand != nil {
+		out.Append("$expand", fmt.Sprintf("%v", *o.Expand))
+	}
+	return &out
+}
+
+// GetAtManagementGroup ...
+func (c PolicySetDefinitionsClient) GetAtManagementGroup(ctx context.Context, id Providers2PolicySetDefinitionId, options GetAtManagementGroupOperationOptions) (result GetAtManagementGroupOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodGet,
+		OptionsObject: options,
+		Path:          id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model PolicySetDefinition
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2025-01-01/policysetdefinitions/method_getbuiltin.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2025-01-01/policysetdefinitions/method_getbuiltin.go
@@ -1,0 +1,83 @@
+package policysetdefinitions
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetBuiltInOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *PolicySetDefinition
+}
+
+type GetBuiltInOperationOptions struct {
+	Expand *string
+}
+
+func DefaultGetBuiltInOperationOptions() GetBuiltInOperationOptions {
+	return GetBuiltInOperationOptions{}
+}
+
+func (o GetBuiltInOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+
+	return &out
+}
+
+func (o GetBuiltInOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+
+	return &out
+}
+
+func (o GetBuiltInOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+	if o.Expand != nil {
+		out.Append("$expand", fmt.Sprintf("%v", *o.Expand))
+	}
+	return &out
+}
+
+// GetBuiltIn ...
+func (c PolicySetDefinitionsClient) GetBuiltIn(ctx context.Context, id PolicySetDefinitionId, options GetBuiltInOperationOptions) (result GetBuiltInOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodGet,
+		OptionsObject: options,
+		Path:          id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model PolicySetDefinition
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2025-01-01/policysetdefinitions/method_list.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2025-01-01/policysetdefinitions/method_list.go
@@ -1,0 +1,143 @@
+package policysetdefinitions
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]PolicySetDefinition
+}
+
+type ListCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []PolicySetDefinition
+}
+
+type ListOperationOptions struct {
+	Expand *string
+	Filter *string
+	Top    *int64
+}
+
+func DefaultListOperationOptions() ListOperationOptions {
+	return ListOperationOptions{}
+}
+
+func (o ListOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+
+	return &out
+}
+
+func (o ListOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+
+	return &out
+}
+
+func (o ListOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+	if o.Expand != nil {
+		out.Append("$expand", fmt.Sprintf("%v", *o.Expand))
+	}
+	if o.Filter != nil {
+		out.Append("$filter", fmt.Sprintf("%v", *o.Filter))
+	}
+	if o.Top != nil {
+		out.Append("$top", fmt.Sprintf("%v", *o.Top))
+	}
+	return &out
+}
+
+type ListCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *ListCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// List ...
+func (c PolicySetDefinitionsClient) List(ctx context.Context, id commonids.SubscriptionId, options ListOperationOptions) (result ListOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodGet,
+		OptionsObject: options,
+		Pager:         &ListCustomPager{},
+		Path:          fmt.Sprintf("%s/providers/Microsoft.Authorization/policySetDefinitions", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]PolicySetDefinition `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListComplete retrieves all the results into a single object
+func (c PolicySetDefinitionsClient) ListComplete(ctx context.Context, id commonids.SubscriptionId, options ListOperationOptions) (ListCompleteResult, error) {
+	return c.ListCompleteMatchingPredicate(ctx, id, options, PolicySetDefinitionOperationPredicate{})
+}
+
+// ListCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c PolicySetDefinitionsClient) ListCompleteMatchingPredicate(ctx context.Context, id commonids.SubscriptionId, options ListOperationOptions, predicate PolicySetDefinitionOperationPredicate) (result ListCompleteResult, err error) {
+	items := make([]PolicySetDefinition, 0)
+
+	resp, err := c.List(ctx, id, options)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2025-01-01/policysetdefinitions/method_listbuiltin.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2025-01-01/policysetdefinitions/method_listbuiltin.go
@@ -1,0 +1,142 @@
+package policysetdefinitions
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListBuiltInOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]PolicySetDefinition
+}
+
+type ListBuiltInCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []PolicySetDefinition
+}
+
+type ListBuiltInOperationOptions struct {
+	Expand *string
+	Filter *string
+	Top    *int64
+}
+
+func DefaultListBuiltInOperationOptions() ListBuiltInOperationOptions {
+	return ListBuiltInOperationOptions{}
+}
+
+func (o ListBuiltInOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+
+	return &out
+}
+
+func (o ListBuiltInOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+
+	return &out
+}
+
+func (o ListBuiltInOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+	if o.Expand != nil {
+		out.Append("$expand", fmt.Sprintf("%v", *o.Expand))
+	}
+	if o.Filter != nil {
+		out.Append("$filter", fmt.Sprintf("%v", *o.Filter))
+	}
+	if o.Top != nil {
+		out.Append("$top", fmt.Sprintf("%v", *o.Top))
+	}
+	return &out
+}
+
+type ListBuiltInCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *ListBuiltInCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// ListBuiltIn ...
+func (c PolicySetDefinitionsClient) ListBuiltIn(ctx context.Context, options ListBuiltInOperationOptions) (result ListBuiltInOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodGet,
+		OptionsObject: options,
+		Pager:         &ListBuiltInCustomPager{},
+		Path:          "/providers/Microsoft.Authorization/policySetDefinitions",
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]PolicySetDefinition `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListBuiltInComplete retrieves all the results into a single object
+func (c PolicySetDefinitionsClient) ListBuiltInComplete(ctx context.Context, options ListBuiltInOperationOptions) (ListBuiltInCompleteResult, error) {
+	return c.ListBuiltInCompleteMatchingPredicate(ctx, options, PolicySetDefinitionOperationPredicate{})
+}
+
+// ListBuiltInCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c PolicySetDefinitionsClient) ListBuiltInCompleteMatchingPredicate(ctx context.Context, options ListBuiltInOperationOptions, predicate PolicySetDefinitionOperationPredicate) (result ListBuiltInCompleteResult, err error) {
+	items := make([]PolicySetDefinition, 0)
+
+	resp, err := c.ListBuiltIn(ctx, options)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListBuiltInCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2025-01-01/policysetdefinitions/method_listbymanagementgroup.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2025-01-01/policysetdefinitions/method_listbymanagementgroup.go
@@ -1,0 +1,143 @@
+package policysetdefinitions
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListByManagementGroupOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]PolicySetDefinition
+}
+
+type ListByManagementGroupCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []PolicySetDefinition
+}
+
+type ListByManagementGroupOperationOptions struct {
+	Expand *string
+	Filter *string
+	Top    *int64
+}
+
+func DefaultListByManagementGroupOperationOptions() ListByManagementGroupOperationOptions {
+	return ListByManagementGroupOperationOptions{}
+}
+
+func (o ListByManagementGroupOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+
+	return &out
+}
+
+func (o ListByManagementGroupOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+
+	return &out
+}
+
+func (o ListByManagementGroupOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+	if o.Expand != nil {
+		out.Append("$expand", fmt.Sprintf("%v", *o.Expand))
+	}
+	if o.Filter != nil {
+		out.Append("$filter", fmt.Sprintf("%v", *o.Filter))
+	}
+	if o.Top != nil {
+		out.Append("$top", fmt.Sprintf("%v", *o.Top))
+	}
+	return &out
+}
+
+type ListByManagementGroupCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *ListByManagementGroupCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// ListByManagementGroup ...
+func (c PolicySetDefinitionsClient) ListByManagementGroup(ctx context.Context, id commonids.ManagementGroupId, options ListByManagementGroupOperationOptions) (result ListByManagementGroupOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodGet,
+		OptionsObject: options,
+		Pager:         &ListByManagementGroupCustomPager{},
+		Path:          fmt.Sprintf("%s/providers/Microsoft.Authorization/policySetDefinitions", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]PolicySetDefinition `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListByManagementGroupComplete retrieves all the results into a single object
+func (c PolicySetDefinitionsClient) ListByManagementGroupComplete(ctx context.Context, id commonids.ManagementGroupId, options ListByManagementGroupOperationOptions) (ListByManagementGroupCompleteResult, error) {
+	return c.ListByManagementGroupCompleteMatchingPredicate(ctx, id, options, PolicySetDefinitionOperationPredicate{})
+}
+
+// ListByManagementGroupCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c PolicySetDefinitionsClient) ListByManagementGroupCompleteMatchingPredicate(ctx context.Context, id commonids.ManagementGroupId, options ListByManagementGroupOperationOptions, predicate PolicySetDefinitionOperationPredicate) (result ListByManagementGroupCompleteResult, err error) {
+	items := make([]PolicySetDefinition, 0)
+
+	resp, err := c.ListByManagementGroup(ctx, id, options)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListByManagementGroupCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2025-01-01/policysetdefinitions/model_parameterdefinitionsvalue.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2025-01-01/policysetdefinitions/model_parameterdefinitionsvalue.go
@@ -1,0 +1,12 @@
+package policysetdefinitions
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ParameterDefinitionsValue struct {
+	AllowedValues *[]interface{}                     `json:"allowedValues,omitempty"`
+	DefaultValue  *interface{}                       `json:"defaultValue,omitempty"`
+	Metadata      *ParameterDefinitionsValueMetadata `json:"metadata,omitempty"`
+	Schema        *interface{}                       `json:"schema,omitempty"`
+	Type          *ParameterType                     `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2025-01-01/policysetdefinitions/model_parameterdefinitionsvaluemetadata.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2025-01-01/policysetdefinitions/model_parameterdefinitionsvaluemetadata.go
@@ -1,0 +1,11 @@
+package policysetdefinitions
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ParameterDefinitionsValueMetadata struct {
+	AssignPermissions *bool   `json:"assignPermissions,omitempty"`
+	Description       *string `json:"description,omitempty"`
+	DisplayName       *string `json:"displayName,omitempty"`
+	StrongType        *string `json:"strongType,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2025-01-01/policysetdefinitions/model_parametervaluesvalue.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2025-01-01/policysetdefinitions/model_parametervaluesvalue.go
@@ -1,0 +1,8 @@
+package policysetdefinitions
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ParameterValuesValue struct {
+	Value *interface{} `json:"value,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2025-01-01/policysetdefinitions/model_policydefinitiongroup.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2025-01-01/policysetdefinitions/model_policydefinitiongroup.go
@@ -1,0 +1,12 @@
+package policysetdefinitions
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PolicyDefinitionGroup struct {
+	AdditionalMetadataId *string `json:"additionalMetadataId,omitempty"`
+	Category             *string `json:"category,omitempty"`
+	Description          *string `json:"description,omitempty"`
+	DisplayName          *string `json:"displayName,omitempty"`
+	Name                 string  `json:"name"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2025-01-01/policysetdefinitions/model_policydefinitionreference.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2025-01-01/policysetdefinitions/model_policydefinitionreference.go
@@ -1,0 +1,14 @@
+package policysetdefinitions
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PolicyDefinitionReference struct {
+	DefinitionVersion           *string                          `json:"definitionVersion,omitempty"`
+	EffectiveDefinitionVersion  *string                          `json:"effectiveDefinitionVersion,omitempty"`
+	GroupNames                  *[]string                        `json:"groupNames,omitempty"`
+	LatestDefinitionVersion     *string                          `json:"latestDefinitionVersion,omitempty"`
+	Parameters                  *map[string]ParameterValuesValue `json:"parameters,omitempty"`
+	PolicyDefinitionId          string                           `json:"policyDefinitionId"`
+	PolicyDefinitionReferenceId *string                          `json:"policyDefinitionReferenceId,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2025-01-01/policysetdefinitions/model_policysetdefinition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2025-01-01/policysetdefinitions/model_policysetdefinition.go
@@ -1,0 +1,16 @@
+package policysetdefinitions
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/systemdata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PolicySetDefinition struct {
+	Id         *string                        `json:"id,omitempty"`
+	Name       *string                        `json:"name,omitempty"`
+	Properties *PolicySetDefinitionProperties `json:"properties,omitempty"`
+	SystemData *systemdata.SystemData         `json:"systemData,omitempty"`
+	Type       *string                        `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2025-01-01/policysetdefinitions/model_policysetdefinitionproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2025-01-01/policysetdefinitions/model_policysetdefinitionproperties.go
@@ -1,0 +1,16 @@
+package policysetdefinitions
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PolicySetDefinitionProperties struct {
+	Description            *string                               `json:"description,omitempty"`
+	DisplayName            *string                               `json:"displayName,omitempty"`
+	Metadata               *interface{}                          `json:"metadata,omitempty"`
+	Parameters             *map[string]ParameterDefinitionsValue `json:"parameters,omitempty"`
+	PolicyDefinitionGroups *[]PolicyDefinitionGroup              `json:"policyDefinitionGroups,omitempty"`
+	PolicyDefinitions      []PolicyDefinitionReference           `json:"policyDefinitions"`
+	PolicyType             *PolicyType                           `json:"policyType,omitempty"`
+	Version                *string                               `json:"version,omitempty"`
+	Versions               *[]string                             `json:"versions,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2025-01-01/policysetdefinitions/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2025-01-01/policysetdefinitions/predicates.go
@@ -1,0 +1,27 @@
+package policysetdefinitions
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PolicySetDefinitionOperationPredicate struct {
+	Id   *string
+	Name *string
+	Type *string
+}
+
+func (p PolicySetDefinitionOperationPredicate) Matches(input PolicySetDefinition) bool {
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2025-01-01/policysetdefinitions/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2025-01-01/policysetdefinitions/version.go
@@ -1,0 +1,10 @@
+package policysetdefinitions
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2025-01-01"
+
+func userAgent() string {
+	return "hashicorp/go-azure-sdk/policysetdefinitions/2025-01-01"
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1008,6 +1008,7 @@ github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/deployme
 github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/resourcegroups
 github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/resources
 github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/tags
+github.com/hashicorp/go-azure-sdk/resource-manager/resources/2025-01-01/policysetdefinitions
 github.com/hashicorp/go-azure-sdk/resource-manager/search/2024-06-01-preview/adminkeys
 github.com/hashicorp/go-azure-sdk/resource-manager/search/2024-06-01-preview/querykeys
 github.com/hashicorp/go-azure-sdk/resource-manager/search/2024-06-01-preview/services

--- a/website/docs/5.0-upgrade-guide.html.markdown
+++ b/website/docs/5.0-upgrade-guide.html.markdown
@@ -285,6 +285,10 @@ Please follow the format in the example below for listing breaking changes in re
 
 * The `plan_id` property now defaults to `panw-cngfw-payg`.
 
+### `azurerm_policy_set_definition`
+
+* The `management_group_id` property has been removed in favour of the `azurerm_management_group_policy_set_definition` resource.
+
 ### `azurerm_redis_cache`
 
 * The property `minimum_tls_version` no longer accepts `1.0` or `1.1` as a value.

--- a/website/docs/r/management_group_policy_set_definition.html.markdown
+++ b/website/docs/r/management_group_policy_set_definition.html.markdown
@@ -18,12 +18,12 @@ resource "azurerm_management_group" "example" {
 }
 
 resource "azurerm_management_group_policy_set_definition" "example" {
- name                = "example"
- policy_type         = "Custom"
- display_name        = "Example"
- management_group_id = azurerm_management_group.example.id
+  name                = "example"
+  policy_type         = "Custom"
+  display_name        = "Example"
+  management_group_id = azurerm_management_group.example.id
 
- parameters = <<PARAMETERS
+  parameters = <<PARAMETERS
    {
        "allowedLocations": {
            "type": "Array",
@@ -36,14 +36,14 @@ resource "azurerm_management_group_policy_set_definition" "example" {
    }
 PARAMETERS
 
- policy_definition_reference {
-   policy_definition_id = "/providers/Microsoft.Authorization/policyDefinitions/e765b5de-1225-4ba3-bd56-1ac6695af988"
-   parameter_values     = <<VALUES
+  policy_definition_reference {
+    policy_definition_id = "/providers/Microsoft.Authorization/policyDefinitions/e765b5de-1225-4ba3-bd56-1ac6695af988"
+    parameter_values     = <<VALUES
    {
      "listOfAllowedLocations": {"value": "[parameters('allowedLocations')]"}
    }
 VALUES
- }
+  }
 }
 ```
 

--- a/website/docs/r/management_group_policy_set_definition.html.markdown
+++ b/website/docs/r/management_group_policy_set_definition.html.markdown
@@ -1,54 +1,59 @@
 ---
 subcategory: "Policy"
 layout: "azurerm"
-page_title: "Azure Resource Manager: azurerm_policy_set_definition"
+page_title: "Azure Resource Manager: azurerm_management_group_policy_set_definition"
 description: |-
-  Manages a policy set definition.
+  Manages a Policy Set Definition for a Management Group.
 ---
 
-# azurerm_policy_set_definition
+# azurerm_management_group_policy_set_definition
 
-Manages a Policy Set Definition.
-
--> **Note:** Policy set definitions (also known as policy initiatives) do not take effect until they are assigned to a scope using a Policy Set Assignment.
+Manages a Policy Set Definition for a Management Group.
 
 ## Example Usage
 
 ```hcl
-resource "azurerm_policy_set_definition" "example" {
-  name         = "example"
-  policy_type  = "Custom"
+resource "azurerm_management_group" "example" {
   display_name = "Example"
+}
 
-  parameters = <<PARAMETERS
-    {
-        "allowedLocations": {
-            "type": "Array",
-            "metadata": {
-                "description": "The list of allowed locations for resources.",
-                "displayName": "Allowed locations",
-                "strongType": "location"
-            }
-        }
-    }
+resource "azurerm_management_group_policy_set_definition" "example" {
+ name                = "example"
+ policy_type         = "Custom"
+ display_name        = "Example"
+ management_group_id = azurerm_management_group.example.id
+
+ parameters = <<PARAMETERS
+   {
+       "allowedLocations": {
+           "type": "Array",
+           "metadata": {
+               "description": "The list of allowed locations for resources.",
+               "displayName": "Allowed locations",
+               "strongType": "location"
+           }
+       }
+   }
 PARAMETERS
 
-  policy_definition_reference {
-    policy_definition_id = "/providers/Microsoft.Authorization/policyDefinitions/e765b5de-1225-4ba3-bd56-1ac6695af988"
-    parameter_values     = <<VALUE
-    {
-      "listOfAllowedLocations": {"value": "[parameters('allowedLocations')]"}
-    }
-    VALUE
-  }
+ policy_definition_reference {
+   policy_definition_id = "/providers/Microsoft.Authorization/policyDefinitions/e765b5de-1225-4ba3-bd56-1ac6695af988"
+   parameter_values     = <<VALUES
+   {
+     "listOfAllowedLocations": {"value": "[parameters('allowedLocations')]"}
+   }
+VALUES
+ }
 }
 ```
 
-## Argument Reference
+## Arguments Reference
 
 The following arguments are supported:
 
 * `name` - (Required) The name which should be used for this Policy Set Definition. Changing this forces a new Policy Set Definition to be created.
+ 
+* `management_group_id` - (Required) The ID of the Management Group where this Policy Set Definition should be created. Changing this forces a new Policy Set Definition to be created.
 
 * `display_name` - (Required) The display name of this Policy Set Definition.
 
@@ -68,7 +73,7 @@ The following arguments are supported:
 
 ---
 
-An `policy_definition_group` block supports the following:
+A `policy_definition_group` block supports the following:
 
 * `name` - (Required) The name which should be used for this Policy Definition Group.
 
@@ -94,7 +99,7 @@ A `policy_definition_reference` block supports the following:
 
 ## Attributes Reference
 
-In addition to the Arguments listed above - the following Attributes are exported:
+In addition to the Arguments listed above - the following Attributes are exported: 
 
 * `id` - The ID of the Policy Set Definition.
 
@@ -112,5 +117,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Policy Set Definitions can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_policy_set_definition.example /subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policySetDefinitions/policySetDefinitionName
+terraform import azurerm_management_group_policy_set_definition.example /providers/Microsoft.Management/managementGroups/0000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policySetDefinitions/policySetDefinitionName
 ```


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This PR migrates `azurerm_policy_set_definition` to `go-azure-sdk` and deprecates `management_group_id` in favour of a new resource `azurerm_management_group_policy_set_definition` since there are distinct operations and IDs for a policy set definition defined at a management group level.

The state migration added to `azurerm_policy_set_definition` is out of an abundance of caution, since the previous resource ID was parsed insensitively and users could have an ID with lowercased static segments, this state migration won't apply until 5.0 has been released.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [x] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

4.0 testing:

<img width="322" alt="image" src="https://github.com/user-attachments/assets/9394d439-d7dd-4507-81d6-5945fce261a2" />

5.0 testing:

<img width="338" alt="image" src="https://github.com/user-attachments/assets/f06d6e41-a406-4496-b522-11797b8f2954" />


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [x] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
