### PR TITLE
`azurerm_mobile_network_packet_core_control_plane` - correct updating `site_ids`

### DIFF
--- a/internal/services/mobilenetwork/mobile_network_packet_core_control_plane_resource.go
+++ b/internal/services/mobilenetwork/mobile_network_packet_core_control_plane_resource.go
@@ -119,6 +119,7 @@ func (r PacketCoreControlPlaneResource) Arguments() map[string]*pluginsdk.Schema
 			Type:     pluginsdk.TypeList,
 			Required: true,
 			MinItems: 1,
+			MaxItems: 1,
 			Elem: &pluginsdk.Schema{
 				Type:         pluginsdk.TypeString,
 				ValidateFunc: site.ValidateSiteID,

--- a/internal/services/mobilenetwork/mobile_network_packet_core_control_plane_resource.go
+++ b/internal/services/mobilenetwork/mobile_network_packet_core_control_plane_resource.go
@@ -120,6 +120,7 @@ func (r PacketCoreControlPlaneResource) Arguments() map[string]*pluginsdk.Schema
 			Required: true,
 			MinItems: 1,
 			MaxItems: 1,
+			ForceNew: true,
 			Elem: &pluginsdk.Schema{
 				Type:         pluginsdk.TypeString,
 				ValidateFunc: site.ValidateSiteID,
@@ -425,10 +426,6 @@ func (r PacketCoreControlPlaneResource) Update() sdk.ResourceFunc {
 
 			if metadata.ResourceData.HasChange("local_diagnostics_access") {
 				model.Properties.LocalDiagnosticsAccess = expandPacketCoreControlLocalDiagnosticsAccessConfiguration(plan.LocalDiagnosticsAccess)
-			}
-
-			if metadata.ResourceData.HasChange("site_ids") {
-				model.Properties.Sites = expandPacketCoreControlPlaneSites(plan.SiteIds)
 			}
 
 			if metadata.ResourceData.HasChange("platform") {

--- a/internal/services/mobilenetwork/mobile_network_packet_core_control_plane_resource.go
+++ b/internal/services/mobilenetwork/mobile_network_packet_core_control_plane_resource.go
@@ -426,7 +426,7 @@ func (r PacketCoreControlPlaneResource) Update() sdk.ResourceFunc {
 				model.Properties.LocalDiagnosticsAccess = expandPacketCoreControlLocalDiagnosticsAccessConfiguration(plan.LocalDiagnosticsAccess)
 			}
 
-			if metadata.ResourceData.HasChange("mobile_network_id") {
+			if metadata.ResourceData.HasChange("site_ids") {
 				model.Properties.Sites = expandPacketCoreControlPlaneSites(plan.SiteIds)
 			}
 

--- a/internal/services/mobilenetwork/mobile_network_packet_core_control_plane_resource_test.go
+++ b/internal/services/mobilenetwork/mobile_network_packet_core_control_plane_resource_test.go
@@ -121,6 +121,13 @@ func TestAccMobileNetworkPacketCoreControlPlane_update(t *testing.T) {
 			),
 		},
 		data.ImportStep(),
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
 	})
 }
 
@@ -401,14 +408,20 @@ resource "azurerm_mobile_network_packet_core_control_plane" "import" {
 
 func (r MobileNetworkPacketCoreControlPlaneResource) update(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-			%s
+			%[1]s
+
+resource "azurerm_mobile_network_site" "test2" {
+  name              = "acctest-mns2-%[2]d"
+  mobile_network_id = azurerm_mobile_network.test.id
+  location          = azurerm_mobile_network.test.location
+}
 
 resource "azurerm_mobile_network_packet_core_control_plane" "test" {
-  name                              = "acctest-mnpccp-%d"
+  name                              = "acctest-mnpccp-%[2]d"
   resource_group_name               = azurerm_resource_group.test.name
-  location                          = "%s"
+  location                          = "%[3]s"
   sku                               = "G0"
-  site_ids                          = [azurerm_mobile_network_site.test.id]
+  site_ids                          = [azurerm_mobile_network_site.test.id, azurerm_mobile_network_site.test2.id]
   control_plane_access_name         = "default-interface"
   control_plane_access_ipv4_address = "192.168.1.199"
   control_plane_access_ipv4_gateway = "192.168.1.1"

--- a/internal/services/mobilenetwork/mobile_network_packet_core_control_plane_resource_test.go
+++ b/internal/services/mobilenetwork/mobile_network_packet_core_control_plane_resource_test.go
@@ -421,7 +421,7 @@ resource "azurerm_mobile_network_packet_core_control_plane" "test" {
   resource_group_name               = azurerm_resource_group.test.name
   location                          = "%[3]s"
   sku                               = "G0"
-  site_ids                          = [azurerm_mobile_network_site.test.id, azurerm_mobile_network_site.test2.id]
+  site_ids                          = [azurerm_mobile_network_site.test2.id]
   control_plane_access_name         = "default-interface"
   control_plane_access_ipv4_address = "192.168.1.199"
   control_plane_access_ipv4_gateway = "192.168.1.1"

--- a/internal/services/mobilenetwork/mobile_network_packet_core_control_plane_resource_test.go
+++ b/internal/services/mobilenetwork/mobile_network_packet_core_control_plane_resource_test.go
@@ -410,18 +410,12 @@ func (r MobileNetworkPacketCoreControlPlaneResource) update(data acceptance.Test
 	return fmt.Sprintf(`
 			%[1]s
 
-resource "azurerm_mobile_network_site" "test2" {
-  name              = "acctest-mns2-%[2]d"
-  mobile_network_id = azurerm_mobile_network.test.id
-  location          = azurerm_mobile_network.test.location
-}
-
 resource "azurerm_mobile_network_packet_core_control_plane" "test" {
   name                              = "acctest-mnpccp-%[2]d"
   resource_group_name               = azurerm_resource_group.test.name
   location                          = "%[3]s"
   sku                               = "G0"
-  site_ids                          = [azurerm_mobile_network_site.test2.id]
+  site_ids                          = [azurerm_mobile_network_site.test.id]
   control_plane_access_name         = "default-interface"
   control_plane_access_ipv4_address = "192.168.1.199"
   control_plane_access_ipv4_gateway = "192.168.1.1"

--- a/internal/services/mobilenetwork/mobile_network_packet_core_control_plane_resource_test.go
+++ b/internal/services/mobilenetwork/mobile_network_packet_core_control_plane_resource_test.go
@@ -121,13 +121,6 @@ func TestAccMobileNetworkPacketCoreControlPlane_update(t *testing.T) {
 			),
 		},
 		data.ImportStep(),
-		{
-			Config: r.basic(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
 	})
 }
 
@@ -408,12 +401,12 @@ resource "azurerm_mobile_network_packet_core_control_plane" "import" {
 
 func (r MobileNetworkPacketCoreControlPlaneResource) update(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-			%[1]s
+			%s
 
 resource "azurerm_mobile_network_packet_core_control_plane" "test" {
-  name                              = "acctest-mnpccp-%[2]d"
+  name                              = "acctest-mnpccp-%d"
   resource_group_name               = azurerm_resource_group.test.name
-  location                          = "%[3]s"
+  location                          = "%s"
   sku                               = "G0"
   site_ids                          = [azurerm_mobile_network_site.test.id]
   control_plane_access_name         = "default-interface"

--- a/website/docs/r/mobile_network_packet_core_control_plane.html.markdown
+++ b/website/docs/r/mobile_network_packet_core_control_plane.html.markdown
@@ -81,7 +81,7 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the Azure Region where the Mobile Network Packet Core Control Plane should exist. Changing this forces a new Mobile Network Packet Core Control Plane to be created.
 
-* `site_ids` - (Required) A list of Mobile Network Site IDs in which this packet core control plane should be deployed. The Sites must be in the same location as the packet core control plane.
+* `site_ids` - (Required) A list of Mobile Network Site IDs in which this packet core control plane should be deployed. The Sites must be in the same location as the packet core control plane. Currently, the API supports exactly 1 resource ID in the list.
 
 * `sku` - (Required) The SKU defining the throughput and SIM allowances for this packet core control plane deployment. Possible values are `G0`, `G1`, `G2`, `G3`, `G4`, `G5` and `G10`.
 

--- a/website/docs/r/mobile_network_packet_core_control_plane.html.markdown
+++ b/website/docs/r/mobile_network_packet_core_control_plane.html.markdown
@@ -81,7 +81,7 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the Azure Region where the Mobile Network Packet Core Control Plane should exist. Changing this forces a new Mobile Network Packet Core Control Plane to be created.
 
-* `site_ids` - (Required) A list of Mobile Network Site IDs in which this packet core control plane should be deployed. The Sites must be in the same location as the packet core control plane. Currently, the API supports exactly 1 resource ID in the list.
+* `site_ids` - (Required) A list of Mobile Network Site IDs in which this packet core control plane should be deployed. The Sites must be in the same location as the packet core control plane. Currently, the API supports exactly 1 resource ID in the list. Changing this forces a new resource to be created.
 
 * `sku` - (Required) The SKU defining the throughput and SIM allowances for this packet core control plane deployment. Possible values are `G0`, `G1`, `G2`, `G3`, `G4`, `G5` and `G10`.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_mobile_network_packet_core_control_plane` - correct updating `site_ids` [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
