### PR TITLE
azurerm_mssql_job_step – support managed-identity authentication by making job_credential_id optional

### DIFF
--- a/internal/services/mssql/mssql_job_step_resource.go
+++ b/internal/services/mssql/mssql_job_step_resource.go
@@ -65,7 +65,7 @@ func (MsSqlJobStepResource) Arguments() map[string]*pluginsdk.Schema {
 		},
 		"job_credential_id": {
 			Type:         pluginsdk.TypeString,
-			Required:     true,
+			Optional:     true,
 			ValidateFunc: jobcredentials.ValidateCredentialID,
 		},
 		"job_step_index": {
@@ -209,7 +209,7 @@ func (r MsSqlJobStepResource) Create() sdk.ResourceFunc {
 					Action: jobsteps.JobStepAction{
 						Value: model.SqlScript,
 					},
-					Credential: pointer.To(model.JobCredentialID),
+					Credential: stringPtrIfSet(model.JobCredentialID),
 					ExecutionOptions: pointer.To(jobsteps.JobStepExecutionOptions{
 						InitialRetryIntervalSeconds:    pointer.To(model.InitialRetryIntervalSeconds),
 						MaximumRetryIntervalSeconds:    pointer.To(model.MaximumRetryIntervalSeconds),
@@ -331,7 +331,7 @@ func (r MsSqlJobStepResource) Update() sdk.ResourceFunc {
 			props := existing.Model.Properties
 
 			if metadata.ResourceData.HasChange("job_credential_id") {
-				props.Credential = pointer.To(config.JobCredentialID)
+				props.Credential = stringPtrIfSet(config.JobCredentialID)
 			}
 
 			if metadata.ResourceData.HasChange("job_step_index") {
@@ -453,4 +453,11 @@ func flattenOutputTarget(input *jobsteps.JobStepOutput) ([]JobStepOutputTarget, 
 			SchemaName:      pointer.From(input.SchemaName),
 		},
 	}, nil
+}
+
+func stringPtrIfSet(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return pointer.To(s)
 }

--- a/internal/services/mssql/mssql_job_step_resource.go
+++ b/internal/services/mssql/mssql_job_step_resource.go
@@ -103,7 +103,7 @@ func (MsSqlJobStepResource) Arguments() map[string]*pluginsdk.Schema {
 				Schema: map[string]*pluginsdk.Schema{
 					"job_credential_id": {
 						Type:         pluginsdk.TypeString,
-						Required:     true,
+						Optional:     true,
 						ValidateFunc: jobcredentials.ValidateCredentialID,
 					},
 					"mssql_database_id": {

--- a/website/docs/r/mssql_job_step.html.markdown
+++ b/website/docs/r/mssql_job_step.html.markdown
@@ -89,7 +89,7 @@ The following arguments are supported:
 
 * `job_id` - (Required) The ID of the Elastic Job. Changing this forces a new Elastic Job Step to be created.
 
-* `job_credential_id` - (Required) The ID of the Elastic Job Credential to use when executing this Elastic Job Step.
+* `job_credential_id` - (Optional) The ID of the Elastic Job Credential to use when executing this Elastic Job Step. Omit this argument to run the step under the Job Agent's managed identity (system- or user-assigned).
 
 * `job_step_index` - (Required) The index at which to insert this Elastic Job Step into the Elastic Job.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Resolves #29076 – Support managed identity instead of job_credential_id

Elastic Job Steps can now run under the Job Agent’s User/System-Assigned Managed Identity by simply omitting job_credential_id from azurerm_mssql_job_step.
This change makes hybrid and key-vault scenarios easier because secrets no longer need to be stored in SQL credentials.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_mssql_job_step` – feature: `job_credential_id` is now optional; when omitted the Job Step authenticates with the Job Agent’s managed identity [GH-29076]

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #29076 

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
