### PR TITLE
`azurerm_virtual_hub_bgp_connection` - add support for Resource Identity

### DIFF
--- a/internal/services/network/virtual_hub_bgp_connection_resource.go
+++ b/internal/services/network/virtual_hub_bgp_connection_resource.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2024-05-01/virtualwans"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
@@ -19,6 +20,8 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
+
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name virtual_hub_bgp_connection -service-package-name network -properties "connection_name:name" -compare-values "subscription_id:virtual_hub_id,resource_group_name:virtual_hub_id,hub_name:virtual_hub_id"
 
 func resourceVirtualHubBgpConnection() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
@@ -34,10 +37,11 @@ func resourceVirtualHubBgpConnection() *pluginsdk.Resource {
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 
-		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
-			_, err := commonids.ParseVirtualHubBGPConnectionID(id)
-			return err
-		}),
+		Importer: pluginsdk.ImporterValidatingIdentity(&commonids.VirtualHubBGPConnectionId{}),
+
+		Identity: &schema.ResourceIdentity{
+			SchemaFunc: pluginsdk.GenerateIdentitySchema(&commonids.VirtualHubBGPConnectionId{}),
+		},
 
 		Schema: map[string]*pluginsdk.Schema{
 			"name": {
@@ -215,7 +219,7 @@ func resourceVirtualHubBgpConnectionRead(d *pluginsdk.ResourceData, meta interfa
 		}
 	}
 
-	return nil
+	return pluginsdk.SetResourceIdentityData(d, id)
 }
 
 func resourceVirtualHubBgpConnectionDelete(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/network/virtual_hub_bgp_connection_resource_identity_gen_test.go
+++ b/internal/services/network/virtual_hub_bgp_connection_resource_identity_gen_test.go
@@ -1,0 +1,43 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package network_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
+)
+
+func TestAccVirtualHubBgpConnection_resourceIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_virtual_hub_bgp_connection", "test")
+	r := VirtualHubBgpConnectionResource{}
+
+	resource.ParallelTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []resource.TestStep{
+			{
+				Config: r.basic(data),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_virtual_hub_bgp_connection.test", tfjsonpath.New("connection_name"), tfjsonpath.New("name")),
+					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_virtual_hub_bgp_connection.test", tfjsonpath.New("hub_name"), tfjsonpath.New("virtual_hub_id")),
+					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_virtual_hub_bgp_connection.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("virtual_hub_id")),
+					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_virtual_hub_bgp_connection.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("virtual_hub_id")),
+				},
+			},
+			data.ImportBlockWithResourceIdentityStep(),
+			data.ImportBlockWithIDStep(),
+		},
+	})
+}

--- a/internal/services/network/virtual_hub_bgp_connection_resource_test.go
+++ b/internal/services/network/virtual_hub_bgp_connection_resource_test.go
@@ -16,11 +16,11 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
-type VirtualHubBGPConnectionResource struct{}
+type VirtualHubBgpConnectionResource struct{}
 
 func TestAccVirtualHubBgpConnection_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_virtual_hub_bgp_connection", "test")
-	r := VirtualHubBGPConnectionResource{}
+	r := VirtualHubBgpConnectionResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.basic(data),
@@ -34,7 +34,7 @@ func TestAccVirtualHubBgpConnection_basic(t *testing.T) {
 
 func TestAccVirtualHubBgpConnection_virtualWan(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_virtual_hub_bgp_connection", "test")
-	r := VirtualHubBGPConnectionResource{}
+	r := VirtualHubBgpConnectionResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.virtualWan(data),
@@ -62,7 +62,7 @@ func TestAccVirtualHubBgpConnection_virtualWan(t *testing.T) {
 
 func TestAccVirtualHubBgpConnection_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_virtual_hub_bgp_connection", "test")
-	r := VirtualHubBGPConnectionResource{}
+	r := VirtualHubBgpConnectionResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.basic(data),
@@ -74,7 +74,7 @@ func TestAccVirtualHubBgpConnection_requiresImport(t *testing.T) {
 	})
 }
 
-func (t VirtualHubBGPConnectionResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+func (t VirtualHubBgpConnectionResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := commonids.ParseVirtualHubBGPConnectionID(state.ID)
 	if err != nil {
 		return nil, err
@@ -88,7 +88,7 @@ func (t VirtualHubBGPConnectionResource) Exists(ctx context.Context, clients *cl
 	return pointer.To(resp.Model != nil), nil
 }
 
-func (VirtualHubBGPConnectionResource) template(data acceptance.TestData) string {
+func (VirtualHubBgpConnectionResource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -139,7 +139,7 @@ resource "azurerm_virtual_hub_ip" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
-func (r VirtualHubBGPConnectionResource) basic(data acceptance.TestData) string {
+func (r VirtualHubBgpConnectionResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -154,7 +154,7 @@ resource "azurerm_virtual_hub_bgp_connection" "test" {
 `, r.template(data), data.RandomInteger)
 }
 
-func (r VirtualHubBGPConnectionResource) virtualWanTemplate(data acceptance.TestData) string {
+func (r VirtualHubBgpConnectionResource) virtualWanTemplate(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -206,7 +206,7 @@ resource "azurerm_virtual_hub" "test" {
 `, data.RandomInteger, data.Locations.Primary)
 }
 
-func (r VirtualHubBGPConnectionResource) virtualWan(data acceptance.TestData) string {
+func (r VirtualHubBgpConnectionResource) virtualWan(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -226,7 +226,7 @@ resource "azurerm_virtual_hub_bgp_connection" "test" {
 `, r.virtualWanTemplate(data), data.RandomInteger)
 }
 
-func (r VirtualHubBGPConnectionResource) update(data acceptance.TestData) string {
+func (r VirtualHubBgpConnectionResource) update(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -285,7 +285,7 @@ resource "azurerm_virtual_hub_bgp_connection" "test" {
 `, r.virtualWanTemplate(data), data.RandomInteger)
 }
 
-func (r VirtualHubBGPConnectionResource) requiresImport(data acceptance.TestData) string {
+func (r VirtualHubBgpConnectionResource) requiresImport(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 


### PR DESCRIPTION
--- PASS: TestAccVirtualHubBgpConnection_resourceIdentity (1342.07s)