### PR TITLE
`azurerm_logic_app_standard` - refactor to leverage shared code with `appservice`

### DIFF
--- a/internal/provider/services.go
+++ b/internal/provider/services.go
@@ -187,6 +187,7 @@ func SupportedTypedServices() []sdk.TypedServiceRegistration {
 		loadbalancer.Registration{},
 		loadtestservice.Registration{},
 		loganalytics.Registration{},
+		logic.Registration{},
 		machinelearning.Registration{},
 		maintenance.Registration{},
 		managedhsm.Registration{},

--- a/internal/services/appservice/helpers/logic_apps.go
+++ b/internal/services/appservice/helpers/logic_apps.go
@@ -1,0 +1,229 @@
+package helpers
+
+import (
+	"github.com/hashicorp/go-azure-sdk/resource-manager/web/2023-12-01/webapps"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+type LogicAppSiteConfig struct {
+	AlwaysOn                      bool            `tfschema:"always_on"`
+	Cors                          []CorsSetting   `tfschema:"cors"`
+	FTPSState                     string          `tfschema:"ftps_state"`
+	HTTP2Enabled                  bool            `tfschema:"http2_enabled"`
+	IpRestriction                 []IpRestriction `tfschema:"ip_restriction"`
+	LinuxFxVersion                string          `tfschema:"linux_fx_version"`
+	MinTLSVersion                 string          `tfschema:"min_tls_version"`
+	PreWarmedInstanceCount        int64           `tfschema:"pre_warmed_instance_count"`
+	SCMIPRestriction              []IpRestriction `tfschema:"scm_ip_restriction"`
+	SCMUseMainIpRestriction       bool            `tfschema:"scm_use_main_ip_restriction"`
+	SCMMinTLSVersion              string          `tfschema:"scm_min_tls_version"`
+	SCMType                       string          `tfschema:"scm_type"`
+	Use32BitWorkerProcess         bool            `tfschema:"use_32_bit_worker_process"`
+	WebSocketsEnabled             bool            `tfschema:"websockets_enabled"`
+	HealthCheckPath               string          `tfschema:"health_check_path"`
+	ElasticInstanceMinimum        int64           `tfschema:"elastic_instance_minimum"`
+	AppScaleLimit                 int64           `tfschema:"app_scale_limit"`
+	RuntimeScaleMonitoringEnabled bool            `tfschema:"runtime_scale_monitoring_enabled"`
+	DotnetFrameworkVersion        string          `tfschema:"dotnet_framework_version"`
+	VNETRouteAllEnabled           bool            `tfschema:"vnet_route_all_enabled"`
+	AutoSwapSlotName              string          `tfschema:"auto_swap_slot_name"`
+
+	PublicNetworkAccessEnabled bool `tfschema:"public_network_access_enabled,removedInNextMajorVersion"`
+}
+
+func SchemaLogicAppStandardSiteConfig() *pluginsdk.Schema {
+	schema := &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		Computed: true,
+		MaxItems: 1,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"always_on": {
+					Type:     pluginsdk.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+
+				"cors": CorsSettingsSchema(),
+
+				"ftps_state": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					Computed: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						string(webapps.FtpsStateAllAllowed),
+						string(webapps.FtpsStateDisabled),
+						string(webapps.FtpsStateFtpsOnly),
+					}, false),
+				},
+
+				"http2_enabled": {
+					Type:     pluginsdk.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+
+				"ip_restriction": IpRestrictionSchema(),
+
+				"linux_fx_version": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+
+				"min_tls_version": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					Computed: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						string(webapps.SupportedTlsVersionsOnePointTwo),
+						string(webapps.SupportedTlsVersionsOnePointThree),
+					}, false),
+				},
+
+				"pre_warmed_instance_count": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: validation.IntBetween(0, 20),
+				},
+
+				"scm_ip_restriction": IpRestrictionSchema(),
+
+				"scm_use_main_ip_restriction": {
+					Type:     pluginsdk.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+
+				"scm_min_tls_version": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					Computed: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						string(webapps.SupportedTlsVersionsOnePointTwo),
+						string(webapps.SupportedTlsVersionsOnePointThree),
+					}, false),
+				},
+
+				"scm_type": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					Computed: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						string(webapps.ScmTypeBitbucketGit),
+						string(webapps.ScmTypeBitbucketHg),
+						string(webapps.ScmTypeCodePlexGit),
+						string(webapps.ScmTypeCodePlexHg),
+						string(webapps.ScmTypeDropbox),
+						string(webapps.ScmTypeExternalGit),
+						string(webapps.ScmTypeExternalHg),
+						string(webapps.ScmTypeGitHub),
+						string(webapps.ScmTypeLocalGit),
+						string(webapps.ScmTypeNone),
+						string(webapps.ScmTypeOneDrive),
+						string(webapps.ScmTypeTfs),
+						string(webapps.ScmTypeVSO),
+						string(webapps.ScmTypeVSTSRM),
+					}, false),
+				},
+
+				"use_32_bit_worker_process": {
+					Type:     pluginsdk.TypeBool,
+					Optional: true,
+					Default:  true,
+				},
+
+				"websockets_enabled": {
+					Type:     pluginsdk.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+
+				"health_check_path": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+				},
+
+				"elastic_instance_minimum": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: validation.IntBetween(0, 20),
+				},
+
+				"app_scale_limit": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: validation.IntAtLeast(0),
+				},
+
+				"runtime_scale_monitoring_enabled": {
+					Type:     pluginsdk.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+
+				"dotnet_framework_version": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					Default:  "v4.0",
+					ValidateFunc: validation.StringInSlice([]string{
+						"v4.0",
+						"v5.0",
+						"v6.0",
+						"v8.0",
+					}, false),
+				},
+
+				"vnet_route_all_enabled": {
+					Type:     pluginsdk.TypeBool,
+					Optional: true,
+					Computed: true,
+				},
+
+				"auto_swap_slot_name": {
+					Type:     pluginsdk.TypeString,
+					Computed: true,
+				},
+			},
+		},
+	}
+
+	if !features.FivePointOh() {
+		schema.Elem.(*pluginsdk.Resource).Schema["public_network_access_enabled"] = &pluginsdk.Schema{
+			Type:       pluginsdk.TypeBool,
+			Optional:   true,
+			Computed:   true,
+			Deprecated: "the `site_config.public_network_access_enabled` property has been superseded by the `public_network_access` property and will be removed in v5.0 of the AzureRM Provider.",
+		}
+		schema.Elem.(*pluginsdk.Resource).Schema["scm_min_tls_version"] = &pluginsdk.Schema{
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Computed: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				string(webapps.SupportedTlsVersionsOnePointZero),
+				string(webapps.SupportedTlsVersionsOnePointOne),
+				string(webapps.SupportedTlsVersionsOnePointTwo),
+				string(webapps.SupportedTlsVersionsOnePointThree),
+			}, false),
+		}
+		schema.Elem.(*pluginsdk.Resource).Schema["min_tls_version"] = &pluginsdk.Schema{
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Computed: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				string(webapps.SupportedTlsVersionsOnePointZero),
+				string(webapps.SupportedTlsVersionsOnePointOne),
+				string(webapps.SupportedTlsVersionsOnePointTwo),
+				string(webapps.SupportedTlsVersionsOnePointThree),
+			}, false),
+		}
+	}
+
+	return schema
+}

--- a/internal/services/appservice/helpers/shared_schema.go
+++ b/internal/services/appservice/helpers/shared_schema.go
@@ -405,6 +405,11 @@ type SiteCredential struct {
 	Password string `tfschema:"password"`
 }
 
+type SiteCredentialLogicApp struct {
+	Username string `tfschema:"username"`
+	Password string `tfschema:"password"`
+}
+
 func SiteCredentialSchema() *pluginsdk.Schema { // TODO - This can apparently be disabled as a security option for the service?
 	return &pluginsdk.Schema{
 		Type:      pluginsdk.TypeList,
@@ -1595,6 +1600,21 @@ func FlattenSiteCredentials(input *webapps.User) []SiteCredential {
 
 	userProps := *input.Properties
 	result = append(result, SiteCredential{
+		Username: userProps.PublishingUserName,
+		Password: pointer.From(userProps.PublishingPassword),
+	})
+
+	return result
+}
+
+func FlattenSiteCredentialsLogicApp(input *webapps.User) []SiteCredentialLogicApp {
+	var result []SiteCredentialLogicApp
+	if input == nil || input.Properties == nil {
+		return result
+	}
+
+	userProps := *input.Properties
+	result = append(result, SiteCredentialLogicApp{
 		Username: userProps.PublishingUserName,
 		Password: pointer.From(userProps.PublishingPassword),
 	})

--- a/internal/services/logic/logic_app_standard_data_source.go
+++ b/internal/services/logic/logic_app_standard_data_source.go
@@ -428,3 +428,65 @@ func flattenLogicAppStandardDataSourceSiteConfig(input *webapps.SiteConfig) []in
 	results = append(results, result)
 	return results
 }
+
+func flattenLogicAppStandardSiteCredential(input *webapps.User) []interface{} {
+	results := make([]interface{}, 0)
+	result := make(map[string]interface{})
+
+	if input == nil || input.Properties == nil {
+		log.Printf("[DEBUG] UserProperties is nil")
+		return results
+	}
+
+	result["username"] = input.Properties.PublishingUserName
+
+	result["password"] = pointer.From(input.Properties.PublishingPassword)
+
+	return append(results, result)
+}
+
+func flattenLogicAppStandardCorsSettings(input *webapps.CorsSettings) []interface{} {
+	results := make([]interface{}, 0)
+	if input == nil {
+		return results
+	}
+
+	result := make(map[string]interface{})
+
+	allowedOrigins := make([]interface{}, 0)
+	if s := input.AllowedOrigins; s != nil {
+		for _, v := range *s {
+			allowedOrigins = append(allowedOrigins, v)
+		}
+	}
+	result["allowed_origins"] = pluginsdk.NewSet(pluginsdk.HashString, allowedOrigins)
+
+	if input.SupportCredentials != nil {
+		result["support_credentials"] = *input.SupportCredentials
+	}
+
+	return append(results, result)
+}
+
+func flattenHeaders(input map[string][]string) []interface{} {
+	output := make([]interface{}, 0)
+	headers := make(map[string]interface{})
+	if input == nil {
+		return output
+	}
+
+	if forwardedHost, ok := input["x-forwarded-host"]; ok && len(forwardedHost) > 0 {
+		headers["x_forwarded_host"] = forwardedHost
+	}
+	if forwardedFor, ok := input["x-forwarded-for"]; ok && len(forwardedFor) > 0 {
+		headers["x_forwarded_for"] = forwardedFor
+	}
+	if fdids, ok := input["x-azure-fdid"]; ok && len(fdids) > 0 {
+		headers["x_azure_fdid"] = fdids
+	}
+	if healthProbe, ok := input["x-fd-healthprobe"]; ok && len(healthProbe) > 0 {
+		headers["x_fd_health_probe"] = healthProbe
+	}
+
+	return append(output, headers)
+}

--- a/internal/services/logic/logic_app_standard_data_source.go
+++ b/internal/services/logic/logic_app_standard_data_source.go
@@ -6,6 +6,7 @@ package logic
 import (
 	"fmt"
 	"log"
+	"math"
 	"strings"
 	"time"
 
@@ -18,9 +19,11 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/web/2023-12-01/webapps"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appservice/helpers"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/logic/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
 
@@ -98,7 +101,7 @@ func dataSourceLogicAppStandard() *pluginsdk.Resource {
 				Computed: true,
 			},
 
-			"site_config": schemaLogicAppStandardSiteConfig(),
+			"site_config": schemaLogicAppStandardSiteConfigDataSource(),
 
 			"connection_string": {
 				Type:     pluginsdk.TypeSet,
@@ -489,4 +492,311 @@ func flattenHeaders(input map[string][]string) []interface{} {
 	}
 
 	return append(output, headers)
+}
+
+func schemaLogicAppStandardSiteConfigDataSource() *pluginsdk.Schema {
+	schema := &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Computed: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"always_on": {
+					Type:     pluginsdk.TypeBool,
+					Computed: true,
+				},
+
+				"cors": schemaLogicAppCorsSettingsDataSource(),
+
+				"ftps_state": {
+					Type:     pluginsdk.TypeString,
+					Computed: true,
+				},
+
+				"http2_enabled": {
+					Type:     pluginsdk.TypeBool,
+					Computed: true,
+				},
+
+				"ip_restriction": schemaLogicAppStandardIpRestrictionDataSource(),
+
+				"linux_fx_version": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+
+				"min_tls_version": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					Computed: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						string(webapps.SupportedTlsVersionsOnePointTwo),
+					}, false),
+				},
+
+				"pre_warmed_instance_count": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: validation.IntBetween(0, 20),
+				},
+
+				"scm_ip_restriction": schemaLogicAppStandardIpRestrictionDataSource(),
+
+				"scm_use_main_ip_restriction": {
+					Type:     pluginsdk.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+
+				"scm_min_tls_version": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					Computed: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						string(webapps.SupportedTlsVersionsOnePointTwo),
+					}, false),
+				},
+
+				"scm_type": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					Computed: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						string(webapps.ScmTypeBitbucketGit),
+						string(webapps.ScmTypeBitbucketHg),
+						string(webapps.ScmTypeCodePlexGit),
+						string(webapps.ScmTypeCodePlexHg),
+						string(webapps.ScmTypeDropbox),
+						string(webapps.ScmTypeExternalGit),
+						string(webapps.ScmTypeExternalHg),
+						string(webapps.ScmTypeGitHub),
+						string(webapps.ScmTypeLocalGit),
+						string(webapps.ScmTypeNone),
+						string(webapps.ScmTypeOneDrive),
+						string(webapps.ScmTypeTfs),
+						string(webapps.ScmTypeVSO),
+						string(webapps.ScmTypeVSTSRM),
+					}, false),
+				},
+
+				"use_32_bit_worker_process": {
+					Type:     pluginsdk.TypeBool,
+					Optional: true,
+					Default:  true,
+				},
+
+				"websockets_enabled": {
+					Type:     pluginsdk.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+
+				"health_check_path": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+				},
+
+				"elastic_instance_minimum": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: validation.IntBetween(0, 20),
+				},
+
+				"app_scale_limit": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: validation.IntAtLeast(0),
+				},
+
+				"runtime_scale_monitoring_enabled": {
+					Type:     pluginsdk.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+
+				"dotnet_framework_version": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					Default:  "v4.0",
+					ValidateFunc: validation.StringInSlice([]string{
+						"v4.0",
+						"v5.0",
+						"v6.0",
+						"v8.0",
+					}, false),
+				},
+
+				"vnet_route_all_enabled": {
+					Type:     pluginsdk.TypeBool,
+					Optional: true,
+					Computed: true,
+				},
+
+				"auto_swap_slot_name": {
+					Type:     pluginsdk.TypeString,
+					Computed: true,
+				},
+			},
+		},
+	}
+
+	if !features.FivePointOh() {
+		schema.Elem.(*pluginsdk.Resource).Schema["public_network_access_enabled"] = &pluginsdk.Schema{
+			Type:       pluginsdk.TypeBool,
+			Optional:   true,
+			Computed:   true,
+			Deprecated: "the `site_config.public_network_access_enabled` property has been superseded by the `public_network_access` property and will be removed in v5.0 of the AzureRM Provider.",
+		}
+		schema.Elem.(*pluginsdk.Resource).Schema["scm_min_tls_version"] = &pluginsdk.Schema{
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Computed: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				string(webapps.SupportedTlsVersionsOnePointZero),
+				string(webapps.SupportedTlsVersionsOnePointOne),
+				string(webapps.SupportedTlsVersionsOnePointTwo),
+			}, false),
+		}
+		schema.Elem.(*pluginsdk.Resource).Schema["min_tls_version"] = &pluginsdk.Schema{
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Computed: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				string(webapps.SupportedTlsVersionsOnePointZero),
+				string(webapps.SupportedTlsVersionsOnePointOne),
+				string(webapps.SupportedTlsVersionsOnePointTwo),
+			}, false),
+		}
+	}
+
+	return schema
+}
+
+func schemaLogicAppCorsSettingsDataSource() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Computed: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"allowed_origins": {
+					Type:     pluginsdk.TypeSet,
+					Computed: true,
+					Elem:     &pluginsdk.Schema{Type: pluginsdk.TypeString},
+				},
+				"support_credentials": {
+					Type:     pluginsdk.TypeBool,
+					Computed: true,
+				},
+			},
+		},
+	}
+}
+
+func schemaLogicAppStandardIpRestrictionDataSource() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Computed: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"ip_address": {
+					Type:     pluginsdk.TypeString,
+					Computed: true,
+				},
+
+				"service_tag": {
+					Type:     pluginsdk.TypeString,
+					Computed: true,
+				},
+
+				"virtual_network_subnet_id": {
+					Type:     pluginsdk.TypeString,
+					Computed: true,
+				},
+
+				"name": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+
+				"priority": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					Default:      65000,
+					ValidateFunc: validation.IntBetween(1, math.MaxInt32),
+				},
+
+				"action": {
+					Type:     pluginsdk.TypeString,
+					Default:  "Allow",
+					Optional: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						"Allow",
+						"Deny",
+					}, false),
+				},
+
+				// lintignore:XS003
+				"headers": {
+					Type:       pluginsdk.TypeList,
+					Optional:   true,
+					Computed:   true,
+					MaxItems:   1,
+					ConfigMode: pluginsdk.SchemaConfigModeAttr,
+					Elem: &pluginsdk.Resource{
+						Schema: map[string]*pluginsdk.Schema{
+							// lintignore:S018
+							"x_forwarded_host": {
+								Type:     pluginsdk.TypeSet,
+								Optional: true,
+								MaxItems: 8,
+								Elem: &pluginsdk.Schema{
+									Type: pluginsdk.TypeString,
+								},
+							},
+
+							// lintignore:S018
+							"x_forwarded_for": {
+								Type:     pluginsdk.TypeSet,
+								Optional: true,
+								MaxItems: 8,
+								Elem: &pluginsdk.Schema{
+									Type:         pluginsdk.TypeString,
+									ValidateFunc: validation.IsCIDR,
+								},
+							},
+
+							// lintignore:S018
+							"x_azure_fdid": {
+								Type:     pluginsdk.TypeSet,
+								Optional: true,
+								MaxItems: 8,
+								Elem: &pluginsdk.Schema{
+									Type:         pluginsdk.TypeString,
+									ValidateFunc: validation.IsUUID,
+								},
+							},
+
+							// lintignore:S018
+							"x_fd_health_probe": {
+								Type:     pluginsdk.TypeSet,
+								Optional: true,
+								MaxItems: 1,
+								Elem: &pluginsdk.Schema{
+									Type: pluginsdk.TypeString,
+									ValidateFunc: validation.StringInSlice([]string{
+										"1",
+									}, false),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
 }

--- a/internal/services/logic/logic_app_standard_resource.go
+++ b/internal/services/logic/logic_app_standard_resource.go
@@ -812,6 +812,10 @@ func (r LogicAppResource) Update() sdk.ResourceFunc {
 
 			existing.Model.Properties = pointer.To(siteEnvelope)
 
+			if metadata.ResourceData.HasChange("tags") {
+				existing.Model.Tags = pointer.To(data.Tags)
+			}
+
 			if err := client.CreateOrUpdateThenPoll(ctx, *id, *existing.Model); err != nil {
 				return fmt.Errorf("updating %s: %+v", *id, err)
 			}
@@ -1497,11 +1501,11 @@ func expandLogicAppStandardSiteConfigForUpdate(d []helpers.LogicAppSiteConfig, m
 		siteConfig.LinuxFxVersion = pointer.To(config.LinuxFxVersion)
 	}
 
-	if metadata.ResourceData.HasChanges("site_config.0.cors") {
+	if metadata.ResourceData.HasChange("site_config.0.cors") {
 		siteConfig.Cors = helpers.ExpandCorsSettings(config.Cors)
 	}
 
-	if metadata.ResourceData.HasChanges("site_config.0.ip_restriction") {
+	if metadata.ResourceData.HasChange("site_config.0.ip_restriction") {
 		ipr, err := helpers.ExpandIpRestrictions(config.IpRestriction)
 		if err != nil {
 			return nil, err
@@ -1509,7 +1513,7 @@ func expandLogicAppStandardSiteConfigForUpdate(d []helpers.LogicAppSiteConfig, m
 		siteConfig.IPSecurityRestrictions = ipr
 	}
 
-	if metadata.ResourceData.HasChanges("site_config.0.scm_ip_restriction") {
+	if metadata.ResourceData.HasChange("site_config.0.scm_ip_restriction") {
 		ipr, err := helpers.ExpandIpRestrictions(config.SCMIPRestriction)
 		if err != nil {
 			return nil, err
@@ -1517,19 +1521,19 @@ func expandLogicAppStandardSiteConfigForUpdate(d []helpers.LogicAppSiteConfig, m
 		siteConfig.ScmIPSecurityRestrictions = ipr
 	}
 
-	if metadata.ResourceData.HasChanges("site_config.0.min_scm_tls_version") {
+	if metadata.ResourceData.HasChange("site_config.0.scm_min_tls_version") {
 		siteConfig.ScmMinTlsVersion = pointer.ToEnum[webapps.SupportedTlsVersions](config.SCMMinTLSVersion)
 	}
 
-	if metadata.ResourceData.HasChanges("site_config.0.scm_type") {
+	if metadata.ResourceData.HasChange("site_config.0.scm_type") {
 		siteConfig.ScmType = pointer.ToEnum[webapps.ScmType](config.SCMType)
 	}
 
-	if metadata.ResourceData.HasChanges("site_config.0.min_tls_version") {
+	if metadata.ResourceData.HasChange("site_config.0.min_tls_version") {
 		siteConfig.MinTlsVersion = pointer.ToEnum[webapps.SupportedTlsVersions](config.MinTLSVersion)
 	}
 
-	if metadata.ResourceData.HasChanges("site_config.0.ftps_state") {
+	if metadata.ResourceData.HasChange("site_config.0.ftps_state") {
 		siteConfig.FtpsState = pointer.ToEnum[webapps.FtpsState](config.FTPSState)
 	}
 
@@ -1549,7 +1553,7 @@ func expandLogicAppStandardSiteConfigForUpdate(d []helpers.LogicAppSiteConfig, m
 		siteConfig.FunctionAppScaleLimit = pointer.To(config.AppScaleLimit)
 	}
 
-	if metadata.ResourceData.HasChanges("site_config.0.dotnet_framework_version") {
+	if metadata.ResourceData.HasChange("site_config.0.dotnet_framework_version") {
 		siteConfig.NetFrameworkVersion = pointer.To(config.DotnetFrameworkVersion)
 	}
 
@@ -1646,6 +1650,10 @@ func mergeAppSettings(existing []webapps.NameValuePair, old, new map[string]inte
 			break
 		}
 
+		addOrUpdate[k] = v
+	}
+
+	for k, v := range cMap {
 		addOrUpdate[k] = v
 	}
 

--- a/internal/services/logic/logic_app_standard_resource.go
+++ b/internal/services/logic/logic_app_standard_resource.go
@@ -67,8 +67,8 @@ type LogicAppResourceModel struct {
 }
 
 var (
-	LogicAppStdKind   = "functionapp,workflowapp"
-	LogicAppLinuxKind = "functionapp,linux,container,workflowapp"
+	logicAppStdKind   = "functionapp,workflowapp"
+	logicAppLinuxKind = "functionapp,linux,container,workflowapp"
 
 	storageConnectionStringFmt           = "DefaultEndpointsProtocol=https;AccountName=%s;AccountKey=%s;EndpointSuffix=%s"
 	storageAppSettingName                = "AzureWebJobsStorage"
@@ -418,9 +418,9 @@ func (r LogicAppResource) Create() sdk.ResourceFunc {
 				return fmt.Errorf("expanding `site_config`: %+v", err)
 			}
 
-			kind := LogicAppStdKind
+			kind := logicAppStdKind
 			if siteConfig.LinuxFxVersion != nil && len(*siteConfig.LinuxFxVersion) > 0 {
-				kind = LogicAppLinuxKind
+				kind = logicAppLinuxKind
 			}
 
 			appSettings := expandAppSettings(data.AppSettings)

--- a/internal/services/logic/logic_app_standard_resource.go
+++ b/internal/services/logic/logic_app_standard_resource.go
@@ -26,6 +26,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/logic/validate"
 	storageValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 )
 
@@ -251,6 +252,12 @@ func (r LogicAppResource) Arguments() map[string]*pluginsdk.Schema {
 		s["client_certificate_mode"].Default = nil
 		s["public_network_access"].Default = nil
 		s["public_network_access"].Computed = true
+		s["site_config"].Elem.(*pluginsdk.Resource).Schema["ip_restriction"].Elem.(*pluginsdk.Resource).Schema["headers"].Elem.(*pluginsdk.Resource).Schema["x_forwarded_host"].DiffSuppressFunc = suppress.ListOrder
+		s["site_config"].Elem.(*pluginsdk.Resource).Schema["ip_restriction"].Elem.(*pluginsdk.Resource).Schema["headers"].Elem.(*pluginsdk.Resource).Schema["x_forwarded_for"].DiffSuppressFunc = suppress.ListOrder
+		s["site_config"].Elem.(*pluginsdk.Resource).Schema["ip_restriction"].Elem.(*pluginsdk.Resource).Schema["headers"].Elem.(*pluginsdk.Resource).Schema["x_azure_fdid"].DiffSuppressFunc = suppress.ListOrder
+		s["site_config"].Elem.(*pluginsdk.Resource).Schema["scm_ip_restriction"].Elem.(*pluginsdk.Resource).Schema["headers"].Elem.(*pluginsdk.Resource).Schema["x_forwarded_host"].DiffSuppressFunc = suppress.ListOrder
+		s["site_config"].Elem.(*pluginsdk.Resource).Schema["scm_ip_restriction"].Elem.(*pluginsdk.Resource).Schema["headers"].Elem.(*pluginsdk.Resource).Schema["x_forwarded_for"].DiffSuppressFunc = suppress.ListOrder
+		s["site_config"].Elem.(*pluginsdk.Resource).Schema["scm_ip_restriction"].Elem.(*pluginsdk.Resource).Schema["headers"].Elem.(*pluginsdk.Resource).Schema["x_azure_fdid"].DiffSuppressFunc = suppress.ListOrder
 	}
 
 	return s

--- a/internal/services/logic/logic_app_standard_resource.go
+++ b/internal/services/logic/logic_app_standard_resource.go
@@ -4,10 +4,10 @@
 package logic
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"math"
-	"strconv"
 	"strings"
 	"time"
 
@@ -17,783 +17,846 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
-	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/web/2023-01-01/resourceproviders"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/web/2023-12-01/webapps"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appservice/helpers"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/logic/validate"
 	storageValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
-func resourceLogicAppStandard() *pluginsdk.Resource {
-	resource := &pluginsdk.Resource{
-		Create: resourceLogicAppStandardCreate,
-		Read:   resourceLogicAppStandardRead,
-		Update: resourceLogicAppStandardUpdate,
-		Delete: resourceLogicAppStandardDelete,
-		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
-			_, err := commonids.ParseLogicAppId(id)
-			return err
-		}),
+type LogicAppResource struct{}
 
-		Timeouts: &pluginsdk.ResourceTimeout{
-			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
-			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
-			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
-			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
+type LogicAppResourceModel struct {
+	Name                       string                                     `tfschema:"name"`
+	ResourceGroupName          string                                     `tfschema:"resource_group_name"`
+	Location                   string                                     `tfschema:"location"`
+	AppServicePlanId           string                                     `tfschema:"app_service_plan_id"`
+	AppSettings                map[string]string                          `tfschema:"app_settings"`
+	UseExtensionBundle         bool                                       `tfschema:"use_extension_bundle"`
+	BundleVersion              string                                     `tfschema:"bundle_version"`
+	ClientAffinityEnabled      bool                                       `tfschema:"client_affinity_enabled"`
+	ClientCertificateMode      string                                     `tfschema:"client_certificate_mode"`
+	Enabled                    bool                                       `tfschema:"enabled"`
+	FtpPublishBasicAuthEnabled bool                                       `tfschema:"ftp_publish_basic_authentication_enabled"`
+	HTTPSOnly                  bool                                       `tfschema:"https_only"`
+	Identity                   []identity.ModelSystemAssignedUserAssigned `tfschema:"identity"`
+	SCMPublishBasicAuthEnabled bool                                       `tfschema:"scm_publish_basic_authentication_enabled"`
+	SiteConfig                 []helpers.LogicAppSiteConfig               `tfschema:"site_config"`
+	ConnectionStrings          []helpers.ConnectionString                 `tfschema:"connection_string"`
+	StorageAccountName         string                                     `tfschema:"storage_account_name"`
+	StorageAccountAccessKey    string                                     `tfschema:"storage_account_access_key"`
+	PublicNetworkAccess        string                                     `tfschema:"public_network_access"`
+	StorageAccountShareName    string                                     `tfschema:"storage_account_share_name"`
+	Version                    string                                     `tfschema:"version"`
+	VNETContentShareEnabled    bool                                       `tfschema:"vnet_content_share_enabled"`
+	VirtualNetworkSubnetId     string                                     `tfschema:"virtual_network_subnet_id"`
+	Tags                       map[string]string                          `tfschema:"tags"`
+
+	CustomDomainVerificationId  string                           `tfschema:"custom_domain_verification_id"`
+	DefaultHostname             string                           `tfschema:"default_hostname"`
+	Kind                        string                           `tfschema:"kind"`
+	OutboundIpAddresses         string                           `tfschema:"outbound_ip_addresses"`
+	PossibleOutboundIpAddresses string                           `tfschema:"possible_outbound_ip_addresses"`
+	SiteCredential              []helpers.SiteCredentialLogicApp `tfschema:"site_credential"`
+}
+
+var (
+	LogicAppStdKind   = "functionapp,workflowapp"
+	LogicAppLinuxKind = "functionapp,linux,container,workflowapp"
+
+	storageConnectionStringFmt           = "DefaultEndpointsProtocol=https;AccountName=%s;AccountKey=%s;EndpointSuffix=%s"
+	storageAppSettingName                = "AzureWebJobsStorage"
+	contentShareAppSettingName           = "WEBSITE_CONTENTSHARE"
+	contentFileConnStringAppSettingName  = "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING"
+	functionVersionAppSettingName        = "FUNCTIONS_EXTENSION_VERSION"
+	extensionBundleAppSettingName        = "AzureFunctionsJobHost__extensionBundle__id"
+	extensionBundleAppSettingValue       = "Microsoft.Azure.Functions.ExtensionBundle.Workflows"
+	extensionBundleVersionAppSettingName = "AzureFunctionsJobHost__extensionBundle__version"
+)
+
+func (r LogicAppResource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validate.LogicAppStandardName,
 		},
 
-		Schema: map[string]*pluginsdk.Schema{
-			"name": {
-				Type:         pluginsdk.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validate.LogicAppStandardName,
+		"resource_group_name": commonschema.ResourceGroupName(),
+
+		"location": commonschema.Location(),
+
+		"app_service_plan_id": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+		},
+
+		"app_settings": {
+			Type:     pluginsdk.TypeMap,
+			Optional: true,
+			Computed: true,
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
 			},
+		},
 
-			"resource_group_name": commonschema.ResourceGroupName(),
+		"use_extension_bundle": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Default:  true,
+		},
 
-			"location": commonschema.Location(),
+		"bundle_version": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Default:  "[1.*, 2.0.0)",
+		},
 
-			"app_service_plan_id": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-			},
+		"client_affinity_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Computed: true,
+		},
 
-			"app_settings": {
-				Type:     pluginsdk.TypeMap,
-				Optional: true,
-				Computed: true,
-				Elem: &pluginsdk.Schema{
-					Type: pluginsdk.TypeString,
-				},
-			},
+		"client_certificate_mode": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.StringInSlice(webapps.PossibleValuesForClientCertMode(), false),
+		},
 
-			"use_extension_bundle": {
-				Type:     pluginsdk.TypeBool,
-				Optional: true,
-				Default:  true,
-			},
+		"enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Default:  true,
+		},
 
-			"bundle_version": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				Default:  "[1.*, 2.0.0)",
-			},
+		"ftp_publish_basic_authentication_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Default:  true,
+		},
 
-			"client_affinity_enabled": {
-				Type:     pluginsdk.TypeBool,
-				Optional: true,
-				Computed: true,
-			},
+		"https_only": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Default:  false,
+		},
 
-			"client_certificate_mode": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					"Required",
-					"Optional",
-				}, false),
-			},
+		"identity": commonschema.SystemAssignedUserAssignedIdentityOptional(),
 
-			"enabled": {
-				Type:     pluginsdk.TypeBool,
-				Optional: true,
-				Default:  true,
-			},
+		"scm_publish_basic_authentication_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Default:  true,
+		},
 
-			"ftp_publish_basic_authentication_enabled": {
-				Type:     pluginsdk.TypeBool,
-				Optional: true,
-				Default:  true,
-			},
+		"site_config": helpers.SchemaLogicAppStandardSiteConfig(),
 
-			"https_only": {
-				Type:     pluginsdk.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-
-			"identity": commonschema.SystemAssignedUserAssignedIdentityOptional(),
-
-			"scm_publish_basic_authentication_enabled": {
-				Type:     pluginsdk.TypeBool,
-				Optional: true,
-				Default:  true,
-			},
-
-			"site_config": schemaLogicAppStandardSiteConfig(),
-
-			"connection_string": {
-				Type:     pluginsdk.TypeSet,
-				Optional: true,
-				Computed: true,
-				Elem: &pluginsdk.Resource{
-					Schema: map[string]*pluginsdk.Schema{
-						"name": {
-							Type:     pluginsdk.TypeString,
-							Required: true,
-						},
-
-						"type": {
-							Type:     pluginsdk.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(webapps.ConnectionStringTypeApiHub),
-								string(webapps.ConnectionStringTypeCustom),
-								string(webapps.ConnectionStringTypeDocDb),
-								string(webapps.ConnectionStringTypeEventHub),
-								string(webapps.ConnectionStringTypeMySql),
-								string(webapps.ConnectionStringTypeNotificationHub),
-								string(webapps.ConnectionStringTypePostgreSQL),
-								string(webapps.ConnectionStringTypeRedisCache),
-								string(webapps.ConnectionStringTypeServiceBus),
-								string(webapps.ConnectionStringTypeSQLAzure),
-								string(webapps.ConnectionStringTypeSQLServer),
-							}, false),
-						},
-
-						"value": {
-							Type:      pluginsdk.TypeString,
-							Required:  true,
-							Sensitive: true,
-						},
+		"connection_string": {
+			Type:     pluginsdk.TypeSet,
+			Optional: true,
+			Computed: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"name": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
 					},
-				},
-			},
 
-			"storage_account_name": {
-				Type:         pluginsdk.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: storageValidate.StorageAccountName,
-			},
+					"type": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+						ValidateFunc: validation.StringInSlice([]string{
+							string(webapps.ConnectionStringTypeApiHub),
+							string(webapps.ConnectionStringTypeCustom),
+							string(webapps.ConnectionStringTypeDocDb),
+							string(webapps.ConnectionStringTypeEventHub),
+							string(webapps.ConnectionStringTypeMySql),
+							string(webapps.ConnectionStringTypeNotificationHub),
+							string(webapps.ConnectionStringTypePostgreSQL),
+							string(webapps.ConnectionStringTypeRedisCache),
+							string(webapps.ConnectionStringTypeServiceBus),
+							string(webapps.ConnectionStringTypeSQLAzure),
+							string(webapps.ConnectionStringTypeSQLServer),
+						}, false),
+					},
 
-			"storage_account_access_key": {
-				Type:         pluginsdk.TypeString,
-				Required:     true,
-				Sensitive:    true,
-				ValidateFunc: validation.NoZeroValues,
-			},
-
-			"public_network_access": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				Default:  helpers.PublicNetworkAccessEnabled,
-				ValidateFunc: validation.StringInSlice([]string{
-					helpers.PublicNetworkAccessEnabled,
-					helpers.PublicNetworkAccessDisabled,
-				}, false),
-			},
-
-			"storage_account_share_name": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-
-			"version": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				Default:  "~4",
-			},
-
-			"vnet_content_share_enabled": {
-				Type:     pluginsdk.TypeBool,
-				Optional: true,
-			},
-
-			"virtual_network_subnet_id": {
-				Type:         pluginsdk.TypeString,
-				Optional:     true,
-				ValidateFunc: commonids.ValidateSubnetID,
-			},
-
-			"tags": commonschema.Tags(),
-
-			// Computed Only
-			"custom_domain_verification_id": {
-				Type:     pluginsdk.TypeString,
-				Computed: true,
-			},
-
-			"default_hostname": {
-				Type:     pluginsdk.TypeString,
-				Computed: true,
-			},
-
-			"kind": {
-				Type:     pluginsdk.TypeString,
-				Computed: true,
-			},
-
-			"outbound_ip_addresses": {
-				Type:     pluginsdk.TypeString,
-				Computed: true,
-			},
-
-			"possible_outbound_ip_addresses": {
-				Type:     pluginsdk.TypeString,
-				Computed: true,
-			},
-
-			"site_credential": {
-				Type:     pluginsdk.TypeList,
-				Computed: true,
-				Elem: &pluginsdk.Resource{
-					Schema: map[string]*pluginsdk.Schema{
-						"username": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
-						"password": {
-							Type:      pluginsdk.TypeString,
-							Computed:  true,
-							Sensitive: true,
-						},
+					"value": {
+						Type:      pluginsdk.TypeString,
+						Required:  true,
+						Sensitive: true,
 					},
 				},
 			},
 		},
-	}
 
-	if !features.FivePointOh() {
-		// Due to the way the `site_config.public_network_access_enabled` property and the `public_network_access` property
-		// influence each other, the default needs to be handled in the Create for now until `site_config.public_network_access_enabled`
-		// is removed in v5.0
-		resource.Schema["public_network_access"].Default = nil
-		resource.Schema["public_network_access"].Computed = true
+		"storage_account_name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: storageValidate.StorageAccountName,
+		},
+
+		"storage_account_access_key": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			Sensitive:    true,
+			ValidateFunc: validation.NoZeroValues,
+		},
+
+		"public_network_access": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Default:  helpers.PublicNetworkAccessEnabled,
+			ValidateFunc: validation.StringInSlice([]string{
+				helpers.PublicNetworkAccessEnabled,
+				helpers.PublicNetworkAccessDisabled,
+			}, false),
+		},
+
+		"storage_account_share_name": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Computed: true,
+		},
+
+		"version": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Default:  "~4",
+		},
+
+		"vnet_content_share_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+		},
+
+		"virtual_network_subnet_id": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: commonids.ValidateSubnetID,
+		},
+
+		"tags": commonschema.Tags(),
 	}
-	return resource
 }
 
-func resourceLogicAppStandardCreate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).AppService.WebAppsClient
-	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
-	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
-	defer cancel()
+func (r LogicAppResource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"custom_domain_verification_id": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
 
-	resourcesClient := meta.(*clients.Client).AppService.ResourceProvidersClient
+		"default_hostname": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
 
-	env := meta.(*clients.Client).Account.Environment
-	storageAccountDomainSuffix, ok := env.Storage.DomainSuffix()
-	if !ok {
-		return fmt.Errorf("could not determine the domain suffix for storage accounts in environment %q: %+v", env.Name, env.Storage)
-	}
+		"kind": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
 
-	log.Printf("[INFO] preparing arguments for AzureRM Logic App Standard creation.")
+		"outbound_ip_addresses": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
 
-	id := commonids.NewAppServiceID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
-	existing, err := client.Get(ctx, id)
-	if err != nil {
-		if !response.WasNotFound(existing.HttpResponse) {
-			return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
-		}
-	}
+		"possible_outbound_ip_addresses": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
 
-	if !response.WasNotFound(existing.HttpResponse) {
-		return tf.ImportAsExistsError("azurerm_logic_app_standard", id.ID())
-	}
-
-	availabilityRequest := resourceproviders.ResourceNameAvailabilityRequest{
-		Name: id.SiteName,
-		Type: resourceproviders.CheckNameResourceTypesMicrosoftPointWebSites,
-	}
-
-	available, err := resourcesClient.CheckNameAvailability(ctx, commonids.NewSubscriptionID(subscriptionId), availabilityRequest)
-	if err != nil {
-		return fmt.Errorf("checking if name %q was available: %+v", id.SiteName, err)
-	}
-
-	if available.Model == nil || available.Model.NameAvailable == nil {
-		return fmt.Errorf("checking if name %q was available: `model` was nil", id.SiteName)
-	}
-
-	if !*available.Model.NameAvailable {
-		return fmt.Errorf("the name %q used for the Logic App Standard needs to be globally unique and isn't available: %+v", id.SiteName, pointer.From(available.Model.Message))
-	}
-
-	clientCertMode := d.Get("client_certificate_mode").(string)
-	clientCertEnabled := clientCertMode != ""
-
-	basicAppSettings, err := getBasicLogicAppSettings(d, *storageAccountDomainSuffix)
-	if err != nil {
-		return err
-	}
-
-	siteConfig, err := expandLogicAppStandardSiteConfig(d)
-	if err != nil {
-		return fmt.Errorf("expanding `site_config`: %+v", err)
-	}
-
-	kind := "functionapp,workflowapp"
-	if siteConfig.LinuxFxVersion != nil && len(*siteConfig.LinuxFxVersion) > 0 {
-		kind = "functionapp,linux,container,workflowapp"
-	}
-
-	// Some appSettings declared by user are required at creation time so we will combine both settings
-	appSettings := expandAppSettings(d)
-	appSettings = append(appSettings, basicAppSettings...)
-
-	siteConfig.AppSettings = &appSettings
-
-	siteEnvelope := webapps.Site{
-		Kind:     &kind,
-		Location: location.Normalize(d.Get("location").(string)),
-		Tags:     tags.Expand(d.Get("tags").(map[string]interface{})),
-		Properties: &webapps.SiteProperties{
-			ServerFarmId:            pointer.To(d.Get("app_service_plan_id").(string)),
-			Enabled:                 pointer.To(d.Get("enabled").(bool)),
-			ClientAffinityEnabled:   pointer.To(d.Get("client_affinity_enabled").(bool)),
-			ClientCertEnabled:       pointer.To(clientCertEnabled),
-			HTTPSOnly:               pointer.To(d.Get("https_only").(bool)),
-			SiteConfig:              &siteConfig,
-			VnetContentShareEnabled: pointer.To(d.Get("vnet_content_share_enabled").(bool)),
+		"site_credential": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"username": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+					"password": {
+						Type:      pluginsdk.TypeString,
+						Computed:  true,
+						Sensitive: true,
+					},
+				},
+			},
 		},
 	}
-
-	publicNetworkAccess := d.Get("public_network_access").(string)
-	if !features.FivePointOh() {
-		// if a user is still using `site_config.public_network_access_enabled` we should be setting `public_network_access` for them
-		publicNetworkAccess = reconcilePNA(d)
-		if v := siteEnvelope.Properties.SiteConfig.PublicNetworkAccess; v != nil && *v == helpers.PublicNetworkAccessDisabled {
-			publicNetworkAccess = helpers.PublicNetworkAccessDisabled
-		}
-	}
-
-	// conversely if `public_network_access` has been set it should take precedence, and we should be propagating the value for that to `site_config.public_network_access_enabled`
-	if publicNetworkAccess == helpers.PublicNetworkAccessDisabled {
-		siteEnvelope.Properties.SiteConfig.PublicNetworkAccess = pointer.To(helpers.PublicNetworkAccessDisabled)
-	} else if publicNetworkAccess == helpers.PublicNetworkAccessEnabled {
-		siteEnvelope.Properties.SiteConfig.PublicNetworkAccess = pointer.To(helpers.PublicNetworkAccessEnabled)
-	}
-
-	siteEnvelope.Properties.PublicNetworkAccess = pointer.To(publicNetworkAccess)
-
-	if clientCertEnabled {
-		siteEnvelope.Properties.ClientCertMode = pointer.To(webapps.ClientCertMode(clientCertMode))
-	}
-
-	if v := d.Get("virtual_network_subnet_id").(string); v != "" {
-		siteEnvelope.Properties.VirtualNetworkSubnetId = pointer.To(v)
-	}
-
-	if _, ok := d.GetOk("identity"); ok {
-		expandedIdentity, err := identity.ExpandSystemAndUserAssignedMap(d.Get("identity").([]interface{}))
-		if err != nil {
-			return fmt.Errorf("expanding `identity`: %+v", err)
-		}
-		siteEnvelope.Identity = expandedIdentity
-	}
-
-	if err := client.CreateOrUpdateThenPoll(ctx, id, siteEnvelope); err != nil {
-		return fmt.Errorf("creating %s: %+v", id, err)
-	}
-
-	d.SetId(id.ID())
-
-	// This setting is enabled by default on creation of a logic app, we only need to update if config sets this as `false`
-	if ftpAuth := d.Get("ftp_publish_basic_authentication_enabled").(bool); !ftpAuth {
-		policy := webapps.CsmPublishingCredentialsPoliciesEntity{
-			Properties: &webapps.CsmPublishingCredentialsPoliciesEntityProperties{
-				Allow: ftpAuth,
-			},
-		}
-
-		if _, err := client.UpdateFtpAllowed(ctx, id, policy); err != nil {
-			return fmt.Errorf("updating FTP publish basic authentication policy for %s: %+v", id, err)
-		}
-	}
-
-	// This setting is enabled by default on creation of a logic app, we only need to update if config sets this as `false`
-	if scmAuth := d.Get("scm_publish_basic_authentication_enabled").(bool); !scmAuth {
-		policy := webapps.CsmPublishingCredentialsPoliciesEntity{
-			Properties: &webapps.CsmPublishingCredentialsPoliciesEntityProperties{
-				Allow: scmAuth,
-			},
-		}
-
-		if _, err := client.UpdateScmAllowed(ctx, id, policy); err != nil {
-			return fmt.Errorf("updating SCM publish basic authentication policy for %s: %+v", id, err)
-		}
-	}
-
-	return resourceLogicAppStandardUpdate(d, meta)
 }
 
-func resourceLogicAppStandardUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).AppService.WebAppsClient
-	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
-	defer cancel()
+func (r LogicAppResource) ModelObject() interface{} {
+	return &LogicAppResourceModel{}
+}
 
-	env := meta.(*clients.Client).Account.Environment
-	storageAccountDomainSuffix, ok := env.Storage.DomainSuffix()
-	if !ok {
-		return fmt.Errorf("could not determine the domain suffix for storage accounts in environment %q: %+v", env.Name, env.Storage)
-	}
+func (r LogicAppResource) ResourceType() string {
+	return "azurerm_logic_app_standard"
+}
 
-	id, err := commonids.ParseLogicAppId(d.Id())
-	if err != nil {
-		return err
-	}
+func (r LogicAppResource) Create() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.AppService.WebAppsClient
+			resourcesClient := metadata.Client.AppService.ResourceProvidersClient
+			servicePlanClient := metadata.Client.AppService.ServicePlanClient
+			aseClient := metadata.Client.AppService.AppServiceEnvironmentClient
+			subscriptionId := metadata.Client.Account.SubscriptionId
 
-	clientCertMode := d.Get("client_certificate_mode").(string)
-	clientCertEnabled := clientCertMode != ""
-
-	basicAppSettings, err := getBasicLogicAppSettings(d, *storageAccountDomainSuffix)
-	if err != nil {
-		return err
-	}
-
-	siteConfig, err := expandLogicAppStandardSiteConfig(d)
-	if err != nil {
-		return fmt.Errorf("expanding `site_config`: %+v", err)
-	}
-
-	kind := "functionapp,workflowapp"
-	if siteConfig.LinuxFxVersion != nil && len(*siteConfig.LinuxFxVersion) > 0 {
-		kind = "functionapp,linux,container,workflowapp"
-	}
-
-	siteConfig.AppSettings = &basicAppSettings
-
-	// WEBSITE_VNET_ROUTE_ALL is superseded by a setting in site_config that defaults to false from 2021-02-01
-	appSettings, err := expandLogicAppStandardSettings(d, *storageAccountDomainSuffix)
-	if err != nil {
-		return fmt.Errorf("expanding `app_settings`: %+v", err)
-	}
-	if vnetRouteAll, ok := appSettings["WEBSITE_VNET_ROUTE_ALL"]; ok {
-		if !d.HasChange("site_config.0.vnet_route_all_enabled") {
-			vnetRouteAllEnabled, _ := strconv.ParseBool(vnetRouteAll)
-			siteConfig.VnetRouteAllEnabled = &vnetRouteAllEnabled
-		}
-	}
-
-	siteEnvelope := webapps.Site{
-		Kind:     &kind,
-		Location: location.Normalize(d.Get("location").(string)),
-		Tags:     tags.Expand(d.Get("tags").(map[string]interface{})),
-		Properties: &webapps.SiteProperties{
-			ServerFarmId:          pointer.To(d.Get("app_service_plan_id").(string)),
-			Enabled:               pointer.To(d.Get("enabled").(bool)),
-			ClientAffinityEnabled: pointer.To(d.Get("client_affinity_enabled").(bool)),
-			ClientCertEnabled:     pointer.To(clientCertEnabled),
-			HTTPSOnly:             pointer.To(d.Get("https_only").(bool)),
-			PublicNetworkAccess:   pointer.To(d.Get("public_network_access").(string)),
-			SiteConfig:            &siteConfig,
-		},
-	}
-
-	if d.HasChange("public_network_access") {
-		publicNetworkAccess := d.Get("public_network_access").(string)
-		siteEnvelope.Properties.PublicNetworkAccess = pointer.To(publicNetworkAccess)
-		if publicNetworkAccess == helpers.PublicNetworkAccessEnabled {
-			siteEnvelope.Properties.SiteConfig.PublicNetworkAccess = pointer.To(helpers.PublicNetworkAccessEnabled)
-		} else {
-			siteEnvelope.Properties.SiteConfig.PublicNetworkAccess = pointer.To(helpers.PublicNetworkAccessDisabled)
-		}
-	}
-
-	if d.HasChange("vnet_content_share_enabled") {
-		siteEnvelope.Properties.VnetContentShareEnabled = pointer.To(d.Get("vnet_content_share_enabled").(bool))
-	}
-
-	if !features.FivePointOh() { // Until 5.0 the site_config value of this must be reflected back into the top-level property if not set there
-		siteConfig.PublicNetworkAccess = pointer.To(reconcilePNA(d))
-	}
-
-	if clientCertEnabled {
-		siteEnvelope.Properties.ClientCertMode = pointer.To(webapps.ClientCertMode(clientCertMode))
-	}
-
-	if d.HasChange("virtual_network_subnet_id") {
-		subnetId := d.Get("virtual_network_subnet_id").(string)
-		if subnetId == "" {
-			if _, err := client.DeleteSwiftVirtualNetwork(ctx, *id); err != nil {
-				return fmt.Errorf("removing `virtual_network_subnet_id` association for %s: %+v", *id, err)
+			env := metadata.Client.Account.Environment
+			storageAccountDomainSuffix, ok := env.Storage.DomainSuffix()
+			if !ok {
+				return fmt.Errorf("could not determine the domain suffix for storage accounts in environment %q: %+v", env.Name, env.Storage)
 			}
-			var empty *string
-			siteEnvelope.Properties.VirtualNetworkSubnetId = empty
-		} else {
-			siteEnvelope.Properties.VirtualNetworkSubnetId = pointer.To(subnetId)
-		}
-	}
 
-	if _, ok := d.GetOk("identity"); ok {
-		expandedIdentity, err := identity.ExpandSystemAndUserAssignedMap(d.Get("identity").([]interface{}))
-		if err != nil {
-			return fmt.Errorf("expanding `identity`: %+v", err)
-		}
-		siteEnvelope.Identity = expandedIdentity
-	}
+			data := LogicAppResourceModel{}
 
-	if err := client.CreateOrUpdateThenPoll(ctx, *id, siteEnvelope); err != nil {
-		return fmt.Errorf("updating %s: %+v", *id, err)
-	}
+			if err := metadata.Decode(&data); err != nil {
+				return err
+			}
 
-	if d.HasChange("site_config") || (d.HasChange("public_network_access") && !features.FivePointOh()) { // update siteConfig before appSettings in case the appSettings get covered by basicAppSettings
-		siteConfigResource := webapps.SiteConfigResource{
-			Properties: &siteConfig,
-		}
+			id := commonids.NewAppServiceID(subscriptionId, data.ResourceGroupName, data.Name)
+			existing, err := client.Get(ctx, id)
+			if err != nil {
+				if !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+				}
+			}
 
-		if _, err := client.CreateOrUpdateConfiguration(ctx, *id, siteConfigResource); err != nil {
-			return fmt.Errorf("updating Configuration for %s: %+v", *id, err)
-		}
-	}
+			if !response.WasNotFound(existing.HttpResponse) {
+				return tf.ImportAsExistsError("azurerm_logic_app_standard", id.ID())
+			}
 
-	settings := webapps.StringDictionary{
-		Properties: pointer.To(appSettings),
-	}
-
-	if _, err = client.UpdateApplicationSettings(ctx, *id, settings); err != nil {
-		return fmt.Errorf("updating Application Settings for %s: %+v", *id, err)
-	}
-
-	if d.HasChange("connection_string") {
-		connectionStrings := expandLogicAppStandardConnectionStrings(d)
-		properties := webapps.ConnectionStringDictionary{
-			Properties: pointer.To(connectionStrings),
-		}
-
-		if _, err := client.UpdateConnectionStrings(ctx, *id, properties); err != nil {
-			return fmt.Errorf("updating Connection Strings for %s: %+v", *id, err)
-		}
-	}
-
-	// HasChange will return `true` when config specifies this argument as `true` during initial creation.
-	// To avoid unnecessary updates, check if the resource is new.
-	if d.HasChange("ftp_publish_basic_authentication_enabled") && !d.IsNewResource() {
-		policy := webapps.CsmPublishingCredentialsPoliciesEntity{
-			Properties: &webapps.CsmPublishingCredentialsPoliciesEntityProperties{
-				Allow: d.Get("ftp_publish_basic_authentication_enabled").(bool),
-			},
-		}
-
-		if _, err := client.UpdateFtpAllowed(ctx, *id, policy); err != nil {
-			return fmt.Errorf("updating FTP publish basic authentication policy for %s: %+v", id, err)
-		}
-	}
-
-	// HasChange will return `true` when config specifies this argument as `true` during initial creation.
-	// To avoid unnecessary updates, check if the resource is new.
-	if d.HasChange("scm_publish_basic_authentication_enabled") && !d.IsNewResource() {
-		policy := webapps.CsmPublishingCredentialsPoliciesEntity{
-			Properties: &webapps.CsmPublishingCredentialsPoliciesEntityProperties{
-				Allow: d.Get("scm_publish_basic_authentication_enabled").(bool),
-			},
-		}
-
-		if _, err := client.UpdateScmAllowed(ctx, *id, policy); err != nil {
-			return fmt.Errorf("updating SCM publish basic authentication policy for %s: %+v", id, err)
-		}
-	}
-
-	return resourceLogicAppStandardRead(d, meta)
-}
-
-func resourceLogicAppStandardRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).AppService.WebAppsClient
-	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
-	defer cancel()
-
-	id, err := commonids.ParseLogicAppId(d.Id())
-	if err != nil {
-		return err
-	}
-
-	resp, err := client.Get(ctx, *id)
-	if err != nil {
-		if response.WasNotFound(resp.HttpResponse) {
-			log.Printf("[DEBUG] %s was not found - removing from state", *id)
-			d.SetId("")
-			return nil
-		}
-		return fmt.Errorf("retrieving %s: %+v", *id, err)
-	}
-
-	d.Set("name", id.SiteName)
-	d.Set("resource_group_name", id.ResourceGroupName)
-
-	if model := resp.Model; model != nil {
-		d.Set("kind", pointer.From(model.Kind))
-		d.Set("location", location.Normalize(model.Location))
-
-		flattenedIdentity, err := identity.FlattenSystemAndUserAssignedMap(model.Identity)
-		if err != nil {
-			return fmt.Errorf("flattening `identity`: %+v", err)
-		}
-		if err := d.Set("identity", flattenedIdentity); err != nil {
-			return fmt.Errorf("setting `identity`: %s", err)
-		}
-
-		if err := tags.FlattenAndSet(d, model.Tags); err != nil {
-			return fmt.Errorf("setting `tags`: %+v", err)
-		}
-
-		if props := model.Properties; props != nil {
-			servicePlanId, err := commonids.ParseAppServicePlanIDInsensitively(*props.ServerFarmId)
+			servicePlanId, err := commonids.ParseAppServicePlanID(data.AppServicePlanId)
 			if err != nil {
 				return err
 			}
-			d.Set("app_service_plan_id", servicePlanId.ID())
-			d.Set("enabled", pointer.From(props.Enabled))
-			d.Set("default_hostname", pointer.From(props.DefaultHostName))
-			d.Set("https_only", pointer.From(props.HTTPSOnly))
-			d.Set("outbound_ip_addresses", pointer.From(props.OutboundIPAddresses))
-			d.Set("possible_outbound_ip_addresses", pointer.From(props.PossibleOutboundIPAddresses))
-			d.Set("client_affinity_enabled", pointer.From(props.ClientAffinityEnabled))
-			d.Set("custom_domain_verification_id", pointer.From(props.CustomDomainVerificationId))
-			d.Set("virtual_network_subnet_id", pointer.From(props.VirtualNetworkSubnetId))
-			d.Set("vnet_content_share_enabled", pointer.From(props.VnetContentShareEnabled))
-			d.Set("public_network_access", pointer.From(props.PublicNetworkAccess))
 
-			clientCertMode := ""
-			if props.ClientCertEnabled != nil && *props.ClientCertEnabled {
-				clientCertMode = string(pointer.From(props.ClientCertMode))
+			servicePlan, err := servicePlanClient.Get(ctx, *servicePlanId)
+			if err != nil {
+				return fmt.Errorf("reading %s: %+v", servicePlanId, err)
 			}
-			d.Set("client_certificate_mode", clientCertMode)
-		}
-	}
 
-	appSettingsResp, err := client.ListApplicationSettings(ctx, *id)
-	if err != nil {
-		return fmt.Errorf("listing application settings for %s: %+v", *id, err)
-	}
+			availabilityRequest := resourceproviders.ResourceNameAvailabilityRequest{
+				Name: data.Name,
+				Type: resourceproviders.CheckNameResourceTypesMicrosoftPointWebSites,
+			}
+			if servicePlanModel := servicePlan.Model; servicePlanModel != nil {
+				if ase := servicePlanModel.Properties.HostingEnvironmentProfile; ase != nil {
+					// Attempt to check the ASE for the appropriate suffix for the name availability request.
+					// This varies between internal and external ASE Types, and potentially has other names in other clouds
+					// We use the "internal" as the fallback here, if we can read the ASE, we'll get the full one
+					nameSuffix := "appserviceenvironment.net"
+					if ase.Id != nil {
+						aseId, err := commonids.ParseAppServiceEnvironmentIDInsensitively(*ase.Id)
+						nameSuffix = fmt.Sprintf("%s.%s", aseId.HostingEnvironmentName, nameSuffix)
+						if err != nil {
+							metadata.Logger.Warnf("could not parse App Service Environment ID determine FQDN for name availability check, defaulting to `%s.%s.appserviceenvironment.net`", data.Name, servicePlanId)
+						} else {
+							existingASE, err := aseClient.Get(ctx, *aseId)
+							if err != nil || existingASE.Model == nil {
+								metadata.Logger.Warnf("could not read App Service Environment to determine FQDN for name availability check, defaulting to `%s.%s.appserviceenvironment.net`", data.Name, servicePlanId)
+							} else if props := existingASE.Model.Properties; props != nil && props.DnsSuffix != nil && *props.DnsSuffix != "" {
+								nameSuffix = *props.DnsSuffix
+							}
+						}
+					}
 
-	if model := appSettingsResp.Model; model != nil {
-		appSettings := pointer.From(model.Properties)
-
-		connectionString := appSettings["AzureWebJobsStorage"]
-
-		// This teases out the necessary attributes from the storage connection string
-		connectionStringParts := strings.Split(connectionString, ";")
-		for _, part := range connectionStringParts {
-			if strings.HasPrefix(part, "AccountName") {
-				accountNameParts := strings.Split(part, "AccountName=")
-				if len(accountNameParts) > 1 {
-					d.Set("storage_account_name", accountNameParts[1])
+					availabilityRequest.Name = fmt.Sprintf("%s.%s", data.Name, nameSuffix)
+					availabilityRequest.IsFqdn = pointer.To(true)
 				}
 			}
-			if strings.HasPrefix(part, "AccountKey") {
-				accountKeyParts := strings.Split(part, "AccountKey=")
-				if len(accountKeyParts) > 1 {
-					d.Set("storage_account_access_key", accountKeyParts[1])
+
+			subId := commonids.NewSubscriptionID(subscriptionId)
+
+			checkName, err := resourcesClient.CheckNameAvailability(ctx, subId, availabilityRequest)
+			if err != nil {
+				return fmt.Errorf("checking name availability for Linux %s: %+v", id, err)
+			}
+			if model := checkName.Model; model != nil && model.NameAvailable != nil && !*model.NameAvailable {
+				return fmt.Errorf("the Site Name %q failed the availability check: %+v", id.SiteName, *model.Message)
+			}
+
+			clientCertEnabled := data.ClientCertificateMode != ""
+
+			basicAppSettings, err := getBasicLogicAppSettings(data, *storageAccountDomainSuffix)
+			if err != nil {
+				return err
+			}
+
+			siteConfig, err := expandLogicAppStandardSiteConfigForCreate(data.SiteConfig, metadata)
+			if err != nil {
+				return fmt.Errorf("expanding `site_config`: %+v", err)
+			}
+
+			kind := LogicAppStdKind
+			if siteConfig.LinuxFxVersion != nil && len(*siteConfig.LinuxFxVersion) > 0 {
+				kind = LogicAppLinuxKind
+			}
+
+			appSettings := expandAppSettings(data.AppSettings)
+			appSettings = append(appSettings, basicAppSettings...)
+
+			siteConfig.AppSettings = pointer.To(appSettings)
+
+			expandedIdentity, err := identity.ExpandSystemAndUserAssignedMapFromModel(data.Identity)
+			if err != nil {
+				return fmt.Errorf("expanding `identity`: %+v", err)
+			}
+
+			siteEnvelope := webapps.Site{
+				Identity: expandedIdentity,
+				Kind:     pointer.To(kind),
+				Location: location.Normalize(data.Location),
+				Properties: &webapps.SiteProperties{
+					ServerFarmId:            pointer.To(data.AppServicePlanId),
+					Enabled:                 pointer.To(data.Enabled),
+					ClientAffinityEnabled:   pointer.To(data.ClientAffinityEnabled),
+					ClientCertEnabled:       pointer.To(clientCertEnabled),
+					HTTPSOnly:               pointer.To(data.HTTPSOnly),
+					SiteConfig:              siteConfig,
+					VnetContentShareEnabled: pointer.To(data.VNETContentShareEnabled),
+				},
+				Tags: pointer.To(data.Tags),
+			}
+
+			publicNetworkAccess := data.PublicNetworkAccess
+			if !features.FivePointOh() {
+				// if a user is still using `site_config.public_network_access_enabled` we should be setting `public_network_access` for them
+				publicNetworkAccess = reconcilePNA(metadata)
+				if v := siteEnvelope.Properties.SiteConfig.PublicNetworkAccess; v != nil && *v == helpers.PublicNetworkAccessDisabled {
+					publicNetworkAccess = helpers.PublicNetworkAccessDisabled
 				}
 			}
-		}
 
-		d.Set("version", appSettings["FUNCTIONS_EXTENSION_VERSION"])
-
-		if _, ok := appSettings["AzureFunctionsJobHost__extensionBundle__id"]; ok {
-			d.Set("use_extension_bundle", true)
-			if val, ok := appSettings["AzureFunctionsJobHost__extensionBundle__version"]; ok {
-				d.Set("bundle_version", val)
+			// conversely if `public_network_access` has been set it should take precedence, and we should be propagating the value for that to `site_config.public_network_access_enabled`
+			if publicNetworkAccess == helpers.PublicNetworkAccessDisabled {
+				siteEnvelope.Properties.SiteConfig.PublicNetworkAccess = pointer.To(helpers.PublicNetworkAccessDisabled)
+			} else if publicNetworkAccess == helpers.PublicNetworkAccessEnabled {
+				siteEnvelope.Properties.SiteConfig.PublicNetworkAccess = pointer.To(helpers.PublicNetworkAccessEnabled)
 			}
-		} else {
-			d.Set("use_extension_bundle", false)
-			d.Set("bundle_version", "[1.*, 2.0.0)")
-		}
 
-		d.Set("storage_account_share_name", appSettings["WEBSITE_CONTENTSHARE"])
+			siteEnvelope.Properties.PublicNetworkAccess = pointer.To(publicNetworkAccess)
 
-		// Remove all the settings that are created by this resource so we don't to have to specify in app_settings
-		// block whenever we use azurerm_logic_app_standard.
-		delete(appSettings, "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING")
-		delete(appSettings, "APP_KIND")
-		delete(appSettings, "AzureFunctionsJobHost__extensionBundle__id")
-		delete(appSettings, "AzureFunctionsJobHost__extensionBundle__version")
-		delete(appSettings, "AzureWebJobsDashboard")
-		delete(appSettings, "AzureWebJobsStorage")
-		delete(appSettings, "FUNCTIONS_EXTENSION_VERSION")
-		delete(appSettings, "WEBSITE_CONTENTSHARE")
+			if clientCertEnabled {
+				siteEnvelope.Properties.ClientCertMode = pointer.ToEnum[webapps.ClientCertMode](data.ClientCertificateMode)
+			}
 
-		if err = d.Set("app_settings", appSettings); err != nil {
-			return err
-		}
+			if data.VirtualNetworkSubnetId != "" {
+				siteEnvelope.Properties.VirtualNetworkSubnetId = pointer.To(data.VirtualNetworkSubnetId)
+			}
+
+			if err := client.CreateOrUpdateThenPoll(ctx, id, siteEnvelope); err != nil {
+				return fmt.Errorf("creating %s: %+v", id, err)
+			}
+
+			metadata.SetID(id)
+
+			if !data.FtpPublishBasicAuthEnabled {
+				policy := webapps.CsmPublishingCredentialsPoliciesEntity{
+					Properties: &webapps.CsmPublishingCredentialsPoliciesEntityProperties{
+						Allow: data.FtpPublishBasicAuthEnabled,
+					},
+				}
+
+				if _, err := client.UpdateFtpAllowed(ctx, id, policy); err != nil {
+					return fmt.Errorf("updating FTP publish basic authentication policy for %s: %+v", id, err)
+				}
+			}
+
+			if !data.SCMPublishBasicAuthEnabled {
+				policy := webapps.CsmPublishingCredentialsPoliciesEntity{
+					Properties: &webapps.CsmPublishingCredentialsPoliciesEntityProperties{
+						Allow: data.SCMPublishBasicAuthEnabled,
+					},
+				}
+
+				if _, err := client.UpdateScmAllowed(ctx, id, policy); err != nil {
+					return fmt.Errorf("updating FTP publish basic authentication policy for %s: %+v", id, err)
+				}
+			}
+
+			connectionStrings := helpers.ExpandConnectionStrings(data.ConnectionStrings)
+			if connectionStrings.Properties != nil {
+				if _, err := client.UpdateConnectionStrings(ctx, id, *connectionStrings); err != nil {
+					return fmt.Errorf("setting Connection Strings for Linux %s: %+v", id, err)
+				}
+			}
+
+			return nil
+		},
 	}
-
-	connectionStringsResp, err := client.ListConnectionStrings(ctx, *id)
-	if err != nil {
-		return fmt.Errorf("listing connection strings for %s: %+v", *id, err)
-	}
-
-	if model := connectionStringsResp.Model; model != nil {
-		if err = d.Set("connection_string", flattenLogicAppStandardConnectionStrings(model.Properties)); err != nil {
-			return err
-		}
-	}
-
-	ftpBasicAuth, err := client.GetFtpAllowed(ctx, *id)
-	if err != nil || ftpBasicAuth.Model == nil {
-		return fmt.Errorf("retrieving FTP publish basic authentication policy for %s: %+v", id, err)
-	}
-
-	if props := ftpBasicAuth.Model.Properties; props != nil {
-		d.Set("ftp_publish_basic_authentication_enabled", props.Allow)
-	}
-
-	scmBasicAuth, err := client.GetScmAllowed(ctx, *id)
-	if err != nil || scmBasicAuth.Model == nil {
-		return fmt.Errorf("retrieving SCM publish basic authentication policy for %s: %+v", id, err)
-	}
-
-	if props := scmBasicAuth.Model.Properties; props != nil {
-		d.Set("scm_publish_basic_authentication_enabled", props.Allow)
-	}
-
-	siteCredentials, err := helpers.ListPublishingCredentials(ctx, client, *id)
-	if err != nil {
-		return fmt.Errorf("listing publishing credentials for %s: %+v", *id, err)
-	}
-
-	if err = d.Set("site_credential", flattenLogicAppStandardSiteCredential(siteCredentials)); err != nil {
-		return err
-	}
-
-	configResp, err := client.GetConfiguration(ctx, *id)
-	if err != nil {
-		return fmt.Errorf("retrieving the configuration for %s: %+v", *id, err)
-	}
-
-	if model := configResp.Model; model != nil {
-		siteConfig := flattenLogicAppStandardSiteConfig(model.Properties)
-		if err = d.Set("site_config", siteConfig); err != nil {
-			return err
-		}
-	}
-
-	return nil
 }
 
-func resourceLogicAppStandardDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).AppService.WebAppsClient
-	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
-	defer cancel()
+func (r LogicAppResource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.AppService.WebAppsClient
 
-	id, err := commonids.ParseLogicAppId(d.Id())
-	if err != nil {
-		return err
+			var state LogicAppResourceModel
+
+			id, err := commonids.ParseLogicAppId(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.Get(ctx, *id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return metadata.MarkAsGone(id)
+				}
+				return fmt.Errorf("reading Linux %s: %+v", id, err)
+			}
+
+			state.Name = id.SiteName
+			state.ResourceGroupName = id.ResourceGroupName
+
+			if model := resp.Model; model != nil {
+				state.Kind = pointer.From(model.Kind)
+				state.Location = location.Normalize(model.Location)
+				ident, err := identity.FlattenSystemAndUserAssignedMapToModel(model.Identity)
+				if err != nil {
+					return err
+				}
+				state.Identity = pointer.From(ident)
+				state.Tags = pointer.From(model.Tags)
+				if props := model.Properties; props != nil {
+					servicePlanId, err := commonids.ParseAppServicePlanIDInsensitively(*props.ServerFarmId)
+					if err != nil {
+						return err
+					}
+
+					state.AppServicePlanId = servicePlanId.ID()
+					state.Enabled = pointer.From(props.Enabled)
+					state.DefaultHostname = pointer.From(props.DefaultHostName)
+					state.HTTPSOnly = pointer.From(props.HTTPSOnly)
+					state.OutboundIpAddresses = pointer.From(props.OutboundIPAddresses)
+					state.PossibleOutboundIpAddresses = pointer.From(props.PossibleOutboundIPAddresses)
+					state.ClientAffinityEnabled = pointer.From(props.ClientAffinityEnabled)
+					state.CustomDomainVerificationId = pointer.From(props.CustomDomainVerificationId)
+					state.VirtualNetworkSubnetId = pointer.From(props.VirtualNetworkSubnetId)
+					state.VNETContentShareEnabled = pointer.From(props.VnetContentShareEnabled)
+					state.PublicNetworkAccess = pointer.From(props.PublicNetworkAccess)
+					state.ClientCertificateMode = pointer.FromEnum(props.ClientCertMode)
+				}
+			}
+
+			appSettingsResp, err := client.ListApplicationSettings(ctx, *id)
+			if err != nil {
+				return fmt.Errorf("listing application settings for %s: %+v", *id, err)
+			}
+
+			if model := appSettingsResp.Model; model != nil {
+				appSettings := pointer.From(model.Properties)
+
+				connectionString := appSettings["AzureWebJobsStorage"]
+
+				for _, part := range strings.Split(connectionString, ";") {
+					if strings.HasPrefix(part, "AccountName") {
+						accountNameParts := strings.Split(part, "AccountName=")
+						if len(accountNameParts) > 1 {
+							state.StorageAccountName = accountNameParts[1]
+						}
+					}
+					if strings.HasPrefix(part, "AccountKey") {
+						accountKeyParts := strings.Split(part, "AccountKey=")
+						if len(accountKeyParts) > 1 {
+							state.StorageAccountAccessKey = accountKeyParts[1]
+						}
+					}
+				}
+
+				if v, ok := appSettings["FUNCTIONS_EXTENSION_VERSION"]; ok {
+					state.Version = v
+				}
+
+				if _, ok := appSettings["AzureFunctionsJobHost__extensionBundle__id"]; ok {
+					state.UseExtensionBundle = true
+
+					if val, ok := appSettings["AzureFunctionsJobHost__extensionBundle__version"]; ok {
+						state.BundleVersion = val
+					}
+				} else {
+					state.UseExtensionBundle = false
+					state.BundleVersion = "[1.*, 2.0.0)"
+				}
+
+				state.StorageAccountShareName = appSettings["WEBSITE_CONTENTSHARE"]
+				delete(appSettings, "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING")
+				delete(appSettings, "APP_KIND")
+				delete(appSettings, "AzureFunctionsJobHost__extensionBundle__id")
+				delete(appSettings, "AzureFunctionsJobHost__extensionBundle__version")
+				delete(appSettings, "AzureWebJobsDashboard")
+				delete(appSettings, "AzureWebJobsStorage")
+				delete(appSettings, "FUNCTIONS_EXTENSION_VERSION")
+				delete(appSettings, "WEBSITE_CONTENTSHARE")
+
+				state.AppSettings = appSettings
+			}
+
+			connectionStringsResp, err := client.ListConnectionStrings(ctx, *id)
+			if err != nil {
+				return fmt.Errorf("listing connection strings for %s: %+v", *id, err)
+			}
+
+			if model := connectionStringsResp.Model; model != nil {
+				state.ConnectionStrings = helpers.FlattenConnectionStrings(model)
+			}
+
+			ftpBasicAuth, err := client.GetFtpAllowed(ctx, *id)
+			if err != nil || ftpBasicAuth.Model == nil {
+				return fmt.Errorf("retrieving FTP publish basic authentication policy for %s: %+v", id, err)
+			}
+
+			if props := ftpBasicAuth.Model.Properties; props != nil {
+				state.FtpPublishBasicAuthEnabled = props.Allow
+			}
+
+			scmBasicAuth, err := client.GetScmAllowed(ctx, *id)
+			if err != nil || scmBasicAuth.Model == nil {
+				return fmt.Errorf("retrieving SCM publish basic authentication policy for %s: %+v", id, err)
+			}
+
+			if props := scmBasicAuth.Model.Properties; props != nil {
+				state.SCMPublishBasicAuthEnabled = props.Allow
+			}
+
+			siteCredentials, err := helpers.ListPublishingCredentials(ctx, client, *id)
+			if err != nil {
+				return fmt.Errorf("listing publishing credentials for %s: %+v", *id, err)
+			}
+
+			state.SiteCredential = helpers.FlattenSiteCredentialsLogicApp(siteCredentials)
+
+			configResp, err := client.GetConfiguration(ctx, *id)
+			if err != nil {
+				return fmt.Errorf("retrieving the configuration for %s: %+v", *id, err)
+			}
+
+			if model := configResp.Model; model != nil {
+				state.SiteConfig = flattenLogicAppStandardSiteConfig(model.Properties)
+			}
+
+			return metadata.Encode(&state)
+		},
 	}
-
-	opts := webapps.DefaultDeleteOperationOptions()
-	opts.DeleteMetrics = pointer.To(true)
-	opts.DeleteEmptyServerFarm = pointer.To(false)
-
-	if _, err := client.Delete(ctx, *id, opts); err != nil {
-		return fmt.Errorf("deleting %s: %+v", *id, err)
-	}
-
-	return nil
 }
 
-func getBasicLogicAppSettings(d *pluginsdk.ResourceData, endpointSuffix string) ([]webapps.NameValuePair, error) {
+func (r LogicAppResource) Delete() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.AppService.WebAppsClient
+			id, err := commonids.ParseLogicAppId(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			metadata.Logger.Infof("deleting Linux %s", *id)
+
+			delOptions := webapps.DeleteOperationOptions{
+				DeleteMetrics:         pointer.To(true),
+				DeleteEmptyServerFarm: pointer.To(false),
+			}
+
+			if _, err = client.Delete(ctx, *id, delOptions); err != nil {
+				return fmt.Errorf("deleting %s: %+v", id, err)
+			}
+			return nil
+		},
+	}
+}
+
+func (r LogicAppResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return commonids.ValidateLogicAppId
+}
+
+func (r LogicAppResource) Update() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.AppService.WebAppsClient
+
+			id, err := commonids.ParseLogicAppId(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			data := LogicAppResourceModel{}
+
+			if err := metadata.Decode(&data); err != nil {
+				return err
+			}
+
+			existing, err := client.Get(ctx, *id)
+			if err != nil {
+				return fmt.Errorf("reading %s: %v", *id, err)
+			}
+			if existing.Model == nil || existing.Model.Properties == nil {
+				return fmt.Errorf("reading %s for update", id)
+			}
+
+			siteEnvelope := *existing.Model.Properties
+
+			sc, err := client.GetConfiguration(ctx, *id)
+			if err != nil || sc.Model == nil {
+				return fmt.Errorf("reading site_config for %s: %v", *id, err)
+			}
+
+			existingSiteConfig := sc.Model.Properties
+			siteEnvelope.SiteConfig = existingSiteConfig
+
+			appSettingsResp, err := client.ListApplicationSettings(ctx, *id)
+			if err != nil || appSettingsResp.Model == nil {
+				return fmt.Errorf("reading App Settings for Linux %s: %+v", id, err)
+			}
+
+			currentAppSettings := make([]webapps.NameValuePair, 0)
+			if appSettingsResp.Model.Properties != nil {
+				currentAppSettings = expandAppSettings(*appSettingsResp.Model.Properties)
+			}
+			existingSiteConfig.AppSettings = pointer.To(currentAppSettings)
+
+			if metadata.ResourceData.HasChanges("site_config", "app_settings") {
+				existingSiteConfig, err = expandLogicAppStandardSiteConfigForUpdate(data.SiteConfig, metadata, existingSiteConfig)
+				if err != nil {
+					return fmt.Errorf("expanding site_config update for %s: %v", *id, err)
+				}
+
+				siteEnvelope.SiteConfig = existingSiteConfig
+			}
+
+			if metadata.ResourceData.HasChange("site_config.0.linux_fx_version") {
+				kind := "functionapp,workflowapp"
+				if metadata.ResourceData.Get("site_config.0.linux_fx_version").(string) != "" {
+					kind = "functionapp,linux,container,workflowapp"
+				}
+				existing.Model.Kind = pointer.To(kind)
+			}
+
+			if metadata.ResourceData.HasChange("app_service_plan_id") {
+				planId, err := commonids.ParseLogicAppIdInsensitively(metadata.ResourceData.Id())
+				if err != nil {
+					return err
+				}
+
+				siteEnvelope.ServerFarmId = pointer.To(planId.ID())
+			}
+
+			if metadata.ResourceData.HasChange("enabled") {
+				siteEnvelope.Enabled = pointer.To(metadata.ResourceData.Get("enabled").(bool))
+			}
+
+			if metadata.ResourceData.HasChange("client_affinity_enabled") {
+				siteEnvelope.ClientAffinityEnabled = pointer.To(metadata.ResourceData.Get("client_affinity_enabled").(bool))
+			}
+
+			if metadata.ResourceData.HasChanges("client_certificate_mode") {
+				siteEnvelope.ClientCertMode = pointer.ToEnum[webapps.ClientCertMode](metadata.ResourceData.Get("client_certificate_mode").(string))
+				siteEnvelope.ClientCertEnabled = pointer.To(metadata.ResourceData.Get("client_certificate_mode").(string) != "")
+			}
+
+			if metadata.ResourceData.HasChanges("https_only") {
+				siteEnvelope.HTTPSOnly = pointer.To(metadata.ResourceData.Get("https_only").(bool))
+			}
+
+			if metadata.ResourceData.HasChange("public_network_access") {
+				if strings.EqualFold(data.PublicNetworkAccess, helpers.PublicNetworkAccessEnabled) {
+					siteEnvelope.PublicNetworkAccess = pointer.To(helpers.PublicNetworkAccessEnabled)
+					if !features.FivePointOh() {
+						siteEnvelope.SiteConfig.PublicNetworkAccess = pointer.To(helpers.PublicNetworkAccessEnabled)
+					}
+				} else {
+					siteEnvelope.PublicNetworkAccess = pointer.To(helpers.PublicNetworkAccessDisabled)
+					if !features.FivePointOh() {
+						siteEnvelope.SiteConfig.PublicNetworkAccess = pointer.To(helpers.PublicNetworkAccessDisabled)
+					}
+				}
+			}
+
+			if metadata.ResourceData.HasChange("vnet_content_share_enabled") {
+				siteEnvelope.VnetContentShareEnabled = pointer.To(data.VNETContentShareEnabled)
+			}
+
+			if metadata.ResourceData.HasChange("virtual_network_subnet_id") {
+				subnetId := data.VirtualNetworkSubnetId
+				if subnetId == "" {
+					if _, err := client.DeleteSwiftVirtualNetwork(ctx, *id); err != nil {
+						return fmt.Errorf("removing `virtual_network_subnet_id` association for %s: %+v", *id, err)
+					}
+					var empty *string
+					siteEnvelope.VirtualNetworkSubnetId = empty
+				} else {
+					siteEnvelope.VirtualNetworkSubnetId = pointer.To(subnetId)
+				}
+			}
+
+			if metadata.ResourceData.HasChange("identity") {
+				expandedIdentity, err := identity.ExpandSystemAndUserAssignedMapFromModel(data.Identity)
+				if err != nil {
+					return fmt.Errorf("expanding `identity`: %+v", err)
+				}
+
+				existing.Model.Identity = expandedIdentity
+			}
+
+			existing.Model.Properties = pointer.To(siteEnvelope)
+
+			if err := client.CreateOrUpdateThenPoll(ctx, *id, *existing.Model); err != nil {
+				return fmt.Errorf("updating %s: %+v", *id, err)
+			}
+
+			if metadata.ResourceData.HasChange("connection_string") {
+				connectionStrings := helpers.ExpandConnectionStrings(data.ConnectionStrings)
+				if connectionStrings.Properties != nil {
+					if _, err := client.UpdateConnectionStrings(ctx, *id, *connectionStrings); err != nil {
+						return fmt.Errorf("setting Connection Strings for Linux %s: %+v", id, err)
+					}
+				}
+			}
+
+			if metadata.ResourceData.HasChange("ftp_publish_basic_authentication_enabled") {
+				policy := webapps.CsmPublishingCredentialsPoliciesEntity{
+					Properties: &webapps.CsmPublishingCredentialsPoliciesEntityProperties{
+						Allow: data.FtpPublishBasicAuthEnabled,
+					},
+				}
+
+				if _, err := client.UpdateFtpAllowed(ctx, *id, policy); err != nil {
+					return fmt.Errorf("updating FTP publish basic authentication policy for %s: %+v", id, err)
+				}
+			}
+
+			if metadata.ResourceData.HasChange("scm_publish_basic_authentication_enabled") {
+				policy := webapps.CsmPublishingCredentialsPoliciesEntity{
+					Properties: &webapps.CsmPublishingCredentialsPoliciesEntityProperties{
+						Allow: data.SCMPublishBasicAuthEnabled,
+					},
+				}
+
+				if _, err := client.UpdateScmAllowed(ctx, *id, policy); err != nil {
+					return fmt.Errorf("updating SCM publish basic authentication policy for %s: %+v", id, err)
+				}
+			}
+
+			return nil
+		},
+	}
+}
+
+var _ sdk.ResourceWithUpdate = &LogicAppResource{}
+
+func getBasicLogicAppSettings(d LogicAppResourceModel, endpointSuffix string) ([]webapps.NameValuePair, error) {
 	storagePropName := "AzureWebJobsStorage"
 	functionVersionPropName := "FUNCTIONS_EXTENSION_VERSION"
 	contentSharePropName := "WEBSITE_CONTENTSHARE"
@@ -801,19 +864,19 @@ func getBasicLogicAppSettings(d *pluginsdk.ResourceData, endpointSuffix string) 
 	appKindPropName := "APP_KIND"
 	appKindPropValue := "workflowApp"
 
-	storageAccount := d.Get("storage_account_name").(string)
-	accountKey := d.Get("storage_account_access_key").(string)
+	storageAccount := d.StorageAccountName
+	accountKey := d.StorageAccountAccessKey
 	storageConnection := fmt.Sprintf(
 		"DefaultEndpointsProtocol=https;AccountName=%s;AccountKey=%s;EndpointSuffix=%s",
 		storageAccount,
 		accountKey,
 		endpointSuffix,
 	)
-	functionVersion := d.Get("version").(string)
+	functionVersion := d.Version
 
-	contentShare := strings.ToLower(d.Get("name").(string)) + "-content"
-	if _, ok := d.GetOk("storage_account_share_name"); ok {
-		contentShare = d.Get("storage_account_share_name").(string)
+	contentShare := strings.ToLower(d.Name) + "-content"
+	if d.StorageAccountShareName != "" {
+		contentShare = d.StorageAccountShareName
 	}
 
 	basicSettings := []webapps.NameValuePair{
@@ -824,12 +887,11 @@ func getBasicLogicAppSettings(d *pluginsdk.ResourceData, endpointSuffix string) 
 		{Name: &contentFileConnStringPropName, Value: &storageConnection},
 	}
 
-	useExtensionBundle := d.Get("use_extension_bundle").(bool)
-	if useExtensionBundle {
+	if d.UseExtensionBundle {
 		extensionBundlePropName := "AzureFunctionsJobHost__extensionBundle__id"
 		extensionBundleName := "Microsoft.Azure.Functions.ExtensionBundle.Workflows"
 		extensionBundleVersionPropName := "AzureFunctionsJobHost__extensionBundle__version"
-		extensionBundleVersion := d.Get("bundle_version").(string)
+		extensionBundleVersion := d.BundleVersion
 
 		if extensionBundleVersion == "" {
 			return nil, fmt.Errorf(
@@ -1173,67 +1235,47 @@ func schemaLogicAppStandardIpRestriction() *pluginsdk.Schema {
 	}
 }
 
-func flattenLogicAppStandardConnectionStrings(input *map[string]webapps.ConnStringValueTypePair) interface{} {
-	results := make([]interface{}, 0)
-
-	if input == nil || len(*input) == 0 {
-		return results
-	}
-
-	for k, v := range *input {
-		result := make(map[string]interface{})
-		result["name"] = k
-		result["type"] = string(v.Type)
-		result["value"] = v.Value
-		results = append(results, result)
-	}
-
-	return results
-}
-
-func flattenLogicAppStandardSiteConfig(input *webapps.SiteConfig) []interface{} {
-	results := make([]interface{}, 0)
-	result := make(map[string]interface{})
+func flattenLogicAppStandardSiteConfig(input *webapps.SiteConfig) []helpers.LogicAppSiteConfig {
+	results := make([]helpers.LogicAppSiteConfig, 0)
+	result := helpers.LogicAppSiteConfig{}
 
 	if input == nil {
 		log.Printf("[DEBUG] SiteConfig is nil")
 		return results
 	}
 
-	result["always_on"] = pointer.From(input.AlwaysOn)
-	result["use_32_bit_worker_process"] = pointer.From(input.Use32BitWorkerProcess)
-	result["websockets_enabled"] = pointer.From(input.WebSocketsEnabled)
-	result["linux_fx_version"] = pointer.From(input.LinuxFxVersion)
-	result["http2_enabled"] = pointer.From(input.HTTP20Enabled)
-	result["pre_warmed_instance_count"] = pointer.From(input.PreWarmedInstanceCount)
+	result.AlwaysOn = pointer.From(input.AlwaysOn)
+	result.Use32BitWorkerProcess = pointer.From(input.Use32BitWorkerProcess)
+	result.WebSocketsEnabled = pointer.From(input.WebSocketsEnabled)
+	result.LinuxFxVersion = pointer.From(input.LinuxFxVersion)
+	result.HTTP2Enabled = pointer.From(input.HTTP20Enabled)
+	result.PreWarmedInstanceCount = pointer.From(input.PreWarmedInstanceCount)
+	result.IpRestriction = helpers.FlattenIpRestrictions(input.IPSecurityRestrictions)
+	result.SCMIPRestriction = helpers.FlattenIpRestrictions(input.ScmIPSecurityRestrictions)
 
-	result["ip_restriction"] = flattenLogicAppStandardIpRestriction(input.IPSecurityRestrictions)
+	result.SCMUseMainIpRestriction = pointer.From(input.ScmIPSecurityRestrictionsUseMain)
 
-	result["scm_ip_restriction"] = flattenLogicAppStandardIpRestriction(input.ScmIPSecurityRestrictions)
+	result.SCMType = pointer.FromEnum(input.ScmType)
+	result.SCMMinTLSVersion = pointer.FromEnum(input.ScmMinTlsVersion)
 
-	result["scm_use_main_ip_restriction"] = pointer.From(input.ScmIPSecurityRestrictionsUseMain)
+	result.MinTLSVersion = pointer.FromEnum(input.MinTlsVersion)
+	result.FTPSState = pointer.FromEnum(input.FtpsState)
 
-	result["scm_type"] = string(pointer.From(input.ScmType))
-	result["scm_min_tls_version"] = string(pointer.From(input.ScmMinTlsVersion))
+	result.Cors = helpers.FlattenCorsSettings(input.Cors)
 
-	result["min_tls_version"] = string(pointer.From(input.MinTlsVersion))
-	result["ftps_state"] = string(pointer.From(input.FtpsState))
+	result.AutoSwapSlotName = pointer.From(input.AutoSwapSlotName)
 
-	result["cors"] = flattenLogicAppStandardCorsSettings(input.Cors)
+	result.HealthCheckPath = pointer.From(input.HealthCheckPath)
 
-	result["auto_swap_slot_name"] = pointer.From(input.AutoSwapSlotName)
+	result.ElasticInstanceMinimum = pointer.From(input.MinimumElasticInstanceCount)
 
-	result["health_check_path"] = pointer.From(input.HealthCheckPath)
+	result.AppScaleLimit = pointer.From(input.FunctionAppScaleLimit)
 
-	result["elastic_instance_minimum"] = pointer.From(input.MinimumElasticInstanceCount)
+	result.RuntimeScaleMonitoringEnabled = pointer.From(input.FunctionsRuntimeScaleMonitoringEnabled)
 
-	result["app_scale_limit"] = pointer.From(input.FunctionAppScaleLimit)
+	result.DotnetFrameworkVersion = pointer.From(input.NetFrameworkVersion)
 
-	result["runtime_scale_monitoring_enabled"] = pointer.From(input.FunctionsRuntimeScaleMonitoringEnabled)
-
-	result["dotnet_framework_version"] = pointer.From(input.NetFrameworkVersion)
-
-	result["vnet_route_all_enabled"] = pointer.From(input.VnetRouteAllEnabled)
+	result.VNETRouteAllEnabled = pointer.From(input.VnetRouteAllEnabled)
 
 	publicNetworkAccessEnabled := true
 	if input.PublicNetworkAccess != nil {
@@ -1241,7 +1283,7 @@ func flattenLogicAppStandardSiteConfig(input *webapps.SiteConfig) []interface{} 
 	}
 
 	if !features.FivePointOh() {
-		result["public_network_access_enabled"] = publicNetworkAccessEnabled
+		result.PublicNetworkAccessEnabled = publicNetworkAccessEnabled
 	}
 
 	results = append(results, result)
@@ -1268,7 +1310,7 @@ func flattenLogicAppStandardIpRestriction(input *[]webapps.IPSecurityRestriction
 	restrictions := make([]interface{}, 0)
 
 	if input == nil {
-		return restrictions
+		return nil
 	}
 
 	for _, v := range *input {
@@ -1366,136 +1408,176 @@ func flattenHeaders(input map[string][]string) []interface{} {
 	return append(output, headers)
 }
 
-func expandLogicAppStandardSiteConfig(d *pluginsdk.ResourceData) (webapps.SiteConfig, error) {
-	configs := d.Get("site_config").([]interface{})
-	siteConfig := webapps.SiteConfig{}
-
-	if len(configs) == 0 {
+func expandLogicAppStandardSiteConfigForCreate(d []helpers.LogicAppSiteConfig, metadata sdk.ResourceMetaData) (*webapps.SiteConfig, error) {
+	siteConfig := &webapps.SiteConfig{}
+	if len(d) == 0 {
 		return siteConfig, nil
 	}
 
-	config := configs[0].(map[string]interface{})
+	config := d[0]
 
-	if v, ok := config["always_on"]; ok {
-		siteConfig.AlwaysOn = pointer.To(v.(bool))
+	siteConfig.AlwaysOn = pointer.To(config.AlwaysOn)
+	siteConfig.HTTP20Enabled = pointer.To(config.HTTP2Enabled)
+	siteConfig.FunctionsRuntimeScaleMonitoringEnabled = pointer.To(config.RuntimeScaleMonitoringEnabled)
+	siteConfig.Use32BitWorkerProcess = pointer.To(config.Use32BitWorkerProcess)
+	siteConfig.WebSocketsEnabled = pointer.To(config.WebSocketsEnabled)
+
+	if config.LinuxFxVersion != "" {
+		siteConfig.LinuxFxVersion = pointer.To(config.LinuxFxVersion)
 	}
 
-	if v, ok := config["use_32_bit_worker_process"]; ok {
-		siteConfig.Use32BitWorkerProcess = pointer.To(v.(bool))
+	if config.Cors != nil && len(config.Cors) > 0 {
+		siteConfig.Cors = helpers.ExpandCorsSettings(config.Cors)
 	}
 
-	if v, ok := config["websockets_enabled"]; ok {
-		siteConfig.WebSocketsEnabled = pointer.To(v.(bool))
+	ipr, err := helpers.ExpandIpRestrictions(config.IpRestriction)
+	if err != nil {
+		return nil, err
+	}
+	siteConfig.IPSecurityRestrictions = ipr
+
+	ipr, err = helpers.ExpandIpRestrictions(config.SCMIPRestriction)
+	if err != nil {
+		return nil, err
+	}
+	siteConfig.ScmIPSecurityRestrictions = ipr
+
+	siteConfig.ScmIPSecurityRestrictionsUseMain = pointer.To(config.SCMUseMainIpRestriction)
+
+	siteConfig.ScmMinTlsVersion = pointer.ToEnum[webapps.SupportedTlsVersions](config.SCMMinTLSVersion)
+	siteConfig.ScmType = pointer.ToEnum[webapps.ScmType](config.SCMType)
+	siteConfig.MinTlsVersion = pointer.ToEnum[webapps.SupportedTlsVersions](config.MinTLSVersion)
+
+	siteConfig.FtpsState = pointer.ToEnum[webapps.FtpsState](config.FTPSState)
+
+	if metadata.ResourceData.GetRawConfig().AsValueMap()["site_config"].AsValueSlice()[0].AsValueMap()["pre_warmed_instance_count"].IsKnown() {
+		siteConfig.PreWarmedInstanceCount = pointer.To(config.PreWarmedInstanceCount)
+	}
+	siteConfig.HealthCheckPath = pointer.To(config.HealthCheckPath)
+
+	if metadata.ResourceData.GetRawConfig().AsValueMap()["site_config"].AsValueSlice()[0].AsValueMap()["elastic_instance_minimum"].IsKnown() {
+		siteConfig.MinimumElasticInstanceCount = pointer.To(config.ElasticInstanceMinimum)
 	}
 
-	if v, ok := config["linux_fx_version"]; ok {
-		siteConfig.LinuxFxVersion = pointer.To(v.(string))
+	if metadata.ResourceData.GetRawConfig().AsValueMap()["site_config"].AsValueSlice()[0].AsValueMap()["app_scale_limit"].IsKnown() {
+		siteConfig.FunctionAppScaleLimit = pointer.To(config.AppScaleLimit)
 	}
 
-	if v, ok := config["cors"]; ok {
-		expand := expandLogicAppStandardCorsSettings(v)
-		siteConfig.Cors = &expand
-	}
-
-	if v, ok := config["http2_enabled"]; ok {
-		siteConfig.HTTP20Enabled = pointer.To(v.(bool))
-	}
-
-	if v, ok := config["ip_restriction"]; ok {
-		restrictions, err := expandLogicAppStandardIpRestriction(v)
-		if err != nil {
-			return siteConfig, err
-		}
-		siteConfig.IPSecurityRestrictions = &restrictions
-	}
-
-	if v, ok := config["scm_ip_restriction"]; ok {
-		scmIPSecurityRestrictions := v.([]interface{})
-		scmRestrictions, err := expandLogicAppStandardIpRestriction(scmIPSecurityRestrictions)
-		if err != nil {
-			return siteConfig, err
-		}
-		siteConfig.ScmIPSecurityRestrictions = &scmRestrictions
-	}
-
-	if v, ok := config["scm_use_main_ip_restriction"]; ok {
-		siteConfig.ScmIPSecurityRestrictionsUseMain = pointer.To(v.(bool))
-	}
-
-	if v, ok := config["scm_min_tls_version"]; ok {
-		siteConfig.ScmMinTlsVersion = pointer.To(webapps.SupportedTlsVersions(v.(string)))
-	}
-
-	if v, ok := config["scm_type"]; ok {
-		siteConfig.ScmType = pointer.To(webapps.ScmType(v.(string)))
-	}
-
-	if v, ok := config["min_tls_version"]; ok {
-		siteConfig.MinTlsVersion = pointer.To(webapps.SupportedTlsVersions(v.(string)))
-	}
-
-	if v, ok := config["ftps_state"]; ok {
-		siteConfig.FtpsState = pointer.To(webapps.FtpsState(v.(string)))
-	}
-
-	// get value from `d` rather than the `config` map, or it will be covered by the zero-value "0" instead of nil.
-	if v, ok := d.GetOk("site_config.0.pre_warmed_instance_count"); ok {
-		siteConfig.PreWarmedInstanceCount = pointer.To(int64(v.(int)))
-	}
-
-	if v, ok := config["health_check_path"]; ok {
-		siteConfig.HealthCheckPath = pointer.To(v.(string))
-	}
-
-	if v, ok := d.GetOk("site_config.0.elastic_instance_minimum"); ok {
-		siteConfig.MinimumElasticInstanceCount = pointer.To(int64(v.(int)))
-	}
-
-	if v, ok := d.GetOk("site_config.0.app_scale_limit"); ok {
-		siteConfig.FunctionAppScaleLimit = pointer.To(int64(v.(int)))
-	}
-
-	if v, ok := config["runtime_scale_monitoring_enabled"]; ok {
-		siteConfig.FunctionsRuntimeScaleMonitoringEnabled = pointer.To(v.(bool))
-	}
-
-	if v, ok := config["dotnet_framework_version"]; ok {
-		siteConfig.NetFrameworkVersion = pointer.To(v.(string))
-	}
-
-	if v, ok := config["vnet_route_all_enabled"]; ok {
-		siteConfig.VnetRouteAllEnabled = pointer.To(v.(bool))
-	}
+	siteConfig.NetFrameworkVersion = pointer.To(config.DotnetFrameworkVersion)
+	siteConfig.VnetRouteAllEnabled = pointer.To(config.VNETRouteAllEnabled)
 
 	if !features.FivePointOh() {
-		siteConfig.PublicNetworkAccess = pointer.To(reconcilePNA(d))
+		siteConfig.PublicNetworkAccess = pointer.To(reconcilePNA(metadata))
 	}
 
 	return siteConfig, nil
 }
 
-func expandLogicAppStandardSettings(d *pluginsdk.ResourceData, endpointSuffix string) (map[string]string, error) {
-	output := make(map[string]string)
-	appSettings := expandAppSettings(d)
-	basicAppSettings, err := getBasicLogicAppSettings(d, endpointSuffix)
-	if err != nil {
-		return nil, err
-	}
-	for _, p := range append(basicAppSettings, appSettings...) {
-		output[*p.Name] = pointer.From(p.Value)
+func expandLogicAppStandardSiteConfigForUpdate(d []helpers.LogicAppSiteConfig, metadata sdk.ResourceMetaData, existing *webapps.SiteConfig) (*webapps.SiteConfig, error) {
+	if len(d) == 0 {
+		return nil, nil
 	}
 
-	return output, nil
+	siteConfig := &webapps.SiteConfig{}
+	if existing != nil {
+		siteConfig = existing
+	}
+
+	config := d[0]
+
+	siteConfig.AlwaysOn = pointer.To(config.AlwaysOn)
+	siteConfig.HTTP20Enabled = pointer.To(config.HTTP2Enabled)
+	siteConfig.FunctionsRuntimeScaleMonitoringEnabled = pointer.To(config.RuntimeScaleMonitoringEnabled)
+	siteConfig.Use32BitWorkerProcess = pointer.To(config.Use32BitWorkerProcess)
+	siteConfig.ScmIPSecurityRestrictionsUseMain = pointer.To(config.SCMUseMainIpRestriction)
+	siteConfig.WebSocketsEnabled = pointer.To(config.WebSocketsEnabled)
+	siteConfig.VnetRouteAllEnabled = pointer.To(config.VNETRouteAllEnabled)
+
+	if metadata.ResourceData.HasChange("site_config.0.linux_fx_version") {
+		siteConfig.LinuxFxVersion = pointer.To(config.LinuxFxVersion)
+	}
+
+	if metadata.ResourceData.HasChanges("site_config.0.cors") {
+		siteConfig.Cors = helpers.ExpandCorsSettings(config.Cors)
+	}
+
+	if metadata.ResourceData.HasChanges("site_config.0.ip_restriction") {
+		ipr, err := helpers.ExpandIpRestrictions(config.IpRestriction)
+		if err != nil {
+			return nil, err
+		}
+		siteConfig.IPSecurityRestrictions = ipr
+	}
+
+	if metadata.ResourceData.HasChanges("site_config.0.scm_ip_restriction") {
+		ipr, err := helpers.ExpandIpRestrictions(config.SCMIPRestriction)
+		if err != nil {
+			return nil, err
+		}
+		siteConfig.ScmIPSecurityRestrictions = ipr
+	}
+
+	if metadata.ResourceData.HasChanges("site_config.0.min_scm_tls_version") {
+		siteConfig.ScmMinTlsVersion = pointer.ToEnum[webapps.SupportedTlsVersions](config.SCMMinTLSVersion)
+	}
+
+	if metadata.ResourceData.HasChanges("site_config.0.scm_type") {
+		siteConfig.ScmType = pointer.ToEnum[webapps.ScmType](config.SCMType)
+	}
+
+	if metadata.ResourceData.HasChanges("site_config.0.min_tls_version") {
+		siteConfig.MinTlsVersion = pointer.ToEnum[webapps.SupportedTlsVersions](config.MinTLSVersion)
+	}
+
+	if metadata.ResourceData.HasChanges("site_config.0.ftps_state") {
+		siteConfig.FtpsState = pointer.ToEnum[webapps.FtpsState](config.FTPSState)
+	}
+
+	if metadata.ResourceData.GetRawConfig().AsValueMap()["site_config"].AsValueSlice()[0].AsValueMap()["pre_warmed_instance_count"].IsKnown() {
+		siteConfig.PreWarmedInstanceCount = pointer.To(config.PreWarmedInstanceCount)
+	}
+
+	if metadata.ResourceData.HasChange("site_config.0.health_check_path") {
+		siteConfig.HealthCheckPath = pointer.To(config.HealthCheckPath)
+	}
+
+	if metadata.ResourceData.GetRawConfig().AsValueMap()["site_config"].AsValueSlice()[0].AsValueMap()["elastic_instance_minimum"].IsKnown() {
+		siteConfig.MinimumElasticInstanceCount = pointer.To(config.ElasticInstanceMinimum)
+	}
+
+	if metadata.ResourceData.GetRawConfig().AsValueMap()["site_config"].AsValueSlice()[0].AsValueMap()["app_scale_limit"].IsKnown() {
+		siteConfig.FunctionAppScaleLimit = pointer.To(config.AppScaleLimit)
+	}
+
+	if metadata.ResourceData.HasChanges("site_config.0.dotnet_framework_version") {
+		siteConfig.NetFrameworkVersion = pointer.To(config.DotnetFrameworkVersion)
+	}
+
+	if !features.FivePointOh() && metadata.ResourceData.HasChanges("site_config.0.public_network_access_enabled") {
+		siteConfig.PublicNetworkAccess = pointer.To(reconcilePNA(metadata))
+	}
+
+	if metadata.ResourceData.HasChanges("app_settings", "storage_account_name", "storage_account_share_name", "storage_account_access_key", "version") {
+		o, n := metadata.ResourceData.GetChange("app_settings")
+
+		appSettings := make([]webapps.NameValuePair, 0)
+		if existing != nil {
+			appSettings = *existing.AppSettings
+		}
+
+		siteConfig.AppSettings = mergeAppSettings(appSettings, o.(map[string]interface{}), n.(map[string]interface{}), metadata)
+	}
+
+	return siteConfig, nil
 }
 
-func expandAppSettings(d *pluginsdk.ResourceData) []webapps.NameValuePair {
-	input := d.Get("app_settings").(map[string]interface{})
+func expandAppSettings(input map[string]string) []webapps.NameValuePair {
 	output := make([]webapps.NameValuePair, 0)
 
 	for k, v := range input {
 		nameValue := webapps.NameValuePair{
 			Name:  pointer.To(k),
-			Value: pointer.To(v.(string)),
+			Value: pointer.To(v),
 		}
 		output = append(output, nameValue)
 	}
@@ -1503,167 +1585,95 @@ func expandAppSettings(d *pluginsdk.ResourceData) []webapps.NameValuePair {
 	return output
 }
 
-func expandLogicAppStandardConnectionStrings(d *pluginsdk.ResourceData) map[string]webapps.ConnStringValueTypePair {
-	input := d.Get("connection_string").(*pluginsdk.Set).List()
-	output := make(map[string]webapps.ConnStringValueTypePair, len(input))
+func mergeAppSettings(existing []webapps.NameValuePair, old, new map[string]interface{}, metadata sdk.ResourceMetaData) *[]webapps.NameValuePair {
+	f := func(input map[string]interface{}) (result map[string]string) {
+		result = make(map[string]string)
+		for k, v := range input {
+			result[k] = v.(string)
+		}
 
-	for _, v := range input {
-		vals := v.(map[string]interface{})
+		return
+	}
 
-		csName := vals["name"].(string)
-		csType := vals["type"].(string)
-		csValue := vals["value"].(string)
+	eMap := make(map[string]string)
+	for _, i := range existing {
+		n, v := pointer.From(i.Name), pointer.From(i.Value)
+		eMap[n] = v
+	}
 
-		output[csName] = webapps.ConnStringValueTypePair{
-			Value: csValue,
-			Type:  webapps.ConnectionStringType(csType),
+	oMap := f(old)
+	cMap := f(new)
+
+	if metadata.ResourceData.HasChanges("storage_account_name", "storage_account_access_key") {
+		accountName := metadata.ResourceData.Get("storage_account_name").(string)
+		accountAccessKey := metadata.ResourceData.Get("storage_account_access_key").(string)
+		suffix, _ := metadata.Client.Account.Environment.Storage.DomainSuffix()
+
+		eMap[storageAppSettingName] = fmt.Sprintf(storageConnectionStringFmt, accountName, accountAccessKey, *suffix)
+		eMap[contentFileConnStringAppSettingName] = fmt.Sprintf(storageConnectionStringFmt, accountName, accountAccessKey, *suffix)
+	}
+
+	if metadata.ResourceData.HasChange("storage_account_share_name") {
+		n := metadata.ResourceData.Get("storage_account_share_name").(string)
+
+		if n != "" {
+			eMap[contentShareAppSettingName] = n
+		} else {
+			name := metadata.ResourceData.Get("name").(string)
+			eMap[contentShareAppSettingName] = strings.ToLower(name) + "-content"
 		}
 	}
 
-	return output
+	if metadata.ResourceData.HasChange("version") {
+		eMap[functionVersionAppSettingName] = metadata.ResourceData.Get("version").(string)
+	}
+
+	if metadata.ResourceData.HasChanges("bundle_version", "use_extension_bundle") {
+		if bundleVersion := metadata.ResourceData.Get("bundle_version").(string); bundleVersion != "" {
+			eMap[extensionBundleAppSettingName] = extensionBundleAppSettingValue
+			eMap[extensionBundleVersionAppSettingName] = bundleVersion
+		} else {
+			delete(eMap, extensionBundleAppSettingName)
+		}
+	}
+
+	remove := map[string]string{}
+	addOrUpdate := map[string]string{}
+
+	for k, v := range oMap {
+		if _, ok := cMap[k]; !ok {
+			remove[k] = v
+			break
+		}
+
+		addOrUpdate[k] = v
+	}
+
+	for k := range remove {
+		delete(eMap, k)
+	}
+
+	for k, v := range addOrUpdate {
+		eMap[k] = v
+	}
+
+	return pointer.To(expandAppSettings(eMap))
 }
 
-func expandLogicAppStandardCorsSettings(input interface{}) webapps.CorsSettings {
-	settings := input.([]interface{})
-	corsSettings := webapps.CorsSettings{}
-
-	if len(settings) == 0 {
-		return corsSettings
-	}
-
-	setting := settings[0].(map[string]interface{})
-
-	if v, ok := setting["allowed_origins"]; ok {
-		input := v.(*pluginsdk.Set).List()
-
-		allowedOrigins := make([]string, 0)
-		for _, param := range input {
-			allowedOrigins = append(allowedOrigins, param.(string))
-		}
-
-		corsSettings.AllowedOrigins = &allowedOrigins
-	}
-
-	if v, ok := setting["support_credentials"]; ok {
-		corsSettings.SupportCredentials = pointer.To(v.(bool))
-	}
-
-	return corsSettings
-}
-
-func expandLogicAppStandardIpRestriction(input interface{}) ([]webapps.IPSecurityRestriction, error) {
-	restrictions := make([]webapps.IPSecurityRestriction, 0)
-
-	for _, r := range input.([]interface{}) {
-		if r == nil {
-			continue
-		}
-
-		restriction := r.(map[string]interface{})
-
-		ipAddress := restriction["ip_address"].(string)
-		vNetSubnetID := ""
-
-		if subnetID, ok := restriction["virtual_network_subnet_id"]; ok && subnetID != "" {
-			vNetSubnetID = subnetID.(string)
-		}
-
-		serviceTag := restriction["service_tag"].(string)
-
-		name := restriction["name"].(string)
-		priority := restriction["priority"].(int)
-		action := restriction["action"].(string)
-
-		if vNetSubnetID != "" && ipAddress != "" && serviceTag != "" {
-			return nil, fmt.Errorf(
-				"only one of `ip_address`, `service_tag` or `virtual_network_subnet_id` can be set for an IP restriction",
-			)
-		}
-
-		if vNetSubnetID == "" && ipAddress == "" && serviceTag == "" {
-			return nil, fmt.Errorf(
-				"one of `ip_address`, `service_tag` or `virtual_network_subnet_id` must be set for an IP restriction",
-			)
-		}
-
-		ipSecurityRestriction := webapps.IPSecurityRestriction{}
-		if ipAddress == "Any" {
-			continue
-		}
-
-		if ipAddress != "" {
-			ipSecurityRestriction.IPAddress = &ipAddress
-		}
-
-		if serviceTag != "" {
-			ipSecurityRestriction.IPAddress = &serviceTag
-			ipSecurityRestriction.Tag = pointer.To(webapps.IPFilterTagServiceTag)
-		}
-
-		if vNetSubnetID != "" {
-			ipSecurityRestriction.VnetSubnetResourceId = &vNetSubnetID
-		}
-
-		if name != "" {
-			ipSecurityRestriction.Name = &name
-		}
-
-		if priority != 0 {
-			ipSecurityRestriction.Priority = pointer.To(int64(priority))
-		}
-
-		if action != "" {
-			ipSecurityRestriction.Action = &action
-		}
-		if headers, ok := restriction["headers"]; ok {
-			ipSecurityRestriction.Headers = pointer.To(expandHeaders(headers.([]interface{})))
-		}
-
-		restrictions = append(restrictions, ipSecurityRestriction)
-	}
-
-	return restrictions, nil
-}
-
-func expandHeaders(input interface{}) map[string][]string {
-	output := make(map[string][]string)
-
-	for _, r := range input.([]interface{}) {
-		if r == nil {
-			continue
-		}
-
-		val := r.(map[string]interface{})
-		if raw := val["x_forwarded_host"].(*pluginsdk.Set).List(); len(raw) > 0 {
-			output["x-forwarded-host"] = *utils.ExpandStringSlice(raw)
-		}
-		if raw := val["x_forwarded_for"].(*pluginsdk.Set).List(); len(raw) > 0 {
-			output["x-forwarded-for"] = *utils.ExpandStringSlice(raw)
-		}
-		if raw := val["x_azure_fdid"].(*pluginsdk.Set).List(); len(raw) > 0 {
-			output["x-azure-fdid"] = *utils.ExpandStringSlice(raw)
-		}
-		if raw := val["x_fd_health_probe"].(*pluginsdk.Set).List(); len(raw) > 0 {
-			output["x-fd-healthprobe"] = *utils.ExpandStringSlice(raw)
-		}
-	}
-
-	return output
-}
-
-func reconcilePNA(d *pluginsdk.ResourceData) string {
+func reconcilePNA(d sdk.ResourceMetaData) string {
 	pna := ""
 	scPNASet := true
-	if !d.GetRawConfig().AsValueMap()["public_network_access"].IsNull() { // is top level set, takes precedence
-		pna = d.Get("public_network_access").(string)
+	d.ResourceData.GetRawConfig().AsValueMap()["public_network_access"].IsNull()
+	if !d.ResourceData.GetRawConfig().AsValueMap()["public_network_access"].IsNull() { // is top level set, takes precedence
+		pna = d.ResourceData.Get("public_network_access").(string)
 	}
-	if sc := d.GetRawConfig().AsValueMap()["site_config"]; !sc.IsNull() {
+	if sc := d.ResourceData.GetRawConfig().AsValueMap()["site_config"]; !sc.IsNull() {
 		if len(sc.AsValueSlice()) > 0 && !sc.AsValueSlice()[0].AsValueMap()["public_network_access_enabled"].IsNull() {
 			scPNASet = true
 		}
 	}
 	if pna == "" && scPNASet { // if not, or it's empty, is site_config value set
-		pnaBool := d.Get("site_config.0.public_network_access_enabled").(bool)
+		pnaBool := d.ResourceData.Get("site_config.0.public_network_access_enabled").(bool)
 		if pnaBool {
 			pna = helpers.PublicNetworkAccessEnabled
 		} else {

--- a/internal/services/logic/logic_app_standard_resource.go
+++ b/internal/services/logic/logic_app_standard_resource.go
@@ -459,9 +459,8 @@ func (r LogicAppResource) Create() sdk.ResourceFunc {
 			}
 
 			if !features.FivePointOh() {
-				publicNetworkAccess := data.PublicNetworkAccess
 				// if a user is still using `site_config.public_network_access_enabled` we should be setting `public_network_access` for them
-				publicNetworkAccess = reconcilePNA(metadata)
+				publicNetworkAccess := reconcilePNA(metadata)
 				if v := siteEnvelope.Properties.SiteConfig.PublicNetworkAccess; v != nil && *v == helpers.PublicNetworkAccessDisabled {
 					publicNetworkAccess = helpers.PublicNetworkAccessDisabled
 				}

--- a/internal/services/logic/logic_app_standard_resource.go
+++ b/internal/services/logic/logic_app_standard_resource.go
@@ -1669,8 +1669,8 @@ func mergeAppSettings(existing []webapps.NameValuePair, old, new map[string]inte
 }
 
 func reconcilePNA(d sdk.ResourceMetaData) string {
-	pna := ""
-	scPNASet := true
+	pna := helpers.PublicNetworkAccessEnabled
+	scPNASet := false
 	d.ResourceData.GetRawConfig().AsValueMap()["public_network_access"].IsNull()
 	if !d.ResourceData.GetRawConfig().AsValueMap()["public_network_access"].IsNull() { // is top level set, takes precedence
 		pna = d.ResourceData.Get("public_network_access").(string)

--- a/internal/services/logic/logic_app_standard_resource.go
+++ b/internal/services/logic/logic_app_standard_resource.go
@@ -1561,7 +1561,7 @@ func expandLogicAppStandardSiteConfigForUpdate(d []helpers.LogicAppSiteConfig, m
 		siteConfig.FtpsState = pointer.ToEnum[webapps.FtpsState](config.FTPSState)
 	}
 
-	if metadata.ResourceData.GetRawConfig().AsValueMap()["site_config"].AsValueSlice()[0].AsValueMap()["pre_warmed_instance_count"].IsKnown() {
+	if len(metadata.ResourceData.GetRawConfig().AsValueMap()["site_config"].AsValueSlice()) > 0 && metadata.ResourceData.GetRawConfig().AsValueMap()["site_config"].AsValueSlice()[0].AsValueMap()["pre_warmed_instance_count"].IsKnown() {
 		siteConfig.PreWarmedInstanceCount = pointer.To(config.PreWarmedInstanceCount)
 	}
 
@@ -1569,11 +1569,11 @@ func expandLogicAppStandardSiteConfigForUpdate(d []helpers.LogicAppSiteConfig, m
 		siteConfig.HealthCheckPath = pointer.To(config.HealthCheckPath)
 	}
 
-	if metadata.ResourceData.GetRawConfig().AsValueMap()["site_config"].AsValueSlice()[0].AsValueMap()["elastic_instance_minimum"].IsKnown() {
+	if len(metadata.ResourceData.GetRawConfig().AsValueMap()["site_config"].AsValueSlice()) > 0 && metadata.ResourceData.GetRawConfig().AsValueMap()["site_config"].AsValueSlice()[0].AsValueMap()["elastic_instance_minimum"].IsKnown() {
 		siteConfig.MinimumElasticInstanceCount = pointer.To(config.ElasticInstanceMinimum)
 	}
 
-	if metadata.ResourceData.GetRawConfig().AsValueMap()["site_config"].AsValueSlice()[0].AsValueMap()["app_scale_limit"].IsKnown() {
+	if len(metadata.ResourceData.GetRawConfig().AsValueMap()["site_config"].AsValueSlice()) > 0 && metadata.ResourceData.GetRawConfig().AsValueMap()["site_config"].AsValueSlice()[0].AsValueMap()["app_scale_limit"].IsKnown() {
 		siteConfig.FunctionAppScaleLimit = pointer.To(config.AppScaleLimit)
 	}
 

--- a/internal/services/logic/logic_app_standard_resource_test.go
+++ b/internal/services/logic/logic_app_standard_resource_test.go
@@ -702,6 +702,42 @@ func TestAccLogicAppStandard_scmIpRestrictionRemoved(t *testing.T) {
 	})
 }
 
+func TestAccLogicAppStandard_scmIpRestrictionUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_logic_app_standard", "test")
+	r := LogicAppStandardResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.scmIpRestriction(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.scmMultiIpRestriction(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.scmIpRestriction(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.unsetScmIpRestriction(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccLogicAppStandard_manyIpRestrictions(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_logic_app_standard", "test")
 	r := LogicAppStandardResource{}
@@ -2078,6 +2114,33 @@ resource "azurerm_logic_app_standard" "test" {
     always_on = true
     scm_ip_restriction {
       ip_address = "10.10.10.10/32"
+    }
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+func (r LogicAppStandardResource) scmMultiIpRestriction(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_logic_app_standard" "test" {
+  name                       = "acctest-%d-func"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  app_service_plan_id        = azurerm_app_service_plan.test.id
+  storage_account_name       = azurerm_storage_account.test.name
+  storage_account_access_key = azurerm_storage_account.test.primary_access_key
+
+  site_config {
+    always_on = true
+    scm_ip_restriction {
+      ip_address = "10.10.10.10/32"
+    }
+    scm_ip_restriction {
+      ip_address = "10.10.10.11/32"
+    }
+    scm_ip_restriction {
+      ip_address = "10.10.10.12/32"
     }
   }
 }

--- a/internal/services/logic/logic_app_standard_resource_test.go
+++ b/internal/services/logic/logic_app_standard_resource_test.go
@@ -1347,7 +1347,7 @@ resource "azurerm_logic_app_standard" "test" {
     use_32_bit_worker_process = true
     websockets_enabled = false
     health_check_path = "/"
-	elastic_instance_minimum = 0
+	elastic_instance_minimum = 1
     app_scale_limit = 12
     runtime_scale_monitoring_enabled = false
     dotnet_framework_version = "v8.0"

--- a/internal/services/logic/logic_app_standard_resource_test.go
+++ b/internal/services/logic/logic_app_standard_resource_test.go
@@ -477,6 +477,37 @@ func TestAccLogicAppStandard_corsSettings(t *testing.T) {
 	})
 }
 
+func TestAccLogicAppStandard_corsSettingsRemoved(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_logic_app_standard", "test")
+	r := LogicAppStandardResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("site_config.0.cors.#").HasValue("0"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.corsSettings(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("site_config.0.cors.#").HasValue("0"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccLogicAppStandard_enableHttp2(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_logic_app_standard", "test")
 	r := LogicAppStandardResource{}
@@ -633,7 +664,6 @@ func TestAccLogicAppStandard_ipRestrictionRemoved(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			// This configuration includes a single explicit ip_restriction
 			Config: r.oneIpRestriction(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
@@ -641,19 +671,9 @@ func TestAccLogicAppStandard_ipRestrictionRemoved(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			// This configuration has no site_config blocks at all.
-			Config: r.basic(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			// This configuration explicitly sets ip_restriction to [] using attribute syntax.
 			Config: r.ipRestrictionRemoved(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				// check.That(data.ResourceName).Key("site_config.0.ip_restriction.#").HasValue("0"),
 			),
 		},
 		data.ImportStep(),
@@ -666,7 +686,6 @@ func TestAccLogicAppStandard_scmIpRestrictionRemoved(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			// This configuration includes a single explicit ip_restriction
 			Config: r.scmIpRestriction(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
@@ -674,11 +693,9 @@ func TestAccLogicAppStandard_scmIpRestrictionRemoved(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			// This configuration explicitly sets ip_restriction to [] using attribute syntax.
 			Config: r.unsetScmIpRestriction(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				// check.That(data.ResourceName).Key("site_config.0.ip_restriction.#").HasValue("0"),
 			),
 		},
 		data.ImportStep(),
@@ -1156,7 +1173,6 @@ resource "azurerm_logic_app_standard" "test" {
   storage_account_access_key = azurerm_storage_account.test.primary_access_key
   use_extension_bundle       = true
   bundle_version             = "[1.31.12]"
-  // client_affinity_enabled                  = true
   client_certificate_mode                  = "Required"
   enabled                                  = false
   https_only                               = true
@@ -1279,7 +1295,6 @@ resource "azurerm_logic_app_standard" "test" {
   storage_account_access_key = azurerm_storage_account.test.primary_access_key
   use_extension_bundle       = true
   bundle_version             = "[1.31.13]"
-  // client_affinity_enabled                  = true
   client_certificate_mode                  = "Required"
   enabled                                  = false
   https_only                               = true
@@ -2001,7 +2016,6 @@ resource "azurerm_logic_app_standard" "test" {
 
   site_config {
     always_on = true
-    // ip_restriction = []
   }
 }
 `, r.template(data), data.RandomInteger)
@@ -2084,7 +2098,6 @@ resource "azurerm_logic_app_standard" "test" {
 
   site_config {
     always_on = true
-    //   scm_ip_restriction = []
   }
 }
 `, r.template(data), data.RandomInteger)

--- a/internal/services/logic/logic_app_standard_resource_test.go
+++ b/internal/services/logic/logic_app_standard_resource_test.go
@@ -653,7 +653,7 @@ func TestAccLogicAppStandard_ipRestrictionRemoved(t *testing.T) {
 			Config: r.ipRestrictionRemoved(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("site_config.0.ip_restriction.#").HasValue("0"),
+				// check.That(data.ResourceName).Key("site_config.0.ip_restriction.#").HasValue("0"),
 			),
 		},
 		data.ImportStep(),
@@ -667,15 +667,7 @@ func TestAccLogicAppStandard_scmIpRestrictionRemoved(t *testing.T) {
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			// This configuration includes a single explicit ip_restriction
-			Config: r.oneIpRestriction(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			// This configuration has no site_config blocks at all.
-			Config: r.basic(data),
+			Config: r.scmIpRestriction(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -683,10 +675,10 @@ func TestAccLogicAppStandard_scmIpRestrictionRemoved(t *testing.T) {
 		data.ImportStep(),
 		{
 			// This configuration explicitly sets ip_restriction to [] using attribute syntax.
-			Config: r.ipRestrictionRemoved(data),
+			Config: r.unsetScmIpRestriction(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("site_config.0.ip_restriction.#").HasValue("0"),
+				// check.That(data.ResourceName).Key("site_config.0.ip_restriction.#").HasValue("0"),
 			),
 		},
 		data.ImportStep(),
@@ -1156,14 +1148,14 @@ resource "azurerm_user_assigned_identity" "test" {
 }
 
 resource "azurerm_logic_app_standard" "test" {
-  name                                     = "acctest-%[2]d-func"
-  location                                 = azurerm_resource_group.test.location
-  resource_group_name                      = azurerm_resource_group.test.name
-  app_service_plan_id                      = azurerm_app_service_plan.test.id
-  storage_account_name                     = azurerm_storage_account.test.name
-  storage_account_access_key               = azurerm_storage_account.test.primary_access_key
-  use_extension_bundle                     = true
-  bundle_version                           = "[1.31.12]"
+  name                       = "acctest-%[2]d-func"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  app_service_plan_id        = azurerm_app_service_plan.test.id
+  storage_account_name       = azurerm_storage_account.test.name
+  storage_account_access_key = azurerm_storage_account.test.primary_access_key
+  use_extension_bundle       = true
+  bundle_version             = "[1.31.12]"
   // client_affinity_enabled                  = true
   client_certificate_mode                  = "Required"
   enabled                                  = false
@@ -1186,11 +1178,11 @@ resource "azurerm_logic_app_standard" "test" {
   }
 
   site_config {
-    always_on 			= true
+    always_on           = true
     min_tls_version     = 1.2
     scm_min_tls_version = 1.2
 
-	cors {
+    cors {
       allowed_origins = [
         "http://www.contoso.com",
         "www.contoso.com",
@@ -1201,18 +1193,18 @@ resource "azurerm_logic_app_standard" "test" {
       support_credentials = true
     }
 
-    ftps_state = "FtpsOnly"
-    http2_enabled = true
-	pre_warmed_instance_count = 2
-    scm_use_main_ip_restriction = true
-    scm_type = "GitHub"
-    use_32_bit_worker_process = false
-    websockets_enabled = true
-    health_check_path = "/health"
-	elastic_instance_minimum = 1
-    app_scale_limit = 10
+    ftps_state                       = "FtpsOnly"
+    http2_enabled                    = true
+    pre_warmed_instance_count        = 2
+    scm_use_main_ip_restriction      = true
+    scm_type                         = "GitHub"
+    use_32_bit_worker_process        = false
+    websockets_enabled               = true
+    health_check_path                = "/health"
+    elastic_instance_minimum         = 1
+    app_scale_limit                  = 10
     runtime_scale_monitoring_enabled = true
-    dotnet_framework_version = "v6.0"
+    dotnet_framework_version         = "v6.0"
 
     ip_restriction {
       ip_address = "10.10.10.10/32"
@@ -1235,7 +1227,7 @@ resource "azurerm_logic_app_standard" "test" {
   }
 
   tags = {
-	environment = "AccTest"
+    environment = "AccTest"
   }
 }
 `, r.template(data), data.RandomInteger)
@@ -1279,14 +1271,14 @@ resource "azurerm_user_assigned_identity" "test2" {
 }
 
 resource "azurerm_logic_app_standard" "test" {
-  name                                     = "acctest-%[2]d-func"
-  location                                 = azurerm_resource_group.test.location
-  resource_group_name                      = azurerm_resource_group.test.name
-  app_service_plan_id                      = azurerm_app_service_plan.test.id
-  storage_account_name                     = azurerm_storage_account.test.name
-  storage_account_access_key               = azurerm_storage_account.test.primary_access_key
-  use_extension_bundle                     = true
-  bundle_version                           = "[1.31.13]"
+  name                       = "acctest-%[2]d-func"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  app_service_plan_id        = azurerm_app_service_plan.test.id
+  storage_account_name       = azurerm_storage_account.test.name
+  storage_account_access_key = azurerm_storage_account.test.primary_access_key
+  use_extension_bundle       = true
+  bundle_version             = "[1.31.13]"
   // client_affinity_enabled                  = true
   client_certificate_mode                  = "Required"
   enabled                                  = false
@@ -1309,11 +1301,11 @@ resource "azurerm_logic_app_standard" "test" {
   }
 
   site_config {
-    always_on 			= true
+    always_on           = true
     min_tls_version     = 1.3
     scm_min_tls_version = 1.3
 
-	cors {
+    cors {
       allowed_origins = [
         "http://www.contoso.com",
         "www.contoso.com",
@@ -1324,18 +1316,18 @@ resource "azurerm_logic_app_standard" "test" {
       support_credentials = true
     }
 
-    ftps_state = "Disabled"
-    http2_enabled = false
-	pre_warmed_instance_count = 3
-    scm_use_main_ip_restriction = false
-    scm_type = "ExternalGit"
-    use_32_bit_worker_process = true
-    websockets_enabled = false
-    health_check_path = "/"
-	elastic_instance_minimum = 1
-    app_scale_limit = 12
+    ftps_state                       = "Disabled"
+    http2_enabled                    = false
+    pre_warmed_instance_count        = 3
+    scm_use_main_ip_restriction      = false
+    scm_type                         = "ExternalGit"
+    use_32_bit_worker_process        = true
+    websockets_enabled               = false
+    health_check_path                = "/"
+    elastic_instance_minimum         = 1
+    app_scale_limit                  = 12
     runtime_scale_monitoring_enabled = false
-    dotnet_framework_version = "v8.0"
+    dotnet_framework_version         = "v8.0"
 
     ip_restriction {
       ip_address = "10.10.10.10/32"
@@ -1376,8 +1368,8 @@ resource "azurerm_logic_app_standard" "test" {
   }
 
   tags = {
-	environment = "AccTestUpdated"
-    foo = "bar"
+    environment = "AccTestUpdated"
+    foo         = "bar"
   }
 }
 `, r.template(data), data.RandomInteger)
@@ -2008,7 +2000,8 @@ resource "azurerm_logic_app_standard" "test" {
   storage_account_access_key = azurerm_storage_account.test.primary_access_key
 
   site_config {
-    ip_restriction = []
+    always_on = true
+    // ip_restriction = []
   }
 }
 `, r.template(data), data.RandomInteger)
@@ -2068,6 +2061,7 @@ resource "azurerm_logic_app_standard" "test" {
   storage_account_access_key = azurerm_storage_account.test.primary_access_key
 
   site_config {
+    always_on = true
     scm_ip_restriction {
       ip_address = "10.10.10.10/32"
     }
@@ -2089,7 +2083,8 @@ resource "azurerm_logic_app_standard" "test" {
   storage_account_access_key = azurerm_storage_account.test.primary_access_key
 
   site_config {
-    scm_ip_restriction = []
+    always_on = true
+    //   scm_ip_restriction = []
   }
 }
 `, r.template(data), data.RandomInteger)

--- a/internal/services/logic/logic_app_standard_resource_test.go
+++ b/internal/services/logic/logic_app_standard_resource_test.go
@@ -360,6 +360,7 @@ func TestAccLogicAppStandard_updateVersion(t *testing.T) {
 				check.That(data.ResourceName).Key("version").HasValue("~1"),
 			),
 		},
+		data.ImportStep(),
 		{
 			Config: r.version(data, "~2"),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -367,6 +368,7 @@ func TestAccLogicAppStandard_updateVersion(t *testing.T) {
 				check.That(data.ResourceName).Key("version").HasValue("~2"),
 			),
 		},
+		data.ImportStep(),
 	})
 }
 
@@ -379,9 +381,9 @@ func TestAccLogicAppStandard_3264bit(t *testing.T) {
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("site_config.0.use_32_bit_worker_process").HasValue("true"),
 			),
 		},
+		data.ImportStep(),
 		{
 			Config: r.app64bit(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -389,6 +391,7 @@ func TestAccLogicAppStandard_3264bit(t *testing.T) {
 				check.That(data.ResourceName).Key("site_config.0.use_32_bit_worker_process").HasValue("false"),
 			),
 		},
+		data.ImportStep(),
 	})
 }
 
@@ -401,9 +404,9 @@ func TestAccLogicAppStandard_httpsOnly(t *testing.T) {
 			Config: r.httpsOnly(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("https_only").HasValue("true"),
 			),
 		},
+		data.ImportStep(),
 	})
 }
 
@@ -416,12 +419,9 @@ func TestAccLogicAppStandard_createIdentity(t *testing.T) {
 			Config: r.basicIdentity(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("identity.#").HasValue("1"),
-				check.That(data.ResourceName).Key("identity.0.type").HasValue("SystemAssigned"),
-				check.That(data.ResourceName).Key("identity.0.principal_id").IsUUID(),
-				check.That(data.ResourceName).Key("identity.0.tenant_id").IsUUID(),
 			),
 		},
+		data.ImportStep(),
 	})
 }
 
@@ -434,19 +434,16 @@ func TestAccLogicAppStandard_updateIdentity(t *testing.T) {
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("identity.#").HasValue("0"),
 			),
 		},
+		data.ImportStep(),
 		{
 			Config: r.basicIdentity(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("identity.#").HasValue("1"),
-				check.That(data.ResourceName).Key("identity.0.type").HasValue("SystemAssigned"),
-				check.That(data.ResourceName).Key("identity.0.principal_id").IsUUID(),
-				check.That(data.ResourceName).Key("identity.0.tenant_id").IsUUID(),
 			),
 		},
+		data.ImportStep(),
 	})
 }
 
@@ -459,10 +456,9 @@ func TestAccLogicAppStandard_userAssignedIdentity(t *testing.T) {
 			Config: r.userAssignedIdentity(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("identity.#").HasValue("1"),
-				check.That(data.ResourceName).Key("identity.0.type").HasValue("UserAssigned"),
 			),
 		},
+		data.ImportStep(),
 	})
 }
 
@@ -475,9 +471,6 @@ func TestAccLogicAppStandard_corsSettings(t *testing.T) {
 			Config: r.corsSettings(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("site_config.0.cors.#").HasValue("1"),
-				check.That(data.ResourceName).Key("site_config.0.cors.0.support_credentials").HasValue("true"),
-				check.That(data.ResourceName).Key("site_config.0.cors.0.allowed_origins.#").HasValue("4"),
 			),
 		},
 		data.ImportStep(),
@@ -493,7 +486,6 @@ func TestAccLogicAppStandard_enableHttp2(t *testing.T) {
 			Config: r.enableHttp2(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("site_config.0.http2_enabled").HasValue("true"),
 			),
 		},
 		data.ImportStep(),
@@ -509,7 +501,6 @@ func TestAccLogicAppStandard_minTlsVersion(t *testing.T) {
 			Config: r.minTlsVersion(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("site_config.0.min_tls_version").HasValue("1.2"),
 			),
 		},
 		data.ImportStep(),
@@ -525,7 +516,6 @@ func TestAccLogicAppStandard_ftpsState(t *testing.T) {
 			Config: r.ftpsState(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("site_config.0.ftps_state").HasValue("AllAllowed"),
 			),
 		},
 		data.ImportStep(),
@@ -541,7 +531,6 @@ func TestAccLogicAppStandard_preWarmedInstanceCount(t *testing.T) {
 			Config: r.preWarmedInstanceCount(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("site_config.0.pre_warmed_instance_count").HasValue("1"),
 			),
 		},
 		data.ImportStep(),
@@ -557,7 +546,6 @@ func TestAccLogicAppStandard_computedPreWarmedInstanceCount(t *testing.T) {
 			Config: r.computedPreWarmedInstanceCount(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("site_config.0.pre_warmed_instance_count").HasValue("1"),
 			),
 		},
 		data.ImportStep(),
@@ -573,7 +561,6 @@ func TestAccLogicAppStandard_oneIpRestriction(t *testing.T) {
 			Config: r.oneIpRestriction(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("site_config.0.ip_restriction.0.ip_address").HasValue("10.10.10.10/32"),
 			),
 		},
 		data.ImportStep(),
@@ -589,7 +576,6 @@ func TestAccLogicAppStandard_oneServiceTagIpRestriction(t *testing.T) {
 			Config: r.oneServiceTagIpRestriction(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("site_config.0.ip_restriction.0.service_tag").HasValue("AzureEventGrid"),
 			),
 		},
 		data.ImportStep(),
@@ -605,16 +591,16 @@ func TestAccLogicAppStandard_changeIpToServiceTagIpRestriction(t *testing.T) {
 			Config: r.oneIpRestriction(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("site_config.0.ip_restriction.0.ip_address").HasValue("10.10.10.10/32"),
 			),
 		},
+		data.ImportStep(),
 		{
 			Config: r.oneServiceTagIpRestriction(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("site_config.0.ip_restriction.0.service_tag").HasValue("AzureEventGrid"),
 			),
 		},
+		data.ImportStep(),
 		{
 			Config: r.oneIpRestriction(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -622,6 +608,7 @@ func TestAccLogicAppStandard_changeIpToServiceTagIpRestriction(t *testing.T) {
 				check.That(data.ResourceName).Key("site_config.0.ip_restriction.0.ip_address").HasValue("10.10.10.10/32"),
 			),
 		},
+		data.ImportStep(),
 	})
 }
 
@@ -650,17 +637,17 @@ func TestAccLogicAppStandard_ipRestrictionRemoved(t *testing.T) {
 			Config: r.oneIpRestriction(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("site_config.0.ip_restriction.#").HasValue("1"),
 			),
 		},
+		data.ImportStep(),
 		{
 			// This configuration has no site_config blocks at all.
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("site_config.0.ip_restriction.#").HasValue("1"),
 			),
 		},
+		data.ImportStep(),
 		{
 			// This configuration explicitly sets ip_restriction to [] using attribute syntax.
 			Config: r.ipRestrictionRemoved(data),
@@ -669,6 +656,7 @@ func TestAccLogicAppStandard_ipRestrictionRemoved(t *testing.T) {
 				check.That(data.ResourceName).Key("site_config.0.ip_restriction.#").HasValue("0"),
 			),
 		},
+		data.ImportStep(),
 	})
 }
 
@@ -682,17 +670,17 @@ func TestAccLogicAppStandard_scmIpRestrictionRemoved(t *testing.T) {
 			Config: r.oneIpRestriction(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("site_config.0.ip_restriction.#").HasValue("1"),
 			),
 		},
+		data.ImportStep(),
 		{
 			// This configuration has no site_config blocks at all.
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("site_config.0.ip_restriction.#").HasValue("1"),
 			),
 		},
+		data.ImportStep(),
 		{
 			// This configuration explicitly sets ip_restriction to [] using attribute syntax.
 			Config: r.ipRestrictionRemoved(data),
@@ -701,6 +689,7 @@ func TestAccLogicAppStandard_scmIpRestrictionRemoved(t *testing.T) {
 				check.That(data.ResourceName).Key("site_config.0.ip_restriction.#").HasValue("0"),
 			),
 		},
+		data.ImportStep(),
 	})
 }
 
@@ -824,28 +813,34 @@ func TestAccLogicAppStandard_clientCertMode(t *testing.T) {
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("client_certificate_mode").HasValue(""),
 			),
 		},
+		data.ImportStep(),
 		{
 			Config: r.clientCertMode(data, "Required"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("client_certificate_mode").HasValue("Required"),
 			),
 		},
+		data.ImportStep(),
 		{
 			Config: r.clientCertMode(data, "Optional"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("client_certificate_mode").HasValue("Optional"),
 			),
 		},
+		data.ImportStep(),
+		{
+			Config: r.clientCertMode(data, "OptionalInteractiveUser"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
 		{
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("client_certificate_mode").HasValue(""),
 			),
 		},
 		data.ImportStep(),
@@ -861,7 +856,6 @@ func TestAccLogicAppStandard_elasticInstanceMinimum(t *testing.T) {
 			Config: r.elasticInstanceMinimum(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("site_config.0.elastic_instance_minimum").HasValue("1"),
 			),
 		},
 		data.ImportStep(),
@@ -877,7 +871,6 @@ func TestAccLogicAppStandard_appScaleLimit(t *testing.T) {
 			Config: r.appScaleLimit(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("site_config.0.app_scale_limit").HasValue("1"),
 			),
 		},
 		data.ImportStep(),
@@ -893,7 +886,6 @@ func TestAccLogicAppStandard_runtimeScaleMonitoringEnabled(t *testing.T) {
 			Config: r.runtimeScaleMonitoringEnabled(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("site_config.0.runtime_scale_monitoring_enabled").HasValue("true"),
 			),
 		},
 		data.ImportStep(),
@@ -909,7 +901,6 @@ func TestAccLogicAppStandard_dotnetVersion4(t *testing.T) {
 			Config: r.dotnetVersion(data, "~1", "v4.0"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("site_config.0.dotnet_framework_version").HasValue("v4.0"),
 			),
 		},
 		data.ImportStep(),
@@ -925,7 +916,6 @@ func TestAccLogicAppStandard_dotnetVersion5(t *testing.T) {
 			Config: r.dotnetVersion(data, "~4", "v5.0"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("site_config.0.dotnet_framework_version").HasValue("v5.0"),
 			),
 		},
 		data.ImportStep(),
@@ -941,7 +931,6 @@ func TestAccLogicAppStandard_dotnetVersion6(t *testing.T) {
 			Config: r.dotnetVersion(data, "~4", "v6.0"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("site_config.0.dotnet_framework_version").HasValue("v6.0"),
 			),
 		},
 		data.ImportStep(),
@@ -957,7 +946,6 @@ func TestAccLogicAppStandard_dotnetVersion8(t *testing.T) {
 			Config: r.dotnetVersion(data, "~4", "v8.0"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("site_config.0.dotnet_framework_version").HasValue("v8.0"),
 			),
 		},
 		data.ImportStep(),
@@ -1060,7 +1048,6 @@ func TestAccLogicAppStandard_vnetContentShareEnabled(t *testing.T) {
 			Config: r.vnetContentShareEnabled(data, false),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("vnet_content_share_enabled").HasValue("false"),
 			),
 		},
 		data.ImportStep(),
@@ -1068,7 +1055,6 @@ func TestAccLogicAppStandard_vnetContentShareEnabled(t *testing.T) {
 			Config: r.vnetContentShareEnabled(data, true),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("vnet_content_share_enabled").HasValue("true"),
 			),
 		},
 		data.ImportStep(),
@@ -1076,7 +1062,6 @@ func TestAccLogicAppStandard_vnetContentShareEnabled(t *testing.T) {
 			Config: r.vnetContentShareEnabled(data, false),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("vnet_content_share_enabled").HasValue("false"),
 			),
 		},
 		data.ImportStep(),

--- a/internal/services/logic/registration.go
+++ b/internal/services/logic/registration.go
@@ -10,7 +10,18 @@ import (
 
 type Registration struct{}
 
+func (r Registration) DataSources() []sdk.DataSource {
+	return []sdk.DataSource{}
+}
+
+func (r Registration) Resources() []sdk.Resource {
+	return []sdk.Resource{
+		LogicAppResource{},
+	}
+}
+
 var _ sdk.UntypedServiceRegistrationWithAGitHubLabel = Registration{}
+var _ sdk.TypedServiceRegistration = Registration{}
 
 func (r Registration) AssociatedGitHubLabel() string {
 	return "service/logic"
@@ -55,7 +66,6 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 		"azurerm_logic_app_trigger_http_request":                    resourceLogicAppTriggerHttpRequest(),
 		"azurerm_logic_app_trigger_recurrence":                      resourceLogicAppTriggerRecurrence(),
 		"azurerm_logic_app_workflow":                                resourceLogicAppWorkflow(),
-		"azurerm_logic_app_standard":                                resourceLogicAppStandard(),
 	}
 
 	return resources

--- a/internal/services/logic/registration.go
+++ b/internal/services/logic/registration.go
@@ -20,8 +20,10 @@ func (r Registration) Resources() []sdk.Resource {
 	}
 }
 
-var _ sdk.UntypedServiceRegistrationWithAGitHubLabel = Registration{}
-var _ sdk.TypedServiceRegistration = Registration{}
+var (
+	_ sdk.UntypedServiceRegistrationWithAGitHubLabel = Registration{}
+	_ sdk.TypedServiceRegistration                   = Registration{}
+)
 
 func (r Registration) AssociatedGitHubLabel() string {
 	return "service/logic"

--- a/internal/tf/suppress/list.go
+++ b/internal/tf/suppress/list.go
@@ -12,7 +12,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-// ListOrder TODO remove for 4.0
+// ListOrder is a DiffSuppressFunc intended to temporarily avoid breaking changes when moving from TypeSet to TypeList for lists that are not ordered but TF would otherwise detect as a change.
+// It should not be used in any other case and should be removed from any schema it is present in at a Major version as a breaking change notification.
 func ListOrder(key, old, new string, d *schema.ResourceData) bool {
 	// Taken from https://github.com/hashicorp/terraform-plugin-sdk/issues/477#issuecomment-1238807249
 	// For a list, the key is path to the element, rather than the list.

--- a/website/docs/5.0-upgrade-guide.html.markdown
+++ b/website/docs/5.0-upgrade-guide.html.markdown
@@ -54,6 +54,10 @@ This deprecated resource has been superseded/retired and has been removed from t
 
 * This deprecated resource has been retired and has been removed from the Azure Provider.
 
+### `azurerm_logic_app_standard`
+
+* The `client_certificate_mode` property now defaults to `Required` aligning with the service default for this value.
+
 ### `azurerm_maps_creator`
 
 * This deprecated resource has been removed from the Azure Provider. Please see the [documentation for more details](https://aka.ms/AzureMapsCreatorDeprecation).

--- a/website/docs/5.0-upgrade-guide.html.markdown
+++ b/website/docs/5.0-upgrade-guide.html.markdown
@@ -124,6 +124,7 @@ This deprecated data source has been superseded/retired and has been removed fro
 ### `azurerm_logic_app_standard`
 
 * The deprecated `site_config.public_network_access_enabled` property has been removed and superseded by the `public_network_access` property.
+* The `client_certificate_mode` property now defaults to `Required` to match API default value.
 
 ### `azurerm_postgresql_server`
 

--- a/website/docs/r/logic_app_standard.html.markdown
+++ b/website/docs/r/logic_app_standard.html.markdown
@@ -131,7 +131,7 @@ The following arguments are supported:
 
 * `client_affinity_enabled` - (Optional) Should the Logic App send session affinity cookies, which route client requests in the same session to the same instance?
 
-* `client_certificate_mode` - (Optional) The mode of the Logic App's client certificates requirement for incoming requests. Possible values are `Required` and `Optional`.
+* `client_certificate_mode` - (Optional) The mode of the Logic App's client certificates requirement for incoming requests. Possible values are `Required`, `Optional`, and `OptionalInteractiveUser`.
 
 * `enabled` - (Optional) Is the Logic App enabled? Defaults to `true`.
 
@@ -239,9 +239,9 @@ The `site_config` block supports the following:
 
 A `cors` block supports the following:
 
-* `allowed_origins` - (Required) A list of origins which should be able to make cross-origin calls. `*` can be used to allow all calls.
+* `allowed_origins` - (Optional) A list of origins which should be able to make cross-origin calls. `*` can be used to allow all calls.
 
-* `support_credentials` - (Optional) Are credentials supported?
+* `support_credentials` - (Optional) Are credentials supported? 
 
 ---
 
@@ -260,6 +260,8 @@ An `identity` block supports the following:
 A `ip_restriction` block supports the following:
 
 * `ip_address` - (Optional) The IP Address used for this IP Restriction in CIDR notation.
+
+* `description` - (Optional) The Description of this IP Restriction.
 
 * `service_tag` - (Optional) The Service Tag used for this IP Restriction.
 
@@ -280,6 +282,8 @@ A `ip_restriction` block supports the following:
 A `scm_ip_restriction` block supports the following:
 
 * `ip_address` - (Optional) The IP Address used for this IP Restriction in CIDR notation.
+
+* `description` - (Optional) The Description of this IP Restriction.
 
 * `service_tag` - (Optional) The Service Tag used for this IP Restriction.
 


### PR DESCRIPTION
## Description

This PR addresses several state issues with the Logic App Standard resource resulting from incorrect use of `TypeSet` in place of `TypeList` resulting in bugs that manifested as diffs. In this PR the implementation of the resource is changed over to the newer `TypedSDK` and leverages compatible shared code from the `appservice` service.

## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_logic_app_standard` - refactor to leverage shared code with `appservice`


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
