### PR TITLE
Add sub_path property to container app job

### DIFF
--- a/internal/services/containerapps/container_app_job_resource_test.go
+++ b/internal/services/containerapps/container_app_job_resource_test.go
@@ -452,7 +452,6 @@ resource "azurerm_container_app_job" "test" {
       volume_mounts {
         path = "/appsettings"
         name = "appsettings-volume"
-        sub_path = "subdirectory"
       }
     }
   }
@@ -1405,7 +1404,6 @@ resource "azurerm_container_app_job" "test" {
       volume_mounts {
         path = "/appsettings"
         name = azurerm_container_app_environment_storage.test.name
-        sub_path = "subdirectory"
       }
     }
 
@@ -1417,7 +1415,6 @@ resource "azurerm_container_app_job" "test" {
       volume_mounts {
         name = azurerm_container_app_environment_storage.test.name
         path = "/appsettings"
-        sub_path = "subdirectory"
       }
     }
   }

--- a/internal/services/containerapps/container_app_job_resource_test.go
+++ b/internal/services/containerapps/container_app_job_resource_test.go
@@ -1217,6 +1217,7 @@ resource "azurerm_container_app_job" "test" {
 func (r ContainerAppJobResource) complete(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 
+
 %[1]s
 
 resource "azurerm_container_app_job" "test" {
@@ -1290,8 +1291,8 @@ resource "azurerm_container_app_job" "test" {
       cpu    = 0.5
       memory = "1Gi"
       volume_mounts {
-        path = "/appsettings"
-        name = azurerm_container_app_environment_storage.test.name
+        path     = "/appsettings"
+        name     = azurerm_container_app_environment_storage.test.name
         sub_path = "subdirectory"
       }
     }
@@ -1302,8 +1303,8 @@ resource "azurerm_container_app_job" "test" {
       cpu    = 0.25
       memory = "0.5Gi"
       volume_mounts {
-        name = azurerm_container_app_environment_storage.test.name
-        path = "/appsettings"
+        name     = azurerm_container_app_environment_storage.test.name
+        path     = "/appsettings"
         sub_path = "subdirectory"
       }
     }

--- a/internal/services/containerapps/container_app_job_resource_test.go
+++ b/internal/services/containerapps/container_app_job_resource_test.go
@@ -452,6 +452,7 @@ resource "azurerm_container_app_job" "test" {
       volume_mounts {
         path = "/appsettings"
         name = "appsettings-volume"
+        sub_path = "subdirectory"
       }
     }
   }
@@ -1292,6 +1293,7 @@ resource "azurerm_container_app_job" "test" {
       volume_mounts {
         path = "/appsettings"
         name = azurerm_container_app_environment_storage.test.name
+        sub_path = "subdirectory"
       }
     }
 
@@ -1303,6 +1305,7 @@ resource "azurerm_container_app_job" "test" {
       volume_mounts {
         name = azurerm_container_app_environment_storage.test.name
         path = "/appsettings"
+        sub_path = "subdirectory"
       }
     }
   }
@@ -1402,6 +1405,7 @@ resource "azurerm_container_app_job" "test" {
       volume_mounts {
         path = "/appsettings"
         name = azurerm_container_app_environment_storage.test.name
+        sub_path = "subdirectory"
       }
     }
 
@@ -1413,6 +1417,7 @@ resource "azurerm_container_app_job" "test" {
       volume_mounts {
         name = azurerm_container_app_environment_storage.test.name
         path = "/appsettings"
+        sub_path = "subdirectory"
       }
     }
   }

--- a/internal/services/containerapps/helpers/container_app_job.go
+++ b/internal/services/containerapps/helpers/container_app_job.go
@@ -535,6 +535,7 @@ func expandContainerJobVolumeMounts(input []ContainerVolumeMount) *[]jobs.Volume
 		volumeMounts = append(volumeMounts, jobs.VolumeMount{
 			MountPath:  pointer.To(v.Path),
 			VolumeName: pointer.To(v.Name),
+			SubPath:    pointer.To(v.SubPath),
 		})
 	}
 
@@ -700,8 +701,9 @@ func flattenContainerJobVolumeMounts(input *[]jobs.VolumeMount) []ContainerVolum
 	result := make([]ContainerVolumeMount, 0)
 	for _, v := range *input {
 		result = append(result, ContainerVolumeMount{
-			Name: pointer.From(v.VolumeName),
-			Path: pointer.From(v.MountPath),
+			Name:    pointer.From(v.VolumeName),
+			Path:    pointer.From(v.MountPath),
+			SubPath: pointer.From(v.SubPath),
 		})
 	}
 

--- a/website/docs/r/container_app_job.html.markdown
+++ b/website/docs/r/container_app_job.html.markdown
@@ -296,6 +296,8 @@ A `volume_mounts` block supports the following:
 
 * `path` - (Required) The path within the container at which the volume should be mounted. Must not contain `:`.
 
+* `sub_path` - (Optional) The sub path of the volume to be mounted in the container.
+
 ---
 
 A `volume` block supports the following:


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Applies changes from https://github.com/hashicorp/terraform-provider-azurerm/pull/27533 for container app jobs.

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/29167

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
