### PR TITLE
acctest machinelearning fix: distribute locations to avoid hitting quota and rate limit

### DIFF
--- a/internal/services/machinelearning/ai_foundry_resource_test.go
+++ b/internal/services/machinelearning/ai_foundry_resource_test.go
@@ -496,5 +496,5 @@ resource "azurerm_ai_services" "test" {
   resource_group_name = azurerm_resource_group.test.name
   sku_name            = "S0"
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+`, data.RandomInteger, data.Locations.Secondary, data.RandomString)
 }

--- a/internal/services/machinelearning/machine_learning_compute_cluster_resource_test.go
+++ b/internal/services/machinelearning/machine_learning_compute_cluster_resource_test.go
@@ -555,7 +555,7 @@ resource "azurerm_machine_learning_workspace" "test" {
     type = "SystemAssigned"
   }
 }
-`, data.RandomInteger, data.Locations.Primary,
+`, data.RandomInteger, data.Locations.Secondary,
 		data.RandomInteger, data.RandomIntOfLength(15), data.RandomIntOfLength(16),
 		data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
@@ -685,5 +685,5 @@ resource "azurerm_subnet_network_security_group_association" "test" {
   subnet_id                 = azurerm_subnet.test.id
   network_security_group_id = azurerm_network_security_group.test.id
 }
-`, data.RandomInteger, data.Locations.Primary)
+`, data.RandomInteger, data.Locations.Secondary)
 }

--- a/internal/services/machinelearning/machine_learning_compute_instance_resource_test.go
+++ b/internal/services/machinelearning/machine_learning_compute_instance_resource_test.go
@@ -372,6 +372,6 @@ resource "azurerm_machine_learning_workspace" "test" {
     type = "SystemAssigned"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger,
+`, data.RandomInteger, data.Locations.Ternary, data.RandomInteger,
 		data.RandomIntOfLength(15), data.RandomIntOfLength(16))
 }

--- a/internal/services/machinelearning/machine_learning_datastore_blobstorage_resource_test.go
+++ b/internal/services/machinelearning/machine_learning_datastore_blobstorage_resource_test.go
@@ -371,5 +371,5 @@ resource "azurerm_machine_learning_workspace" "test" {
     type = "SystemAssigned"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomIntOfLength(15))
+`, data.RandomInteger, data.Locations.Ternary, data.RandomString, data.RandomIntOfLength(15))
 }

--- a/internal/services/machinelearning/machine_learning_datastore_datalake_gen2_resource_test.go
+++ b/internal/services/machinelearning/machine_learning_datastore_datalake_gen2_resource_test.go
@@ -316,5 +316,5 @@ resource "azurerm_machine_learning_workspace" "test" {
     type = "SystemAssigned"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomIntOfLength(15))
+`, data.RandomInteger, data.Locations.Ternary, data.RandomString, data.RandomIntOfLength(15))
 }

--- a/internal/services/machinelearning/machine_learning_datastore_fileshare_resource_test.go
+++ b/internal/services/machinelearning/machine_learning_datastore_fileshare_resource_test.go
@@ -271,5 +271,5 @@ resource "azurerm_machine_learning_workspace" "test" {
     type = "SystemAssigned"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomIntOfLength(15))
+`, data.RandomInteger, data.Locations.Ternary, data.RandomString, data.RandomIntOfLength(15))
 }

--- a/internal/services/machinelearning/machine_learning_inference_cluster_resource_test.go
+++ b/internal/services/machinelearning/machine_learning_inference_cluster_resource_test.go
@@ -469,7 +469,7 @@ resource "azurerm_kubernetes_cluster" "test" {
     type = "SystemAssigned"
   }
 }
-`, data.RandomInteger, data.Locations.Primary,
+`, data.RandomInteger, data.Locations.Secondary,
 		data.RandomIntOfLength(17), data.RandomIntOfLength(17), data.RandomIntOfLength(16),
 		data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, nodeCount, vmSize)
 }
@@ -571,7 +571,7 @@ resource "azurerm_kubernetes_cluster" "test" {
     type = "SystemAssigned"
   }
 }
-`, data.RandomInteger, data.Locations.Primary,
+`, data.RandomInteger, data.Locations.Secondary,
 		data.RandomIntOfLength(17), data.RandomIntOfLength(17), data.RandomIntOfLength(16),
 		data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, nodeCount, vmSize)
 }

--- a/internal/services/machinelearning/machine_learning_synapse_spark_resource_test.go
+++ b/internal/services/machinelearning/machine_learning_synapse_spark_resource_test.go
@@ -321,7 +321,7 @@ resource "azurerm_synapse_spark_pool" "test" {
   node_count           = 3
   spark_version        = "3.4"
 }
-`, data.RandomInteger, data.Locations.Primary,
+`, data.RandomInteger, data.Locations.Ternary,
 		data.RandomInteger, data.RandomIntOfLength(15), data.RandomIntOfLength(16),
 		data.RandomIntOfLength(8), data.RandomIntOfLength(8), data.RandomIntOfLength(8), data.RandomIntOfLength(8))
 }

--- a/internal/services/machinelearning/machine_learning_workspace_network_outbound_rule_service_tag_resource_test.go
+++ b/internal/services/machinelearning/machine_learning_workspace_network_outbound_rule_service_tag_resource_test.go
@@ -137,7 +137,7 @@ resource "azurerm_storage_account" "test" {
   account_tier             = "Standard"
   account_replication_type = "LRS"
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomIntOfLength(10))
+`, data.RandomInteger, data.Locations.Ternary, data.RandomString, data.RandomIntOfLength(10))
 }
 
 func (r WorkspaceNetworkOutboundRuleServiceTagResource) basic(data acceptance.TestData) string {


### PR DESCRIPTION

<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
