### PR TITLE
azurerm_key_vault_certificate_issuer - handling destroy when issuer is already deleted

### DIFF
--- a/internal/services/keyvault/key_vault_certificate_issuer_resource.go
+++ b/internal/services/keyvault/key_vault_certificate_issuer_resource.go
@@ -272,8 +272,8 @@ func resourceKeyVaultCertificateIssuerDelete(d *pluginsdk.ResourceData, meta int
 	if resp, err := client.DeleteCertificateIssuer(ctx, id.KeyVaultBaseUrl, id.Name); err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			log.Printf("[DEBUG] Issuer %q (Key Vault %q) was not found in Key Vault at URI %q - removing from state", id.Name, *keyVaultId, id.KeyVaultBaseUrl)
-            d.SetId("")
-            return nil
+			d.SetId("")
+			return nil
 		}
 	}
 

--- a/internal/services/keyvault/key_vault_certificate_issuer_resource.go
+++ b/internal/services/keyvault/key_vault_certificate_issuer_resource.go
@@ -269,7 +269,14 @@ func resourceKeyVaultCertificateIssuerDelete(d *pluginsdk.ResourceData, meta int
 		return nil
 	}
 
-	_, err = client.DeleteCertificateIssuer(ctx, id.KeyVaultBaseUrl, id.Name)
+	if resp, err := client.DeleteCertificateIssuer(ctx, id.KeyVaultBaseUrl, id.Name); err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[DEBUG] Issuer %q (Key Vault %q) was not found in Key Vault at URI %q - removing from state", id.Name, *keyVaultId, id.KeyVaultBaseUrl)
+            d.SetId("")
+            return nil
+		}
+	}
+
 	return err
 }
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->
`TestAccKeyVaultCertificateIssuer_disappears` is failing:
```
=== RUN   TestAccKeyVaultCertificateIssuer_disappears
=== PAUSE TestAccKeyVaultCertificateIssuer_disappears
=== CONT  TestAccKeyVaultCertificateIssuer_disappears
    testcase.go:173: Error running post-test destroy, there may be dangling resources: exit status 1
        Error: keyvault.BaseClient#DeleteCertificateIssuer: Failure responding to request: StatusCode=404 -- Original Error: autorest/azure: Service returned an error. Status=404 Code="CertificateIssuerNotFound" Message="Issuer acctestKVCI-250813235406360846 not found"
--- FAIL: TestAccKeyVaultCertificateIssuer_disappears (203.48s)
FAIL
```
The delete function of azurerm_key_vault_certificate_issuer does not handle the case where the issuer has already been deleted (e.g., if the parent Key Vault was deleted outside of Terraform). This causes a stale certificate issuer resolution that leads to data-plane calls against a dead hostname after the parent was deleted, resulting in a 404 CertificateIssuerNotFound error during post-test destroy.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->
<img width="1471" height="572" alt="image" src="https://github.com/user-attachments/assets/9b0fd672-e653-40ad-8eca-893de757d248" />


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

azurerm_key_vault_certificate_issuer - handling destroy when issuer is already deleted


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related PR(s)
* #30455

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
