### PR TITLE
`azurerm_virtual_network` - suppress perpetual diff for `address_space` when using `ip_address_pool`

### DIFF
--- a/internal/services/network/virtual_network_resource.go
+++ b/internal/services/network/virtual_network_resource.go
@@ -85,6 +85,17 @@ func resourceVirtualNetworkSchema() map[string]*pluginsdk.Schema {
 				Type:         pluginsdk.TypeString,
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
+			DiffSuppressFunc: func(_, old, new string, d *schema.ResourceData) bool {
+				// If `ip_address_pool` is used instead of `address_space` there is a perpetual diff
+				// due to the API returning a CIDR range provisioned by the IP Address Management Pool.
+				// Note: using `GetRawConfig` to avoid suppressing a diff if a user updates from `ip_address_pool` to `address_space`.
+				rawIpAddressPool := d.GetRawConfig().AsValueMap()["ip_address_pool"]
+				if !rawIpAddressPool.IsNull() && len(rawIpAddressPool.AsValueSlice()) > 0 {
+					return true
+				}
+
+				return false
+			},
 		},
 
 		"bgp_community": {

--- a/internal/services/network/virtual_network_resource_test.go
+++ b/internal/services/network/virtual_network_resource_test.go
@@ -689,10 +689,6 @@ resource "azurerm_virtual_network" "test" {
     id                     = azurerm_network_manager_ipam_pool.test.id
     number_of_ip_addresses = "100"
   }
-
-  lifecycle {
-    ignore_changes = [address_space]
-  }
 }
 `, data.RandomInteger, data.Locations.Primary)
 }
@@ -755,10 +751,6 @@ resource "azurerm_virtual_network" "test" {
     id                     = azurerm_network_manager_ipam_pool.test2.id
     number_of_ip_addresses = "200"
   }
-
-  lifecycle {
-    ignore_changes = [address_space]
-  }
 }
 `, data.RandomInteger, data.Locations.Primary)
 }
@@ -801,10 +793,6 @@ resource "azurerm_virtual_network" "test" {
   ip_address_pool {
     id                     = azurerm_network_manager_ipam_pool.test.id
     number_of_ip_addresses = "300"
-  }
-
-  lifecycle {
-    ignore_changes = [address_space]
   }
 }
 `, data.RandomInteger, data.Locations.Primary)
@@ -851,10 +839,6 @@ resource "azurerm_virtual_network" "test" {
   ip_address_pool {
     id                     = azurerm_network_manager_ipam_pool.test.id
     number_of_ip_addresses = "5192296858534827628530496329220096"
-  }
-
-  lifecycle {
-    ignore_changes = [address_space]
   }
 }
 `, data.RandomInteger, data.Locations.Primary)

--- a/website/docs/r/virtual_network.html.markdown
+++ b/website/docs/r/virtual_network.html.markdown
@@ -69,7 +69,7 @@ The following arguments are supported:
 
 * `address_space` - (Optional) The address space that is used the virtual network. You can supply more than one address space.
 
--> **Note:** Exactly one of `address_space` or `ip_address_pool` must be specified. If `address_space` is not specified but you encounter a diff, this might indicate the `address_space` is allocated from the IP Address Pool. If this is the case, you may need to add this to [ignore_changes](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#ignore_changes).
+-> **Note:** Exactly one of `address_space` or `ip_address_pool` must be specified.
 
 * `bgp_community` - (Optional) The BGP community attribute in format `<as-number>:<community-value>`.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Suppresses a perpetual diff when `ip_address_pool` is used. E.g.:

```
        address_space                  = [
          - "10.0.0.0/16",
        ]
```

With the diff suppress func, if config is changed from using `address_space` to `ip_address_pool` the diff does not show the removal of `address_space`, however since it does show the addition of `ip_address_pool` I think this is an acceptable middle ground. We could extend the diff suppress func to try and address this, but it would likely become a mess of `GetRawConfig/GetRawPlan/GetRawState` calls which increases the risk of introducing a regression.

If this isn't the approach we want to take, another option is making `address_space` Optional + Computed, though this has an even larger risk of introducing behavioural changes.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

Running...

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
