### PR TITLE
`azurerm_public_ip_prefix` - add support for Resource Identity

### DIFF
--- a/internal/services/network/public_ip_prefix_resource.go
+++ b/internal/services/network/public_ip_prefix_resource.go
@@ -23,16 +23,19 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
 
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name public_ip_prefix -service-package-name network -properties "public_ip_prefix_name:name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
+
 func resourcePublicIpPrefix() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
-		Create: resourcePublicIpPrefixCreate,
-		Read:   resourcePublicIpPrefixRead,
-		Update: resourcePublicIpPrefixUpdate,
-		Delete: resourcePublicIpPrefixDelete,
-		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
-			_, err := publicipprefixes.ParsePublicIPPrefixID(id)
-			return err
-		}),
+		Create:   resourcePublicIpPrefixCreate,
+		Read:     resourcePublicIpPrefixRead,
+		Update:   resourcePublicIpPrefixUpdate,
+		Delete:   resourcePublicIpPrefixDelete,
+		Importer: pluginsdk.ImporterValidatingIdentity(&publicipprefixes.PublicIPPrefixId{}),
+
+		Identity: &schema.ResourceIdentity{
+			SchemaFunc: pluginsdk.GenerateIdentitySchema(&publicipprefixes.PublicIPPrefixId{}),
+		},
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
@@ -209,9 +212,12 @@ func resourcePublicIpPrefixRead(d *pluginsdk.ResourceData, meta interface{}) err
 				d.Set("ip_version", string(*version))
 			}
 		}
-		return tags.FlattenAndSet(d, model.Tags)
+		if err := tags.FlattenAndSet(d, model.Tags); err != nil {
+			return err
+		}
 	}
-	return nil
+
+	return pluginsdk.SetResourceIdentityData(d, id)
 }
 
 func resourcePublicIpPrefixDelete(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/network/public_ip_prefix_resource_identity_gen_test.go
+++ b/internal/services/network/public_ip_prefix_resource_identity_gen_test.go
@@ -1,0 +1,42 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package network_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
+)
+
+func TestAccPublicIpPrefix_resourceIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_public_ip_prefix", "test")
+	r := PublicIpPrefixResource{}
+
+	resource.ParallelTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []resource.TestStep{
+			{
+				Config: r.basic(data),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectIdentityValue("azurerm_public_ip_prefix.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_public_ip_prefix.test", tfjsonpath.New("public_ip_prefix_name"), tfjsonpath.New("name")),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_public_ip_prefix.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
+				},
+			},
+			data.ImportBlockWithResourceIdentityStep(),
+			data.ImportBlockWithIDStep(),
+		},
+	})
+}

--- a/internal/services/network/public_ip_prefix_resource_test.go
+++ b/internal/services/network/public_ip_prefix_resource_test.go
@@ -17,9 +17,9 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
-type PublicIPPrefixResource struct{}
+type PublicIpPrefixResource struct{}
 
-func (t PublicIPPrefixResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+func (r PublicIpPrefixResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := publicipprefixes.ParsePublicIPPrefixID(state.ID)
 	if err != nil {
 		return nil, err
@@ -33,7 +33,7 @@ func (t PublicIPPrefixResource) Exists(ctx context.Context, clients *clients.Cli
 	return pointer.To(resp.Model != nil), nil
 }
 
-func (PublicIPPrefixResource) Destroy(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+func (PublicIpPrefixResource) Destroy(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := publicipprefixes.ParsePublicIPPrefixID(state.ID)
 	if err != nil {
 		return nil, err
@@ -48,7 +48,7 @@ func (PublicIPPrefixResource) Destroy(ctx context.Context, client *clients.Clien
 
 func TestAccPublicIpPrefix_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_public_ip_prefix", "test")
-	r := PublicIPPrefixResource{}
+	r := PublicIpPrefixResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -65,7 +65,7 @@ func TestAccPublicIpPrefix_basic(t *testing.T) {
 
 func TestAccPublicIpPrefix_globalTier(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_public_ip_prefix", "test")
-	r := PublicIPPrefixResource{}
+	r := PublicIpPrefixResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -81,7 +81,7 @@ func TestAccPublicIpPrefix_globalTier(t *testing.T) {
 
 func TestAccPublicIpPrefix_regionalTier(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_public_ip_prefix", "test")
-	r := PublicIPPrefixResource{}
+	r := PublicIpPrefixResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -97,7 +97,7 @@ func TestAccPublicIpPrefix_regionalTier(t *testing.T) {
 
 func TestAccPublicIpPrefix_ipv6(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_public_ip_prefix", "test")
-	r := PublicIPPrefixResource{}
+	r := PublicIpPrefixResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -114,7 +114,7 @@ func TestAccPublicIpPrefix_ipv6(t *testing.T) {
 
 func TestAccPublicIpPrefix_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_public_ip_prefix", "test")
-	r := PublicIPPrefixResource{}
+	r := PublicIpPrefixResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -129,7 +129,7 @@ func TestAccPublicIpPrefix_requiresImport(t *testing.T) {
 
 func TestAccPublicIpPrefix_prefixLength31(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_public_ip_prefix", "test")
-	r := PublicIPPrefixResource{}
+	r := PublicIpPrefixResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -150,7 +150,7 @@ func TestAccPublicIpPrefix_prefixLength24(t *testing.T) {
 	// more detail about [public ip limits](https://learn.microsoft.com/en-us/azure/virtual-network/ip-services/public-ip-addresses#limits)
 	// you can submit a support request to increase the limit in [Azure Portal](https://learn.microsoft.com/en-us/azure/networking/check-usage-against-limits#azure-portal)
 	data := acceptance.BuildTestData(t, "azurerm_public_ip_prefix", "test")
-	r := PublicIPPrefixResource{}
+	r := PublicIpPrefixResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -167,7 +167,7 @@ func TestAccPublicIpPrefix_prefixLength24(t *testing.T) {
 
 func TestAccPublicIpPrefix_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_public_ip_prefix", "test")
-	r := PublicIPPrefixResource{}
+	r := PublicIpPrefixResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -192,7 +192,7 @@ func TestAccPublicIpPrefix_update(t *testing.T) {
 
 func TestAccPublicIpPrefix_disappears(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_public_ip_prefix", "test")
-	r := PublicIPPrefixResource{}
+	r := PublicIpPrefixResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		data.DisappearsStep(acceptance.DisappearsStepData{
@@ -204,7 +204,7 @@ func TestAccPublicIpPrefix_disappears(t *testing.T) {
 
 func TestAccPublicIpPrefix_zonesSingle(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_public_ip_prefix", "test")
-	r := PublicIPPrefixResource{}
+	r := PublicIpPrefixResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -219,7 +219,7 @@ func TestAccPublicIpPrefix_zonesSingle(t *testing.T) {
 
 func TestAccPublicIpPrefix_zonesMultiple(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_public_ip_prefix", "test")
-	r := PublicIPPrefixResource{}
+	r := PublicIpPrefixResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -232,7 +232,7 @@ func TestAccPublicIpPrefix_zonesMultiple(t *testing.T) {
 	})
 }
 
-func (PublicIPPrefixResource) basic(data acceptance.TestData) string {
+func (PublicIpPrefixResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -251,7 +251,7 @@ resource "azurerm_public_ip_prefix" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
-func (PublicIPPrefixResource) ipv6(data acceptance.TestData) string {
+func (PublicIpPrefixResource) ipv6(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -273,7 +273,7 @@ resource "azurerm_public_ip_prefix" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
-func (r PublicIPPrefixResource) requiresImport(data acceptance.TestData) string {
+func (r PublicIpPrefixResource) requiresImport(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -285,7 +285,7 @@ resource "azurerm_public_ip_prefix" "import" {
 `, r.basic(data))
 }
 
-func (PublicIPPrefixResource) withTags(data acceptance.TestData) string {
+func (PublicIpPrefixResource) withTags(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -309,7 +309,7 @@ resource "azurerm_public_ip_prefix" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
-func (PublicIPPrefixResource) withTagsUpdate(data acceptance.TestData) string {
+func (PublicIpPrefixResource) withTagsUpdate(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -332,7 +332,7 @@ resource "azurerm_public_ip_prefix" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
-func (PublicIPPrefixResource) prefixLength31(data acceptance.TestData) string {
+func (PublicIpPrefixResource) prefixLength31(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -353,7 +353,7 @@ resource "azurerm_public_ip_prefix" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
-func (PublicIPPrefixResource) prefixLength24(data acceptance.TestData) string {
+func (PublicIpPrefixResource) prefixLength24(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -374,7 +374,7 @@ resource "azurerm_public_ip_prefix" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
-func (PublicIPPrefixResource) sku_tier(data acceptance.TestData, tier string) string {
+func (PublicIpPrefixResource) sku_tier(data acceptance.TestData, tier string) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -394,7 +394,7 @@ resource "azurerm_public_ip_prefix" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, tier)
 }
 
-func (PublicIPPrefixResource) zonesSingle(data acceptance.TestData) string {
+func (PublicIpPrefixResource) zonesSingle(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -414,7 +414,7 @@ resource "azurerm_public_ip_prefix" "test" {
 `, data.RandomInteger, data.Locations.Primary)
 }
 
-func (PublicIPPrefixResource) zonesMultiple(data acceptance.TestData) string {
+func (PublicIpPrefixResource) zonesMultiple(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}

--- a/internal/tf/pluginsdk/resource_identity.go
+++ b/internal/tf/pluginsdk/resource_identity.go
@@ -7,28 +7,16 @@ import (
 	"fmt"
 	"slices"
 	"strings"
-	"unicode"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/iancoleman/strcase"
 )
 
 // These functions support generating the resource identity schema for the following types of identities and resources
 // * Hierarchical IDs (untyped and typed resources)
 // * IDs for resources with a Discriminated Type (untyped and typed resources)
-
-func convertToSnakeCase(input string) string {
-	output := ""
-	for _, r := range input {
-		if unicode.IsUpper(r) {
-			output += "_"
-		}
-		output += string(r)
-	}
-
-	return strings.ToLower(output)
-}
 
 // segmentTypeSupported contains a list of segments that should be used to construct the resource identity schema
 // this list will need to be extended to support hierarchical resource IDs for management groups or resources
@@ -68,7 +56,7 @@ func GenerateIdentitySchema(id resourceids.ResourceId) func() map[string]*schema
 func identitySchema(id resourceids.ResourceId) map[string]*schema.Schema {
 	idSchema := make(map[string]*schema.Schema, 0)
 	for _, segment := range id.Segments() {
-		name := convertToSnakeCase(segment.Name)
+		name := strcase.ToSnake(segment.Name)
 
 		if segmentTypeSupported(segment.Type) {
 			idSchema[name] = &schema.Schema{
@@ -90,7 +78,7 @@ func ValidateResourceIdentityData(d *schema.ResourceData, id resourceids.Resourc
 
 	identityString := "/"
 	for _, segment := range id.Segments() {
-		name := convertToSnakeCase(segment.Name)
+		name := strcase.ToSnake(segment.Name)
 
 		if segment.Type == resourceids.StaticSegmentType || segment.Type == resourceids.ResourceProviderSegmentType {
 			identityString += pointer.From(segment.FixedValue) + "/"
@@ -168,7 +156,7 @@ func resourceIdentityData(identity *schema.IdentityData, id resourceids.Resource
 	}
 
 	for _, segment := range id.Segments() {
-		name := convertToSnakeCase(segment.Name)
+		name := strcase.ToSnake(segment.Name)
 
 		if segmentTypeSupported(segment.Type) {
 			field, ok := parsed.Parsed[segment.Name]


### PR DESCRIPTION
* Adds resource identity to `azurerm_public_ip_prefix`
* replaces `convertToSnakeCase` with `strcase.ToSnake` which resolves the issue where consecutive uppercase letters in struct fields would be separated by underscores

--- PASS: TestAccPublicIpPrefix_resourceIdentity (216.13s)

and some additional tests ran to confirm `convertToSnakeCase` to `strcase.ToSnake` didn't cause any failures:

--- PASS: TestAccRouteFilter_resourceIdentity (98.62s)
--- PASS: TestAccVirtualNetwork_resourceIdentity (106.36s)
--- PASS: TestAccNetworkSecurityRule_resourceIdentity (111.60s)
--- PASS: TestAccSubnet_resourceIdentity (121.71s)
--- PASS: TestAccLocalNetworkGateway_resourceIdentity (133.10s)
--- PASS: TestAccNatGateway_resourceIdentity (149.64s)
--- PASS: TestAccApplicationSecurityGroup_resourceIdentity (152.10s)
--- PASS: TestAccNetworkSecurityGroup_resourceIdentity (58.25s)
--- PASS: TestAccIpGroup_resourceIdentity (181.00s)
--- PASS: TestAccPrivateEndpoint_resourceIdentity (192.86s)
--- PASS: TestAccPrivateLinkService_resourceIdentity (198.16s)
--- PASS: TestAccNetworkInterface_resourceIdentity (112.01s)
--- PASS: TestAccPublicIpPrefix_resourceIdentity (216.13s)
--- PASS: TestAccNetworkProfile_resourceIdentity (231.99s)
--- PASS: TestAccApplicationGateway_resourceIdentity (746.48s)
--- PASS: TestAccBastionHost_resourceIdentity (1164.17s)