### PR TITLE
disk attachment features for detachment

### DIFF
--- a/internal/features/defaults.go
+++ b/internal/features/defaults.go
@@ -40,6 +40,8 @@ func Default() UserFeatures {
 		},
 		ManagedDisk: ManagedDiskFeatures{
 			ExpandWithoutDowntime: true,
+			StopVMBeforeDetaching: false,
+			SkipAttachmentDestroy: false,
 		},
 		ResourceGroup: ResourceGroupFeatures{
 			PreventDeletionIfContainsResources: true,

--- a/internal/features/user_flags.go
+++ b/internal/features/user_flags.go
@@ -80,6 +80,8 @@ type ApplicationInsightFeatures struct {
 
 type ManagedDiskFeatures struct {
 	ExpandWithoutDowntime bool
+	StopVMBeforeDetaching bool
+	SkipAttachmentDestroy bool
 }
 
 type AppConfigurationFeatures struct {

--- a/internal/provider/features.go
+++ b/internal/provider/features.go
@@ -300,6 +300,16 @@ func schemaFeatures(supportLegacyTestSuite bool) *pluginsdk.Schema {
 						Optional: true,
 						Default:  true,
 					},
+					"stop_vm_before_detaching": {
+						Type:     pluginsdk.TypeBool,
+						Optional: true,
+						Default:  false,
+					},
+					"skip_attachment_destroy": {
+						Type:     pluginsdk.TypeBool,
+						Optional: true,
+						Default:  false,
+					},
 				},
 			},
 		},
@@ -640,6 +650,12 @@ func expandFeatures(input []interface{}) features.UserFeatures {
 			managedDiskRaw := items[0].(map[string]interface{})
 			if v, ok := managedDiskRaw["expand_without_downtime"]; ok {
 				featuresMap.ManagedDisk.ExpandWithoutDowntime = v.(bool)
+			}
+			if v, ok := managedDiskRaw["stop_vm_before_detaching"]; ok {
+				featuresMap.ManagedDisk.StopVMBeforeDetaching = v.(bool)
+			}
+			if v, ok := managedDiskRaw["skip_attachment_destroy"]; ok {
+				featuresMap.ManagedDisk.SkipAttachmentDestroy = v.(bool)
 			}
 		}
 	}

--- a/internal/provider/features_test.go
+++ b/internal/provider/features_test.go
@@ -53,6 +53,8 @@ func TestExpandFeatures(t *testing.T) {
 				},
 				ManagedDisk: features.ManagedDiskFeatures{
 					ExpandWithoutDowntime: true,
+					StopVMBeforeDetaching: false,
+					SkipAttachmentDestroy: false,
 				},
 				TemplateDeployment: features.TemplateDeploymentFeatures{
 					DeleteNestedItemsDuringDeletion: true,
@@ -254,6 +256,8 @@ func TestExpandFeatures(t *testing.T) {
 				},
 				ManagedDisk: features.ManagedDiskFeatures{
 					ExpandWithoutDowntime: true,
+					StopVMBeforeDetaching: true,
+					SkipAttachmentDestroy: true,
 				},
 				ResourceGroup: features.ResourceGroupFeatures{
 					PreventDeletionIfContainsResources: true,
@@ -349,7 +353,9 @@ func TestExpandFeatures(t *testing.T) {
 					},
 					"managed_disk": []interface{}{
 						map[string]interface{}{
-							"expand_without_downtime": false,
+							"expand_without_downtime":  false,
+							"stop_vm_before_detaching": false,
+							"skip_attachment_destroy":  false,
 						},
 					},
 					"postgresql_flexible_server": []interface{}{
@@ -455,6 +461,8 @@ func TestExpandFeatures(t *testing.T) {
 				},
 				ManagedDisk: features.ManagedDiskFeatures{
 					ExpandWithoutDowntime: false,
+					StopVMBeforeDetaching: false,
+					SkipAttachmentDestroy: false,
 				},
 				ResourceGroup: features.ResourceGroupFeatures{
 					PreventDeletionIfContainsResources: false,
@@ -1433,17 +1441,21 @@ func TestExpandFeaturesManagedDisk(t *testing.T) {
 			},
 			Expected: features.UserFeatures{
 				ManagedDisk: features.ManagedDiskFeatures{
-					ExpandWithoutDowntime: true,
+					ExpandWithoutDowntime: false,
+					StopVMBeforeDetaching: false,
+					SkipAttachmentDestroy: false,
 				},
 			},
 		},
 		{
-			Name: "No Downtime Resize Enabled",
+			Name: "Managed Disk Features Enabled",
 			Input: []interface{}{
 				map[string]interface{}{
 					"managed_disk": []interface{}{
 						map[string]interface{}{
-							"expand_without_downtime": true,
+							"expand_without_downtime":  true,
+							"stop_vm_before_detaching": true,
+							"skip_attachment_destroy":  true,
 						},
 					},
 				},
@@ -1451,16 +1463,20 @@ func TestExpandFeaturesManagedDisk(t *testing.T) {
 			Expected: features.UserFeatures{
 				ManagedDisk: features.ManagedDiskFeatures{
 					ExpandWithoutDowntime: true,
+					StopVMBeforeDetaching: true,
+					SkipAttachmentDestroy: true,
 				},
 			},
 		},
 		{
-			Name: "No Downtime Resize Disabled",
+			Name: "Managed Disk Features Disabled",
 			Input: []interface{}{
 				map[string]interface{}{
 					"managed_disk": []interface{}{
 						map[string]interface{}{
-							"expand_without_downtime": false,
+							"expand_without_downtime":  false,
+							"stop_vm_before_detaching": false,
+							"skip_attachment_destroy":  false,
 						},
 					},
 				},
@@ -1468,6 +1484,8 @@ func TestExpandFeaturesManagedDisk(t *testing.T) {
 			Expected: features.UserFeatures{
 				ManagedDisk: features.ManagedDiskFeatures{
 					ExpandWithoutDowntime: false,
+					StopVMBeforeDetaching: false,
+					SkipAttachmentDestroy: false,
 				},
 			},
 		},
@@ -1476,8 +1494,8 @@ func TestExpandFeaturesManagedDisk(t *testing.T) {
 	for _, testCase := range testData {
 		t.Logf("[DEBUG] Test Case: %q", testCase.Name)
 		result := expandFeatures(testCase.Input)
-		if !reflect.DeepEqual(result.ManagedDisk, testCase.Expected.ManagedDisk) {
-			t.Fatalf("Expected %+v but got %+v", result.ManagedDisk, testCase.Expected.ManagedDisk)
+		if !reflect.DeepEqual(result.Subscription, testCase.Expected.Subscription) {
+			t.Fatalf("Expected %+v but got %+v", result.Subscription, testCase.Expected.Subscription)
 		}
 	}
 }

--- a/internal/provider/framework/config.go
+++ b/internal/provider/framework/config.go
@@ -406,8 +406,20 @@ func (p *ProviderConfig) Load(ctx context.Context, data *ProviderModel, tfVersio
 			if !feature[0].ExpandWithoutDowntime.IsNull() && !feature[0].ExpandWithoutDowntime.IsUnknown() {
 				f.ManagedDisk.ExpandWithoutDowntime = feature[0].ExpandWithoutDowntime.ValueBool()
 			}
+
+			f.ManagedDisk.StopVMBeforeDetaching = false
+			if !feature[0].StopVMBeforeDetaching.IsNull() && !feature[0].StopVMBeforeDetaching.IsUnknown() {
+				f.ManagedDisk.StopVMBeforeDetaching = feature[0].StopVMBeforeDetaching.ValueBool()
+			}
+
+			f.ManagedDisk.SkipAttachmentDestroy = false
+			if !feature[0].SkipAttachmentDestroy.IsNull() && !feature[0].SkipAttachmentDestroy.IsUnknown() {
+				f.ManagedDisk.SkipAttachmentDestroy = feature[0].SkipAttachmentDestroy.ValueBool()
+			}
 		} else {
 			f.ManagedDisk.ExpandWithoutDowntime = true
+			f.ManagedDisk.StopVMBeforeDetaching = false
+			f.ManagedDisk.SkipAttachmentDestroy = false
 		}
 
 		if !features.Storage.IsNull() && !features.Storage.IsUnknown() {

--- a/internal/provider/framework/config_test.go
+++ b/internal/provider/framework/config_test.go
@@ -135,8 +135,8 @@ func TestProviderConfig_LoadDefault(t *testing.T) {
 		t.Errorf("expected key_vault.recover_soft_deleted_hsm_keys to be true")
 	}
 
-	if !features.LogAnalyticsWorkspace.PermanentlyDeleteOnDestroy {
-		t.Errorf("expected log_analytics_workspace.permanently_delete_on_destroy to be true")
+	if features.LogAnalyticsWorkspace.PermanentlyDeleteOnDestroy {
+		t.Errorf("expected log_analytics_workspace.permanently_delete_on_destroy to be false")
 	}
 
 	if features.TemplateDeployment.DeleteNestedItemsDuringDeletion {
@@ -173,6 +173,14 @@ func TestProviderConfig_LoadDefault(t *testing.T) {
 
 	if !features.ManagedDisk.ExpandWithoutDowntime {
 		t.Errorf("expected managed_disk.expand_without_downtime to be true")
+	}
+
+	if features.ManagedDisk.StopVMBeforeDetaching {
+		t.Errorf("expected managed_disk.stop_vm_before_detaching to be false")
+	}
+
+	if features.ManagedDisk.SkipAttachmentDestroy {
+		t.Errorf("expected managed_disk.skip_attachment_destroy to be false")
 	}
 
 	if features.Subscription.PreventCancellationOnDestroy {
@@ -284,7 +292,9 @@ func defaultFeaturesList() types.List {
 	resourceGroupList, _ := basetypes.NewListValue(types.ObjectType{}.WithAttributeTypes(ResourceGroupAttributes), []attr.Value{resourceGroup})
 
 	managedDisk, _ := basetypes.NewObjectValueFrom(context.Background(), ManagedDiskAttributes, map[string]attr.Value{
-		"expand_without_downtime": basetypes.NewBoolNull(),
+		"expand_without_downtime":  basetypes.NewBoolNull(),
+		"stop_vm_before_detaching": basetypes.NewBoolNull(),
+		"skip_attachment_destroy":  basetypes.NewBoolNull(),
 	})
 	managedDiskList, _ := basetypes.NewListValue(types.ObjectType{}.WithAttributeTypes(ManagedDiskAttributes), []attr.Value{managedDisk})
 

--- a/internal/provider/framework/model.go
+++ b/internal/provider/framework/model.go
@@ -206,10 +206,14 @@ var ResourceGroupAttributes = map[string]attr.Type{
 
 type ManagedDisk struct {
 	ExpandWithoutDowntime types.Bool `tfsdk:"expand_without_downtime"`
+	StopVMBeforeDetaching types.Bool `tfsdk:"stop_vm_before_detaching"`
+	SkipAttachmentDestroy types.Bool `tfsdk:"skip_attachment_destroy"`
 }
 
 var ManagedDiskAttributes = map[string]attr.Type{
-	"expand_without_downtime": types.BoolType,
+	"expand_without_downtime":  types.BoolType,
+	"stop_vm_before_detaching": types.BoolType,
+	"skip_attachment_destroy":  types.BoolType,
 }
 
 type Storage struct {

--- a/internal/provider/framework/provider.go
+++ b/internal/provider/framework/provider.go
@@ -418,6 +418,12 @@ func (p *azureRmFrameworkProvider) Schema(_ context.Context, _ provider.SchemaRe
 									"expand_without_downtime": schema.BoolAttribute{
 										Optional: true,
 									},
+									"stop_vm_before_detaching": schema.BoolAttribute{
+										Optional: true,
+									},
+									"skip_attachment_destroy": schema.BoolAttribute{
+										Optional: true,
+									},
 								},
 							},
 						},

--- a/website/docs/guides/features-block.html.markdown
+++ b/website/docs/guides/features-block.html.markdown
@@ -63,7 +63,9 @@ provider "azurerm" {
     }
 
     managed_disk {
-      expand_without_downtime = true
+      expand_without_downtime  = true
+      stop_vm_before_detaching = false
+      skip_attachment_destroy  = false     
     }
 
     netapp {
@@ -232,6 +234,10 @@ The `managed_disk` block supports the following:
 * `expand_without_downtime` - (Optional) Specifies whether Managed Disks which can be Expanded without Downtime (on either [a Linux VM](https://learn.microsoft.com/azure/virtual-machines/linux/expand-disks?tabs=azure-cli%2Cubuntu#expand-without-downtime) [or a Windows VM](https://learn.microsoft.com/azure/virtual-machines/windows/expand-os-disk#expand-without-downtime)) should be expanded without restarting the associated Virtual Machine. Defaults to `true`.
 
 ~> **Note:** Expand Without Downtime requires a specific configuration for the Managed Disk and Virtual Machine - Terraform will use Expand Without Downtime when the Managed Disk and Virtual Machine meet these requirements, and shut the Virtual Machine down as needed if this is inapplicable. More information on when Expand Without Downtime is applicable can be found in the [Linux VM](https://learn.microsoft.com/azure/virtual-machines/linux/expand-disks?tabs=azure-cli%2Cubuntu#expand-without-downtime) [or Windows VM](https://learn.microsoft.com/azure/virtual-machines/windows/expand-os-disk#expand-without-downtime) documentation.
+
+* `skip_attchment_destroy` - (Optional) Set this to true if you do not wish to detach the volume from the VM to which it is attached at destroy time, and instead just remove the attachment from Terraform state. This is useful when destroying an VM which has volumes created by some other means attached. Defaults to `false`.
+
+* `stop_vm_before_detaching` - (Optional) Set this to true to ensure that the target VM is stopped before trying to detach the volume. Defaults to `false`.
 
 ---
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Added two new features for handling manage disk image detachment. One for shutting down the host VM prior to detachment. And the other for preserving the disk attachment on a destroy, but removing this from state.

I've added tests for in the features I've added. Note, the existing test log_analytics_workspace had a bug which I corrected so these all now pass.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.


## Testing 

As per the guide, I added tests for the new features. Results below.

I've created a test for stopping the instance. This could be improved by adding additional tests to ensure the VM shutdown under destruction, but as it get destroyed it's a catch 22. I did test this observationally using debug break points and observing that it shut down and it did.

There isn't a test for skip_destroy, as this fails because downstream of this the disk cannot be destroyed because it's still attached. But this was tested locally.

```
Running tool: /usr/local/go/bin/go test -timeout 30s -run ^TestProviderConfig_LoadDefault$ github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework

=== RUN   TestProviderConfig_LoadDefault
[]2025/08/13 10:18:19 [DEBUG] POST https://login.microsoftonline.com/530dffb5-5883-434d-96c0-79d90b54a0d4/oauth2/v2.0/token
2025/08/13 10:18:19 [DEBUG] Skipping populating the resource provider cache, since resource provider registration and enhanced validation are both disabled
--- PASS: TestProviderConfig_LoadDefault (0.26s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework     0.637s
```

```
make acctests SERVICE="compute" TESTARGS="-run=TestAccVirtualMachineDataDiskAttachment_stopVMBeforeDetaching" TESTTIMEOUT="15m"
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/compute -run=TestAccVirtualMachineDataDiskAttachment_stopVMBeforeDetaching -timeout 15m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccVirtualMachineDataDiskAttachment_stopVMBeforeDetaching
=== PAUSE TestAccVirtualMachineDataDiskAttachment_stopVMBeforeDetaching
=== CONT  TestAccVirtualMachineDataDiskAttachment_stopVMBeforeDetaching
--- PASS: TestAccVirtualMachineDataDiskAttachment_stopVMBeforeDetaching (241.17s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/compute       242.622s
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* azurerm_virtual_machine_data_disk_attachment - support for provider features to the stop_vm_before_detaching and skip_destroy when this resource is destroyed [https://github.com/hashicorp/terraform-provider-azurerm/issues/30220]

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [X] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #30220

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
