### PR TITLE
`azurerm_subnet_service_endpoint_storage_policy` - add support for Resource Identity

### DIFF
--- a/internal/services/network/subnet_service_endpoint_storage_policy_resource.go
+++ b/internal/services/network/subnet_service_endpoint_storage_policy_resource.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2024-05-01/serviceendpointpolicies"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -25,6 +26,8 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name subnet_service_endpoint_storage_policy -service-package-name network -properties "service_endpoint_policy_name:name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
+
 func resourceSubnetServiceEndpointStoragePolicy() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
 		Create: resourceSubnetServiceEndpointStoragePolicyCreate,
@@ -32,10 +35,11 @@ func resourceSubnetServiceEndpointStoragePolicy() *pluginsdk.Resource {
 		Update: resourceSubnetServiceEndpointStoragePolicyUpdate,
 		Delete: resourceSubnetServiceEndpointStoragePolicyDelete,
 
-		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
-			_, err := serviceendpointpolicies.ParseServiceEndpointPolicyID(id)
-			return err
-		}),
+		Importer: pluginsdk.ImporterValidatingIdentity(&serviceendpointpolicies.ServiceEndpointPolicyId{}),
+
+		Identity: &schema.ResourceIdentity{
+			SchemaFunc: pluginsdk.GenerateIdentitySchema(&serviceendpointpolicies.ServiceEndpointPolicyId{}),
+		},
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
@@ -222,9 +226,12 @@ func resourceSubnetServiceEndpointStoragePolicyRead(d *pluginsdk.ResourceData, m
 				return fmt.Errorf("setting `definition`: %v", err)
 			}
 		}
-		return tags.FlattenAndSet(d, model.Tags)
+		if err := tags.FlattenAndSet(d, model.Tags); err != nil {
+			return err
+		}
 	}
-	return nil
+
+	return pluginsdk.SetResourceIdentityData(d, id)
 }
 
 func resourceSubnetServiceEndpointStoragePolicyDelete(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/network/subnet_service_endpoint_storage_policy_resource_identity_gen_test.go
+++ b/internal/services/network/subnet_service_endpoint_storage_policy_resource_identity_gen_test.go
@@ -1,0 +1,42 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package network_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
+)
+
+func TestAccSubnetServiceEndpointStoragePolicy_resourceIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_subnet_service_endpoint_storage_policy", "test")
+	r := SubnetServiceEndpointStoragePolicyResource{}
+
+	resource.ParallelTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []resource.TestStep{
+			{
+				Config: r.basic(data),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectIdentityValue("azurerm_subnet_service_endpoint_storage_policy.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_subnet_service_endpoint_storage_policy.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_subnet_service_endpoint_storage_policy.test", tfjsonpath.New("service_endpoint_policy_name"), tfjsonpath.New("name")),
+				},
+			},
+			data.ImportBlockWithResourceIdentityStep(),
+			data.ImportBlockWithIDStep(),
+		},
+	})
+}

--- a/internal/services/network/subnet_service_endpoint_storage_policy_resource_test.go
+++ b/internal/services/network/subnet_service_endpoint_storage_policy_resource_test.go
@@ -16,11 +16,11 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
-type SubnetServiceEndpointPolicyStorageResource struct{}
+type SubnetServiceEndpointStoragePolicyResource struct{}
 
 func TestAccSubnetServiceEndpointStoragePolicy_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_subnet_service_endpoint_storage_policy", "test")
-	r := SubnetServiceEndpointPolicyStorageResource{}
+	r := SubnetServiceEndpointStoragePolicyResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -35,7 +35,7 @@ func TestAccSubnetServiceEndpointStoragePolicy_basic(t *testing.T) {
 
 func TestAccSubnetServiceEndpointStoragePolicy_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_subnet_service_endpoint_storage_policy", "test")
-	r := SubnetServiceEndpointPolicyStorageResource{}
+	r := SubnetServiceEndpointStoragePolicyResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -50,7 +50,7 @@ func TestAccSubnetServiceEndpointStoragePolicy_complete(t *testing.T) {
 
 func TestAccSubnetServiceEndpointStoragePolicy_alias(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_subnet_service_endpoint_storage_policy", "test")
-	r := SubnetServiceEndpointPolicyStorageResource{}
+	r := SubnetServiceEndpointStoragePolicyResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -65,7 +65,7 @@ func TestAccSubnetServiceEndpointStoragePolicy_alias(t *testing.T) {
 
 func TestAccSubnetServiceEndpointStoragePolicy_storage(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_subnet_service_endpoint_storage_policy", "test")
-	r := SubnetServiceEndpointPolicyStorageResource{}
+	r := SubnetServiceEndpointStoragePolicyResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -80,7 +80,7 @@ func TestAccSubnetServiceEndpointStoragePolicy_storage(t *testing.T) {
 
 func TestAccSubnetServiceEndpointStoragePolicy_update_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_subnet_service_endpoint_storage_policy", "test")
-	r := SubnetServiceEndpointPolicyStorageResource{}
+	r := SubnetServiceEndpointStoragePolicyResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -109,7 +109,7 @@ func TestAccSubnetServiceEndpointStoragePolicy_update_complete(t *testing.T) {
 
 func TestAccSubnetServiceEndpointStoragePolicy_update_alias(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_subnet_service_endpoint_storage_policy", "test")
-	r := SubnetServiceEndpointPolicyStorageResource{}
+	r := SubnetServiceEndpointStoragePolicyResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -138,7 +138,7 @@ func TestAccSubnetServiceEndpointStoragePolicy_update_alias(t *testing.T) {
 
 func TestAccSubnetServiceEndpointStoragePolicy_update_storage(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_subnet_service_endpoint_storage_policy", "test")
-	r := SubnetServiceEndpointPolicyStorageResource{}
+	r := SubnetServiceEndpointStoragePolicyResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -167,7 +167,7 @@ func TestAccSubnetServiceEndpointStoragePolicy_update_storage(t *testing.T) {
 
 func TestAccSubnetServiceEndpointStoragePolicy_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_subnet_service_endpoint_storage_policy", "test")
-	r := SubnetServiceEndpointPolicyStorageResource{}
+	r := SubnetServiceEndpointStoragePolicyResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -180,7 +180,7 @@ func TestAccSubnetServiceEndpointStoragePolicy_requiresImport(t *testing.T) {
 	})
 }
 
-func (t SubnetServiceEndpointPolicyStorageResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+func (t SubnetServiceEndpointStoragePolicyResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := serviceendpointpolicies.ParseServiceEndpointPolicyID(state.ID)
 	if err != nil {
 		return nil, err
@@ -194,7 +194,7 @@ func (t SubnetServiceEndpointPolicyStorageResource) Exists(ctx context.Context, 
 	return pointer.To(resp.Model != nil), nil
 }
 
-func (r SubnetServiceEndpointPolicyStorageResource) basic(data acceptance.TestData) string {
+func (r SubnetServiceEndpointStoragePolicyResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -206,7 +206,7 @@ resource "azurerm_subnet_service_endpoint_storage_policy" "test" {
 `, r.template(data), data.RandomInteger)
 }
 
-func (r SubnetServiceEndpointPolicyStorageResource) complete(data acceptance.TestData) string {
+func (r SubnetServiceEndpointStoragePolicyResource) complete(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -255,7 +255,7 @@ resource "azurerm_subnet_service_endpoint_storage_policy" "test" {
 `, r.template(data), data.RandomString, data.RandomInteger, data.Client().SubscriptionID)
 }
 
-func (r SubnetServiceEndpointPolicyStorageResource) alias(data acceptance.TestData) string {
+func (r SubnetServiceEndpointStoragePolicyResource) alias(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -293,7 +293,7 @@ resource "azurerm_subnet_service_endpoint_storage_policy" "test" {
 `, r.template(data), data.RandomString, data.RandomInteger)
 }
 
-func (r SubnetServiceEndpointPolicyStorageResource) storage(data acceptance.TestData) string {
+func (r SubnetServiceEndpointStoragePolicyResource) storage(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -328,7 +328,7 @@ resource "azurerm_subnet_service_endpoint_storage_policy" "test" {
 `, r.template(data), data.RandomString, data.RandomInteger, data.Client().SubscriptionID)
 }
 
-func (r SubnetServiceEndpointPolicyStorageResource) requiresImport(data acceptance.TestData) string {
+func (r SubnetServiceEndpointStoragePolicyResource) requiresImport(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -340,7 +340,7 @@ resource "azurerm_subnet_service_endpoint_storage_policy" "import" {
 `, r.basic(data))
 }
 
-func (SubnetServiceEndpointPolicyStorageResource) template(data acceptance.TestData) string {
+func (SubnetServiceEndpointStoragePolicyResource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}


### PR DESCRIPTION
--- PASS: TestAccSubnetServiceEndpointStoragePolicy_resourceIdentity (78.06s)