### PR TITLE
fix `response.WasNotFound` condition for `kusto_*` resources

### DIFF
--- a/internal/services/kusto/kusto_attached_database_configuration_resource.go
+++ b/internal/services/kusto/kusto_attached_database_configuration_resource.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
@@ -198,7 +199,7 @@ func resourceKustoAttachedDatabaseConfigurationCreateUpdate(d *pluginsdk.Resourc
 
 	configurationProperties := expandKustoAttachedDatabaseConfigurationProperties(d)
 	configurationRequest := attacheddatabaseconfigurations.AttachedDatabaseConfiguration{
-		Location:   utils.String(location.Normalize(d.Get("location").(string))),
+		Location:   pointer.To(location.Normalize(d.Get("location").(string))),
 		Properties: configurationProperties,
 	}
 
@@ -223,7 +224,7 @@ func resourceKustoAttachedDatabaseConfigurationRead(d *pluginsdk.ResourceData, m
 
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
-		if !response.WasNotFound(resp.HttpResponse) {
+		if response.WasNotFound(resp.HttpResponse) {
 			d.SetId("")
 			return nil
 		}

--- a/internal/services/kusto/kusto_cluster_customer_managed_key_resource.go
+++ b/internal/services/kusto/kusto_cluster_customer_managed_key_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2024-04-13/clusters"
@@ -21,7 +22,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceKustoClusterCustomerManagedKey() *pluginsdk.Resource {
@@ -180,15 +180,15 @@ func resourceKustoClusterCustomerManagedKeyCreateUpdate(d *pluginsdk.ResourceDat
 	props := clusters.ClusterUpdate{
 		Properties: &clusters.ClusterProperties{
 			KeyVaultProperties: &clusters.KeyVaultProperties{
-				KeyName:     utils.String(keyName),
-				KeyVersion:  utils.String(keyVersion),
-				KeyVaultUri: utils.String(keyVaultURI),
+				KeyName:     pointer.To(keyName),
+				KeyVersion:  pointer.To(keyVersion),
+				KeyVaultUri: pointer.To(keyVaultURI),
 			},
 		},
 	}
 
 	if v, ok := d.GetOk("user_identity"); ok {
-		props.Properties.KeyVaultProperties.UserIdentity = utils.String(v.(string))
+		props.Properties.KeyVaultProperties.UserIdentity = pointer.To(v.(string))
 	}
 
 	err = clusterClient.UpdateThenPoll(ctx, *clusterID, props, clusters.UpdateOperationOptions{})
@@ -215,7 +215,7 @@ func resourceKustoClusterCustomerManagedKeyRead(d *pluginsdk.ResourceData, meta 
 
 	cluster, err := clusterClient.Get(ctx, *id)
 	if err != nil {
-		if !response.WasNotFound(cluster.HttpResponse) {
+		if response.WasNotFound(cluster.HttpResponse) {
 			log.Printf("[DEBUG] %s was not found - removing from state!", id)
 			d.SetId("")
 			return nil

--- a/internal/services/kusto/kusto_cluster_data_source.go
+++ b/internal/services/kusto/kusto_cluster_data_source.go
@@ -64,8 +64,8 @@ func dataSourceKustoClusterRead(d *pluginsdk.ResourceData, meta interface{}) err
 	id := commonids.NewKustoClusterID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 	resp, err := client.Get(ctx, id)
 	if err != nil {
-		if !response.WasNotFound(resp.HttpResponse) {
-			return fmt.Errorf("%s does not exist", id)
+		if response.WasNotFound(resp.HttpResponse) {
+			return fmt.Errorf("%s was not found", id)
 		}
 
 		return fmt.Errorf("retrieving %s: %+v", id, err)

--- a/internal/services/kusto/kusto_cluster_principal_assignment_resource.go
+++ b/internal/services/kusto/kusto_cluster_principal_assignment_resource.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2024-04-13/clusterprincipalassignments"
@@ -17,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceKustoClusterPrincipalAssignment() *pluginsdk.Resource {
@@ -127,7 +127,7 @@ func resourceKustoClusterPrincipalAssignmentCreate(d *pluginsdk.ResourceData, me
 
 	principalAssignment := clusterprincipalassignments.ClusterPrincipalAssignment{
 		Properties: &clusterprincipalassignments.ClusterPrincipalProperties{
-			TenantId:      utils.String(tenantID),
+			TenantId:      pointer.To(tenantID),
 			PrincipalId:   principalID,
 			PrincipalType: clusterprincipalassignments.PrincipalType(principalType),
 			Role:          clusterprincipalassignments.ClusterPrincipalRole(role),
@@ -155,7 +155,7 @@ func resourceKustoClusterPrincipalAssignmentRead(d *pluginsdk.ResourceData, meta
 
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
-		if !response.WasNotFound(resp.HttpResponse) {
+		if response.WasNotFound(resp.HttpResponse) {
 			d.SetId("")
 			return nil
 		}


### PR DESCRIPTION
Condition in read function was negated, causing errors rather than the resource being removed from the state file