### PR TITLE
`azurerm_application_insights_web_test` - add `classic` to resource name

### DIFF
--- a/internal/services/applicationinsights/application_insights_classic_web_test_resource.go
+++ b/internal/services/applicationinsights/application_insights_classic_web_test_resource.go
@@ -25,18 +25,16 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
 
-func resourceApplicationInsightsWebTests() *pluginsdk.Resource {
+func resourceApplicationInsightsClassicWebTests() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
-		Create: resourceApplicationInsightsWebTestsCreateUpdate,
-		Read:   resourceApplicationInsightsWebTestsRead,
-		Update: resourceApplicationInsightsWebTestsCreateUpdate,
-		Delete: resourceApplicationInsightsWebTestsDelete,
+		Create: resourceApplicationInsightsClassicWebTestsCreateUpdate,
+		Read:   resourceApplicationInsightsClassicWebTestsRead,
+		Update: resourceApplicationInsightsClassicWebTestsCreateUpdate,
+		Delete: resourceApplicationInsightsClassicWebTestsDelete,
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
 			_, err := webtests.ParseWebTestID(id)
 			return err
 		}),
-
-		DeprecationMessage: "The `azurerm_application_insights_web_test` resource is deprecated and will be removed in favour of the `azurerm_application_insights_classic_web_test` resource in version 5.0 of the AzureRM Provider.",
 
 		SchemaVersion: 1,
 		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
@@ -139,7 +137,7 @@ func resourceApplicationInsightsWebTests() *pluginsdk.Resource {
 	}
 }
 
-func resourceApplicationInsightsWebTestsCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+func resourceApplicationInsightsClassicWebTestsCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).AppInsights.WebTestsClient
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -162,7 +160,7 @@ func resourceApplicationInsightsWebTestsCreateUpdate(d *pluginsdk.ResourceData, 
 		}
 
 		if !response.WasNotFound(existing.HttpResponse) {
-			return tf.ImportAsExistsError("azurerm_application_insights_web_test", id.ID())
+			return tf.ImportAsExistsError("azurerm_application_insights_classic_web_test", id.ID())
 		}
 	}
 
@@ -173,7 +171,7 @@ func resourceApplicationInsightsWebTestsCreateUpdate(d *pluginsdk.ResourceData, 
 	isEnabled := d.Get("enabled").(bool)
 	retryEnabled := d.Get("retry_enabled").(bool)
 	geoLocationsRaw := d.Get("geo_locations").([]interface{})
-	geoLocations := expandApplicationInsightsWebTestGeoLocations(geoLocationsRaw)
+	geoLocations := expandApplicationInsightsClassicWebTestGeoLocations(geoLocationsRaw)
 	testConf := d.Get("configuration").(string)
 
 	t := d.Get("tags").(map[string]interface{})
@@ -208,10 +206,10 @@ func resourceApplicationInsightsWebTestsCreateUpdate(d *pluginsdk.ResourceData, 
 
 	d.SetId(id.ID())
 
-	return resourceApplicationInsightsWebTestsRead(d, meta)
+	return resourceApplicationInsightsClassicWebTestsRead(d, meta)
 }
 
-func resourceApplicationInsightsWebTestsRead(d *pluginsdk.ResourceData, meta interface{}) error {
+func resourceApplicationInsightsClassicWebTestsRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).AppInsights.WebTestsClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -265,7 +263,7 @@ func resourceApplicationInsightsWebTestsRead(d *pluginsdk.ResourceData, meta int
 				d.Set("configuration", config.WebTest)
 			}
 
-			if err := d.Set("geo_locations", flattenApplicationInsightsWebTestGeoLocations(props.Locations)); err != nil {
+			if err := d.Set("geo_locations", flattenApplicationInsightsClassicWebTestGeoLocations(props.Locations)); err != nil {
 				return fmt.Errorf("setting `geo_locations`: %+v", err)
 			}
 		}
@@ -281,7 +279,7 @@ func resourceApplicationInsightsWebTestsRead(d *pluginsdk.ResourceData, meta int
 	return nil
 }
 
-func resourceApplicationInsightsWebTestsDelete(d *pluginsdk.ResourceData, meta interface{}) error {
+func resourceApplicationInsightsClassicWebTestsDelete(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).AppInsights.WebTestsClient
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -302,7 +300,7 @@ func resourceApplicationInsightsWebTestsDelete(d *pluginsdk.ResourceData, meta i
 	return err
 }
 
-func expandApplicationInsightsWebTestGeoLocations(input []interface{}) []webtests.WebTestGeolocation {
+func expandApplicationInsightsClassicWebTestGeoLocations(input []interface{}) []webtests.WebTestGeolocation {
 	locations := make([]webtests.WebTestGeolocation, 0)
 
 	for _, v := range input {
@@ -316,7 +314,7 @@ func expandApplicationInsightsWebTestGeoLocations(input []interface{}) []webtest
 	return locations
 }
 
-func flattenApplicationInsightsWebTestGeoLocations(input []webtests.WebTestGeolocation) []string {
+func flattenApplicationInsightsClassicWebTestGeoLocations(input []webtests.WebTestGeolocation) []string {
 	results := make([]string, 0)
 	if len(input) == 0 {
 		return results

--- a/internal/services/applicationinsights/application_insights_classic_web_test_resource_test.go
+++ b/internal/services/applicationinsights/application_insights_classic_web_test_resource_test.go
@@ -1,0 +1,220 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package applicationinsights_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	webtests "github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type AppInsightsClassicWebTestsResource struct{}
+
+func TestAccApplicationInsightsClassicWebTests_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_application_insights_classic_web_test", "test")
+	r := AppInsightsClassicWebTestsResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccApplicationInsightsClassicWebTests_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_application_insights_classic_web_test", "test")
+	r := AppInsightsClassicWebTestsResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccApplicationInsightsClassicWebTests_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_application_insights_classic_web_test", "test")
+	r := AppInsightsClassicWebTestsResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("geo_locations.#").HasValue("1"),
+				check.That(data.ResourceName).Key("frequency").HasValue("300"),
+				check.That(data.ResourceName).Key("timeout").HasValue("30"),
+			),
+		},
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("geo_locations.#").HasValue("2"),
+				check.That(data.ResourceName).Key("frequency").HasValue("900"),
+				check.That(data.ResourceName).Key("timeout").HasValue("120"),
+			),
+		},
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("geo_locations.#").HasValue("1"),
+				check.That(data.ResourceName).Key("frequency").HasValue("300"),
+				check.That(data.ResourceName).Key("timeout").HasValue("30"),
+			),
+		},
+	})
+}
+
+func TestAccApplicationInsightsClassicWebTests_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_application_insights_classic_web_test", "test")
+	r := AppInsightsClassicWebTestsResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func (t AppInsightsClassicWebTestsResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := webtests.ParseWebTestID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := clients.AppInsights.WebTestsClient.WebTestsGet(ctx, *id)
+	if err != nil {
+		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	return pointer.To(resp.Model != nil), nil
+}
+
+func (AppInsightsClassicWebTestsResource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-appinsights-%d"
+  location = "%s"
+}
+
+resource "azurerm_application_insights" "test" {
+  name                = "acctestappinsights-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  application_type    = "web"
+}
+
+resource "azurerm_application_insights_classic_web_test" "test" {
+  name                    = "acctestappinsightswebtests-%d"
+  location                = azurerm_resource_group.test.location
+  resource_group_name     = azurerm_resource_group.test.name
+  application_insights_id = azurerm_application_insights.test.id
+  kind                    = "ping"
+  geo_locations           = ["us-tx-sn1-azr"]
+
+  configuration = <<XML
+<WebTest Name="WebTest1" Id="ABD48585-0831-40CB-9069-682EA6BB3583" Enabled="True" CssProjectStructure="" CssIteration="" Timeout="0" WorkItemIds="" xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010" Description="" CredentialUserName="" CredentialPassword="" PreAuthenticate="True" Proxy="default" StopOnError="False" RecordedResultFile="" ResultsLocale="">
+  <Items>
+    <Request Method="GET" Guid="a5f10126-e4cd-570d-961c-cea43999a200" Version="1.1" Url="http://microsoft.com" ThinkTime="0" Timeout="300" ParseDependentRequests="True" FollowRedirects="True" RecordResult="True" Cache="False" ResponseTimeGoal="0" Encoding="utf-8" ExpectedHttpStatusCode="200" ExpectedResponseUrl="" ReportingName="" IgnoreHttpStatusCode="False" />
+  </Items>
+</WebTest>
+XML
+
+  lifecycle {
+    ignore_changes = ["tags"]
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func (AppInsightsClassicWebTestsResource) complete(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-appinsights-%d"
+  location = "%s"
+}
+
+resource "azurerm_application_insights" "test" {
+  name                = "acctestappinsights-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  application_type    = "web"
+}
+
+resource "azurerm_application_insights_classic_web_test" "test" {
+  name                    = "acctestappinsightswebtests-%d"
+  location                = azurerm_resource_group.test.location
+  resource_group_name     = azurerm_resource_group.test.name
+  application_insights_id = azurerm_application_insights.test.id
+  kind                    = "ping"
+  frequency               = 900
+  timeout                 = 120
+  enabled                 = true
+  description             = "web_test"
+  retry_enabled           = true
+  tags = {
+    ENV = "web_test"
+  }
+  geo_locations = ["us-tx-sn1-azr", "us-il-ch1-azr"]
+
+  configuration = <<XML
+<WebTest Name="WebTest1" Id="ABD48585-0831-40CB-9069-682EA6BB3583" Enabled="True" CssProjectStructure="" CssIteration="" Timeout="0" WorkItemIds="" xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010" Description="" CredentialUserName="" CredentialPassword="" PreAuthenticate="True" Proxy="default" StopOnError="False" RecordedResultFile="" ResultsLocale="">
+  <Items>
+    <Request Method="GET" Guid="a5f10126-e4cd-570d-961c-cea43999a200" Version="1.1" Url="http://microsoft.com" ThinkTime="0" Timeout="300" ParseDependentRequests="True" FollowRedirects="True" RecordResult="True" Cache="False" ResponseTimeGoal="0" Encoding="utf-8" ExpectedHttpStatusCode="200" ExpectedResponseUrl="" ReportingName="" IgnoreHttpStatusCode="False" />
+  </Items>
+</WebTest>
+XML
+
+  lifecycle {
+    ignore_changes = ["tags"]
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func (AppInsightsClassicWebTestsResource) requiresImport(data acceptance.TestData) string {
+	template := AppInsightsClassicWebTestsResource{}.basic(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_application_insights_classic_web_test" "import" {
+  name                    = azurerm_application_insights_classic_web_test.test.name
+  location                = azurerm_application_insights_classic_web_test.test.location
+  resource_group_name     = azurerm_application_insights_classic_web_test.test.resource_group_name
+  application_insights_id = azurerm_application_insights_classic_web_test.test.application_insights_id
+  kind                    = azurerm_application_insights_classic_web_test.test.kind
+  configuration           = azurerm_application_insights_classic_web_test.test.configuration
+  geo_locations           = azurerm_application_insights_classic_web_test.test.geo_locations
+}
+`, template)
+}

--- a/internal/services/applicationinsights/registration.go
+++ b/internal/services/applicationinsights/registration.go
@@ -4,6 +4,7 @@
 package applicationinsights
 
 import (
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
@@ -40,15 +41,19 @@ func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 
 // SupportedResources returns the supported Resources supported by this Service
 func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
-	return map[string]*pluginsdk.Resource{
+	resources := map[string]*pluginsdk.Resource{
 		"azurerm_application_insights_api_key":              resourceApplicationInsightsAPIKey(),
 		"azurerm_application_insights":                      resourceApplicationInsights(),
 		"azurerm_application_insights_analytics_item":       resourceApplicationInsightsAnalyticsItem(),
 		"azurerm_application_insights_smart_detection_rule": resourceApplicationInsightsSmartDetectionRule(),
-
-		// TODO change in 4.0 to azurerm_application_insights_classic_web_test
-		"azurerm_application_insights_web_test": resourceApplicationInsightsWebTests(),
+		"azurerm_application_insights_classic_web_test":     resourceApplicationInsightsClassicWebTests(),
 	}
+
+	if !features.FivePointOh() {
+		resources["azurerm_application_insights_web_test"] = resourceApplicationInsightsWebTests()
+	}
+
+	return resources
 }
 
 // DataSources returns a list of Data Sources supported by this Service

--- a/website/docs/r/application_insights_web_test.html.markdown
+++ b/website/docs/r/application_insights_web_test.html.markdown
@@ -1,14 +1,14 @@
 ---
 subcategory: "Application Insights"
 layout: "azurerm"
-page_title: "Azure Resource Manager: azurerm_application_insights_web_test"
+page_title: "Azure Resource Manager: azurerm_application_insights_classic_web_test"
 description: |-
   Manages an Application Insights WebTest.
 ---
 
-# azurerm_application_insights_web_test
+# azurerm_application_insights_classic_web_test
 
-Manages an Application Insights WebTest.
+Manages an Application Insights Classic WebTest.
 
 ## Example Usage
 
@@ -25,7 +25,7 @@ resource "azurerm_application_insights" "example" {
   application_type    = "web"
 }
 
-resource "azurerm_application_insights_web_test" "example" {
+resource "azurerm_application_insights_classic_web_test" "example" {
   name                    = "tf-test-appinsights-webtest"
   location                = azurerm_application_insights.example.location
   resource_group_name     = azurerm_resource_group.example.name
@@ -47,11 +47,11 @@ XML
 }
 
 output "webtest_id" {
-  value = azurerm_application_insights_web_test.example.id
+  value = azurerm_application_insights_classic_web_test.example.id
 }
 
 output "webtests_synthetic_id" {
-  value = azurerm_application_insights_web_test.example.synthetic_monitor_id
+  value = azurerm_application_insights_classic_web_test.example.synthetic_monitor_id
 }
 ```
 
@@ -101,7 +101,7 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Application Insights Web Tests can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_application_insights_web_test.my_test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Insights/webTests/my_test
+terraform import azurerm_application_insights_classic_web_test.my_test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Insights/webTests/my_test
 ```
 
 ## API Providers


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
