### PR TITLE
`azurerm_[linux|windows]_virtual_machine` - add support for `os_managed_disk_id` property

### DIFF
--- a/.github/labeler-issue-triage.yml
+++ b/.github/labeler-issue-triage.yml
@@ -72,7 +72,7 @@ service/cognitive-services:
   - '### (|New or )Affected Resource\(s\)\/Data Source\(s\)((.|\n)*)azurerm_(ai_services|cognitive_)((.|\n)*)###'
 
 service/communication:
-  - '### (|New or )Affected Resource\(s\)\/Data Source\(s\)((.|\n)*)azurerm_(communication_service|email_communication_service|gallery_application|orchestrated_virtual_machine_scale_set\W+|restore_point_collection|virtual_machine_gallery_application_assignment\W+|virtual_machine_implicit_data_disk_from_source\W+|virtual_machine_restore_point\W+|virtual_machine_restore_point_collection\W+|virtual_machine_run_command\W+|virtual_machine_scale_set_standby_pool\W+)((.|\n)*)###'
+  - '### (|New or )Affected Resource\(s\)\/Data Source\(s\)((.|\n)*)azurerm_(communication_service|email_communication_service|gallery_application|managed_disks|orchestrated_virtual_machine_scale_set\W+|restore_point_collection|virtual_machine_gallery_application_assignment\W+|virtual_machine_implicit_data_disk_from_source\W+|virtual_machine_restore_point\W+|virtual_machine_restore_point_collection\W+|virtual_machine_run_command\W+|virtual_machine_scale_set_standby_pool\W+)((.|\n)*)###'
 
 service/connections:
   - '### (|New or )Affected Resource\(s\)\/Data Source\(s\)((.|\n)*)azurerm_(api_connection|managed_api)((.|\n)*)###'

--- a/internal/services/compute/custompoller/managed_disk_detached_poller.go
+++ b/internal/services/compute/custompoller/managed_disk_detached_poller.go
@@ -1,0 +1,66 @@
+package custompoller
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2023-04-02/disks"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachines"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+)
+
+type managedDiskDetachedPoller struct {
+	client *disks.DisksClient
+	id     commonids.ManagedDiskId
+	vmId   virtualmachines.VirtualMachineId
+}
+
+var _ pollers.PollerType = &managedDiskDetachedPoller{}
+
+var (
+	pollingSuccess = pollers.PollResult{
+		Status: pollers.PollingStatusSucceeded,
+	}
+
+	pollingFailed = pollers.PollResult{
+		Status: pollers.PollingStatusFailed,
+	}
+
+	pollingInProgress = pollers.PollResult{
+		Status:       pollers.PollingStatusInProgress,
+		PollInterval: 10 * time.Second,
+	}
+
+	pollingUnknown = pollers.PollResult{
+		Status:       pollers.PollingStatusUnknown,
+		PollInterval: 10 * time.Second,
+	}
+)
+
+func NewManagedDiskDetachedPoller(client *disks.DisksClient, id commonids.ManagedDiskId, vmId virtualmachines.VirtualMachineId) *managedDiskDetachedPoller {
+	return &managedDiskDetachedPoller{
+		client: client,
+		id:     id,
+		vmId:   vmId,
+	}
+}
+
+func (m managedDiskDetachedPoller) Poll(ctx context.Context) (*pollers.PollResult, error) {
+	resp, err := m.client.Get(ctx, m.id)
+	if err != nil {
+		return &pollingFailed, fmt.Errorf("checking Managed Disk (%s) for detach operation during deletion of %s: %+v", m.id, m.vmId, err)
+	}
+
+	if resp.Model != nil && resp.Model.Properties != nil {
+		if pointer.From(resp.Model.Properties.DiskState) == disks.DiskStateAttached {
+			return &pollingInProgress, nil
+		}
+	} else {
+		return &pollingUnknown, nil
+	}
+
+	return &pollingSuccess, nil
+}

--- a/internal/services/compute/linux_virtual_machine_resource.go
+++ b/internal/services/compute/linux_virtual_machine_resource.go
@@ -498,7 +498,10 @@ func resourceLinuxVirtualMachineCreate(d *pluginsdk.ResourceData, meta interface
 	additionalCapabilitiesRaw := d.Get("additional_capabilities").([]interface{})
 	additionalCapabilities := expandVirtualMachineAdditionalCapabilities(additionalCapabilitiesRaw)
 
-	allowExtensionOperations := d.Get("allow_extension_operations").(bool)
+	allowExtensionOperations := true
+	if !d.GetRawConfig().AsValueMap()["allow_extension_operations"].IsNull() {
+		allowExtensionOperations = d.Get("allow_extension_operations").(bool)
+	}
 
 	bootDiagnosticsRaw := d.Get("boot_diagnostics").([]interface{})
 	bootDiagnostics := expandBootDiagnostics(bootDiagnosticsRaw)

--- a/internal/services/compute/linux_virtual_machine_resource.go
+++ b/internal/services/compute/linux_virtual_machine_resource.go
@@ -155,6 +155,7 @@ func resourceLinuxVirtualMachine() *pluginsdk.Resource {
 			"bypass_platform_safety_checks_on_user_schedule_enabled": {
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
+				Default:  false,
 				ConflictsWith: []string{
 					"os_managed_disk_id",
 				},

--- a/internal/services/compute/linux_virtual_machine_resource.go
+++ b/internal/services/compute/linux_virtual_machine_resource.go
@@ -22,11 +22,13 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-01/proximityplacementgroups"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2023-04-02/disks"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachines"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	azValidate "github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/custompoller"
 	computeValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/base64"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -68,8 +70,14 @@ func resourceLinuxVirtualMachine() *pluginsdk.Resource {
 
 			// Required
 			"admin_username": {
-				Type:         pluginsdk.TypeString,
-				Required:     true,
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				RequiredWith: []string{
+					"os_disk",
+				},
+				ConflictsWith: []string{
+					"os_managed_disk_id",
+				},
 				ForceNew:     true,
 				ValidateFunc: computeValidate.LinuxAdminUsername,
 			},
@@ -85,6 +93,21 @@ func resourceLinuxVirtualMachine() *pluginsdk.Resource {
 			},
 
 			"os_disk": virtualMachineOSDiskSchema(),
+
+			"os_managed_disk_id": {
+				// Note: O+C as this is the same value as `id` below but to support
+				// import of the OSDisk and not break compatibility with existing configs / references
+				// we're adding it as a separate property.
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				ValidateFunc: commonids.ValidateManagedDiskID,
+				AtLeastOneOf: []string{
+					"os_disk",
+					"os_managed_disk_id",
+				},
+			},
 
 			"size": {
 				Type:         pluginsdk.TypeString,
@@ -102,14 +125,17 @@ func resourceLinuxVirtualMachine() *pluginsdk.Resource {
 				Sensitive:        true,
 				DiffSuppressFunc: adminPasswordDiffSuppressFunc,
 				ValidateFunc:     computeValidate.LinuxAdminPassword,
+				ConflictsWith: []string{
+					"os_managed_disk_id",
+				},
 			},
 
-			"admin_ssh_key": SSHKeysSchema(true),
+			"admin_ssh_key": SSHKeysSchemaVM(),
 
 			"allow_extension_operations": {
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
-				Default:  true,
+				Computed: true,
 			},
 
 			"availability_set_id": {
@@ -132,7 +158,6 @@ func resourceLinuxVirtualMachine() *pluginsdk.Resource {
 			"bypass_platform_safety_checks_on_user_schedule_enabled": {
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
-				Default:  false,
 			},
 
 			"capacity_reservation_group_id": {
@@ -186,10 +211,11 @@ func resourceLinuxVirtualMachine() *pluginsdk.Resource {
 			},
 
 			"disable_password_authentication": {
+				// O+C OsProfile vs os_managed_disk_id
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
 				ForceNew: true,
-				Default:  true,
+				Computed: true,
 			},
 
 			"disk_controller_type": {
@@ -270,30 +296,42 @@ func resourceLinuxVirtualMachine() *pluginsdk.Resource {
 			},
 
 			"provision_vm_agent": {
+				// O+C due to incompatibility between specifying `os_managed_disk_id` and sending OsProfile in the create/update requests
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
-				Default:  true,
+				Computed: true,
 				ForceNew: true,
+				ConflictsWith: []string{
+					"os_managed_disk_id",
+				},
 			},
 
 			"patch_mode": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
+				Computed: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					string(virtualmachines.LinuxVMGuestPatchModeAutomaticByPlatform),
 					string(virtualmachines.LinuxVMGuestPatchModeImageDefault),
 				}, false),
-				Default: string(virtualmachines.LinuxVMGuestPatchModeImageDefault),
+				ConflictsWith: []string{
+					"os_managed_disk_id",
+				},
 			},
 
 			"patch_assessment_mode": {
+				// O+C due to incompatibility between `os_managed_disk_id` and sending `OsProfile` in create/update
 				Type:     pluginsdk.TypeString,
 				Optional: true,
-				Default:  string(virtualmachines.LinuxPatchAssessmentModeImageDefault),
+				Computed: true,
+				// Default:  string(virtualmachines.LinuxPatchAssessmentModeImageDefault),
 				ValidateFunc: validation.StringInSlice([]string{
 					string(virtualmachines.LinuxPatchAssessmentModeAutomaticByPlatform),
 					string(virtualmachines.LinuxPatchAssessmentModeImageDefault),
 				}, false),
+				ConflictsWith: []string{
+					"os_managed_disk_id",
+				},
 			},
 
 			"proximity_placement_group_id": {
@@ -316,6 +354,9 @@ func resourceLinuxVirtualMachine() *pluginsdk.Resource {
 					string(virtualmachines.LinuxVMGuestPatchAutomaticByPlatformRebootSettingIfRequired),
 					string(virtualmachines.LinuxVMGuestPatchAutomaticByPlatformRebootSettingNever),
 				}, false),
+				ConflictsWith: []string{
+					"os_managed_disk_id",
+				},
 			},
 
 			"secret": linuxSecretSchema(),
@@ -340,12 +381,13 @@ func resourceLinuxVirtualMachine() *pluginsdk.Resource {
 					computeValidate.SharedGalleryImageVersionID,
 				),
 				ExactlyOneOf: []string{
+					"os_managed_disk_id",
 					"source_image_id",
 					"source_image_reference",
 				},
 			},
 
-			"source_image_reference": sourceImageReferenceSchema(true),
+			"source_image_reference": sourceImageReferenceSchemaVM(),
 
 			"virtual_machine_scale_set_id": {
 				Type:     pluginsdk.TypeString,
@@ -456,23 +498,16 @@ func resourceLinuxVirtualMachineCreate(d *pluginsdk.ResourceData, meta interface
 	additionalCapabilitiesRaw := d.Get("additional_capabilities").([]interface{})
 	additionalCapabilities := expandVirtualMachineAdditionalCapabilities(additionalCapabilitiesRaw)
 
-	adminUsername := d.Get("admin_username").(string)
 	allowExtensionOperations := d.Get("allow_extension_operations").(bool)
 
 	bootDiagnosticsRaw := d.Get("boot_diagnostics").([]interface{})
 	bootDiagnostics := expandBootDiagnostics(bootDiagnosticsRaw)
 
-	var computerName string
-	if v, ok := d.GetOk("computer_name"); ok && len(v.(string)) > 0 {
-		computerName = v.(string)
-	} else {
-		_, errs := computeValidate.LinuxComputerNameFull(d.Get("name"), "computer_name")
-		if len(errs) > 0 {
-			return fmt.Errorf("unable to assume default computer name %s Please adjust the %q, or specify an explicit %q", errs[0], "name", "computer_name")
-		}
-		computerName = id.VirtualMachineName
+	disablePasswordAuthentication := true
+	if !d.GetRawConfig().AsValueMap()["disable_password_authentication"].IsNull() {
+		disablePasswordAuthentication = d.Get("disable_password_authentication").(bool)
 	}
-	disablePasswordAuthentication := d.Get("disable_password_authentication").(bool)
+
 	identityExpanded, err := identity.ExpandSystemAndUserAssignedMap(d.Get("identity").([]interface{}))
 	if err != nil {
 		return fmt.Errorf("expanding `identity`: %+v", err)
@@ -480,29 +515,21 @@ func resourceLinuxVirtualMachineCreate(d *pluginsdk.ResourceData, meta interface
 	planRaw := d.Get("plan").([]interface{})
 	plan := expandPlan(planRaw)
 	priority := virtualmachines.VirtualMachinePriorityTypes(d.Get("priority").(string))
-	provisionVMAgent := d.Get("provision_vm_agent").(bool)
+
+	provisionVMAgent := true
+	if p, ok := d.GetRawConfig().AsValueMap()["provision_vm_agent"]; ok && !p.IsNull() {
+		provisionVMAgent = d.Get("provision_vm_agent").(bool)
+	}
+
 	size := d.Get("size").(string)
 	t := d.Get("tags").(map[string]interface{})
 
 	networkInterfaceIdsRaw := d.Get("network_interface_ids").([]interface{})
 	networkInterfaceIds := expandVirtualMachineNetworkInterfaceIDs(networkInterfaceIdsRaw)
 
-	osDiskRaw := d.Get("os_disk").([]interface{})
-	osDisk, err := expandVirtualMachineOSDisk(osDiskRaw, virtualmachines.OperatingSystemTypesLinux)
-	if err != nil {
-		return fmt.Errorf("expanding `os_disk`: %+v", err)
-	}
-	securityEncryptionType := osDiskRaw[0].(map[string]interface{})["security_encryption_type"].(string)
+	managedDiskIdRaw := d.Get("os_managed_disk_id").(string)
 
-	secretsRaw := d.Get("secret").([]interface{})
-	secrets := expandLinuxSecrets(secretsRaw)
-
-	sourceImageReferenceRaw := d.Get("source_image_reference").([]interface{})
-	sourceImageId := d.Get("source_image_id").(string)
-	sourceImageReference := expandSourceImageReference(sourceImageReferenceRaw, sourceImageId)
-
-	sshKeysRaw := d.Get("admin_ssh_key").(*pluginsdk.Set).List()
-	sshKeys := expandSSHKeys(sshKeysRaw)
+	securityEncryptionType := ""
 
 	params := virtualmachines.VirtualMachine{
 		Name:             pointer.To(id.VirtualMachineName),
@@ -517,29 +544,13 @@ func resourceLinuxVirtualMachineCreate(d *pluginsdk.ResourceData, meta interface
 			HardwareProfile: &virtualmachines.HardwareProfile{
 				VMSize: pointer.To(virtualmachines.VirtualMachineSizeTypes(size)),
 			},
-			OsProfile: &virtualmachines.OSProfile{
-				AdminUsername:            pointer.To(adminUsername),
-				ComputerName:             pointer.To(computerName),
-				AllowExtensionOperations: pointer.To(allowExtensionOperations),
-				LinuxConfiguration: &virtualmachines.LinuxConfiguration{
-					DisablePasswordAuthentication: pointer.To(disablePasswordAuthentication),
-					ProvisionVMAgent:              pointer.To(provisionVMAgent),
-					Ssh: &virtualmachines.SshConfiguration{
-						PublicKeys: &sshKeys,
-					},
-				},
-				Secrets: secrets,
-			},
 			NetworkProfile: &virtualmachines.NetworkProfile{
 				NetworkInterfaces: &networkInterfaceIds,
 			},
 			Priority: pointer.To(priority),
 			StorageProfile: &virtualmachines.StorageProfile{
-				ImageReference: sourceImageReference,
-				OsDisk:         osDisk,
-
-				// Data Disks are instead handled via the Association resource - as such we can send an empty value here
-				// but for Updates this'll need to be nil, else any associations will be overwritten
+				// Data Disks are currently handled via the Association resource
+				// TODO - investigate how to facilitate in-lining data disks. NB: Probably won't be compatible with using the association resource
 				DataDisks: &[]virtualmachines.DataDisk{},
 			},
 
@@ -549,6 +560,134 @@ func resourceLinuxVirtualMachineCreate(d *pluginsdk.ResourceData, meta interface
 			ExtensionsTimeBudget:   pointer.To(d.Get("extensions_time_budget").(string)),
 		},
 		Tags: tags.Expand(t),
+	}
+
+	// Note: The API fails if OsProfile is anything but nil with CreateOption = "Attach"
+	osDiskIsImported := managedDiskIdRaw != ""
+
+	osDiskRaw := d.Get("os_disk").([]interface{})
+	osDisk, err := expandVirtualMachineOSDisk(osDiskRaw, virtualmachines.OperatingSystemTypesLinux)
+	if err != nil {
+		return fmt.Errorf("expanding `os_disk`: %+v", err)
+	}
+	if !osDiskIsImported {
+		securityEncryptionType = osDiskRaw[0].(map[string]interface{})["security_encryption_type"].(string)
+		var computerName string
+		if v, ok := d.GetOk("computer_name"); ok && len(v.(string)) > 0 {
+			computerName = v.(string)
+		} else {
+			_, errs := computeValidate.LinuxComputerNameFull(d.Get("name"), "computer_name")
+			if len(errs) > 0 {
+				return fmt.Errorf("unable to assume default computer name %s Please adjust the %q, or specify an explicit %q", errs[0], "name", "computer_name")
+			}
+			computerName = id.VirtualMachineName
+		}
+
+		sshKeysRaw := d.Get("admin_ssh_key").(*pluginsdk.Set).List()
+		sshKeys := expandSSHKeys(sshKeysRaw)
+
+		secretsRaw := d.Get("secret").([]interface{})
+		secrets := expandLinuxSecrets(secretsRaw)
+
+		params.Properties.OsProfile = &virtualmachines.OSProfile{
+			AdminUsername:            pointer.To(d.Get("admin_username").(string)),
+			ComputerName:             pointer.To(computerName),
+			AllowExtensionOperations: pointer.To(allowExtensionOperations),
+			LinuxConfiguration: &virtualmachines.LinuxConfiguration{
+				DisablePasswordAuthentication: pointer.To(disablePasswordAuthentication),
+				ProvisionVMAgent:              pointer.To(provisionVMAgent),
+				Ssh: &virtualmachines.SshConfiguration{
+					PublicKeys: &sshKeys,
+				},
+			},
+			Secrets: secrets,
+		}
+		//
+		patchMode := string(virtualmachines.LinuxVMGuestPatchModeImageDefault)
+		if patchModeRaw, ok := d.GetOk("patch_mode"); ok {
+			patchMode = patchModeRaw.(string)
+		}
+
+		if patchMode == string(virtualmachines.LinuxVMGuestPatchModeAutomaticByPlatform) && !provisionVMAgent {
+			return fmt.Errorf("%q cannot be set to %q when %q is set to %q", "patch_mode", "AutomaticByPlatform", "provision_vm_agent", "false")
+		}
+
+		params.Properties.OsProfile.LinuxConfiguration.PatchSettings = &virtualmachines.LinuxPatchSettings{
+			PatchMode: pointer.To(virtualmachines.LinuxVMGuestPatchMode(patchMode)),
+		}
+
+		mode := string(virtualmachines.LinuxVMGuestPatchModeImageDefault)
+
+		if v := d.Get("patch_assessment_mode").(string); v != "" {
+			mode = v
+		}
+
+		if mode == string(virtualmachines.LinuxPatchAssessmentModeAutomaticByPlatform) && !provisionVMAgent {
+			return fmt.Errorf("`provision_vm_agent` must be set to `true` when `patch_assessment_mode` is set to `AutomaticByPlatform`")
+		}
+
+		if params.Properties.OsProfile.LinuxConfiguration.PatchSettings == nil {
+			params.Properties.OsProfile.LinuxConfiguration.PatchSettings = &virtualmachines.LinuxPatchSettings{}
+		}
+		params.Properties.OsProfile.LinuxConfiguration.PatchSettings.AssessmentMode = pointer.To(virtualmachines.LinuxPatchAssessmentMode(mode))
+
+		if d.Get("bypass_platform_safety_checks_on_user_schedule_enabled").(bool) {
+			if patchMode != string(virtualmachines.LinuxVMGuestPatchModeAutomaticByPlatform) {
+				return fmt.Errorf("`patch_mode` must be set to `AutomaticByPlatform` when `bypass_platform_safety_checks_on_user_schedule_enabled` is set to `true`")
+			}
+
+			if params.Properties.OsProfile.LinuxConfiguration.PatchSettings == nil {
+				params.Properties.OsProfile.LinuxConfiguration.PatchSettings = &virtualmachines.LinuxPatchSettings{}
+			}
+
+			if params.Properties.OsProfile.LinuxConfiguration.PatchSettings.AutomaticByPlatformSettings == nil {
+				params.Properties.OsProfile.LinuxConfiguration.PatchSettings.AutomaticByPlatformSettings = &virtualmachines.LinuxVMGuestPatchAutomaticByPlatformSettings{}
+			}
+
+			params.Properties.OsProfile.LinuxConfiguration.PatchSettings.AutomaticByPlatformSettings.BypassPlatformSafetyChecksOnUserSchedule = pointer.To(true)
+		}
+
+		if v, ok := d.GetOk("reboot_setting"); ok {
+			if patchMode != string(virtualmachines.LinuxVMGuestPatchModeAutomaticByPlatform) {
+				return fmt.Errorf("`patch_mode` must be set to `AutomaticByPlatform` when `reboot_setting` is specified")
+			}
+
+			if params.Properties.OsProfile.LinuxConfiguration.PatchSettings == nil {
+				params.Properties.OsProfile.LinuxConfiguration.PatchSettings = &virtualmachines.LinuxPatchSettings{}
+			}
+
+			if params.Properties.OsProfile.LinuxConfiguration.PatchSettings.AutomaticByPlatformSettings == nil {
+				params.Properties.OsProfile.LinuxConfiguration.PatchSettings.AutomaticByPlatformSettings = &virtualmachines.LinuxVMGuestPatchAutomaticByPlatformSettings{}
+			}
+
+			params.Properties.OsProfile.LinuxConfiguration.PatchSettings.AutomaticByPlatformSettings.RebootSetting = pointer.To(virtualmachines.LinuxVMGuestPatchAutomaticByPlatformRebootSetting(v.(string)))
+		}
+
+		adminPassword := d.Get("admin_password").(string)
+		if disablePasswordAuthentication && len(sshKeys) == 0 {
+			return fmt.Errorf("at least one `admin_ssh_key` must be specified when `disable_password_authentication` is set to `true`")
+		} else if !disablePasswordAuthentication {
+			if adminPassword == "" {
+				return fmt.Errorf("an `admin_password` must be specified if `disable_password_authentication` is set to `false`")
+			}
+
+			params.Properties.OsProfile.AdminPassword = pointer.To(adminPassword)
+		}
+	} else {
+		diskId, err := commonids.ParseManagedDiskID(managedDiskIdRaw)
+		if err != nil {
+			return err
+		}
+
+		osDisk.ManagedDisk.Id = pointer.To(diskId.ID())
+		osDisk.CreateOption = virtualmachines.DiskCreateOptionTypesAttach
+	}
+	params.Properties.StorageProfile.OsDisk = osDisk
+
+	sourceImageReferenceRaw := d.Get("source_image_reference").([]interface{})
+	sourceImageId := d.Get("source_image_id").(string)
+	if len(sourceImageReferenceRaw) != 0 || sourceImageId != "" {
+		params.Properties.StorageProfile.ImageReference = expandSourceImageReference(sourceImageReferenceRaw, sourceImageId)
 	}
 
 	if diskControllerType, ok := d.GetOk("disk_controller_type"); ok {
@@ -569,60 +708,6 @@ func resourceLinuxVirtualMachineCreate(d *pluginsdk.ResourceData, meta interface
 
 	if v, ok := d.GetOk("license_type"); ok {
 		params.Properties.LicenseType = pointer.To(v.(string))
-	}
-
-	patchMode := d.Get("patch_mode").(string)
-	if patchMode != "" {
-		if patchMode == string(virtualmachines.LinuxVMGuestPatchModeAutomaticByPlatform) && !provisionVMAgent {
-			return fmt.Errorf("%q cannot be set to %q when %q is set to %q", "patch_mode", "AutomaticByPlatform", "provision_vm_agent", "false")
-		}
-
-		params.Properties.OsProfile.LinuxConfiguration.PatchSettings = &virtualmachines.LinuxPatchSettings{
-			PatchMode: pointer.To(virtualmachines.LinuxVMGuestPatchMode(patchMode)),
-		}
-	}
-
-	if v, ok := d.GetOk("patch_assessment_mode"); ok {
-		if v.(string) == string(virtualmachines.LinuxPatchAssessmentModeAutomaticByPlatform) && !provisionVMAgent {
-			return fmt.Errorf("`provision_vm_agent` must be set to `true` when `patch_assessment_mode` is set to `AutomaticByPlatform`")
-		}
-
-		if params.Properties.OsProfile.LinuxConfiguration.PatchSettings == nil {
-			params.Properties.OsProfile.LinuxConfiguration.PatchSettings = &virtualmachines.LinuxPatchSettings{}
-		}
-		params.Properties.OsProfile.LinuxConfiguration.PatchSettings.AssessmentMode = pointer.To(virtualmachines.LinuxPatchAssessmentMode(v.(string)))
-	}
-
-	if d.Get("bypass_platform_safety_checks_on_user_schedule_enabled").(bool) {
-		if patchMode != string(virtualmachines.LinuxVMGuestPatchModeAutomaticByPlatform) {
-			return fmt.Errorf("`patch_mode` must be set to `AutomaticByPlatform` when `bypass_platform_safety_checks_on_user_schedule_enabled` is set to `true`")
-		}
-
-		if params.Properties.OsProfile.LinuxConfiguration.PatchSettings == nil {
-			params.Properties.OsProfile.LinuxConfiguration.PatchSettings = &virtualmachines.LinuxPatchSettings{}
-		}
-
-		if params.Properties.OsProfile.LinuxConfiguration.PatchSettings.AutomaticByPlatformSettings == nil {
-			params.Properties.OsProfile.LinuxConfiguration.PatchSettings.AutomaticByPlatformSettings = &virtualmachines.LinuxVMGuestPatchAutomaticByPlatformSettings{}
-		}
-
-		params.Properties.OsProfile.LinuxConfiguration.PatchSettings.AutomaticByPlatformSettings.BypassPlatformSafetyChecksOnUserSchedule = pointer.To(true)
-	}
-
-	if v, ok := d.GetOk("reboot_setting"); ok {
-		if patchMode != string(virtualmachines.LinuxVMGuestPatchModeAutomaticByPlatform) {
-			return fmt.Errorf("`patch_mode` must be set to `AutomaticByPlatform` when `reboot_setting` is specified")
-		}
-
-		if params.Properties.OsProfile.LinuxConfiguration.PatchSettings == nil {
-			params.Properties.OsProfile.LinuxConfiguration.PatchSettings = &virtualmachines.LinuxPatchSettings{}
-		}
-
-		if params.Properties.OsProfile.LinuxConfiguration.PatchSettings.AutomaticByPlatformSettings == nil {
-			params.Properties.OsProfile.LinuxConfiguration.PatchSettings.AutomaticByPlatformSettings = &virtualmachines.LinuxVMGuestPatchAutomaticByPlatformSettings{}
-		}
-
-		params.Properties.OsProfile.LinuxConfiguration.PatchSettings.AutomaticByPlatformSettings.RebootSetting = pointer.To(virtualmachines.LinuxVMGuestPatchAutomaticByPlatformRebootSetting(v.(string)))
 	}
 
 	secureBootEnabled := d.Get("secure_boot_enabled").(bool)
@@ -687,7 +772,7 @@ func resourceLinuxVirtualMachineCreate(d *pluginsdk.ResourceData, meta interface
 		}
 	}
 
-	if !provisionVMAgent && allowExtensionOperations {
+	if !provisionVMAgent && allowExtensionOperations { // TODO - Replace this with CustomizeDiff for plan-time catch?
 		return fmt.Errorf("`allow_extension_operations` cannot be set to `true` when `provision_vm_agent` is set to `false`")
 	}
 
@@ -769,16 +854,6 @@ func resourceLinuxVirtualMachineCreate(d *pluginsdk.ResourceData, meta interface
 	}
 
 	// "Authentication using either SSH or by user name and password must be enabled in Linux profile." Target="linuxConfiguration"
-	adminPassword := d.Get("admin_password").(string)
-	if disablePasswordAuthentication && len(sshKeys) == 0 {
-		return fmt.Errorf("at least one `admin_ssh_key` must be specified when `disable_password_authentication` is set to `true`")
-	} else if !disablePasswordAuthentication {
-		if adminPassword == "" {
-			return fmt.Errorf("an `admin_password` must be specified if `disable_password_authentication` is set to `false`")
-		}
-
-		params.Properties.OsProfile.AdminPassword = pointer.To(adminPassword)
-	}
 
 	if err := client.CreateOrUpdateThenPoll(ctx, id, params, virtualmachines.DefaultCreateOrUpdateOperationOptions()); err != nil {
 		return fmt.Errorf("creating Linux %s: %+v", id, err)
@@ -985,7 +1060,7 @@ func resourceLinuxVirtualMachineRead(d *pluginsdk.ResourceData, meta interface{}
 				if err := d.Set("os_disk", flattenedOSDisk); err != nil {
 					return fmt.Errorf("settings `os_disk`: %+v", err)
 				}
-
+				d.Set("os_managed_disk_id", profile.OsDisk.ManagedDisk.Id)
 				var storageImageId string
 				if profile.ImageReference != nil && profile.ImageReference.Id != nil {
 					storageImageId = *profile.ImageReference.Id
@@ -1060,6 +1135,8 @@ func resourceLinuxVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interface
 	if err != nil {
 		return err
 	}
+
+	// vmFromExistingDisk := !d.GetRawConfig().AsValueMap()["os_managed_disk_id"].IsNull()
 
 	locks.ByName(id.VirtualMachineName, VirtualMachineResourceName)
 	defer locks.UnlockByName(id.VirtualMachineName, VirtualMachineResourceName)
@@ -1731,6 +1808,26 @@ func resourceLinuxVirtualMachineDelete(d *pluginsdk.ResourceData, meta interface
 		}
 	} else {
 		log.Printf("[DEBUG] Skipping Deleting OS Disk from Linux %s", id)
+		// Wait for the Disk to be no longer `Attached` so we know it's released and free to be attached to any subsequent VM etc
+		disksClient := meta.(*clients.Client).Compute.DisksClient
+		managedDiskId := ""
+		if props := existing.Model.Properties; props != nil && props.StorageProfile != nil && props.StorageProfile.OsDisk != nil {
+			if disk := props.StorageProfile.OsDisk.ManagedDisk; disk != nil && disk.Id != nil {
+				managedDiskId = *disk.Id
+			}
+		}
+		if managedDiskId != "" {
+			diskId, err := commonids.ParseManagedDiskID(managedDiskId)
+			if err != nil {
+				return err
+			}
+
+			pollerType := custompoller.NewManagedDiskDetachedPoller(disksClient, *diskId, *id)
+			poller := pollers.NewPoller(pollerType, 10*time.Second, pollers.DefaultNumberOfDroppedConnectionsToAllow)
+			if err := poller.PollUntilDone(ctx); err != nil {
+				return err
+			}
+		}
 	}
 
 	// Need to add a get and a state wait to avoid bug in network API where the attached disk(s) are not actually deleted

--- a/internal/services/compute/linux_virtual_machine_resource_disk_os_test.go
+++ b/internal/services/compute/linux_virtual_machine_resource_disk_os_test.go
@@ -382,7 +382,7 @@ func TestAccLinuxVirtualMachine_diskOSImportManagedDisk(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		// data.ImportStep(),
+		data.ImportStep(),
 		{
 			Config: r.osDiskImportTemplateWithProvider(data), // Remove the initial VM
 		},
@@ -394,6 +394,7 @@ func TestAccLinuxVirtualMachine_diskOSImportManagedDisk(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
+			// This step does nothing except flip the delete OS disk with VM to true to avoid the RG preventing being deleted
 			Config: r.diskOSImportManagedDiskCleanup(data),
 		},
 	})
@@ -1249,7 +1250,7 @@ provider "azurerm" {
 %[1]s
 
 data "azurerm_managed_disks" "test" {
-	resource_group_name = azurerm_resource_group.test.name
+  resource_group_name = azurerm_resource_group.test.name
 }
 
 resource "azurerm_linux_virtual_machine" "test" {
@@ -1262,7 +1263,7 @@ resource "azurerm_linux_virtual_machine" "test" {
     azurerm_network_interface.test.id,
   ]
 
-  os_managed_disk_id      = data.azurerm_managed_disks.test.disk.0.id
+  os_managed_disk_id = data.azurerm_managed_disks.test.disk.0.id
 
   os_disk {
     caching              = "ReadWrite"
@@ -1285,7 +1286,7 @@ provider "azurerm" {
 %[1]s
 
 data "azurerm_managed_disks" "test" {
-	resource_group_name = azurerm_resource_group.test.name
+  resource_group_name = azurerm_resource_group.test.name
 }
 
 resource "azurerm_linux_virtual_machine" "test" {
@@ -1298,7 +1299,7 @@ resource "azurerm_linux_virtual_machine" "test" {
     azurerm_network_interface.test.id,
   ]
 
-  os_managed_disk_id      = data.azurerm_managed_disks.test.disk.0.id
+  os_managed_disk_id = data.azurerm_managed_disks.test.disk.0.id
 
   os_disk {
     caching              = "ReadWrite"

--- a/internal/services/compute/linux_virtual_machine_resource_disk_os_test.go
+++ b/internal/services/compute/linux_virtual_machine_resource_disk_os_test.go
@@ -264,42 +264,6 @@ func TestAccLinuxVirtualMachine_diskOSStorageTypePremiumZRS(t *testing.T) {
 	})
 }
 
-func TestAccLinuxVirtualMachine_diskOSStorageTypeUpdate(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
-	r := LinuxVirtualMachineResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.diskOSStorageAccountType(data, "Standard_LRS"),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.diskOSStorageAccountType(data, "Premium_LRS"),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.diskOSStorageAccountType(data, "StandardSSD_LRS"),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.diskOSStorageAccountType(data, "Standard_LRS"),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-	})
-}
-
 func TestAccLinuxVirtualMachine_diskOSControllerType(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
 	r := LinuxVirtualMachineResource{}

--- a/internal/services/compute/linux_virtual_machine_resource_other_test.go
+++ b/internal/services/compute/linux_virtual_machine_resource_other_test.go
@@ -1698,7 +1698,7 @@ resource "azurerm_linux_virtual_machine" "test" {
   }
 
   gallery_application {
-    version_id = azurerm_gallery_application_version.test2.id
+    version_id                                  = azurerm_gallery_application_version.test2.id
     order                                       = 2
     configuration_blob_uri                      = azurerm_storage_blob.test2.id
     tag                                         = "app2"

--- a/internal/services/compute/linux_virtual_machine_resource_other_test.go
+++ b/internal/services/compute/linux_virtual_machine_resource_other_test.go
@@ -1698,7 +1698,7 @@ resource "azurerm_linux_virtual_machine" "test" {
   }
 
   gallery_application {
-    version_id                                  = azurerm_gallery_application_version.test2.id
+    version_id = azurerm_gallery_application_version.test2.id
     // automatic_upgrade_enabled                   = true
     order                                       = 2
     configuration_blob_uri                      = azurerm_storage_blob.test2.id

--- a/internal/services/compute/linux_virtual_machine_resource_other_test.go
+++ b/internal/services/compute/linux_virtual_machine_resource_other_test.go
@@ -1699,7 +1699,7 @@ resource "azurerm_linux_virtual_machine" "test" {
 
   gallery_application {
     version_id                                  = azurerm_gallery_application_version.test2.id
-    automatic_upgrade_enabled                   = true
+    // automatic_upgrade_enabled                   = true
     order                                       = 2
     configuration_blob_uri                      = azurerm_storage_blob.test2.id
     tag                                         = "app2"
@@ -1999,7 +1999,7 @@ resource "azurerm_linux_virtual_machine" "test" {
   name                = "acctestVM-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  size                = "Standard_F2"
+  size                = "Standard_F2s_v2"
   admin_username      = "adminuser"
   license_type        = "SLES_BYOS"
   network_interface_ids = [

--- a/internal/services/compute/linux_virtual_machine_resource_other_test.go
+++ b/internal/services/compute/linux_virtual_machine_resource_other_test.go
@@ -1965,7 +1965,7 @@ resource "azurerm_linux_virtual_machine" "test" {
   name                = "acctestVM-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  size                = "Standard_F2"
+  size                = "Standard_F2s_v2"
   admin_username      = "adminuser"
   network_interface_ids = [
     azurerm_network_interface.test.id,

--- a/internal/services/compute/linux_virtual_machine_resource_other_test.go
+++ b/internal/services/compute/linux_virtual_machine_resource_other_test.go
@@ -1699,7 +1699,6 @@ resource "azurerm_linux_virtual_machine" "test" {
 
   gallery_application {
     version_id = azurerm_gallery_application_version.test2.id
-    // automatic_upgrade_enabled                   = true
     order                                       = 2
     configuration_blob_uri                      = azurerm_storage_blob.test2.id
     tag                                         = "app2"

--- a/internal/services/compute/managed_disks_data_source.go
+++ b/internal/services/compute/managed_disks_data_source.go
@@ -1,0 +1,277 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package compute
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/zones"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
+)
+
+//
+// type ManagedDisksDataSource struct{}
+// type ManagedDisksDataSourceModel struct {
+// 	ResourceGroupName string `tfschema:"resource_group_name"`
+// 	Disks             []Disk `tfschema:"disk"`
+// }
+//
+// type Disk struct {
+// 	Name                string              `tfschema:"name"`
+// 	CreateOption        string              `tfschema:"create_option"`
+// 	DiskAccessId        string              `tfschema:"disk_access_id"`
+// 	DiskEncryptionSetId string              `tfschema:"disk_encryption_set_id"`
+// 	DiskIOPSReadWrite   int64               `tfschema:"disk_iops_read_write"`
+// 	DiskMBPSReadWrite   int64               `tfschema:"disk_mbps_read_write"`
+// 	DiskSizeMB          int64               `tfschema:"disk_size_gb"`
+// 	EncryptionSettings  []EncryptionSetting `tfschema:"encryption_settings"`
+// 	Location            string              `tfschema:"location"`
+// 	ImageReferenceID    string              `tfschema:"image_reference_id"`
+// 	NetworkAccessPolicy string              `tfschema:"network_access_policy"`
+// 	OSType              string              `tfschema:"os_type"`
+// 	SourceResourceID    string              `tfschema:"source_resource_id"`
+// 	SourceURI           string              `tfschema:"source_uri"`
+// 	StorageAccountID    string              `tfschema:"storage_account_id"`
+// 	StorageAccountType  string              `tfschema:"storage_account_type"`
+// 	Tags                map[string]string   `tfschema:"tags"`
+// 	Zones               []string            `tfschema:"zones"`
+// }
+//
+// type EncryptionSetting struct {
+// 	Enabled bool `tfschema:"enabled"`
+// 	DiskEncryptionKey []DiskEncryptionKey `tfschema:"disk_encryption_key"`
+// }
+
+func dataSourceManagedDisks() *pluginsdk.Resource {
+	return &pluginsdk.Resource{
+		Read: dataSourceManagedDisksRead,
+
+		Timeouts: &pluginsdk.ResourceTimeout{
+			Read: pluginsdk.DefaultTimeout(5 * time.Minute),
+		},
+
+		Schema: map[string]*pluginsdk.Schema{
+			"resource_group_name": commonschema.ResourceGroupNameForDataSource(),
+
+			"disk": {
+				Type:     pluginsdk.TypeList,
+				Computed: true,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+
+						"create_option": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+
+						"disk_access_id": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+
+						"disk_encryption_set_id": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+
+						"disk_iops_read_write": {
+							Type:     pluginsdk.TypeInt,
+							Computed: true,
+						},
+
+						"disk_mbps_read_write": {
+							Type:     pluginsdk.TypeInt,
+							Computed: true,
+						},
+
+						"disk_size_gb": {
+							Type:     pluginsdk.TypeInt,
+							Computed: true,
+						},
+
+						"encryption_settings": {
+							Type:     pluginsdk.TypeList,
+							Computed: true,
+							Elem: &pluginsdk.Resource{
+								Schema: map[string]*pluginsdk.Schema{
+									"enabled": {
+										Type:     pluginsdk.TypeBool,
+										Computed: true,
+									},
+
+									"disk_encryption_key": {
+										Type:     pluginsdk.TypeList,
+										Computed: true,
+										Elem: &pluginsdk.Resource{
+											Schema: map[string]*pluginsdk.Schema{
+												"secret_url": {
+													Type:     pluginsdk.TypeString,
+													Computed: true,
+												},
+
+												"source_vault_id": {
+													Type:     pluginsdk.TypeString,
+													Computed: true,
+												},
+											},
+										},
+									},
+									"key_encryption_key": {
+										Type:     pluginsdk.TypeList,
+										Computed: true,
+										Elem: &pluginsdk.Resource{
+											Schema: map[string]*pluginsdk.Schema{
+												"key_url": {
+													Type:     pluginsdk.TypeString,
+													Computed: true,
+												},
+
+												"source_vault_id": {
+													Type:     pluginsdk.TypeString,
+													Computed: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+
+						"location": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+
+						"image_reference_id": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+
+						"network_access_policy": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+
+						"os_type": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+
+						"source_resource_id": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+
+						"source_uri": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+
+						"storage_account_id": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+
+						"storage_account_type": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+
+						"tags": commonschema.TagsDataSource(),
+
+						"zones": commonschema.ZonesMultipleComputed(),
+
+						"id": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceManagedDisksRead(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Compute.DisksClient
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id := commonids.NewResourceGroupID(subscriptionId, d.Get("resource_group_name").(string))
+
+	resp, err := client.ListByResourceGroup(ctx, id)
+	if err != nil {
+		if response.WasNotFound(resp.HttpResponse) {
+			return fmt.Errorf("%s was not found", id)
+		}
+		return fmt.Errorf("making Read request on %s: %s", id, err)
+	}
+
+	d.SetId(id.ID())
+
+	disks := make([]interface{}, 0)
+	if model := resp.Model; model != nil {
+		for _, disk := range *model {
+			r := map[string]interface{}{
+				"name":     pointer.From(disk.Name),
+				"zones":    zones.FlattenUntyped(disk.Zones),
+				"location": location.Normalize(disk.Location),
+				"id":       commonids.NewManagedDiskID(id.SubscriptionId, id.ResourceGroupName, pointer.From(disk.Name)).ID(),
+			}
+
+			if props := disk.Properties; props != nil {
+				r["create_option"] = props.CreationData.CreateOption
+				r["source_uri"] = pointer.From(props.CreationData.SourceUri)
+				r["source_resource_id"] = pointer.From(props.CreationData.SourceResourceId)
+				r["storage_account_id"] = pointer.From(props.CreationData.StorageAccountId)
+
+				if props.CreationData.ImageReference != nil {
+					r["image_reference_id"] = pointer.From(props.CreationData.ImageReference.Id)
+				}
+
+				r["disk_access_id"] = pointer.From(props.DiskAccessId)
+				r["network_access_policy"] = pointer.From(props.NetworkAccessPolicy)
+				r["disk_size_gb"] = pointer.From(props.DiskSizeGB)
+				r["disk_iops_read_write"] = pointer.From(props.DiskIOPSReadWrite)
+				r["disk_mbps_read_write"] = pointer.From(props.DiskMBpsReadWrite)
+				r["os_type"] = pointer.From(props.OsType)
+
+				if enc := props.Encryption; enc != nil {
+					r["disk_encryption_set_id"] = pointer.From(enc.DiskEncryptionSetId)
+				}
+
+				r["encryption_settings"] = flattenManagedDiskEncryptionSettings(props.EncryptionSettingsCollection)
+			}
+
+			if sku := disk.Sku; sku != nil {
+				r["storage_account_type"] = pointer.From(sku.Name)
+			}
+
+			r["tags"] = tags.Flatten(disk.Tags)
+
+			disks = append(disks, r)
+		}
+	}
+
+	d.Set("disk", disks)
+
+	d.Set("resource_group_name", id.ResourceGroupName)
+
+	return nil
+}

--- a/internal/services/compute/managed_disks_data_source.go
+++ b/internal/services/compute/managed_disks_data_source.go
@@ -4,6 +4,7 @@
 package compute
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -12,194 +13,211 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
-	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/zones"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2023-04-02/disks"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
 
-//
-// type ManagedDisksDataSource struct{}
-// type ManagedDisksDataSourceModel struct {
-// 	ResourceGroupName string `tfschema:"resource_group_name"`
-// 	Disks             []Disk `tfschema:"disk"`
-// }
-//
-// type Disk struct {
-// 	Name                string              `tfschema:"name"`
-// 	CreateOption        string              `tfschema:"create_option"`
-// 	DiskAccessId        string              `tfschema:"disk_access_id"`
-// 	DiskEncryptionSetId string              `tfschema:"disk_encryption_set_id"`
-// 	DiskIOPSReadWrite   int64               `tfschema:"disk_iops_read_write"`
-// 	DiskMBPSReadWrite   int64               `tfschema:"disk_mbps_read_write"`
-// 	DiskSizeMB          int64               `tfschema:"disk_size_gb"`
-// 	EncryptionSettings  []EncryptionSetting `tfschema:"encryption_settings"`
-// 	Location            string              `tfschema:"location"`
-// 	ImageReferenceID    string              `tfschema:"image_reference_id"`
-// 	NetworkAccessPolicy string              `tfschema:"network_access_policy"`
-// 	OSType              string              `tfschema:"os_type"`
-// 	SourceResourceID    string              `tfschema:"source_resource_id"`
-// 	SourceURI           string              `tfschema:"source_uri"`
-// 	StorageAccountID    string              `tfschema:"storage_account_id"`
-// 	StorageAccountType  string              `tfschema:"storage_account_type"`
-// 	Tags                map[string]string   `tfschema:"tags"`
-// 	Zones               []string            `tfschema:"zones"`
-// }
-//
-// type EncryptionSetting struct {
-// 	Enabled bool `tfschema:"enabled"`
-// 	DiskEncryptionKey []DiskEncryptionKey `tfschema:"disk_encryption_key"`
-// }
+type ManagedDisksDataSource struct{}
 
-func dataSourceManagedDisks() *pluginsdk.Resource {
-	return &pluginsdk.Resource{
-		Read: dataSourceManagedDisksRead,
+var _ sdk.DataSource = &ManagedDisksDataSource{}
 
-		Timeouts: &pluginsdk.ResourceTimeout{
-			Read: pluginsdk.DefaultTimeout(5 * time.Minute),
-		},
+func (m ManagedDisksDataSource) ModelObject() interface{} {
+	return &ManagedDisksDataSourceModel{}
+}
 
-		Schema: map[string]*pluginsdk.Schema{
-			"resource_group_name": commonschema.ResourceGroupNameForDataSource(),
+func (m ManagedDisksDataSource) ResourceType() string {
+	return "azurerm_managed_disks"
+}
 
-			"disk": {
-				Type:     pluginsdk.TypeList,
-				Computed: true,
-				Elem: &pluginsdk.Resource{
-					Schema: map[string]*schema.Schema{
-						"name": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
+type ManagedDisksDataSourceModel struct {
+	ResourceGroupName string `tfschema:"resource_group_name"`
+	Disks             []Disk `tfschema:"disk"`
+}
 
-						"create_option": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
+type Disk struct {
+	Name                string              `tfschema:"name"`
+	ID                  string              `tfschema:"id"`
+	CreateOption        string              `tfschema:"create_option"`
+	DiskAccessId        string              `tfschema:"disk_access_id"`
+	DiskEncryptionSetId string              `tfschema:"disk_encryption_set_id"`
+	DiskIOPSReadWrite   int64               `tfschema:"disk_iops_read_write"`
+	DiskMBPSReadWrite   int64               `tfschema:"disk_mbps_read_write"`
+	DiskSizeGB          int64               `tfschema:"disk_size_in_gb"`
+	EncryptionSettings  []EncryptionSetting `tfschema:"encryption_settings"`
+	Location            string              `tfschema:"location"`
+	ImageReferenceID    string              `tfschema:"image_reference_id"`
+	NetworkAccessPolicy string              `tfschema:"network_access_policy"`
+	OSType              string              `tfschema:"os_type"`
+	SourceResourceID    string              `tfschema:"source_resource_id"`
+	SourceURI           string              `tfschema:"source_uri"`
+	StorageAccountID    string              `tfschema:"storage_account_id"`
+	StorageAccountType  string              `tfschema:"storage_account_type"`
+	Tags                map[string]string   `tfschema:"tags"`
+	Zones               []string            `tfschema:"zones"`
+}
 
-						"disk_access_id": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
+type EncryptionSetting struct {
+	Enabled            bool                `tfschema:"enabled"`
+	DiskEncryptionKeys []DiskEncryptionKey `tfschema:"disk_encryption_keys"`
+	KeyEncryptionKeys  []KeyEncryptionKey  `tfschema:"key_encryption_keys"`
+}
 
-						"disk_encryption_set_id": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
+type DiskEncryptionKey struct {
+	SecretURL     string `tfschema:"secret_url"`
+	SourceVaultID string `tfschema:"source_vault_id"`
+}
 
-						"disk_iops_read_write": {
-							Type:     pluginsdk.TypeInt,
-							Computed: true,
-						},
+type KeyEncryptionKey struct {
+	KeyURL        string `tfschema:"key_url"`
+	SourceVaultID string `tfschema:"source_vault_id"`
+}
 
-						"disk_mbps_read_write": {
-							Type:     pluginsdk.TypeInt,
-							Computed: true,
-						},
+func (m ManagedDisksDataSource) Arguments() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"resource_group_name": commonschema.ResourceGroupNameForDataSource(),
+	}
+}
 
-						"disk_size_gb": {
-							Type:     pluginsdk.TypeInt,
-							Computed: true,
-						},
+func (m ManagedDisksDataSource) Attributes() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"disk": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*schema.Schema{
+					"name": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
 
-						"encryption_settings": {
-							Type:     pluginsdk.TypeList,
-							Computed: true,
-							Elem: &pluginsdk.Resource{
-								Schema: map[string]*pluginsdk.Schema{
-									"enabled": {
-										Type:     pluginsdk.TypeBool,
-										Computed: true,
-									},
+					"create_option": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
 
-									"disk_encryption_key": {
-										Type:     pluginsdk.TypeList,
-										Computed: true,
-										Elem: &pluginsdk.Resource{
-											Schema: map[string]*pluginsdk.Schema{
-												"secret_url": {
-													Type:     pluginsdk.TypeString,
-													Computed: true,
-												},
+					"disk_access_id": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
 
-												"source_vault_id": {
-													Type:     pluginsdk.TypeString,
-													Computed: true,
-												},
+					"disk_encryption_set_id": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+
+					"disk_iops_read_write": {
+						Type:     pluginsdk.TypeInt,
+						Computed: true,
+					},
+
+					"disk_mbps_read_write": {
+						Type:     pluginsdk.TypeInt,
+						Computed: true,
+					},
+
+					"disk_size_in_gb": {
+						Type:     pluginsdk.TypeInt,
+						Computed: true,
+					},
+
+					"encryption_settings": {
+						Type:     pluginsdk.TypeList,
+						Computed: true,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"enabled": {
+									Type:     pluginsdk.TypeBool,
+									Computed: true,
+								},
+
+								"disk_encryption_key": {
+									Type:     pluginsdk.TypeList,
+									Computed: true,
+									Elem: &pluginsdk.Resource{
+										Schema: map[string]*pluginsdk.Schema{
+											"secret_url": {
+												Type:     pluginsdk.TypeString,
+												Computed: true,
+											},
+
+											"source_vault_id": {
+												Type:     pluginsdk.TypeString,
+												Computed: true,
 											},
 										},
 									},
-									"key_encryption_key": {
-										Type:     pluginsdk.TypeList,
-										Computed: true,
-										Elem: &pluginsdk.Resource{
-											Schema: map[string]*pluginsdk.Schema{
-												"key_url": {
-													Type:     pluginsdk.TypeString,
-													Computed: true,
-												},
+								},
+								"key_encryption_key": {
+									Type:     pluginsdk.TypeList,
+									Computed: true,
+									Elem: &pluginsdk.Resource{
+										Schema: map[string]*pluginsdk.Schema{
+											"key_url": {
+												Type:     pluginsdk.TypeString,
+												Computed: true,
+											},
 
-												"source_vault_id": {
-													Type:     pluginsdk.TypeString,
-													Computed: true,
-												},
+											"source_vault_id": {
+												Type:     pluginsdk.TypeString,
+												Computed: true,
 											},
 										},
 									},
 								},
 							},
 						},
+					},
 
-						"location": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
+					"location": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
 
-						"image_reference_id": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
+					"image_reference_id": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
 
-						"network_access_policy": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
+					"network_access_policy": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
 
-						"os_type": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
+					"os_type": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
 
-						"source_resource_id": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
+					"source_resource_id": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
 
-						"source_uri": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
+					"source_uri": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
 
-						"storage_account_id": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
+					"storage_account_id": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
 
-						"storage_account_type": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
+					"storage_account_type": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
 
-						"tags": commonschema.TagsDataSource(),
+					"tags": commonschema.TagsDataSource(),
 
-						"zones": commonschema.ZonesMultipleComputed(),
+					"zones": commonschema.ZonesMultipleComputed(),
 
-						"id": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
+					"id": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
 					},
 				},
 			},
@@ -207,71 +225,129 @@ func dataSourceManagedDisks() *pluginsdk.Resource {
 	}
 }
 
-func dataSourceManagedDisksRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Compute.DisksClient
-	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
-	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
-	defer cancel()
+func (m ManagedDisksDataSource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Compute.DisksClient
 
-	id := commonids.NewResourceGroupID(subscriptionId, d.Get("resource_group_name").(string))
+			state := ManagedDisksDataSourceModel{}
 
-	resp, err := client.ListByResourceGroup(ctx, id)
-	if err != nil {
-		if response.WasNotFound(resp.HttpResponse) {
-			return fmt.Errorf("%s was not found", id)
-		}
-		return fmt.Errorf("making Read request on %s: %s", id, err)
+			if err := metadata.Decode(&state); err != nil {
+				return fmt.Errorf("decoding %+v", err)
+			}
+
+			id := commonids.NewResourceGroupID(metadata.Client.Account.SubscriptionId, state.ResourceGroupName)
+
+			resp, err := client.ListByResourceGroup(ctx, id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return fmt.Errorf("%s was not found", id)
+				}
+				return fmt.Errorf("making Read request on %s: %s", id, err)
+			}
+
+			metadata.SetID(id)
+
+			if model := resp.Model; model != nil {
+				managedDisks := make([]Disk, 0)
+				for _, d := range *model {
+					disk := Disk{
+						Name:     pointer.From(d.Name),
+						ID:       pointer.From(d.Id),
+						Location: location.Normalize(d.Location),
+						Zones:    zones.Flatten(d.Zones),
+						Tags:     pointer.From(d.Tags),
+					}
+					if props := d.Properties; props != nil {
+						disk.CreateOption = string(props.CreationData.CreateOption)
+						disk.SourceURI = pointer.From(props.CreationData.SourceUri)
+						disk.SourceResourceID = pointer.From(props.CreationData.SourceResourceId)
+						disk.StorageAccountID = pointer.From(props.CreationData.StorageAccountId)
+						if props.CreationData.ImageReference != nil {
+							disk.ImageReferenceID = pointer.From(props.CreationData.ImageReference.Id)
+						}
+
+						disk.DiskAccessId = pointer.From(props.DiskAccessId)
+						disk.NetworkAccessPolicy = pointer.FromEnum(props.NetworkAccessPolicy)
+						disk.DiskSizeGB = pointer.From(props.DiskSizeGB)
+						disk.DiskIOPSReadWrite = pointer.From(props.DiskIOPSReadWrite)
+						disk.DiskMBPSReadWrite = pointer.From(props.DiskMBpsReadWrite)
+						disk.OSType = pointer.FromEnum(props.OsType)
+						if enc := props.Encryption; enc != nil {
+							disk.DiskEncryptionSetId = pointer.From(enc.DiskEncryptionSetId)
+						}
+
+						disk.EncryptionSettings = flattenManagedDiskEncryptionSettingsTyped(props.EncryptionSettingsCollection)
+					}
+
+					if sku := d.Sku; sku != nil {
+						disk.StorageAccountType = pointer.FromEnum(sku.Name)
+					}
+
+					disk.Tags = pointer.From(d.Tags)
+
+					managedDisks = append(managedDisks, disk)
+				}
+				state.Disks = managedDisks
+			}
+
+			return metadata.Encode(&state)
+		},
+	}
+}
+
+func flattenManagedDiskEncryptionSettingsTyped(encryptionSettings *disks.EncryptionSettingsCollection) []EncryptionSetting {
+	if encryptionSettings == nil {
+		return []EncryptionSetting{}
 	}
 
-	d.SetId(id.ID())
+	diskEncryptionKeys := make([]DiskEncryptionKey, 0)
+	keyEncryptionKeys := make([]KeyEncryptionKey, 0)
+	if encryptionSettings.EncryptionSettings != nil && len(*encryptionSettings.EncryptionSettings) > 0 {
+		settings := (*encryptionSettings.EncryptionSettings)[0]
 
-	disks := make([]interface{}, 0)
-	if model := resp.Model; model != nil {
-		for _, disk := range *model {
-			r := map[string]interface{}{
-				"name":     pointer.From(disk.Name),
-				"zones":    zones.FlattenUntyped(disk.Zones),
-				"location": location.Normalize(disk.Location),
-				"id":       commonids.NewManagedDiskID(id.SubscriptionId, id.ResourceGroupName, pointer.From(disk.Name)).ID(),
+		if key := settings.DiskEncryptionKey; key != nil {
+			secretUrl := ""
+			if key.SecretURL != "" {
+				secretUrl = key.SecretURL
 			}
 
-			if props := disk.Properties; props != nil {
-				r["create_option"] = props.CreationData.CreateOption
-				r["source_uri"] = pointer.From(props.CreationData.SourceUri)
-				r["source_resource_id"] = pointer.From(props.CreationData.SourceResourceId)
-				r["storage_account_id"] = pointer.From(props.CreationData.StorageAccountId)
-
-				if props.CreationData.ImageReference != nil {
-					r["image_reference_id"] = pointer.From(props.CreationData.ImageReference.Id)
-				}
-
-				r["disk_access_id"] = pointer.From(props.DiskAccessId)
-				r["network_access_policy"] = pointer.From(props.NetworkAccessPolicy)
-				r["disk_size_gb"] = pointer.From(props.DiskSizeGB)
-				r["disk_iops_read_write"] = pointer.From(props.DiskIOPSReadWrite)
-				r["disk_mbps_read_write"] = pointer.From(props.DiskMBpsReadWrite)
-				r["os_type"] = pointer.From(props.OsType)
-
-				if enc := props.Encryption; enc != nil {
-					r["disk_encryption_set_id"] = pointer.From(enc.DiskEncryptionSetId)
-				}
-
-				r["encryption_settings"] = flattenManagedDiskEncryptionSettings(props.EncryptionSettingsCollection)
+			sourceVaultId := ""
+			if key.SourceVault.Id != nil {
+				sourceVaultId = *key.SourceVault.Id
 			}
 
-			if sku := disk.Sku; sku != nil {
-				r["storage_account_type"] = pointer.From(sku.Name)
+			diskEncryptionKeys = append(diskEncryptionKeys, DiskEncryptionKey{
+				SecretURL:     secretUrl,
+				SourceVaultID: sourceVaultId,
+			})
+		}
+
+		if key := settings.KeyEncryptionKey; key != nil {
+			keyUrl := ""
+			if key.KeyURL != "" {
+				keyUrl = key.KeyURL
 			}
 
-			r["tags"] = tags.Flatten(disk.Tags)
+			sourceVaultId := ""
+			if key.SourceVault.Id != nil {
+				sourceVaultId = *key.SourceVault.Id
+			}
 
-			disks = append(disks, r)
+			keyEncryptionKeys = append(keyEncryptionKeys, KeyEncryptionKey{
+				KeyURL:        keyUrl,
+				SourceVaultID: sourceVaultId,
+			})
+		}
+
+		return []EncryptionSetting{
+			{
+				DiskEncryptionKeys: diskEncryptionKeys,
+				KeyEncryptionKeys:  keyEncryptionKeys,
+			},
 		}
 	}
 
-	d.Set("disk", disks)
-
-	d.Set("resource_group_name", id.ResourceGroupName)
-
-	return nil
+	return []EncryptionSetting{}
 }

--- a/internal/services/compute/managed_disks_data_source_test.go
+++ b/internal/services/compute/managed_disks_data_source_test.go
@@ -1,0 +1,76 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package compute_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+)
+
+type ManagedDisksDataSource struct{}
+
+func TestAccDataSourceManagedDisks_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_managed_disks", "test")
+	r := ManagedDisksDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("disk.#").HasValue("2"),
+			),
+		},
+	})
+}
+
+func (ManagedDisksDataSource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[2]d"
+  location = "%[1]s"
+}
+
+resource "azurerm_managed_disk" "test" {
+  name                 = "acctestmanageddisk-%[2]d"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  storage_account_type = "Premium_LRS"
+  create_option        = "Empty"
+  disk_size_gb         = "10"
+  zone                 = "2"
+
+  tags = {
+    environment = "acctest"
+  }
+}
+
+resource "azurerm_managed_disk" "test2" {
+  name                 = "acctestmanageddisk2-%[2]d"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  storage_account_type = "Premium_LRS"
+  create_option        = "Empty"
+  disk_size_gb         = "10"
+  zone                 = "2"
+
+  tags = {
+    environment = "acctest"
+  }
+}
+
+data "azurerm_managed_disks" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+
+  // Force Terraform to create the resources before evaluating this Data Source
+  depends_on = [azurerm_managed_disk.test, azurerm_managed_disk.test2]
+}
+`, data.Locations.Primary, data.RandomInteger)
+}

--- a/internal/services/compute/registration.go
+++ b/internal/services/compute/registration.go
@@ -30,7 +30,6 @@ func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 		"azurerm_dedicated_host_group":      dataSourceDedicatedHostGroup(),
 		"azurerm_disk_encryption_set":       dataSourceDiskEncryptionSet(),
 		"azurerm_managed_disk":              dataSourceManagedDisk(),
-		"azurerm_managed_disks":             dataSourceManagedDisks(),
 		"azurerm_image":                     dataSourceImage(),
 		"azurerm_images":                    dataSourceImages(),
 		"azurerm_disk_access":               dataSourceDiskAccess(),
@@ -83,6 +82,7 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 
 func (r Registration) DataSources() []sdk.DataSource {
 	return []sdk.DataSource{
+		ManagedDisksDataSource{},
 		OrchestratedVirtualMachineScaleSetDataSource{},
 	}
 }

--- a/internal/services/compute/registration.go
+++ b/internal/services/compute/registration.go
@@ -30,6 +30,7 @@ func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 		"azurerm_dedicated_host_group":      dataSourceDedicatedHostGroup(),
 		"azurerm_disk_encryption_set":       dataSourceDiskEncryptionSet(),
 		"azurerm_managed_disk":              dataSourceManagedDisk(),
+		"azurerm_managed_disks":             dataSourceManagedDisks(),
 		"azurerm_image":                     dataSourceImage(),
 		"azurerm_images":                    dataSourceImages(),
 		"azurerm_disk_access":               dataSourceDiskAccess(),

--- a/internal/services/compute/shared_schema.go
+++ b/internal/services/compute/shared_schema.go
@@ -622,6 +622,7 @@ func sourceImageReferenceSchemaVM() *pluginsdk.Schema {
 		},
 	}
 }
+
 func sourceImageReferenceSchema(isVirtualMachine bool) *pluginsdk.Schema {
 	// whilst originally I was hoping we could use the 'id' from `azurerm_platform_image' unfortunately Azure doesn't
 	// like this as a value for the 'id' field:
@@ -893,6 +894,7 @@ func winRmListenerSchema() *pluginsdk.Schema {
 		},
 	}
 }
+
 func winRmListenerSchemaVM() *pluginsdk.Schema {
 	return &pluginsdk.Schema{
 		Type:     pluginsdk.TypeSet,
@@ -1049,6 +1051,7 @@ func windowsSecretSchema() *pluginsdk.Schema {
 		},
 	}
 }
+
 func windowsSecretSchemaVM() *pluginsdk.Schema {
 	return &pluginsdk.Schema{
 		Type:     pluginsdk.TypeList,

--- a/internal/services/compute/shared_schema.go
+++ b/internal/services/compute/shared_schema.go
@@ -547,6 +547,47 @@ func flattenPlanVMSS(input *virtualmachinescalesets.Plan) []interface{} {
 	}
 }
 
+func sourceImageReferenceSchemaVM() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		ForceNew: true,
+		MaxItems: 1,
+		ExactlyOneOf: []string{
+			"os_managed_disk_id",
+			"source_image_id",
+			"source_image_reference",
+		},
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"publisher": {
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+				"offer": {
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+				"sku": {
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+				"version": {
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+			},
+		},
+	}
+}
 func sourceImageReferenceSchema(isVirtualMachine bool) *pluginsdk.Schema {
 	// whilst originally I was hoping we could use the 'id' from `azurerm_platform_image' unfortunately Azure doesn't
 	// like this as a value for the 'id' field:

--- a/internal/services/compute/ssh_keys.go
+++ b/internal/services/compute/ssh_keys.go
@@ -18,6 +18,36 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 )
 
+func SSHKeysSchemaVM() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeSet,
+		Optional: true,
+		ForceNew: true,
+		Set:      SSHKeySchemaHash,
+		ConflictsWith: []string{
+			"os_managed_disk_id",
+		},
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"public_key": {
+					Type:             pluginsdk.TypeString,
+					Required:         true,
+					ForceNew:         true,
+					ValidateFunc:     validate.SSHKey,
+					DiffSuppressFunc: suppress.SSHKey,
+				},
+
+				"username": {
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+			},
+		},
+	}
+}
+
 func SSHKeysSchema(isVirtualMachine bool) *pluginsdk.Schema {
 	// the SSH Keys for a Virtual Machine cannot be changed once provisioned:
 	// Code="PropertyChangeNotAllowed" Message="Changing property 'linuxConfiguration.ssh.publicKeys' is not allowed."

--- a/internal/services/compute/virtual_machine.go
+++ b/internal/services/compute/virtual_machine.go
@@ -6,7 +6,6 @@ package compute
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"math"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -15,6 +14,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-03/galleryapplicationversions"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2023-04-02/disks"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachines"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	azValidate "github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"

--- a/internal/services/compute/virtual_machine_import.go
+++ b/internal/services/compute/virtual_machine_import.go
@@ -44,11 +44,6 @@ func importVirtualMachine(osType virtualmachines.OperatingSystemTypes, resourceT
 			return []*pluginsdk.ResourceData{}, fmt.Errorf("the %q resource only supports %s Virtual Machines", resourceType, string(osType))
 		}
 
-		// we don't support VM's without an OS Profile / attach
-		// if vm.Model.Properties.OsProfile == nil {
-		// 	return []*pluginsdk.ResourceData{}, fmt.Errorf("the %q resource doesn't support attaching OS Disks - please use the `azurerm_virtual_machine` resource instead", resourceType)
-		// }
-
 		if vm.Model.Properties.OsProfile != nil { // machines importing existing managed disks do not have an OSProfile
 			hasSshKeys := false
 			if osType == virtualmachines.OperatingSystemTypesLinux {

--- a/internal/services/compute/virtual_machine_import.go
+++ b/internal/services/compute/virtual_machine_import.go
@@ -45,21 +45,23 @@ func importVirtualMachine(osType virtualmachines.OperatingSystemTypes, resourceT
 		}
 
 		// we don't support VM's without an OS Profile / attach
-		if vm.Model.Properties.OsProfile == nil {
-			return []*pluginsdk.ResourceData{}, fmt.Errorf("the %q resource doesn't support attaching OS Disks - please use the `azurerm_virtual_machine` resource instead", resourceType)
-		}
+		// if vm.Model.Properties.OsProfile == nil {
+		// 	return []*pluginsdk.ResourceData{}, fmt.Errorf("the %q resource doesn't support attaching OS Disks - please use the `azurerm_virtual_machine` resource instead", resourceType)
+		// }
 
-		hasSshKeys := false
-		if osType == virtualmachines.OperatingSystemTypesLinux {
-			if linux := vm.Model.Properties.OsProfile.LinuxConfiguration; linux != nil {
-				if linux.Ssh != nil && linux.Ssh.PublicKeys != nil {
-					hasSshKeys = len(*linux.Ssh.PublicKeys) > 0
+		if vm.Model.Properties.OsProfile != nil { // machines importing existing managed disks do not have an OSProfile
+			hasSshKeys := false
+			if osType == virtualmachines.OperatingSystemTypesLinux {
+				if linux := vm.Model.Properties.OsProfile.LinuxConfiguration; linux != nil {
+					if linux.Ssh != nil && linux.Ssh.PublicKeys != nil {
+						hasSshKeys = len(*linux.Ssh.PublicKeys) > 0
+					}
 				}
 			}
-		}
 
-		if !hasSshKeys {
-			d.Set("admin_password", "ignored-as-imported")
+			if !hasSshKeys {
+				d.Set("admin_password", "ignored-as-imported")
+			}
 		}
 
 		return []*pluginsdk.ResourceData{d}, nil

--- a/internal/services/compute/windows_virtual_machine_resource.go
+++ b/internal/services/compute/windows_virtual_machine_resource.go
@@ -95,6 +95,21 @@ func resourceWindowsVirtualMachine() *pluginsdk.Resource {
 
 			"os_disk": virtualMachineOSDiskSchema(),
 
+			"os_managed_disk_id": {
+				// Note: O+C as this is the same value as `id` below but to support
+				// import of the OSDisk and not break compatibility with existing configs / references
+				// we're adding it as a separate property.
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				ValidateFunc: commonids.ValidateManagedDiskID,
+				AtLeastOneOf: []string{
+					"os_disk",
+					"os_managed_disk_id",
+				},
+			},
+
 			"size": {
 				Type:         pluginsdk.TypeString,
 				Required:     true,

--- a/internal/services/compute/windows_virtual_machine_resource.go
+++ b/internal/services/compute/windows_virtual_machine_resource.go
@@ -304,7 +304,6 @@ func resourceWindowsVirtualMachine() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
 				Computed: true,
-				// Default:  string(virtualmachines.WindowsVMGuestPatchModeAutomaticByOS),
 				ValidateFunc: validation.StringInSlice([]string{
 					string(virtualmachines.WindowsVMGuestPatchModeAutomaticByOS),
 					string(virtualmachines.WindowsVMGuestPatchModeAutomaticByPlatform),
@@ -639,7 +638,7 @@ func resourceWindowsVirtualMachineCreate(d *pluginsdk.ResourceData, meta interfa
 		} else {
 			_, errs := computeValidate.WindowsComputerNameFull(d.Get("name"), "computer_name")
 			if len(errs) > 0 {
-				return fmt.Errorf("unable to assume default computer name %s. Please adjust the %q, or specify an explicit %q", errs[0], "name", "computer_name")
+				return fmt.Errorf("unable to assume default computer name %s. Please adjust the `name`, or specify an explicit `computer_name`", errs[0])
 			}
 			computerName = id.VirtualMachineName
 		}
@@ -1140,7 +1139,15 @@ func resourceWindowsVirtualMachineRead(d *pluginsdk.ResourceData, meta interface
 				if err := d.Set("os_disk", flattenedOSDisk); err != nil {
 					return fmt.Errorf("settings `os_disk`: %+v", err)
 				}
-				d.Set("os_managed_disk_id", profile.OsDisk.ManagedDisk.Id)
+				osManagedDiskId := ""
+				if profile.OsDisk != nil && profile.OsDisk.ManagedDisk != nil && profile.OsDisk.ManagedDisk.Id != nil {
+					osDiskId, err := commonids.ParseManagedDiskID(*profile.OsDisk.ManagedDisk.Id)
+					if err != nil {
+						return err
+					}
+					osManagedDiskId = osDiskId.ID()
+				}
+				d.Set("os_managed_disk_id", osManagedDiskId)
 				var storageImageId string
 				if profile.ImageReference != nil && profile.ImageReference.Id != nil {
 					storageImageId = *profile.ImageReference.Id

--- a/internal/services/compute/windows_virtual_machine_resource.go
+++ b/internal/services/compute/windows_virtual_machine_resource.go
@@ -1052,7 +1052,10 @@ func resourceWindowsVirtualMachineRead(d *pluginsdk.ResourceData, meta interface
 						return fmt.Errorf("setting `additional_unattend_content`: %+v", err)
 					}
 
-					d.Set("enable_automatic_updates", config.EnableAutomaticUpdates)
+					d.Set("automatic_updates_enabled", config.EnableAutomaticUpdates)
+					if !features.FivePointOh() {
+						d.Set("enable_automatic_updates", config.EnableAutomaticUpdates)
+					}
 					d.Set("provision_vm_agent", config.ProvisionVMAgent)
 					d.Set("vm_agent_platform_updates_enabled", config.EnableVMAgentPlatformUpdates)
 

--- a/internal/services/compute/windows_virtual_machine_resource.go
+++ b/internal/services/compute/windows_virtual_machine_resource.go
@@ -75,6 +75,9 @@ func resourceWindowsVirtualMachine() *pluginsdk.Resource {
 				RequiredWith: []string{
 					"admin_username",
 				},
+				ConflictsWith: []string{
+					"os_managed_disk_id",
+				},
 				ValidateFunc: computeValidate.WindowsAdminPassword,
 			},
 

--- a/internal/services/compute/windows_virtual_machine_resource.go
+++ b/internal/services/compute/windows_virtual_machine_resource.go
@@ -5,7 +5,6 @@ package compute
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"log"
 	"strconv"
 	"strings"
@@ -23,6 +22,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-01/proximityplacementgroups"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2023-04-02/disks"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachines"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	azValidate "github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -458,7 +458,7 @@ func resourceWindowsVirtualMachine() *pluginsdk.Resource {
 				ForceNew: true,
 			},
 
-			"winrm_listener": winRmListenerSchema(),
+			"winrm_listener": winRmListenerSchemaVM(),
 
 			"zone": commonschema.ZoneSingleOptionalForceNew(),
 
@@ -513,11 +513,8 @@ func resourceWindowsVirtualMachine() *pluginsdk.Resource {
 				// Suppress diff if replacement property is used and the values are the same
 				oldVal := d.Get("enable_automatic_updates").(bool)
 				newVal := d.Get("automatic_updates_enabled").(bool)
-				if oldVal == newVal {
-					return true
-				}
 
-				return false
+				return oldVal == newVal
 			},
 			DiffSuppressOnRefresh: true,
 			Deprecated:            "this property has been deprecated in favour of automatic_updates_enabled and will be removed in 5.0 of the provider.",

--- a/internal/services/compute/windows_virtual_machine_resource.go
+++ b/internal/services/compute/windows_virtual_machine_resource.go
@@ -528,7 +528,6 @@ func resourceWindowsVirtualMachine() *pluginsdk.Resource {
 			"enable_automatic_updates",
 			"os_managed_disk_id",
 		}
-
 	}
 
 	return resource

--- a/internal/services/compute/windows_virtual_machine_resource.go
+++ b/internal/services/compute/windows_virtual_machine_resource.go
@@ -160,6 +160,7 @@ func resourceWindowsVirtualMachine() *pluginsdk.Resource {
 			"bypass_platform_safety_checks_on_user_schedule_enabled": {
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
+				Default:  false,
 				ConflictsWith: []string{
 					"os_managed_disk_id",
 				},

--- a/internal/services/compute/windows_virtual_machine_resource_deprecation_test.go
+++ b/internal/services/compute/windows_virtual_machine_resource_deprecation_test.go
@@ -1,0 +1,106 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package compute_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
+)
+
+func TestAccWindowsVirtualMachine_automaticUpdatesDeprecated(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Test not valid in 5.0")
+	}
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+	r := WindowsVirtualMachineResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.automaticUpdatesDeprecation(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			Config: r.automaticUpdatesPostDeprecation(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
+func (r WindowsVirtualMachineResource) automaticUpdatesDeprecation(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
+
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+
+  enable_automatic_updates = false
+  patch_mode               = "Manual"
+}
+`, r.template(data))
+}
+
+func (r WindowsVirtualMachineResource) automaticUpdatesPostDeprecation(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
+
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+
+  automatic_updates_enabled = false
+  patch_mode                = "Manual"
+}
+`, r.template(data))
+}

--- a/internal/services/compute/windows_virtual_machine_resource_disk_os_test.go
+++ b/internal/services/compute/windows_virtual_machine_resource_disk_os_test.go
@@ -279,42 +279,6 @@ func TestAccWindowsVirtualMachine_diskOSStorageTypePremiumZRS(t *testing.T) {
 	})
 }
 
-func TestAccWindowsVirtualMachine_diskOSStorageTypeUpdate(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
-	r := WindowsVirtualMachineResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.diskOSStorageAccountType(data, "Standard_LRS"),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep("admin_password"),
-		{
-			Config: r.diskOSStorageAccountType(data, "Premium_LRS"),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep("admin_password"),
-		{
-			Config: r.diskOSStorageAccountType(data, "StandardSSD_LRS"),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep("admin_password"),
-		{
-			Config: r.diskOSStorageAccountType(data, "Standard_LRS"),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep("admin_password"),
-	})
-}
-
 func TestAccWindowsVirtualMachine_diskOSControllerType(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
 	r := WindowsVirtualMachineResource{}

--- a/internal/services/compute/windows_virtual_machine_resource_disk_os_test.go
+++ b/internal/services/compute/windows_virtual_machine_resource_disk_os_test.go
@@ -421,6 +421,36 @@ func TestAccWindowsVirtualMachine_diskOSConfidentialVmWithDiskAndVMGuestStateCMK
 	})
 }
 
+func TestAccWindowsVirtualMachine_diskOSImportManagedDisk(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+	r := WindowsVirtualMachineResource{}
+
+	// Ignoring Recreate as we're deliberately deleting the VM to leave behind a viable managed OS disk for import.
+	data.ResourceTestIgnoreRecreate(t, r, []acceptance.TestStep{
+		{
+			Config: r.diskOSBasicNoDelete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			Config: r.osDiskImportTemplateWithProvider(data), // Remove the initial VM
+		},
+		{
+			Config: r.diskOSImportManagedDisk(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			// This step does nothing except flip the delete OS disk with VM to true to avoid the RG preventing being deleted
+			Config: r.diskOSImportManagedDiskCleanup(data),
+		},
+	})
+}
+
 func (r WindowsVirtualMachineResource) diskOSBasic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
@@ -449,6 +479,114 @@ resource "azurerm_windows_virtual_machine" "test" {
   }
 }
 `, r.template(data))
+}
+
+func (r WindowsVirtualMachineResource) diskOSBasicNoDelete(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    virtual_machine {
+      delete_os_disk_on_deletion = false
+    }
+  }
+}
+
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, r.osDiskImportTemplate(data))
+}
+
+func (r WindowsVirtualMachineResource) diskOSImportManagedDisk(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    virtual_machine {
+      delete_os_disk_on_deletion = false
+    }
+  }
+}
+
+%s
+
+data "azurerm_managed_disks" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_managed_disk_id = data.azurerm_managed_disks.test.disk.0.id
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+}
+`, r.osDiskImportTemplate(data))
+}
+
+func (r WindowsVirtualMachineResource) diskOSImportManagedDiskCleanup(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    virtual_machine {
+      delete_os_disk_on_deletion = true
+    }
+  }
+}
+
+%s
+
+data "azurerm_managed_disks" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_managed_disk_id = data.azurerm_managed_disks.test.disk.0.id
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+}
+`, r.osDiskImportTemplate(data))
 }
 
 func (r WindowsVirtualMachineResource) diskOSCachingType(data acceptance.TestData, cachingType string) string {
@@ -1191,4 +1329,58 @@ resource "azurerm_key_vault_access_policy" "disk-encryption" {
   object_id = azurerm_disk_encryption_set.test.identity.0.principal_id
 }
 `, r.templateWithOutProvider(data), data.RandomInteger, data.RandomString)
+}
+
+func (r WindowsVirtualMachineResource) osDiskImportTemplate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+locals {
+  vm_name = "acctestvm%s"
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[2]d"
+  location = "%[3]s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestnw-%[2]d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "internal"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.2.0/24"]
+}
+
+resource "azurerm_network_interface" "test" {
+  name                = "acctestnic-%[2]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = azurerm_subnet.test.id
+    private_ip_address_allocation = "Dynamic"
+  }
+}
+`, data.RandomString, data.RandomInteger, data.Locations.Primary)
+}
+
+func (r WindowsVirtualMachineResource) osDiskImportTemplateWithProvider(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+ features {
+   virtual_machine {
+     delete_os_disk_on_deletion = false
+   }
+ }
+}
+
+%s
+
+`, r.osDiskImportTemplate(data))
 }

--- a/internal/services/compute/windows_virtual_machine_resource_other_test.go
+++ b/internal/services/compute/windows_virtual_machine_resource_other_test.go
@@ -76,13 +76,6 @@ func TestAccWindowsVirtualMachine_otherPatchModeUpdate(t *testing.T) {
 			),
 		},
 		data.ImportStep("admin_password"),
-		{
-			Config: r.otherPatchModeManual(data), // this update requires force replacement actually
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep("admin_password"),
 	})
 }
 
@@ -1905,10 +1898,11 @@ resource "azurerm_virtual_network" "test" {
 }
 
 resource "azurerm_subnet" "test" {
-  name                 = "internal"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes     = ["10.0.2.0/24"]
+  name                            = "internal"
+  resource_group_name             = azurerm_resource_group.test.name
+  virtual_network_name            = azurerm_virtual_network.test.name
+  address_prefixes                = ["10.0.2.0/24"]
+  default_outbound_access_enabled = false
 }
 
 resource "azurerm_network_interface" "test" {

--- a/internal/services/compute/windows_virtual_machine_resource_other_test.go
+++ b/internal/services/compute/windows_virtual_machine_resource_other_test.go
@@ -1376,8 +1376,8 @@ resource "azurerm_windows_virtual_machine" "test" {
     version   = "latest"
   }
 
-  enable_automatic_updates = false
-  patch_mode               = "Manual"
+  automatic_updates_enabled = false
+  patch_mode                = "Manual"
 }
 `, r.template(data))
 }

--- a/internal/services/compute/windows_virtual_machine_resource_test.go
+++ b/internal/services/compute/windows_virtual_machine_resource_test.go
@@ -16,7 +16,7 @@ import (
 
 type WindowsVirtualMachineResource struct{}
 
-func (t WindowsVirtualMachineResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+func (r WindowsVirtualMachineResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := virtualmachines.ParseVirtualMachineID(state.ID)
 	if err != nil {
 		return nil, err

--- a/website/docs/d/managed_disks.html.markdown
+++ b/website/docs/d/managed_disks.html.markdown
@@ -42,7 +42,7 @@ The `disk` block exports:
 
 * `disk_mbps_read_write` - The bandwidth allowed for this disk.
 
-* `disk_size_gb` - The size of the Managed Disk in gigabytes.
+* `disk_size_in_gb` - The size of the Managed Disk in gigabytes.
 
 * `image_reference_id` - The ID of the source image used for creating this Managed Disk.
 
@@ -66,7 +66,7 @@ The `disk` block exports:
 
 * `disk_access_id` - The ID of the disk access resource for using private endpoints on disks.
 
-* `encryption_settings` - A `encryption_settings` block as defined below.
+* `encryption_settings` - An `encryption_settings` block as defined below.
 
 ---
 

--- a/website/docs/d/managed_disks.html.markdown
+++ b/website/docs/d/managed_disks.html.markdown
@@ -1,0 +1,105 @@
+---
+subcategory: "Compute"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_managed_disk"
+description: |-
+  Get information about an existing Managed Disk.
+---
+
+# Data Source: azurerm_managed_disks
+
+Use this data source to access information about an existing Managed Disk.
+
+## Example Usage
+
+```hcl
+data "azurerm_managed_disks" "existing" {
+  resource_group_name = "example-resources"
+}
+
+output "first_disk_id" {
+  value = data.azurerm_managed_disk.existing.disk.0.id
+}
+```
+
+## Argument Reference
+
+* `resource_group_name` - Specifies the name of the Resource Group where this Managed Disk exists.
+
+## Attributes Reference
+
+* `disk` - a `disk` block as detailed below.
+
+--- 
+
+The `disk` block exports:
+
+* `name` - The name of the Managed Disk.
+
+* `disk_encryption_set_id` - The ID of the Disk Encryption Set used to encrypt this Managed Disk.
+
+* `disk_iops_read_write` - The number of IOPS allowed for this disk, where one operation can transfer between 4k and 256k bytes.
+
+* `disk_mbps_read_write` - The bandwidth allowed for this disk.
+
+* `disk_size_gb` - The size of the Managed Disk in gigabytes.
+
+* `image_reference_id` - The ID of the source image used for creating this Managed Disk.
+
+* `location` - The Azure location of the Managed Disk.
+
+* `os_type` - The operating system used for this Managed Disk.
+
+* `storage_account_type` - The storage account type for the Managed Disk.
+
+* `source_uri` - The Source URI for this Managed Disk.
+
+* `source_resource_id` - The ID of an existing Managed Disk which this Disk was created from.
+
+* `storage_account_id` - The ID of the Storage Account where the `source_uri` is located.
+
+* `tags` - A mapping of tags assigned to the resource.
+
+* `zones` - A list of Availability Zones where the Managed Disk exists.
+
+* `network_access_policy` - Policy for accessing the disk via network.
+
+* `disk_access_id` - The ID of the disk access resource for using private endpoints on disks.
+
+* `encryption_settings` - A `encryption_settings` block as defined below.
+
+---
+
+The `encryption_settings` block exports:
+
+* `disk_encryption_key` - A `disk_encryption_key` block as defined above.
+
+* `key_encryption_key` - A `key_encryption_key` block as defined below.
+
+---
+
+The `disk_encryption_key` block exports:
+
+* `secret_url` - The URL to the Key Vault Secret used as the Disk Encryption Key.
+
+* `source_vault_id` - The ID of the source Key Vault.
+
+---
+
+The `key_encryption_key` block exports:
+
+* `key_url` - The URL to the Key Vault Key used as the Key Encryption Key.
+
+* `source_vault_id` - The ID of the source Key Vault.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Managed Disk.
+
+## API Providers
+<!-- This section is generated, changes will be overwritten -->
+This data source uses the following Azure API Providers:
+
+* `Microsoft.Compute` - 2023-04-02

--- a/website/docs/r/linux_virtual_machine.html.markdown
+++ b/website/docs/r/linux_virtual_machine.html.markdown
@@ -214,7 +214,7 @@ The following arguments are supported:
 
 * `os_managed_disk_id` - (Optional) The ID of an existing Managed Disk to use as the OS Disk for this Linux Virtual Machine. 
 
-~> **Note:** When specifying an existing Managed Disk it is not currently possible to subsequently manage the Operating System Profile properties: `admin_username`, `admin_password`, `bypass_platform_safety_checks_on_user_schedule_enabled`, `computer_name`, `custom_data`, `provision_vm_agent`, `patch_mode`, `patch_assessment_mode`, or `reboot_setting`.  
+~> **Note:** When specifying an existing Managed Disk it is not currently possible to subsequently manage the Operating System Profile properties: `admin_username`, `admin_password`, `bypass_platform_safety_checks_on_user_schedule_enabled`, `computer_name`, `custom_data`, `provision_vm_agent`, `patch_mode`, `patch_assessment_mode`, or `reboot_setting`.
 
 * `termination_notification` - (Optional) A `termination_notification` block as defined below.
 

--- a/website/docs/r/linux_virtual_machine.html.markdown
+++ b/website/docs/r/linux_virtual_machine.html.markdown
@@ -212,6 +212,10 @@ The following arguments are supported:
 
 * `os_image_notification` - (Optional) A `os_image_notification` block as defined below.
 
+* `os_managed_disk_id` - (Optional) The ID of an existing Managed Disk to use as the OS Disk for this Linux Virtual Machine. 
+
+~> **Note:** When specifying an existing Managed Disk it is not currently possible to subsequently manage the Operating System Profile properties: `admin_username`, `admin_password`, `bypass_platform_safety_checks_on_user_schedule_enabled`, `computer_name`, `custom_data`, `provision_vm_agent`, `patch_mode`, `patch_assessment_mode`, or `reboot_setting`.  
+
 * `termination_notification` - (Optional) A `termination_notification` block as defined below.
 
 * `user_data` - (Optional) The Base64-Encoded User Data which should be used for this Virtual Machine.
@@ -306,7 +310,7 @@ A `os_disk` block supports the following:
 
 * `diff_disk_settings` - (Optional) A `diff_disk_settings` block as defined above. Changing this forces a new resource to be created.
 
--> **Note:** `diff_disk_settings` can only be set when `caching` is set to `ReadOnly`. More information can be found [here](https://docs.microsoft.com/azure/virtual-machines/ephemeral-os-disks-deploy#vm-template-deployment)
+-> **Note:** `diff_disk_settings` can only be set when `caching` is set to `ReadOnly`. More information can be found [here](https://docs.microsoft.com/azure/virtual-machines/ephemeral-os-disks-deploy#vm-template-deployment). Additionally, this property cannot be set when an existing Managed Disk is used to create the Virtual Machine by setting `os_managed_disk_id`.
 
 * `disk_encryption_set_id` - (Optional) The ID of the Disk Encryption Set which should be used to Encrypt this OS Disk. Conflicts with `secure_vm_disk_encryption_set_id`.
 
@@ -317,6 +321,8 @@ A `os_disk` block supports the following:
 -> **Note:** If specified this must be equal to or larger than the size of the Image the Virtual Machine is based on. When creating a larger disk than exists in the image you'll need to repartition the disk to use the remaining space.
 
 * `name` - (Optional) The name which should be used for the Internal OS Disk. Changing this forces a new resource to be created.
+
+-> **Note:** a value for `name` cannot be specified if/when the Virtual Machine is/has been created using an existing Managed Disk for the OS by setting `os_managed_disk_id`.
 
 * `secure_vm_disk_encryption_set_id` - (Optional) The ID of the Disk Encryption Set which should be used to Encrypt this OS Disk when the Virtual Machine is a Confidential VM. Conflicts with `disk_encryption_set_id`. Changing this forces a new resource to be created.
 

--- a/website/docs/r/linux_virtual_machine.html.markdown
+++ b/website/docs/r/linux_virtual_machine.html.markdown
@@ -93,8 +93,6 @@ resource "azurerm_linux_virtual_machine" "example" {
 
 The following arguments are supported:
 
-* `admin_username` - (Required) The username of the local administrator used for the Virtual Machine. Changing this forces a new resource to be created.
-
 * `location` - (Required) The Azure location where the Linux Virtual Machine should exist. Changing this forces a new resource to be created.
 
 * `license_type` - (Optional) Specifies the License Type for this Virtual Machine. Possible values are `RHEL_BYOS`, `RHEL_BASE`, `RHEL_EUS`, `RHEL_SAPAPPS`, `RHEL_SAPHA`, `RHEL_BASESAPAPPS`, `RHEL_BASESAPHA`, `SLES_BYOS`, `SLES_SAP`, `SLES_HPC`, `UBUNTU_PRO`.
@@ -110,6 +108,10 @@ The following arguments are supported:
 * `size` - (Required) The SKU which should be used for this Virtual Machine, such as `Standard_F2`.
 
 ---
+
+* `admin_username` - (Optional) The username of the local administrator used for the Virtual Machine. Changing this forces a new resource to be created.
+
+~> **Note:** This is required unless using an existing OS Managed Disk by specifying `os_managed_disk_id`.
 
 * `additional_capabilities` - (Optional) A `additional_capabilities` block as defined below.
 
@@ -306,7 +308,9 @@ A `os_disk` block supports the following:
 
 * `caching` - (Required) The Type of Caching which should be used for the Internal OS Disk. Possible values are `None`, `ReadOnly` and `ReadWrite`.
 
-* `storage_account_type` - (Required) The Type of Storage Account which should back this the Internal OS Disk. Possible values are `Standard_LRS`, `StandardSSD_LRS`, `Premium_LRS`, `StandardSSD_ZRS` and `Premium_ZRS`. Changing this forces a new resource to be created.
+* `storage_account_type` - (Optional) The Type of Storage Account which should back this the Internal OS Disk. Possible values are `Standard_LRS`, `StandardSSD_LRS`, `Premium_LRS`, `StandardSSD_ZRS` and `Premium_ZRS`. Changing this forces a new resource to be created.
+
+~> **Note:** This is required unless using an existing OS Managed Disk by specifying `os_managed_disk_id`.
 
 * `diff_disk_settings` - (Optional) A `diff_disk_settings` block as defined above. Changing this forces a new resource to be created.
 

--- a/website/docs/r/windows_virtual_machine.html.markdown
+++ b/website/docs/r/windows_virtual_machine.html.markdown
@@ -93,10 +93,6 @@ resource "azurerm_windows_virtual_machine" "example" {
 
 The following arguments are supported:
 
-* `admin_password` - (Required) The Password which should be used for the local-administrator on this Virtual Machine. Changing this forces a new resource to be created.
-
-* `admin_username` - (Required) The username of the local administrator used for the Virtual Machine. Changing this forces a new resource to be created.
-
 * `location` - (Required) The Azure location where the Windows Virtual Machine should exist. Changing this forces a new resource to be created.
 
 * `name` - (Required) The name of the Windows Virtual Machine. Changing this forces a new resource to be created.
@@ -110,6 +106,14 @@ The following arguments are supported:
 * `size` - (Required) The SKU which should be used for this Virtual Machine, such as `Standard_F2`.
 
 ---
+
+* `admin_password` - (Optional) The Password which should be used for the local-administrator on this Virtual Machine. Changing this forces a new resource to be created.
+
+~> **Note:** This is required unless using an existing OS Managed Disk by specifying `os_managed_disk_id`.
+
+* `admin_username` - (Optional) The username of the local administrator used for the Virtual Machine. Changing this forces a new resource to be created.
+
+~> **Note:** This is required unless using an existing OS Managed Disk by specifying `os_managed_disk_id`.
 
 * `additional_capabilities` - (Optional) A `additional_capabilities` block as defined below.
 
@@ -307,7 +311,10 @@ A `os_disk` block supports the following:
 
 * `caching` - (Required) The Type of Caching which should be used for the Internal OS Disk. Possible values are `None`, `ReadOnly` and `ReadWrite`.
 
-* `storage_account_type` - (Required) The Type of Storage Account which should back this the Internal OS Disk. Possible values are `Standard_LRS`, `StandardSSD_LRS`, `Premium_LRS`, `StandardSSD_ZRS` and `Premium_ZRS`. Changing this forces a new resource to be created.
+* `storage_account_type` - (Optional) The Type of Storage Account which should back this the Internal OS Disk. Possible values are `Standard_LRS`, `StandardSSD_LRS`, `Premium_LRS`, `StandardSSD_ZRS` and `Premium_ZRS`. Changing this forces a new resource to be created.
+
+~> **Note:** This is required unless using an existing OS Managed Disk by specifying `os_managed_disk_id`.
+
 
 * `diff_disk_settings` - (Optional) A `diff_disk_settings` block as defined above. Changing this forces a new resource to be created.
 

--- a/website/docs/r/windows_virtual_machine.html.markdown
+++ b/website/docs/r/windows_virtual_machine.html.markdown
@@ -207,6 +207,10 @@ The following arguments are supported:
 
 * `os_image_notification` - (Optional) A `os_image_notification` block as defined below.
 
+* `os_managed_disk_id` - (Optional) The ID of an existing Managed Disk to use as the OS Disk for this Windows Virtual Machine.
+
+~> **Note:** When specifying an existing Managed Disk it is not currently possible to subsequently manage the Operating System Profile properties: `admin_username`, `admin_password`, `bypass_platform_safety_checks_on_user_schedule_enabled`, `computer_name`, `custom_data`, `provision_vm_agent`, `patch_mode`, `patch_assessment_mode`, or `reboot_setting`.
+
 * `termination_notification` - (Optional) A `termination_notification` block as defined below.
 
 * `timezone` - (Optional) Specifies the Time Zone which should be used by the Virtual Machine, [the possible values are defined here](https://jackstromberg.com/2017/01/list-of-time-zones-consumed-by-azure/). Changing this forces a new resource to be created.
@@ -307,7 +311,7 @@ A `os_disk` block supports the following:
 
 * `diff_disk_settings` - (Optional) A `diff_disk_settings` block as defined above. Changing this forces a new resource to be created.
 
--> **Note:** `diff_disk_settings` can only be set when `caching` is set to `ReadOnly`. More information can be found [here](https://docs.microsoft.com/azure/virtual-machines/ephemeral-os-disks-deploy#vm-template-deployment)
+-> **Note:** `diff_disk_settings` can only be set when `caching` is set to `ReadOnly`. More information can be found [here](https://docs.microsoft.com/azure/virtual-machines/ephemeral-os-disks-deploy#vm-template-deployment). Additionally, this property cannot be set when an existing Managed Disk is used to create the Virtual Machine by setting `os_managed_disk_id`.
 
 * `disk_encryption_set_id` - (Optional) The ID of the Disk Encryption Set which should be used to Encrypt this OS Disk. Conflicts with `secure_vm_disk_encryption_set_id`.
 
@@ -318,6 +322,8 @@ A `os_disk` block supports the following:
 -> **Note:** If specified this must be equal to or larger than the size of the Image the Virtual Machine is based on. When creating a larger disk than exists in the image you'll need to repartition the disk to use the remaining space.
 
 * `name` - (Optional) The name which should be used for the Internal OS Disk. Changing this forces a new resource to be created.
+
+-> **Note:** a value for `name` cannot be specified if/when the Virtual Machine has been created using an existing Managed Disk for the OS by setting `os_managed_disk_id`.
 
 * `secure_vm_disk_encryption_set_id` - (Optional) The ID of the Disk Encryption Set which should be used to Encrypt this OS Disk when the Virtual Machine is a Confidential VM. Conflicts with `disk_encryption_set_id`. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This PR introduces a new top-level property `os_managed_disk_id`. The purpose of this property is to allow users to create a Linux or Windows Virtual Machine from an existing OS Managed Disk, such as might be created when migrating to Azure from another environment and help facilitate "BYOL".  This is similar to the `Create Virtual Machine` button in the Managed Disk blade in the Azure Portal.

At this time, using this property prohibits using values that would otherwise configure the `OsProfile` configuration.


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_linux_virtual_machine` - add support for `os_managed_disk_id` property
* `azurerm_windows_virtual_machine` - add support for `os_managed_disk_id` property
* **New Data Source:** `azurerm_managed_disks`

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [x] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #8794
Closes #26598
Closes #23346

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
