### PR TITLE
New Datasource: `azurerm_network_manager_ipam_pool`

### DIFF
--- a/internal/services/network/network_manager_ipam_pool_data_source.go
+++ b/internal/services/network/network_manager_ipam_pool_data_source.go
@@ -1,0 +1,132 @@
+package network
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2024-05-01/ipampools"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+type ManagerIpamPoolDataSource struct{}
+
+var _ sdk.DataSource = ManagerIpamPoolDataSource{}
+
+func (r ManagerIpamPoolDataSource) ResourceType() string {
+	return "azurerm_network_manager_ipam_pool"
+}
+
+func (r ManagerIpamPoolDataSource) ModelObject() interface{} {
+	return &ManagerIpamPoolDataSourceModel{}
+}
+
+type ManagerIpamPoolDataSourceModel struct {
+	AddressPrefixes  []string          `tfschema:"address_prefixes"`
+	Description      string            `tfschema:"description"`
+	DisplayName      string            `tfschema:"display_name"`
+	Location         string            `tfschema:"location"`
+	Name             string            `tfschema:"name"`
+	NetworkManagerId string            `tfschema:"network_manager_id"`
+	ParentPoolName   string            `tfschema:"parent_pool_name"`
+	Tags             map[string]string `tfschema:"tags"`
+}
+
+func (r ManagerIpamPoolDataSource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"network_manager_id": commonschema.ResourceIDReferenceRequired(&ipampools.NetworkManagerId{}),
+	}
+}
+
+func (r ManagerIpamPoolDataSource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"address_prefixes": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+			},
+		},
+
+		"display_name": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"location": commonschema.LocationComputed(),
+
+		"parent_pool_name": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"description": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"tags": commonschema.TagsDataSource(),
+	}
+}
+
+func (r ManagerIpamPoolDataSource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Network.IPamPools
+
+			var model ManagerIpamPoolDataSourceModel
+			if err := metadata.Decode(&model); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			networkManagerId, err := ipampools.ParseNetworkManagerID(model.NetworkManagerId)
+			if err != nil {
+				return err
+			}
+
+			id := ipampools.NewIPamPoolID(networkManagerId.SubscriptionId, networkManagerId.ResourceGroupName, networkManagerId.NetworkManagerName, model.Name)
+
+			existing, err := client.Get(ctx, id)
+			if err != nil {
+				if response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("%s does not exist", id)
+				}
+
+				return fmt.Errorf("retrieving %s: %+v", id, err)
+			}
+
+			state := ManagerIpamPoolDataSourceModel{
+				Name:             id.IpamPoolName,
+				NetworkManagerId: ipampools.NewNetworkManagerID(id.SubscriptionId, id.ResourceGroupName, id.NetworkManagerName).ID(),
+			}
+
+			if model := existing.Model; model != nil {
+				state.Location = location.Normalize(model.Location)
+				state.Tags = pointer.From(model.Tags)
+
+				props := model.Properties
+				state.AddressPrefixes = props.AddressPrefixes
+				state.Description = pointer.From(props.Description)
+				state.DisplayName = pointer.From(props.DisplayName)
+				state.ParentPoolName = pointer.From(props.ParentPoolName)
+			}
+
+			metadata.SetID(id)
+
+			return metadata.Encode(&state)
+		},
+	}
+}

--- a/internal/services/network/network_manager_ipam_pool_data_source_test.go
+++ b/internal/services/network/network_manager_ipam_pool_data_source_test.go
@@ -1,0 +1,40 @@
+package network_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+)
+
+type ManagerIpamPoolDataSource struct{}
+
+func testAccNetworkManagerIpamPoolDataSource_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_network_manager_ipam_pool", "test")
+	d := ManagerIpamPoolDataSource{}
+	data.DataSourceTestInSequence(t, []acceptance.TestStep{
+		{
+			Config: d.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("address_prefixes.#").HasValue("2"),
+				check.That(data.ResourceName).Key("description").HasValue("This is a test IPAM pool"),
+				check.That(data.ResourceName).Key("display_name").HasValue("ipampool1"),
+				check.That(data.ResourceName).Key("location").HasValue(data.Locations.Primary),
+				check.That(data.ResourceName).Key("parent_pool_name").IsNotEmpty(),
+				check.That(data.ResourceName).Key("tags.%").HasValue("2"),
+			),
+		},
+	})
+}
+
+func (d ManagerIpamPoolDataSource) complete(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_network_manager_ipam_pool" "test" {
+  name               = azurerm_network_manager_ipam_pool.test.name
+  network_manager_id = azurerm_network_manager_ipam_pool.test.network_manager_id
+}
+`, ManagerIpamPoolResource{}.complete(data))
+}

--- a/internal/services/network/network_manager_resource_test.go
+++ b/internal/services/network/network_manager_resource_test.go
@@ -101,6 +101,7 @@ func TestAccNetworkManager(t *testing.T) {
 			"complete":       testAccNetworkManagerIpamPool_complete,
 			"update":         testAccNetworkManagerIpamPool_update,
 			"requiresImport": testAccNetworkManagerIpamPool_requiresImport,
+			"dataSource":     testAccNetworkManagerIpamPoolDataSource_complete,
 		},
 		"VerifierWorkspace": {
 			"basic":          testAccNetworkManagerVerifierWorkspace_basic,

--- a/internal/services/network/registration.go
+++ b/internal/services/network/registration.go
@@ -37,6 +37,7 @@ func (r Registration) DataSources() []sdk.DataSource {
 		ManagerDataSource{},
 		ManagerNetworkGroupDataSource{},
 		ManagerConnectivityConfigurationDataSource{},
+		ManagerIpamPoolDataSource{},
 		VPNServerConfigurationDataSource{},
 		VirtualNetworkPeeringDataSource{},
 	}

--- a/website/docs/d/network_manager_ipam_pool.html.markdown
+++ b/website/docs/d/network_manager_ipam_pool.html.markdown
@@ -1,0 +1,80 @@
+---
+subcategory: "Network"
+layout: "azurerm"
+page_title: "Azure Resource Manager: Data Source: azurerm_network_manager_ipam_pool"
+description: |-
+  Gets information about an existing Network Manager IPAM Pool.
+---
+
+# Data Source: azurerm_network_manager_ipam_pool
+
+Use this data source to access information about an existing Network Manager IPAM Pool.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+data "azurerm_subscription" "current" {}
+
+resource "azurerm_network_manager" "example" {
+  name                = "example-network-manager"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  scope {
+    subscription_ids = [data.azurerm_subscription.current.id]
+  }
+}
+
+resource "azurerm_network_manager_ipam_pool" "example" {
+  name               = "example-ipam-pool"
+  location           = "West Europe"
+  network_manager_id = azurerm_network_manager.example.id
+  display_name       = "example-pool"
+  address_prefixes   = ["10.0.0.0/24"]
+}
+
+data "azurerm_network_manager_ipam_pool" "example" {
+  name               = azurerm_network_manager_ipam_pool.example.name
+  network_manager_id = azurerm_network_manager.example.id
+}
+
+output "id" {
+  value = data.azurerm_network_manager_ipam_pool.example.id
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of this Network Manager IPAM Pool.
+
+* `network_manager_id` - (Required) The ID of the parent Network Manager.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the Network Manager IPAM Pool.
+
+* `address_prefixes` - A list of IPv4 or IPv6 IP address prefixes assigned to the Network Manager IPAM Pool.
+
+* `description` - The description of the Network Manager IPAM Pool.
+
+* `display_name` - The display name of the Network Manager IPAM Pool.
+
+* `location` - The Azure Region where the Network Manager IPAM Pool exists.
+
+* `parent_pool_name` - The name of the parent IPAM Pool.
+
+* `tags` - A mapping of tags assigned to the Network Manager IPAM Pool.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Network Manager IPAM Pool.


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->
New Datasource: `azurerm_network_manager_ipam_pool`

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* New Datasource: `azurerm_network_manager_ipam_pool` [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [x] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #30108

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
