### PR TITLE
`azurerm_route_server_bgp_connection` - add support for Resource Identity

### DIFF
--- a/internal/services/network/route_server_bgp_connection_resource.go
+++ b/internal/services/network/route_server_bgp_connection_resource.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2024-05-01/virtualwans"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
@@ -19,6 +20,8 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
+
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name route_server_bgp_connection -service-package-name network -properties "connection_name:name" -compare-values "subscription_id:route_server_id,resource_group_name:route_server_id,hub_name:route_server_id"
 
 func resourceRouteServerBgpConnection() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
@@ -32,10 +35,11 @@ func resourceRouteServerBgpConnection() *pluginsdk.Resource {
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 
-		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
-			_, err := commonids.ParseVirtualHubBGPConnectionID(id)
-			return err
-		}),
+		Importer: pluginsdk.ImporterValidatingIdentity(&commonids.VirtualHubBGPConnectionId{}),
+
+		Identity: &schema.ResourceIdentity{
+			SchemaFunc: pluginsdk.GenerateIdentitySchema(&commonids.VirtualHubBGPConnectionId{}),
+		},
 
 		Schema: map[string]*pluginsdk.Schema{
 			"name": {
@@ -146,7 +150,8 @@ func resourceRouteServerBgpConnectionRead(d *pluginsdk.ResourceData, meta interf
 			}
 		}
 	}
-	return nil
+
+	return pluginsdk.SetResourceIdentityData(d, id)
 }
 
 func resourceRouteServerBgpConnectionDelete(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/network/route_server_bgp_connection_resource_identity_gen_test.go
+++ b/internal/services/network/route_server_bgp_connection_resource_identity_gen_test.go
@@ -1,0 +1,43 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package network_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
+)
+
+func TestAccRouteServerBgpConnection_resourceIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_route_server_bgp_connection", "test")
+	r := RouteServerBgpConnectionResource{}
+
+	resource.ParallelTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []resource.TestStep{
+			{
+				Config: r.basic(data),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_route_server_bgp_connection.test", tfjsonpath.New("connection_name"), tfjsonpath.New("name")),
+					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_route_server_bgp_connection.test", tfjsonpath.New("hub_name"), tfjsonpath.New("route_server_id")),
+					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_route_server_bgp_connection.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("route_server_id")),
+					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_route_server_bgp_connection.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("route_server_id")),
+				},
+			},
+			data.ImportBlockWithResourceIdentityStep(),
+			data.ImportBlockWithIDStep(),
+		},
+	})
+}

--- a/internal/services/network/route_server_bgp_connection_resource_test.go
+++ b/internal/services/network/route_server_bgp_connection_resource_test.go
@@ -16,11 +16,11 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
-type RouteServerBGPConnectionResource struct{}
+type RouteServerBgpConnectionResource struct{}
 
 func TestAccRouteServerBgpConnection_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_route_server_bgp_connection", "test")
-	r := RouteServerBGPConnectionResource{}
+	r := RouteServerBgpConnectionResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.basic(data),
@@ -33,7 +33,7 @@ func TestAccRouteServerBgpConnection_basic(t *testing.T) {
 
 func TestAccRouteServerBgpConnection_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_route_server_bgp_connection", "test")
-	r := RouteServerBGPConnectionResource{}
+	r := RouteServerBgpConnectionResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -45,7 +45,7 @@ func TestAccRouteServerBgpConnection_requiresImport(t *testing.T) {
 	})
 }
 
-func (r RouteServerBGPConnectionResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+func (r RouteServerBgpConnectionResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := commonids.ParseVirtualHubBGPConnectionID(state.ID)
 	if err != nil {
 		return nil, err
@@ -58,7 +58,7 @@ func (r RouteServerBGPConnectionResource) Exists(ctx context.Context, clients *c
 	return pointer.To(resp.Model != nil), nil
 }
 
-func (r RouteServerBGPConnectionResource) basic(data acceptance.TestData) string {
+func (r RouteServerBgpConnectionResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -72,7 +72,7 @@ resource "azurerm_route_server_bgp_connection" "test" {
 `, RouteServerResource{}.basic(data), data.RandomInteger)
 }
 
-func (r RouteServerBGPConnectionResource) requiresImport(data acceptance.TestData) string {
+func (r RouteServerBgpConnectionResource) requiresImport(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 


### PR DESCRIPTION
--- PASS: TestAccRouteServerBgpConnection_resourceIdentity (1503.37s)