### PR TITLE
`azurerm_monitor_diagnostic_setting` - allow management group IDs for `target_resource_id`

### DIFF
--- a/internal/services/monitor/monitor_diagnostic_setting_resource.go
+++ b/internal/services/monitor/monitor_diagnostic_setting_resource.go
@@ -56,10 +56,13 @@ func resourceMonitorDiagnosticSetting() *pluginsdk.Resource {
 			},
 
 			"target_resource_id": {
-				Type:         pluginsdk.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: azure.ValidateResourceID,
+				Type:     pluginsdk.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.Any(
+					azure.ValidateResourceID,
+					commonids.ValidateManagementGroupID,
+				),
 			},
 
 			"eventhub_name": {

--- a/internal/services/monitor/monitor_diagnostic_setting_resource_test.go
+++ b/internal/services/monitor/monitor_diagnostic_setting_resource_test.go
@@ -1545,7 +1545,7 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name = "acctestRG%[1]d"
+  name     = "acctestRG%[1]d"
   location = "eastus"
 }
 
@@ -1554,15 +1554,15 @@ resource "azurerm_management_group" "test" {
 }
 
 resource "azurerm_log_analytics_workspace" "test" {
-  name = "acctestLAW%[1]d"
-  location = azurerm_resource_group.test.location
+  name                = "acctestLAW%[1]d"
+  location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
 }
 
 resource "azurerm_monitor_diagnostic_setting" "test" {
   name = "acctestMDS%[1]d"
 
-  target_resource_id = azurerm_management_group.test.id
+  target_resource_id         = azurerm_management_group.test.id
   log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
 
   enabled_log {


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Allows management group IDs for `target_resource_id`


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

```
=== RUN   TestAccMonitorDiagnosticSetting_managementGroup
=== PAUSE TestAccMonitorDiagnosticSetting_managementGroup
=== CONT  TestAccMonitorDiagnosticSetting_managementGroup
--- PASS: TestAccMonitorDiagnosticSetting_managementGroup (191.64s)
PASS
```


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #21540

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
