### PR TITLE
remove discriminated type functionality from resource identity

### DIFF
--- a/internal/sdk/resource.go
+++ b/internal/sdk/resource.go
@@ -122,14 +122,6 @@ type ResourceWithIdentityTypeOverride interface {
 	IdentityType() pluginsdk.ResourceTypeForIdentity
 }
 
-type ResourceWithIdentityDiscriminatedType interface {
-	ResourceWithIdentity
-
-	// DiscriminatedType returns a struct containing the API field name of the discriminated type
-	// as well as the resource's discriminated type value
-	DiscriminatedType() pluginsdk.DiscriminatedType
-}
-
 // ResourceWithUpdate is an optional interface
 //
 // Notably the Arguments for Resources implementing this interface

--- a/internal/sdk/wrapper_resource.go
+++ b/internal/sdk/wrapper_resource.go
@@ -186,11 +186,6 @@ and we recommend using the %[2]q resource instead.
 		resource.Identity = &schema.ResourceIdentity{
 			SchemaFunc: pluginsdk.GenerateIdentitySchema(resourceId, idType),
 		}
-		if v, ok := rw.resource.(ResourceWithIdentityDiscriminatedType); ok {
-			resource.Identity = &schema.ResourceIdentity{
-				SchemaFunc: pluginsdk.GenerateIdentitySchemaWithDiscriminatedType(resourceId, v.DiscriminatedType().Field, idType),
-			}
-		}
 
 		resource.Importer = pluginsdk.ImporterValidatingIdentityThen(resourceId, func(ctx context.Context, d *pluginsdk.ResourceData, meta interface{}) ([]*pluginsdk.ResourceData, error) {
 			if v, ok := rw.resource.(ResourceWithCustomImporter); ok {

--- a/internal/services/appservice/linux_function_app_resource.go
+++ b/internal/services/appservice/linux_function_app_resource.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-//go:generate go run ../../tools/generator-tests resourceidentity -resource-name linux_function_app -properties "name,resource_group_name" -service-package-name appservice -test-params "B1" -known-values "subscription_id:data.Subscriptions.Primary,kind:functionapp;linux"
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name linux_function_app -properties "name,resource_group_name" -service-package-name appservice -test-params "B1" -known-values "subscription_id:data.Subscriptions.Primary"
 
 package appservice
 
@@ -89,15 +89,13 @@ type LinuxFunctionAppModel struct {
 	SiteCredentials []helpers.SiteCredential `tfschema:"site_credential"`
 }
 
-var _ sdk.ResourceWithUpdate = LinuxFunctionAppResource{}
-
-var _ sdk.ResourceWithCustomImporter = LinuxFunctionAppResource{}
-
-var _ sdk.ResourceWithCustomizeDiff = LinuxFunctionAppResource{}
-
-var _ sdk.ResourceWithStateMigration = LinuxFunctionAppResource{}
-
-var _ sdk.ResourceWithIdentityDiscriminatedType = LinuxFunctionAppResource{}
+var (
+	_ sdk.ResourceWithUpdate         = LinuxFunctionAppResource{}
+	_ sdk.ResourceWithCustomImporter = LinuxFunctionAppResource{}
+	_ sdk.ResourceWithCustomizeDiff  = LinuxFunctionAppResource{}
+	_ sdk.ResourceWithStateMigration = LinuxFunctionAppResource{}
+	_ sdk.ResourceWithIdentity       = LinuxFunctionAppResource{}
+)
 
 func (r LinuxFunctionAppResource) ModelObject() interface{} {
 	return &LinuxFunctionAppModel{}
@@ -109,13 +107,6 @@ func (r LinuxFunctionAppResource) ResourceType() string {
 
 func (r LinuxFunctionAppResource) Identity() resourceids.ResourceId {
 	return &commonids.FunctionAppId{}
-}
-
-func (r LinuxFunctionAppResource) DiscriminatedType() pluginsdk.DiscriminatedType {
-	return pluginsdk.DiscriminatedType{
-		Field: "kind",
-		Value: "functionapp,linux",
-	}
 }
 
 func (r LinuxFunctionAppResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
@@ -860,11 +851,7 @@ func (r LinuxFunctionAppResource) Read() sdk.ResourceFunc {
 				}
 			}
 
-			if err := pluginsdk.SetResourceIdentityDataDiscriminatedType(metadata.ResourceData, id, r.DiscriminatedType()); err != nil {
-				return err
-			}
-
-			return nil
+			return pluginsdk.SetResourceIdentityData(metadata.ResourceData, id)
 		},
 	}
 }

--- a/internal/services/appservice/linux_function_app_resource_identity_gen_test.go
+++ b/internal/services/appservice/linux_function_app_resource_identity_gen_test.go
@@ -30,7 +30,6 @@ func TestAccLinuxFunctionApp_resourceIdentity(t *testing.T) {
 			{
 				Config: r.basic(data, "B1"),
 				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValue("azurerm_linux_function_app.test", tfjsonpath.New("kind"), knownvalue.StringExact("functionapp,linux")),
 					statecheck.ExpectIdentityValue("azurerm_linux_function_app.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
 					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_linux_function_app.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
 					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_linux_function_app.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),

--- a/internal/tf/pluginsdk/resource.go
+++ b/internal/tf/pluginsdk/resource.go
@@ -12,11 +12,7 @@ import (
 // without introducing a merge conflict into every PR.
 
 type (
-	BasicMapReader    = schema.BasicMapReader
-	DiscriminatedType = struct {
-		Field string
-		Value string
-	}
+	BasicMapReader         = schema.BasicMapReader
 	MapFieldReader         = schema.MapFieldReader
 	MapFieldWriter         = schema.MapFieldWriter
 	Resource               = schema.Resource

--- a/internal/tf/pluginsdk/resource_identity.go
+++ b/internal/tf/pluginsdk/resource_identity.go
@@ -16,7 +16,6 @@ import (
 
 // These functions support generating the resource identity schema for the following types of identities and resources
 // * Hierarchical IDs (untyped and typed resources)
-// * IDs for resources with a Discriminated Type (untyped and typed resources)
 
 // ResourceTypeForIdentity is used to select different schema generation behaviours depending on the type of resource/resource ID
 type ResourceTypeForIdentity int
@@ -64,21 +63,6 @@ func segmentName(segment resourceids.Segment, idType ResourceTypeForIdentity, nu
 			return "name"
 		}
 		return strcase.ToSnake(segment.Name)
-	}
-}
-
-// GenerateIdentitySchemaWithDiscriminatedType appends a discriminated type field to the resource identity schema generated
-// from the resource ID type
-func GenerateIdentitySchemaWithDiscriminatedType(id resourceids.ResourceId, field string, idType ...ResourceTypeForIdentity) func() map[string]*schema.Schema {
-	return func() map[string]*schema.Schema {
-		identitySchema := identitySchema(id, identityType(idType))
-
-		identitySchema[field] = &schema.Schema{
-			Type:              schema.TypeString,
-			RequiredForImport: true,
-		}
-
-		return identitySchema
 	}
 }
 
@@ -166,24 +150,6 @@ func SetResourceIdentityData(d *schema.ResourceData, id resourceids.ResourceId, 
 
 	if err := resourceIdentityData(identity, id, identityType(idType)); err != nil {
 		return err
-	}
-
-	return nil
-}
-
-// SetResourceIdentityDataDiscriminatedType sets the resource identity data, which includes a discriminated type in state
-func SetResourceIdentityDataDiscriminatedType(d *schema.ResourceData, id resourceids.ResourceId, discriminatedType DiscriminatedType, idType ...ResourceTypeForIdentity) error {
-	identity, err := d.Identity()
-	if err != nil {
-		return fmt.Errorf("getting identity: %+v", err)
-	}
-
-	if err := resourceIdentityData(identity, id, identityType(idType)); err != nil {
-		return err
-	}
-
-	if err = identity.Set(discriminatedType.Field, discriminatedType.Value); err != nil {
-		return fmt.Errorf("setting `%s` in resource identity: %+v", discriminatedType, err)
 	}
 
 	return nil


### PR DESCRIPTION
CustomImporter() already validates that during an import the resource being imported is of the correct type (`kind` in this case), this also applies when importing a resource using resource identity, so the discriminated type field is unnecessary

--- PASS: TestAccLinuxFunctionApp_resourceIdentity (328.96s)