### PR TITLE
`azurerm_service_plan` - fix CustomizeDiff

### DIFF
--- a/internal/services/appservice/helpers/service_plan.go
+++ b/internal/services/appservice/helpers/service_plan.go
@@ -15,11 +15,11 @@ import (
 )
 
 const (
-	ServicePlanTypeConsumption     = "consumption"
-	ServicePlanTypeFlexConsumption = "flexconsumption"
-	ServicePlanTypeElastic         = "elastic"
-	ServicePlanTypeIsolated        = "isolated"
 	ServicePlanTypeAppPlan         = "app"
+	ServicePlanTypeConsumption     = "consumption"
+	ServicePlanTypeElastic         = "elastic"
+	ServicePlanTypeFlexConsumption = "flexconsumption"
+	ServicePlanTypeIsolated        = "isolated"
 	ServicePlanTypePremium         = "premium"
 	ServicePlanTypeWorkflow        = "workflow"
 )
@@ -27,9 +27,6 @@ const (
 var appServicePlanSkus = []string{
 	"B1", "B2", "B3", // basic
 	"S1", "S2", "S3", // standard
-	"P1v2", "P2v2", "P3v2", // Premium V2
-	"P0v3", "P1v3", "P2v3", "P3v3", // Premium V3
-	"P1mv3", "P2mv3", "P3mv3", "P4mv3", "P5mv3", // Premium V3 memory optimized
 }
 
 var freeSkus = []string{
@@ -78,6 +75,7 @@ func AllKnownServicePlanSkus() []string {
 	allSkus = append(allSkus, flexConsumptionSkus...)
 	allSkus = append(allSkus, freeSkus...)
 	allSkus = append(allSkus, isolatedSkus...)
+	allSkus = append(allSkus, premiumSkus...)
 	allSkus = append(allSkus, sharedSkus...)
 	allSkus = append(allSkus, workflowSkus...)
 
@@ -211,8 +209,13 @@ func PlanSupportsZoneBalancing(input string) bool {
 	switch PlanTypeFromSku(input) {
 	case ServicePlanTypePremium, ServicePlanTypeElastic, ServicePlanTypeWorkflow, ServicePlanTypeConsumption, ServicePlanTypeFlexConsumption, ServicePlanTypeIsolated:
 		return true
+	default:
+		return false
 	}
-	return false
+}
+
+func PlanSupportsScaleOut(plan string) bool {
+	return strings.HasPrefix(plan, "EP") || strings.HasPrefix(plan, "WS")
 }
 
 // ServicePlanInfoForApp returns the OS type and Service Plan SKU for a given App Service Resource
@@ -222,7 +225,7 @@ func ServicePlanInfoForApp(ctx context.Context, metadata sdk.ResourceMetaData, i
 
 	site, err := client.Get(ctx, id)
 	if err != nil || site.Model == nil || site.Model.Properties == nil {
-		return nil, nil, fmt.Errorf("reading %s: %+v", id, err)
+		return nil, nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 	props := *site.Model.Properties
 	if props.ServerFarmId == nil {
@@ -235,7 +238,7 @@ func ServicePlanInfoForApp(ctx context.Context, metadata sdk.ResourceMetaData, i
 
 	sp, err := servicePlanClient.Get(ctx, *servicePlanId)
 	if err != nil || sp.Model.Kind == nil {
-		return nil, nil, fmt.Errorf("reading Service Plan for %s: %+v", id, err)
+		return nil, nil, fmt.Errorf("retrieving Service Plan for %s: %+v", id, err)
 	}
 
 	osType = pointer.To("windows")
@@ -251,14 +254,14 @@ func ServicePlanInfoForApp(ctx context.Context, metadata sdk.ResourceMetaData, i
 	return osType, planSku, nil
 }
 
-// ServicePlanInfoForApp returns the OS type and Service Plan SKU for a given App Service Resource
+// ServicePlanInfoForAppSlot returns the OS type and Service Plan SKU for a given App Service Resource
 func ServicePlanInfoForAppSlot(ctx context.Context, metadata sdk.ResourceMetaData, id webapps.SlotId) (osType *string, planSku *string, err error) {
 	client := metadata.Client.AppService.WebAppsClient
 	servicePlanClient := metadata.Client.AppService.ServicePlanClient
 
 	site, err := client.GetSlot(ctx, id)
 	if err != nil || site.Model == nil || site.Model.Properties == nil {
-		return nil, nil, fmt.Errorf("reading %s: %+v", id, err)
+		return nil, nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 	props := *site.Model.Properties
 	if props.ServerFarmId == nil {
@@ -271,7 +274,7 @@ func ServicePlanInfoForAppSlot(ctx context.Context, metadata sdk.ResourceMetaDat
 
 	sp, err := servicePlanClient.Get(ctx, *servicePlanId)
 	if err != nil || sp.Model.Kind == nil {
-		return nil, nil, fmt.Errorf("reading Service Plan for %s: %+v", id, err)
+		return nil, nil, fmt.Errorf("retrieving Service Plan for %s: %+v", id, err)
 	}
 
 	osType = pointer.To("windows")

--- a/internal/services/appservice/helpers/service_plan_test.go
+++ b/internal/services/appservice/helpers/service_plan_test.go
@@ -135,7 +135,7 @@ func TestPlanIsAppPlan(t *testing.T) {
 		},
 		{
 			name:      pointer.To("P1v3"),
-			isAppPlan: true,
+			isAppPlan: false,
 		},
 		{
 			name:      pointer.To("I1"),

--- a/internal/services/appservice/helpers/service_plan_test.go
+++ b/internal/services/appservice/helpers/service_plan_test.go
@@ -6,8 +6,8 @@ package helpers_test
 import (
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appservice/helpers"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func TestPlanIsConsumption(t *testing.T) {
@@ -16,19 +16,19 @@ func TestPlanIsConsumption(t *testing.T) {
 		isConsumption bool
 	}{
 		{
-			name:          utils.String(""),
+			name:          pointer.To(""),
 			isConsumption: false,
 		},
 		{
-			name:          utils.String("Y1"),
+			name:          pointer.To("Y1"),
 			isConsumption: true,
 		},
 		{
-			name:          utils.String("EP1"),
+			name:          pointer.To("EP1"),
 			isConsumption: false,
 		},
 		{
-			name:          utils.String("S1"),
+			name:          pointer.To("S1"),
 			isConsumption: false,
 		},
 	}
@@ -46,19 +46,19 @@ func TestPlanIsElastic(t *testing.T) {
 		isElastic bool
 	}{
 		{
-			name:      utils.String(""),
+			name:      pointer.To(""),
 			isElastic: false,
 		},
 		{
-			name:      utils.String("Y1"),
+			name:      pointer.To("Y1"),
 			isElastic: false,
 		},
 		{
-			name:      utils.String("EP1"),
+			name:      pointer.To("EP1"),
 			isElastic: true,
 		},
 		{
-			name:      utils.String("S1"),
+			name:      pointer.To("S1"),
 			isElastic: false,
 		},
 	}
@@ -76,27 +76,27 @@ func TestPlanIsIsolated(t *testing.T) {
 		isIsolated bool
 	}{
 		{
-			name:       utils.String(""),
+			name:       pointer.To(""),
 			isIsolated: false,
 		},
 		{
-			name:       utils.String("Y1"),
+			name:       pointer.To("Y1"),
 			isIsolated: false,
 		},
 		{
-			name:       utils.String("EP1"),
+			name:       pointer.To("EP1"),
 			isIsolated: false,
 		},
 		{
-			name:       utils.String("S1"),
+			name:       pointer.To("S1"),
 			isIsolated: false,
 		},
 		{
-			name:       utils.String("I1"),
+			name:       pointer.To("I1"),
 			isIsolated: true,
 		},
 		{
-			name:       utils.String("I1v2"),
+			name:       pointer.To("I1v2"),
 			isIsolated: true,
 		},
 	}
@@ -114,35 +114,35 @@ func TestPlanIsAppPlan(t *testing.T) {
 		isAppPlan bool
 	}{
 		{
-			name:      utils.String(""),
+			name:      pointer.To(""),
 			isAppPlan: false,
 		},
 		{
-			name:      utils.String("Y1"),
+			name:      pointer.To("Y1"),
 			isAppPlan: false,
 		},
 		{
-			name:      utils.String("EP1"),
+			name:      pointer.To("EP1"),
 			isAppPlan: false,
 		},
 		{
-			name:      utils.String("B1"),
+			name:      pointer.To("B1"),
 			isAppPlan: true,
 		},
 		{
-			name:      utils.String("S1"),
+			name:      pointer.To("S1"),
 			isAppPlan: true,
 		},
 		{
-			name:      utils.String("P1v3"),
+			name:      pointer.To("P1v3"),
 			isAppPlan: true,
 		},
 		{
-			name:      utils.String("I1"),
+			name:      pointer.To("I1"),
 			isAppPlan: false,
 		},
 		{
-			name:      utils.String("I1v2"),
+			name:      pointer.To("I1v2"),
 			isAppPlan: false,
 		},
 	}
@@ -181,7 +181,7 @@ func TestPlanTypeFromSku(t *testing.T) {
 		},
 		{
 			name:     "P1v3",
-			expected: "app",
+			expected: "premium",
 		},
 		{
 			name:     "I1",

--- a/internal/services/appservice/service_plan_resource.go
+++ b/internal/services/appservice/service_plan_resource.go
@@ -396,7 +396,7 @@ func (r ServicePlanResource) CustomizeDiff() sdk.ResourceFunc {
 
 			if rd.HasChange("maximum_elastic_worker_count") && newEcValue.(int) > 1 {
 				if !helpers.PlanSupportsScaleOut(servicePlanSku) && helpers.PlanIsPremium(servicePlanSku) && !newAutoScaleEnabled.(bool) {
-					return fmt.Errorf("`maximum_elastic_worker_count` can only be specified with Elastic Premium Skus or with Premium Skus when `premium_plan_auto_scale_enabled` is set to `true`")
+					return fmt.Errorf("`maximum_elastic_worker_count` can only be specified with Elastic Premium Skus, or with Premium Skus when `premium_plan_auto_scale_enabled` is set to `true`")
 				}
 			}
 

--- a/internal/services/appservice/service_plan_resource_test.go
+++ b/internal/services/appservice/service_plan_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ServicePlanResource struct{}
@@ -270,14 +270,14 @@ func (r ServicePlanResource) Exists(ctx context.Context, client *clients.Client,
 	resp, err := client.AppService.ServicePlanClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retreiving %s: %v", id, err)
 	}
 	if response.WasNotFound(resp.HttpResponse) {
-		return utils.Bool(false), nil
+		return pointer.To(false), nil
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 // Configs

--- a/website/docs/r/service_plan.html.markdown
+++ b/website/docs/r/service_plan.html.markdown
@@ -67,7 +67,7 @@ The following arguments are supported:
 
 ~> **Note:** If this setting is set to `true` and the `worker_count` value is specified, it should be set to a multiple of the number of availability zones in the region. Please see the Azure documentation for the number of Availability Zones in your region.
 
-~> **Note:** `zone_balancing_enabled` can only be set to `true` when the SKU tier is Premium. It can be disabled. To enable it, the `worker_count` must be greater than `1`, and the Service Plan must support more than one availability zone. In all other cases, changing this forces a new resource to be created. For more information, please see the [Availability Zone Support](https://learn.microsoft.com/en-us/azure/reliability/reliability-app-service?tabs=azurecli&pivots=free-shared-basic#availability-zone-support).
+~> **Note:** `zone_balancing_enabled` can only be set to `true` on Consumption, Premium, Isolated, or Workflow SKUs. It can be disabled. To enable it, the `worker_count` must be greater than `1`, and the Service Plan must support more than one availability zone. In all other cases, changing this forces a new resource to be created. For more information, please see the [Availability Zone Support](https://learn.microsoft.com/en-us/azure/reliability/reliability-app-service?tabs=azurecli&pivots=free-shared-basic#availability-zone-support).
 
 * `tags` - (Optional) A mapping of tags which should be assigned to the AppService.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

- Fixes the CustomizeDiff that prevented SKUs other than Premium (P*) from specifying `zone_balancing_enabled` as true. 
- Clean up code


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<img width="332" height="159" alt="image" src="https://github.com/user-attachments/assets/38d2c0af-8886-47f1-8b33-bc3fc220a54c" />

Failed test was due to an intermittent error that occurs with this test, reran:

<img width="579" height="50" alt="image" src="https://github.com/user-attachments/assets/2bad07b3-fb3a-4f36-b473-485864663def" />


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #30149 

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
