### PR TITLE
azurerm_databricks_workspace - Adding `custom_parameters` attributes to datasource

### DIFF
--- a/internal/services/databricks/databricks_workspace_data_source_test.go
+++ b/internal/services/databricks/databricks_workspace_data_source_test.go
@@ -67,6 +67,29 @@ func TestAccDatabricksWorkspaceDataSource_enhancedComplianceSecurity(t *testing.
 	})
 }
 
+func TestAccDatabricksWorkspaceDataSource_customParameters(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_databricks_workspace", "test")
+	r := DatabricksWorkspaceDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.customProperties(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				acceptance.TestMatchResourceAttr(data.ResourceName, "workspace_url", regexp.MustCompile("azuredatabricks.net")),
+				check.That(data.ResourceName).Key("workspace_id").Exists(),
+				check.That(data.ResourceName).Key("location").Exists(),
+				check.That(data.ResourceName).Key("custom_parameters.#").HasValue("1"),
+				check.That(data.ResourceName).Key("custom_parameters.0.no_public_ip").IsNotEmpty(),
+				check.That(data.ResourceName).Key("custom_parameters.0.private_subnet_name").IsNotEmpty(),
+				check.That(data.ResourceName).Key("custom_parameters.0.public_subnet_name").IsNotEmpty(),
+				check.That(data.ResourceName).Key("custom_parameters.0.storage_account_name").IsNotEmpty(),
+				check.That(data.ResourceName).Key("custom_parameters.0.storage_account_sku_name").IsNotEmpty(),
+				check.That(data.ResourceName).Key("custom_parameters.0.virtual_network_id").IsNotEmpty(),
+			),
+		},
+	})
+}
+
 func (DatabricksWorkspaceDataSource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -247,4 +270,16 @@ data "azurerm_databricks_workspace" "test" {
   resource_group_name = azurerm_resource_group.test.name
 }
   `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (DatabricksWorkspaceDataSource) customProperties(data acceptance.TestData) string {
+	r := DatabricksWorkspaceResource{}
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_databricks_workspace" "test" {
+  name                = azurerm_databricks_workspace.test.name
+  resource_group_name = azurerm_resource_group.test.name
+}
+  `, r.complete(data))
 }

--- a/website/docs/d/databricks_workspace.html.markdown
+++ b/website/docs/d/databricks_workspace.html.markdown
@@ -46,6 +46,8 @@ output "databricks_workspace_id" {
 
 * `enhanced_security_compliance` - An `enhanced_security_compliance` block as documented below.
 
+* `custom_parameters` - A `custom_parameters` block as documented below.
+* 
 * `tags` - A mapping of tags to assign to the Databricks Workspace.
 
 ---
@@ -79,6 +81,30 @@ An `enhanced_security_compliance` block exports the following:
 * `compliance_security_profile_standards` - A list of standards enforced on this workspace.
 
 * `enhanced_security_monitoring_enabled` - Whether enhanced security monitoring for this workspace is enabled.
+
+---
+
+A `custom_parameters` block exports the following:
+
+* `machine_learning_workspace_id` - The ID of a Azure Machine Learning workspace to link with Databricks workspace.
+
+* `nat_gateway_name` - Name of the NAT gateway for Secure Cluster Connectivity (No Public IP) workspace subnets (only for workspace with managed virtual network).
+
+* `no_public_ip` - Are public IP Addresses not allowed?
+
+* `private_subnet_name` - The name of the Private Subnet within the Virtual Network.
+
+* `public_ip_name` - Name of the Public IP for No Public IP workspace with managed virtual network.
+
+* `public_subnet_name` - The name of the Public Subnet within the Virtual Network.
+
+* `storage_account_name` - Default Databricks File Storage account name.
+
+* `storage_account_sku_name` - Storage account SKU name.
+
+* `virtual_network_id` - The ID of a Virtual Network where this Databricks Cluster should be created.
+
+* `vnet_address_prefix` - Address prefix for Managed virtual network.
 
 ## Timeouts
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Adding `custom_parameters` attributes list to `azurerm_databricks_workspace` datasource:

```json
....
  "custom_parameters": [
    {
      "machine_learning_workspace_id": "<machine_learning_workspace_id>",
      "nat_gateway_name": "<nat_gateway_name>",
      "no_public_ip": <true/false>,
      "private_subnet_name": "<private_subnet_name>",
      "public_ip_name": "<public_ip_name>",
      "public_subnet_name": "<public_subnet_name>",
      "storage_account_name": "<default_storage_account_name>",
      "storage_account_sku_name": "<default_storage_account_sku_name>",
      "virtual_network_id": "<virtual_network_resource_id>",
      "vnet_address_prefix": "<virtual_network_address_prefix>"
    }
  ],
...
```

Please note that the following resource attributes are not included in the datasource as these are no available in the [REST API](https://learn.microsoft.com/en-us/rest/api/databricks/workspaces/get?view=rest-databricks-2024-05-01&tabs=HTTP#workspacecustomparameters):

- private_subnet_network_security_group_association_id
- public_subnet_network_security_group_association_id

Also created a simple acceptance test reusing the existing resource test code.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_databricks_workspace` - Adding `custom_parameters` attributes to datasource

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #30068 

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
