### PR TITLE
`azurerm_container_app_environment` - fix import for `workload_profile`

### DIFF
--- a/internal/services/containerapps/container_app_environment_resource_test.go
+++ b/internal/services/containerapps/container_app_environment_resource_test.go
@@ -614,22 +614,6 @@ resource "azurerm_container_app_environment" "test" {
 `, r.templateVNet(data), data.RandomInteger)
 }
 
-func (r ContainerAppEnvironmentResource) consumptionWorkloadProfileRemoved(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-%[1]s
-
-resource "azurerm_container_app_environment" "test" {
-  name                = "acctest-CAEnv%[2]d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-}
-`, r.templateVNet(data), data.RandomInteger)
-}
-
 func (r ContainerAppEnvironmentResource) completeUpdate(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {

--- a/internal/services/containerapps/container_app_environment_resource_test.go
+++ b/internal/services/containerapps/container_app_environment_resource_test.go
@@ -65,6 +65,21 @@ func TestAccContainerAppEnvironment_requiresImport(t *testing.T) {
 	})
 }
 
+func TestAccContainerAppEnvironment_requiresImportWithConsumptionProfile(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_app_environment", "test")
+	r := ContainerAppEnvironmentResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.consumptionWorkloadProfile(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
 func TestAccContainerAppEnvironment_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_container_app_environment", "test")
 	r := ContainerAppEnvironmentResource{}
@@ -595,6 +610,22 @@ resource "azurerm_container_app_environment" "test" {
     name                  = "Consumption"
     workload_profile_type = "Consumption"
   }
+}
+`, r.templateVNet(data), data.RandomInteger)
+}
+
+func (r ContainerAppEnvironmentResource) consumptionWorkloadProfileRemoved(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_container_app_environment" "test" {
+  name                = "acctest-CAEnv%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
 }
 `, r.templateVNet(data), data.RandomInteger)
 }

--- a/internal/services/containerapps/helpers/container_app_environment.go
+++ b/internal/services/containerapps/helpers/container_app_environment.go
@@ -57,10 +57,7 @@ func WorkloadProfileSchema() *pluginsdk.Schema {
 			oldProfiles := o.(*pluginsdk.Set)
 			newProfiles := n.(*pluginsdk.Set)
 
-			if OneAdditionalConsumptionProfileReturnedByAPI(oldProfiles, newProfiles) {
-				return true
-			}
-			return false
+			return OneAdditionalConsumptionProfileReturnedByAPI(oldProfiles, newProfiles)
 		},
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{

--- a/internal/services/containerapps/helpers/container_app_environment.go
+++ b/internal/services/containerapps/helpers/container_app_environment.go
@@ -4,8 +4,6 @@
 package helpers
 
 import (
-	"strings"
-
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-01-01/managedenvironments"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -50,8 +48,20 @@ type WorkloadProfileModel struct {
 
 func WorkloadProfileSchema() *pluginsdk.Schema {
 	return &pluginsdk.Schema{
-		Type:     pluginsdk.TypeSet,
-		Optional: true,
+		Type:                  pluginsdk.TypeSet,
+		Optional:              true,
+		DiffSuppressOnRefresh: true,
+		DiffSuppressFunc: func(k, _, _ string, d *pluginsdk.ResourceData) bool {
+			o, n := d.GetChange("workload_profile")
+
+			oldProfiles := o.(*pluginsdk.Set)
+			newProfiles := n.(*pluginsdk.Set)
+
+			if OneAdditionalConsumptionProfileReturnedByAPI(oldProfiles, newProfiles) {
+				return true
+			}
+			return false
+		},
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
 				"name": {
@@ -106,16 +116,13 @@ func ExpandWorkloadProfiles(input []WorkloadProfileModel) *[]managedenvironments
 	return &result
 }
 
-func FlattenWorkloadProfiles(input *[]managedenvironments.WorkloadProfile, consumptionDefined bool) []WorkloadProfileModel {
+func FlattenWorkloadProfiles(input *[]managedenvironments.WorkloadProfile /*, consumptionDefined bool*/) []WorkloadProfileModel {
 	if input == nil || len(*input) == 0 {
 		return []WorkloadProfileModel{}
 	}
 	result := make([]WorkloadProfileModel, 0)
 
 	for _, v := range *input {
-		if strings.EqualFold(v.WorkloadProfileType, string(WorkloadProfileSkuConsumption)) && !consumptionDefined {
-			continue
-		}
 		result = append(result, WorkloadProfileModel{
 			Name:                v.Name,
 			MaximumCount:        pointer.From(v.MaximumCount),
@@ -125,4 +132,26 @@ func FlattenWorkloadProfiles(input *[]managedenvironments.WorkloadProfile, consu
 	}
 
 	return result
+}
+
+func OneAdditionalConsumptionProfileReturnedByAPI(returnedProfiles, definedProfiles *pluginsdk.Set) bool {
+	// if 1 more profile is returned by the API than is defined, then check if it is a consumption profile
+	if returnedProfiles.Len() == definedProfiles.Len()+1 {
+		// check if we have defined a consumption profile
+		for _, v := range definedProfiles.List() {
+			profile := v.(map[string]interface{})
+			if profile["workload_profile_type"].(string) == string(WorkloadProfileSkuConsumption) {
+				return false
+			}
+		}
+
+		// now that we know there are no consumption profiles defined in the config, check if the API returned a consumption profile
+		for _, v := range returnedProfiles.List() {
+			profile := v.(map[string]interface{})
+			if profile["workload_profile_type"].(string) == string(WorkloadProfileSkuConsumption) {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/internal/services/containerapps/helpers/container_app_environment.go
+++ b/internal/services/containerapps/helpers/container_app_environment.go
@@ -116,7 +116,7 @@ func ExpandWorkloadProfiles(input []WorkloadProfileModel) *[]managedenvironments
 	return &result
 }
 
-func FlattenWorkloadProfiles(input *[]managedenvironments.WorkloadProfile /*, consumptionDefined bool*/) []WorkloadProfileModel {
+func FlattenWorkloadProfiles(input *[]managedenvironments.WorkloadProfile) []WorkloadProfileModel {
 	if input == nil || len(*input) == 0 {
 		return []WorkloadProfileModel{}
 	}


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This pr fixes an issue that occurs when trying to import an `azurerm_container_app_environment` with workload profiles by ensuring ForceNew is false if a default Consumption workload profile is returned by the API and also suppressing a diff when this happens.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #27057, fixes #29383, supersedes #29128

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
