### PR TITLE
fix blob storage backup policy flapping plan and  docs

### DIFF
--- a/internal/services/dataprotection/data_protection_backup_policy_blob_storage_resource.go
+++ b/internal/services/dataprotection/data_protection_backup_policy_blob_storage_resource.go
@@ -59,6 +59,13 @@ func resourceDataProtectionBackupPolicyBlobStorage() *schema.Resource {
 				ValidateFunc: backuppolicies.ValidateBackupVaultID,
 			},
 
+			"time_zone": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
 			"backup_repeating_time_intervals": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -75,13 +82,6 @@ func resourceDataProtectionBackupPolicyBlobStorage() *schema.Resource {
 				ForceNew:     true,
 				AtLeastOneOf: []string{"operational_default_retention_duration", "vault_default_retention_duration"},
 				ValidateFunc: helperValidate.ISO8601Duration,
-			},
-
-			"time_zone": {
-				Type:         pluginsdk.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringIsNotEmpty,
 			},
 
 			"vault_default_retention_duration": {

--- a/internal/services/dataprotection/data_protection_backup_policy_blob_storage_resource.go
+++ b/internal/services/dataprotection/data_protection_backup_policy_blob_storage_resource.go
@@ -64,6 +64,7 @@ func resourceDataProtectionBackupPolicyBlobStorage() *schema.Resource {
 				Optional:     true,
 				ForceNew:     true,
 				ValidateFunc: validation.StringIsNotEmpty,
+				RequiredWith: []string{"backup_repeating_time_intervals"},
 			},
 
 			"backup_repeating_time_intervals": {
@@ -74,6 +75,7 @@ func resourceDataProtectionBackupPolicyBlobStorage() *schema.Resource {
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
+				RequiredWith: []string{"vault_default_retention_duration"},
 			},
 
 			"operational_default_retention_duration": {

--- a/website/docs/r/data_protection_backup_policy_blob_storage.html.markdown
+++ b/website/docs/r/data_protection_backup_policy_blob_storage.html.markdown
@@ -41,19 +41,21 @@ The following arguments are supported:
 
 * `vault_id` - (Required) The ID of the Backup Vault within which the Backup Policy Blob Storage should exist. Changing this forces a new Backup Policy Blob Storage to be created.
 
-* `backup_repeating_time_intervals` - (Optional) Specifies a list of repeating time interval. It should follow `ISO 8601` repeating time interval. Changing this forces a new Backup Policy Blob Storage to be created.
+* `time_zone` - (Optional) Specifies the Time Zone which should be used by the *backup scheduler* `backup_repeating_time_intervals`. Changing this forces a new Backup Policy Blob Storage to be created.
+
+* `backup_repeating_time_intervals` - (Optional) The backup scheduler, specifies a list of repeating time interval. It should follow `ISO 8601` repeating time interval. Changing this forces a new Backup Policy Blob Storage to be created.
+
+-> **Note:** `time_zone` and `backup_repeating_time_intervals` are only evaluated when VaultStore (`vault_default_retention_duration`) is used.
 
 * `operational_default_retention_duration` - (Optional) The duration of operational default retention rule. It should follow `ISO 8601` duration format. Changing this forces a new Backup Policy Blob Storage to be created.
-
-* `retention_rule` - (Optional) One or more `retention_rule` blocks as defined below. Changing this forces a new Backup Policy Blob Storage to be created.
-
--> **Note:** Setting `retention_rule` also requires setting `vault_default_retention_duration`.
-
-* `time_zone` - (Optional) Specifies the Time Zone which should be used by the backup schedule. Changing this forces a new Backup Policy Blob Storage to be created.
 
 * `vault_default_retention_duration` - (Optional) The duration of vault default retention rule. It should follow `ISO 8601` duration format. Changing this forces a new Backup Policy Blob Storage to be created.
 
 -> **Note:** Setting `vault_default_retention_duration` also requires setting `backup_repeating_time_intervals`. At least one of `operational_default_retention_duration` or `vault_default_retention_duration` must be specified.
+
+* `retention_rule` - (Optional) One or more `retention_rule` blocks as defined below. Changing this forces a new Backup Policy Blob Storage to be created.
+
+-> **Note:** Setting `retention_rule` also requires setting `vault_default_retention_duration`.
 
 ---
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

When setting `time_zone` or `backup_repeating_time_intervals` with only OperationalStore, it results in a flapping plan.

The `time_zone` and `backup_repeating_time_intervals` are only sent when `vault_default_retention_duration` is enabled. They are omitted when only `operational_default_retention_duration`.

This also update the docs, to clarify that `time_zone` is tied with `backup_repeating_time_intervals`.

```terraform
STDOUT terraform: -/+ resource "azurerm_data_protection_backup_policy_blob_storage" "policy" {
STDOUT terraform:       ~ backup_repeating_time_intervals        = [ # forces replacement
STDOUT terraform:           + "R/2025-06-25T00:00:00Z/P1D",
STDOUT terraform:         ]
STDOUT terraform:       ~ id                                     = "..." -> (known after apply)
STDOUT terraform:         name                                   = "my_operational_policy_name"
STDOUT terraform:       + time_zone                              = "UTC" # forces replacement
STDOUT terraform:         # (3 unchanged attributes hidden)
```

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_data_protection_backup_policy_blob_storage` - fix flapping plan [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
