### PR TITLE
`azurerm_automation_software_update_configuration` - Deprecate Automation Software Update Configuration resource

### DIFF
--- a/internal/services/automation/automation_software_update_configuration_resource.go
+++ b/internal/services/automation/automation_software_update_configuration_resource.go
@@ -134,7 +134,8 @@ var _ sdk.ResourceWithDeprecationAndNoReplacement = SoftwareUpdateConfigurationR
 func (m SoftwareUpdateConfigurationResource) DeprecationMessage() string {
 	return "The `azurerm_automation_software_update_configuration` resource is deprecated and will be removed in version 5.0 of the AzureRM Provider. " +
 		"Azure Automation Update Management was deprecated on 2024-08-31 and has been shut down on 2025-02-28. " +
-		"For more details, see: https://aka.ms/azurerm-automation-software-update-configuration-deprecation"
+		"Please migrate to Azure Update Manager, and use the `azurerm_maintenance_configuration` resource combined with the appropriate assignment resources instead. " +
+		"For more details, see: https://techcommunity.microsoft.com/blog/azuregovernanceandmanagementblog/log-analytics-agent-based-azure-management-services-shut-down-starting-28-februa/4381853"
 }
 
 func (m SoftwareUpdateConfigurationResource) Arguments() map[string]*pluginsdk.Schema {

--- a/internal/services/automation/automation_software_update_configuration_resource.go
+++ b/internal/services/automation/automation_software_update_configuration_resource.go
@@ -129,6 +129,14 @@ type SoftwareUpdateConfigurationResource struct{}
 
 var _ sdk.ResourceWithUpdate = SoftwareUpdateConfigurationResource{}
 
+var _ sdk.ResourceWithDeprecationAndNoReplacement = SoftwareUpdateConfigurationResource{}
+
+func (m SoftwareUpdateConfigurationResource) DeprecationMessage() string {
+	return "The `azurerm_automation_software_update_configuration` resource is deprecated and will be removed in version 5.0 of the AzureRM Provider. " +
+		"Azure Automation Update Management was deprecated on 2024-08-31 and has been shut down on 2025-02-28. " +
+		"For more details, see: https://aka.ms/azurerm-automation-software-update-configuration-deprecation"
+}
+
 func (m SoftwareUpdateConfigurationResource) Arguments() map[string]*pluginsdk.Schema {
 	linux := pluginsdk.Resource{
 		Schema: map[string]*pluginsdk.Schema{

--- a/internal/services/automation/automation_software_update_configuration_resource_test.go
+++ b/internal/services/automation/automation_software_update_configuration_resource_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/automation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
@@ -49,6 +50,10 @@ func (a SoftwareUpdateConfigurationResource) Exists(ctx context.Context, client 
 }
 
 func TestAccSoftwareUpdateConfiguration_linuxBasic(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skipf("Skipping since `azurerm_automation_software_update_configuration` is deprecated and will be removed in 5.0")
+	}
+
 	data := acceptance.BuildTestData(t, automation.SoftwareUpdateConfigurationResource{}.ResourceType(), "test")
 	r := newSoftwareUpdateConfigurationResource()
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -64,6 +69,10 @@ func TestAccSoftwareUpdateConfiguration_linuxBasic(t *testing.T) {
 }
 
 func TestAccSoftwareUpdateConfiguration_occurrence(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skipf("Skipping since `azurerm_automation_software_update_configuration` is deprecated and will be removed in 5.0")
+	}
+
 	data := acceptance.BuildTestData(t, automation.SoftwareUpdateConfigurationResource{}.ResourceType(), "test")
 	r := newSoftwareUpdateConfigurationResource()
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -79,6 +88,10 @@ func TestAccSoftwareUpdateConfiguration_occurrence(t *testing.T) {
 }
 
 func TestAccSoftwareUpdateConfiguration_linuxComplete(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skipf("Skipping since `azurerm_automation_software_update_configuration` is deprecated and will be removed in 5.0")
+	}
+
 	data := acceptance.BuildTestData(t, automation.SoftwareUpdateConfigurationResource{}.ResourceType(), "test")
 	r := newSoftwareUpdateConfigurationResource()
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -94,6 +107,10 @@ func TestAccSoftwareUpdateConfiguration_linuxComplete(t *testing.T) {
 }
 
 func TestAccSoftwareUpdateConfiguration_linuxUpdate(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skipf("Skipping since `azurerm_automation_software_update_configuration` is deprecated and will be removed in 5.0")
+	}
+
 	data := acceptance.BuildTestData(t, automation.SoftwareUpdateConfigurationResource{}.ResourceType(), "test")
 	r := newSoftwareUpdateConfigurationResource()
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -125,6 +142,10 @@ func TestAccSoftwareUpdateConfiguration_linuxUpdate(t *testing.T) {
 }
 
 func TestAccSoftwareUpdateConfiguration_CompleteUpdate(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skipf("Skipping since `azurerm_automation_software_update_configuration` is deprecated and will be removed in 5.0")
+	}
+
 	data := acceptance.BuildTestData(t, automation.SoftwareUpdateConfigurationResource{}.ResourceType(), "test")
 	r := newSoftwareUpdateConfigurationResource()
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -156,6 +177,10 @@ func TestAccSoftwareUpdateConfiguration_CompleteUpdate(t *testing.T) {
 }
 
 func TestAccSoftwareUpdateConfiguration_withTask(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skipf("Skipping since `azurerm_automation_software_update_configuration` is deprecated and will be removed in 5.0")
+	}
+
 	data := acceptance.BuildTestData(t, automation.SoftwareUpdateConfigurationResource{}.ResourceType(), "test")
 	r := newSoftwareUpdateConfigurationResource()
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -171,6 +196,10 @@ func TestAccSoftwareUpdateConfiguration_withTask(t *testing.T) {
 }
 
 func TestAccSoftwareUpdateConfiguration_defaultTimeZone(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skipf("Skipping since `azurerm_automation_software_update_configuration` is deprecated and will be removed in 5.0")
+	}
+
 	data := acceptance.BuildTestData(t, automation.SoftwareUpdateConfigurationResource{}.ResourceType(), "test")
 	r := newSoftwareUpdateConfigurationResource()
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -194,6 +223,10 @@ func TestAccSoftwareUpdateConfiguration_defaultTimeZone(t *testing.T) {
 }
 
 func TestAccSoftwareUpdateConfiguration_update(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skipf("Skipping since `azurerm_automation_software_update_configuration` is deprecated and will be removed in 5.0")
+	}
+
 	data := acceptance.BuildTestData(t, automation.SoftwareUpdateConfigurationResource{}.ResourceType(), "test")
 	r := newSoftwareUpdateConfigurationResource()
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -217,6 +250,10 @@ func TestAccSoftwareUpdateConfiguration_update(t *testing.T) {
 }
 
 func TestAccSoftwareUpdateConfiguration_windowsBasic(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skipf("Skipping since `azurerm_automation_software_update_configuration` is deprecated and will be removed in 5.0")
+	}
+
 	data := acceptance.BuildTestData(t, automation.SoftwareUpdateConfigurationResource{}.ResourceType(), "test")
 	r := newSoftwareUpdateConfigurationResource()
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -232,6 +269,10 @@ func TestAccSoftwareUpdateConfiguration_windowsBasic(t *testing.T) {
 }
 
 func TestAccSoftwareUpdateConfiguration_windowsComplete(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skipf("Skipping since `azurerm_automation_software_update_configuration` is deprecated and will be removed in 5.0")
+	}
+
 	data := acceptance.BuildTestData(t, automation.SoftwareUpdateConfigurationResource{}.ResourceType(), "test")
 	r := newSoftwareUpdateConfigurationResource()
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -247,6 +288,10 @@ func TestAccSoftwareUpdateConfiguration_windowsComplete(t *testing.T) {
 }
 
 func TestAccSoftwareUpdateConfiguration_windowsUpdate(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skipf("Skipping since `azurerm_automation_software_update_configuration` is deprecated and will be removed in 5.0")
+	}
+
 	data := acceptance.BuildTestData(t, automation.SoftwareUpdateConfigurationResource{}.ResourceType(), "test")
 	r := newSoftwareUpdateConfigurationResource()
 	data.ResourceTest(t, r, []acceptance.TestStep{

--- a/internal/services/automation/registration.go
+++ b/internal/services/automation/registration.go
@@ -4,6 +4,7 @@
 package automation
 
 import (
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
@@ -23,16 +24,21 @@ func (r Registration) DataSources() []sdk.DataSource {
 }
 
 func (r Registration) Resources() []sdk.Resource {
-	return []sdk.Resource{
+	resources := []sdk.Resource{
 		AutomationConnectionTypeResource{},
 		HybridRunbookWorkerGroupResource{},
 		HybridRunbookWorkerResource{},
-		SoftwareUpdateConfigurationResource{},
 		SourceControlResource{},
 		WatcherResource{},
 		Python3PackageResource{},
 		PowerShell72ModuleResource{},
 	}
+
+	if !features.FivePointOh() {
+		resources = append(resources, SoftwareUpdateConfigurationResource{})
+	}
+
+	return resources
 }
 
 func (r Registration) AssociatedGitHubLabel() string {

--- a/website/docs/5.0-upgrade-guide.html.markdown
+++ b/website/docs/5.0-upgrade-guide.html.markdown
@@ -34,6 +34,10 @@ Please follow the format in the example below for adding removed resources:
 This deprecated resource has been superseded/retired and has been removed from the Azure Provider.
 ```
 
+### `azurerm_automation_software_update_configuration`
+
+* This deprecated resource has been retired and has been removed from the Azure Provider.
+
 ### `azurerm_hpc_cache`
 
 * This deprecated resource has been retired and has been removed from the Azure Provider.

--- a/website/docs/r/automation_software_update_configuration.html.markdown
+++ b/website/docs/r/automation_software_update_configuration.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Manages an Automation Software Update Configuration.
 
+!> **Note:** The `azurerm_automation_software_update_configuration` resource has been deprecated because the Azure Automation Update Management was retired on 2024-08-31 and has been shutdown on 2025-02-28. This resource will be removed in v5.0 of the AzureRM Provider. See https://techcommunity.microsoft.com/blog/azuregovernanceandmanagementblog/log-analytics-agent-based-azure-management-services-shut-down-starting-28-februa/4381853 for more information.
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/automation_software_update_configuration.html.markdown
+++ b/website/docs/r/automation_software_update_configuration.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Manages an Automation Software Update Configuration.
 
-!> **Note:** The `azurerm_automation_software_update_configuration` resource has been deprecated because the Azure Automation Update Management was retired on 2024-08-31 and has been shutdown on 2025-02-28. This resource will be removed in v5.0 of the AzureRM Provider. See https://techcommunity.microsoft.com/blog/azuregovernanceandmanagementblog/log-analytics-agent-based-azure-management-services-shut-down-starting-28-februa/4381853 for more information.
+!> **Note:** The `azurerm_automation_software_update_configuration` resource has been deprecated because the Azure Automation Update Management was retired on 2024-08-31 and has been shutdown on 2025-02-28. This resource will be removed in v5.0 of the AzureRM Provider. Please migrate to Azure Update Manager, and use the `azurerm_maintenance_configuration` resource combined with the appropriate assignment resources instead. See https://techcommunity.microsoft.com/blog/azuregovernanceandmanagementblog/log-analytics-agent-based-azure-management-services-shut-down-starting-28-februa/4381853 for more information.
 
 ## Example Usage
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->
Recently we found test cases related with `azurerm_automation_software_update_configuration` failed. The error message indicates that the underlying resource Azure Automation Update Management was deprecated on 31st August 2024 and has been shut down on 28th February 2025. Users are suggested to migrate to Azure Update Manager. There is no direct 1:1 replacement for this resource but `azurerm_maintenance_configuration` resource combined with the appropriate assignment resources are available to use after migration.  See [https://techcommunity.microsoft.com/blog/azuregovernanceandmanagementblog/log-analytics-agent-based-azure-management-services-shut-down-starting-28-februa/4381853](https://techcommunity.microsoft.com/blog/azuregovernanceandmanagementblog/log-analytics-agent-based-azure-management-services-shut-down-starting-28-februa/4381853)

Error Message:
`unexpected status 400 (400 Bad Request) with response: {"code":"BadRequest","message":"Azure Automation Update Management was deprecated on 31st August 2024 and has been shut down on 28th February 2025.  Please move to Azure Update Manager. Learn more-https://aka.ms/mmaagentbasedservicesshutdown"}`


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_automation_software_update_configuration` - deprecate automation software update configuration resource


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
