### PR TITLE
`azurerm_network_security_rule` - add support for Resource Identity

### DIFF
--- a/internal/services/network/network_security_rule_resource.go
+++ b/internal/services/network/network_security_rule_resource.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2024-05-01/securityrules"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -19,16 +20,20 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
 
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name network_security_rule -service-package-name network -properties "security_rule_name:name,network_security_group_name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
+
 func resourceNetworkSecurityRule() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
 		Create: resourceNetworkSecurityRuleCreate,
 		Read:   resourceNetworkSecurityRuleRead,
 		Update: resourceNetworkSecurityRuleUpdate,
 		Delete: resourceNetworkSecurityRuleDelete,
-		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
-			_, err := securityrules.ParseSecurityRuleID(id)
-			return err
-		}),
+
+		Importer: pluginsdk.ImporterValidatingIdentity(&securityrules.SecurityRuleId{}),
+
+		Identity: &schema.ResourceIdentity{
+			SchemaFunc: pluginsdk.GenerateIdentitySchema(&securityrules.SecurityRuleId{}),
+		},
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
@@ -469,7 +474,7 @@ func resourceNetworkSecurityRuleRead(d *pluginsdk.ResourceData, meta interface{}
 		}
 	}
 
-	return nil
+	return pluginsdk.SetResourceIdentityData(d, id)
 }
 
 func resourceNetworkSecurityRuleDelete(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/network/network_security_rule_resource_identity_gen_test.go
+++ b/internal/services/network/network_security_rule_resource_identity_gen_test.go
@@ -1,0 +1,40 @@
+package network_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
+)
+
+func TestAccNetworkSecurityRule_resourceIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_network_security_rule", "test")
+	r := NetworkSecurityRuleResource{}
+
+	resource.ParallelTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []resource.TestStep{
+			{
+				Config: r.basic(data),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectIdentityValue("azurerm_network_security_rule.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_network_security_rule.test", tfjsonpath.New("network_security_group_name"), tfjsonpath.New("network_security_group_name")),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_network_security_rule.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_network_security_rule.test", tfjsonpath.New("security_rule_name"), tfjsonpath.New("name")),
+				},
+			},
+			data.ImportBlockWithResourceIdentityStep(),
+			data.ImportBlockWithIDStep(),
+		},
+	})
+}


### PR DESCRIPTION
--- PASS: TestAccNetworkSecurityRule_resourceIdentity (86.70s)