### PR TITLE
Resource Identity - Default last segment in resource ID to `name` instead of snake casing segment name

### DIFF
--- a/internal/sdk/resource.go
+++ b/internal/sdk/resource.go
@@ -115,8 +115,16 @@ type ResourceWithIdentity interface {
 	Identity() resourceids.ResourceId
 }
 
-type ResourceWithDiscriminatedType interface {
-	Resource
+// todo rename?
+type ResourceWithIdentityTypeOverride interface {
+	ResourceWithIdentity
+
+	// IdentityType returns the type of resource ID, this is used to influence schema generation behaviours
+	IdentityType() pluginsdk.IdentityType
+}
+
+type ResourceWithIdentityDiscriminatedType interface {
+	ResourceWithIdentity
 
 	// DiscriminatedType returns a struct containing the API field name of the discriminated type
 	// as well as the resource's discriminated type value

--- a/internal/sdk/resource.go
+++ b/internal/sdk/resource.go
@@ -115,12 +115,11 @@ type ResourceWithIdentity interface {
 	Identity() resourceids.ResourceId
 }
 
-// todo rename?
 type ResourceWithIdentityTypeOverride interface {
 	ResourceWithIdentity
 
 	// IdentityType returns the type of resource ID, this is used to influence schema generation behaviours
-	IdentityType() pluginsdk.IdentityType
+	IdentityType() pluginsdk.ResourceTypeForIdentity
 }
 
 type ResourceWithIdentityDiscriminatedType interface {

--- a/internal/sdk/wrapper_resource.go
+++ b/internal/sdk/wrapper_resource.go
@@ -177,7 +177,7 @@ and we recommend using the %[2]q resource instead.
 	// TODO: State Migrations
 
 	if v, ok := rw.resource.(ResourceWithIdentity); ok {
-		var idType pluginsdk.IdentityType = pluginsdk.IdentityTypeDefault
+		var idType pluginsdk.ResourceTypeForIdentity = pluginsdk.ResourceTypeForIdentityDefault
 		if v, ok := rw.resource.(ResourceWithIdentityTypeOverride); ok {
 			idType = v.IdentityType()
 		}

--- a/internal/sdk/wrapper_resource.go
+++ b/internal/sdk/wrapper_resource.go
@@ -177,17 +177,22 @@ and we recommend using the %[2]q resource instead.
 	// TODO: State Migrations
 
 	if v, ok := rw.resource.(ResourceWithIdentity); ok {
-		idType := v.Identity()
-		resource.Identity = &schema.ResourceIdentity{
-			SchemaFunc: pluginsdk.GenerateIdentitySchema(idType),
+		var idType pluginsdk.IdentityType = pluginsdk.IdentityTypeDefault
+		if v, ok := rw.resource.(ResourceWithIdentityTypeOverride); ok {
+			idType = v.IdentityType()
 		}
-		if v, ok := rw.resource.(ResourceWithDiscriminatedType); ok {
+
+		resourceId := v.Identity()
+		resource.Identity = &schema.ResourceIdentity{
+			SchemaFunc: pluginsdk.GenerateIdentitySchema(resourceId, idType),
+		}
+		if v, ok := rw.resource.(ResourceWithIdentityDiscriminatedType); ok {
 			resource.Identity = &schema.ResourceIdentity{
-				SchemaFunc: pluginsdk.GenerateIdentitySchemaWithDiscriminatedType(idType, v.DiscriminatedType().Field),
+				SchemaFunc: pluginsdk.GenerateIdentitySchemaWithDiscriminatedType(resourceId, v.DiscriminatedType().Field, idType),
 			}
 		}
 
-		resource.Importer = pluginsdk.ImporterValidatingIdentityThen(idType, func(ctx context.Context, d *pluginsdk.ResourceData, meta interface{}) ([]*pluginsdk.ResourceData, error) {
+		resource.Importer = pluginsdk.ImporterValidatingIdentityThen(resourceId, func(ctx context.Context, d *pluginsdk.ResourceData, meta interface{}) ([]*pluginsdk.ResourceData, error) {
 			if v, ok := rw.resource.(ResourceWithCustomImporter); ok {
 				metaData := runArgs(d, meta, rw.logger)
 
@@ -202,7 +207,7 @@ and we recommend using the %[2]q resource instead.
 			}
 
 			return schema.ImportStatePassthroughContext(ctx, d, meta)
-		})
+		}, idType)
 	}
 
 	return &resource, nil

--- a/internal/services/appservice/linux_function_app_resource.go
+++ b/internal/services/appservice/linux_function_app_resource.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-//go:generate go run ../../tools/generator-tests resourceidentity -resource-name linux_function_app -properties "site_name:name,resource_group_name" -service-package-name appservice -test-params "B1" -known-values "subscription_id:data.Subscriptions.Primary,kind:functionapp;linux"
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name linux_function_app -properties "name,resource_group_name" -service-package-name appservice -test-params "B1" -known-values "subscription_id:data.Subscriptions.Primary,kind:functionapp;linux"
 
 package appservice
 
@@ -97,7 +97,7 @@ var _ sdk.ResourceWithCustomizeDiff = LinuxFunctionAppResource{}
 
 var _ sdk.ResourceWithStateMigration = LinuxFunctionAppResource{}
 
-var _ sdk.ResourceWithIdentity = LinuxFunctionAppResource{}
+var _ sdk.ResourceWithIdentityDiscriminatedType = LinuxFunctionAppResource{}
 
 func (r LinuxFunctionAppResource) ModelObject() interface{} {
 	return &LinuxFunctionAppModel{}

--- a/internal/services/appservice/linux_function_app_resource_identity_gen_test.go
+++ b/internal/services/appservice/linux_function_app_resource_identity_gen_test.go
@@ -32,8 +32,8 @@ func TestAccLinuxFunctionApp_resourceIdentity(t *testing.T) {
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectIdentityValue("azurerm_linux_function_app.test", tfjsonpath.New("kind"), knownvalue.StringExact("functionapp,linux")),
 					statecheck.ExpectIdentityValue("azurerm_linux_function_app.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_linux_function_app.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
 					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_linux_function_app.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_linux_function_app.test", tfjsonpath.New("site_name"), tfjsonpath.New("name")),
 				},
 			},
 			data.ImportBlockWithResourceIdentityStep(),

--- a/internal/services/compute/availability_set_resource.go
+++ b/internal/services/compute/availability_set_resource.go
@@ -26,7 +26,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
-//go:generate go run ../../tools/generator-tests resourceidentity -resource-name availability_set -service-package-name compute -properties "availability_set_name:name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name availability_set -service-package-name compute -properties "name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
 
 func resourceAvailabilitySet() *pluginsdk.Resource {
 	return &pluginsdk.Resource{

--- a/internal/services/compute/availability_set_resource_identity_gen_test.go
+++ b/internal/services/compute/availability_set_resource_identity_gen_test.go
@@ -31,7 +31,7 @@ func TestAccAvailabilitySet_resourceIdentity(t *testing.T) {
 				Config: r.basic(data),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectIdentityValue("azurerm_availability_set.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_availability_set.test", tfjsonpath.New("availability_set_name"), tfjsonpath.New("name")),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_availability_set.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
 					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_availability_set.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 				},
 			},

--- a/internal/services/compute/capacity_reservation_group_resource.go
+++ b/internal/services/compute/capacity_reservation_group_resource.go
@@ -23,7 +23,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
-//go:generate go run ../../tools/generator-tests resourceidentity -resource-name capacity_reservation_group -service-package-name compute -properties "capacity_reservation_group_name:name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name capacity_reservation_group -service-package-name compute -properties "name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
 
 func resourceCapacityReservationGroup() *pluginsdk.Resource {
 	return &pluginsdk.Resource{

--- a/internal/services/compute/capacity_reservation_group_resource_identity_gen_test.go
+++ b/internal/services/compute/capacity_reservation_group_resource_identity_gen_test.go
@@ -31,7 +31,7 @@ func TestAccCapacityReservationGroup_resourceIdentity(t *testing.T) {
 				Config: r.basic(data),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectIdentityValue("azurerm_capacity_reservation_group.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_capacity_reservation_group.test", tfjsonpath.New("capacity_reservation_group_name"), tfjsonpath.New("name")),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_capacity_reservation_group.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
 					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_capacity_reservation_group.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 				},
 			},

--- a/internal/services/compute/capacity_reservation_resource.go
+++ b/internal/services/compute/capacity_reservation_resource.go
@@ -25,7 +25,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
-//go:generate go run ../../tools/generator-tests resourceidentity -resource-name capacity_reservation -service-package-name compute -properties "capacity_reservation_name:name" -compare-values "subscription_id:capacity_reservation_group_id,resource_group_name:capacity_reservation_group_id,capacity_reservation_group_name:capacity_reservation_group_id"
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name capacity_reservation -service-package-name compute -properties "name" -compare-values "subscription_id:capacity_reservation_group_id,resource_group_name:capacity_reservation_group_id,capacity_reservation_group_name:capacity_reservation_group_id"
 
 func resourceCapacityReservation() *pluginsdk.Resource {
 	return &pluginsdk.Resource{

--- a/internal/services/compute/capacity_reservation_resource_identity_gen_test.go
+++ b/internal/services/compute/capacity_reservation_resource_identity_gen_test.go
@@ -30,7 +30,7 @@ func TestAccCapacityReservation_resourceIdentity(t *testing.T) {
 			{
 				Config: r.basic(data),
 				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_capacity_reservation.test", tfjsonpath.New("capacity_reservation_name"), tfjsonpath.New("name")),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_capacity_reservation.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
 					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_capacity_reservation.test", tfjsonpath.New("capacity_reservation_group_name"), tfjsonpath.New("capacity_reservation_group_id")),
 					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_capacity_reservation.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("capacity_reservation_group_id")),
 					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_capacity_reservation.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("capacity_reservation_group_id")),

--- a/internal/services/compute/dedicated_host_group_resource.go
+++ b/internal/services/compute/dedicated_host_group_resource.go
@@ -24,7 +24,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
-//go:generate go run ../../tools/generator-tests resourceidentity -resource-name dedicated_host_group -service-package-name compute -properties "host_group_name:name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name dedicated_host_group -service-package-name compute -properties "name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
 
 func resourceDedicatedHostGroup() *pluginsdk.Resource {
 	return &pluginsdk.Resource{

--- a/internal/services/compute/dedicated_host_group_resource_identity_gen_test.go
+++ b/internal/services/compute/dedicated_host_group_resource_identity_gen_test.go
@@ -31,7 +31,7 @@ func TestAccDedicatedHostGroup_resourceIdentity(t *testing.T) {
 				Config: r.basic(data),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectIdentityValue("azurerm_dedicated_host_group.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_dedicated_host_group.test", tfjsonpath.New("host_group_name"), tfjsonpath.New("name")),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_dedicated_host_group.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
 					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_dedicated_host_group.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 				},
 			},

--- a/internal/services/compute/dedicated_host_resource.go
+++ b/internal/services/compute/dedicated_host_resource.go
@@ -26,7 +26,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
-//go:generate go run ../../tools/generator-tests resourceidentity -resource-name dedicated_host -service-package-name compute -properties "host_name:name" -compare-values "subscription_id:dedicated_host_group_id,resource_group_name:dedicated_host_group_id,host_group_name:dedicated_host_group_id"
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name dedicated_host -service-package-name compute -properties "name" -compare-values "subscription_id:dedicated_host_group_id,resource_group_name:dedicated_host_group_id,host_group_name:dedicated_host_group_id"
 
 func resourceDedicatedHost() *pluginsdk.Resource {
 	return &pluginsdk.Resource{

--- a/internal/services/compute/dedicated_host_resource_identity_gen_test.go
+++ b/internal/services/compute/dedicated_host_resource_identity_gen_test.go
@@ -30,7 +30,7 @@ func TestAccDedicatedHost_resourceIdentity(t *testing.T) {
 			{
 				Config: r.basic(data),
 				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_dedicated_host.test", tfjsonpath.New("host_name"), tfjsonpath.New("name")),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_dedicated_host.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
 					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_dedicated_host.test", tfjsonpath.New("host_group_name"), tfjsonpath.New("dedicated_host_group_id")),
 					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_dedicated_host.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("dedicated_host_group_id")),
 					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_dedicated_host.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("dedicated_host_group_id")),

--- a/internal/services/compute/gallery_application_resource.go
+++ b/internal/services/compute/gallery_application_resource.go
@@ -23,7 +23,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
-//go:generate go run ../../tools/generator-tests resourceidentity -resource-name gallery_application -properties "application_name:name" -service-package-name compute -compare-values "subscription_id:gallery_id,resource_group_name:gallery_id,gallery_name:gallery_id"
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name gallery_application -properties "name" -service-package-name compute -compare-values "subscription_id:gallery_id,resource_group_name:gallery_id,gallery_name:gallery_id"
 
 type GalleryApplicationResource struct{}
 

--- a/internal/services/compute/gallery_application_resource_identity_gen_test.go
+++ b/internal/services/compute/gallery_application_resource_identity_gen_test.go
@@ -30,7 +30,7 @@ func TestAccGalleryApplication_resourceIdentity(t *testing.T) {
 			{
 				Config: r.basic(data),
 				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_gallery_application.test", tfjsonpath.New("application_name"), tfjsonpath.New("name")),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_gallery_application.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
 					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_gallery_application.test", tfjsonpath.New("gallery_name"), tfjsonpath.New("gallery_id")),
 					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_gallery_application.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("gallery_id")),
 					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_gallery_application.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("gallery_id")),

--- a/internal/services/compute/gallery_application_version_resource.go
+++ b/internal/services/compute/gallery_application_version_resource.go
@@ -23,7 +23,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
-//go:generate go run ../../tools/generator-tests resourceidentity -resource-name gallery_application_version -properties "version_name:name" -service-package-name compute -compare-values "subscription_id:gallery_application_id,resource_group_name:gallery_application_id,gallery_name:gallery_application_id,application_name:gallery_application_id"
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name gallery_application_version -properties "name" -service-package-name compute -compare-values "subscription_id:gallery_application_id,resource_group_name:gallery_application_id,gallery_name:gallery_application_id,application_name:gallery_application_id"
 
 type GalleryApplicationVersionResource struct{}
 

--- a/internal/services/compute/gallery_application_version_resource_identity_gen_test.go
+++ b/internal/services/compute/gallery_application_version_resource_identity_gen_test.go
@@ -30,7 +30,7 @@ func TestAccGalleryApplicationVersion_resourceIdentity(t *testing.T) {
 			{
 				Config: r.basic(data),
 				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_gallery_application_version.test", tfjsonpath.New("version_name"), tfjsonpath.New("name")),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_gallery_application_version.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
 					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_gallery_application_version.test", tfjsonpath.New("application_name"), tfjsonpath.New("gallery_application_id")),
 					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_gallery_application_version.test", tfjsonpath.New("gallery_name"), tfjsonpath.New("gallery_application_id")),
 					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_gallery_application_version.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("gallery_application_id")),

--- a/internal/services/compute/proximity_placement_group_resource.go
+++ b/internal/services/compute/proximity_placement_group_resource.go
@@ -23,7 +23,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
-//go:generate go run ../../tools/generator-tests resourceidentity -resource-name proximity_placement_group -service-package-name compute -properties "proximity_placement_group_name:name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name proximity_placement_group -service-package-name compute -properties "name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
 
 func resourceProximityPlacementGroup() *pluginsdk.Resource {
 	return &pluginsdk.Resource{

--- a/internal/services/compute/proximity_placement_group_resource_identity_gen_test.go
+++ b/internal/services/compute/proximity_placement_group_resource_identity_gen_test.go
@@ -31,7 +31,7 @@ func TestAccProximityPlacementGroup_resourceIdentity(t *testing.T) {
 				Config: r.basic(data),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectIdentityValue("azurerm_proximity_placement_group.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_proximity_placement_group.test", tfjsonpath.New("proximity_placement_group_name"), tfjsonpath.New("name")),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_proximity_placement_group.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
 					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_proximity_placement_group.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 				},
 			},

--- a/internal/services/compute/shared_image_gallery_resource.go
+++ b/internal/services/compute/shared_image_gallery_resource.go
@@ -25,7 +25,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
 
-//go:generate go run ../../tools/generator-tests resourceidentity -resource-name shared_image_gallery -service-package-name compute -properties "gallery_name:name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name shared_image_gallery -service-package-name compute -properties "name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
 
 func resourceSharedImageGallery() *pluginsdk.Resource {
 	return &pluginsdk.Resource{

--- a/internal/services/compute/shared_image_gallery_resource_identity_gen_test.go
+++ b/internal/services/compute/shared_image_gallery_resource_identity_gen_test.go
@@ -31,7 +31,7 @@ func TestAccSharedImageGallery_resourceIdentity(t *testing.T) {
 				Config: r.basic(data),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectIdentityValue("azurerm_shared_image_gallery.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_shared_image_gallery.test", tfjsonpath.New("gallery_name"), tfjsonpath.New("name")),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_shared_image_gallery.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
 					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_shared_image_gallery.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 				},
 			},

--- a/internal/services/compute/shared_image_resource.go
+++ b/internal/services/compute/shared_image_resource.go
@@ -29,7 +29,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
 
-//go:generate go run ../../tools/generator-tests resourceidentity -resource-name shared_image -service-package-name compute -properties "image_name:name,resource_group_name,gallery_name" -known-values "subscription_id:data.Subscriptions.Primary"
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name shared_image -service-package-name compute -properties "name,resource_group_name,gallery_name" -known-values "subscription_id:data.Subscriptions.Primary"
 
 func resourceSharedImage() *pluginsdk.Resource {
 	return &pluginsdk.Resource{

--- a/internal/services/compute/shared_image_resource_identity_gen_test.go
+++ b/internal/services/compute/shared_image_resource_identity_gen_test.go
@@ -32,7 +32,7 @@ func TestAccSharedImage_resourceIdentity(t *testing.T) {
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectIdentityValue("azurerm_shared_image.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
 					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_shared_image.test", tfjsonpath.New("gallery_name"), tfjsonpath.New("gallery_name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_shared_image.test", tfjsonpath.New("image_name"), tfjsonpath.New("name")),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_shared_image.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
 					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_shared_image.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 				},
 			},

--- a/internal/services/firewall/firewall_policy_resource.go
+++ b/internal/services/firewall/firewall_policy_resource.go
@@ -28,7 +28,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
-//go:generate go run ../../tools/generator-tests resourceidentity -resource-name firewall_policy -service-package-name firewall -properties "firewall_policy_name:name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name firewall_policy -service-package-name firewall -properties "name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
 
 const AzureFirewallPolicyResourceName = "azurerm_firewall_policy"
 

--- a/internal/services/firewall/firewall_policy_resource_identity_gen_test.go
+++ b/internal/services/firewall/firewall_policy_resource_identity_gen_test.go
@@ -31,7 +31,7 @@ func TestAccFirewallPolicy_resourceIdentity(t *testing.T) {
 				Config: r.basic(data),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectIdentityValue("azurerm_firewall_policy.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_firewall_policy.test", tfjsonpath.New("firewall_policy_name"), tfjsonpath.New("name")),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_firewall_policy.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
 					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_firewall_policy.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 				},
 			},

--- a/internal/services/firewall/firewall_resource.go
+++ b/internal/services/firewall/firewall_resource.go
@@ -31,7 +31,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
-//go:generate go run ../../tools/generator-tests resourceidentity -resource-name firewall -service-package-name firewall -properties "azure_firewall_name:name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name firewall -service-package-name firewall -properties "name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
 
 var AzureFirewallResourceName = "azurerm_firewall"
 

--- a/internal/services/firewall/firewall_resource_identity_gen_test.go
+++ b/internal/services/firewall/firewall_resource_identity_gen_test.go
@@ -31,7 +31,7 @@ func TestAccFirewall_resourceIdentity(t *testing.T) {
 				Config: r.basic(data),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectIdentityValue("azurerm_firewall.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_firewall.test", tfjsonpath.New("azure_firewall_name"), tfjsonpath.New("name")),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_firewall.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
 					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_firewall.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 				},
 			},

--- a/internal/services/network/application_gateway_resource.go
+++ b/internal/services/network/application_gateway_resource.go
@@ -34,7 +34,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
-//go:generate go run ../../tools/generator-tests resourceidentity -resource-name application_gateway -service-package-name network -properties "application_gateway_name:name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name application_gateway -service-package-name network -properties "name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
 
 func base64EncodedStateFunc(v interface{}) string {
 	switch s := v.(type) {

--- a/internal/services/network/application_gateway_resource_identity_gen_test.go
+++ b/internal/services/network/application_gateway_resource_identity_gen_test.go
@@ -31,7 +31,7 @@ func TestAccApplicationGateway_resourceIdentity(t *testing.T) {
 				Config: r.basic(data),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectIdentityValue("azurerm_application_gateway.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_application_gateway.test", tfjsonpath.New("application_gateway_name"), tfjsonpath.New("name")),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_application_gateway.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
 					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_application_gateway.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 				},
 			},

--- a/internal/services/network/application_security_group_resource.go
+++ b/internal/services/network/application_security_group_resource.go
@@ -21,7 +21,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
 
-//go:generate go run ../../tools/generator-tests resourceidentity -resource-name application_security_group -service-package-name network -properties "application_security_group_name:name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name application_security_group -service-package-name network -properties "name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
 
 func resourceApplicationSecurityGroup() *pluginsdk.Resource {
 	return &pluginsdk.Resource{

--- a/internal/services/network/application_security_group_resource_identity_gen_test.go
+++ b/internal/services/network/application_security_group_resource_identity_gen_test.go
@@ -31,7 +31,7 @@ func TestAccApplicationSecurityGroup_resourceIdentity(t *testing.T) {
 				Config: r.basic(data),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectIdentityValue("azurerm_application_security_group.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_application_security_group.test", tfjsonpath.New("application_security_group_name"), tfjsonpath.New("name")),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_application_security_group.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
 					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_application_security_group.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 				},
 			},

--- a/internal/services/network/bastion_host_resource.go
+++ b/internal/services/network/bastion_host_resource.go
@@ -26,7 +26,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
 
-//go:generate go run ../../tools/generator-tests resourceidentity -resource-name bastion_host -service-package-name network -properties "bastion_host_name:name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name bastion_host -service-package-name network -properties "name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
 
 var skuWeight = map[string]int8{
 	"Developer": 1,

--- a/internal/services/network/bastion_host_resource_identity_gen_test.go
+++ b/internal/services/network/bastion_host_resource_identity_gen_test.go
@@ -31,7 +31,7 @@ func TestAccBastionHost_resourceIdentity(t *testing.T) {
 				Config: r.basic(data),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectIdentityValue("azurerm_bastion_host.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_bastion_host.test", tfjsonpath.New("bastion_host_name"), tfjsonpath.New("name")),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_bastion_host.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
 					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_bastion_host.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 				},
 			},

--- a/internal/services/network/ip_group_resource.go
+++ b/internal/services/network/ip_group_resource.go
@@ -27,7 +27,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
-//go:generate go run ../../tools/generator-tests resourceidentity -resource-name ip_group -service-package-name network -properties "ip_group_name:name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name ip_group -service-package-name network -properties "name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
 
 func resourceIpGroup() *pluginsdk.Resource {
 	return &pluginsdk.Resource{

--- a/internal/services/network/ip_group_resource_identity_gen_test.go
+++ b/internal/services/network/ip_group_resource_identity_gen_test.go
@@ -31,7 +31,7 @@ func TestAccIpGroup_resourceIdentity(t *testing.T) {
 				Config: r.basic(data),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectIdentityValue("azurerm_ip_group.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_ip_group.test", tfjsonpath.New("ip_group_name"), tfjsonpath.New("name")),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_ip_group.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
 					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_ip_group.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 				},
 			},

--- a/internal/services/network/local_network_gateway_resource.go
+++ b/internal/services/network/local_network_gateway_resource.go
@@ -23,7 +23,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
 
-//go:generate go run ../../tools/generator-tests resourceidentity -resource-name local_network_gateway -service-package-name network -properties "local_network_gateway_name:name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name local_network_gateway -service-package-name network -properties "name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
 
 func resourceLocalNetworkGateway() *pluginsdk.Resource {
 	return &pluginsdk.Resource{

--- a/internal/services/network/local_network_gateway_resource_identity_gen_test.go
+++ b/internal/services/network/local_network_gateway_resource_identity_gen_test.go
@@ -31,7 +31,7 @@ func TestAccLocalNetworkGateway_resourceIdentity(t *testing.T) {
 				Config: r.basic(data),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectIdentityValue("azurerm_local_network_gateway.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_local_network_gateway.test", tfjsonpath.New("local_network_gateway_name"), tfjsonpath.New("name")),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_local_network_gateway.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
 					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_local_network_gateway.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 				},
 			},

--- a/internal/services/network/nat_gateway_resource.go
+++ b/internal/services/network/nat_gateway_resource.go
@@ -25,7 +25,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
 
-//go:generate go run ../../tools/generator-tests resourceidentity -resource-name nat_gateway -service-package-name network -properties "nat_gateway_name:name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name nat_gateway -service-package-name network -properties "name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
 
 var natGatewayResourceName = "azurerm_nat_gateway"
 

--- a/internal/services/network/nat_gateway_resource_identity_gen_test.go
+++ b/internal/services/network/nat_gateway_resource_identity_gen_test.go
@@ -31,7 +31,7 @@ func TestAccNatGateway_resourceIdentity(t *testing.T) {
 				Config: r.basic(data),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectIdentityValue("azurerm_nat_gateway.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_nat_gateway.test", tfjsonpath.New("nat_gateway_name"), tfjsonpath.New("name")),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_nat_gateway.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
 					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_nat_gateway.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 				},
 			},

--- a/internal/services/network/network_interface_resource.go
+++ b/internal/services/network/network_interface_resource.go
@@ -26,7 +26,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
 
-//go:generate go run ../../tools/generator-tests resourceidentity -resource-name network_interface -service-package-name network -properties "network_interface_name:name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name network_interface -service-package-name network -properties "name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
 
 var networkInterfaceResourceName = "azurerm_network_interface"
 

--- a/internal/services/network/network_interface_resource_identity_gen_test.go
+++ b/internal/services/network/network_interface_resource_identity_gen_test.go
@@ -31,7 +31,7 @@ func TestAccNetworkInterface_resourceIdentity(t *testing.T) {
 				Config: r.basic(data),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectIdentityValue("azurerm_network_interface.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_network_interface.test", tfjsonpath.New("network_interface_name"), tfjsonpath.New("name")),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_network_interface.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
 					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_network_interface.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 				},
 			},

--- a/internal/services/network/network_profile_resource.go
+++ b/internal/services/network/network_profile_resource.go
@@ -25,7 +25,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
-//go:generate go run ../../tools/generator-tests resourceidentity -resource-name network_profile -service-package-name network -properties "network_profile_name:name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name network_profile -service-package-name network -properties "name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
 
 const azureNetworkProfileResourceName = "azurerm_network_profile"
 

--- a/internal/services/network/network_profile_resource_identity_gen_test.go
+++ b/internal/services/network/network_profile_resource_identity_gen_test.go
@@ -31,7 +31,7 @@ func TestAccNetworkProfile_resourceIdentity(t *testing.T) {
 				Config: r.basic(data),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectIdentityValue("azurerm_network_profile.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_network_profile.test", tfjsonpath.New("network_profile_name"), tfjsonpath.New("name")),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_network_profile.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
 					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_network_profile.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 				},
 			},

--- a/internal/services/network/network_security_group_resource.go
+++ b/internal/services/network/network_security_group_resource.go
@@ -25,7 +25,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
 
-//go:generate go run ../../tools/generator-tests resourceidentity -resource-name network_security_group -service-package-name network -properties "network_security_group_name:name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name network_security_group -service-package-name network -properties "name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
 
 var networkSecurityGroupResourceName = "azurerm_network_security_group"
 

--- a/internal/services/network/network_security_group_resource_identity_gen_test.go
+++ b/internal/services/network/network_security_group_resource_identity_gen_test.go
@@ -31,7 +31,7 @@ func TestAccNetworkSecurityGroup_resourceIdentity(t *testing.T) {
 				Config: r.basic(data),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectIdentityValue("azurerm_network_security_group.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_network_security_group.test", tfjsonpath.New("network_security_group_name"), tfjsonpath.New("name")),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_network_security_group.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
 					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_network_security_group.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 				},
 			},

--- a/internal/services/network/network_security_rule_resource.go
+++ b/internal/services/network/network_security_rule_resource.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
 
-//go:generate go run ../../tools/generator-tests resourceidentity -resource-name network_security_rule -service-package-name network -properties "security_rule_name:name,network_security_group_name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name network_security_rule -service-package-name network -properties "name,network_security_group_name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
 
 func resourceNetworkSecurityRule() *pluginsdk.Resource {
 	return &pluginsdk.Resource{

--- a/internal/services/network/network_security_rule_resource_identity_gen_test.go
+++ b/internal/services/network/network_security_rule_resource_identity_gen_test.go
@@ -31,9 +31,9 @@ func TestAccNetworkSecurityRule_resourceIdentity(t *testing.T) {
 				Config: r.basic(data),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectIdentityValue("azurerm_network_security_rule.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_network_security_rule.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
 					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_network_security_rule.test", tfjsonpath.New("network_security_group_name"), tfjsonpath.New("network_security_group_name")),
 					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_network_security_rule.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_network_security_rule.test", tfjsonpath.New("security_rule_name"), tfjsonpath.New("name")),
 				},
 			},
 			data.ImportBlockWithResourceIdentityStep(),

--- a/internal/services/network/private_endpoint_resource.go
+++ b/internal/services/network/private_endpoint_resource.go
@@ -39,7 +39,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
-//go:generate go run ../../tools/generator-tests resourceidentity -resource-name private_endpoint -service-package-name network -properties "private_endpoint_name:name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name private_endpoint -service-package-name network -properties "name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
 
 func resourcePrivateEndpoint() *pluginsdk.Resource {
 	return &pluginsdk.Resource{

--- a/internal/services/network/private_endpoint_resource_identity_gen_test.go
+++ b/internal/services/network/private_endpoint_resource_identity_gen_test.go
@@ -31,7 +31,7 @@ func TestAccPrivateEndpoint_resourceIdentity(t *testing.T) {
 				Config: r.basic(data),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectIdentityValue("azurerm_private_endpoint.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_private_endpoint.test", tfjsonpath.New("private_endpoint_name"), tfjsonpath.New("name")),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_private_endpoint.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
 					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_private_endpoint.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 				},
 			},

--- a/internal/services/network/private_link_service_resource.go
+++ b/internal/services/network/private_link_service_resource.go
@@ -28,7 +28,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
-//go:generate go run ../../tools/generator-tests resourceidentity -resource-name private_link_service -service-package-name network -properties "private_link_service_name:name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name private_link_service -service-package-name network -properties "name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
 
 func resourcePrivateLinkService() *pluginsdk.Resource {
 	return &pluginsdk.Resource{

--- a/internal/services/network/private_link_service_resource_identity_gen_test.go
+++ b/internal/services/network/private_link_service_resource_identity_gen_test.go
@@ -31,7 +31,7 @@ func TestAccPrivateLinkService_resourceIdentity(t *testing.T) {
 				Config: r.basic(data),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectIdentityValue("azurerm_private_link_service.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_private_link_service.test", tfjsonpath.New("private_link_service_name"), tfjsonpath.New("name")),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_private_link_service.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
 					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_private_link_service.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 				},
 			},

--- a/internal/services/network/public_ip_prefix_resource.go
+++ b/internal/services/network/public_ip_prefix_resource.go
@@ -23,7 +23,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
 
-//go:generate go run ../../tools/generator-tests resourceidentity -resource-name public_ip_prefix -service-package-name network -properties "public_ip_prefix_name:name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name public_ip_prefix -service-package-name network -properties "name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
 
 func resourcePublicIpPrefix() *pluginsdk.Resource {
 	return &pluginsdk.Resource{

--- a/internal/services/network/public_ip_prefix_resource_identity_gen_test.go
+++ b/internal/services/network/public_ip_prefix_resource_identity_gen_test.go
@@ -31,7 +31,7 @@ func TestAccPublicIpPrefix_resourceIdentity(t *testing.T) {
 				Config: r.basic(data),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectIdentityValue("azurerm_public_ip_prefix.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_public_ip_prefix.test", tfjsonpath.New("public_ip_prefix_name"), tfjsonpath.New("name")),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_public_ip_prefix.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
 					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_public_ip_prefix.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 				},
 			},

--- a/internal/services/network/route_filter_resource.go
+++ b/internal/services/network/route_filter_resource.go
@@ -24,7 +24,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
-//go:generate go run ../../tools/generator-tests resourceidentity -resource-name route_filter -service-package-name network -properties "route_filter_name:name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name route_filter -service-package-name network -properties "name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
 
 func resourceRouteFilter() *pluginsdk.Resource {
 	return &pluginsdk.Resource{

--- a/internal/services/network/route_filter_resource_identity_gen_test.go
+++ b/internal/services/network/route_filter_resource_identity_gen_test.go
@@ -31,8 +31,8 @@ func TestAccRouteFilter_resourceIdentity(t *testing.T) {
 				Config: r.basic(data),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectIdentityValue("azurerm_route_filter.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_route_filter.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
 					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_route_filter.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_route_filter.test", tfjsonpath.New("route_filter_name"), tfjsonpath.New("name")),
 				},
 			},
 			data.ImportBlockWithResourceIdentityStep(),

--- a/internal/services/network/route_map_resource.go
+++ b/internal/services/network/route_map_resource.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 )
 
-//go:generate go run ../../tools/generator-tests resourceidentity -resource-name route_map -service-package-name network -properties "route_map_name:name" -compare-values "subscription_id:virtual_hub_id,resource_group_name:virtual_hub_id,virtual_hub_name:virtual_hub_id" -test-params "ident"
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name route_map -service-package-name network -properties "name" -compare-values "subscription_id:virtual_hub_id,resource_group_name:virtual_hub_id,virtual_hub_name:virtual_hub_id" -test-params "ident"
 
 type RouteMapModel struct {
 	Name         string `tfschema:"name"`

--- a/internal/services/network/route_map_resource_identity_gen_test.go
+++ b/internal/services/network/route_map_resource_identity_gen_test.go
@@ -30,7 +30,7 @@ func TestAccRouteMap_resourceIdentity(t *testing.T) {
 			{
 				Config: r.basic(data, "ident"),
 				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_route_map.test", tfjsonpath.New("route_map_name"), tfjsonpath.New("name")),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_route_map.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
 					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_route_map.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("virtual_hub_id")),
 					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_route_map.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("virtual_hub_id")),
 					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_route_map.test", tfjsonpath.New("virtual_hub_name"), tfjsonpath.New("virtual_hub_id")),

--- a/internal/services/network/route_resource.go
+++ b/internal/services/network/route_resource.go
@@ -21,7 +21,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
 
-//go:generate go run ../../tools/generator-tests resourceidentity -resource-name route -service-package-name network -properties "route_name:name,route_table_name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name route -service-package-name network -properties "name,route_table_name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
 
 func resourceRoute() *pluginsdk.Resource {
 	return &pluginsdk.Resource{

--- a/internal/services/network/route_resource_identity_gen_test.go
+++ b/internal/services/network/route_resource_identity_gen_test.go
@@ -31,8 +31,8 @@ func TestAccRoute_resourceIdentity(t *testing.T) {
 				Config: r.basic(data),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectIdentityValue("azurerm_route.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_route.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
 					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_route.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_route.test", tfjsonpath.New("route_name"), tfjsonpath.New("name")),
 					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_route.test", tfjsonpath.New("route_table_name"), tfjsonpath.New("route_table_name")),
 				},
 			},

--- a/internal/services/network/route_server_bgp_connection_resource.go
+++ b/internal/services/network/route_server_bgp_connection_resource.go
@@ -21,7 +21,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
 
-//go:generate go run ../../tools/generator-tests resourceidentity -resource-name route_server_bgp_connection -service-package-name network -properties "connection_name:name" -compare-values "subscription_id:route_server_id,resource_group_name:route_server_id,hub_name:route_server_id"
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name route_server_bgp_connection -service-package-name network -properties "name" -compare-values "subscription_id:route_server_id,resource_group_name:route_server_id,hub_name:route_server_id"
 
 func resourceRouteServerBgpConnection() *pluginsdk.Resource {
 	return &pluginsdk.Resource{

--- a/internal/services/network/route_server_bgp_connection_resource_identity_gen_test.go
+++ b/internal/services/network/route_server_bgp_connection_resource_identity_gen_test.go
@@ -30,7 +30,7 @@ func TestAccRouteServerBgpConnection_resourceIdentity(t *testing.T) {
 			{
 				Config: r.basic(data),
 				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_route_server_bgp_connection.test", tfjsonpath.New("connection_name"), tfjsonpath.New("name")),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_route_server_bgp_connection.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
 					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_route_server_bgp_connection.test", tfjsonpath.New("hub_name"), tfjsonpath.New("route_server_id")),
 					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_route_server_bgp_connection.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("route_server_id")),
 					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_route_server_bgp_connection.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("route_server_id")),

--- a/internal/services/network/route_server_resource.go
+++ b/internal/services/network/route_server_resource.go
@@ -27,7 +27,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
 
-//go:generate go run ../../tools/generator-tests resourceidentity -resource-name route_server -service-package-name network -properties "virtual_hub_name:name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name route_server -service-package-name network -properties "name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
 
 func resourceRouteServer() *pluginsdk.Resource {
 	return &pluginsdk.Resource{

--- a/internal/services/network/route_server_resource_identity_gen_test.go
+++ b/internal/services/network/route_server_resource_identity_gen_test.go
@@ -31,8 +31,8 @@ func TestAccRouteServer_resourceIdentity(t *testing.T) {
 				Config: r.basic(data),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectIdentityValue("azurerm_route_server.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_route_server.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
 					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_route_server.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_route_server.test", tfjsonpath.New("virtual_hub_name"), tfjsonpath.New("name")),
 				},
 			},
 			data.ImportBlockWithResourceIdentityStep(),

--- a/internal/services/network/route_table_resource.go
+++ b/internal/services/network/route_table_resource.go
@@ -23,7 +23,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
-//go:generate go run ../../tools/generator-tests resourceidentity -resource-name route_table -service-package-name network -properties "route_table_name:name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name route_table -service-package-name network -properties "name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
 
 var routeTableResourceName = "azurerm_route_table"
 

--- a/internal/services/network/route_table_resource_identity_gen_test.go
+++ b/internal/services/network/route_table_resource_identity_gen_test.go
@@ -31,8 +31,8 @@ func TestAccRouteTable_resourceIdentity(t *testing.T) {
 				Config: r.basic(data),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectIdentityValue("azurerm_route_table.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_route_table.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
 					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_route_table.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_route_table.test", tfjsonpath.New("route_table_name"), tfjsonpath.New("name")),
 				},
 			},
 			data.ImportBlockWithResourceIdentityStep(),

--- a/internal/services/network/subnet_resource.go
+++ b/internal/services/network/subnet_resource.go
@@ -26,7 +26,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
-//go:generate go run ../../tools/generator-tests resourceidentity -resource-name subnet -service-package-name network -properties "subnet_name:name,resource_group_name,virtual_network_name" -known-values "subscription_id:data.Subscriptions.Primary"
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name subnet -service-package-name network -properties "name,resource_group_name,virtual_network_name" -known-values "subscription_id:data.Subscriptions.Primary"
 
 var SubnetResourceName = "azurerm_subnet"
 

--- a/internal/services/network/subnet_resource_identity_gen_test.go
+++ b/internal/services/network/subnet_resource_identity_gen_test.go
@@ -31,8 +31,8 @@ func TestAccSubnet_resourceIdentity(t *testing.T) {
 				Config: r.basic(data),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectIdentityValue("azurerm_subnet.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_subnet.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
 					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_subnet.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_subnet.test", tfjsonpath.New("subnet_name"), tfjsonpath.New("name")),
 					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_subnet.test", tfjsonpath.New("virtual_network_name"), tfjsonpath.New("virtual_network_name")),
 				},
 			},

--- a/internal/services/network/subnet_service_endpoint_storage_policy_resource.go
+++ b/internal/services/network/subnet_service_endpoint_storage_policy_resource.go
@@ -26,7 +26,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
-//go:generate go run ../../tools/generator-tests resourceidentity -resource-name subnet_service_endpoint_storage_policy -service-package-name network -properties "service_endpoint_policy_name:name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name subnet_service_endpoint_storage_policy -service-package-name network -properties "name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
 
 func resourceSubnetServiceEndpointStoragePolicy() *pluginsdk.Resource {
 	return &pluginsdk.Resource{

--- a/internal/services/network/subnet_service_endpoint_storage_policy_resource_identity_gen_test.go
+++ b/internal/services/network/subnet_service_endpoint_storage_policy_resource_identity_gen_test.go
@@ -31,8 +31,8 @@ func TestAccSubnetServiceEndpointStoragePolicy_resourceIdentity(t *testing.T) {
 				Config: r.basic(data),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectIdentityValue("azurerm_subnet_service_endpoint_storage_policy.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_subnet_service_endpoint_storage_policy.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
 					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_subnet_service_endpoint_storage_policy.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_subnet_service_endpoint_storage_policy.test", tfjsonpath.New("service_endpoint_policy_name"), tfjsonpath.New("name")),
 				},
 			},
 			data.ImportBlockWithResourceIdentityStep(),

--- a/internal/services/network/virtual_hub_connection_resource.go
+++ b/internal/services/network/virtual_hub_connection_resource.go
@@ -24,7 +24,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
-//go:generate go run ../../tools/generator-tests resourceidentity -resource-name virtual_hub_connection -service-package-name network -properties "hub_virtual_network_connection_name:name" -compare-values "subscription_id:virtual_hub_id,resource_group_name:virtual_hub_id,virtual_hub_name:virtual_hub_id"
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name virtual_hub_connection -service-package-name network -properties "name" -compare-values "subscription_id:virtual_hub_id,resource_group_name:virtual_hub_id,virtual_hub_name:virtual_hub_id"
 
 func resourceVirtualHubConnection() *pluginsdk.Resource {
 	return &pluginsdk.Resource{

--- a/internal/services/network/virtual_hub_connection_resource_identity_gen_test.go
+++ b/internal/services/network/virtual_hub_connection_resource_identity_gen_test.go
@@ -30,7 +30,7 @@ func TestAccVirtualHubConnection_resourceIdentity(t *testing.T) {
 			{
 				Config: r.basic(data),
 				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_virtual_hub_connection.test", tfjsonpath.New("hub_virtual_network_connection_name"), tfjsonpath.New("name")),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_virtual_hub_connection.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
 					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_virtual_hub_connection.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("virtual_hub_id")),
 					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_virtual_hub_connection.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("virtual_hub_id")),
 					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_virtual_hub_connection.test", tfjsonpath.New("virtual_hub_name"), tfjsonpath.New("virtual_hub_id")),

--- a/internal/services/network/virtual_hub_ip_resource.go
+++ b/internal/services/network/virtual_hub_ip_resource.go
@@ -21,7 +21,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
 
-//go:generate go run ../../tools/generator-tests resourceidentity -resource-name virtual_hub_ip -service-package-name network -properties "ip_config_name:name" -compare-values "subscription_id:virtual_hub_id,resource_group_name:virtual_hub_id,virtual_hub_name:virtual_hub_id"
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name virtual_hub_ip -service-package-name network -properties "name" -compare-values "subscription_id:virtual_hub_id,resource_group_name:virtual_hub_id,virtual_hub_name:virtual_hub_id"
 
 func resourceVirtualHubIP() *pluginsdk.Resource {
 	return &pluginsdk.Resource{

--- a/internal/services/network/virtual_hub_ip_resource_identity_gen_test.go
+++ b/internal/services/network/virtual_hub_ip_resource_identity_gen_test.go
@@ -30,7 +30,7 @@ func TestAccVirtualHubIp_resourceIdentity(t *testing.T) {
 			{
 				Config: r.basic(data),
 				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_virtual_hub_ip.test", tfjsonpath.New("ip_config_name"), tfjsonpath.New("name")),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_virtual_hub_ip.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
 					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_virtual_hub_ip.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("virtual_hub_id")),
 					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_virtual_hub_ip.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("virtual_hub_id")),
 					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_virtual_hub_ip.test", tfjsonpath.New("virtual_hub_name"), tfjsonpath.New("virtual_hub_id")),

--- a/internal/services/network/virtual_hub_resource.go
+++ b/internal/services/network/virtual_hub_resource.go
@@ -27,7 +27,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
-//go:generate go run ../../tools/generator-tests resourceidentity -resource-name virtual_hub -service-package-name network -properties "virtual_hub_name:name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name virtual_hub -service-package-name network -properties "name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
 
 const virtualHubResourceName = "azurerm_virtual_hub"
 

--- a/internal/services/network/virtual_hub_resource_identity_gen_test.go
+++ b/internal/services/network/virtual_hub_resource_identity_gen_test.go
@@ -31,8 +31,8 @@ func TestAccVirtualHub_resourceIdentity(t *testing.T) {
 				Config: r.basic(data),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectIdentityValue("azurerm_virtual_hub.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_virtual_hub.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
 					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_virtual_hub.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_virtual_hub.test", tfjsonpath.New("virtual_hub_name"), tfjsonpath.New("name")),
 				},
 			},
 			data.ImportBlockWithResourceIdentityStep(),

--- a/internal/services/network/virtual_hub_route_table_resource.go
+++ b/internal/services/network/virtual_hub_route_table_resource.go
@@ -23,7 +23,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
-//go:generate go run ../../tools/generator-tests resourceidentity -resource-name virtual_hub_route_table -service-package-name network -properties "hub_route_table_name:name" -compare-values "subscription_id:virtual_hub_id,resource_group_name:virtual_hub_id,virtual_hub_name:virtual_hub_id"
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name virtual_hub_route_table -service-package-name network -properties "name" -compare-values "subscription_id:virtual_hub_id,resource_group_name:virtual_hub_id,virtual_hub_name:virtual_hub_id"
 
 func resourceVirtualHubRouteTable() *pluginsdk.Resource {
 	return &pluginsdk.Resource{

--- a/internal/services/network/virtual_hub_route_table_resource_identity_gen_test.go
+++ b/internal/services/network/virtual_hub_route_table_resource_identity_gen_test.go
@@ -30,7 +30,7 @@ func TestAccVirtualHubRouteTable_resourceIdentity(t *testing.T) {
 			{
 				Config: r.basic(data),
 				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_virtual_hub_route_table.test", tfjsonpath.New("hub_route_table_name"), tfjsonpath.New("name")),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_virtual_hub_route_table.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
 					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_virtual_hub_route_table.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("virtual_hub_id")),
 					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_virtual_hub_route_table.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("virtual_hub_id")),
 					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_virtual_hub_route_table.test", tfjsonpath.New("virtual_hub_name"), tfjsonpath.New("virtual_hub_id")),

--- a/internal/services/network/virtual_hub_routing_intent_resource.go
+++ b/internal/services/network/virtual_hub_routing_intent_resource.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 )
 
-//go:generate go run ../../tools/generator-tests resourceidentity -resource-name virtual_hub_routing_intent -service-package-name network -properties "routing_intent_name:name" -compare-values "subscription_id:virtual_hub_id,resource_group_name:virtual_hub_id,virtual_hub_name:virtual_hub_id"
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name virtual_hub_routing_intent -service-package-name network -properties "name" -compare-values "subscription_id:virtual_hub_id,resource_group_name:virtual_hub_id,virtual_hub_name:virtual_hub_id"
 
 type VirtualHubRoutingIntentModel struct {
 	Name            string          `tfschema:"name"`

--- a/internal/services/network/virtual_hub_routing_intent_resource_identity_gen_test.go
+++ b/internal/services/network/virtual_hub_routing_intent_resource_identity_gen_test.go
@@ -30,7 +30,7 @@ func TestAccVirtualHubRoutingIntent_resourceIdentity(t *testing.T) {
 			{
 				Config: r.basic(data),
 				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_virtual_hub_routing_intent.test", tfjsonpath.New("routing_intent_name"), tfjsonpath.New("name")),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_virtual_hub_routing_intent.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
 					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_virtual_hub_routing_intent.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("virtual_hub_id")),
 					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_virtual_hub_routing_intent.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("virtual_hub_id")),
 					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_virtual_hub_routing_intent.test", tfjsonpath.New("virtual_hub_name"), tfjsonpath.New("virtual_hub_id")),

--- a/internal/services/network/virtual_network_resource.go
+++ b/internal/services/network/virtual_network_resource.go
@@ -36,7 +36,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
-//go:generate go run ../../tools/generator-tests resourceidentity -resource-name virtual_network -service-package-name network -properties "virtual_network_name:name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name virtual_network -service-package-name network -properties "name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
 
 var VirtualNetworkResourceName = "azurerm_virtual_network"
 

--- a/internal/services/network/virtual_network_resource_identity_gen_test.go
+++ b/internal/services/network/virtual_network_resource_identity_gen_test.go
@@ -31,8 +31,8 @@ func TestAccVirtualNetwork_resourceIdentity(t *testing.T) {
 				Config: r.basic(data),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectIdentityValue("azurerm_virtual_network.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_virtual_network.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
 					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_virtual_network.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_virtual_network.test", tfjsonpath.New("virtual_network_name"), tfjsonpath.New("name")),
 				},
 			},
 			data.ImportBlockWithResourceIdentityStep(),

--- a/internal/services/storage/storage_account_customer_managed_key_resource.go
+++ b/internal/services/storage/storage_account_customer_managed_key_resource.go
@@ -33,10 +33,10 @@ func resourceStorageAccountCustomerManagedKey() *pluginsdk.Resource {
 		Update: resourceStorageAccountCustomerManagedKeyCreateUpdate,
 		Delete: resourceStorageAccountCustomerManagedKeyDelete,
 
-		Importer: pluginsdk.ImporterValidatingIdentity(&commonids.StorageAccountId{}, pluginsdk.IdentityTypeVirtual),
+		Importer: pluginsdk.ImporterValidatingIdentity(&commonids.StorageAccountId{}, pluginsdk.ResourceTypeForIdentityVirtual),
 
 		Identity: &schema.ResourceIdentity{
-			SchemaFunc: pluginsdk.GenerateIdentitySchema(&commonids.StorageAccountId{}, pluginsdk.IdentityTypeVirtual),
+			SchemaFunc: pluginsdk.GenerateIdentitySchema(&commonids.StorageAccountId{}, pluginsdk.ResourceTypeForIdentityVirtual),
 		},
 
 		Timeouts: &pluginsdk.ResourceTimeout{
@@ -300,7 +300,7 @@ func resourceStorageAccountCustomerManagedKeyRead(d *pluginsdk.ResourceData, met
 		return nil
 	}
 
-	return pluginsdk.SetResourceIdentityData(d, id, pluginsdk.IdentityTypeVirtual)
+	return pluginsdk.SetResourceIdentityData(d, id, pluginsdk.ResourceTypeForIdentityVirtual)
 }
 
 func resourceStorageAccountCustomerManagedKeyDelete(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/storage/storage_account_customer_managed_key_resource.go
+++ b/internal/services/storage/storage_account_customer_managed_key_resource.go
@@ -33,10 +33,10 @@ func resourceStorageAccountCustomerManagedKey() *pluginsdk.Resource {
 		Update: resourceStorageAccountCustomerManagedKeyCreateUpdate,
 		Delete: resourceStorageAccountCustomerManagedKeyDelete,
 
-		Importer: pluginsdk.ImporterValidatingIdentity(&commonids.StorageAccountId{}),
+		Importer: pluginsdk.ImporterValidatingIdentity(&commonids.StorageAccountId{}, pluginsdk.IdentityTypeVirtual),
 
 		Identity: &schema.ResourceIdentity{
-			SchemaFunc: pluginsdk.GenerateIdentitySchema(&commonids.StorageAccountId{}),
+			SchemaFunc: pluginsdk.GenerateIdentitySchema(&commonids.StorageAccountId{}, pluginsdk.IdentityTypeVirtual),
 		},
 
 		Timeouts: &pluginsdk.ResourceTimeout{
@@ -300,7 +300,7 @@ func resourceStorageAccountCustomerManagedKeyRead(d *pluginsdk.ResourceData, met
 		return nil
 	}
 
-	return pluginsdk.SetResourceIdentityData(d, id)
+	return pluginsdk.SetResourceIdentityData(d, id, pluginsdk.IdentityTypeVirtual)
 }
 
 func resourceStorageAccountCustomerManagedKeyDelete(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/storage/storage_account_local_user_resource.go
+++ b/internal/services/storage/storage_account_local_user_resource.go
@@ -24,7 +24,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
-//go:generate go run ../../tools/generator-tests resourceidentity -resource-name storage_account_local_user -service-package-name storage -properties "local_user_name:name" -compare-values "subscription_id:storage_account_id,resource_group_name:storage_account_id,storage_account_name:storage_account_id" -test-name "passwordOnly"
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name storage_account_local_user -service-package-name storage -properties "name" -compare-values "subscription_id:storage_account_id,resource_group_name:storage_account_id,storage_account_name:storage_account_id" -test-name "passwordOnly"
 
 type LocalUserResource struct{}
 

--- a/internal/services/storage/storage_account_local_user_resource_identity_gen_test.go
+++ b/internal/services/storage/storage_account_local_user_resource_identity_gen_test.go
@@ -30,7 +30,7 @@ func TestAccStorageAccountLocalUser_resourceIdentity(t *testing.T) {
 			{
 				Config: r.passwordOnly(data),
 				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_storage_account_local_user.test", tfjsonpath.New("local_user_name"), tfjsonpath.New("name")),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_storage_account_local_user.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
 					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_account_local_user.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("storage_account_id")),
 					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_account_local_user.test", tfjsonpath.New("storage_account_name"), tfjsonpath.New("storage_account_id")),
 					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_account_local_user.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("storage_account_id")),

--- a/internal/services/storage/storage_account_network_rules_resource.go
+++ b/internal/services/storage/storage_account_network_rules_resource.go
@@ -32,10 +32,10 @@ func resourceStorageAccountNetworkRules() *pluginsdk.Resource {
 		Update: resourceStorageAccountNetworkRulesUpdate,
 		Delete: resourceStorageAccountNetworkRulesDelete,
 
-		Importer: pluginsdk.ImporterValidatingIdentity(&commonids.StorageAccountId{}, pluginsdk.IdentityTypeVirtual),
+		Importer: pluginsdk.ImporterValidatingIdentity(&commonids.StorageAccountId{}, pluginsdk.ResourceTypeForIdentityVirtual),
 
 		Identity: &schema.ResourceIdentity{
-			SchemaFunc: pluginsdk.GenerateIdentitySchema(&commonids.StorageAccountId{}, pluginsdk.IdentityTypeVirtual),
+			SchemaFunc: pluginsdk.GenerateIdentitySchema(&commonids.StorageAccountId{}, pluginsdk.ResourceTypeForIdentityVirtual),
 		},
 
 		Timeouts: &pluginsdk.ResourceTimeout{
@@ -296,7 +296,7 @@ func resourceStorageAccountNetworkRulesRead(d *pluginsdk.ResourceData, meta inte
 		}
 	}
 
-	return pluginsdk.SetResourceIdentityData(d, id, pluginsdk.IdentityTypeVirtual)
+	return pluginsdk.SetResourceIdentityData(d, id, pluginsdk.ResourceTypeForIdentityVirtual)
 }
 
 func resourceStorageAccountNetworkRulesDelete(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/storage/storage_account_network_rules_resource.go
+++ b/internal/services/storage/storage_account_network_rules_resource.go
@@ -32,10 +32,10 @@ func resourceStorageAccountNetworkRules() *pluginsdk.Resource {
 		Update: resourceStorageAccountNetworkRulesUpdate,
 		Delete: resourceStorageAccountNetworkRulesDelete,
 
-		Importer: pluginsdk.ImporterValidatingIdentity(&commonids.StorageAccountId{}),
+		Importer: pluginsdk.ImporterValidatingIdentity(&commonids.StorageAccountId{}, pluginsdk.IdentityTypeVirtual),
 
 		Identity: &schema.ResourceIdentity{
-			SchemaFunc: pluginsdk.GenerateIdentitySchema(&commonids.StorageAccountId{}),
+			SchemaFunc: pluginsdk.GenerateIdentitySchema(&commonids.StorageAccountId{}, pluginsdk.IdentityTypeVirtual),
 		},
 
 		Timeouts: &pluginsdk.ResourceTimeout{
@@ -296,7 +296,7 @@ func resourceStorageAccountNetworkRulesRead(d *pluginsdk.ResourceData, meta inte
 		}
 	}
 
-	return pluginsdk.SetResourceIdentityData(d, id)
+	return pluginsdk.SetResourceIdentityData(d, id, pluginsdk.IdentityTypeVirtual)
 }
 
 func resourceStorageAccountNetworkRulesDelete(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/storage/storage_account_queue_properties_resource.go
+++ b/internal/services/storage/storage_account_queue_properties_resource.go
@@ -25,8 +25,8 @@ import (
 type AccountQueuePropertiesResource struct{}
 
 var (
-	_ sdk.ResourceWithUpdate   = AccountQueuePropertiesResource{}
-	_ sdk.ResourceWithIdentity = AccountQueuePropertiesResource{}
+	_ sdk.ResourceWithUpdate               = AccountQueuePropertiesResource{}
+	_ sdk.ResourceWithIdentityTypeOverride = AccountQueuePropertiesResource{}
 )
 
 type AccountQueuePropertiesModel struct {
@@ -272,6 +272,10 @@ func (s AccountQueuePropertiesResource) Identity() resourceids.ResourceId {
 	return &commonids.StorageAccountId{}
 }
 
+func (s AccountQueuePropertiesResource) IdentityType() pluginsdk.IdentityType {
+	return pluginsdk.IdentityTypeVirtual
+}
+
 func (s AccountQueuePropertiesResource) Create() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
 		Timeout: 30 * time.Minute,
@@ -478,7 +482,7 @@ func (s AccountQueuePropertiesResource) Read() sdk.ResourceFunc {
 				}
 			}
 
-			if err = pluginsdk.SetResourceIdentityData(metadata.ResourceData, id); err != nil {
+			if err = pluginsdk.SetResourceIdentityData(metadata.ResourceData, id, pluginsdk.IdentityTypeVirtual); err != nil {
 				return err
 			}
 

--- a/internal/services/storage/storage_account_queue_properties_resource.go
+++ b/internal/services/storage/storage_account_queue_properties_resource.go
@@ -272,8 +272,8 @@ func (s AccountQueuePropertiesResource) Identity() resourceids.ResourceId {
 	return &commonids.StorageAccountId{}
 }
 
-func (s AccountQueuePropertiesResource) IdentityType() pluginsdk.IdentityType {
-	return pluginsdk.IdentityTypeVirtual
+func (s AccountQueuePropertiesResource) IdentityType() pluginsdk.ResourceTypeForIdentity {
+	return pluginsdk.ResourceTypeForIdentityVirtual
 }
 
 func (s AccountQueuePropertiesResource) Create() sdk.ResourceFunc {
@@ -482,7 +482,7 @@ func (s AccountQueuePropertiesResource) Read() sdk.ResourceFunc {
 				}
 			}
 
-			if err = pluginsdk.SetResourceIdentityData(metadata.ResourceData, id, pluginsdk.IdentityTypeVirtual); err != nil {
+			if err = pluginsdk.SetResourceIdentityData(metadata.ResourceData, id, pluginsdk.ResourceTypeForIdentityVirtual); err != nil {
 				return err
 			}
 

--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -47,7 +47,7 @@ import (
 	"github.com/jackofallops/giovanni/storage/2023-11-03/queue/queues"
 )
 
-//go:generate go run ../../tools/generator-tests resourceidentity -resource-name storage_account -service-package-name storage -properties "storage_account_name:name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name storage_account -service-package-name storage -properties "name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
 
 var (
 	storageAccountResourceName  = "azurerm_storage_account"

--- a/internal/services/storage/storage_account_resource_identity_gen_test.go
+++ b/internal/services/storage/storage_account_resource_identity_gen_test.go
@@ -31,8 +31,8 @@ func TestAccStorageAccount_resourceIdentity(t *testing.T) {
 				Config: r.basic(data),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectIdentityValue("azurerm_storage_account.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_storage_account.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
 					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_storage_account.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_storage_account.test", tfjsonpath.New("storage_account_name"), tfjsonpath.New("name")),
 				},
 			},
 			data.ImportBlockWithResourceIdentityStep(),

--- a/internal/services/storage/storage_account_static_website_resource.go
+++ b/internal/services/storage/storage_account_static_website_resource.go
@@ -81,8 +81,8 @@ func (a AccountStaticWebsiteResource) Identity() resourceids.ResourceId {
 	return &commonids.StorageAccountId{}
 }
 
-func (a AccountStaticWebsiteResource) IdentityType() pluginsdk.IdentityType {
-	return pluginsdk.IdentityTypeVirtual
+func (a AccountStaticWebsiteResource) IdentityType() pluginsdk.ResourceTypeForIdentity {
+	return pluginsdk.ResourceTypeForIdentityVirtual
 }
 
 func (a AccountStaticWebsiteResource) Create() sdk.ResourceFunc {
@@ -197,7 +197,7 @@ func (a AccountStaticWebsiteResource) Read() sdk.ResourceFunc {
 				state.Error404Document = website.ErrorDocument404Path
 			}
 
-			if err = pluginsdk.SetResourceIdentityData(metadata.ResourceData, id, pluginsdk.IdentityTypeVirtual); err != nil {
+			if err = pluginsdk.SetResourceIdentityData(metadata.ResourceData, id, pluginsdk.ResourceTypeForIdentityVirtual); err != nil {
 				return err
 			}
 

--- a/internal/services/storage/storage_account_static_website_resource.go
+++ b/internal/services/storage/storage_account_static_website_resource.go
@@ -23,8 +23,8 @@ import (
 type AccountStaticWebsiteResource struct{}
 
 var (
-	_ sdk.ResourceWithUpdate   = AccountStaticWebsiteResource{}
-	_ sdk.ResourceWithIdentity = AccountStaticWebsiteResource{}
+	_ sdk.ResourceWithUpdate               = AccountStaticWebsiteResource{}
+	_ sdk.ResourceWithIdentityTypeOverride = AccountStaticWebsiteResource{}
 )
 
 type AccountStaticWebsiteResourceModel struct {
@@ -77,8 +77,12 @@ func (a AccountStaticWebsiteResource) IDValidationFunc() pluginsdk.SchemaValidat
 	return commonids.ValidateStorageAccountID
 }
 
-func (s AccountStaticWebsiteResource) Identity() resourceids.ResourceId {
+func (a AccountStaticWebsiteResource) Identity() resourceids.ResourceId {
 	return &commonids.StorageAccountId{}
+}
+
+func (a AccountStaticWebsiteResource) IdentityType() pluginsdk.IdentityType {
+	return pluginsdk.IdentityTypeVirtual
 }
 
 func (a AccountStaticWebsiteResource) Create() sdk.ResourceFunc {
@@ -193,7 +197,7 @@ func (a AccountStaticWebsiteResource) Read() sdk.ResourceFunc {
 				state.Error404Document = website.ErrorDocument404Path
 			}
 
-			if err = pluginsdk.SetResourceIdentityData(metadata.ResourceData, id); err != nil {
+			if err = pluginsdk.SetResourceIdentityData(metadata.ResourceData, id, pluginsdk.IdentityTypeVirtual); err != nil {
 				return err
 			}
 

--- a/internal/services/storage/storage_blob_inventory_policy_resource.go
+++ b/internal/services/storage/storage_blob_inventory_policy_resource.go
@@ -39,10 +39,10 @@ func resourceStorageBlobInventoryPolicy() *pluginsdk.Resource {
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 
-		Importer: pluginsdk.ImporterValidatingIdentity(&commonids.StorageAccountId{}, pluginsdk.IdentityTypeVirtual),
+		Importer: pluginsdk.ImporterValidatingIdentity(&commonids.StorageAccountId{}, pluginsdk.ResourceTypeForIdentityVirtual),
 
 		Identity: &schema.ResourceIdentity{
-			SchemaFunc: pluginsdk.GenerateIdentitySchema(&commonids.StorageAccountId{}, pluginsdk.IdentityTypeVirtual),
+			SchemaFunc: pluginsdk.GenerateIdentitySchema(&commonids.StorageAccountId{}, pluginsdk.ResourceTypeForIdentityVirtual),
 		},
 
 		SchemaVersion: 1,
@@ -253,7 +253,7 @@ func resourceStorageBlobInventoryPolicyRead(d *pluginsdk.ResourceData, meta inte
 		}
 	}
 
-	return pluginsdk.SetResourceIdentityData(d, id, pluginsdk.IdentityTypeVirtual)
+	return pluginsdk.SetResourceIdentityData(d, id, pluginsdk.ResourceTypeForIdentityVirtual)
 }
 
 func resourceStorageBlobInventoryPolicyDelete(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/storage/storage_blob_inventory_policy_resource.go
+++ b/internal/services/storage/storage_blob_inventory_policy_resource.go
@@ -39,10 +39,10 @@ func resourceStorageBlobInventoryPolicy() *pluginsdk.Resource {
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 
-		Importer: pluginsdk.ImporterValidatingIdentity(&commonids.StorageAccountId{}),
+		Importer: pluginsdk.ImporterValidatingIdentity(&commonids.StorageAccountId{}, pluginsdk.IdentityTypeVirtual),
 
 		Identity: &schema.ResourceIdentity{
-			SchemaFunc: pluginsdk.GenerateIdentitySchema(&commonids.StorageAccountId{}),
+			SchemaFunc: pluginsdk.GenerateIdentitySchema(&commonids.StorageAccountId{}, pluginsdk.IdentityTypeVirtual),
 		},
 
 		SchemaVersion: 1,
@@ -253,7 +253,7 @@ func resourceStorageBlobInventoryPolicyRead(d *pluginsdk.ResourceData, meta inte
 		}
 	}
 
-	return pluginsdk.SetResourceIdentityData(d, id)
+	return pluginsdk.SetResourceIdentityData(d, id, pluginsdk.IdentityTypeVirtual)
 }
 
 func resourceStorageBlobInventoryPolicyDelete(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/tf/pluginsdk/imports.go
+++ b/internal/tf/pluginsdk/imports.go
@@ -49,7 +49,7 @@ func ImporterValidatingResourceIdThen(validateFunc IDValidationFunc, thenFunc Im
 
 // ImporterValidatingIdentity validates the ID provided at import time is valid or that the resource identity data provided in the import block is valid
 // based on the expected resource ID type.
-func ImporterValidatingIdentity(id resourceids.ResourceId, idType ...IdentityType) *schema.ResourceImporter {
+func ImporterValidatingIdentity(id resourceids.ResourceId, idType ...ResourceTypeForIdentity) *schema.ResourceImporter {
 	thenFunc := func(ctx context.Context, d *ResourceData, meta interface{}) ([]*ResourceData, error) {
 		return []*ResourceData{d}, nil
 	}
@@ -59,7 +59,7 @@ func ImporterValidatingIdentity(id resourceids.ResourceId, idType ...IdentityTyp
 
 // ImporterValidatingIdentityThen validates the ID provided at import time is valid or that the resource identity data provided in the import block is valid
 // based on the expected resource ID type, then runs the 'thenFunc', allowing the import to be customised.
-func ImporterValidatingIdentityThen(id resourceids.ResourceId, thenFunc ImporterFunc, idType ...IdentityType) *schema.ResourceImporter {
+func ImporterValidatingIdentityThen(id resourceids.ResourceId, thenFunc ImporterFunc, idType ...ResourceTypeForIdentity) *schema.ResourceImporter {
 	return &schema.ResourceImporter{
 		StateContext: func(ctx context.Context, d *ResourceData, meta interface{}) ([]*ResourceData, error) {
 			log.Printf("[DEBUG] Importing Resource - parsing %q", d.Id())

--- a/internal/tf/pluginsdk/imports.go
+++ b/internal/tf/pluginsdk/imports.go
@@ -49,17 +49,17 @@ func ImporterValidatingResourceIdThen(validateFunc IDValidationFunc, thenFunc Im
 
 // ImporterValidatingIdentity validates the ID provided at import time is valid or that the resource identity data provided in the import block is valid
 // based on the expected resource ID type.
-func ImporterValidatingIdentity(id resourceids.ResourceId) *schema.ResourceImporter {
+func ImporterValidatingIdentity(id resourceids.ResourceId, idType ...IdentityType) *schema.ResourceImporter {
 	thenFunc := func(ctx context.Context, d *ResourceData, meta interface{}) ([]*ResourceData, error) {
 		return []*ResourceData{d}, nil
 	}
 
-	return ImporterValidatingIdentityThen(id, thenFunc)
+	return ImporterValidatingIdentityThen(id, thenFunc, idType...)
 }
 
 // ImporterValidatingIdentityThen validates the ID provided at import time is valid or that the resource identity data provided in the import block is valid
 // based on the expected resource ID type, then runs the 'thenFunc', allowing the import to be customised.
-func ImporterValidatingIdentityThen(id resourceids.ResourceId, thenFunc ImporterFunc) *schema.ResourceImporter {
+func ImporterValidatingIdentityThen(id resourceids.ResourceId, thenFunc ImporterFunc, idType ...IdentityType) *schema.ResourceImporter {
 	return &schema.ResourceImporter{
 		StateContext: func(ctx context.Context, d *ResourceData, meta interface{}) ([]*ResourceData, error) {
 			log.Printf("[DEBUG] Importing Resource - parsing %q", d.Id())
@@ -79,7 +79,7 @@ func ImporterValidatingIdentityThen(id resourceids.ResourceId, thenFunc Importer
 				return thenFunc(ctx, d, meta)
 			}
 
-			if err := ValidateResourceIdentityData(d, id); err != nil {
+			if err := ValidateResourceIdentityData(d, id, idType...); err != nil {
 				return nil, err
 			}
 

--- a/internal/tf/pluginsdk/resource_identity.go
+++ b/internal/tf/pluginsdk/resource_identity.go
@@ -18,21 +18,20 @@ import (
 // * Hierarchical IDs (untyped and typed resources)
 // * IDs for resources with a Discriminated Type (untyped and typed resources)
 
-// IdentityType is used to select different schema generation behaviours depending on the kind of resource/resource ID
-// TODO: does this want a different name?
-type IdentityType int
+// ResourceTypeForIdentity is used to select different schema generation behaviours depending on the type of resource/resource ID
+type ResourceTypeForIdentity int
 
 const (
-	IdentityTypeDefault = iota
-	IdentityTypeVirtual
+	ResourceTypeForIdentityDefault = iota
+	ResourceTypeForIdentityVirtual
 )
 
-func identityType(idType []IdentityType) IdentityType {
-	var t IdentityType
+func identityType(idType []ResourceTypeForIdentity) ResourceTypeForIdentity {
+	var t ResourceTypeForIdentity
 
 	switch len(idType) {
 	case 0:
-		t = IdentityTypeDefault
+		t = ResourceTypeForIdentityDefault
 	case 1:
 		t = idType[0]
 	default:
@@ -55,9 +54,9 @@ func segmentTypeSupported(segment resourceids.SegmentType) bool {
 	return slices.Contains(supportedSegmentTypes, segment)
 }
 
-func segmentName(segment resourceids.Segment, idType IdentityType, numSegments, idx int) string {
+func segmentName(segment resourceids.Segment, idType ResourceTypeForIdentity, numSegments, idx int) string {
 	switch idType {
-	case IdentityTypeVirtual:
+	case ResourceTypeForIdentityVirtual:
 		return strcase.ToSnake(segment.Name)
 	default:
 		// For the last segment, if it's a `*Name` field, we generate it as `name` rather than snake casing the segment's name
@@ -70,7 +69,7 @@ func segmentName(segment resourceids.Segment, idType IdentityType, numSegments, 
 
 // GenerateIdentitySchemaWithDiscriminatedType appends a discriminated type field to the resource identity schema generated
 // from the resource ID type
-func GenerateIdentitySchemaWithDiscriminatedType(id resourceids.ResourceId, field string, idType ...IdentityType) func() map[string]*schema.Schema {
+func GenerateIdentitySchemaWithDiscriminatedType(id resourceids.ResourceId, field string, idType ...ResourceTypeForIdentity) func() map[string]*schema.Schema {
 	return func() map[string]*schema.Schema {
 		identitySchema := identitySchema(id, identityType(idType))
 
@@ -84,13 +83,13 @@ func GenerateIdentitySchemaWithDiscriminatedType(id resourceids.ResourceId, fiel
 }
 
 // GenerateIdentitySchema generates the resource identity schema from the resource ID type
-func GenerateIdentitySchema(id resourceids.ResourceId, idType ...IdentityType) func() map[string]*schema.Schema {
+func GenerateIdentitySchema(id resourceids.ResourceId, idType ...ResourceTypeForIdentity) func() map[string]*schema.Schema {
 	return func() map[string]*schema.Schema {
 		return identitySchema(id, identityType(idType))
 	}
 }
 
-func identitySchema(id resourceids.ResourceId, idType IdentityType) map[string]*schema.Schema {
+func identitySchema(id resourceids.ResourceId, idType ResourceTypeForIdentity) map[string]*schema.Schema {
 	idSchema := make(map[string]*schema.Schema)
 
 	segments := id.Segments()
@@ -110,7 +109,7 @@ func identitySchema(id resourceids.ResourceId, idType IdentityType) map[string]*
 
 // ValidateResourceIdentityData validates the resource identity data provided by the user when performing a plannable
 // import using resource identity
-func ValidateResourceIdentityData(d *schema.ResourceData, id resourceids.ResourceId, idType ...IdentityType) error {
+func ValidateResourceIdentityData(d *schema.ResourceData, id resourceids.ResourceId, idType ...ResourceTypeForIdentity) error {
 	identity, err := d.Identity()
 	if err != nil {
 		return fmt.Errorf("getting identity: %+v", err)
@@ -159,7 +158,7 @@ func ValidateResourceIdentityData(d *schema.ResourceData, id resourceids.Resourc
 }
 
 // SetResourceIdentityData sets the resource identity data in state
-func SetResourceIdentityData(d *schema.ResourceData, id resourceids.ResourceId, idType ...IdentityType) error {
+func SetResourceIdentityData(d *schema.ResourceData, id resourceids.ResourceId, idType ...ResourceTypeForIdentity) error {
 	identity, err := d.Identity()
 	if err != nil {
 		return fmt.Errorf("getting identity: %+v", err)
@@ -173,7 +172,7 @@ func SetResourceIdentityData(d *schema.ResourceData, id resourceids.ResourceId, 
 }
 
 // SetResourceIdentityDataDiscriminatedType sets the resource identity data, which includes a discriminated type in state
-func SetResourceIdentityDataDiscriminatedType(d *schema.ResourceData, id resourceids.ResourceId, discriminatedType DiscriminatedType, idType ...IdentityType) error {
+func SetResourceIdentityDataDiscriminatedType(d *schema.ResourceData, id resourceids.ResourceId, discriminatedType DiscriminatedType, idType ...ResourceTypeForIdentity) error {
 	identity, err := d.Identity()
 	if err != nil {
 		return fmt.Errorf("getting identity: %+v", err)
@@ -190,7 +189,7 @@ func SetResourceIdentityDataDiscriminatedType(d *schema.ResourceData, id resourc
 	return nil
 }
 
-func resourceIdentityData(identity *schema.IdentityData, id resourceids.ResourceId, idType IdentityType) error {
+func resourceIdentityData(identity *schema.IdentityData, id resourceids.ResourceId, idType ResourceTypeForIdentity) error {
 	parser := resourceids.NewParserFromResourceIdType(id)
 	parsed, err := parser.Parse(id.ID(), true)
 	if err != nil {

--- a/internal/tf/pluginsdk/resource_identity.go
+++ b/internal/tf/pluginsdk/resource_identity.go
@@ -198,7 +198,7 @@ func resourceIdentityData(identity *schema.IdentityData, id resourceids.Resource
 
 	segments := id.Segments()
 	numSegments := len(segments)
-	for idx, segment := range id.Segments() {
+	for idx, segment := range segments {
 		if segmentTypeSupported(segment.Type) {
 			name := segmentName(segment, idType, numSegments, idx)
 


### PR DESCRIPTION
Changes:

- Defaults `*Name` ID struct fields to `name` instead of snake casing the field if it is the last segment
- Adds `ResourceTypeForIdentity` allowing for overriding the schema generation behaviour from a resource definition

Tests:

AppService:
--- PASS: TestAccLinuxFunctionApp_resourceIdentity (302.73s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/appservice    304.235s

Compute:
--- PASS: TestAccProximityPlacementGroup_resourceIdentity (54.20s)
--- PASS: TestAccAvailabilitySet_resourceIdentity (67.79s)
--- PASS: TestAccDedicatedHostGroup_resourceIdentity (80.28s)
--- PASS: TestAccCapacityReservationGroup_resourceIdentity (100.85s)
--- PASS: TestAccCapacityReservation_resourceIdentity (134.92s)
--- PASS: TestAccSharedImageGallery_resourceIdentity (147.32s)
--- PASS: TestAccGalleryApplication_resourceIdentity (169.71s)
--- PASS: TestAccDedicatedHost_resourceIdentity (286.66s)
--- PASS: TestAccSharedImage_resourceIdentity (293.18s)
--- PASS: TestAccGalleryApplicationVersion_resourceIdentity (874.18s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/compute       875.711s

Firewall:
--- PASS: TestAccFirewallPolicy_resourceIdentity (85.90s)
--- PASS: TestAccFirewall_resourceIdentity (716.38s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/firewall      717.912s

Network:
--- PASS: TestAccRouteTable_resourceIdentity (66.34s)
--- PASS: TestAccSubnetServiceEndpointStoragePolicy_resourceIdentity (111.60s)
--- PASS: TestAccNetworkInterface_resourceIdentity (121.09s)
--- PASS: TestAccRoute_resourceIdentity (130.88s)
--- PASS: TestAccIpGroup_resourceIdentity (71.65s)
--- PASS: TestAccVirtualNetwork_resourceIdentity (153.95s)
--- PASS: TestAccSubnet_resourceIdentity (170.33s)
--- PASS: TestAccNatGateway_resourceIdentity (61.06s)
--- PASS: TestAccLocalNetworkGateway_resourceIdentity (76.87s)
--- PASS: TestAccRouteFilter_resourceIdentity (66.32s)
--- PASS: TestAccNetworkProfile_resourceIdentity (243.58s)
--- PASS: TestAccPrivateLinkService_resourceIdentity (115.95s)
--- PASS: TestAccNetworkSecurityRule_resourceIdentity (75.64s)
--- PASS: TestAccPublicIpPrefix_resourceIdentity (103.83s)
--- PASS: TestAccNetworkSecurityGroup_resourceIdentity (60.52s)
--- PASS: TestAccApplicationSecurityGroup_resourceIdentity (58.42s)
--- PASS: TestAccPrivateEndpoint_resourceIdentity (186.47s)
--- PASS: TestAccApplicationGateway_resourceIdentity (821.54s)
--- PASS: TestAccBastionHost_resourceIdentity (982.20s)
--- PASS: TestAccVirtualHubIp_resourceIdentity (1231.51s)
--- PASS: TestAccRouteServer_resourceIdentity (1310.46s)
--- PASS: TestAccRouteServerBgpConnection_resourceIdentity (1614.37s)
--- PASS: TestAccVirtualHub_resourceIdentity (1922.63s)
--- PASS: TestAccVirtualHubConnection_resourceIdentity (2317.40s)
--- PASS: TestAccVirtualHubRouteTable_resourceIdentity (2371.42s)
--- PASS: TestAccRouteMap_resourceIdentity (2753.79s)
--- PASS: TestAccVirtualHubRoutingIntent_resourceIdentity (3772.04s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/network       3773.645s

Storage:
--- PASS: TestAccStorageAccountLocalUser_resourceIdentity (146.79s)
--- PASS: TestAccStorageAccountStaticWebsite_resourceIdentity (153.49s)
--- PASS: TestAccStorageBlobInventoryPolicy_resourceIdentity (163.38s)
--- PASS: TestAccStorageAccountQueueProperties_resourceIdentity (168.70s)
--- PASS: TestAccStorageAccount_resourceIdentity (175.52s)
--- PASS: TestAccStorageAccountNetworkRules_resourceIdentity (192.45s)
--- PASS: TestAccStorageAccountCustomerManagedKey_resourceIdentity (339.79s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/storage       341.341s
