### PR TITLE
Docs: Fix formatting of `azurerm_container_app` resource/datasource docs

### DIFF
--- a/website/docs/d/container_app.html.markdown
+++ b/website/docs/d/container_app.html.markdown
@@ -256,6 +256,7 @@ A `volume_mounts` block supports the following:
 * `path` - The path in the container at which to mount this volume.
 
 * `sub_path` - The sub path of the volume to be mounted in the container.
+
 ---
 
 An `identity` block supports the following:

--- a/website/docs/r/container_app.html.markdown
+++ b/website/docs/r/container_app.html.markdown
@@ -367,6 +367,7 @@ A `volume_mounts` block supports the following:
 * `path` - (Required) The path in the container at which to mount this volume.
 
 * `sub_path` - (Optional) The sub path of the volume to be mounted in the container.
+
 ---
 
 An `identity` block supports the following:


### PR DESCRIPTION
Due to the missing new line before the separator (`---`), the registry is formatting this as a heading:

![image](https://github.com/user-attachments/assets/e381a632-1ee8-42ae-8e94-f30388ce9c90)

