### PR TITLE
`azurerm_dev_center_project_pool` - support new property for `single_sign_on_enabled`

### DIFF
--- a/internal/services/devcenter/dev_center_project_pool_data_source.go
+++ b/internal/services/devcenter/dev_center_project_pool_data_source.go
@@ -30,6 +30,7 @@ type DevCenterProjectPoolDataSourceModel struct {
 	DevBoxDefinitionName               string            `tfschema:"dev_box_definition_name"`
 	LocalAdministratorEnabled          bool              `tfschema:"local_administrator_enabled"`
 	DevCenterAttachedNetworkName       string            `tfschema:"dev_center_attached_network_name"`
+	SingleSignOnEnabled                bool              `tfschema:"single_sign_on_enabled"`
 	StopOnDisconnectGracePeriodMinutes int64             `tfschema:"stop_on_disconnect_grace_period_minutes"`
 	Tags                               map[string]string `tfschema:"tags"`
 }
@@ -64,6 +65,11 @@ func (DevCenterProjectPoolDataSource) Attributes() map[string]*pluginsdk.Schema 
 		},
 
 		"location": commonschema.LocationComputed(),
+
+		"single_sign_on_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Computed: true,
+		},
 
 		"stop_on_disconnect_grace_period_minutes": {
 			Type:     pluginsdk.TypeInt,
@@ -122,6 +128,7 @@ func (r DevCenterProjectPoolDataSource) Read() sdk.ResourceFunc {
 					state.DevBoxDefinitionName = pointer.From(props.DevBoxDefinitionName)
 					state.LocalAdministratorEnabled = pointer.From(props.LocalAdministrator) == pools.LocalAdminStatusEnabled
 					state.DevCenterAttachedNetworkName = pointer.From(props.NetworkConnectionName)
+					state.SingleSignOnEnabled = pointer.From(props.SingleSignOnStatus) == pools.SingleSignOnStatusEnabled
 					state.StopOnDisconnectGracePeriodMinutes = flattenDevCenterProjectPoolStopOnDisconnectForDataSource(props.StopOnDisconnect)
 				}
 			}

--- a/internal/services/devcenter/dev_center_project_pool_resource.go
+++ b/internal/services/devcenter/dev_center_project_pool_resource.go
@@ -39,6 +39,7 @@ type DevCenterProjectPoolResourceModel struct {
 	LocalAdministratorEnabled          bool              `tfschema:"local_administrator_enabled"`
 	DevCenterAttachedNetworkName       string            `tfschema:"dev_center_attached_network_name"`
 	ManagedVirtualNetworkRegions       []string          `tfschema:"managed_virtual_network_regions"`
+	SingleSignOnEnabled                bool              `tfschema:"single_sign_on_enabled"`
 	StopOnDisconnectGracePeriodMinutes int64             `tfschema:"stop_on_disconnect_grace_period_minutes"`
 	Tags                               map[string]string `tfschema:"tags"`
 }
@@ -91,6 +92,11 @@ func (r DevCenterProjectPoolResource) Arguments() map[string]*pluginsdk.Schema {
 				StateFunc:        location.StateFunc,
 				DiffSuppressFunc: location.DiffSuppressFunc,
 			},
+		},
+
+		"single_sign_on_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
 		},
 
 		"stop_on_disconnect_grace_period_minutes": {
@@ -159,6 +165,12 @@ func (r DevCenterProjectPoolResource) Create() sdk.ResourceFunc {
 				parameters.Properties.LocalAdministrator = pointer.To(pools.LocalAdminStatusDisabled)
 			}
 
+			if model.SingleSignOnEnabled {
+				parameters.Properties.SingleSignOnStatus = pointer.To(pools.SingleSignOnStatusEnabled)
+			} else {
+				parameters.Properties.SingleSignOnStatus = pointer.To(pools.SingleSignOnStatusDisabled)
+			}
+
 			if err := client.CreateOrUpdateThenPoll(ctx, id, parameters); err != nil {
 				return fmt.Errorf("creating %s: %+v", id, err)
 			}
@@ -202,6 +214,7 @@ func (r DevCenterProjectPoolResource) Read() sdk.ResourceFunc {
 					state.LocalAdministratorEnabled = pointer.From(props.LocalAdministrator) == pools.LocalAdminStatusEnabled
 					state.DevCenterAttachedNetworkName = pointer.From(props.NetworkConnectionName)
 					state.ManagedVirtualNetworkRegions = flattenDevCenterProjectManagedVirtualNetworkRegions(props.ManagedVirtualNetworkRegions)
+					state.SingleSignOnEnabled = pointer.From(props.SingleSignOnStatus) == pools.SingleSignOnStatusEnabled
 					state.StopOnDisconnectGracePeriodMinutes = flattenDevCenterProjectPoolStopOnDisconnect(props.StopOnDisconnect)
 				}
 			}
@@ -253,6 +266,14 @@ func (r DevCenterProjectPoolResource) Update() sdk.ResourceFunc {
 
 				if len(model.ManagedVirtualNetworkRegions) != 0 {
 					parameters.Properties.VirtualNetworkType = pointer.To(pools.VirtualNetworkTypeManaged)
+				}
+			}
+
+			if metadata.ResourceData.HasChange("single_sign_on_enabled") {
+				if model.SingleSignOnEnabled {
+					parameters.Properties.SingleSignOnStatus = pointer.To(pools.SingleSignOnStatusEnabled)
+				} else {
+					parameters.Properties.SingleSignOnStatus = pointer.To(pools.SingleSignOnStatusDisabled)
 				}
 			}
 

--- a/internal/services/devcenter/dev_center_project_pool_resource.go
+++ b/internal/services/devcenter/dev_center_project_pool_resource.go
@@ -97,6 +97,7 @@ func (r DevCenterProjectPoolResource) Arguments() map[string]*pluginsdk.Schema {
 		"single_sign_on_enabled": {
 			Type:     pluginsdk.TypeBool,
 			Optional: true,
+			Default:  false,
 		},
 
 		"stop_on_disconnect_grace_period_minutes": {
@@ -165,10 +166,9 @@ func (r DevCenterProjectPoolResource) Create() sdk.ResourceFunc {
 				parameters.Properties.LocalAdministrator = pointer.To(pools.LocalAdminStatusDisabled)
 			}
 
+			parameters.Properties.SingleSignOnStatus = pointer.To(pools.SingleSignOnStatusDisabled)
 			if model.SingleSignOnEnabled {
 				parameters.Properties.SingleSignOnStatus = pointer.To(pools.SingleSignOnStatusEnabled)
-			} else {
-				parameters.Properties.SingleSignOnStatus = pointer.To(pools.SingleSignOnStatusDisabled)
 			}
 
 			if err := client.CreateOrUpdateThenPoll(ctx, id, parameters); err != nil {
@@ -270,10 +270,9 @@ func (r DevCenterProjectPoolResource) Update() sdk.ResourceFunc {
 			}
 
 			if metadata.ResourceData.HasChange("single_sign_on_enabled") {
+				parameters.Properties.SingleSignOnStatus = pointer.To(pools.SingleSignOnStatusDisabled)
 				if model.SingleSignOnEnabled {
 					parameters.Properties.SingleSignOnStatus = pointer.To(pools.SingleSignOnStatusEnabled)
-				} else {
-					parameters.Properties.SingleSignOnStatus = pointer.To(pools.SingleSignOnStatusDisabled)
 				}
 			}
 

--- a/internal/services/devcenter/dev_center_project_pool_resource_test.go
+++ b/internal/services/devcenter/dev_center_project_pool_resource_test.go
@@ -319,18 +319,30 @@ resource "azurerm_dev_center_network_connection" "test" {
   name                = "acctest-dcnc-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  domain_join_type    = "HybridAzureADJoin"
+  domain_join_type    = "AzureADJoin"
   subnet_id           = azurerm_subnet.test.id
-  domain_name         = "never.gonna.shut.you.down"
-  domain_username     = "tfuser@microsoft.com"
-  domain_password     = "P@ssW0RD7890"
-  organization_unit   = "OU=Sales,DC=Fabrikam,DC=com"
 }
 
 resource "azurerm_dev_center_attached_network" "test" {
   name                  = "acctest-dcan-%d"
   dev_center_id         = azurerm_dev_center.test.id
   network_connection_id = azurerm_dev_center_network_connection.test.id
+  depends_on            = [azurerm_dev_center_dev_box_definition.test]
+}
+
+resource "azurerm_dev_center_dev_box_definition" "test2" {
+  name               = "acctest-dcet2-%d"
+  location           = azurerm_resource_group.test.location
+  dev_center_id      = azurerm_dev_center.test.id
+  image_reference_id = "${azurerm_dev_center.test.id}/galleries/default/images/microsoftvisualstudio_visualstudioplustools_vs-2022-ent-general-win10-m365-gen2"
+  sku_name           = "general_i_8c32gb256ssd_v2"
+}
+
+resource "azurerm_dev_center_attached_network" "test2" {
+  name                  = "acctest-dcan2-%d"
+  dev_center_id         = azurerm_dev_center.test.id
+  network_connection_id = azurerm_dev_center_network_connection.test.id
+  depends_on            = [azurerm_dev_center_dev_box_definition.test2]
 }
 
 resource "azurerm_dev_center_project" "test" {
@@ -338,8 +350,7 @@ resource "azurerm_dev_center_project" "test" {
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   dev_center_id       = azurerm_dev_center.test.id
-
-  depends_on = [azurerm_dev_center_attached_network.test]
+  depends_on          = [azurerm_dev_center_attached_network.test, azurerm_dev_center_attached_network.test2]
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }

--- a/internal/services/devcenter/dev_center_project_pool_resource_test.go
+++ b/internal/services/devcenter/dev_center_project_pool_resource_test.go
@@ -304,8 +304,6 @@ resource "azurerm_virtual_network" "test" {
   address_space       = ["10.0.0.0/16"]
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-
-  depends_on = [azurerm_dev_center_dev_box_definition.test]
 }
 
 resource "azurerm_subnet" "test" {
@@ -327,7 +325,8 @@ resource "azurerm_dev_center_attached_network" "test" {
   name                  = "acctest-dcan-%d"
   dev_center_id         = azurerm_dev_center.test.id
   network_connection_id = azurerm_dev_center_network_connection.test.id
-  depends_on            = [azurerm_dev_center_dev_box_definition.test]
+
+  depends_on = [azurerm_dev_center_dev_box_definition.test]
 }
 
 resource "azurerm_dev_center_dev_box_definition" "test2" {
@@ -342,7 +341,8 @@ resource "azurerm_dev_center_attached_network" "test2" {
   name                  = "acctest-dcan2-%d"
   dev_center_id         = azurerm_dev_center.test.id
   network_connection_id = azurerm_dev_center_network_connection.test.id
-  depends_on            = [azurerm_dev_center_dev_box_definition.test2]
+
+  depends_on = [azurerm_dev_center_dev_box_definition.test2]
 }
 
 resource "azurerm_dev_center_project" "test" {
@@ -350,7 +350,8 @@ resource "azurerm_dev_center_project" "test" {
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   dev_center_id       = azurerm_dev_center.test.id
-  depends_on          = [azurerm_dev_center_attached_network.test, azurerm_dev_center_attached_network.test2]
+
+  depends_on = [azurerm_dev_center_attached_network.test, azurerm_dev_center_attached_network.test2]
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }

--- a/website/docs/d/dev_center_project_pool.html.markdown
+++ b/website/docs/d/dev_center_project_pool.html.markdown
@@ -43,6 +43,8 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `dev_center_attached_network_name` - The name of the Dev Center Attached Network in parent Project of the Dev Center Project Pool.
 
+* `single_sign_on_enabled` - Specifies whether Dev Boxes in the Pool will have SSO enabled or disabled.
+
 * `stop_on_disconnect_grace_period_minutes` - The specified time in minutes to wait before stopping a Dev Center Dev Box once disconnect is detected.
 
 * `location` - The Azure Region where the Dev Center Project Pool exists.

--- a/website/docs/r/dev_center_project_pool.html.markdown
+++ b/website/docs/r/dev_center_project_pool.html.markdown
@@ -102,7 +102,7 @@ The following arguments are supported:
 
 ~> **Note:** Currently only one region can be specified for `managed_virtual_network_regions`.
 
-* `single_sign_on_enabled` - (Optional) Specifies whether Dev Boxes in the Pool will have SSO enabled or disabled.
+* `single_sign_on_enabled` - (Optional) Specifies whether Dev Boxes in the Pool will have SSO enabled or disabled. Defaults to `false`.
 
 * `stop_on_disconnect_grace_period_minutes` - (Optional) The specified time in minutes to wait before stopping a Dev Center Dev Box once disconnect is detected. Possible values are between `60` and `480`.
 

--- a/website/docs/r/dev_center_project_pool.html.markdown
+++ b/website/docs/r/dev_center_project_pool.html.markdown
@@ -102,6 +102,8 @@ The following arguments are supported:
 
 ~> **Note:** Currently only one region can be specified for `managed_virtual_network_regions`.
 
+* `single_sign_on_enabled` - (Optional) Specifies whether Dev Boxes in the Pool will have SSO enabled or disabled.
+
 * `stop_on_disconnect_grace_period_minutes` - (Optional) The specified time in minutes to wait before stopping a Dev Center Dev Box once disconnect is detected. Possible values are between `60` and `480`.
 
 * `tags` - (Optional) A mapping of tags which should be assigned to the Dev Center Project Pool.


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description
This PR is to support new property [SingleSignOnStatus](https://github.com/Azure/azure-rest-api-specs/blob/ca2020cf5a4953c007f54135db73652bb94dd408/specification/devcenter/resource-manager/Microsoft.DevCenter/stable/2025-02-01/vdi.json#L1267).
<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

Note: The failed test cases also failed on Teamcity Daily Run due to quota issue so that they are not related with this PR.
<img width="264" height="44" alt="image" src="https://github.com/user-attachments/assets/18157e6d-e497-4aa2-a0ae-de5c3fc2dda1" />

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_dev_center_project_pool` - support new property for `single_sign_on_enabled`


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/30410

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
