### PR TITLE
Doc Fix: `azurerm_mysql_flexible_server` - `create_mode`

### DIFF
--- a/website/docs/r/mysql_flexible_server.html.markdown
+++ b/website/docs/r/mysql_flexible_server.html.markdown
@@ -101,6 +101,8 @@ The following arguments are supported:
 
 ~> **Note:** When a server is first created it may not be immediately available for `geo restore` or `replica`. It may take a few minutes to several hours for the necessary metadata to be populated. Please see the [Geo Restore](https://learn.microsoft.com/azure/mysql/single-server/how-to-restore-server-portal#geo-restore) and the [Replica](https://learn.microsoft.com/azure/mysql/flexible-server/concepts-read-replicas#create-a-replica) for more information.
 
+~> **Note:** When importing a MySQL Flexible Server, `create_mode` is not returned by the api so you will see a diff if `create_mode` is specified in your config. To prevent recreation, use the `ignore_changes` lifecycle meta-argument.
+
 * `customer_managed_key` - (Optional) A `customer_managed_key` block as defined below.
 
 ~> **Note:** `identity` is required when `customer_managed_key` is specified.


### PR DESCRIPTION
We are unable to read `create_mode` from the api which is causing Terraform to want to recreate this resource when importing it. Writing a note detailing what is happening and how to get around it