### PR TITLE
`azurerm_app_service_environment_v3` - fix order of API requests

### DIFF
--- a/internal/services/appservice/app_service_environment_v3_resource_test.go
+++ b/internal/services/appservice/app_service_environment_v3_resource_test.go
@@ -33,6 +33,28 @@ func TestAccAppServiceEnvironmentV3_basic(t *testing.T) {
 	})
 }
 
+func TestAccAppServiceEnvironmentV3_basicUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_app_service_environment_v3", "test")
+	r := AppServiceEnvironmentV3Resource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basicUpdate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccAppServiceEnvironmentV3_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_app_service_environment_v3", "test")
 	r := AppServiceEnvironmentV3Resource{}
@@ -171,6 +193,30 @@ resource "azurerm_app_service_environment_v3" "test" {
   name                = "acctest-ase-%d"
   resource_group_name = azurerm_resource_group.test.name
   subnet_id           = azurerm_subnet.test.id
+  
+  zone_redundant               = false
+  internal_load_balancing_mode = "Web, Publishing"
+  tags                         = {
+    "tag1" = "test1",
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func (r AppServiceEnvironmentV3Resource) basicUpdate(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+resource "azurerm_app_service_environment_v3" "test" {
+  name                = "acctest-ase-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  subnet_id           = azurerm_subnet.test.id
+
+  zone_redundant               = false
+  internal_load_balancing_mode = "Web, Publishing"
+  tags                         = {
+    "tag1" = "test2",
+  }
 }
 `, template, data.RandomInteger)
 }


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

The main `PUT`/`CreateOrUpdate` request for ASEv3 in the `Update` method was made after the request to update the ASE networking configuration (`UpdateAseNetworkingConfiguration`), which caused drift as `networkConfiguration` properties seemed to be reset as a result of the last request.

I have added a new test that only updates a tag, which prior to the changes in this PR, caused drift and a test failure. With these changes, the test passes.

`networkingConfiguration` is not marshalled into the `appserviceenvironments.AppServiceEnvironmentResource` correctly, so the `CreateOrUpdate` API request never includes the existing `networkingConfiguration` object. This seems to be due to how `pandora` generates the structs in `go-azure-sdk` doesn't seem to take into consideration the `x-ms-client-flatten` tag in the API spec. Investigating/fixing this on the pandora side will take more time, and as such simply changing the order in which we make the requests within the resource is the quick and easy solution for now.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

Running...

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
