### PR TITLE
GHA - Downgrade version of `CodelyTV/pr-size-labeler`

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -15,7 +15,7 @@ jobs:
       with:
         configuration-path: .github/labeler-pull-request-triage.yml
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
-    - uses: CodelyTV/pr-size-labeler@4ec67706cd878fbc1c8db0a5dcd28b6bb412e85a # v1.10.3
+    - uses: CodelyTV/pr-size-labeler@1c3422395d899286d5ee2c809fd5aed264d5eb9b # v1.10.2 -- v1.10.3 contains a bug where size labels are only added, not removed.
       with:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         xs_label: 'size/XS'


### PR DESCRIPTION
Latest version contains a bug causing PR size labels to stack up rather than being replaced, see CodelyTV/pr-size-labeler#96