### PR TITLE
`azurerm_storage_account_queue_properties` - add support for Resource Identity

### DIFF
--- a/internal/services/storage/storage_account_queue_properties_resource.go
+++ b/internal/services/storage/storage_account_queue_properties_resource.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-05-01/storageaccounts"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -19,9 +20,14 @@ import (
 	"github.com/jackofallops/giovanni/storage/2023-11-03/queue/queues"
 )
 
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name storage_account_queue_properties -service-package-name storage -compare-values "subscription_id:storage_account_id,resource_group_name:storage_account_id,storage_account_name:storage_account_id" -test-name "corsOnly"
+
 type AccountQueuePropertiesResource struct{}
 
-var _ sdk.ResourceWithUpdate = AccountQueuePropertiesResource{}
+var (
+	_ sdk.ResourceWithUpdate   = AccountQueuePropertiesResource{}
+	_ sdk.ResourceWithIdentity = AccountQueuePropertiesResource{}
+)
 
 type AccountQueuePropertiesModel struct {
 	StorageAccountId string                                `json:"storage_account_id" tfschema:"storage_account_id"`
@@ -262,6 +268,10 @@ func (s AccountQueuePropertiesResource) IDValidationFunc() pluginsdk.SchemaValid
 	return commonids.ValidateStorageAccountID
 }
 
+func (s AccountQueuePropertiesResource) Identity() resourceids.ResourceId {
+	return &commonids.StorageAccountId{}
+}
+
 func (s AccountQueuePropertiesResource) Create() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
 		Timeout: 30 * time.Minute,
@@ -466,6 +476,10 @@ func (s AccountQueuePropertiesResource) Read() sdk.ResourceFunc {
 						},
 					}
 				}
+			}
+
+			if err = pluginsdk.SetResourceIdentityData(metadata.ResourceData, id); err != nil {
+				return err
 			}
 
 			return metadata.Encode(&state)

--- a/internal/services/storage/storage_account_queue_properties_resource_identity_gen_test.go
+++ b/internal/services/storage/storage_account_queue_properties_resource_identity_gen_test.go
@@ -1,0 +1,42 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package storage_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
+)
+
+func TestAccStorageAccountQueueProperties_resourceIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_account_queue_properties", "test")
+	r := StorageAccountQueuePropertiesResource{}
+
+	resource.ParallelTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []resource.TestStep{
+			{
+				Config: r.corsOnly(data),
+				ConfigStateChecks: []statecheck.StateCheck{
+					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_account_queue_properties.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("storage_account_id")),
+					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_account_queue_properties.test", tfjsonpath.New("storage_account_name"), tfjsonpath.New("storage_account_id")),
+					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_account_queue_properties.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("storage_account_id")),
+				},
+			},
+			data.ImportBlockWithResourceIdentityStep(),
+			data.ImportBlockWithIDStep(),
+		},
+	})
+}

--- a/internal/services/storage/storage_account_queue_properties_resource_test.go
+++ b/internal/services/storage/storage_account_queue_properties_resource_test.go
@@ -18,11 +18,11 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
-type AccountQueuePropertiesResource struct{}
+type StorageAccountQueuePropertiesResource struct{}
 
 func TestAccStorageAccountQueueProperties_corsOnly(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_account_queue_properties", "test")
-	r := AccountQueuePropertiesResource{}
+	r := StorageAccountQueuePropertiesResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -37,7 +37,7 @@ func TestAccStorageAccountQueueProperties_corsOnly(t *testing.T) {
 
 func TestAccStorageAccountQueueProperties_loggingOnly(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_account_queue_properties", "test")
-	r := AccountQueuePropertiesResource{}
+	r := StorageAccountQueuePropertiesResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -52,7 +52,7 @@ func TestAccStorageAccountQueueProperties_loggingOnly(t *testing.T) {
 
 func TestAccStorageAccountQueueProperties_hourMetricsOnly(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_account_queue_properties", "test")
-	r := AccountQueuePropertiesResource{}
+	r := StorageAccountQueuePropertiesResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -67,7 +67,7 @@ func TestAccStorageAccountQueueProperties_hourMetricsOnly(t *testing.T) {
 
 func TestAccStorageAccountQueueProperties_minuteMetricsOnly(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_account_queue_properties", "test")
-	r := AccountQueuePropertiesResource{}
+	r := StorageAccountQueuePropertiesResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -82,7 +82,7 @@ func TestAccStorageAccountQueueProperties_minuteMetricsOnly(t *testing.T) {
 
 func TestAccStorageAccountQueueProperties_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_account_queue_properties", "test")
-	r := AccountQueuePropertiesResource{}
+	r := StorageAccountQueuePropertiesResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -139,7 +139,7 @@ func TestAccStorageAccountQueueProperties_update(t *testing.T) {
 
 func TestAccStorageAccountQueueProperties_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_account_queue_properties", "test")
-	r := AccountQueuePropertiesResource{}
+	r := StorageAccountQueuePropertiesResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -152,7 +152,7 @@ func TestAccStorageAccountQueueProperties_complete(t *testing.T) {
 	})
 }
 
-func (r AccountQueuePropertiesResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+func (r StorageAccountQueuePropertiesResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := commonids.ParseStorageAccountID(state.ID)
 	if err != nil {
 		return nil, err
@@ -180,7 +180,7 @@ func (r AccountQueuePropertiesResource) Exists(ctx context.Context, client *clie
 	return pointer.To(present), nil
 }
 
-func (r AccountQueuePropertiesResource) corsOnly(data acceptance.TestData) string {
+func (r StorageAccountQueuePropertiesResource) corsOnly(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -209,7 +209,7 @@ resource "azurerm_storage_account_queue_properties" "test" {
 `, r.template(data))
 }
 
-func (r AccountQueuePropertiesResource) hourMetricsOnly(data acceptance.TestData) string {
+func (r StorageAccountQueuePropertiesResource) hourMetricsOnly(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -227,7 +227,7 @@ resource "azurerm_storage_account_queue_properties" "test" {
 `, r.template(data))
 }
 
-func (r AccountQueuePropertiesResource) minuteMetricsOnly(data acceptance.TestData) string {
+func (r StorageAccountQueuePropertiesResource) minuteMetricsOnly(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -245,7 +245,7 @@ resource "azurerm_storage_account_queue_properties" "test" {
 `, r.template(data))
 }
 
-func (r AccountQueuePropertiesResource) loggingOnly(data acceptance.TestData) string {
+func (r StorageAccountQueuePropertiesResource) loggingOnly(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -266,7 +266,7 @@ resource "azurerm_storage_account_queue_properties" "test" {
 `, r.template(data))
 }
 
-func (r AccountQueuePropertiesResource) complete(data acceptance.TestData) string {
+func (r StorageAccountQueuePropertiesResource) complete(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -305,7 +305,7 @@ resource "azurerm_storage_account_queue_properties" "test" {
 `, r.template(data))
 }
 
-func (r AccountQueuePropertiesResource) template(data acceptance.TestData) string {
+func (r StorageAccountQueuePropertiesResource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 
 resource "azurerm_resource_group" "test" {


### PR DESCRIPTION
```
--- PASS: TestAccStorageAccountQueueProperties_resourceIdentity (153.94s)
```