### PR TITLE
azurerm_gallery_application_version - add support for Resource Identity

### DIFF
--- a/internal/services/compute/gallery_application_version_resource.go
+++ b/internal/services/compute/gallery_application_version_resource.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-03/galleryapplications"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-03/galleryapplicationversions"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
@@ -22,12 +23,19 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name gallery_application_version -properties "version_name:name" -service-package-name compute -compare-values "subscription_id:gallery_application_id,resource_group_name:gallery_application_id,gallery_name:gallery_application_id,application_name:gallery_application_id"
+
 type GalleryApplicationVersionResource struct{}
 
 var (
 	_ sdk.ResourceWithUpdate        = GalleryApplicationVersionResource{}
 	_ sdk.ResourceWithCustomizeDiff = GalleryApplicationVersionResource{}
+	_ sdk.ResourceWithIdentity      = GalleryApplicationVersionResource{}
 )
+
+func (r GalleryApplicationVersionResource) Identity() resourceids.ResourceId {
+	return &galleryapplicationversions.ApplicationVersionId{}
+}
 
 type GalleryApplicationVersionModel struct {
 	Name                 string            `tfschema:"name"`
@@ -351,6 +359,10 @@ func (r GalleryApplicationVersionResource) Read() sdk.ResourceFunc {
 					state.Source = flattenGalleryApplicationVersionSource(props.PublishingProfile.Source)
 					state.TargetRegion = flattenGalleryApplicationVersionTargetRegion(props.PublishingProfile.TargetRegions)
 				}
+			}
+
+			if err := pluginsdk.SetResourceIdentityData(metadata.ResourceData, id); err != nil {
+				return err
 			}
 
 			return metadata.Encode(state)

--- a/internal/services/compute/gallery_application_version_resource_identity_gen_test.go
+++ b/internal/services/compute/gallery_application_version_resource_identity_gen_test.go
@@ -1,0 +1,41 @@
+package compute_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
+)
+
+func TestAccGalleryApplicationVersion_resourceIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_gallery_application_version", "test")
+	r := GalleryApplicationVersionResource{}
+
+	resource.ParallelTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []resource.TestStep{
+			{
+				Config: r.basic(data),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_gallery_application_version.test", tfjsonpath.New("version_name"), tfjsonpath.New("name")),
+					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_gallery_application_version.test", tfjsonpath.New("application_name"), tfjsonpath.New("gallery_application_id")),
+					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_gallery_application_version.test", tfjsonpath.New("gallery_name"), tfjsonpath.New("gallery_application_id")),
+					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_gallery_application_version.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("gallery_application_id")),
+					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_gallery_application_version.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("gallery_application_id")),
+				},
+			},
+			data.ImportBlockWithResourceIdentityStep(),
+			data.ImportBlockWithIDStep(),
+		},
+	})
+}


### PR DESCRIPTION
```
--- PASS: TestAccGalleryApplicationVersion_resourceIdentity (891.48s)
```