### PR TITLE
azurerm_user_assigned_identity: support for optional subscription_id argument and attribute

### DIFF
--- a/website/docs/r/user_assigned_identity.html.markdown
+++ b/website/docs/r/user_assigned_identity.html.markdown
@@ -38,11 +38,15 @@ The following arguments are supported:
 
 * `tags` - (Optional) A mapping of tags which should be assigned to the User Assigned Identity.
 
+* `subscription_id` - (Optional) The ID of the subscription in which to create the User Assigned Identity.
+
 ## Attributes Reference
 
 In addition to the Arguments listed above - the following Attributes are exported:
 
 * `id` - The ID of the User Assigned Identity.
+
+* `subscription_id` - The ID of the subscription associated with the User Assigned Identity.
 
 * `client_id` - The ID of the app associated with the Identity.
 


### PR DESCRIPTION
## Community Note

* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This PR adds support for the optional `subscription_id` argument and attribute to the `azurerm_user_assigned_identity` resource.

This enhancement allows users to create user assigned identities in a specific Azure subscription, enabling advanced multi-subscription scenarios and automation.
For example, it is now possible to provision a user assigned identity directly in a newly created subscription within the same Terraform module.


## PR Checklist

- [X] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [X] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [X] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [X] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [X] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [X] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [X] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [X] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [X] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [X] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)


## Change Log


* `azurerm_user_assigned_identity` - support for the optional `subscription_id` argument and attribute 

This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [X] Enhancement
- [ ] Breaking Change


## Related Issue(s)

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Nothing to do here. :)
