### PR TITLE
`azurerm_local_network_gateway` - add support for Resource Identity

### DIFF
--- a/internal/services/network/local_network_gateway_resource.go
+++ b/internal/services/network/local_network_gateway_resource.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2024-05-01/localnetworkgateways"
 	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/custompollers"
@@ -22,16 +23,19 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
 
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name local_network_gateway -service-package-name network -properties "local_network_gateway_name:name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
+
 func resourceLocalNetworkGateway() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
-		Create: resourceLocalNetworkGatewayCreate,
-		Read:   resourceLocalNetworkGatewayRead,
-		Update: resourceLocalNetworkGatewayUpdate,
-		Delete: resourceLocalNetworkGatewayDelete,
-		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
-			_, err := localnetworkgateways.ParseLocalNetworkGatewayID(id)
-			return err
-		}),
+		Create:   resourceLocalNetworkGatewayCreate,
+		Read:     resourceLocalNetworkGatewayRead,
+		Update:   resourceLocalNetworkGatewayUpdate,
+		Delete:   resourceLocalNetworkGatewayDelete,
+		Importer: pluginsdk.ImporterValidatingIdentity(&localnetworkgateways.LocalNetworkGatewayId{}),
+
+		Identity: &schema.ResourceIdentity{
+			SchemaFunc: pluginsdk.GenerateIdentitySchema(&localnetworkgateways.LocalNetworkGatewayId{}),
+		},
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
@@ -271,9 +275,12 @@ func resourceLocalNetworkGatewayRead(d *pluginsdk.ResourceData, meta interface{}
 			return err
 		}
 
-		return tags.FlattenAndSet(d, model.Tags)
+		if err := tags.FlattenAndSet(d, model.Tags); err != nil {
+			return err
+		}
 	}
-	return nil
+
+	return pluginsdk.SetResourceIdentityData(d, id)
 }
 
 func resourceLocalNetworkGatewayDelete(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/network/local_network_gateway_resource_identity_gen_test.go
+++ b/internal/services/network/local_network_gateway_resource_identity_gen_test.go
@@ -1,0 +1,39 @@
+package network_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
+)
+
+func TestAccLocalNetworkGateway_resourceIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_local_network_gateway", "test")
+	r := LocalNetworkGatewayResource{}
+
+	resource.ParallelTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []resource.TestStep{
+			{
+				Config: r.basic(data),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectIdentityValue("azurerm_local_network_gateway.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_local_network_gateway.test", tfjsonpath.New("local_network_gateway_name"), tfjsonpath.New("name")),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_local_network_gateway.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
+				},
+			},
+			data.ImportBlockWithResourceIdentityStep(),
+			data.ImportBlockWithIDStep(),
+		},
+	})
+}


### PR DESCRIPTION
--- PASS: TestAccLocalNetworkGateway_resourceIdentity (122.52s)