### PR TITLE
azurerm_postgresql_flexible_server - support importing PGSQL replica servers

### DIFF
--- a/internal/services/postgres/postgresql_flexible_server_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_resource.go
@@ -692,6 +692,7 @@ func resourcePostgresqlFlexibleServerRead(d *pluginsdk.ResourceData, meta interf
 			d.Set("zone", props.AvailabilityZone)
 			d.Set("version", pointer.From(props.Version))
 			d.Set("fqdn", props.FullyQualifiedDomainName)
+			d.Set("source_server_id", props.SourceServerResourceId)
 
 			// Currently, `replicationRole` is set to `Primary` when `createMode` is `Replica` and `replicationRole` is updated to `None`. Service team confirmed it should be set to `None` for this scenario. See more details from https://github.com/Azure/azure-rest-api-specs/issues/22499
 			d.Set("replication_role", d.Get("replication_role").(string))


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

The change sets the `source_server_id` when calling `postgres.resourcePostgresqlFlexibleServerRead`.  

Given a Postgres Flexible Server exists, and the user wants to *import* it into state, Terraform currently ignores this field, and creates the replica server as a standalone server. 

Subsequent `terraform apply` then recognize the `source_server_id` from Azure, and then force replacements. This is not ideal for a DB server. 


## PR Checklist

- [X] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [X] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [X] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [X] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [X] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [X] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.

## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

### Current Version
Force replacement of Replica Server, due to missing source_server_id:
```
-/+ resource "azurerm_postgresql_flexible_server" "this" {
         [REDACTED]
      + source_server_id                  = "/subscriptions/[REDACTED]/resourceGroups/[REDACTED]/providers/Microsoft.DBforPostgreSQL/flexibleServers/[REDACTED]" # forces replacement
         [REDACTED]
        # (2 unchanged blocks hidden)
    }
```
```
2025-08-07T19:34:13.039-0700 [WARN]  Provider "registry.terraform.io/hashicorp/azurerm" produced an unexpected new value for module.azure_baseline.module.postgresqlflex_server["tffx"].azurerm_postgresql_flexible_server.this during refresh.
      - .sku_name: was null, but now cty.StringVal("GP_Standard_D4s_v3")
      - .storage_mb: was null, but now cty.NumberIntVal(262144)
      - .zone: was null, but now cty.StringVal("")
      - .backup_retention_days: was null, but now cty.NumberIntVal(7)
      - .location: was null, but now cty.StringVal("westcentralus")
      - .public_network_access_enabled: was null, but now cty.False
      - .name: was null, but now cty.StringVal("[REDACTED]")
      - .administrator_password_wo_version: was null, but now cty.NumberIntVal(0)
      - .delegated_subnet_id: was null, but now cty.StringVal("")
      - .replication_role: was null, but now cty.StringVal("")
      - .tags: was null, but now cty.MapVal(map[string]cty.Value{"source":cty.StringVal("terraform"), "version":cty.StringVal("v1.0.11")})
      - .version: was null, but now cty.StringVal("16")
      - .auto_grow_enabled: was null, but now cty.True
      - .private_dns_zone_id: was null, but now cty.StringVal("")
      - .geo_redundant_backup_enabled: was null, but now cty.False
      - .resource_group_name: was null, but now cty.StringVal("[REDACTED]")
      - .storage_tier: was null, but now cty.StringVal("P15")
      - .administrator_login: was null, but now cty.StringVal("kpadmuser")
      - .fqdn: was null, but now cty.StringVal("[REDACTED].postgres.database.azure.com")
      - .authentication: block count changed from 0 to 1
      - .customer_managed_key: block count changed from 0 to 1
      - .identity: block count changed from 0 to 1
      - .maintenance_window: block count changed from 0 to 1
```

### Pull Request

```
2025-08-07T19:45:26.815-0700 [WARN]  Provider "registry.terraform.io/hashicorp/azurerm" produced an unexpected new value for module.azure_baseline.module.postgresqlflex_server["tffx"].azurerm_postgresql_flexible_server.this during refresh.
      - .fqdn: was null, but now cty.StringVal("[REDACTED].postgres.database.azure.com")
      - .public_network_access_enabled: was null, but now cty.False
      - .resource_group_name: was null, but now cty.StringVal("[REDACTED]")
      - .sku_name: was null, but now cty.StringVal("GP_Standard_D4s_v3")
      - .storage_tier: was null, but now cty.StringVal("P15")
      - .tags: was null, but now cty.MapVal(map[string]cty.Value{"source":cty.StringVal("terraform"), "version":cty.StringVal("v1.0.11")})
      - .backup_retention_days: was null, but now cty.NumberIntVal(7)
      - .storage_mb: was null, but now cty.NumberIntVal(262144)
      - .zone: was null, but now cty.StringVal("")
      - .administrator_login: was null, but now cty.StringVal("[REDACTED]")
      - .administrator_password_wo_version: was null, but now cty.NumberIntVal(0)
      - .auto_grow_enabled: was null, but now cty.True
      - .geo_redundant_backup_enabled: was null, but now cty.False
      - .location: was null, but now cty.StringVal("westcentralus")
      - .private_dns_zone_id: was null, but now cty.StringVal("")
      - .delegated_subnet_id: was null, but now cty.StringVal("")
      - .name: was null, but now cty.StringVal("kppgsflxtfpoceng02wcustffx")
      - .replication_role: was null, but now cty.StringVal("")
      - .source_server_id: was null, but now cty.StringVal("/subscriptions/[REDACTED]/resourceGroups/[REDACTED]/providers/Microsoft.DBforPostgreSQL/flexibleServers/[REDACTED]")
      - .version: was null, but now cty.StringVal("16")
      - .authentication: block count changed from 0 to 1
      - .customer_managed_key: block count changed from 0 to 1
      - .identity: block count changed from 0 to 1
      - .maintenance_window: block count changed from 0 to 1
```
```
  ~ resource "azurerm_postgresql_flexible_server" "this" {
      + administrator_password            = (sensitive value)
      + create_mode                       = "Replica"
        id                                = "/subscriptions/[REDACTED]/resourceGroups/[REDACTED]/providers/Microsoft.DBforPostgreSQL/flexibleServers/[REDACTED]"
        name                              = "[REDACTED]"
      ~ sku_name                          = "GP_Standard_D4s_v3" -> "GP_Standard_D8s_v3"
        tags                              = {
            "source"  = "terraform"
            "version" = "v1.0.11"
        }
        # (17 unchanged attributes hidden)

      ~ maintenance_window {
          # Warning: this attribute value will be marked as sensitive and will not
          # display in UI output after applying this change.
          ~ day_of_week  = (sensitive value)
          # Warning: this attribute value will be marked as sensitive and will not
          # display in UI output after applying this change.
          ~ start_hour   = (sensitive value)
          # Warning: this attribute value will be marked as sensitive and will not
          # display in UI output after applying this change.
          ~ start_minute = (sensitive value)
        }

        # (3 unchanged blocks hidden)
    }
```
## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_postgresql_flexible_server` - Adds source_server_id to resourcePostgresqlFlexibleServerRead.[GH-30350]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [X] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
N/A

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

> Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

No.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
