### PR TITLE
`azurerm_windows_virtual_machine` - Support for `admin_password_wo` and `admin_password_wo_version`

### DIFF
--- a/internal/services/compute/windows_virtual_machine_resource.go
+++ b/internal/services/compute/windows_virtual_machine_resource.go
@@ -5,6 +5,7 @@ package compute
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -23,6 +24,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-01/proximityplacementgroups"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2023-04-02/disks"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachines"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	azValidate "github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -55,6 +57,10 @@ func resourceWindowsVirtualMachine() *pluginsdk.Resource {
 			Delete: pluginsdk.DefaultTimeout(45 * time.Minute),
 		},
 
+		CustomizeDiff: pluginsdk.CustomDiffWithAll(
+			pluginsdk.CustomizeDiffShim(resourceWindowsVirtualMachineCustomizeDiff),
+		),
+
 		Schema: map[string]*pluginsdk.Schema{
 			"name": {
 				Type:         pluginsdk.TypeString,
@@ -73,22 +79,33 @@ func resourceWindowsVirtualMachine() *pluginsdk.Resource {
 				ForceNew:         true,
 				Sensitive:        true,
 				DiffSuppressFunc: adminPasswordDiffSuppressFunc,
-				RequiredWith: []string{
-					"admin_username",
-				},
 				ConflictsWith: []string{
 					"os_managed_disk_id",
+					"admin_password_wo",
 				},
 				ValidateFunc: computeValidate.WindowsAdminPassword,
+			},
+
+			"admin_password_wo": {
+				Type:          pluginsdk.TypeString,
+				Optional:      true,
+				WriteOnly:     true,
+				RequiredWith:  []string{"admin_password_wo_version"},
+				ConflictsWith: []string{"admin_password", "os_managed_disk_id"},
+				ValidateFunc:  computeValidate.WindowsAdminPassword,
+			},
+
+			"admin_password_wo_version": {
+				Type:         pluginsdk.TypeInt,
+				Optional:     true,
+				ForceNew:     true,
+				RequiredWith: []string{"admin_password_wo"},
 			},
 
 			"admin_username": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
 				ForceNew: true,
-				RequiredWith: []string{
-					"admin_password",
-				},
 				ExactlyOneOf: []string{
 					"admin_username",
 					"os_managed_disk_id",
@@ -485,6 +502,34 @@ func resourceWindowsVirtualMachine() *pluginsdk.Resource {
 	}
 }
 
+func resourceWindowsVirtualMachineCustomizeDiff(ctx context.Context, diff *pluginsdk.ResourceDiff, meta interface{}) error {
+	rawConfig := diff.GetRawConfig().AsValueMap()
+	adminUsername, ok := rawConfig["admin_username"]
+	if !ok || adminUsername.IsNull() || !adminUsername.IsKnown() {
+		return nil
+	}
+
+	if osManagedDiskId, ok := rawConfig["os_managed_disk_id"]; ok && (!osManagedDiskId.IsNull() || !osManagedDiskId.IsKnown()) {
+		return nil
+	}
+
+	adminPasswordSet := false
+	if adminPassword, ok := rawConfig["admin_password"]; ok && !adminPassword.IsNull() {
+		adminPasswordSet = true
+	}
+
+	adminPasswordWOVersionSet := false
+	if adminPasswordWOVersion, ok := rawConfig["admin_password_wo_version"]; ok && !adminPasswordWOVersion.IsNull() {
+		adminPasswordWOVersionSet = true
+	}
+
+	if !adminPasswordSet && !adminPasswordWOVersionSet {
+		return errors.New("one of `admin_password` or `admin_password_wo_version` must be specified when `admin_username` is specified")
+	}
+
+	return nil
+}
+
 func resourceWindowsVirtualMachineCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Compute.VirtualMachinesClient
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
@@ -514,6 +559,16 @@ func resourceWindowsVirtualMachineCreate(d *pluginsdk.ResourceData, meta interfa
 
 	additionalUnattendContentRaw := d.Get("additional_unattend_content").([]interface{})
 	additionalUnattendContent := expandAdditionalUnattendContent(additionalUnattendContentRaw)
+
+	adminPassword := d.Get("admin_password").(string)
+
+	woPassword, err := pluginsdk.GetWriteOnly(d, "admin_password_wo", cty.String)
+	if err != nil {
+		return err
+	}
+	if !woPassword.IsNull() {
+		adminPassword = woPassword.AsString()
+	}
 
 	allowExtensionOperations := true
 	if !d.GetRawConfig().AsValueMap()["allow_extension_operations"].IsNull() {
@@ -614,7 +669,7 @@ func resourceWindowsVirtualMachineCreate(d *pluginsdk.ResourceData, meta interfa
 		}
 
 		params.Properties.OsProfile = &virtualmachines.OSProfile{
-			AdminPassword:            pointer.To(d.Get("admin_password").(string)),
+			AdminPassword:            pointer.To(adminPassword),
 			AdminUsername:            pointer.To(d.Get("admin_username").(string)),
 			ComputerName:             pointer.To(computerName),
 			AllowExtensionOperations: pointer.To(allowExtensionOperations),
@@ -1010,6 +1065,8 @@ func resourceWindowsVirtualMachineRead(d *pluginsdk.ResourceData, meta interface
 				d.Set("admin_username", profile.AdminUsername)
 				d.Set("allow_extension_operations", profile.AllowExtensionOperations)
 				d.Set("computer_name", profile.ComputerName)
+
+				d.Set("admin_password_wo_version", d.Get("admin_password_wo_version"))
 
 				if config := profile.WindowsConfiguration; config != nil {
 					if err := d.Set("additional_unattend_content", flattenAdditionalUnattendContent(config.AdditionalUnattendContent, d)); err != nil {

--- a/internal/services/compute/windows_virtual_machine_resource_auth_test.go
+++ b/internal/services/compute/windows_virtual_machine_resource_auth_test.go
@@ -4,11 +4,17 @@
 package compute_test
 
 import (
+	"context"
 	"fmt"
+	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccWindowsVirtualMachine_authPassword(t *testing.T) {
@@ -23,6 +29,52 @@ func TestAccWindowsVirtualMachine_authPassword(t *testing.T) {
 			),
 		},
 		data.ImportStep("admin_password"),
+	})
+}
+
+func TestAccWindowsVirtualMachine_authPasswordWriteOnly(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+	r := WindowsVirtualMachineResource{}
+
+	resource.ParallelTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.11.0"))),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []acceptance.TestStep{
+			{
+				Config: r.authPasswordWriteOnly(data, 1),
+				Check: acceptance.ComposeTestCheckFunc(
+					check.That(data.ResourceName).ExistsInAzure(r),
+				),
+			},
+			data.ImportStep("admin_password", "admin_password_wo_version"),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_authPasswordMissing(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+	r := WindowsVirtualMachineResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config:      r.authPasswordMissing(data),
+			ExpectError: regexp.MustCompile("one of `admin_password` or `admin_password_wo_version` must be specified when `admin_username` is specified"),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_authPasswordKnownAfterApply(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+	r := WindowsVirtualMachineResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config:             r.authPasswordKnownAfterApply(data),
+			PlanOnly:           true,
+			ExpectNonEmptyPlan: true,
+		},
 	})
 }
 
@@ -54,4 +106,135 @@ resource "azurerm_windows_virtual_machine" "test" {
   }
 }
 `, r.template(data))
+}
+
+func (r WindowsVirtualMachineResource) authPasswordKnownAfterApply(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "random_password" "test" {
+  length           = 16
+  special          = true
+  override_special = "_%%@!"
+}
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = random_password.test.result
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, r.template(data))
+}
+
+func (r WindowsVirtualMachineResource) authPasswordMissing(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, r.template(data))
+}
+
+func (r WindowsVirtualMachineResource) authPasswordWriteOnly(data acceptance.TestData, version int) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_key_vault" "test" {
+  name                       = "acctestkv%[2]s"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "standard"
+  rbac_authorization_enabled = false
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+
+    secret_permissions = [
+      "Get",
+      "Set",
+      "Delete",
+      "Purge",
+    ]
+  }
+}
+
+resource "azurerm_key_vault_secret" "test" {
+  name         = "admin-password"
+  value        = "P@$$w0rd1234!%[3]d"
+  key_vault_id = azurerm_key_vault.test.id
+}
+
+ephemeral "azurerm_key_vault_secret" "test" {
+  name         = azurerm_key_vault_secret.test.name
+  key_vault_id = azurerm_key_vault.test.id
+}
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                      = local.vm_name
+  resource_group_name       = azurerm_resource_group.test.name
+  location                  = azurerm_resource_group.test.location
+  size                      = "Standard_F2"
+  admin_username            = "adminuser"
+  admin_password_wo         = ephemeral.azurerm_key_vault_secret.test.value
+  admin_password_wo_version = %[3]d
+
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, r.template(data), data.RandomString, version)
 }

--- a/website/docs/r/windows_virtual_machine.html.markdown
+++ b/website/docs/r/windows_virtual_machine.html.markdown
@@ -109,7 +109,11 @@ The following arguments are supported:
 
 * `admin_password` - (Optional) The Password which should be used for the local-administrator on this Virtual Machine. Changing this forces a new resource to be created.
 
-~> **Note:** This is required unless using an existing OS Managed Disk by specifying `os_managed_disk_id`.
+* `admin_password_wo` - (Optional, Write-Only) The write-only Password which should be used for the local-administrator on this Virtual Machine. This property should be used when sensitive values should not be stored in state.
+
+~> **Note:** One of `admin_password` or `admin_password_wo` must be specified when not using an existing OS Managed Disk.
+
+* `admin_password_wo_version` - (Optional) An integer value used to trigger an update for `admin_password_wo`. This property should be incremented when updating `admin_password_wo`. Changing this forces a new resource to be created.
 
 * `admin_username` - (Optional) The username of the local administrator used for the Virtual Machine. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
## Community Note

* Please vote on this PR by adding a :thumbsup: reaction to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

Adds `admin_password_wo` and `admin_password_wo_version` to `azurerm_windows_virtual_machine` so the administrator password can be supplied without storing it in Terraform state.

The write-only password and its version must be configured together and conflict with `admin_password`. The existing requirement for a password when `admin_username` is configured is preserved through a raw-config `CustomizeDiff` check, including support for values that are not known until apply.

Write-only attributes require Terraform 1.11 or later.

## PR Checklist

- [x] I have followed the guidelines in our Contributing Documentation.
- [x] I have checked to ensure there are not other open Pull Requests for the same update/change.
- [x] I have checked if my changes close any open issues.
- [x] I have updated/added Documentation as required.
- [x] I have used a meaningful PR title.

## Changes to existing Resource / Data Source

- [x] I have explained the behavior change.
- [x] I have added test coverage and updated the documentation.
- [ ] State migration only.

## Testing

The current test merge was checked against the latest main branch. Password checks passed; the two managed-disk import failures below were independently reproduced on exact main and traced to unchanged Read/import code.

Offline verification passed:

- 20 valid/invalid, missing, null and unknown-value authentication cases using the actual resource schema and CustomizeDiff.
- SDK plan/state checks for write-only nonpersistence and replacement behaviour. Azure callbacks were stubbed for these checks; they are not cloud lifecycle evidence.
- Seven fully rendered fixture checks and the existing Windows password validator tests.
- Current repository-pinned lint for compute and compute/validate, with no issues.

[TeamCity 743445](https://hashicorp.teamcity.com/build/743445) finished on the exact validated current merge: **4 passed, 2 failed, 0 ignored**. Normal and write-only password creation/import, missing-password validation, and the known-after-apply planning case passed. Both managed-OS-disk cases failed at Step 7 import verification because `bypass_platform_safety_checks_on_user_schedule_enabled=false` was missing after import.

All six selected names and the actual revision were verified. [Exact-base control 743448](https://hashicorp.teamcity.com/build/743448) finished with both managed-disk tests failing identically at Step 7/7, against the same main revision with matching execution settings. The relevant importer, attach/update paths, safety-check normalization and test fixtures are unchanged. Windows Read does not populate the safety-check flag for a fresh import when the specialized VM has no OSProfile.

This establishes a pre-existing import-normalization issue, not a write-only password regression. No ignore list was expanded and neither failure is hidden: the PR run remains **4 passed / 2 failed**, while all four password/validation cases passed.

[Historical run 706793](https://hashicorp.teamcity.com/build/706793) passed all four authentication cases but failed overall: 121 passed, 4 failed and 5 ignored. Both managed-disk compatibility cases failed import checks in that old run, so they are included in the fresh selection rather than dismissed as unrelated.

Earlier local Azure attempts were blocked by an expired tenant; they are historical, not the result of the fresh run above. Existing live coverage does not test password-version replacement or every authentication-mode transition.

Write-only nonpersistence refers to the VM's write-only field. The fixture separately seeds Key Vault with an ordinary secret resource, so this is not a claim that the whole Terraform test state contains no secret value.

## Change Log

* `azurerm_windows_virtual_machine` - support `admin_password_wo` and `admin_password_wo_version`

This is an Enhancement.

## Related Issue(s)

Fixes #29366

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

No changes to security controls.
