### PR TITLE
`azurerm_eventgrid_namespace` - `route_topic_id` validation now accepts namespace topics

### DIFF
--- a/internal/services/eventgrid/eventgrid_namespace_resource.go
+++ b/internal/services/eventgrid/eventgrid_namespace_resource.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2022-06-15/topics"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2023-12-15-preview/namespaces"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2023-12-15-preview/namespacetopics"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -149,9 +150,12 @@ func (r EventGridNamespaceResource) Arguments() map[string]*pluginsdk.Schema {
 					},
 
 					"route_topic_id": {
-						Type:         pluginsdk.TypeString,
-						Optional:     true,
-						ValidateFunc: topics.ValidateTopicID,
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						ValidateFunc: validation.Any(
+							topics.ValidateTopicID,
+							namespacetopics.ValidateNamespaceTopicID,
+						),
 					},
 
 					"dynamic_routing_enrichment": {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2023-12-15-preview/namespacetopics/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2023-12-15-preview/namespacetopics/README.md
@@ -1,0 +1,132 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2023-12-15-preview/namespacetopics` Documentation
+
+The `namespacetopics` SDK allows for interaction with Azure Resource Manager `eventgrid` (API Version `2023-12-15-preview`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2023-12-15-preview/namespacetopics"
+```
+
+
+### Client Initialization
+
+```go
+client := namespacetopics.NewNamespaceTopicsClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `NamespaceTopicsClient.CreateOrUpdate`
+
+```go
+ctx := context.TODO()
+id := namespacetopics.NewNamespaceTopicID("12345678-1234-9876-4563-123456789012", "example-resource-group", "namespaceName", "topicName")
+
+payload := namespacetopics.NamespaceTopic{
+	// ...
+}
+
+
+if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `NamespaceTopicsClient.Delete`
+
+```go
+ctx := context.TODO()
+id := namespacetopics.NewNamespaceTopicID("12345678-1234-9876-4563-123456789012", "example-resource-group", "namespaceName", "topicName")
+
+if err := client.DeleteThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `NamespaceTopicsClient.Get`
+
+```go
+ctx := context.TODO()
+id := namespacetopics.NewNamespaceTopicID("12345678-1234-9876-4563-123456789012", "example-resource-group", "namespaceName", "topicName")
+
+read, err := client.Get(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `NamespaceTopicsClient.ListByNamespace`
+
+```go
+ctx := context.TODO()
+id := namespacetopics.NewNamespaceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "namespaceName")
+
+// alternatively `client.ListByNamespace(ctx, id, namespacetopics.DefaultListByNamespaceOperationOptions())` can be used to do batched pagination
+items, err := client.ListByNamespaceComplete(ctx, id, namespacetopics.DefaultListByNamespaceOperationOptions())
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `NamespaceTopicsClient.ListSharedAccessKeys`
+
+```go
+ctx := context.TODO()
+id := namespacetopics.NewNamespaceTopicID("12345678-1234-9876-4563-123456789012", "example-resource-group", "namespaceName", "topicName")
+
+read, err := client.ListSharedAccessKeys(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `NamespaceTopicsClient.RegenerateKey`
+
+```go
+ctx := context.TODO()
+id := namespacetopics.NewNamespaceTopicID("12345678-1234-9876-4563-123456789012", "example-resource-group", "namespaceName", "topicName")
+
+payload := namespacetopics.TopicRegenerateKeyRequest{
+	// ...
+}
+
+
+if err := client.RegenerateKeyThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `NamespaceTopicsClient.Update`
+
+```go
+ctx := context.TODO()
+id := namespacetopics.NewNamespaceTopicID("12345678-1234-9876-4563-123456789012", "example-resource-group", "namespaceName", "topicName")
+
+payload := namespacetopics.NamespaceTopicUpdateParameters{
+	// ...
+}
+
+
+if err := client.UpdateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2023-12-15-preview/namespacetopics/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2023-12-15-preview/namespacetopics/client.go
@@ -1,0 +1,26 @@
+package namespacetopics
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NamespaceTopicsClient struct {
+	Client *resourcemanager.Client
+}
+
+func NewNamespaceTopicsClientWithBaseURI(sdkApi sdkEnv.Api) (*NamespaceTopicsClient, error) {
+	client, err := resourcemanager.NewClient(sdkApi, "namespacetopics", defaultApiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating NamespaceTopicsClient: %+v", err)
+	}
+
+	return &NamespaceTopicsClient{
+		Client: client,
+	}, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2023-12-15-preview/namespacetopics/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2023-12-15-preview/namespacetopics/constants.go
@@ -1,0 +1,151 @@
+package namespacetopics
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type EventInputSchema string
+
+const (
+	EventInputSchemaCloudEventSchemaVOneZero EventInputSchema = "CloudEventSchemaV1_0"
+)
+
+func PossibleValuesForEventInputSchema() []string {
+	return []string{
+		string(EventInputSchemaCloudEventSchemaVOneZero),
+	}
+}
+
+func (s *EventInputSchema) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseEventInputSchema(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseEventInputSchema(input string) (*EventInputSchema, error) {
+	vals := map[string]EventInputSchema{
+		"cloudeventschemav1_0": EventInputSchemaCloudEventSchemaVOneZero,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := EventInputSchema(input)
+	return &out, nil
+}
+
+type NamespaceTopicProvisioningState string
+
+const (
+	NamespaceTopicProvisioningStateCanceled      NamespaceTopicProvisioningState = "Canceled"
+	NamespaceTopicProvisioningStateCreateFailed  NamespaceTopicProvisioningState = "CreateFailed"
+	NamespaceTopicProvisioningStateCreating      NamespaceTopicProvisioningState = "Creating"
+	NamespaceTopicProvisioningStateDeleteFailed  NamespaceTopicProvisioningState = "DeleteFailed"
+	NamespaceTopicProvisioningStateDeleted       NamespaceTopicProvisioningState = "Deleted"
+	NamespaceTopicProvisioningStateDeleting      NamespaceTopicProvisioningState = "Deleting"
+	NamespaceTopicProvisioningStateFailed        NamespaceTopicProvisioningState = "Failed"
+	NamespaceTopicProvisioningStateSucceeded     NamespaceTopicProvisioningState = "Succeeded"
+	NamespaceTopicProvisioningStateUpdatedFailed NamespaceTopicProvisioningState = "UpdatedFailed"
+	NamespaceTopicProvisioningStateUpdating      NamespaceTopicProvisioningState = "Updating"
+)
+
+func PossibleValuesForNamespaceTopicProvisioningState() []string {
+	return []string{
+		string(NamespaceTopicProvisioningStateCanceled),
+		string(NamespaceTopicProvisioningStateCreateFailed),
+		string(NamespaceTopicProvisioningStateCreating),
+		string(NamespaceTopicProvisioningStateDeleteFailed),
+		string(NamespaceTopicProvisioningStateDeleted),
+		string(NamespaceTopicProvisioningStateDeleting),
+		string(NamespaceTopicProvisioningStateFailed),
+		string(NamespaceTopicProvisioningStateSucceeded),
+		string(NamespaceTopicProvisioningStateUpdatedFailed),
+		string(NamespaceTopicProvisioningStateUpdating),
+	}
+}
+
+func (s *NamespaceTopicProvisioningState) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseNamespaceTopicProvisioningState(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseNamespaceTopicProvisioningState(input string) (*NamespaceTopicProvisioningState, error) {
+	vals := map[string]NamespaceTopicProvisioningState{
+		"canceled":      NamespaceTopicProvisioningStateCanceled,
+		"createfailed":  NamespaceTopicProvisioningStateCreateFailed,
+		"creating":      NamespaceTopicProvisioningStateCreating,
+		"deletefailed":  NamespaceTopicProvisioningStateDeleteFailed,
+		"deleted":       NamespaceTopicProvisioningStateDeleted,
+		"deleting":      NamespaceTopicProvisioningStateDeleting,
+		"failed":        NamespaceTopicProvisioningStateFailed,
+		"succeeded":     NamespaceTopicProvisioningStateSucceeded,
+		"updatedfailed": NamespaceTopicProvisioningStateUpdatedFailed,
+		"updating":      NamespaceTopicProvisioningStateUpdating,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := NamespaceTopicProvisioningState(input)
+	return &out, nil
+}
+
+type PublisherType string
+
+const (
+	PublisherTypeCustom PublisherType = "Custom"
+)
+
+func PossibleValuesForPublisherType() []string {
+	return []string{
+		string(PublisherTypeCustom),
+	}
+}
+
+func (s *PublisherType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parsePublisherType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parsePublisherType(input string) (*PublisherType, error) {
+	vals := map[string]PublisherType{
+		"custom": PublisherTypeCustom,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := PublisherType(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2023-12-15-preview/namespacetopics/id_namespace.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2023-12-15-preview/namespacetopics/id_namespace.go
@@ -1,0 +1,130 @@
+package namespacetopics
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&NamespaceId{})
+}
+
+var _ resourceids.ResourceId = &NamespaceId{}
+
+// NamespaceId is a struct representing the Resource ID for a Namespace
+type NamespaceId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	NamespaceName     string
+}
+
+// NewNamespaceID returns a new NamespaceId struct
+func NewNamespaceID(subscriptionId string, resourceGroupName string, namespaceName string) NamespaceId {
+	return NamespaceId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		NamespaceName:     namespaceName,
+	}
+}
+
+// ParseNamespaceID parses 'input' into a NamespaceId
+func ParseNamespaceID(input string) (*NamespaceId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&NamespaceId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := NamespaceId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseNamespaceIDInsensitively parses 'input' case-insensitively into a NamespaceId
+// note: this method should only be used for API response data and not user input
+func ParseNamespaceIDInsensitively(input string) (*NamespaceId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&NamespaceId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := NamespaceId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *NamespaceId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.NamespaceName, ok = input.Parsed["namespaceName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", input)
+	}
+
+	return nil
+}
+
+// ValidateNamespaceID checks that 'input' can be parsed as a Namespace ID
+func ValidateNamespaceID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseNamespaceID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Namespace ID
+func (id NamespaceId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.EventGrid/namespaces/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.NamespaceName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Namespace ID
+func (id NamespaceId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftEventGrid", "Microsoft.EventGrid", "Microsoft.EventGrid"),
+		resourceids.StaticSegment("staticNamespaces", "namespaces", "namespaces"),
+		resourceids.UserSpecifiedSegment("namespaceName", "namespaceName"),
+	}
+}
+
+// String returns a human-readable description of this Namespace ID
+func (id NamespaceId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Namespace Name: %q", id.NamespaceName),
+	}
+	return fmt.Sprintf("Namespace (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2023-12-15-preview/namespacetopics/id_namespacetopic.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2023-12-15-preview/namespacetopics/id_namespacetopic.go
@@ -1,0 +1,139 @@
+package namespacetopics
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&NamespaceTopicId{})
+}
+
+var _ resourceids.ResourceId = &NamespaceTopicId{}
+
+// NamespaceTopicId is a struct representing the Resource ID for a Namespace Topic
+type NamespaceTopicId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	NamespaceName     string
+	TopicName         string
+}
+
+// NewNamespaceTopicID returns a new NamespaceTopicId struct
+func NewNamespaceTopicID(subscriptionId string, resourceGroupName string, namespaceName string, topicName string) NamespaceTopicId {
+	return NamespaceTopicId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		NamespaceName:     namespaceName,
+		TopicName:         topicName,
+	}
+}
+
+// ParseNamespaceTopicID parses 'input' into a NamespaceTopicId
+func ParseNamespaceTopicID(input string) (*NamespaceTopicId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&NamespaceTopicId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := NamespaceTopicId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseNamespaceTopicIDInsensitively parses 'input' case-insensitively into a NamespaceTopicId
+// note: this method should only be used for API response data and not user input
+func ParseNamespaceTopicIDInsensitively(input string) (*NamespaceTopicId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&NamespaceTopicId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := NamespaceTopicId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *NamespaceTopicId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.NamespaceName, ok = input.Parsed["namespaceName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", input)
+	}
+
+	if id.TopicName, ok = input.Parsed["topicName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "topicName", input)
+	}
+
+	return nil
+}
+
+// ValidateNamespaceTopicID checks that 'input' can be parsed as a Namespace Topic ID
+func ValidateNamespaceTopicID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseNamespaceTopicID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Namespace Topic ID
+func (id NamespaceTopicId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.EventGrid/namespaces/%s/topics/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.NamespaceName, id.TopicName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Namespace Topic ID
+func (id NamespaceTopicId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftEventGrid", "Microsoft.EventGrid", "Microsoft.EventGrid"),
+		resourceids.StaticSegment("staticNamespaces", "namespaces", "namespaces"),
+		resourceids.UserSpecifiedSegment("namespaceName", "namespaceName"),
+		resourceids.StaticSegment("staticTopics", "topics", "topics"),
+		resourceids.UserSpecifiedSegment("topicName", "topicName"),
+	}
+}
+
+// String returns a human-readable description of this Namespace Topic ID
+func (id NamespaceTopicId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Namespace Name: %q", id.NamespaceName),
+		fmt.Sprintf("Topic Name: %q", id.TopicName),
+	}
+	return fmt.Sprintf("Namespace Topic (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2023-12-15-preview/namespacetopics/method_createorupdate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2023-12-15-preview/namespacetopics/method_createorupdate.go
@@ -1,0 +1,75 @@
+package namespacetopics
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateOrUpdateOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *NamespaceTopic
+}
+
+// CreateOrUpdate ...
+func (c NamespaceTopicsClient) CreateOrUpdate(ctx context.Context, id NamespaceTopicId, input NamespaceTopic) (result CreateOrUpdateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPut,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// CreateOrUpdateThenPoll performs CreateOrUpdate then polls until it's completed
+func (c NamespaceTopicsClient) CreateOrUpdateThenPoll(ctx context.Context, id NamespaceTopicId, input NamespaceTopic) error {
+	result, err := c.CreateOrUpdate(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing CreateOrUpdate: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after CreateOrUpdate: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2023-12-15-preview/namespacetopics/method_delete.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2023-12-15-preview/namespacetopics/method_delete.go
@@ -1,0 +1,71 @@
+package namespacetopics
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeleteOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// Delete ...
+func (c NamespaceTopicsClient) Delete(ctx context.Context, id NamespaceTopicId) (result DeleteOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusNoContent,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodDelete,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// DeleteThenPoll performs Delete then polls until it's completed
+func (c NamespaceTopicsClient) DeleteThenPoll(ctx context.Context, id NamespaceTopicId) error {
+	result, err := c.Delete(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing Delete: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Delete: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2023-12-15-preview/namespacetopics/method_get.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2023-12-15-preview/namespacetopics/method_get.go
@@ -1,0 +1,53 @@
+package namespacetopics
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *NamespaceTopic
+}
+
+// Get ...
+func (c NamespaceTopicsClient) Get(ctx context.Context, id NamespaceTopicId) (result GetOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model NamespaceTopic
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2023-12-15-preview/namespacetopics/method_listbynamespace.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2023-12-15-preview/namespacetopics/method_listbynamespace.go
@@ -1,0 +1,138 @@
+package namespacetopics
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListByNamespaceOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]NamespaceTopic
+}
+
+type ListByNamespaceCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []NamespaceTopic
+}
+
+type ListByNamespaceOperationOptions struct {
+	Filter *string
+	Top    *int64
+}
+
+func DefaultListByNamespaceOperationOptions() ListByNamespaceOperationOptions {
+	return ListByNamespaceOperationOptions{}
+}
+
+func (o ListByNamespaceOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+
+	return &out
+}
+
+func (o ListByNamespaceOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+
+	return &out
+}
+
+func (o ListByNamespaceOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+	if o.Filter != nil {
+		out.Append("$filter", fmt.Sprintf("%v", *o.Filter))
+	}
+	if o.Top != nil {
+		out.Append("$top", fmt.Sprintf("%v", *o.Top))
+	}
+	return &out
+}
+
+type ListByNamespaceCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *ListByNamespaceCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// ListByNamespace ...
+func (c NamespaceTopicsClient) ListByNamespace(ctx context.Context, id NamespaceId, options ListByNamespaceOperationOptions) (result ListByNamespaceOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodGet,
+		OptionsObject: options,
+		Pager:         &ListByNamespaceCustomPager{},
+		Path:          fmt.Sprintf("%s/topics", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]NamespaceTopic `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListByNamespaceComplete retrieves all the results into a single object
+func (c NamespaceTopicsClient) ListByNamespaceComplete(ctx context.Context, id NamespaceId, options ListByNamespaceOperationOptions) (ListByNamespaceCompleteResult, error) {
+	return c.ListByNamespaceCompleteMatchingPredicate(ctx, id, options, NamespaceTopicOperationPredicate{})
+}
+
+// ListByNamespaceCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c NamespaceTopicsClient) ListByNamespaceCompleteMatchingPredicate(ctx context.Context, id NamespaceId, options ListByNamespaceOperationOptions, predicate NamespaceTopicOperationPredicate) (result ListByNamespaceCompleteResult, err error) {
+	items := make([]NamespaceTopic, 0)
+
+	resp, err := c.ListByNamespace(ctx, id, options)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListByNamespaceCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2023-12-15-preview/namespacetopics/method_listsharedaccesskeys.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2023-12-15-preview/namespacetopics/method_listsharedaccesskeys.go
@@ -1,0 +1,54 @@
+package namespacetopics
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListSharedAccessKeysOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *TopicSharedAccessKeys
+}
+
+// ListSharedAccessKeys ...
+func (c NamespaceTopicsClient) ListSharedAccessKeys(ctx context.Context, id NamespaceTopicId) (result ListSharedAccessKeysOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/listKeys", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model TopicSharedAccessKeys
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2023-12-15-preview/namespacetopics/method_regeneratekey.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2023-12-15-preview/namespacetopics/method_regeneratekey.go
@@ -1,0 +1,75 @@
+package namespacetopics
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RegenerateKeyOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *TopicSharedAccessKeys
+}
+
+// RegenerateKey ...
+func (c NamespaceTopicsClient) RegenerateKey(ctx context.Context, id NamespaceTopicId, input TopicRegenerateKeyRequest) (result RegenerateKeyOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/regenerateKey", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// RegenerateKeyThenPoll performs RegenerateKey then polls until it's completed
+func (c NamespaceTopicsClient) RegenerateKeyThenPoll(ctx context.Context, id NamespaceTopicId, input TopicRegenerateKeyRequest) error {
+	result, err := c.RegenerateKey(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing RegenerateKey: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after RegenerateKey: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2023-12-15-preview/namespacetopics/method_update.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2023-12-15-preview/namespacetopics/method_update.go
@@ -1,0 +1,75 @@
+package namespacetopics
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpdateOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *NamespaceTopic
+}
+
+// Update ...
+func (c NamespaceTopicsClient) Update(ctx context.Context, id NamespaceTopicId, input NamespaceTopicUpdateParameters) (result UpdateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPatch,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// UpdateThenPoll performs Update then polls until it's completed
+func (c NamespaceTopicsClient) UpdateThenPoll(ctx context.Context, id NamespaceTopicId, input NamespaceTopicUpdateParameters) error {
+	result, err := c.Update(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing Update: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Update: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2023-12-15-preview/namespacetopics/model_namespacetopic.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2023-12-15-preview/namespacetopics/model_namespacetopic.go
@@ -1,0 +1,16 @@
+package namespacetopics
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/systemdata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NamespaceTopic struct {
+	Id         *string                   `json:"id,omitempty"`
+	Name       *string                   `json:"name,omitempty"`
+	Properties *NamespaceTopicProperties `json:"properties,omitempty"`
+	SystemData *systemdata.SystemData    `json:"systemData,omitempty"`
+	Type       *string                   `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2023-12-15-preview/namespacetopics/model_namespacetopicproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2023-12-15-preview/namespacetopics/model_namespacetopicproperties.go
@@ -1,0 +1,11 @@
+package namespacetopics
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NamespaceTopicProperties struct {
+	EventRetentionInDays *int64                           `json:"eventRetentionInDays,omitempty"`
+	InputSchema          *EventInputSchema                `json:"inputSchema,omitempty"`
+	ProvisioningState    *NamespaceTopicProvisioningState `json:"provisioningState,omitempty"`
+	PublisherType        *PublisherType                   `json:"publisherType,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2023-12-15-preview/namespacetopics/model_namespacetopicupdateparameterproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2023-12-15-preview/namespacetopics/model_namespacetopicupdateparameterproperties.go
@@ -1,0 +1,8 @@
+package namespacetopics
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NamespaceTopicUpdateParameterProperties struct {
+	EventRetentionInDays *int64 `json:"eventRetentionInDays,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2023-12-15-preview/namespacetopics/model_namespacetopicupdateparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2023-12-15-preview/namespacetopics/model_namespacetopicupdateparameters.go
@@ -1,0 +1,8 @@
+package namespacetopics
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NamespaceTopicUpdateParameters struct {
+	Properties *NamespaceTopicUpdateParameterProperties `json:"properties,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2023-12-15-preview/namespacetopics/model_topicregeneratekeyrequest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2023-12-15-preview/namespacetopics/model_topicregeneratekeyrequest.go
@@ -1,0 +1,8 @@
+package namespacetopics
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type TopicRegenerateKeyRequest struct {
+	KeyName string `json:"keyName"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2023-12-15-preview/namespacetopics/model_topicsharedaccesskeys.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2023-12-15-preview/namespacetopics/model_topicsharedaccesskeys.go
@@ -1,0 +1,9 @@
+package namespacetopics
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type TopicSharedAccessKeys struct {
+	Key1 *string `json:"key1,omitempty"`
+	Key2 *string `json:"key2,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2023-12-15-preview/namespacetopics/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2023-12-15-preview/namespacetopics/predicates.go
@@ -1,0 +1,27 @@
+package namespacetopics
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NamespaceTopicOperationPredicate struct {
+	Id   *string
+	Name *string
+	Type *string
+}
+
+func (p NamespaceTopicOperationPredicate) Matches(input NamespaceTopic) bool {
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2023-12-15-preview/namespacetopics/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2023-12-15-preview/namespacetopics/version.go
@@ -1,0 +1,10 @@
+package namespacetopics
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2023-12-15-preview"
+
+func userAgent() string {
+	return "hashicorp/go-azure-sdk/namespacetopics/2023-12-15-preview"
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -544,6 +544,7 @@ github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2022-06-15/topics
 github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2022-06-15/topictypes
 github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2022-06-15/verifiedpartners
 github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2023-12-15-preview/namespaces
+github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2023-12-15-preview/namespacetopics
 github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2021-11-01/authorizationrulesnamespaces
 github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2021-11-01/eventhubs
 github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2022-01-01-preview/namespaces


### PR DESCRIPTION
`azurerm_eventgrid_namespace` - fix on route_topic_id validation to accept namespace topics

<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

`azurerm_eventgrid_namespace` can configure a MQTT broker by filling its property `topic_spaces_configuration`. This broker (or topic space) can have a routing configured to route all its received messages to an Event Grid topic. You can setup that routing giving a topic ID under `route_topic_id` in the `topic_spaces_configuration`object. That topic [can either be a Namespace Topic or a Custom Topic](https://learn.microsoft.com/en-us/azure/event-grid/mqtt-routing#routing-configuration). But currently `azurerm_eventgrid_namespace` checks that `route_topic_id` is a Event Grid custom topic by using `topics.ValidateTopicID` and triggers an error if a Namespace Topic is given or read:

```
│ Error: flattening `topic_spaces_configuration`: parsing "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.EventGrid/namespaces/example/topics/topicexample": parsing segment "staticTopics": parsing the Topic ID: the segment at position 6 didn't match
│ 
│ Expected a Topic ID that matched:
│ 
│ > /subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.EventGrid/topics/topicName
│ 
│ However this value was provided:
│ 
│ > /subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.EventGrid/namespaces/example/topics/topicexample
│ 
│ The parsed Resource ID was missing a value for the segment at position 6
│ (which should be the literal value "topics").
```

This PR is initially very small but the necessity to add `vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2023-12-15-preview/namespacetopics` makes it quite big.

## PR Checklist

- [X] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

I have not included new tests for this fix, here is why:

The Event Grid Namespace API and its sub-resource Namespace Topic does not allow to create a Event Grid Namespace with a MQTT Broker (`topic_space`) that would route its message to a Namespace Topic in one operation as **you cannot create a Namespace Topic under that namespace unless the namespace is created while the MQTT Broker configuration is part of the Event Grid Namespace instead of also being a sub-resource** (quite an issue from the API in my opinion). The only way to accomplish that would be to do it in two different `apply`or to use `azapi_update_resource` to modify the Event Grid Namespace after the rest is created.

That problem made it impossible for me to add a test to check a `azurerm_eventgrid_namespace` creation with a `route_topic_id` that would refer to Namespace Topic.

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_eventgrid_namespace` - fix on `route_topic_id` property validation to accept namespace topic id [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [X] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
None

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
