### PR TITLE
`azurerm_netapp_volume` - add support for cool access

### DIFF
--- a/internal/services/netapp/netapp_volume_resource.go
+++ b/internal/services/netapp/netapp_volume_resource.go
@@ -828,7 +828,6 @@ func resourceNetAppVolumeUpdate(d *pluginsdk.ResourceData, meta interface{}) err
 	}
 
 	if d.HasChange("cool_access_retrieval_policy") {
-
 		coolAccessRetrievalPolicy := d.Get("cool_access_retrieval_policy").(string)
 		update.Properties.CoolAccessRetrievalPolicy = pointer.To(volumes.CoolAccessRetrievalPolicy(coolAccessRetrievalPolicy))
 
@@ -839,7 +838,6 @@ func resourceNetAppVolumeUpdate(d *pluginsdk.ResourceData, meta interface{}) err
 	}
 
 	if d.HasChange("cool_access_tiering_policy") {
-
 		coolAccessTieringPolicy := d.Get("cool_access_tiering_policy").(string)
 		update.Properties.CoolAccessTieringPolicy = pointer.To(volumes.CoolAccessTieringPolicy(coolAccessTieringPolicy))
 

--- a/internal/services/netapp/netapp_volume_resource.go
+++ b/internal/services/netapp/netapp_volume_resource.go
@@ -405,7 +405,6 @@ func resourceNetAppVolume() *pluginsdk.Resource {
 				MaxItems: 1,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
-
 						"cool_access_retrieval_policy": {
 							Type:         pluginsdk.TypeString,
 							Required:     true,
@@ -832,7 +831,6 @@ func resourceNetAppVolumeUpdate(d *pluginsdk.ResourceData, meta interface{}) err
 		} else {
 			update.Properties.CoolAccess = pointer.To(false)
 		}
-
 	}
 
 	if d.HasChange("tags") {
@@ -929,7 +927,7 @@ func resourceNetAppVolumeRead(d *pluginsdk.ResourceData, meta interface{}) error
 		d.Set("key_vault_private_endpoint_id", props.KeyVaultPrivateEndpointResourceId)
 		d.Set("large_volume_enabled", props.IsLargeVolume)
 
-		if pointer.From(props.CoolAccess) == true {
+		if pointer.From(props.CoolAccess) {
 			// enums returned from the API are inconsistent so normalize them here
 			// https://github.com/Azure/azure-rest-api-specs/issues/35371
 			coolAccess := map[string]interface{}{

--- a/internal/services/netapp/netapp_volume_resource.go
+++ b/internal/services/netapp/netapp_volume_resource.go
@@ -405,13 +405,13 @@ func resourceNetAppVolume() *pluginsdk.Resource {
 				MaxItems: 1,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
-						"cool_access_retrieval_policy": {
+						"retrieval_policy": {
 							Type:         pluginsdk.TypeString,
 							Required:     true,
 							ValidateFunc: validation.StringInSlice(volumes.PossibleValuesForCoolAccessRetrievalPolicy(), false),
 						},
 
-						"cool_access_tiering_policy": {
+						"tiering_policy": {
 							Type:         pluginsdk.TypeString,
 							Required:     true,
 							ValidateFunc: validation.StringInSlice(volumes.PossibleValuesForCoolAccessTieringPolicy(), false),
@@ -666,8 +666,8 @@ func resourceNetAppVolumeCreate(d *pluginsdk.ResourceData, meta interface{}) err
 	if len(d.Get("cool_access").([]interface{})) > 0 {
 		coolAccess := d.Get("cool_access").([]interface{})[0].(map[string]interface{})
 		parameters.Properties.CoolAccess = pointer.To(true)
-		parameters.Properties.CoolAccessRetrievalPolicy = pointer.To(volumes.CoolAccessRetrievalPolicy(coolAccess["cool_access_retrieval_policy"].(string)))
-		parameters.Properties.CoolAccessTieringPolicy = pointer.To(volumes.CoolAccessTieringPolicy(coolAccess["cool_access_tiering_policy"].(string)))
+		parameters.Properties.CoolAccessRetrievalPolicy = pointer.To(volumes.CoolAccessRetrievalPolicy(coolAccess["retrieval_policy"].(string)))
+		parameters.Properties.CoolAccessTieringPolicy = pointer.To(volumes.CoolAccessTieringPolicy(coolAccess["tiering_policy"].(string)))
 		parameters.Properties.CoolnessPeriod = pointer.To(int64(coolAccess["coolness_period_in_days"].(int)))
 	}
 
@@ -817,12 +817,12 @@ func resourceNetAppVolumeUpdate(d *pluginsdk.ResourceData, meta interface{}) err
 			coolAccess := d.Get("cool_access").([]interface{})[0].(map[string]interface{})
 			update.Properties.CoolAccess = pointer.To(true)
 
-			if d.HasChange("cool_access.0.cool_access_retrieval_policy") {
-				update.Properties.CoolAccessRetrievalPolicy = pointer.To(volumes.CoolAccessRetrievalPolicy(coolAccess["cool_access_retrieval_policy"].(string)))
+			if d.HasChange("cool_access.0.retrieval_policy") {
+				update.Properties.CoolAccessRetrievalPolicy = pointer.To(volumes.CoolAccessRetrievalPolicy(coolAccess["retrieval_policy"].(string)))
 			}
 
-			if d.HasChange("cool_access.0.cool_access_tiering_policy") {
-				update.Properties.CoolAccessTieringPolicy = pointer.To(volumes.CoolAccessTieringPolicy(coolAccess["cool_access_tiering_policy"].(string)))
+			if d.HasChange("cool_access.0.tiering_policy") {
+				update.Properties.CoolAccessTieringPolicy = pointer.To(volumes.CoolAccessTieringPolicy(coolAccess["tiering_policy"].(string)))
 			}
 
 			if d.HasChange("cool_access.0.coolness_period_in_days") {
@@ -931,9 +931,9 @@ func resourceNetAppVolumeRead(d *pluginsdk.ResourceData, meta interface{}) error
 			// enums returned from the API are inconsistent so normalize them here
 			// https://github.com/Azure/azure-rest-api-specs/issues/35371
 			coolAccess := map[string]interface{}{
-				"cool_access_retrieval_policy": normalizeCoolAccessRetrievalPolicy(pointer.From(props.CoolAccessRetrievalPolicy)),
-				"cool_access_tiering_policy":   normalizeCoolAccessTieringPolicy(pointer.From(props.CoolAccessTieringPolicy)),
-				"coolness_period_in_days":      pointer.From(props.CoolnessPeriod),
+				"retrieval_policy":        normalizeCoolAccessRetrievalPolicy(pointer.From(props.CoolAccessRetrievalPolicy)),
+				"tiering_policy":          normalizeCoolAccessTieringPolicy(pointer.From(props.CoolAccessTieringPolicy)),
+				"coolness_period_in_days": pointer.From(props.CoolnessPeriod),
 			}
 			d.Set("cool_access", []interface{}{coolAccess})
 		} else {

--- a/internal/services/netapp/netapp_volume_resource_test.go
+++ b/internal/services/netapp/netapp_volume_resource_test.go
@@ -1862,9 +1862,9 @@ resource "azurerm_netapp_volume" "test" {
   throughput_in_mibps = 1.562
 
   cool_access {
-    tiering_policy   = "Auto"
-    retrieval_policy = "OnRead"
-    coolness_period_in_days      = 10
+    tiering_policy          = "Auto"
+    retrieval_policy        = "OnRead"
+    coolness_period_in_days = 10
   }
   tags = {
     "CreatedOnDate"    = "2022-07-08T23:50:21Z",
@@ -1891,9 +1891,9 @@ resource "azurerm_netapp_volume" "test" {
   throughput_in_mibps = 1.562
 
   cool_access {
-    tiering_policy   = "SnapshotOnly"
-    retrieval_policy = "Default"
-    coolness_period_in_days      = 10
+    tiering_policy          = "SnapshotOnly"
+    retrieval_policy        = "Default"
+    coolness_period_in_days = 10
   }
   tags = {
     "CreatedOnDate"    = "2022-07-08T23:50:21Z",
@@ -1920,9 +1920,9 @@ resource "azurerm_netapp_volume" "test" {
   throughput_in_mibps = 1.562
 
   cool_access {
-    tiering_policy   = "SnapshotOnly"
-    retrieval_policy = "Never"
-    coolness_period_in_days      = 30
+    tiering_policy          = "SnapshotOnly"
+    retrieval_policy        = "Never"
+    coolness_period_in_days = 30
   }
 
   tags = {

--- a/internal/services/netapp/netapp_volume_resource_test.go
+++ b/internal/services/netapp/netapp_volume_resource_test.go
@@ -1885,10 +1885,10 @@ resource "azurerm_netapp_volume" "test" {
   storage_quota_in_gb = 100
   throughput_in_mibps = 1.562
 
-  cool_access_enabled = true
-  cool_access_tiering_policy = "Auto"
+  cool_access_enabled          = true
+  cool_access_tiering_policy   = "Auto"
   cool_access_retrieval_policy = "OnRead"
-  coolness_period_in_days = 10
+  coolness_period_in_days      = 10
 
   tags = {
     "CreatedOnDate"    = "2022-07-08T23:50:21Z",
@@ -1914,10 +1914,10 @@ resource "azurerm_netapp_volume" "test" {
   storage_quota_in_gb = 100
   throughput_in_mibps = 1.562
 
-  cool_access_enabled = true
-  cool_access_tiering_policy = "SnapshotOnly"
+  cool_access_enabled          = true
+  cool_access_tiering_policy   = "SnapshotOnly"
   cool_access_retrieval_policy = "Default"
-  coolness_period_in_days = 10
+  coolness_period_in_days      = 10
 
   tags = {
     "CreatedOnDate"    = "2022-07-08T23:50:21Z",
@@ -1943,10 +1943,10 @@ resource "azurerm_netapp_volume" "test" {
   storage_quota_in_gb = 100
   throughput_in_mibps = 1.562
 
-  cool_access_enabled = true
-  cool_access_tiering_policy = "SnapshotOnly"
+  cool_access_enabled          = true
+  cool_access_tiering_policy   = "SnapshotOnly"
   cool_access_retrieval_policy = "Never"
-  coolness_period_in_days = 30
+  coolness_period_in_days      = 30
 
   tags = {
     "CreatedOnDate"    = "2022-07-08T23:50:21Z",
@@ -1972,10 +1972,10 @@ resource "azurerm_netapp_volume" "test" {
   storage_quota_in_gb = 100
   throughput_in_mibps = 1.562
 
-  cool_access_enabled = false
-  cool_access_tiering_policy = "SnapshotOnly"
+  cool_access_enabled          = false
+  cool_access_tiering_policy   = "SnapshotOnly"
   cool_access_retrieval_policy = "Never"
-  coolness_period_in_days = 30
+  coolness_period_in_days      = 30
 
   tags = {
     "CreatedOnDate"    = "2022-07-08T23:50:21Z",

--- a/internal/services/netapp/netapp_volume_resource_test.go
+++ b/internal/services/netapp/netapp_volume_resource_test.go
@@ -421,6 +421,73 @@ func TestAccNetAppVolume_serviceLevelUpdate(t *testing.T) {
 	})
 }
 
+func TestAccNetAppVolume_coolAccess(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_netapp_volume", "test")
+	r := NetAppVolumeResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.coolAccess(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.coolAccessUpdated(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.coolAccessUpdatedTier(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.coolAccessDisabled(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.coolAccess(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccNetAppVolume_coolAccessDisabledExpectError(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_netapp_volume", "test")
+	r := NetAppVolumeResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config:      r.coolAccessDisabledExpectError(data),
+			ExpectError: regexp.MustCompile("when `cool_access_enabled` is false, `cool_access_retrieval_policy`, `cool_access_tiering_policy`, and `coolness_period_in_days` must not be set"),
+		},
+	})
+}
+
+func TestAccNetAppVolume_coolAccessEnabledExpectError(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_netapp_volume", "test")
+	r := NetAppVolumeResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config:      r.coolAccessEnabledExpectError(data),
+			ExpectError: regexp.MustCompile("when `cool_access_enabled` is true, `cool_access_retrieval_policy`, `cool_access_tiering_policy`, and `coolness_period_in_days` must be set"),
+		},
+	})
+}
+
 func (t NetAppVolumeResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := volumes.ParseVolumeID(state.ID)
 	if err != nil {
@@ -1545,6 +1612,79 @@ resource "azurerm_netapp_pool" "test" {
 `, r.templateProviderFeatureFlags(), data.RandomInteger, overriddenlocations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
+func (r NetAppVolumeResource) templateCoolAccess(data acceptance.TestData) string {
+	overriddenlocations := getOverriddenTestLocations()
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-netapp-%d"
+  location = "%s"
+
+  tags = {
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
+    "SkipASMAzSecPack" = "true",
+    "SkipNRMSNSG"      = "true"
+  }
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctest-VirtualNetwork-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  address_space       = ["10.88.0.0/16"]
+
+  tags = {
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
+    "SkipASMAzSecPack" = "true"
+  }
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctest-Subnet-%d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.88.2.0/24"]
+
+  delegation {
+    name = "testdelegation"
+
+    service_delegation {
+      name    = "Microsoft.Netapp/volumes"
+      actions = ["Microsoft.Network/networkinterfaces/*", "Microsoft.Network/virtualNetworks/subnets/join/action"]
+    }
+  }
+}
+
+resource "azurerm_netapp_account" "test" {
+  name                = "acctest-NetAppAccount-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  tags = {
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
+    "SkipASMAzSecPack" = "true"
+  }
+}
+
+resource "azurerm_netapp_pool" "test" {
+  name                = "acctest-NetAppPool-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  account_name        = azurerm_netapp_account.test.name
+  service_level       = "Standard"
+  size_in_tb          = 4
+  qos_type            = "Manual"
+  cool_access_enabled = true
+
+  tags = {
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
+    "SkipASMAzSecPack" = "true"
+  }
+}
+`, r.templateProviderFeatureFlags(), data.RandomInteger, overriddenlocations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
 func (r NetAppVolumeResource) templatePoolQosManual(data acceptance.TestData) string {
 	overriddenlocations := getOverriddenTestLocations()
 	return fmt.Sprintf(`
@@ -1727,4 +1867,170 @@ resource "azurerm_netapp_volume" "test" {
   }
 }
 `, r.template(data), data.RandomInteger)
+}
+
+func (NetAppVolumeResource) coolAccess(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_netapp_volume" "test" {
+  name                = "acctest-NetAppVolume-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  account_name        = azurerm_netapp_account.test.name
+  pool_name           = azurerm_netapp_pool.test.name
+  volume_path         = "my-unique-file-path-%d"
+  service_level       = "Standard"
+  subnet_id           = azurerm_subnet.test.id
+  storage_quota_in_gb = 100
+  throughput_in_mibps = 1.562
+
+  cool_access_enabled = true
+  cool_access_tiering_policy = "Auto"
+  cool_access_retrieval_policy = "OnRead"
+  coolness_period_in_days = 10
+
+  tags = {
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
+    "SkipASMAzSecPack" = "true"
+  }
+}
+`, NetAppVolumeResource{}.templateCoolAccess(data), data.RandomInteger, data.RandomInteger)
+}
+
+func (NetAppVolumeResource) coolAccessUpdated(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_netapp_volume" "test" {
+  name                = "acctest-NetAppVolume-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  account_name        = azurerm_netapp_account.test.name
+  pool_name           = azurerm_netapp_pool.test.name
+  volume_path         = "my-unique-file-path-%d"
+  service_level       = "Standard"
+  subnet_id           = azurerm_subnet.test.id
+  storage_quota_in_gb = 100
+  throughput_in_mibps = 1.562
+
+  cool_access_enabled = true
+  cool_access_tiering_policy = "SnapshotOnly"
+  cool_access_retrieval_policy = "Default"
+  coolness_period_in_days = 10
+
+  tags = {
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
+    "SkipASMAzSecPack" = "true"
+  }
+}
+`, NetAppVolumeResource{}.templateCoolAccess(data), data.RandomInteger, data.RandomInteger)
+}
+
+func (NetAppVolumeResource) coolAccessUpdatedTier(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_netapp_volume" "test" {
+  name                = "acctest-NetAppVolume-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  account_name        = azurerm_netapp_account.test.name
+  pool_name           = azurerm_netapp_pool.test.name
+  volume_path         = "my-unique-file-path-%d"
+  service_level       = "Standard"
+  subnet_id           = azurerm_subnet.test.id
+  storage_quota_in_gb = 100
+  throughput_in_mibps = 1.562
+
+  cool_access_enabled = true
+  cool_access_tiering_policy = "SnapshotOnly"
+  cool_access_retrieval_policy = "Never"
+  coolness_period_in_days = 30
+
+  tags = {
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
+    "SkipASMAzSecPack" = "true"
+  }
+}
+`, NetAppVolumeResource{}.templateCoolAccess(data), data.RandomInteger, data.RandomInteger)
+}
+
+func (NetAppVolumeResource) coolAccessDisabledExpectError(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_netapp_volume" "test" {
+  name                = "acctest-NetAppVolume-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  account_name        = azurerm_netapp_account.test.name
+  pool_name           = azurerm_netapp_pool.test.name
+  volume_path         = "my-unique-file-path-%d"
+  service_level       = "Standard"
+  subnet_id           = azurerm_subnet.test.id
+  storage_quota_in_gb = 100
+  throughput_in_mibps = 1.562
+
+  cool_access_enabled = false
+  cool_access_tiering_policy = "SnapshotOnly"
+  cool_access_retrieval_policy = "Never"
+  coolness_period_in_days = 30
+
+  tags = {
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
+    "SkipASMAzSecPack" = "true"
+  }
+}
+`, NetAppVolumeResource{}.templateCoolAccess(data), data.RandomInteger, data.RandomInteger)
+}
+
+func (NetAppVolumeResource) coolAccessEnabledExpectError(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_netapp_volume" "test" {
+  name                = "acctest-NetAppVolume-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  account_name        = azurerm_netapp_account.test.name
+  pool_name           = azurerm_netapp_pool.test.name
+  volume_path         = "my-unique-file-path-%d"
+  service_level       = "Standard"
+  subnet_id           = azurerm_subnet.test.id
+  storage_quota_in_gb = 100
+  throughput_in_mibps = 1.562
+
+  cool_access_enabled = true
+
+  tags = {
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
+    "SkipASMAzSecPack" = "true"
+  }
+}
+`, NetAppVolumeResource{}.templateCoolAccess(data), data.RandomInteger, data.RandomInteger)
+}
+
+func (NetAppVolumeResource) coolAccessDisabled(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_netapp_volume" "test" {
+  name                = "acctest-NetAppVolume-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  account_name        = azurerm_netapp_account.test.name
+  pool_name           = azurerm_netapp_pool.test.name
+  volume_path         = "my-unique-file-path-%d"
+  service_level       = "Standard"
+  subnet_id           = azurerm_subnet.test.id
+  storage_quota_in_gb = 100
+  throughput_in_mibps = 1.562
+
+  tags = {
+    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
+    "SkipASMAzSecPack" = "true"
+  }
+}
+`, NetAppVolumeResource{}.templateCoolAccess(data), data.RandomInteger, data.RandomInteger)
 }

--- a/internal/services/netapp/netapp_volume_resource_test.go
+++ b/internal/services/netapp/netapp_volume_resource_test.go
@@ -464,30 +464,6 @@ func TestAccNetAppVolume_coolAccess(t *testing.T) {
 	})
 }
 
-func TestAccNetAppVolume_coolAccessDisabledExpectError(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_netapp_volume", "test")
-	r := NetAppVolumeResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config:      r.coolAccessDisabledExpectError(data),
-			ExpectError: regexp.MustCompile("when `cool_access_enabled` is false, `cool_access_retrieval_policy`, `cool_access_tiering_policy`, and `coolness_period_in_days` must not be set"),
-		},
-	})
-}
-
-func TestAccNetAppVolume_coolAccessEnabledExpectError(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_netapp_volume", "test")
-	r := NetAppVolumeResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config:      r.coolAccessEnabledExpectError(data),
-			ExpectError: regexp.MustCompile("when `cool_access_enabled` is true, `cool_access_retrieval_policy`, `cool_access_tiering_policy`, and `coolness_period_in_days` must be set"),
-		},
-	})
-}
-
 func (t NetAppVolumeResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := volumes.ParseVolumeID(state.ID)
 	if err != nil {
@@ -1885,11 +1861,11 @@ resource "azurerm_netapp_volume" "test" {
   storage_quota_in_gb = 100
   throughput_in_mibps = 1.562
 
-  cool_access_enabled          = true
-  cool_access_tiering_policy   = "Auto"
-  cool_access_retrieval_policy = "OnRead"
-  coolness_period_in_days      = 10
-
+  cool_access {
+    cool_access_tiering_policy   = "Auto"
+    cool_access_retrieval_policy = "OnRead"
+    coolness_period_in_days      = 10
+  }
   tags = {
     "CreatedOnDate"    = "2022-07-08T23:50:21Z",
     "SkipASMAzSecPack" = "true"
@@ -1914,11 +1890,11 @@ resource "azurerm_netapp_volume" "test" {
   storage_quota_in_gb = 100
   throughput_in_mibps = 1.562
 
-  cool_access_enabled          = true
-  cool_access_tiering_policy   = "SnapshotOnly"
-  cool_access_retrieval_policy = "Default"
-  coolness_period_in_days      = 10
-
+  cool_access {
+    cool_access_tiering_policy   = "SnapshotOnly"
+    cool_access_retrieval_policy = "Default"
+    coolness_period_in_days      = 10
+  }
   tags = {
     "CreatedOnDate"    = "2022-07-08T23:50:21Z",
     "SkipASMAzSecPack" = "true"
@@ -1943,65 +1919,11 @@ resource "azurerm_netapp_volume" "test" {
   storage_quota_in_gb = 100
   throughput_in_mibps = 1.562
 
-  cool_access_enabled          = true
-  cool_access_tiering_policy   = "SnapshotOnly"
-  cool_access_retrieval_policy = "Never"
-  coolness_period_in_days      = 30
-
-  tags = {
-    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
-    "SkipASMAzSecPack" = "true"
+  cool_access {
+    cool_access_tiering_policy   = "SnapshotOnly"
+    cool_access_retrieval_policy = "Never"
+    coolness_period_in_days      = 30
   }
-}
-`, NetAppVolumeResource{}.templateCoolAccess(data), data.RandomInteger, data.RandomInteger)
-}
-
-func (NetAppVolumeResource) coolAccessDisabledExpectError(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-%s
-
-resource "azurerm_netapp_volume" "test" {
-  name                = "acctest-NetAppVolume-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  account_name        = azurerm_netapp_account.test.name
-  pool_name           = azurerm_netapp_pool.test.name
-  volume_path         = "my-unique-file-path-%d"
-  service_level       = "Standard"
-  subnet_id           = azurerm_subnet.test.id
-  storage_quota_in_gb = 100
-  throughput_in_mibps = 1.562
-
-  cool_access_enabled          = false
-  cool_access_tiering_policy   = "SnapshotOnly"
-  cool_access_retrieval_policy = "Never"
-  coolness_period_in_days      = 30
-
-  tags = {
-    "CreatedOnDate"    = "2022-07-08T23:50:21Z",
-    "SkipASMAzSecPack" = "true"
-  }
-}
-`, NetAppVolumeResource{}.templateCoolAccess(data), data.RandomInteger, data.RandomInteger)
-}
-
-func (NetAppVolumeResource) coolAccessEnabledExpectError(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-%s
-
-resource "azurerm_netapp_volume" "test" {
-  name                = "acctest-NetAppVolume-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  account_name        = azurerm_netapp_account.test.name
-  pool_name           = azurerm_netapp_pool.test.name
-  volume_path         = "my-unique-file-path-%d"
-  service_level       = "Standard"
-  subnet_id           = azurerm_subnet.test.id
-  storage_quota_in_gb = 100
-  throughput_in_mibps = 1.562
-
-  cool_access_enabled = true
 
   tags = {
     "CreatedOnDate"    = "2022-07-08T23:50:21Z",

--- a/internal/services/netapp/netapp_volume_resource_test.go
+++ b/internal/services/netapp/netapp_volume_resource_test.go
@@ -1862,8 +1862,8 @@ resource "azurerm_netapp_volume" "test" {
   throughput_in_mibps = 1.562
 
   cool_access {
-    cool_access_tiering_policy   = "Auto"
-    cool_access_retrieval_policy = "OnRead"
+    tiering_policy   = "Auto"
+    retrieval_policy = "OnRead"
     coolness_period_in_days      = 10
   }
   tags = {
@@ -1891,8 +1891,8 @@ resource "azurerm_netapp_volume" "test" {
   throughput_in_mibps = 1.562
 
   cool_access {
-    cool_access_tiering_policy   = "SnapshotOnly"
-    cool_access_retrieval_policy = "Default"
+    tiering_policy   = "SnapshotOnly"
+    retrieval_policy = "Default"
     coolness_period_in_days      = 10
   }
   tags = {
@@ -1920,8 +1920,8 @@ resource "azurerm_netapp_volume" "test" {
   throughput_in_mibps = 1.562
 
   cool_access {
-    cool_access_tiering_policy   = "SnapshotOnly"
-    cool_access_retrieval_policy = "Never"
+    tiering_policy   = "SnapshotOnly"
+    retrieval_policy = "Never"
     coolness_period_in_days      = 30
   }
 

--- a/website/docs/r/netapp_volume.html.markdown
+++ b/website/docs/r/netapp_volume.html.markdown
@@ -203,17 +203,21 @@ The following arguments are supported:
 
 -> **Note:** Large volumes must be at least 50 TiB in size and can be up to 1,024 TiB (1 PiB). For more information, please refer to [Requirements and considerations for large volumes](https://learn.microsoft.com/en-us/azure/azure-netapp-files/large-volumes-requirements-considerations)
 
-* `cool_access_enabled` - (Optional) A boolean specifying if the volume is a cool access volume. Defaults to `false`. 
-
-* `cool_access_retrieval_policy` - (Optional) The cool access retrieval policy for the volume. Possible values are `Default`, `Never` and `OnRead`.
-
-* `cool_access_tiering_policy` - (Optional) The cool access tiering policy for the volume. Possible values are `Auto` and `SnapshotOnly`.
-
-* `coolness_period_in_days` - (Optional) The coolness period in days for the volume. Possible vales are between `2` and `183`.
+* `cool_access` - (Optional) A `cool_access` block as defined below.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 -> **Note:** It is highly recommended to use the **lifecycle** property as noted in the example since it will prevent an accidental deletion of the volume if the `protocols` argument changes to a different protocol type.
+
+---
+
+A `cool_access` block supports the following:
+
+* `cool_access_retrieval_policy` - (Required) The cool access retrieval policy for the volume. Possible values are `Default`, `Never` and `OnRead`.
+
+* `cool_access_tiering_policy` - (Required) The cool access tiering policy for the volume. Possible values are `Auto` and `SnapshotOnly`.
+
+* `coolness_period_in_days` - (Required) The coolness period in days for the volume. Possible vales are between `2` and `183`.
 
 ---
 

--- a/website/docs/r/netapp_volume.html.markdown
+++ b/website/docs/r/netapp_volume.html.markdown
@@ -203,6 +203,14 @@ The following arguments are supported:
 
 -> **Note:** Large volumes must be at least 50 TiB in size and can be up to 1,024 TiB (1 PiB). For more information, please refer to [Requirements and considerations for large volumes](https://learn.microsoft.com/en-us/azure/azure-netapp-files/large-volumes-requirements-considerations)
 
+* `cool_access_enabled` - (Optional) A boolean specifying if the volume is a cool access volume. Defaults to `false`. 
+
+* `cool_access_retrieval_policy` - (Optional) The cool access retrieval policy for the volume. Possible values are `Default`, `Never` and `OnRead`.
+
+* `cool_access_tiering_policy` - (Optional) The cool access tiering policy for the volume. Possible values are `Auto` and `SnapshotOnly`.
+
+* `coolness_period_in_days` - (Optional) The coolness period in days for the volume. Possible vales are between `2` and `183`.
+
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 -> **Note:** It is highly recommended to use the **lifecycle** property as noted in the example since it will prevent an accidental deletion of the volume if the `protocols` argument changes to a different protocol type.

--- a/website/docs/r/netapp_volume.html.markdown
+++ b/website/docs/r/netapp_volume.html.markdown
@@ -213,9 +213,9 @@ The following arguments are supported:
 
 A `cool_access` block supports the following:
 
-* `cool_access_retrieval_policy` - (Required) The cool access retrieval policy for the volume. Possible values are `Default`, `Never` and `OnRead`.
+* `retrieval_policy` - (Required) The cool access retrieval policy for the volume. Possible values are `Default`, `Never` and `OnRead`.
 
-* `cool_access_tiering_policy` - (Required) The cool access tiering policy for the volume. Possible values are `Auto` and `SnapshotOnly`.
+* `tiering_policy` - (Required) The cool access tiering policy for the volume. Possible values are `Auto` and `SnapshotOnly`.
 
 * `coolness_period_in_days` - (Required) The coolness period in days for the volume. Possible vales are between `2` and `183`.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_netapp_volume` - add support for the `cool_access_enabled`, `coolness_period_in_days`, `cool_access_retrieval_policy` and `cool_access_tiering_policy` properties [GH-29915]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes[#28455](https://github.com/hashicorp/terraform-provider-azurerm/issues/28455)

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
