### PR TITLE
`azurerm_redis_firewall_rule` - add support for Resource Identity

### DIFF
--- a/internal/services/redis/redis_firewall_rule_resource.go
+++ b/internal/services/redis/redis_firewall_rule_resource.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/redis/2024-11-01/firewallrules"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/redis/migration"
@@ -20,16 +21,19 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
 
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name redis_firewall_rule -service-package-name redis -properties "name,resource_group_name,redis_name:redis_cache_name" -known-values "subscription_id:data.Subscriptions.Primary"
+
 func resourceRedisFirewallRule() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
-		Create: resourceRedisFirewallRuleCreateUpdate,
-		Read:   resourceRedisFirewallRuleRead,
-		Update: resourceRedisFirewallRuleCreateUpdate,
-		Delete: resourceRedisFirewallRuleDelete,
-		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
-			_, err := firewallrules.ParseFirewallRuleID(id)
-			return err
-		}),
+		Create:   resourceRedisFirewallRuleCreateUpdate,
+		Read:     resourceRedisFirewallRuleRead,
+		Update:   resourceRedisFirewallRuleCreateUpdate,
+		Delete:   resourceRedisFirewallRuleDelete,
+		Importer: pluginsdk.ImporterValidatingIdentity(&firewallrules.FirewallRuleId{}),
+
+		Identity: &schema.ResourceIdentity{
+			SchemaFunc: pluginsdk.GenerateIdentitySchema(&firewallrules.FirewallRuleId{}),
+		},
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
@@ -144,7 +148,7 @@ func resourceRedisFirewallRuleRead(d *pluginsdk.ResourceData, meta interface{}) 
 		d.Set("start_ip", model.Properties.StartIP)
 	}
 
-	return nil
+	return pluginsdk.SetResourceIdentityData(d, id)
 }
 
 func resourceRedisFirewallRuleDelete(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/redis/redis_firewall_rule_resource_identity_gen_test.go
+++ b/internal/services/redis/redis_firewall_rule_resource_identity_gen_test.go
@@ -1,0 +1,43 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package redis_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
+)
+
+func TestAccRedisFirewallRule_resourceIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_redis_firewall_rule", "test")
+	r := RedisFirewallRuleResource{}
+
+	resource.ParallelTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []resource.TestStep{
+			{
+				Config: r.basic(data),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectIdentityValue("azurerm_redis_firewall_rule.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_redis_firewall_rule.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_redis_firewall_rule.test", tfjsonpath.New("redis_name"), tfjsonpath.New("redis_cache_name")),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_redis_firewall_rule.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
+				},
+			},
+			data.ImportBlockWithResourceIdentityStep(),
+			data.ImportBlockWithIDStep(),
+		},
+	})
+}


### PR DESCRIPTION
```
--- PASS: TestAccRedisFirewallRule_resourceIdentity (978.32s)
```