### PR TITLE
`azurerm_capacity_reservation_group` - add support for Resource Identity

### DIFF
--- a/internal/services/compute/capacity_reservation_group_resource.go
+++ b/internal/services/compute/capacity_reservation_group_resource.go
@@ -23,6 +23,8 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name capacity_reservation_group -service-package-name compute -properties "capacity_reservation_group_name:name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
+
 func resourceCapacityReservationGroup() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
 		Create: resourceCapacityReservationGroupCreate,
@@ -37,10 +39,11 @@ func resourceCapacityReservationGroup() *pluginsdk.Resource {
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 
-		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
-			_, err := capacityreservationgroups.ParseCapacityReservationGroupID(id)
-			return err
-		}),
+		Importer: pluginsdk.ImporterValidatingIdentity(&capacityreservationgroups.CapacityReservationGroupId{}),
+
+		Identity: &schema.ResourceIdentity{
+			SchemaFunc: pluginsdk.GenerateIdentitySchema(&capacityreservationgroups.CapacityReservationGroupId{}),
+		},
 
 		Schema: map[string]*pluginsdk.Schema{
 			"name": {
@@ -127,7 +130,7 @@ func resourceCapacityReservationGroupRead(d *pluginsdk.ResourceData, meta interf
 		}
 	}
 
-	return nil
+	return pluginsdk.SetResourceIdentityData(d, id)
 }
 
 func resourceCapacityReservationGroupUpdate(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/compute/capacity_reservation_group_resource_identity_gen_test.go
+++ b/internal/services/compute/capacity_reservation_group_resource_identity_gen_test.go
@@ -1,0 +1,39 @@
+package compute_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
+)
+
+func TestAccCapacityReservationGroup_resourceIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_capacity_reservation_group", "test")
+	r := CapacityReservationGroupResource{}
+
+	resource.ParallelTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []resource.TestStep{
+			{
+				Config: r.basic(data),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectIdentityValue("azurerm_capacity_reservation_group.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_capacity_reservation_group.test", tfjsonpath.New("capacity_reservation_group_name"), tfjsonpath.New("name")),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_capacity_reservation_group.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
+				},
+			},
+			data.ImportBlockWithResourceIdentityStep(),
+			data.ImportBlockWithIDStep(),
+		},
+	})
+}


### PR DESCRIPTION
```
--- PASS: TestAccCapacityReservationGroup_resourceIdentity (64.55s)
```