### PR TITLE
Data source: azurerm_marketplace_agreement - support for 'accepted' computed property

### DIFF
--- a/internal/services/compute/marketplace_agreement_data_source.go
+++ b/internal/services/compute/marketplace_agreement_data_source.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/marketplaceordering/2015-06-01/agreements"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"

--- a/internal/services/compute/marketplace_agreement_data_source.go
+++ b/internal/services/compute/marketplace_agreement_data_source.go
@@ -43,6 +43,11 @@ func dataSourceMarketplaceAgreement() *pluginsdk.Resource {
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
 
+			"accepted": {
+				Type:     pluginsdk.TypeBool,
+				Computed: true,
+			},
+
 			"license_text_link": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
@@ -82,6 +87,11 @@ func dataSourceMarketplaceAgreementRead(d *pluginsdk.ResourceData, meta interfac
 		if props := model.Properties; props != nil {
 			d.Set("license_text_link", props.LicenseTextLink)
 			d.Set("privacy_policy_link", props.PrivacyPolicyLink)
+			accepted := false
+			if acc := props.Accepted; acc != nil {
+				accepted = *acc
+			}
+			d.Set("accepted", accepted)
 		}
 	}
 	return nil

--- a/internal/services/compute/marketplace_agreement_data_source.go
+++ b/internal/services/compute/marketplace_agreement_data_source.go
@@ -87,11 +87,7 @@ func dataSourceMarketplaceAgreementRead(d *pluginsdk.ResourceData, meta interfac
 		if props := model.Properties; props != nil {
 			d.Set("license_text_link", props.LicenseTextLink)
 			d.Set("privacy_policy_link", props.PrivacyPolicyLink)
-			accepted := false
-			if acc := props.Accepted; acc != nil {
-				accepted = *acc
-			}
-			d.Set("accepted", accepted)
+			d.Set("accepted", pointer.From(props.Accepted))
 		}
 	}
 	return nil

--- a/internal/services/compute/marketplace_agreement_data_source_test.go
+++ b/internal/services/compute/marketplace_agreement_data_source_test.go
@@ -28,6 +28,7 @@ func TestAccDataSourceMarketplaceAgreement_basic(t *testing.T) {
 		{
 			Config: r.basic(offer),
 			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("accepted").Exists(),
 				check.That(data.ResourceName).Key("license_text_link").Exists(),
 				check.That(data.ResourceName).Key("privacy_policy_link").Exists(),
 			),

--- a/website/docs/d/marketplace_agreement.html.markdown
+++ b/website/docs/d/marketplace_agreement.html.markdown
@@ -22,6 +22,10 @@ data "azurerm_marketplace_agreement" "barracuda" {
 output "azurerm_marketplace_agreement_id" {
   value = data.azurerm_marketplace_agreement.id
 }
+
+output "azurerm_marketplace_agreement_accepted" {
+  value = data.azurerm_marketplace_agreement.accepted
+}
 ```
 
 ## Argument Reference
@@ -37,6 +41,8 @@ The following arguments are supported:
 ## Attributes Reference
 
 The following attributes are exported:
+
+* `accepted` - Whether the Marketplace Agreement has been accepted.
 
 * `id` - The ID of the Marketplace Agreement.
 

--- a/website/docs/d/marketplace_agreement.html.markdown
+++ b/website/docs/d/marketplace_agreement.html.markdown
@@ -42,9 +42,9 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `accepted` - Whether the Marketplace Agreement has been accepted.
-
 * `id` - The ID of the Marketplace Agreement.
+
+* `accepted` - Whether the Marketplace Agreement has been accepted.
 
 ## Timeouts
 

--- a/website/docs/r/marketplace_agreement.html.markdown
+++ b/website/docs/r/marketplace_agreement.html.markdown
@@ -13,10 +13,26 @@ Allows accepting the Legal Terms for a Marketplace Image.
 ## Example Usage
 
 ```hcl
+locals {
+  barracuda = {
+    publisher = "barracudanetworks"
+    offer     = "waf"
+    plan      = "hourly"
+  }
+}
+
+data "azurerm_marketplace_agreement" "barracuda" {
+  offer     = local.barracuda.offer
+  plan      = local.barracuda.plan
+  publisher = local.barracuda.publisher
+}
+
 resource "azurerm_marketplace_agreement" "barracuda" {
-  publisher = "barracudanetworks"
-  offer     = "waf"
-  plan      = "hourly"
+  count = data.azurerm_marketplace_agreement.barracuda.accepted ? 0 : 1
+
+  offer     = local.barracuda.offer
+  plan      = local.barracuda.plan
+  publisher = local.barracuda.publisher
 }
 ```
 

--- a/website/docs/r/marketplace_agreement.html.markdown
+++ b/website/docs/r/marketplace_agreement.html.markdown
@@ -13,23 +13,7 @@ Allows accepting the Legal Terms for a Marketplace Image.
 ## Example Usage
 
 ```hcl
-locals {
-  barracuda = {
-    publisher = "barracudanetworks"
-    offer     = "waf"
-    plan      = "hourly"
-  }
-}
-
-data "azurerm_marketplace_agreement" "barracuda" {
-  offer     = local.barracuda.offer
-  plan      = local.barracuda.plan
-  publisher = local.barracuda.publisher
-}
-
 resource "azurerm_marketplace_agreement" "barracuda" {
-  count = data.azurerm_marketplace_agreement.barracuda.accepted ? 0 : 1
-
   offer     = local.barracuda.offer
   plan      = local.barracuda.plan
   publisher = local.barracuda.publisher

--- a/website/docs/r/marketplace_agreement.html.markdown
+++ b/website/docs/r/marketplace_agreement.html.markdown
@@ -14,9 +14,9 @@ Allows accepting the Legal Terms for a Marketplace Image.
 
 ```hcl
 resource "azurerm_marketplace_agreement" "barracuda" {
-  offer     = local.barracuda.offer
-  plan      = local.barracuda.plan
-  publisher = local.barracuda.publisher
+  publisher = "barracudanetworks"
+  offer     = "waf"
+  plan      = "hourly"
 }
 ```
 


### PR DESCRIPTION
…data source

This commit introduces a new field 'accepted' to the 'marketplace_agreement' data source. The field allows to make a decision whether the 'marketplace_agreement' resource needs to be created.

<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

The Azure Marketplace Agreement must be accepted for each VM offer. However, the Agreement can be accepted only once per Azure subscription. If there are multiple Terraform resources of type 'azurerm_marketplace_agreement' pointing to the same offer, the AzureRM Terraform provider will raise an error pointing out that the resource must be imported. 

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `data_azurerm_marketplace_agreement` - support for the `accepted` property


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #22636

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
