### PR TITLE
`azurerm_synapse_spark_pool`/`azurerm_synapse_workspace`- fix acctests

### DIFF
--- a/internal/services/synapse/synapse_spark_pool_resource.go
+++ b/internal/services/synapse/synapse_spark_pool_resource.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/preview/synapse/mgmt/v2.0/synapse" // nolint: staticcheck
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/synapse/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/synapse/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
@@ -21,7 +22,7 @@ import (
 )
 
 func resourceSynapseSparkPool() *pluginsdk.Resource {
-	return &pluginsdk.Resource{
+	r := &pluginsdk.Resource{
 		Create: resourceSynapseSparkPoolCreate,
 		Read:   resourceSynapseSparkPoolRead,
 		Update: resourceSynapseSparkPoolUpdate,
@@ -215,16 +216,43 @@ func resourceSynapseSparkPool() *pluginsdk.Resource {
 			"spark_version": {
 				Type:     pluginsdk.TypeString,
 				Required: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					"3.2",
+				ValidateFunc: validation.All(validation.StringInSlice([]string{
 					"3.3",
 					"3.4",
 				}, false),
+					func(v interface{}, k string) (warnings []string, errors []error) {
+						if val, ok := v.(string); ok && val == "3.3" {
+							warnings = append(warnings, fmt.Sprintf("Spark version %s is deprecated and will be removed in a future version of the AzureRM provider. Please consider upgrading to version 3.4 or later.", val))
+						}
+						return
+					},
+				),
 			},
 
 			"tags": tags.Schema(),
 		},
 	}
+
+	if !features.FivePointOh() {
+		r.Schema["spark_version"] = &pluginsdk.Schema{
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ValidateFunc: validation.All(validation.StringInSlice([]string{
+				"3.2",
+				"3.3",
+				"3.4",
+			}, false),
+				func(v interface{}, k string) (warnings []string, errors []error) {
+					if val, ok := v.(string); ok && (val == "3.2" || val == "3.3") {
+						warnings = append(warnings, fmt.Sprintf("Spark version %s is deprecated and will be removed in a future version of the AzureRM provider. Please consider upgrading to version 3.4 or later.", val))
+					}
+					return
+				},
+			),
+		}
+	}
+
+	return r
 }
 
 func resourceSynapseSparkPoolCreate(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/synapse/synapse_spark_pool_resource.go
+++ b/internal/services/synapse/synapse_spark_pool_resource.go
@@ -216,17 +216,9 @@ func resourceSynapseSparkPool() *pluginsdk.Resource {
 			"spark_version": {
 				Type:     pluginsdk.TypeString,
 				Required: true,
-				ValidateFunc: validation.All(validation.StringInSlice([]string{
-					"3.3",
+				ValidateFunc: validation.StringInSlice([]string{
 					"3.4",
 				}, false),
-					func(v interface{}, k string) (warnings []string, errors []error) {
-						if val, ok := v.(string); ok && val == "3.3" {
-							warnings = append(warnings, fmt.Sprintf("Spark version %s is deprecated and will be removed in a future version of the AzureRM provider. Please consider upgrading to version 3.4 or later.", val))
-						}
-						return
-					},
-				),
 			},
 
 			"tags": tags.Schema(),

--- a/internal/services/synapse/synapse_spark_pool_resource_test.go
+++ b/internal/services/synapse/synapse_spark_pool_resource_test.go
@@ -100,14 +100,6 @@ func TestAccSynapseSparkPool_sparkVersion(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.sparkVersion(data, "3.2"),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		// not returned by service
-		data.ImportStep("spark_events_folder", "spark_log_folder"),
-		{
 			Config: r.sparkVersion(data, "3.3"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),

--- a/internal/services/synapse/synapse_workspace_resource_test.go
+++ b/internal/services/synapse/synapse_workspace_resource_test.go
@@ -98,8 +98,8 @@ func TestAccSynapseWorkspace_update(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
+			ExpectNonEmptyPlan: true, // removing workspace AAD admin also removes the SQL AAD admin and visa versa so it needs to be recreated
 		},
-		data.ImportStep("sql_administrator_login_password"),
 		{
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -353,7 +353,7 @@ resource "azurerm_synapse_workspace" "test" {
     ENV = "Test"
   }
 }
-`, template, data.RandomString, data.Locations.Secondary, data.RandomString, data.RandomString, data.RandomInteger, data.RandomInteger)
+`, template, data.RandomString, data.Locations.Ternary, data.RandomString, data.RandomString, data.RandomInteger, data.RandomInteger)
 }
 
 func (r SynapseWorkspaceResource) withAadAdmin(data acceptance.TestData) string {

--- a/website/docs/5.0-upgrade-guide.html.markdown
+++ b/website/docs/5.0-upgrade-guide.html.markdown
@@ -331,6 +331,10 @@ Please follow the format in the example below for listing breaking changes in re
 * The deprecated `static_website` block has been removed and superseded by the `azurerm_storage_account_static_website` resource.
 * The property `minimum_tls_version` no longer accepts `TLS1_0` or `TLS1_1` as a value.
 
+### `azurerm_synapse_spark_pool`
+
+* The `spark_version` property no longer accepts `3.2` or `3.3` as a value.
+
 ### `azurerm_storage_container`
 
 * The deprecated `storage_account_name` property has been removed in favour of the `storage_account_id` property.

--- a/website/docs/r/synapse_spark_pool.html.markdown
+++ b/website/docs/r/synapse_spark_pool.html.markdown
@@ -97,7 +97,7 @@ The following arguments are supported:
 
 * `node_size` - (Required) The level of node in the Spark Pool. Possible values are `Small`, `Medium`, `Large`, `None`, `XLarge`, `XXLarge` and `XXXLarge`.
 
-* `spark_version` - (Required) The Apache Spark version. Possible values are `3.2`, `3.3`, and `3.4`.
+* `spark_version` - (Required) The Apache Spark version. Currently, the only possible value is `3.4`.
 
 * `node_count` - (Optional) The number of nodes in the Spark Pool. Exactly one of `node_count` or `auto_scale` must be specified.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description
Fixing the following failing tests: 
`TestAccSynapseSparkPool_sparkVersion` -  spark pool for sparkVersion 3.2 can no longer be created
`TestAccSynapseWorkspace_complete` - `francecentral` is not supported for purview account
`TestAccSynapseWorkspace_update` - unexpected plan refresh

BREAKING CHANGE
Adding a breaking change of removing spark version 3.2 to 5.0 since users can't actually create/ update spark pool with 3.2. (But there may be existing users that have 3.2 already? According to the docs jobs would eventually stop executing in deprecated versions so I'm not sure if anyone is actually using it) 
https://learn.microsoft.com/en-us/azure/synapse-analytics/spark/runtime-for-apache-spark-lifecycle-and-supportability

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- (n/a) I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)
https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_SYNAPSE/415710?buildTab=tests

<img width="2147" height="1021" alt="image" src="https://github.com/user-attachments/assets/7560e59b-06f7-42ec-b876-edd3a6bb68a8" />


<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - removing support for the `thing1` property [GH-00000]

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
