### PR TITLE
azurerm_windows_function_app application_insights_authentication_string setting

### DIFF
--- a/internal/services/appservice/helpers/function_app_schema.go
+++ b/internal/services/appservice/helpers/function_app_schema.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	apimValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/apimanagement/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appservice/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 )
@@ -811,42 +812,43 @@ func SiteConfigSchemaFunctionAppFlexConsumption() *pluginsdk.Schema {
 }
 
 type SiteConfigWindowsFunctionApp struct {
-	AlwaysOn                      bool                                 `tfschema:"always_on"`
-	AppCommandLine                string                               `tfschema:"app_command_line"`
-	ApiDefinition                 string                               `tfschema:"api_definition_url"`
-	ApiManagementConfigId         string                               `tfschema:"api_management_api_id"`
-	AppInsightsInstrumentationKey string                               `tfschema:"application_insights_key"` // App Insights Instrumentation Key
-	AppInsightsConnectionString   string                               `tfschema:"application_insights_connection_string"`
-	AppScaleLimit                 int64                                `tfschema:"app_scale_limit"`
-	AppServiceLogs                []FunctionAppAppServiceLogs          `tfschema:"app_service_logs"`
-	DefaultDocuments              []string                             `tfschema:"default_documents"`
-	ElasticInstanceMinimum        int64                                `tfschema:"elastic_instance_minimum"`
-	Http2Enabled                  bool                                 `tfschema:"http2_enabled"`
-	IpRestriction                 []IpRestriction                      `tfschema:"ip_restriction"`
-	IpRestrictionDefaultAction    string                               `tfschema:"ip_restriction_default_action"`
-	LoadBalancing                 string                               `tfschema:"load_balancing_mode"` // TODO - Valid for FunctionApps?
-	ManagedPipelineMode           string                               `tfschema:"managed_pipeline_mode"`
-	PreWarmedInstanceCount        int64                                `tfschema:"pre_warmed_instance_count"`
-	RemoteDebugging               bool                                 `tfschema:"remote_debugging_enabled"`
-	RemoteDebuggingVersion        string                               `tfschema:"remote_debugging_version"`
-	RuntimeScaleMonitoring        bool                                 `tfschema:"runtime_scale_monitoring_enabled"`
-	ScmIpRestriction              []IpRestriction                      `tfschema:"scm_ip_restriction"`
-	ScmType                       string                               `tfschema:"scm_type"` // Computed?
-	ScmIpRestrictionDefaultAction string                               `tfschema:"scm_ip_restriction_default_action"`
-	ScmUseMainIpRestriction       bool                                 `tfschema:"scm_use_main_ip_restriction"`
-	Use32BitWorker                bool                                 `tfschema:"use_32_bit_worker"`
-	WebSockets                    bool                                 `tfschema:"websockets_enabled"`
-	FtpsState                     string                               `tfschema:"ftps_state"`
-	HealthCheckPath               string                               `tfschema:"health_check_path"`
-	HealthCheckEvictionTime       int64                                `tfschema:"health_check_eviction_time_in_min"`
-	NumberOfWorkers               int64                                `tfschema:"worker_count"`
-	ApplicationStack              []ApplicationStackWindowsFunctionApp `tfschema:"application_stack"`
-	MinTlsVersion                 string                               `tfschema:"minimum_tls_version"`
-	ScmMinTlsVersion              string                               `tfschema:"scm_minimum_tls_version"`
-	Cors                          []CorsSetting                        `tfschema:"cors"`
-	DetailedErrorLogging          bool                                 `tfschema:"detailed_error_logging_enabled"`
-	WindowsFxVersion              string                               `tfschema:"windows_fx_version"`
-	VnetRouteAllEnabled           bool                                 `tfschema:"vnet_route_all_enabled"` // Not supported in Dynamic plans
+	AlwaysOn                        bool                                 `tfschema:"always_on"`
+	AppCommandLine                  string                               `tfschema:"app_command_line"`
+	ApiDefinition                   string                               `tfschema:"api_definition_url"`
+	ApiManagementConfigId           string                               `tfschema:"api_management_api_id"`
+	AppInsightsInstrumentationKey   string                               `tfschema:"application_insights_key"` // App Insights Instrumentation Key
+	AppInsightsConnectionString     string                               `tfschema:"application_insights_connection_string"`
+	AppInsightsAuthenticationString string                               `tfschema:"application_insights_authentication_string"`
+	AppScaleLimit                   int64                                `tfschema:"app_scale_limit"`
+	AppServiceLogs                  []FunctionAppAppServiceLogs          `tfschema:"app_service_logs"`
+	DefaultDocuments                []string                             `tfschema:"default_documents"`
+	ElasticInstanceMinimum          int64                                `tfschema:"elastic_instance_minimum"`
+	Http2Enabled                    bool                                 `tfschema:"http2_enabled"`
+	IpRestriction                   []IpRestriction                      `tfschema:"ip_restriction"`
+	IpRestrictionDefaultAction      string                               `tfschema:"ip_restriction_default_action"`
+	LoadBalancing                   string                               `tfschema:"load_balancing_mode"` // TODO - Valid for FunctionApps?
+	ManagedPipelineMode             string                               `tfschema:"managed_pipeline_mode"`
+	PreWarmedInstanceCount          int64                                `tfschema:"pre_warmed_instance_count"`
+	RemoteDebugging                 bool                                 `tfschema:"remote_debugging_enabled"`
+	RemoteDebuggingVersion          string                               `tfschema:"remote_debugging_version"`
+	RuntimeScaleMonitoring          bool                                 `tfschema:"runtime_scale_monitoring_enabled"`
+	ScmIpRestriction                []IpRestriction                      `tfschema:"scm_ip_restriction"`
+	ScmType                         string                               `tfschema:"scm_type"` // Computed?
+	ScmIpRestrictionDefaultAction   string                               `tfschema:"scm_ip_restriction_default_action"`
+	ScmUseMainIpRestriction         bool                                 `tfschema:"scm_use_main_ip_restriction"`
+	Use32BitWorker                  bool                                 `tfschema:"use_32_bit_worker"`
+	WebSockets                      bool                                 `tfschema:"websockets_enabled"`
+	FtpsState                       string                               `tfschema:"ftps_state"`
+	HealthCheckPath                 string                               `tfschema:"health_check_path"`
+	HealthCheckEvictionTime         int64                                `tfschema:"health_check_eviction_time_in_min"`
+	NumberOfWorkers                 int64                                `tfschema:"worker_count"`
+	ApplicationStack                []ApplicationStackWindowsFunctionApp `tfschema:"application_stack"`
+	MinTlsVersion                   string                               `tfschema:"minimum_tls_version"`
+	ScmMinTlsVersion                string                               `tfschema:"scm_minimum_tls_version"`
+	Cors                            []CorsSetting                        `tfschema:"cors"`
+	DetailedErrorLogging            bool                                 `tfschema:"detailed_error_logging_enabled"`
+	WindowsFxVersion                string                               `tfschema:"windows_fx_version"`
+	VnetRouteAllEnabled             bool                                 `tfschema:"vnet_route_all_enabled"` // Not supported in Dynamic plans
 }
 
 func SiteConfigSchemaWindowsFunctionApp() *pluginsdk.Schema {
@@ -905,6 +907,14 @@ func SiteConfigSchemaWindowsFunctionApp() *pluginsdk.Schema {
 					Sensitive:    true,
 					ValidateFunc: validation.StringIsNotEmpty,
 					Description:  "The Connection String for linking the Windows Function App to Application Insights.",
+				},
+
+				"application_insights_authentication_string": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					Sensitive:    true,
+					ValidateFunc: validate.ApplicationInsightsAuthenticationString,
+					Description:  "The Authentication setting for the Windows Function App to Application Insights.",
 				},
 
 				"application_stack": windowsFunctionAppStackSchema(),
@@ -2293,6 +2303,12 @@ func ExpandSiteConfigWindowsFunctionApp(siteConfig []SiteConfigWindowsFunctionAp
 		appSettings = updateOrAppendAppSettings(appSettings, "APPINSIGHTS_INSTRUMENTATIONKEY", windowsSiteConfig.AppInsightsInstrumentationKey, true)
 	} else {
 		appSettings = updateOrAppendAppSettings(appSettings, "APPINSIGHTS_INSTRUMENTATIONKEY", windowsSiteConfig.AppInsightsInstrumentationKey, false)
+	}
+
+	if windowsSiteConfig.AppInsightsAuthenticationString == "" {
+		appSettings = updateOrAppendAppSettings(appSettings, "APPLICATIONINSIGHTS_AUTHENTICATION_STRING", windowsSiteConfig.AppInsightsAuthenticationString, true)
+	} else {
+		appSettings = updateOrAppendAppSettings(appSettings, "APPLICATIONINSIGHTS_AUTHENTICATION_STRING", windowsSiteConfig.AppInsightsAuthenticationString, false)
 	}
 
 	if metadata.ResourceData.HasChange("site_config.0.api_management_api_id") {

--- a/internal/services/appservice/helpers/function_app_slot_schema.go
+++ b/internal/services/appservice/helpers/function_app_slot_schema.go
@@ -13,48 +13,50 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	apimValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/apimanagement/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appservice/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 )
 
 type SiteConfigWindowsFunctionAppSlot struct {
-	AlwaysOn                      bool                                 `tfschema:"always_on"`
-	AppCommandLine                string                               `tfschema:"app_command_line"`
-	ApiDefinition                 string                               `tfschema:"api_definition_url"`
-	ApiManagementConfigId         string                               `tfschema:"api_management_api_id"`
-	AppInsightsInstrumentationKey string                               `tfschema:"application_insights_key"` // App Insights Instrumentation Key
-	AppInsightsConnectionString   string                               `tfschema:"application_insights_connection_string"`
-	AppScaleLimit                 int64                                `tfschema:"app_scale_limit"`
-	AppServiceLogs                []FunctionAppAppServiceLogs          `tfschema:"app_service_logs"`
-	AutoSwapSlotName              string                               `tfschema:"auto_swap_slot_name"`
-	DefaultDocuments              []string                             `tfschema:"default_documents"`
-	ElasticInstanceMinimum        int64                                `tfschema:"elastic_instance_minimum"`
-	Http2Enabled                  bool                                 `tfschema:"http2_enabled"`
-	IpRestriction                 []IpRestriction                      `tfschema:"ip_restriction"`
-	IpRestrictionDefaultAction    string                               `tfschema:"ip_restriction_default_action"`
-	LoadBalancing                 string                               `tfschema:"load_balancing_mode"` // TODO - Valid for FunctionApps?
-	ManagedPipelineMode           string                               `tfschema:"managed_pipeline_mode"`
-	PreWarmedInstanceCount        int64                                `tfschema:"pre_warmed_instance_count"`
-	RemoteDebugging               bool                                 `tfschema:"remote_debugging_enabled"`
-	RemoteDebuggingVersion        string                               `tfschema:"remote_debugging_version"`
-	RuntimeScaleMonitoring        bool                                 `tfschema:"runtime_scale_monitoring_enabled"`
-	ScmIpRestriction              []IpRestriction                      `tfschema:"scm_ip_restriction"`
-	ScmIpRestrictionDefaultAction string                               `tfschema:"scm_ip_restriction_default_action"`
-	ScmType                       string                               `tfschema:"scm_type"` // Computed?
-	ScmUseMainIpRestriction       bool                                 `tfschema:"scm_use_main_ip_restriction"`
-	Use32BitWorker                bool                                 `tfschema:"use_32_bit_worker"`
-	WebSockets                    bool                                 `tfschema:"websockets_enabled"`
-	FtpsState                     string                               `tfschema:"ftps_state"`
-	HealthCheckPath               string                               `tfschema:"health_check_path"`
-	HealthCheckEvictionTime       int64                                `tfschema:"health_check_eviction_time_in_min"`
-	NumberOfWorkers               int64                                `tfschema:"worker_count"`
-	ApplicationStack              []ApplicationStackWindowsFunctionApp `tfschema:"application_stack"`
-	MinTlsVersion                 string                               `tfschema:"minimum_tls_version"`
-	ScmMinTlsVersion              string                               `tfschema:"scm_minimum_tls_version"`
-	Cors                          []CorsSetting                        `tfschema:"cors"`
-	DetailedErrorLogging          bool                                 `tfschema:"detailed_error_logging_enabled"`
-	WindowsFxVersion              string                               `tfschema:"windows_fx_version"`
-	VnetRouteAllEnabled           bool                                 `tfschema:"vnet_route_all_enabled"` // Not supported in Dynamic plans
+	AlwaysOn                        bool                                 `tfschema:"always_on"`
+	AppCommandLine                  string                               `tfschema:"app_command_line"`
+	ApiDefinition                   string                               `tfschema:"api_definition_url"`
+	ApiManagementConfigId           string                               `tfschema:"api_management_api_id"`
+	AppInsightsInstrumentationKey   string                               `tfschema:"application_insights_key"` // App Insights Instrumentation Key
+	AppInsightsConnectionString     string                               `tfschema:"application_insights_connection_string"`
+	AppInsightsAuthenticationString string                               `tfschema:"application_insights_authentication_string"`
+	AppScaleLimit                   int64                                `tfschema:"app_scale_limit"`
+	AppServiceLogs                  []FunctionAppAppServiceLogs          `tfschema:"app_service_logs"`
+	AutoSwapSlotName                string                               `tfschema:"auto_swap_slot_name"`
+	DefaultDocuments                []string                             `tfschema:"default_documents"`
+	ElasticInstanceMinimum          int64                                `tfschema:"elastic_instance_minimum"`
+	Http2Enabled                    bool                                 `tfschema:"http2_enabled"`
+	IpRestriction                   []IpRestriction                      `tfschema:"ip_restriction"`
+	IpRestrictionDefaultAction      string                               `tfschema:"ip_restriction_default_action"`
+	LoadBalancing                   string                               `tfschema:"load_balancing_mode"` // TODO - Valid for FunctionApps?
+	ManagedPipelineMode             string                               `tfschema:"managed_pipeline_mode"`
+	PreWarmedInstanceCount          int64                                `tfschema:"pre_warmed_instance_count"`
+	RemoteDebugging                 bool                                 `tfschema:"remote_debugging_enabled"`
+	RemoteDebuggingVersion          string                               `tfschema:"remote_debugging_version"`
+	RuntimeScaleMonitoring          bool                                 `tfschema:"runtime_scale_monitoring_enabled"`
+	ScmIpRestriction                []IpRestriction                      `tfschema:"scm_ip_restriction"`
+	ScmIpRestrictionDefaultAction   string                               `tfschema:"scm_ip_restriction_default_action"`
+	ScmType                         string                               `tfschema:"scm_type"` // Computed?
+	ScmUseMainIpRestriction         bool                                 `tfschema:"scm_use_main_ip_restriction"`
+	Use32BitWorker                  bool                                 `tfschema:"use_32_bit_worker"`
+	WebSockets                      bool                                 `tfschema:"websockets_enabled"`
+	FtpsState                       string                               `tfschema:"ftps_state"`
+	HealthCheckPath                 string                               `tfschema:"health_check_path"`
+	HealthCheckEvictionTime         int64                                `tfschema:"health_check_eviction_time_in_min"`
+	NumberOfWorkers                 int64                                `tfschema:"worker_count"`
+	ApplicationStack                []ApplicationStackWindowsFunctionApp `tfschema:"application_stack"`
+	MinTlsVersion                   string                               `tfschema:"minimum_tls_version"`
+	ScmMinTlsVersion                string                               `tfschema:"scm_minimum_tls_version"`
+	Cors                            []CorsSetting                        `tfschema:"cors"`
+	DetailedErrorLogging            bool                                 `tfschema:"detailed_error_logging_enabled"`
+	WindowsFxVersion                string                               `tfschema:"windows_fx_version"`
+	VnetRouteAllEnabled             bool                                 `tfschema:"vnet_route_all_enabled"` // Not supported in Dynamic plans
 }
 
 func SiteConfigSchemaWindowsFunctionAppSlot() *pluginsdk.Schema {
@@ -113,6 +115,14 @@ func SiteConfigSchemaWindowsFunctionAppSlot() *pluginsdk.Schema {
 					Sensitive:    true,
 					ValidateFunc: validation.StringIsNotEmpty,
 					Description:  "The Connection String for linking the Windows Function App to Application Insights.",
+				},
+
+				"application_insights_authentication_string": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					Sensitive:    true,
+					ValidateFunc: validate.ApplicationInsightsAuthenticationString,
+					Description:  "The Authentication setting for the Windows Function App to Application Insights.",
 				},
 
 				"application_stack": windowsFunctionAppStackSchema(),
@@ -731,6 +741,13 @@ func ExpandSiteConfigWindowsFunctionAppSlot(siteConfig []SiteConfigWindowsFuncti
 		appSettings = append(appSettings, webapps.NameValuePair{
 			Name:  pointer.To("APPINSIGHTS_INSTRUMENTATIONKEY"),
 			Value: pointer.To(windowsSlotSiteConfig.AppInsightsInstrumentationKey),
+		})
+	}
+
+	if windowsSlotSiteConfig.AppInsightsAuthenticationString != "" {
+		appSettings = append(appSettings, webapps.NameValuePair{
+			Name:  pointer.To("APPLICATIONINSIGHTS_AUTHENTICATION_STRING"),
+			Value: pointer.To(windowsSlotSiteConfig.AppInsightsAuthenticationString),
 		})
 	}
 

--- a/internal/services/appservice/validate/application_insights_authentication_string.go
+++ b/internal/services/appservice/validate/application_insights_authentication_string.go
@@ -1,0 +1,42 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package validate
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+const autorizationAAD = "Authorization=AAD"
+
+func ApplicationInsightsAuthenticationString(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return warnings, errors
+	}
+
+	var matched bool = false
+
+	if !strings.HasPrefix(v, autorizationAAD) {
+		errors = append(errors, fmt.Errorf("%q must always begin with %q, got: %q", key, autorizationAAD, v))
+		return warnings, errors
+	} else if v == autorizationAAD {
+		matched = true
+	} else {
+		parts := strings.Split(v, ";")
+		if len(parts) == 2 {
+			clientIDString := parts[1]
+			matched = regexp.MustCompile(`^ClientId=([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$`).Match([]byte(clientIDString))
+		}
+	}
+
+	if !matched {
+		errors = append(errors, fmt.Errorf("%q must be in the format \"Authorization=AAD;ClientId=<GUID>\" when used with user-assigned managed identity, got: %q", key, v))
+	}
+
+	return warnings, errors
+}

--- a/internal/services/appservice/validate/application_insights_authentication_string_test.go
+++ b/internal/services/appservice/validate/application_insights_authentication_string_test.go
@@ -1,0 +1,50 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package validate
+
+import "testing"
+
+func TestApplicationInsightsAuthenticationString(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+		{
+			Input: "Notvalid",
+		},
+		{
+			Input: "Notvalid",
+		},
+		{
+			Input: "Authorization=NAD",
+		},
+		{
+			Input: "Authorization=AAD",
+			Valid: true,
+		},
+		{
+			Input: "Authorization=AAD;",
+		},
+		{
+			Input: "Authorization=AAD;Garbage=1234567890",
+		},
+		{
+			Input: "Authorization=AAD;ClientId=ee470da-669-4810-acd4-af4a3410a203",
+		},
+		{
+			Input: "Authorization=AAD;ClientId=eee470da-6969-4810-acd4-af4a3410a203",
+			Valid: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Logf("[DEBUG] Testing Value %s", tc.Input)
+		_, errors := ApplicationInsightsAuthenticationString(tc.Input, "test")
+		valid := len(errors) == 0
+
+		if tc.Valid != valid {
+			t.Fatalf("Expected %t but got %t", tc.Valid, valid)
+		}
+	}
+}

--- a/internal/services/appservice/windows_function_app_data_source.go
+++ b/internal/services/appservice/windows_function_app_data_source.go
@@ -489,6 +489,9 @@ func (m *WindowsFunctionAppDataSourceModel) unpackWindowsFunctionAppSettings(inp
 		case "APPLICATIONINSIGHTS_CONNECTION_STRING":
 			m.SiteConfig[0].AppInsightsConnectionString = v
 
+		case "APPLICATIONINSIGHTS_AUTHENTICATION_STRING":
+			m.SiteConfig[0].AppInsightsAuthenticationString = v
+
 		case "AzureWebJobsStorage":
 			if strings.HasPrefix(v, "@Microsoft.KeyVault") {
 				trimmed := strings.TrimPrefix(strings.TrimSuffix(v, ")"), "@Microsoft.KeyVault(")

--- a/internal/services/appservice/windows_function_app_resource.go
+++ b/internal/services/appservice/windows_function_app_resource.go
@@ -1412,6 +1412,9 @@ func (m *WindowsFunctionAppModel) unpackWindowsFunctionAppSettings(input *webapp
 		case "APPLICATIONINSIGHTS_CONNECTION_STRING":
 			m.SiteConfig[0].AppInsightsConnectionString = v
 
+		case "APPLICATIONINSIGHTS_AUTHENTICATION_STRING":
+			m.SiteConfig[0].AppInsightsAuthenticationString = v
+
 		case "AzureWebJobsStorage":
 			if strings.HasPrefix(v, "@Microsoft.KeyVault") {
 				trimmed := strings.TrimPrefix(strings.TrimSuffix(v, ")"), "@Microsoft.KeyVault(SecretUri=")

--- a/internal/services/appservice/windows_function_app_resource_test.go
+++ b/internal/services/appservice/windows_function_app_resource_test.go
@@ -2454,13 +2454,13 @@ resource "azurerm_windows_function_app" "test" {
   }
 
   site_config {
-    always_on          = true
-    app_command_line   = "whoami"
-    api_definition_url = "https://example.com/azure_function_app_def.json"
-    // api_management_api_id = ""  // TODO
-    application_insights_key               = azurerm_application_insights.test.instrumentation_key
-    application_insights_connection_string = azurerm_application_insights.test.connection_string
-
+    always_on                                  = true
+    app_command_line                           = "whoami"
+    api_definition_url                         = "https://example.com/azure_function_app_def.json"
+    // api_management_api_id                   = "" // TODO
+    application_insights_key                   = azurerm_application_insights.test.instrumentation_key
+    application_insights_connection_string     = azurerm_application_insights.test.connection_string
+    application_insights_authentication_string = "Authorization=AAD;ClientId=${azurerm_user_assigned_identity.test.client_id}"
     application_stack {
       powershell_core_version = "7"
     }

--- a/internal/services/appservice/windows_function_app_slot_resource.go
+++ b/internal/services/appservice/windows_function_app_slot_resource.go
@@ -1189,6 +1189,9 @@ func (m *WindowsFunctionAppSlotModel) unpackWindowsFunctionAppSettings(input *we
 		case "APPLICATIONINSIGHTS_CONNECTION_STRING":
 			m.SiteConfig[0].AppInsightsConnectionString = v
 
+		case "APPLICATIONINSIGHTS_AUTHENTICATION_STRING":
+			m.SiteConfig[0].AppInsightsAuthenticationString = v
+
 		case "AzureWebJobsStorage":
 			if strings.HasPrefix(v, "@Microsoft.KeyVault") {
 				trimmed := strings.TrimPrefix(strings.TrimSuffix(v, ")"), "@Microsoft.KeyVault(SecretUri=")

--- a/internal/services/appservice/windows_function_app_slot_resource_test.go
+++ b/internal/services/appservice/windows_function_app_slot_resource_test.go
@@ -1917,12 +1917,13 @@ resource "azurerm_windows_function_app_slot" "test" {
   }
 
   site_config {
-    always_on          = true
-    app_command_line   = "whoami"
-    api_definition_url = "https://example.com/azure_function_app_def.json"
-    // api_management_api_id = ""  // TODO
-    application_insights_key               = azurerm_application_insights.test.instrumentation_key
-    application_insights_connection_string = azurerm_application_insights.test.connection_string
+    always_on                                  = true
+    app_command_line                           = "whoami"
+    api_definition_url                         = "https://example.com/azure_function_app_def.json"
+    // api_management_api_id                   = "" // TODO
+    application_insights_key                   = azurerm_application_insights.test.instrumentation_key
+    application_insights_connection_string     = azurerm_application_insights.test.connection_string
+    application_insights_authentication_string = "Authorization=AAD;ClientId=${azurerm_user_assigned_identity.test.client_id}"    
 
     application_stack {
       powershell_core_version = "7"

--- a/website/docs/r/windows_function_app.html.markdown
+++ b/website/docs/r/windows_function_app.html.markdown
@@ -73,7 +73,7 @@ The following arguments are supported:
 
 ~> **Note:** For storage related settings, please use related properties that are available such as `storage_account_access_key`, terraform will assign the value to keys such as `WEBSITE_CONTENTAZUREFILECONNECTIONSTRING`, `AzureWebJobsStorage` in app_setting.
 
-~> **Note:** For application insight related settings, please use `application_insights_connection_string` and `application_insights_key`, terraform will assign the value to the key `APPINSIGHTS_INSTRUMENTATIONKEY` and `APPLICATIONINSIGHTS_CONNECTION_STRING` in app setting.
+~> **Note:** For application insight related settings, please use `application_insights_connection_string`, `application_insights_key` and `application_insights_authentication_string`, terraform will assign the value to the key `APPINSIGHTS_INSTRUMENTATIONKEY`,  `APPLICATIONINSIGHTS_CONNECTION_STRING` and `APPLICATIONINSIGHTS_AUTHENTICATION_STRING` in app setting.
 
 ~> **Note:** For health check related settings, please use `health_check_eviction_time_in_min`, terraform will assign the value to the key `WEBSITE_HEALTHCHECK_MAXPINGFAILURES` in app setting.
 
@@ -644,6 +644,10 @@ A `site_config` block supports the following:
 * `application_insights_connection_string` - (Optional) The Connection String for linking the Windows Function App to Application Insights.
 
 * `application_insights_key` - (Optional) The Instrumentation Key for connecting the Windows Function App to Application Insights.
+
+* `application_insights_authentication_string` - (Optional) The Instrumentation Key for connecting the Windows Function App to Application Insights using either the system-assigned or a user-assigned identity.
+
+~> **Note:** For system-assigned identity this must be set to `Authorization=AAD` and for user-assigned `Authorization=AAD;ClientId=<USER_ASSIGNED_CLIENT_ID>`. For additional steps and information on using identity-based authentication see [APPLICATIONINSIGHTS_AUTHENTICATION_STRING](https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings#applicationinsights_authentication_string)
 
 * `application_stack` - (Optional) An `application_stack` block as defined above.
 

--- a/website/docs/r/windows_function_app_slot.html.markdown
+++ b/website/docs/r/windows_function_app_slot.html.markdown
@@ -459,6 +459,8 @@ A `site_config` block supports the following:
 
 * `application_insights_key` - (Optional) The Instrumentation Key for connecting the Windows Function App to Application Insights.
 
+* `application_insights_authentication_string` - (Optional) The Instrumentation Key for connecting the Windows Function App to Application Insights using either the system-assigned or a user-assigned identity.
+
 * `application_stack` - (Optional) an `application_stack` block as detailed below.
 
 * `auto_swap_slot_name` - (Optional) The name of the slot to automatically swap with when this slot is successfully deployed.


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Added a site setting for `application_insights_authentication_string` so that either system or a user managed identity can be used to authenticate the function app with application insights. This includes validation for this setting, as per https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings#applicationinsights_authentication_string

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.



## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


```
make acctests SERVICE="appservice" TESTARGS="-run=TestAccWindowsFunctionAppSlot_standardComplete" TESTTIMEOUT="15m"
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/appservice -run=TestAccWindowsFunctionAppSlot_standardComplete -timeout 15m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccWindowsFunctionAppSlot_standardComplete
=== PAUSE TestAccWindowsFunctionAppSlot_standardComplete
=== CONT  TestAccWindowsFunctionAppSlot_standardComplete
--- PASS: TestAccWindowsFunctionAppSlot_standardComplete (473.06s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/appservice	474.544s

make acctests SERVICE="appservice" TESTARGS="-run=TestAccWindowsFunctionApp_standardComplete" TESTTIMEOUT="15m"
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/appservice -run=TestAccWindowsFunctionApp_standardComplete -timeout 15m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccWindowsFunctionApp_standardComplete
=== PAUSE TestAccWindowsFunctionApp_standardComplete
=== CONT  TestAccWindowsFunctionApp_standardComplete
--- PASS: TestAccWindowsFunctionApp_standardComplete (320.35s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/appservice	321.852s
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_windows_function_app` - support for the `application_insights_authentication_string` property [GH-30001]
* `azurerm_windows_function_app_slot` - support for the `application_insights_authentication_string` property [GH-30001]

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #30001

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
