### PR TITLE
`azurerm_policy_definition` - ForceNew when reducing or renaming parameters

### DIFF
--- a/internal/services/policy/management_group_policy_set_definition_resource.go
+++ b/internal/services/policy/management_group_policy_set_definition_resource.go
@@ -372,8 +372,10 @@ func (r ManagementGroupPolicySetDefinitionResource) CustomizeDiff() sdk.Resource
 						return fmt.Errorf("expanding JSON for `parameters`: %+v", err)
 					}
 
-					if len(*newParameters) < len(*oldParameters) {
-						return metadata.ResourceDiff.ForceNew("parameters")
+					for paramName := range *oldParameters {
+						if _, ok := (*newParameters)[paramName]; !ok {
+							return metadata.ResourceDiff.ForceNew("parameters")
+						}
 					}
 				}
 			}

--- a/internal/services/policy/policy_definition_resource.go
+++ b/internal/services/policy/policy_definition_resource.go
@@ -63,8 +63,10 @@ func resourceArmPolicyDefinition() *pluginsdk.Resource {
 						return fmt.Errorf("expanding JSON for `parameters`: %+v", err)
 					}
 
-					if len(newParameters) < len(oldParameters) {
-						return d.ForceNew("parameters")
+					for paramName := range oldParameters {
+						if _, ok := newParameters[paramName]; !ok {
+							return d.ForceNew("parameters")
+						}
 					}
 				}
 			}

--- a/internal/services/policy/policy_definition_resource_test.go
+++ b/internal/services/policy/policy_definition_resource_test.go
@@ -161,6 +161,18 @@ func TestAccAzureRMPolicyDefinition_removeParameter(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
+			Config: r.renameParameter(data),
+			ConfigPlanChecks: resource.ConfigPlanChecks{
+				PreApply: []plancheck.PlanCheck{
+					plancheck.ExpectResourceAction(data.ResourceName, plancheck.ResourceActionReplace),
+				},
+			},
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
 			Config: r.basic(data),
 			ConfigPlanChecks: resource.ConfigPlanChecks{
 				PreApply: []plancheck.PlanCheck{
@@ -531,6 +543,78 @@ POLICY_RULE
       }
     },
     "requiredRetentionDays": {
+        "type": "Integer",
+        "defaultValue": 365,
+        "allowedValues": [
+          0,
+          30,
+          90,
+          180,
+          365
+        ],
+        "metadata": {
+          "displayName": "Required retention (days)",
+          "description": "The required diagnostic logs retention in days"
+      }
+    }
+  }
+PARAMETERS
+}
+`, data.RandomInteger, data.RandomInteger)
+}
+
+func (r PolicyDefinitionResource) renameParameter(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_policy_definition" "test" {
+  name         = "acctestpol-%d"
+  policy_type  = "Custom"
+  mode         = "All"
+  display_name = "acctestpol-%d"
+
+  policy_rule = <<POLICY_RULE
+	{
+    "if": {
+      "not": {
+        "field": "location",
+        "in": "[parameters('allowedLocations')]"
+      }
+    },
+    "then": {
+       "effect": "AuditIfNotExists",
+        "details": {
+          "type": "Microsoft.Insights/diagnosticSettings",
+          "existenceCondition": {
+            "allOf": [
+            {
+              "field": "Microsoft.Insights/diagnosticSettings/logs[*].retentionPolicy.enabled",
+              "equals": "true"
+            },
+            {
+              "field": "Microsoft.Insights/diagnosticSettings/logs[*].retentionPolicy.days",
+              "equals": "[parameters('requiredRetentionInDays')]"
+            }
+          ]
+        }
+      }
+    }
+  }
+POLICY_RULE
+
+  parameters = <<PARAMETERS
+	{
+    "allowedLocations": {
+      "type": "Array",
+      "metadata": {
+        "description": "The list of allowed locations for resources.",
+        "displayName": "Allowed locations",
+        "strongType": "location"
+      }
+    },
+    "requiredRetentionInDays": {
         "type": "Integer",
         "defaultValue": 365,
         "allowedValues": [

--- a/internal/services/policy/policy_set_definition_resource.go
+++ b/internal/services/policy/policy_set_definition_resource.go
@@ -71,8 +71,10 @@ func resourceArmPolicySetDefinition() *pluginsdk.Resource {
 						return fmt.Errorf("expanding JSON for `parameters`: %+v", err)
 					}
 
-					if len(*newParameters) < len(*oldParameters) {
-						return d.ForceNew("parameters")
+					for paramName := range *oldParameters {
+						if _, ok := (*newParameters)[paramName]; !ok {
+							return d.ForceNew("parameters")
+						}
 					}
 				}
 			}
@@ -1246,8 +1248,10 @@ func (r PolicySetDefinitionResource) CustomizeDiff() sdk.ResourceFunc {
 						return fmt.Errorf("expanding JSON for `parameters`: %+v", err)
 					}
 
-					if len(*newParameters) < len(*oldParameters) {
-						return metadata.ResourceDiff.ForceNew("parameters")
+					for paramName := range *oldParameters {
+						if _, ok := (*newParameters)[paramName]; !ok {
+							return metadata.ResourceDiff.ForceNew("parameters")
+						}
 					}
 				}
 			}

--- a/website/docs/r/management_group_policy_set_definition.html.markdown
+++ b/website/docs/r/management_group_policy_set_definition.html.markdown
@@ -68,7 +68,7 @@ The following arguments are supported:
 
 * `metadata` - (Optional) The metadata for the Policy Set Definition in JSON format.
 
-* `parameters` - (Optional) The parameters for the Policy Set Definition in JSON format. Reducing the number of parameters forces a new resource to be created.
+* `parameters` - (Optional) The parameters for the Policy Set Definition in JSON format. Removing or renaming parameters forces a new resource to be created.
 
 * `policy_definition_group` - (Optional) One or more `policy_definition_group` blocks as defined below.
 

--- a/website/docs/r/policy_definition.html.markdown
+++ b/website/docs/r/policy_definition.html.markdown
@@ -82,7 +82,7 @@ The following arguments are supported:
 
 * `metadata` - (Optional) The metadata for the policy definition. This is a JSON string representing additional metadata that should be stored with the policy definition.
 
-* `parameters` - (Optional) Parameters for the policy definition. This field is a JSON string that allows you to parameterize your policy definition. Reducing the number of parameters forces a new resource to be created.
+* `parameters` - (Optional) Parameters for the policy definition. This field is a JSON string that allows you to parameterize your policy definition. Removing or renaming parameters forces a new resource to be created.
 
 ## Attributes Reference
 

--- a/website/docs/r/policy_set_definition.html.markdown
+++ b/website/docs/r/policy_set_definition.html.markdown
@@ -63,7 +63,7 @@ The following arguments are supported:
 
 * `metadata` - (Optional) The metadata for the Policy Set Definition in JSON format.
 
-* `parameters` - (Optional) The parameters for the Policy Set Definition in JSON format. Reducing the number of parameters forces a new resource to be created.
+* `parameters` - (Optional) The parameters for the Policy Set Definition in JSON format. Removing or renaming parameters forces a new resource to be created.
 
 * `policy_definition_group` - (Optional) One or more `policy_definition_group` blocks as defined below.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

According to MS documentation, parameters can't be removed or renamed from a policy definition, when required, the provider should trigger a force recreation on such actions.

https://learn.microsoft.com/en-us/azure/governance/policy/concepts/definition-structure-parameters

This change updates the previous custom diff function to the below policies:

`azurerm_policy_definition`
`azurerm_policy_set_definition`
`azurerm_management_group_policy_set_definition`

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [x] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_policy_definition` - Removing or renaming parameters force new resource to be created
* `azurerm_policy_set_definition` - Removing or renaming parameters force new resource to be created
* `azurerm_management_group_policy_set_definition` - Removing or renaming parameters force new resource to be created


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
#29866 
#29867
#28769

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
