### PR TITLE
`azurerm_data_factory_linked_service_key_vault`- add `key_vault_base_url_dynamic_expression` attribute to support dynamic expressions for Key Vault base URL

### DIFF
--- a/internal/services/datafactory/data_factory_linked_service_key_vault_resource.go
+++ b/internal/services/datafactory/data_factory_linked_service_key_vault_resource.go
@@ -6,10 +6,11 @@ package datafactory
 import (
 	"fmt"
 	"log"
+	"net/url"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
-	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/datafactory/2018-06-01/factories"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -56,7 +57,36 @@ func resourceDataFactoryLinkedServiceKeyVault() *pluginsdk.Resource {
 				ValidateFunc: factories.ValidateFactoryID,
 			},
 
-			"key_vault_id": commonschema.ResourceIDReferenceRequired(&commonids.KeyVaultId{}),
+			"key_vault_id": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: commonids.ValidateKeyVaultID,
+				ExactlyOneOf: []string{"key_vault_id", "key_vault_base_url_dynamic_expression"},
+			},
+
+			"key_vault_base_url_dynamic_expression": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				ValidateFunc: func(val interface{}, key string) ([]string, []error) {
+					var warnings []string
+					var errors []error
+
+					w, e := validation.StringIsNotEmpty(val, key)
+					warnings = append(warnings, w...)
+					errors = append(errors, e...)
+
+					if _, e := commonids.ParseKeyVaultID(val.(string)); e == nil {
+						errors = append(errors, fmt.Errorf("`%s` must not be a Key Vault ID, use `key_vault_id` attribute instead", key))
+					}
+
+					if _, e := url.ParseRequestURI(val.(string)); e == nil {
+						errors = append(errors, fmt.Errorf("`%s` must be a URL with dynamic expression, use `key_vault_id` attribute instead", key))
+					}
+
+					return warnings, errors
+				},
+				ExactlyOneOf: []string{"key_vault_id", "key_vault_base_url_dynamic_expression"},
+			},
 
 			"description": {
 				Type:         pluginsdk.TypeString,
@@ -111,14 +141,19 @@ func resourceDataFactoryLinkedServiceKeyVaultCreateUpdate(d *pluginsdk.ResourceD
 
 	id := parse.NewLinkedServiceID(subscriptionId, dataFactoryId.ResourceGroupName, dataFactoryId.FactoryName, d.Get("name").(string))
 
-	keyVaultId, err := commonids.ParseKeyVaultID(d.Get("key_vault_id").(string))
-	if err != nil {
-		return err
-	}
+	keyVaultIdRaw := d.Get("key_vault_id").(string)
+	keyVaultBaseUri := pointer.To(d.Get("key_vault_base_url_dynamic_expression").(string))
 
-	keyVaultBaseUri, err := keyVaultsClient.BaseUriForKeyVault(ctx, *keyVaultId)
-	if err != nil {
-		return err
+	if keyVaultIdRaw != "" {
+		keyVaultId, err := commonids.ParseKeyVaultID(keyVaultIdRaw)
+		if err != nil {
+			return fmt.Errorf("parsing Key Vault ID %q: %+v", keyVaultIdRaw, err)
+		}
+
+		keyVaultBaseUri, err = keyVaultsClient.BaseUriForKeyVault(ctx, *keyVaultId)
+		if err != nil {
+			return fmt.Errorf("retrieving Key Vault Base URI for %s: %+v", *keyVaultId, err)
+		}
 	}
 
 	if d.IsNewResource() {
@@ -238,13 +273,18 @@ func resourceDataFactoryLinkedServiceKeyVaultRead(d *pluginsdk.ResourceData, met
 
 	var keyVaultId *string
 	if baseUrl != "" {
-		subscriptionId := commonids.NewSubscriptionID(id.SubscriptionId)
-		keyVaultId, err = keyVaultsClient.KeyVaultIDFromBaseUrl(ctx, subscriptionId, baseUrl)
+		_, err := url.ParseRequestURI(baseUrl)
 		if err != nil {
-			return err
+			d.Set("key_vault_base_url_dynamic_expression", baseUrl)
+		} else {
+			subscriptionId := commonids.NewSubscriptionID(id.SubscriptionId)
+			keyVaultId, err = keyVaultsClient.KeyVaultIDFromBaseUrl(ctx, subscriptionId, baseUrl)
+			if err != nil {
+				return err
+			}
+			d.Set("key_vault_id", keyVaultId)
 		}
 	}
-	d.Set("key_vault_id", keyVaultId)
 
 	return nil
 }

--- a/website/docs/r/data_factory_linked_service_key_vault.html.markdown
+++ b/website/docs/r/data_factory_linked_service_key_vault.html.markdown
@@ -50,7 +50,9 @@ The following arguments are supported:
 
 * `data_factory_id` - (Required) The Data Factory ID in which to associate the Linked Service with. Changing this forces a new resource.
 
-* `key_vault_id` - (Required) The ID the Azure Key Vault resource.
+* `key_vault_id` - (Optional) The ID the Azure Key Vault resource. Mutually exclusive with `key_vault_base_url_dynamic_expression`. Use `key_vault_base_url_dynamic_expression` instead if the URL is a dynamic expression.
+
+* `key_vault_base_url_dynamic_expression` - (Optional) The base url of the Azure Key Vault. Use only if the base url is a dynamic expression (for example `@{concat('https://my-kv-',linkedService().environmentName,'.vault.azure.net')}`). Use `key_vault_id` otherwise. This attribute is mutually exclusive with `key_vault_id`.
 
 * `description` - (Optional) The description for the Data Factory Linked Service Key Vault.
 

--- a/website/docs/r/data_factory_linked_service_key_vault.html.markdown
+++ b/website/docs/r/data_factory_linked_service_key_vault.html.markdown
@@ -50,9 +50,9 @@ The following arguments are supported:
 
 * `data_factory_id` - (Required) The Data Factory ID in which to associate the Linked Service with. Changing this forces a new resource.
 
-* `key_vault_id` - (Optional) The ID the Azure Key Vault resource. Mutually exclusive with `key_vault_base_url_dynamic_expression`. Use `key_vault_base_url_dynamic_expression` instead if the URL is a dynamic expression.
+* `key_vault_id` - (Optional) The ID the Azure Key Vault resource. Use `key_vault_base_url_dynamic_expression` instead if the base URL contains dynamic expressions. This attribute is mutually exclusive with `key_vault_base_url_dynamic_expression`, exactly one must be provided.
 
-* `key_vault_base_url_dynamic_expression` - (Optional) The base url of the Azure Key Vault. Use only if the base url is a dynamic expression (for example `@{concat('https://my-kv-',linkedService().environmentName,'.vault.azure.net')}`). Use `key_vault_id` otherwise. This attribute is mutually exclusive with `key_vault_id`.
+* `key_vault_base_url_dynamic_expression` - (Optional) The base url of the Azure Key Vault. Use only if the base URL contains dynamic expressions (for example `@{concat('https://my-kv-',linkedService().environmentName,'.vault.azure.net')}`). Use `key_vault_id` otherwise. This attribute is mutually exclusive with `key_vault_id`, exactly one must be provided.
 
 * `description` - (Optional) The description for the Data Factory Linked Service Key Vault.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Adding `key_vault_base_url_dynamic_expression` to support dynamic expressions for key vault base url.
The original design using `key_vault_id`  is incompatible with this method of defining the base url as the parser will break trying to read and turn it into a key vault id.  

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

![image](https://github.com/user-attachments/assets/9cf2f975-f4ac-414e-8ab7-6148e9e0c162)

https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_DATAFACTORY/403653?buildTab=overview
## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_data_factory_linked_service_key_vault`- add `key_vault_base_url_dynamic_expression` attribute to support dynamic expressions for Key Vault base URL [GH-29136]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #29136

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
