### PR TITLE
`azurerm_log_analytics_linked_storage_account` - rename `workspace_resource_id`

### DIFF
--- a/internal/services/loganalytics/log_analytics_linked_storage_account_resource.go
+++ b/internal/services/loganalytics/log_analytics_linked_storage_account_resource.go
@@ -83,22 +83,20 @@ func resourceLogAnalyticsLinkedStorageAccount() *pluginsdk.Resource {
 
 	if !features.FivePointOh() {
 		resource.Schema["workspace_id"] = &pluginsdk.Schema{
-			Type:          pluginsdk.TypeString,
-			Optional:      true,
-			Computed:      true,
-			ConflictsWith: []string{"workspace_resource_id"},
-			AtLeastOneOf:  []string{"workspace_id", "workspace_resource_id"},
-			ForceNew:      true,
-			ValidateFunc:  linkedstorageaccounts.ValidateWorkspaceID,
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			Computed:     true,
+			ForceNew:     true,
+			ExactlyOneOf: []string{"workspace_id", "workspace_resource_id"},
+			ValidateFunc: linkedstorageaccounts.ValidateWorkspaceID,
 		}
 		resource.Schema["workspace_resource_id"] = &pluginsdk.Schema{
-			Type:          pluginsdk.TypeString,
-			Optional:      true,
-			Computed:      true,
-			ConflictsWith: []string{"workspace_id"},
-			AtLeastOneOf:  []string{"workspace_id", "workspace_resource_id"},
-			ForceNew:      true,
-			ValidateFunc:  linkedstorageaccounts.ValidateWorkspaceID,
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			Computed:     true,
+			ForceNew:     true,
+			ExactlyOneOf: []string{"workspace_id", "workspace_resource_id"},
+			ValidateFunc: linkedstorageaccounts.ValidateWorkspaceID,
 		}
 	}
 

--- a/internal/services/loganalytics/log_analytics_linked_storage_account_resource.go
+++ b/internal/services/loganalytics/log_analytics_linked_storage_account_resource.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/linkedstorageaccounts"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/loganalytics/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -61,8 +62,7 @@ func resourceLogAnalyticsLinkedStorageAccount() *pluginsdk.Resource {
 
 			"resource_group_name": commonschema.ResourceGroupName(),
 
-			// TODO: rename to `workspace_id` in 4.0
-			"workspace_resource_id": {
+			"workspace_id": {
 				Type:         pluginsdk.TypeString,
 				Required:     true,
 				ForceNew:     true,
@@ -81,6 +81,27 @@ func resourceLogAnalyticsLinkedStorageAccount() *pluginsdk.Resource {
 		},
 	}
 
+	if !features.FivePointOh() {
+		resource.Schema["workspace_id"] = &pluginsdk.Schema{
+			Type:          pluginsdk.TypeString,
+			Optional:      true,
+			Computed:      true,
+			ConflictsWith: []string{"workspace_resource_id"},
+			AtLeastOneOf:  []string{"workspace_id", "workspace_resource_id"},
+			ForceNew:      true,
+			ValidateFunc:  linkedstorageaccounts.ValidateWorkspaceID,
+		}
+		resource.Schema["workspace_resource_id"] = &pluginsdk.Schema{
+			Type:          pluginsdk.TypeString,
+			Optional:      true,
+			Computed:      true,
+			ConflictsWith: []string{"workspace_id"},
+			AtLeastOneOf:  []string{"workspace_id", "workspace_resource_id"},
+			ForceNew:      true,
+			ValidateFunc:  linkedstorageaccounts.ValidateWorkspaceID,
+		}
+	}
+
 	return resource
 }
 
@@ -89,7 +110,13 @@ func resourceLogAnalyticsLinkedStorageAccountCreateUpdate(d *pluginsdk.ResourceD
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	workspace, err := linkedstorageaccounts.ParseWorkspaceID(d.Get("workspace_resource_id").(string))
+	workspaceId := d.Get("workspace_id").(string)
+	if !features.FivePointOh() {
+		if v, ok := d.GetOk("workspace_resource_id"); ok {
+			workspaceId = v.(string)
+		}
+	}
+	workspace, err := linkedstorageaccounts.ParseWorkspaceID(workspaceId)
 	if err != nil {
 		return fmt.Errorf("%v", err)
 	}
@@ -141,7 +168,10 @@ func resourceLogAnalyticsLinkedStorageAccountRead(d *pluginsdk.ResourceData, met
 	}
 
 	d.Set("resource_group_name", id.ResourceGroupName)
-	d.Set("workspace_resource_id", linkedstorageaccounts.NewWorkspaceID(id.SubscriptionId, id.ResourceGroupName, id.WorkspaceName).ID())
+	d.Set("workspace_id", linkedstorageaccounts.NewWorkspaceID(id.SubscriptionId, id.ResourceGroupName, id.WorkspaceName).ID())
+	if !features.FivePointOh() {
+		d.Set("workspace_resource_id", linkedstorageaccounts.NewWorkspaceID(id.SubscriptionId, id.ResourceGroupName, id.WorkspaceName).ID())
+	}
 	d.Set("data_source_type", string(id.DataSourceType))
 
 	if model := resp.Model; model != nil {

--- a/website/docs/5.0-upgrade-guide.html.markdown
+++ b/website/docs/5.0-upgrade-guide.html.markdown
@@ -225,6 +225,10 @@ Please follow the format in the example below for listing breaking changes in re
 
 * The `remote_debugging_version` property no longer accepts `VS2017` and `VS2019` as a value.
 
+### `azurerm_log_analytics_linked_storage_account`
+
+* The deprecated `workspace_resource_id` property has been removed and superseded by the `workspace_id` property.
+
 ### `azurerm_logic_app_standard`
 
 * The deprecated `site_config.public_network_access_enabled` property has been removed and superseded by the `public_network_access` property.

--- a/website/docs/r/log_analytics_linked_storage_account.html.markdown
+++ b/website/docs/r/log_analytics_linked_storage_account.html.markdown
@@ -34,10 +34,10 @@ resource "azurerm_log_analytics_workspace" "example" {
 }
 
 resource "azurerm_log_analytics_linked_storage_account" "example" {
-  data_source_type      = "CustomLogs"
-  resource_group_name   = azurerm_resource_group.example.name
-  workspace_resource_id = azurerm_log_analytics_workspace.example.id
-  storage_account_ids   = [azurerm_storage_account.example.id]
+  data_source_type    = "CustomLogs"
+  resource_group_name = azurerm_resource_group.example.name
+  workspace_id        = azurerm_log_analytics_workspace.example.id
+  storage_account_ids = [azurerm_storage_account.example.id]
 }
 ```
 
@@ -49,7 +49,7 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) The name of the Resource Group where the Log Analytics Linked Storage Account should exist. Changing this forces a new Log Analytics Linked Storage Account to be created.
 
-* `workspace_resource_id` - (Required) The resource ID of the Log Analytics Workspace. Changing this forces a new Log Analytics Linked Storage Account to be created.
+* `workspace_id` - (Required) The resource ID of the Log Analytics Workspace. Changing this forces a new Log Analytics Linked Storage Account to be created.
 
 * `storage_account_ids` - (Required) The storage account resource ids to be linked.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Remove outmoded `resource_` from property `workspace_resource_id`

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<img width="1142" alt="image" src="https://github.com/user-attachments/assets/9f5632c2-4259-4e40-9151-0d308cf3ac5d" />

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_log_analytics_linked_storage_account` - rename `workspace_resource_id` [GH-29890]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
