### PR TITLE
`azurerm_container_registry` and Data Source `azurerm_container_registry` - adding `data_endpoint_host_names` to exported properties

### DIFF
--- a/internal/services/containers/container_registry_data_source.go
+++ b/internal/services/containers/container_registry_data_source.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/containers/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
 
@@ -123,8 +122,7 @@ func dataSourceContainerRegistrySchema() map[string]*pluginsdk.Schema {
 			Type:     pluginsdk.TypeSet,
 			Computed: true,
 			Elem: &pluginsdk.Schema{
-				Type:         pluginsdk.TypeString,
-				ValidateFunc: validation.StringIsNotEmpty,
+				Type: pluginsdk.TypeString,
 			},
 		},
 

--- a/internal/services/containers/container_registry_data_source.go
+++ b/internal/services/containers/container_registry_data_source.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/containers/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
 
@@ -61,6 +62,7 @@ func dataSourceContainerRegistryRead(d *pluginsdk.ResourceData, meta interface{}
 			d.Set("admin_enabled", props.AdminUserEnabled)
 			d.Set("login_server", props.LoginServer)
 			d.Set("data_endpoint_enabled", props.DataEndpointEnabled)
+			d.Set("data_endpoint_host_names", props.DataEndpointHostNames)
 
 			if *props.AdminUserEnabled {
 				credsResp, err := client.ListCredentials(ctx, id)
@@ -115,6 +117,15 @@ func dataSourceContainerRegistrySchema() map[string]*pluginsdk.Schema {
 		"data_endpoint_enabled": {
 			Type:     pluginsdk.TypeBool,
 			Computed: true,
+		},
+
+		"data_endpoint_host_names": {
+			Type:     pluginsdk.TypeSet,
+			Computed: true,
+			Elem: &pluginsdk.Schema{
+				Type:         pluginsdk.TypeString,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
 		},
 
 		"login_server": {

--- a/internal/services/containers/container_registry_data_source_test.go
+++ b/internal/services/containers/container_registry_data_source_test.go
@@ -40,6 +40,8 @@ func TestAccDataSourceAzureRMContainerRegistry_dataEndpointPremium(t *testing.T)
 			Config: r.dataEndpointPremium(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("data_endpoint_enabled").HasValue("true"),
+				check.That(data.ResourceName).Key("data_endpoint_host_names.#").HasValue("1"),
+				check.That(data.ResourceName).Key("data_endpoint_host_names.0").Exists(),
 			),
 		},
 	})

--- a/internal/services/containers/container_registry_resource.go
+++ b/internal/services/containers/container_registry_resource.go
@@ -245,11 +245,9 @@ func resourceContainerRegistry() *pluginsdk.Resource {
 
 			"data_endpoint_host_names": {
 				Type:     pluginsdk.TypeSet,
-				Optional: true,
 				Computed: true,
 				Elem: &pluginsdk.Schema{
-					Type:         pluginsdk.TypeString,
-					ValidateFunc: validation.StringIsNotEmpty,
+					Type: pluginsdk.TypeString,
 				},
 			},
 

--- a/internal/services/containers/container_registry_resource.go
+++ b/internal/services/containers/container_registry_resource.go
@@ -243,6 +243,16 @@ func resourceContainerRegistry() *pluginsdk.Resource {
 				Optional: true,
 			},
 
+			"data_endpoint_host_names": {
+				Type:     pluginsdk.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem: &pluginsdk.Schema{
+					Type:         pluginsdk.TypeString,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+			},
+
 			"network_rule_bypass_option": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
@@ -848,6 +858,7 @@ func resourceContainerRegistryRead(d *pluginsdk.ResourceData, meta interface{}) 
 			d.Set("zone_redundancy_enabled", *props.ZoneRedundancy == registries.ZoneRedundancyEnabled)
 			d.Set("anonymous_pull_enabled", props.AnonymousPullEnabled)
 			d.Set("data_endpoint_enabled", props.DataEndpointEnabled)
+			d.Set("data_endpoint_host_names", props.DataEndpointHostNames)
 			d.Set("network_rule_bypass_option", string(pointer.From(props.NetworkRuleBypassOptions)))
 
 			if policies := props.Policies; policies != nil {

--- a/website/docs/d/container_registry.html.markdown
+++ b/website/docs/d/container_registry.html.markdown
@@ -43,7 +43,7 @@ The following attributes are exported:
 
 * `data_endpoint_enabled` - Whether dedicated data endpoints for this Container Registry are enabled?
 
-* `data_endpoint_host_names` - A set of data endpoints associated with the container registry if data endpoints are enabled.
+* `data_endpoint_host_names` - A set of data endpoint hostnames associated with the container registry if data endpoints are enabled.
 
 * `location` - The Azure Region in which this Container Registry exists.
 

--- a/website/docs/d/container_registry.html.markdown
+++ b/website/docs/d/container_registry.html.markdown
@@ -43,6 +43,8 @@ The following attributes are exported:
 
 * `data_endpoint_enabled` - Whether dedicated data endpoints for this Container Registry are enabled?
 
+* `data_endpoint_host_names` - A set of data endpoints associated with the container registry if data endpoints are enabled.
+
 * `location` - The Azure Region in which this Container Registry exists.
 
 * `admin_enabled` - Is the Administrator account enabled for this Container Registry.

--- a/website/docs/r/container_registry.html.markdown
+++ b/website/docs/r/container_registry.html.markdown
@@ -248,9 +248,9 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `admin_password` - The Password associated with the Container Registry Admin account - if the admin account is enabled.
 
-* `identity` - An `identity` block as defined below.
-
 * `data_endpoint_host_names` - A set of data endpoints associated with the container registry if data endpoints are enabled.
+
+* `identity` - An `identity` block as defined below.
 
 ---
 

--- a/website/docs/r/container_registry.html.markdown
+++ b/website/docs/r/container_registry.html.markdown
@@ -248,7 +248,7 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `admin_password` - The Password associated with the Container Registry Admin account - if the admin account is enabled.
 
-* `data_endpoint_host_names` - A set of data endpoints associated with the container registry if data endpoints are enabled.
+* `data_endpoint_host_names` - A set of data endpoint hostnames associated with the container registry if data endpoints are enabled. 
 
 * `identity` - An `identity` block as defined below.
 

--- a/website/docs/r/container_registry.html.markdown
+++ b/website/docs/r/container_registry.html.markdown
@@ -250,6 +250,8 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `identity` - An `identity` block as defined below.
 
+* `data_endpoint_host_names` - A set of data endpoints associated with the container registry if data endpoints are enabled.
+
 ---
 
 An `identity` block exports the following:


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [X] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [X] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [X] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [X] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [X] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->

Fixes #20695 

## Changes to existing Resource / Data Source

- [X] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [X] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [X] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [X] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

Tests output:

```sh
$ make acctests SERVICE='containers' TESTARGS='-run=TestAccDataSourceAzureRMContainerRegistry_da
taEndpointPremium' TESTTIMEOUT='60m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/containers -run=TestAccDataSourceAzureRMContainerRegistry_dataEndpointPremium -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccDataSourceAzureRMContainerRegistry_dataEndpointPremium
=== PAUSE TestAccDataSourceAzureRMContainerRegistry_dataEndpointPremium
=== CONT  TestAccDataSourceAzureRMContainerRegistry_dataEndpointPremium
--- PASS: TestAccDataSourceAzureRMContainerRegistry_dataEndpointPremium (76.82s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/containers    (cached)
$ make acctests SERVICE='containers' TESTARGS='-run=TestAccContainerRegistry_dataEndpoint' TESTTIMEOUT='60m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/containers -run=TestAccContainerRegistry_dataEndpoint -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccContainerRegistry_dataEndpoint
=== PAUSE TestAccContainerRegistry_dataEndpoint
=== CONT  TestAccContainerRegistry_dataEndpoint
--- PASS: TestAccContainerRegistry_dataEndpoint (159.18s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/containers    159.227s
$ make acctests SERVICE='containers' TESTARGS='-run=TestAccContainerRegistry_basic' TESTTIMEOUT=
'60m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/containers -run=TestAccContainerRegistry_basic -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccContainerRegistry_basic
=== PAUSE TestAccContainerRegistry_basic
=== RUN   TestAccContainerRegistry_basicManagedStandard
=== PAUSE TestAccContainerRegistry_basicManagedStandard
=== RUN   TestAccContainerRegistry_basicManagedPremium
=== PAUSE TestAccContainerRegistry_basicManagedPremium
=== RUN   TestAccContainerRegistry_basic2Premium2basic
=== PAUSE TestAccContainerRegistry_basic2Premium2basic
=== CONT  TestAccContainerRegistry_basic
=== CONT  TestAccContainerRegistry_basicManagedPremium
=== CONT  TestAccContainerRegistry_basicManagedStandard
=== CONT  TestAccContainerRegistry_basic2Premium2basic
--- PASS: TestAccContainerRegistry_basic (95.63s)
--- PASS: TestAccContainerRegistry_basicManagedPremium (104.96s)
--- PASS: TestAccContainerRegistry_basicManagedStandard (107.99s)
--- PASS: TestAccContainerRegistry_basic2Premium2basic (148.90s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/containers    148.950s
$ make acctests SERVICE='containers' TESTARGS='-run=TestAccDataSourceAzureRMContainerRegistry_basic' TESTTIMEOUT='60m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/containers -run=TestAccDataSourceAzureRMContainerRegistry_basic -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccDataSourceAzureRMContainerRegistry_basic
=== PAUSE TestAccDataSourceAzureRMContainerRegistry_basic
=== CONT  TestAccDataSourceAzureRMContainerRegistry_basic
--- PASS: TestAccDataSourceAzureRMContainerRegistry_basic (79.83s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/containers    79.869s
```
(I included a few non-relevant tests just to make sure it worked with non-premium ACR's)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_container_registry ` -  adding `data_endpoint_host_names` to exported properties [GH-20695]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [X] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #20695

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
