### PR TITLE
`azurerm_[management_group]_policy_set_definition` - add `policy_definition_reference.version`

### DIFF
--- a/internal/services/policy/management_group_policy_set_definition_resource_test.go
+++ b/internal/services/policy/management_group_policy_set_definition_resource_test.go
@@ -74,6 +74,35 @@ func TestAccManagementGroupPolicySetDefinition_complete(t *testing.T) {
 	})
 }
 
+func TestAccManagementGroupPolicySetDefinition_policyDefinitionVersion(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_management_group_policy_set_definition", "test")
+	r := ManagementGroupPolicySetDefinitionResourceTest{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.policyDefinitionVersion(data, "9.*"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.policyDefinitionVersion(data, "9.3.*"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.policyDefinitionVersion(data, "9.*.*"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (ManagementGroupPolicySetDefinitionResourceTest) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := policysetdefinitions.ParseProviders2PolicySetDefinitionID(state.ID)
 	if err != nil {
@@ -190,6 +219,30 @@ VALUES
   }
 }
 `, r.template(data), data.RandomInteger)
+}
+
+func (r ManagementGroupPolicySetDefinitionResourceTest) policyDefinitionVersion(data acceptance.TestData, version string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_management_group_policy_set_definition" "test" {
+  name                = "acctestpolset-%[2]d"
+  display_name        = "acctestpolset-%[2]d"
+  management_group_id = azurerm_management_group.test.id
+  policy_type         = "Custom"
+
+  policy_definition_reference {
+    version              = %q
+    policy_definition_id = "/providers/Microsoft.Authorization/policyDefinitions/e345eecc-fa47-480f-9e88-67dcc122b164"
+    parameter_values     = <<VALUES
+    {
+       "cpuLimit": {"value": "100m"},
+       "memoryLimit": {"value": "100Mi"}
+    }
+VALUES
+  }
+}
+`, r.template(data), data.RandomInteger, version)
 }
 
 func (r ManagementGroupPolicySetDefinitionResourceTest) template(data acceptance.TestData) string {

--- a/internal/services/policy/policy_set_definition.go
+++ b/internal/services/policy/policy_set_definition.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"regexp"
 	"strconv"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -22,6 +23,7 @@ type PolicyDefinitionReferenceModel struct {
 	ParameterValues    string   `tfschema:"parameter_values"`
 	ReferenceID        string   `tfschema:"reference_id"`
 	PolicyGroupNames   []string `tfschema:"policy_group_names"`
+	Version            string   `tfschema:"version"`
 }
 
 type PolicyDefinitionGroupModel struct {
@@ -64,6 +66,17 @@ func policyDefinitionReferenceSchema() *pluginsdk.Schema {
 						Type:         pluginsdk.TypeString,
 						ValidateFunc: validation.StringIsNotEmpty,
 					},
+				},
+
+				"version": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					// Note: O+C because Azure returns a version if not sent in the request.
+					Computed: true,
+					ValidateFunc: validation.StringMatch(
+						regexp.MustCompile(`^([1-9]\d*)\.(\d+|\*)(\.\*(-preview)?)?$`),
+						"version must match `{major}.{minor}[.*][-preview]` where each segment is a number or an asterisk. The major version number must be greater than zero and `-preview` is optional.",
+					),
 				},
 			},
 		},
@@ -153,12 +166,18 @@ func expandPolicyDefinitionReference(input []PolicyDefinitionReferenceModel) ([]
 			return nil, fmt.Errorf("expanding `parameter_values`: %+v", err)
 		}
 
-		result = append(result, policysetdefinitions.PolicyDefinitionReference{
+		reference := policysetdefinitions.PolicyDefinitionReference{
 			GroupNames:                  pointer.To(v.PolicyGroupNames),
 			Parameters:                  expandedParameters,
 			PolicyDefinitionId:          v.PolicyDefinitionID,
 			PolicyDefinitionReferenceId: pointer.To(v.ReferenceID),
-		})
+		}
+
+		// The API returns an error if we send an empty string
+		if v.Version != "" {
+			reference.DefinitionVersion = pointer.To(v.Version)
+		}
+		result = append(result, reference)
 	}
 
 	return result, nil
@@ -178,6 +197,7 @@ func flattenPolicyDefinitionReference(input []policysetdefinitions.PolicyDefinit
 			ParameterValues:    parameterValues,
 			ReferenceID:        pointer.From(definition.PolicyDefinitionReferenceId),
 			PolicyGroupNames:   pointer.From(definition.GroupNames),
+			Version:            pointer.From(definition.DefinitionVersion),
 		})
 	}
 

--- a/website/docs/r/management_group_policy_set_definition.html.markdown
+++ b/website/docs/r/management_group_policy_set_definition.html.markdown
@@ -37,6 +37,7 @@ resource "azurerm_management_group_policy_set_definition" "example" {
 PARAMETERS
 
   policy_definition_reference {
+    version              = "1.0.*"
     policy_definition_id = "/providers/Microsoft.Authorization/policyDefinitions/e765b5de-1225-4ba3-bd56-1ac6695af988"
     parameter_values     = <<VALUES
    {
@@ -96,6 +97,8 @@ A `policy_definition_reference` block supports the following:
 * `policy_group_names` - (Optional) Specifies a list of Policy Definition Groups names that this Policy Definition Reference belongs to.
 
 * `reference_id` - (Optional) A unique ID within this Policy Set Definition for this Policy Definition Reference.
+
+* `version` - (Optional) The version of the Policy Definition to use.
 
 ## Attributes Reference
 

--- a/website/docs/r/policy_set_definition.html.markdown
+++ b/website/docs/r/policy_set_definition.html.markdown
@@ -34,6 +34,7 @@ resource "azurerm_policy_set_definition" "example" {
 PARAMETERS
 
   policy_definition_reference {
+    version              = "1.0.*"
     policy_definition_id = "/providers/Microsoft.Authorization/policyDefinitions/e765b5de-1225-4ba3-bd56-1ac6695af988"
     parameter_values     = <<VALUE
     {
@@ -91,6 +92,8 @@ A `policy_definition_reference` block supports the following:
 * `policy_group_names` - (Optional) Specifies a list of Policy Definition Groups names that this Policy Definition Reference belongs to.
 
 * `reference_id` - (Optional) A unique ID within this Policy Set Definition for this Policy Definition Reference.
+
+* `version` - (Optional) The version of the Policy Definition to use.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

4.0:
![image](https://github.com/user-attachments/assets/1ed0d180-d22f-4a3f-827e-b0452504bfb7)

5.0:
![image](https://github.com/user-attachments/assets/995ae8f7-3ca1-470c-b451-092d515d92a3)


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #28907

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
