### PR TITLE
`azurerm_kubernetes_cluster` - adding property `gpu_profile` to skip GPU driver install

### DIFF
--- a/internal/services/containers/kubernetes_cluster_node_pool_data_source.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_data_source.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
@@ -214,8 +215,8 @@ func dataSourceKubernetesClusterNodePoolRead(d *pluginsdk.ResourceData, meta int
 		d.Set("eviction_policy", evictionPolicy)
 
 		gpuDriver := ""
-		if props.GpuProfile != nil && *props.GpuProfile.Driver != "" {
-			gpuDriver = string(*props.GpuProfile.Driver)
+		if props.GpuProfile != nil {
+			gpuDriver = string(pointer.From(props.GpuProfile.Driver))
 		}
 		d.Set("gpu_driver", gpuDriver)
 

--- a/internal/services/containers/kubernetes_cluster_node_pool_data_source.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_data_source.go
@@ -54,7 +54,7 @@ func dataSourceKubernetesClusterNodePool() *pluginsdk.Resource {
 				Computed: true,
 			},
 
-			"gpu_profile": {
+			"gpu_driver": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
 			},
@@ -213,11 +213,11 @@ func dataSourceKubernetesClusterNodePoolRead(d *pluginsdk.ResourceData, meta int
 		}
 		d.Set("eviction_policy", evictionPolicy)
 
-		gpuProfile := ""
+		gpuDriver := ""
 		if props.GpuProfile != nil && *props.GpuProfile.Driver != "" {
-			gpuProfile = string(*props.GpuProfile.Driver)
+			gpuDriver = string(*props.GpuProfile.Driver)
 		}
-		d.Set("gpu_profile", gpuProfile)
+		d.Set("gpu_driver", gpuDriver)
 
 		maxCount := 0
 		if props.MaxCount != nil {

--- a/internal/services/containers/kubernetes_cluster_node_pool_data_source.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_data_source.go
@@ -54,6 +54,11 @@ func dataSourceKubernetesClusterNodePool() *pluginsdk.Resource {
 				Computed: true,
 			},
 
+			"gpu_profile": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
 			"max_count": {
 				Type:     pluginsdk.TypeInt,
 				Computed: true,
@@ -207,6 +212,12 @@ func dataSourceKubernetesClusterNodePoolRead(d *pluginsdk.ResourceData, meta int
 			evictionPolicy = string(*props.ScaleSetEvictionPolicy)
 		}
 		d.Set("eviction_policy", evictionPolicy)
+
+		gpuProfile := ""
+		if props.GpuProfile != nil && *props.GpuProfile.Driver != "" {
+			gpuProfile = string(*props.GpuProfile.Driver)
+		}
+		d.Set("gpu_profile", gpuProfile)
 
 		maxCount := 0
 		if props.MaxCount != nil {

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -1058,7 +1058,7 @@ func resourceKubernetesClusterNodePoolRead(d *pluginsdk.ResourceData, meta inter
 		}
 
 		if v := props.GpuProfile; v != nil {
-			d.Set("gpu_driver", string(*v.Driver))
+			d.Set("gpu_driver", string(pointer.From(v.Driver)))
 		}
 
 		if props.CreationData != nil {

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -164,15 +164,12 @@ func resourceKubernetesClusterNodePoolSchema() map[string]*pluginsdk.Schema {
 			}, false),
 		},
 
-		"gpu_profile": {
-			Type:     pluginsdk.TypeString,
-			Default:  string(agentpools.GPUDriverNone),
-			Optional: true,
-			ForceNew: true,
-			ValidateFunc: validation.StringInSlice([]string{
-				string(agentpools.GPUDriverNone),
-				string(agentpools.GPUDriverInstall),
-			}, false),
+		"gpu_driver": {
+			Type:         pluginsdk.TypeString,
+			Default:      string(agentpools.GPUDriverNone),
+			Optional:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringInSlice(agentpools.PossibleValuesForGPUDriver(), false),
 		},
 
 		"kubelet_disk_type": {
@@ -505,7 +502,7 @@ func resourceKubernetesClusterNodePoolCreate(d *pluginsdk.ResourceData, meta int
 	}
 
 	profile.GpuProfile = &agentpools.GPUProfile{
-		Driver: pointer.To(agentpools.GPUDriver(d.Get("gpu_profile").(string))),
+		Driver: pointer.To(agentpools.GPUDriver(d.Get("gpu_driver").(string))),
 	}
 
 	if osSku := d.Get("os_sku").(string); osSku != "" {
@@ -739,9 +736,9 @@ func resourceKubernetesClusterNodePoolUpdate(d *pluginsdk.ResourceData, meta int
 		props.EnableFIPS = pointer.To(d.Get("fips_enabled").(bool))
 	}
 
-	if d.HasChange("gpu_profile") {
+	if d.HasChange("gpu_driver") {
 		props.GpuProfile = &agentpools.GPUProfile{
-			Driver: pointer.To(agentpools.GPUDriver(d.Get("gpu_profile").(string))),
+			Driver: pointer.To(agentpools.GPUDriver(d.Get("gpu_driver").(string))),
 		}
 	}
 
@@ -1060,7 +1057,7 @@ func resourceKubernetesClusterNodePoolRead(d *pluginsdk.ResourceData, meta inter
 		}
 
 		if v := props.GpuProfile; v != nil {
-			d.Set("gpu_profile", string(*v.Driver))
+			d.Set("gpu_driver", string(*v.Driver))
 		}
 
 		if props.CreationData != nil {

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -502,7 +502,7 @@ func resourceKubernetesClusterNodePoolCreate(d *pluginsdk.ResourceData, meta int
 
 	if gpuDriver := d.Get("gpu_driver").(string); gpuDriver != "" {
 		profile.GpuProfile = &agentpools.GPUProfile{
-			Driver: pointer.To(agentpools.GPUDriver(d.Get("gpu_driver").(string))),
+			Driver: pointer.To(agentpools.GPUDriver(gpuDriver)),
 		}
 	}
 
@@ -735,12 +735,6 @@ func resourceKubernetesClusterNodePoolUpdate(d *pluginsdk.ResourceData, meta int
 
 	if d.HasChange("fips_enabled") {
 		props.EnableFIPS = pointer.To(d.Get("fips_enabled").(bool))
-	}
-
-	if d.HasChange("gpu_driver") {
-		props.GpuProfile = &agentpools.GPUProfile{
-			Driver: pointer.To(agentpools.GPUDriver(d.Get("gpu_driver").(string))),
-		}
 	}
 
 	if d.HasChange("host_encryption_enabled") {

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -166,7 +166,6 @@ func resourceKubernetesClusterNodePoolSchema() map[string]*pluginsdk.Schema {
 
 		"gpu_driver": {
 			Type:         pluginsdk.TypeString,
-			Default:      string(agentpools.GPUDriverNone),
 			Optional:     true,
 			ForceNew:     true,
 			ValidateFunc: validation.StringInSlice(agentpools.PossibleValuesForGPUDriver(), false),
@@ -501,8 +500,10 @@ func resourceKubernetesClusterNodePoolCreate(d *pluginsdk.ResourceData, meta int
 		profile.GpuInstanceProfile = pointer.To(agentpools.GPUInstanceProfile(gpuInstanceProfile))
 	}
 
-	profile.GpuProfile = &agentpools.GPUProfile{
-		Driver: pointer.To(agentpools.GPUDriver(d.Get("gpu_driver").(string))),
+	if gpuDriver := d.Get("gpu_driver").(string); gpuDriver != "" {
+		profile.GpuProfile = &agentpools.GPUProfile{
+			Driver: pointer.To(agentpools.GPUDriver(d.Get("gpu_driver").(string))),
+		}
 	}
 
 	if osSku := d.Get("os_sku").(string); osSku != "" {

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -166,7 +166,7 @@ func resourceKubernetesClusterNodePoolSchema() map[string]*pluginsdk.Schema {
 
 		"gpu_profile": {
 			Type:     pluginsdk.TypeString,
-			Default:  string(agentpools.GPUDriverInstall),
+			Default:  string(agentpools.GPUDriverNone),
 			Optional: true,
 			ForceNew: true,
 			ValidateFunc: validation.StringInSlice([]string{

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -164,6 +164,17 @@ func resourceKubernetesClusterNodePoolSchema() map[string]*pluginsdk.Schema {
 			}, false),
 		},
 
+		"gpu_profile": {
+			Type:     pluginsdk.TypeString,
+			Default:  string(agentpools.GPUDriverInstall),
+			Optional: true,
+			ForceNew: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				string(agentpools.GPUDriverNone),
+				string(agentpools.GPUDriverInstall),
+			}, false),
+		},
+
 		"kubelet_disk_type": {
 			Type:     pluginsdk.TypeString,
 			Optional: true,
@@ -493,6 +504,10 @@ func resourceKubernetesClusterNodePoolCreate(d *pluginsdk.ResourceData, meta int
 		profile.GpuInstanceProfile = pointer.To(agentpools.GPUInstanceProfile(gpuInstanceProfile))
 	}
 
+	profile.GpuProfile = &agentpools.GPUProfile{
+		Driver: pointer.To(agentpools.GPUDriver(d.Get("gpu_profile").(string))),
+	}
+
 	if osSku := d.Get("os_sku").(string); osSku != "" {
 		profile.OsSKU = pointer.To(agentpools.OSSKU(osSku))
 	}
@@ -722,6 +737,12 @@ func resourceKubernetesClusterNodePoolUpdate(d *pluginsdk.ResourceData, meta int
 
 	if d.HasChange("fips_enabled") {
 		props.EnableFIPS = pointer.To(d.Get("fips_enabled").(bool))
+	}
+
+	if d.HasChange("gpu_profile") {
+		props.GpuProfile = &agentpools.GPUProfile{
+			Driver: pointer.To(agentpools.GPUDriver(d.Get("gpu_profile").(string))),
+		}
 	}
 
 	if d.HasChange("host_encryption_enabled") {
@@ -1036,6 +1057,10 @@ func resourceKubernetesClusterNodePoolRead(d *pluginsdk.ResourceData, meta inter
 
 		if v := props.GpuInstanceProfile; v != nil {
 			d.Set("gpu_instance", string(*v))
+		}
+
+		if v := props.GpuProfile; v != nil {
+			d.Set("gpu_profile", string(*v.Driver))
 		}
 
 		if props.CreationData != nil {

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -3015,7 +3015,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   name                  = "internal"
   kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
   vm_size               = "Standard_NC24ads_A100_v4"
-  gpu_driver           = "Install"
+  gpu_driver            = "Install"
 }
  `, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -1060,13 +1060,13 @@ func TestAccKubernetesClusterNodePool_gpuInstance(t *testing.T) {
 	})
 }
 
-func TestAccKubernetesClusterNodePool_gpuProfile(t *testing.T) {
+func TestAccKubernetesClusterNodePool_gpuDriver(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster_node_pool", "test")
 	r := KubernetesClusterNodePoolResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.gpuProfile(data),
+			Config: r.gpuDriver(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -2982,7 +2982,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
  `, data.Locations.Primary, data.RandomInteger)
 }
 
-func (KubernetesClusterNodePoolResource) gpuProfile(data acceptance.TestData) string {
+func (KubernetesClusterNodePoolResource) gpuDriver(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -3015,7 +3015,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   name                  = "internal"
   kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
   vm_size               = "Standard_NC24ads_A100_v4"
-  gpu_profile           = "Install"
+  gpu_driver           = "Install"
 }
  `, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -1060,6 +1060,21 @@ func TestAccKubernetesClusterNodePool_gpuInstance(t *testing.T) {
 	})
 }
 
+func TestAccKubernetesClusterNodePool_gpuProfile(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster_node_pool", "test")
+	r := KubernetesClusterNodePoolResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.gpuProfile(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (t KubernetesClusterNodePoolResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := agentpools.ParseAgentPoolID(state.ID)
 	if err != nil {
@@ -2963,6 +2978,44 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
   vm_size               = "Standard_NC24ads_A100_v4"
   gpu_instance          = "MIG1g"
+}
+ `, data.Locations.Primary, data.RandomInteger)
+}
+
+func (KubernetesClusterNodePoolResource) gpuProfile(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%[2]d"
+  location = "%[1]s"
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%[2]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%[2]d"
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_D2s_v3"
+    upgrade_settings {
+      max_surge = "10%%"
+    }
+  }
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+resource "azurerm_kubernetes_cluster_node_pool" "test" {
+  name                  = "internal"
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
+  vm_size               = "Standard_NC24ads_A100_v4"
+  gpu_profile           = "Install"
 }
  `, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/containers/kubernetes_cluster_other_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_other_resource_test.go
@@ -3225,7 +3225,7 @@ resource "azurerm_kubernetes_cluster" "test" {
     node_count   = 1
     vm_size      = "Standard_NC24ads_A100_v4"
     gpu_instance = "MIG1g"
-    gpu_driver  = "Install"
+    gpu_driver   = "Install"
     upgrade_settings {
       max_surge = "10%%"
     }

--- a/internal/services/containers/kubernetes_cluster_other_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_other_resource_test.go
@@ -3225,7 +3225,7 @@ resource "azurerm_kubernetes_cluster" "test" {
     node_count   = 1
     vm_size      = "Standard_NC24ads_A100_v4"
     gpu_instance = "MIG1g"
-    gpu_profile  = "Install"
+    gpu_driver  = "Install"
     upgrade_settings {
       max_surge = "10%%"
     }

--- a/internal/services/containers/kubernetes_cluster_other_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_other_resource_test.go
@@ -3225,7 +3225,7 @@ resource "azurerm_kubernetes_cluster" "test" {
     node_count   = 1
     vm_size      = "Standard_NC24ads_A100_v4"
     gpu_instance = "MIG1g"
-    gpu_profile = "Install
+    gpu_profile  = "Install"
     upgrade_settings {
       max_surge = "10%%"
     }

--- a/internal/services/containers/kubernetes_cluster_other_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_other_resource_test.go
@@ -3225,6 +3225,7 @@ resource "azurerm_kubernetes_cluster" "test" {
     node_count   = 1
     vm_size      = "Standard_NC24ads_A100_v4"
     gpu_instance = "MIG1g"
+    gpu_profile = "Install
     upgrade_settings {
       max_surge = "10%%"
     }

--- a/internal/services/containers/kubernetes_nodepool.go
+++ b/internal/services/containers/kubernetes_nodepool.go
@@ -1193,7 +1193,10 @@ func FlattenDefaultNodePool(input *[]managedclusters.ManagedClusterAgentPoolProf
 		gpuInstanceProfile = string(*agentPool.GpuInstanceProfile)
 	}
 
-	gpuDriver := string(*agentPool.GpuProfile.Driver)
+	gpuDriver := ""
+	if agentPool.GpuProfile != nil {
+		gpuDriver = string(*agentPool.GpuProfile.Driver)
+	}
 
 	maxCount := 0
 	if agentPool.MaxCount != nil {

--- a/internal/services/containers/kubernetes_nodepool.go
+++ b/internal/services/containers/kubernetes_nodepool.go
@@ -99,15 +99,12 @@ func SchemaDefaultNodePool() *pluginsdk.Schema {
 						}, false),
 					},
 
-					"gpu_profile": {
-						Type:     pluginsdk.TypeString,
-						Default:  string(agentpools.GPUDriverNone),
-						Optional: true,
-						ForceNew: true,
-						ValidateFunc: validation.StringInSlice([]string{
-							string(agentpools.GPUDriverNone),
-							string(agentpools.GPUDriverInstall),
-						}, false),
+					"gpu_driver": {
+						Type:         pluginsdk.TypeString,
+						Default:      string(agentpools.GPUDriverNone),
+						Optional:     true,
+						ForceNew:     true,
+						ValidateFunc: validation.StringInSlice(agentpools.PossibleValuesForGPUDriver(), false),
 					},
 
 					"kubelet_disk_type": {
@@ -911,9 +908,9 @@ func ExpandDefaultNodePool(d *pluginsdk.ResourceData) (*[]managedclusters.Manage
 		profile.GpuInstanceProfile = pointer.To(managedclusters.GPUInstanceProfile(gpuInstanceProfile))
 	}
 
-	gpuProfile := raw["gpu_profile"].(string)
+	gpuDriver := raw["gpu_driver"].(string)
 	profile.GpuProfile = &managedclusters.GPUProfile{
-		Driver: pointer.To(managedclusters.GPUDriver(gpuProfile)),
+		Driver: pointer.To(managedclusters.GPUDriver(gpuDriver)),
 	}
 
 	count := raw["node_count"].(int)
@@ -1196,7 +1193,7 @@ func FlattenDefaultNodePool(input *[]managedclusters.ManagedClusterAgentPoolProf
 		gpuInstanceProfile = string(*agentPool.GpuInstanceProfile)
 	}
 
-	gpuProfile := string(*agentPool.GpuProfile.Driver)
+	gpuDriver := string(*agentPool.GpuProfile.Driver)
 
 	maxCount := 0
 	if agentPool.MaxCount != nil {
@@ -1333,7 +1330,7 @@ func FlattenDefaultNodePool(input *[]managedclusters.ManagedClusterAgentPoolProf
 		"auto_scaling_enabled":          enableAutoScaling,
 		"fips_enabled":                  enableFIPS,
 		"gpu_instance":                  gpuInstanceProfile,
-		"gpu_profile":                   gpuProfile,
+		"gpu_driver":                    gpuDriver,
 		"host_encryption_enabled":       enableHostEncryption,
 		"host_group_id":                 hostGroupID,
 		"kubelet_disk_type":             kubeletDiskType,

--- a/internal/services/containers/kubernetes_nodepool.go
+++ b/internal/services/containers/kubernetes_nodepool.go
@@ -1195,7 +1195,7 @@ func FlattenDefaultNodePool(input *[]managedclusters.ManagedClusterAgentPoolProf
 
 	gpuDriver := ""
 	if agentPool.GpuProfile != nil {
-		gpuDriver = string(*agentPool.GpuProfile.Driver)
+		gpuDriver = string(pointer.From(agentPool.GpuProfile.Driver))
 	}
 
 	maxCount := 0

--- a/internal/services/containers/kubernetes_nodepool.go
+++ b/internal/services/containers/kubernetes_nodepool.go
@@ -101,7 +101,6 @@ func SchemaDefaultNodePool() *pluginsdk.Schema {
 
 					"gpu_driver": {
 						Type:         pluginsdk.TypeString,
-						Default:      string(agentpools.GPUDriverNone),
 						Optional:     true,
 						ForceNew:     true,
 						ValidateFunc: validation.StringInSlice(agentpools.PossibleValuesForGPUDriver(), false),
@@ -908,9 +907,10 @@ func ExpandDefaultNodePool(d *pluginsdk.ResourceData) (*[]managedclusters.Manage
 		profile.GpuInstanceProfile = pointer.To(managedclusters.GPUInstanceProfile(gpuInstanceProfile))
 	}
 
-	gpuDriver := raw["gpu_driver"].(string)
-	profile.GpuProfile = &managedclusters.GPUProfile{
-		Driver: pointer.To(managedclusters.GPUDriver(gpuDriver)),
+	if gpuDriver := raw["gpu_driver"].(string); gpuDriver != "" {
+		profile.GpuProfile = &managedclusters.GPUProfile{
+			Driver: pointer.To(managedclusters.GPUDriver(gpuDriver)),
+		}
 	}
 
 	count := raw["node_count"].(int)

--- a/internal/services/containers/kubernetes_nodepool.go
+++ b/internal/services/containers/kubernetes_nodepool.go
@@ -99,6 +99,17 @@ func SchemaDefaultNodePool() *pluginsdk.Schema {
 						}, false),
 					},
 
+					"gpu_profile": {
+						Type:     pluginsdk.TypeString,
+						Default:  string(agentpools.GPUDriverInstall),
+						Optional: true,
+						ForceNew: true,
+						ValidateFunc: validation.StringInSlice([]string{
+							string(agentpools.GPUDriverNone),
+							string(agentpools.GPUDriverInstall),
+						}, false),
+					},
+
 					"kubelet_disk_type": {
 						Type:     pluginsdk.TypeString,
 						Optional: true,
@@ -900,6 +911,11 @@ func ExpandDefaultNodePool(d *pluginsdk.ResourceData) (*[]managedclusters.Manage
 		profile.GpuInstanceProfile = pointer.To(managedclusters.GPUInstanceProfile(gpuInstanceProfile))
 	}
 
+	gpuProfile := raw["gpu_profile"].(string)
+	profile.GpuProfile = &managedclusters.GPUProfile{
+		Driver: pointer.To(managedclusters.GPUDriver(gpuProfile)),
+	}
+
 	count := raw["node_count"].(int)
 	maxCount := raw["max_count"].(int)
 	minCount := raw["min_count"].(int)
@@ -1180,6 +1196,8 @@ func FlattenDefaultNodePool(input *[]managedclusters.ManagedClusterAgentPoolProf
 		gpuInstanceProfile = string(*agentPool.GpuInstanceProfile)
 	}
 
+	gpuProfile := string(*agentPool.GpuProfile.Driver)
+
 	maxCount := 0
 	if agentPool.MaxCount != nil {
 		maxCount = int(*agentPool.MaxCount)
@@ -1315,6 +1333,7 @@ func FlattenDefaultNodePool(input *[]managedclusters.ManagedClusterAgentPoolProf
 		"auto_scaling_enabled":          enableAutoScaling,
 		"fips_enabled":                  enableFIPS,
 		"gpu_instance":                  gpuInstanceProfile,
+		"gpu_profile":                   gpuProfile,
 		"host_encryption_enabled":       enableHostEncryption,
 		"host_group_id":                 hostGroupID,
 		"kubelet_disk_type":             kubeletDiskType,

--- a/internal/services/containers/kubernetes_nodepool.go
+++ b/internal/services/containers/kubernetes_nodepool.go
@@ -101,7 +101,7 @@ func SchemaDefaultNodePool() *pluginsdk.Schema {
 
 					"gpu_profile": {
 						Type:     pluginsdk.TypeString,
-						Default:  string(agentpools.GPUDriverInstall),
+						Default:  string(agentpools.GPUDriverNone),
 						Optional: true,
 						ForceNew: true,
 						ValidateFunc: validation.StringInSlice([]string{

--- a/terraform-registry-manifest.json
+++ b/terraform-registry-manifest.json
@@ -1,6 +1,0 @@
-{
-    "version": 1,
-    "metadata": {
-        "protocol_versions": ["5.0"]
-    }
-}

--- a/terraform-registry-manifest.json
+++ b/terraform-registry-manifest.json
@@ -1,0 +1,6 @@
+{
+    "version": 1,
+    "metadata": {
+        "protocol_versions": ["5.0"]
+    }
+}

--- a/website/docs/r/kubernetes_cluster_node_pool.html.markdown
+++ b/website/docs/r/kubernetes_cluster_node_pool.html.markdown
@@ -98,7 +98,7 @@ The following arguments are supported:
 
 * `gpu_instance` - (Optional) Specifies the GPU MIG instance profile for supported GPU VM SKU. The allowed values are `MIG1g`, `MIG2g`, `MIG3g`, `MIG4g` and `MIG7g`. Changing this forces a new resource to be created.
 
-* `gpu_profile` - (Optional) Specifies whether to install the GPU Driver for the nodes. Possible values are `Install` and `None`. Defaults to `None`.
+* `gpu_driver` - (Optional) Specifies whether to install the GPU Driver for the nodes. Possible values are `Install` and `None`. Defaults to `None`.
 
 * `kubelet_disk_type` - (Optional) The type of disk used by kubelet. Possible values are `OS` and `Temporary`. Changing this property requires specifying `temporary_name_for_rotation`.
 

--- a/website/docs/r/kubernetes_cluster_node_pool.html.markdown
+++ b/website/docs/r/kubernetes_cluster_node_pool.html.markdown
@@ -98,7 +98,7 @@ The following arguments are supported:
 
 * `gpu_instance` - (Optional) Specifies the GPU MIG instance profile for supported GPU VM SKU. The allowed values are `MIG1g`, `MIG2g`, `MIG3g`, `MIG4g` and `MIG7g`. Changing this forces a new resource to be created.
 
-* `gpu_driver` - (Optional) Specifies whether to install the GPU Driver for the nodes. Possible values are `Install` and `None`.
+* `gpu_driver` - (Optional) Specifies whether to install the GPU Driver for the nodes. Possible values are `Install` and `None`. Changing this forces a new resource to be created.
 
 * `kubelet_disk_type` - (Optional) The type of disk used by kubelet. Possible values are `OS` and `Temporary`. Changing this property requires specifying `temporary_name_for_rotation`.
 

--- a/website/docs/r/kubernetes_cluster_node_pool.html.markdown
+++ b/website/docs/r/kubernetes_cluster_node_pool.html.markdown
@@ -98,7 +98,7 @@ The following arguments are supported:
 
 * `gpu_instance` - (Optional) Specifies the GPU MIG instance profile for supported GPU VM SKU. The allowed values are `MIG1g`, `MIG2g`, `MIG3g`, `MIG4g` and `MIG7g`. Changing this forces a new resource to be created.
 
-* `gpu_driver` - (Optional) Specifies whether to install the GPU Driver for the nodes. Possible values are `Install` and `None`. Defaults to `None`.
+* `gpu_driver` - (Optional) Specifies whether to install the GPU Driver for the nodes. Possible values are `Install` and `None`.
 
 * `kubelet_disk_type` - (Optional) The type of disk used by kubelet. Possible values are `OS` and `Temporary`. Changing this property requires specifying `temporary_name_for_rotation`.
 

--- a/website/docs/r/kubernetes_cluster_node_pool.html.markdown
+++ b/website/docs/r/kubernetes_cluster_node_pool.html.markdown
@@ -98,6 +98,8 @@ The following arguments are supported:
 
 * `gpu_instance` - (Optional) Specifies the GPU MIG instance profile for supported GPU VM SKU. The allowed values are `MIG1g`, `MIG2g`, `MIG3g`, `MIG4g` and `MIG7g`. Changing this forces a new resource to be created.
 
+* `gpu_profile` - (Optional) Specifies whether to install the GPU Driver for the nodes. Possible values are `Install` and `None`. Defaults to `None`.
+
 * `kubelet_disk_type` - (Optional) The type of disk used by kubelet. Possible values are `OS` and `Temporary`. Changing this property requires specifying `temporary_name_for_rotation`.
 
 * `max_pods` - (Optional) The maximum number of pods that can run on each agent. Changing this property requires specifying `temporary_name_for_rotation`.


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

The reason for this PR is described in #29615. The PR itself contains enhancements of the `kubernetes_cluster_node_pool_data_source`, `kubernetes_nodepool` and `kubernetes_cluster_node_pool_resource`. 


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [x] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<img width="1092" alt="Screenshot 2025-06-23 at 21 23 27" src="https://github.com/user-attachments/assets/edfe3c44-848b-43ca-b0a7-4db32990e63c" />

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_kubernetes_cluster_node_pool` data source - support for the `gpu_profile` property
* `azurerm_kubernetes_cluster_node_pool` resource - support for the `gpu_profile` property


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #29615 

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
