### PR TITLE
azurerm_function_app_flex_consumption: storage settings correction

### DIFF
--- a/internal/services/appservice/function_app_flex_consumption_resource.go
+++ b/internal/services/appservice/function_app_flex_consumption_resource.go
@@ -55,19 +55,20 @@ type FunctionAppFlexConsumptionModel struct {
 	ZipDeployFile                    string                     `tfschema:"zip_deploy_file"`
 	PublishingDeployBasicAuthEnabled bool                       `tfschema:"webdeploy_publish_basic_authentication_enabled"`
 
-	StorageContainerType          string                                         `tfschema:"storage_container_type"`
-	StorageContainerEndpoint      string                                         `tfschema:"storage_container_endpoint"`
-	StorageAuthType               string                                         `tfschema:"storage_authentication_type"`
-	StorageAccessKey              string                                         `tfschema:"storage_access_key"`
-	StorageUserAssignedIdentityID string                                         `tfschema:"storage_user_assigned_identity_id"`
-	RuntimeName                   string                                         `tfschema:"runtime_name"`
-	RuntimeVersion                string                                         `tfschema:"runtime_version"`
-	MaximumInstanceCount          int64                                          `tfschema:"maximum_instance_count"`
-	InstanceMemoryInMB            int64                                          `tfschema:"instance_memory_in_mb"`
-	AlwaysReady                   []FunctionAppAlwaysReady                       `tfschema:"always_ready"`
-	SiteConfig                    []helpers.SiteConfigFunctionAppFlexConsumption `tfschema:"site_config"`
-	Identity                      []identity.ModelSystemAssignedUserAssigned     `tfschema:"identity"`
-	Tags                          map[string]string                              `tfschema:"tags"`
+	StorageContainerType                string                                         `tfschema:"storage_container_type"`
+	StorageContainerEndpoint            string                                         `tfschema:"storage_container_endpoint"`
+	StorageAuthType                     string                                         `tfschema:"storage_authentication_type"`
+	StorageAccessKey                    string                                         `tfschema:"storage_access_key"`
+	StorageUserAssignedIdentityID       string                                         `tfschema:"storage_user_assigned_identity_id"`
+	StorageUserAssignedIdentityClientID string                                         `tfschema:"storage_user_assigned_identity_client_id"`
+	RuntimeName                         string                                         `tfschema:"runtime_name"`
+	RuntimeVersion                      string                                         `tfschema:"runtime_version"`
+	MaximumInstanceCount                int64                                          `tfschema:"maximum_instance_count"`
+	InstanceMemoryInMB                  int64                                          `tfschema:"instance_memory_in_mb"`
+	AlwaysReady                         []FunctionAppAlwaysReady                       `tfschema:"always_ready"`
+	SiteConfig                          []helpers.SiteConfigFunctionAppFlexConsumption `tfschema:"site_config"`
+	Identity                            []identity.ModelSystemAssignedUserAssigned     `tfschema:"identity"`
+	Tags                                map[string]string                              `tfschema:"tags"`
 
 	CustomDomainVerificationId    string   `tfschema:"custom_domain_verification_id"`
 	DefaultHostname               string   `tfschema:"default_hostname"`
@@ -157,6 +158,14 @@ func (r FunctionAppFlexConsumptionResource) Arguments() map[string]*pluginsdk.Sc
 			Type:         pluginsdk.TypeString,
 			Optional:     true,
 			ValidateFunc: commonids.ValidateUserAssignedIdentityID,
+			Description:  "The user assigned Managed Identity ID to access the storage account.",
+		},
+
+		"storage_user_assigned_identity_client_id": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.IsUUID,
+			Description:  "The user assigned Managed Identity client ID to access the storage account",
 		},
 
 		"runtime_name": {
@@ -436,10 +445,10 @@ func (r FunctionAppFlexConsumptionResource) Create() sdk.ResourceFunc {
 			storageAuthType := webapps.AuthenticationType(functionAppFlexConsumption.StorageAuthType)
 			storageConnStringForFCApp := "DEPLOYMENT_STORAGE_CONNECTION_STRING"
 			endpoint := strings.TrimPrefix(functionAppFlexConsumption.StorageContainerEndpoint, "https://")
-			var storageString string
+			var storageConnectionString string
 			if storageNameIndex := strings.Index(endpoint, "."); storageNameIndex != -1 {
 				storageName := endpoint[:storageNameIndex]
-				storageString = fmt.Sprintf(StorageStringFmt, storageName, functionAppFlexConsumption.StorageAccessKey, *storageDomainSuffix)
+				storageConnectionString = fmt.Sprintf(StorageStringFmt, storageName, functionAppFlexConsumption.StorageAccessKey, *storageDomainSuffix)
 			} else {
 				return fmt.Errorf("retrieving storage container endpoint error, the expected format is https://storagename.blob.core.windows.net/containername, the received value is %s", functionAppFlexConsumption.StorageContainerEndpoint)
 			}
@@ -447,6 +456,7 @@ func (r FunctionAppFlexConsumptionResource) Create() sdk.ResourceFunc {
 				Type: &storageAuthType,
 			}
 
+			storageClientID := ""
 			if functionAppFlexConsumption.StorageAuthType == string(webapps.AuthenticationTypeStorageAccountConnectionString) {
 				if functionAppFlexConsumption.StorageAccessKey == "" {
 					return fmt.Errorf("the storage account access key must be specified when using the storage key based access")
@@ -457,7 +467,11 @@ func (r FunctionAppFlexConsumptionResource) Create() sdk.ResourceFunc {
 					if functionAppFlexConsumption.StorageUserAssignedIdentityID == "" {
 						return fmt.Errorf("the user assigned identity id must be specified when using the user assigned identity to access the storage account")
 					}
+					if functionAppFlexConsumption.StorageUserAssignedIdentityClientID == "" {
+						return fmt.Errorf("the user assigned identity client id must be specified when using the user assigned identity to access the storage account")
+					}
 					storageAuth.UserAssignedIdentityResourceId = &functionAppFlexConsumption.StorageUserAssignedIdentityID
+					storageClientID = functionAppFlexConsumption.StorageUserAssignedIdentityClientID
 				}
 			}
 
@@ -486,7 +500,7 @@ func (r FunctionAppFlexConsumptionResource) Create() sdk.ResourceFunc {
 				ScaleAndConcurrency: &scaleAndConcurrencyConfig,
 			}
 
-			siteConfig, err := helpers.ExpandSiteConfigFunctionFlexConsumptionApp(functionAppFlexConsumption.SiteConfig, nil, metadata, false, storageString, storageConnStringForFCApp)
+			siteConfig, err := helpers.ExpandSiteConfigFunctionFlexConsumptionApp(functionAppFlexConsumption.SiteConfig, nil, metadata, &storageAuthType, storageConnectionString, storageClientID, storageConnStringForFCApp)
 			if err != nil {
 				return fmt.Errorf("expanding `site_config` for %s: %+v", id, err)
 			}
@@ -848,21 +862,22 @@ func (r FunctionAppFlexConsumptionResource) Update() sdk.ResourceFunc {
 				model.Tags = pointer.To(state.Tags)
 			}
 
-			var storageString string
+			var storageConnectionString string
 			if state.StorageContainerEndpoint != "" || metadata.ResourceData.HasChange("storage_container_endpoint") {
 				endpoint := strings.TrimPrefix(state.StorageContainerEndpoint, "https://")
 				model.Properties.FunctionAppConfig.Deployment.Storage.Value = pointer.To(state.StorageContainerEndpoint)
 				if storageNameIndex := strings.Index(endpoint, "."); storageNameIndex != -1 {
 					storageName := endpoint[:storageNameIndex]
-					storageString = fmt.Sprintf(StorageStringFmt, storageName, state.StorageAccessKey, *storageDomainSuffix)
+					storageConnectionString = fmt.Sprintf(StorageStringFmt, storageName, state.StorageAccessKey, *storageDomainSuffix)
 				} else {
 					return fmt.Errorf("retrieving storage container endpoint error, the expected format is https://storagename.blob.core.windows.net/containername, the received value is %s", state.StorageContainerEndpoint)
 				}
 			}
 
 			storageConnStringForFCApp := "DEPLOYMENT_STORAGE_CONNECTION_STRING"
+
+			storageAuthType := webapps.AuthenticationType(state.StorageAuthType)
 			if metadata.ResourceData.HasChange("storage_authentication_type") {
-				storageAuthType := webapps.AuthenticationType(state.StorageAuthType)
 				storageAuth := webapps.FunctionsDeploymentStorageAuthentication{
 					Type: &storageAuthType,
 				}
@@ -877,6 +892,9 @@ func (r FunctionAppFlexConsumptionResource) Update() sdk.ResourceFunc {
 						if state.StorageUserAssignedIdentityID == "" {
 							return fmt.Errorf("the user assigned identity id must be specified when using the user assigned identity to access the storage account")
 						}
+						if state.StorageUserAssignedIdentityClientID == "" {
+							return fmt.Errorf("the user assigned identity client id must be specified when using the user assigned identity to access the storage account")
+						}
 						storageAuth.UserAssignedIdentityResourceId = &state.StorageUserAssignedIdentityID
 					}
 				}
@@ -887,8 +905,15 @@ func (r FunctionAppFlexConsumptionResource) Update() sdk.ResourceFunc {
 				model.Properties.FunctionAppConfig.Deployment.Storage.Authentication.UserAssignedIdentityResourceId = &state.StorageUserAssignedIdentityID
 			}
 
+			var storageClientID string
+			if state.StorageAuthType == string(webapps.AuthenticationTypeUserAssignedIdentity) {
+				storageClientID = state.StorageUserAssignedIdentityClientID
+			} else {
+				storageClientID = ""
+			}
+
 			// Note: We process this regardless to give us a "clean" view of service-side app_settings, so we can reconcile the user-defined entries later
-			siteConfig, err := helpers.ExpandSiteConfigFunctionFlexConsumptionApp(state.SiteConfig, model.Properties.SiteConfig, metadata, false, storageString, storageConnStringForFCApp)
+			siteConfig, err := helpers.ExpandSiteConfigFunctionFlexConsumptionApp(state.SiteConfig, model.Properties.SiteConfig, metadata, &storageAuthType, storageConnectionString, storageClientID, storageConnStringForFCApp)
 			if err != nil {
 				return fmt.Errorf("expanding Site Config for %s: %+v", id, err)
 			}
@@ -1047,6 +1072,11 @@ func (m *FunctionAppFlexConsumptionModel) unpackFunctionAppFlexConsumptionSettin
 
 		case "AzureWebJobsStorage":
 			_, m.StorageAccessKey = helpers.ParseWebJobsStorageString(v)
+
+		case "AzureWebJobsStorage__accountName":
+
+		case "AzureWebJobsStorage__clientId":
+			m.StorageUserAssignedIdentityClientID = v
 
 		case "WEBSITE_HEALTHCHECK_MAXPINGFAILURES":
 			i, _ := strconv.Atoi(v)

--- a/internal/services/appservice/function_app_flex_consumption_resource_test.go
+++ b/internal/services/appservice/function_app_flex_consumption_resource_test.go
@@ -979,14 +979,15 @@ resource "azurerm_function_app_flex_consumption" "test" {
   resource_group_name = azurerm_resource_group.test.name
   service_plan_id     = azurerm_service_plan.test.id
 
-  storage_container_type            = "blobContainer"
-  storage_container_endpoint        = "${azurerm_storage_account.test.primary_blob_endpoint}${azurerm_storage_container.test.name}"
-  storage_authentication_type       = "UserAssignedIdentity"
-  storage_user_assigned_identity_id = azurerm_user_assigned_identity.test1.id
-  runtime_name                      = "node"
-  runtime_version                   = "20"
-  maximum_instance_count            = 50
-  instance_memory_in_mb             = 2048
+  storage_container_type                   = "blobContainer"
+  storage_container_endpoint               = "${azurerm_storage_account.test.primary_blob_endpoint}${azurerm_storage_container.test.name}"
+  storage_authentication_type              = "UserAssignedIdentity"
+  storage_user_assigned_identity_id        = azurerm_user_assigned_identity.test1.id
+  storage_user_assigned_identity_client_id = azurerm_user_assigned_identity.test1.client_id
+  runtime_name                             = "node"
+  runtime_version                          = "20"
+  maximum_instance_count                   = 50
+  instance_memory_in_mb                    = 2048
 
   site_config {}
 }
@@ -1013,14 +1014,15 @@ resource "azurerm_function_app_flex_consumption" "test" {
   resource_group_name = azurerm_resource_group.test.name
   service_plan_id     = azurerm_service_plan.test.id
 
-  storage_container_type            = "blobContainer"
-  storage_container_endpoint        = "${azurerm_storage_account.test.primary_blob_endpoint}${azurerm_storage_container.test.name}"
-  storage_authentication_type       = "UserAssignedIdentity"
-  storage_user_assigned_identity_id = azurerm_user_assigned_identity.test2.id
-  runtime_name                      = "node"
-  runtime_version                   = "20"
-  maximum_instance_count            = 50
-  instance_memory_in_mb             = 2048
+  storage_container_type                   = "blobContainer"
+  storage_container_endpoint               = "${azurerm_storage_account.test.primary_blob_endpoint}${azurerm_storage_container.test.name}"
+  storage_authentication_type              = "UserAssignedIdentity"
+  storage_user_assigned_identity_id        = azurerm_user_assigned_identity.test2.id
+  storage_user_assigned_identity_client_id = azurerm_user_assigned_identity.test2.client_id
+  runtime_name                             = "node"
+  runtime_version                          = "20"
+  maximum_instance_count                   = 50
+  instance_memory_in_mb                    = 2048
 
   site_config {}
 }
@@ -1047,14 +1049,15 @@ resource "azurerm_function_app_flex_consumption" "test" {
   resource_group_name = azurerm_resource_group.test.name
   service_plan_id     = azurerm_service_plan.test.id
 
-  storage_container_type            = "blobContainer"
-  storage_container_endpoint        = "${azurerm_storage_account.test.primary_blob_endpoint}${azurerm_storage_container.test.name}"
-  storage_authentication_type       = "UserAssignedIdentity"
-  storage_user_assigned_identity_id = azurerm_user_assigned_identity.test2.id
-  runtime_name                      = "node"
-  runtime_version                   = "%s"
-  maximum_instance_count            = 50
-  instance_memory_in_mb             = 2048
+  storage_container_type                   = "blobContainer"
+  storage_container_endpoint               = "${azurerm_storage_account.test.primary_blob_endpoint}${azurerm_storage_container.test.name}"
+  storage_authentication_type              = "UserAssignedIdentity"
+  storage_user_assigned_identity_id        = azurerm_user_assigned_identity.test2.id
+  storage_user_assigned_identity_client_id = azurerm_user_assigned_identity.test2.client_id
+  runtime_name                             = "node"
+  runtime_version                          = "%s"
+  maximum_instance_count                   = 50
+  instance_memory_in_mb                    = 2048
 
   site_config {}
 }
@@ -1081,14 +1084,15 @@ resource "azurerm_function_app_flex_consumption" "test" {
   resource_group_name = azurerm_resource_group.test.name
   service_plan_id     = azurerm_service_plan.test.id
 
-  storage_container_type            = "blobContainer"
-  storage_container_endpoint        = azurerm_storage_container.test.id
-  storage_authentication_type       = "UserAssignedIdentity"
-  storage_user_assigned_identity_id = azurerm_user_assigned_identity.test2.id
-  runtime_name                      = "node"
-  runtime_version                   = "20"
-  maximum_instance_count            = 100
-  instance_memory_in_mb             = 2048
+  storage_container_type                   = "blobContainer"
+  storage_container_endpoint               = azurerm_storage_container.test.id
+  storage_authentication_type              = "UserAssignedIdentity"
+  storage_user_assigned_identity_id        = azurerm_user_assigned_identity.test2.id
+  storage_user_assigned_identity_client_id = azurerm_user_assigned_identity.test2.client_id
+  runtime_name                             = "node"
+  runtime_version                          = "20"
+  maximum_instance_count                   = 100
+  instance_memory_in_mb                    = 2048
   always_ready {
     name           = "function:myHelloWorldFunction"
     instance_count = 20
@@ -1122,14 +1126,15 @@ resource "azurerm_function_app_flex_consumption" "test" {
   resource_group_name = azurerm_resource_group.test.name
   service_plan_id     = azurerm_service_plan.test.id
 
-  storage_container_type            = "blobContainer"
-  storage_container_endpoint        = azurerm_storage_container.test.id
-  storage_authentication_type       = "UserAssignedIdentity"
-  storage_user_assigned_identity_id = azurerm_user_assigned_identity.test2.id
-  runtime_name                      = "node"
-  runtime_version                   = "20"
-  maximum_instance_count            = 100
-  instance_memory_in_mb             = 2048
+  storage_container_type                   = "blobContainer"
+  storage_container_endpoint               = azurerm_storage_container.test.id
+  storage_authentication_type              = "UserAssignedIdentity"
+  storage_user_assigned_identity_id        = azurerm_user_assigned_identity.test2.id
+  storage_user_assigned_identity_client_id = azurerm_user_assigned_identity.test2.client_id
+  runtime_name                             = "node"
+  runtime_version                          = "20"
+  maximum_instance_count                   = 100
+  instance_memory_in_mb                    = 2048
   always_ready {
     name           = "blob"
     instance_count = 20
@@ -1163,14 +1168,15 @@ resource "azurerm_function_app_flex_consumption" "test" {
   resource_group_name = azurerm_resource_group.test.name
   service_plan_id     = azurerm_service_plan.test.id
 
-  storage_container_type            = "blobContainer"
-  storage_container_endpoint        = azurerm_storage_container.test.id
-  storage_authentication_type       = "UserAssignedIdentity"
-  storage_user_assigned_identity_id = azurerm_user_assigned_identity.test2.id
-  runtime_name                      = "node"
-  runtime_version                   = "20"
-  maximum_instance_count            = 50
-  instance_memory_in_mb             = 2048
+  storage_container_type                   = "blobContainer"
+  storage_container_endpoint               = azurerm_storage_container.test.id
+  storage_authentication_type              = "UserAssignedIdentity"
+  storage_user_assigned_identity_id        = azurerm_user_assigned_identity.test2.id
+  storage_user_assigned_identity_client_id = azurerm_user_assigned_identity.test2.client_id
+  runtime_name                             = "node"
+  runtime_version                          = "20"
+  maximum_instance_count                   = 50
+  instance_memory_in_mb                    = 2048
   always_ready {
     name           = "blob"
     instance_count = 20
@@ -1205,14 +1211,15 @@ resource "azurerm_function_app_flex_consumption" "test" {
   resource_group_name = azurerm_resource_group.test.name
   service_plan_id     = azurerm_service_plan.test.id
 
-  storage_container_type            = "blobContainer"
-  storage_container_endpoint        = azurerm_storage_container.test.id
-  storage_authentication_type       = "UserAssignedIdentity"
-  storage_user_assigned_identity_id = azurerm_user_assigned_identity.test2.id
-  runtime_name                      = "node"
-  runtime_version                   = "20"
-  maximum_instance_count            = 100
-  instance_memory_in_mb             = 2048
+  storage_container_type                   = "blobContainer"
+  storage_container_endpoint               = azurerm_storage_container.test.id
+  storage_authentication_type              = "UserAssignedIdentity"
+  storage_user_assigned_identity_id        = azurerm_user_assigned_identity.test2.id
+  storage_user_assigned_identity_client_id = azurerm_user_assigned_identity.test2.client_id
+  runtime_name                             = "node"
+  runtime_version                          = "20"
+  maximum_instance_count                   = 100
+  instance_memory_in_mb                    = 2048
   always_ready {
     name           = "function:myHelloWorldFunction"
     instance_count = 20

--- a/internal/services/appservice/helpers/function_app_schema.go
+++ b/internal/services/appservice/helpers/function_app_schema.go
@@ -2048,7 +2048,7 @@ func ExpandSiteConfigLinuxFunctionApp(siteConfig []SiteConfigLinuxFunctionApp, e
 	return expanded, nil
 }
 
-func ExpandSiteConfigFunctionFlexConsumptionApp(siteConfigFlexConsumption []SiteConfigFunctionAppFlexConsumption, existing *webapps.SiteConfig, metadata sdk.ResourceMetaData, storageUsesMSI bool, storageStringFlex string, storageConnStringForFCApp string) (*webapps.SiteConfig, error) {
+func ExpandSiteConfigFunctionFlexConsumptionApp(siteConfigFlexConsumption []SiteConfigFunctionAppFlexConsumption, existing *webapps.SiteConfig, metadata sdk.ResourceMetaData, storageAuthType *webapps.AuthenticationType, storageConnectionString string, storageClientID string, storageConnStringForFCApp string) (*webapps.SiteConfig, error) {
 	if len(siteConfigFlexConsumption) == 0 {
 		return nil, nil
 	}
@@ -2064,11 +2064,21 @@ func ExpandSiteConfigFunctionFlexConsumptionApp(siteConfigFlexConsumption []Site
 		appSettings = *existing.AppSettings
 	}
 
-	if storageStringFlex != "" {
-		appSettings = updateOrAppendAppSettings(appSettings, "AzureWebJobsStorage", storageStringFlex, false)
+	storageAccountName, _ := ParseWebJobsStorageString(storageConnectionString)
+	appSettings = updateOrAppendAppSettings(appSettings, "AzureWebJobsStorage", storageConnectionString, true)
+	appSettings = updateOrAppendAppSettings(appSettings, "AzureWebJobsStorage__accountName", storageAccountName, true)
+	appSettings = updateOrAppendAppSettings(appSettings, "AzureWebJobsStorage__clientId", storageClientID, true)
+	switch *storageAuthType {
+	case webapps.AuthenticationTypeStorageAccountConnectionString:
+		appSettings = updateOrAppendAppSettings(appSettings, "AzureWebJobsStorage", storageConnectionString, false)
 		if storageConnStringForFCApp != "" {
-			appSettings = updateOrAppendAppSettings(appSettings, storageConnStringForFCApp, storageStringFlex, false)
+			appSettings = updateOrAppendAppSettings(appSettings, storageConnStringForFCApp, storageConnectionString, false)
 		}
+	case webapps.AuthenticationTypeSystemAssignedIdentity:
+		appSettings = updateOrAppendAppSettings(appSettings, "AzureWebJobsStorage__accountName", storageAccountName, false)
+	case webapps.AuthenticationTypeUserAssignedIdentity:
+		appSettings = updateOrAppendAppSettings(appSettings, "AzureWebJobsStorage__accountName", storageAccountName, false)
+		appSettings = updateOrAppendAppSettings(appSettings, "AzureWebJobsStorage__clientId", storageClientID, false)
 	}
 
 	FlexConsumptionSiteConfig := siteConfigFlexConsumption[0]

--- a/website/docs/r/function_app_flex_consumption.html.markdown
+++ b/website/docs/r/function_app_flex_consumption.html.markdown
@@ -91,7 +91,7 @@ The following arguments are supported:
 
 * `app_settings` - (Optional) A map of key-value pairs for [App Settings](https://docs.microsoft.com/azure/azure-functions/functions-app-settings) and custom values.
 
-~> **Note:** For storage related settings, please use related properties that are available such as `storage_access_key`, terraform will assign the value to keys such as `WEBSITE_CONTENTAZUREFILECONNECTIONSTRING`, `AzureWebJobsStorage` in app_setting.
+~> **Note:** For storage related settings, please use related properties that are available such as `storage_access_key`, terraform will assign the value to keys such as `WEBSITE_CONTENTAZUREFILECONNECTIONSTRING`, `AzureWebJobsStorage`, `AzureWebJobsStorage__accountName` and `AzureWebJobsStorage__clientId` in app_setting.
 
 ~> **Note:** For application insight related settings, please use `application_insights_connection_string` and `application_insights_key`, terraform will assign the value to the key `APPINSIGHTS_INSTRUMENTATIONKEY` and `APPLICATIONINSIGHTS_CONNECTION_STRING` in app setting.
 
@@ -127,7 +127,9 @@ The following arguments are supported:
 
 * `storage_user_assigned_identity_id` - (Optional) The user assigned Managed Identity to access the storage account. Conflicts with `storage_access_key`.
 
-~> **Note:** The `storage_user_assigned_identity_id` must be specified when `storage_authentication_type` is set to `UserAssignedIdentity`.
+* `storage_user_assigned_identity_client_id` - (Optional) The user assigned Managed Identity client ID to access the storage account. Conflicts with `storage_access_key`.
+
+~> **Note:** The `storage_user_assigned_identity_id` and its `storage_user_assigned_identity_client_id` must be specified when `storage_authentication_type` is set to `UserAssignedIdentity`.
 
 * `always_ready` - (Optional) One or more `always_ready` blocks as defined below.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

The storage setting where being incorrectly set when using the identity based storage options. This could be manually fixed by removing the `AzureWebJobsStorage` app setting but on a re-apply this was being reset. Also the implementation has a setting `storage_user_assigned_identity_id` which only partially worked as whist this is added to the functions identity settings, the app setting `AzureWebJobsStorage__clientId` is also required.

I've updated this so the provider will manage all three storage connections scenarios including the app settings behind these. I've added a `storage_user_assigned_identity_client_id` setting to mange the `AzureWebJobsStorage__clientId`. 

I've tested all of these manually, and its possible to go from connection string -> system identity -> user managed identity using terraform. I am now able to access the functions host keys, where as before this was hung as the storage would have been inaccessible.

It's worth noting the identity based tests around pass when even when the runtime is down, so the host keys are inaccessible. May be this could be improved by using something like the data `azurerm_function_app_host_keys` in the tests to verify this?

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”

## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.

## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

```
make acctests SERVICE='appservice' TESTARGS='-run=TestAccFunctionAppFlexConsumption_systemAssignedIdentity' TESTTIMEOUT='10m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/appservice -run=TestAccFunctionAppFlexConsumption_systemAssignedIdentity -timeout 10m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccFunctionAppFlexConsumption_systemAssignedIdentity
=== PAUSE TestAccFunctionAppFlexConsumption_systemAssignedIdentity
=== CONT  TestAccFunctionAppFlexConsumption_systemAssignedIdentity
--- PASS: TestAccFunctionAppFlexConsumption_systemAssignedIdentity (280.44s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/appservice    282.415s

make acctests SERVICE='appservice' TESTARGS='-run=TestAccFunctionAppFlexConsumption_userAssignedIdentityUpdate' TESTTIMEOUT='10m' 
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/appservice -run=TestAccFunctionAppFlexConsumption_userAssignedIdentityUpdate -timeout 10m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccFunctionAppFlexConsumption_userAssignedIdentityUpdate
=== PAUSE TestAccFunctionAppFlexConsumption_userAssignedIdentityUpdate
=== CONT  TestAccFunctionAppFlexConsumption_userAssignedIdentityUpdate
--- PASS: TestAccFunctionAppFlexConsumption_userAssignedIdentityUpdate (436.55s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/appservice    437.972s
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_function_app_flex_consumption` - updated logic for using identity based storage. Added `storage_user_assigned_identity_client_id` property for user managed identity based connections [GH-29693]

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #29693

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
