### PR TITLE
[TestCase] Update TestAccLogAnalyticsQueryPackQuery_update and TestAccLogAnalyticsSavedSearch_functionParameter

### DIFF
--- a/internal/services/loganalytics/log_analytics_query_pack_query_resource_test.go
+++ b/internal/services/loganalytics/log_analytics_query_pack_query_resource_test.go
@@ -121,6 +121,7 @@ resource "azurerm_log_analytics_query_pack" "test" {
 }
 
 resource "azurerm_log_analytics_query_pack_query" "test" {
+  name          = "%[3]s"
   query_pack_id = azurerm_log_analytics_query_pack.test.id
   display_name  = "Exceptions - New in the last 24 hours"
 
@@ -139,7 +140,7 @@ resource "azurerm_log_analytics_query_pack_query" "test" {
     | order by count_ desc
   BODY
 }
-`, r.template(data), data.RandomInteger)
+`, r.template(data), data.RandomInteger, r.uuid)
 }
 
 func (r LogAnalyticsQueryPackQueryResource) complete(data acceptance.TestData) string {

--- a/internal/services/loganalytics/log_analytics_saved_search_resource_test.go
+++ b/internal/services/loganalytics/log_analytics_saved_search_resource_test.go
@@ -64,35 +64,6 @@ func TestAccLogAnalyticsSavedSearch_withTag(t *testing.T) {
 	})
 }
 
-func TestAccLogAnalyticsSavedSearch_functionParameter(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_log_analytics_saved_search", "test")
-	r := LogAnalyticsSavedSearchResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.function_parameter(data, "foo:(*)"),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.function_parameter(data, "foo:int=1"),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.function_parameter(data, "foo:(bar:long)"),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-	})
-}
-
 func TestAccLogAnalyticsSavedSearch_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_log_analytics_saved_search", "test")
 	r := LogAnalyticsSavedSearchResource{}
@@ -199,38 +170,6 @@ resource "azurerm_log_analytics_saved_search" "test" {
   function_parameters = ["a:int=1", "b:int=2", "c:int=3"]
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
-}
-
-func (LogAnalyticsSavedSearchResource) function_parameter(data acceptance.TestData, para string) string {
-	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_log_analytics_workspace" "test" {
-  name                = "acctestLAW-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  sku                 = "PerGB2018"
-}
-
-resource "azurerm_log_analytics_saved_search" "test" {
-  name                       = "acctestLASS-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
-
-  category     = "Saved Search Test Category"
-  display_name = "Create or Update Saved Search Test"
-  query        = "Heartbeat | summarize Count() by Computer | take 1"
-
-  function_alias      = "heartbeat_func"
-  function_parameters = ["%s"]
-}
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, para)
 }
 
 func (LogAnalyticsSavedSearchResource) withTag(data acceptance.TestData) string {


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description
Recently we noticed that the following test cases are failed. So I removed TestAccLogAnalyticsSavedSearch_functionParameter since this case is used to test the scenario of updaing functionParameter but this property is a forcenew property. And I added name property for azurerm_log_analytics_query_pack_query in TestAccLogAnalyticsQueryPackQuery_update since it's a forcenew property so that we shouldn't change it.

Testcase1:
```
testcase.go:173: Step 4/9 error: Pre-apply plan check(s) failed:
        'azurerm_log_analytics_query_pack_query.test' - expected action to not be Replace, path: [[name]] tried to update a value that is ForceNew
--- FAIL: TestAccLogAnalyticsQueryPackQuery_update (85.73s)
```

Testcase2:
```
testcase.go:173: Step 4/9 error: Pre-apply plan check(s) failed:
        'azurerm_log_analytics_saved_search.test' - expected action to not be Replace, path: [[function_parameters]] tried to update a value that is ForceNew
--- FAIL: TestAccLogAnalyticsSavedSearch_functionParameter (125.54s)
```
<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

--- PASS: TestAccLogAnalyticsQueryPackQuery_update (135.81s)

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* [TestCase] Update TestAccLogAnalyticsQueryPackQuery_update and TestAccLogAnalyticsSavedSearch_functionParameter


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
