### PR TITLE
`azurerm_kusto_cluster` - fix update func allowing for removal of `language_extensions`

### DIFF
--- a/internal/services/kusto/kusto_cluster_resource.go
+++ b/internal/services/kusto/kusto_cluster_resource.go
@@ -261,7 +261,7 @@ func resourceKustoCluster() *pluginsdk.Resource {
 func resourceKustoClusterCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Kusto.ClustersClient
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
-	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	log.Printf("[INFO] preparing arguments for Azure Kusto Cluster creation.")
@@ -281,7 +281,7 @@ func resourceKustoClusterCreate(d *pluginsdk.ResourceData, meta interface{}) err
 
 	sku, err := expandKustoClusterSku(d.Get("sku").([]interface{}))
 	if err != nil {
-		return err
+		return fmt.Errorf("expanding `sku`: %+v", err)
 	}
 
 	optimizedAutoScale := expandOptimizedAutoScale(d.Get("optimized_auto_scale").([]interface{}))
@@ -377,7 +377,7 @@ func resourceKustoClusterCreate(d *pluginsdk.ResourceData, meta interface{}) err
 
 func resourceKustoClusterUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Kusto.ClustersClient
-	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	id, err := commonids.ParseKustoClusterID(d.Id())
@@ -390,10 +390,15 @@ func resourceKustoClusterUpdate(d *pluginsdk.ResourceData, meta interface{}) err
 
 	existing, err := client.Get(ctx, *id)
 	if err != nil {
-		return fmt.Errorf("updating %s: %+v", id, err)
+		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	if existing.Model == nil || existing.Model.Properties == nil {
-		return fmt.Errorf("retrieving existing %s: `properties` was nil", *id)
+
+	if existing.Model == nil {
+		return fmt.Errorf("retrieving %s: `model` was nil", *id)
+	}
+
+	if existing.Model.Properties == nil {
+		return fmt.Errorf("retrieving %s: `properties` was nil", *id)
 	}
 	model := existing.Model
 	props := model.Properties
@@ -465,9 +470,7 @@ func resourceKustoClusterUpdate(d *pluginsdk.ResourceData, meta interface{}) err
 	}
 
 	if d.HasChange("language_extensions") {
-		if v, ok := d.GetOk("language_extensions"); ok {
-			props.LanguageExtensions = expandKustoClusterLanguageExtensionList(v.([]interface{}))
-		}
+		props.LanguageExtensions = expandKustoClusterLanguageExtensionList(d.Get("language_extensions").([]interface{}))
 	}
 
 	if d.HasChange("outbound_network_access_restricted") {
@@ -719,24 +722,19 @@ func expandKustoClusterVNET(input []interface{}) *clusters.VirtualNetworkConfigu
 }
 
 func expandKustoClusterLanguageExtensionList(input []interface{}) *clusters.LanguageExtensionsList {
-	if len(input) > 0 {
-		extensions := make([]clusters.LanguageExtension, 0)
-		for _, ext := range input {
-			extMap := ext.(map[string]interface{})
-			name := clusters.LanguageExtensionName(extMap["name"].(string))
-			image := clusters.LanguageExtensionImageName(extMap["image"].(string))
-			lanExt := clusters.LanguageExtension{
-				LanguageExtensionName:      &name,
-				LanguageExtensionImageName: &image,
-			}
-			extensions = append(extensions, lanExt)
-		}
-		return &clusters.LanguageExtensionsList{
-			Value: &extensions,
-		}
+	extensions := make([]clusters.LanguageExtension, 0)
+
+	for _, ext := range input {
+		extMap := ext.(map[string]interface{})
+		extensions = append(extensions, clusters.LanguageExtension{
+			LanguageExtensionName:      pointer.To(clusters.LanguageExtensionName(extMap["name"].(string))),
+			LanguageExtensionImageName: pointer.To(clusters.LanguageExtensionImageName(extMap["image"].(string))),
+		})
 	}
 
-	return nil
+	return &clusters.LanguageExtensionsList{
+		Value: &extensions,
+	}
 }
 
 func flattenKustoClusterSku(sku *clusters.AzureSku) []interface{} {

--- a/internal/services/kusto/kusto_cluster_resource_test.go
+++ b/internal/services/kusto/kusto_cluster_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
@@ -41,11 +42,6 @@ func TestAccKustoCluster_complete(t *testing.T) {
 			Config: r.complete(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("allowed_fqdns.#").HasValue("1"),
-				check.That(data.ResourceName).Key("allowed_fqdns.0").HasValue("255.255.255.0/24"),
-				check.That(data.ResourceName).Key("allowed_ip_ranges.#").HasValue("1"),
-				check.That(data.ResourceName).Key("allowed_ip_ranges.0").HasValue("0.0.0.0/0"),
-				check.That(data.ResourceName).Key("outbound_network_access_restricted").HasValue("true"),
 			),
 		},
 		data.ImportStep(),
@@ -61,10 +57,6 @@ func TestAccKustoCluster_update(t *testing.T) {
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("disk_encryption_enabled").HasValue("false"),
-				check.That(data.ResourceName).Key("streaming_ingestion_enabled").HasValue("false"),
-				check.That(data.ResourceName).Key("purge_enabled").HasValue("false"),
-				check.That(data.ResourceName).Key("public_ip_type").HasValue("IPv4"),
 			),
 		},
 		data.ImportStep(),
@@ -72,10 +64,6 @@ func TestAccKustoCluster_update(t *testing.T) {
 			Config: r.update(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("disk_encryption_enabled").HasValue("true"),
-				check.That(data.ResourceName).Key("streaming_ingestion_enabled").HasValue("true"),
-				check.That(data.ResourceName).Key("purge_enabled").HasValue("true"),
-				check.That(data.ResourceName).Key("public_ip_type").HasValue("DualStack"),
 			),
 		},
 		data.ImportStep(),
@@ -83,10 +71,6 @@ func TestAccKustoCluster_update(t *testing.T) {
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("disk_encryption_enabled").HasValue("false"),
-				check.That(data.ResourceName).Key("streaming_ingestion_enabled").HasValue("false"),
-				check.That(data.ResourceName).Key("purge_enabled").HasValue("false"),
-				check.That(data.ResourceName).Key("public_ip_type").HasValue("IPv4"),
 			),
 		},
 		data.ImportStep(),
@@ -117,19 +101,16 @@ func TestAccKustoCluster_withTags(t *testing.T) {
 			Config: r.withTags(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("tags.%").HasValue("1"),
-				check.That(data.ResourceName).Key("tags.label").HasValue("test"),
 			),
 		},
+		data.ImportStep(),
 		{
 			Config: r.withTagsUpdate(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("tags.%").HasValue("2"),
-				check.That(data.ResourceName).Key("tags.label").HasValue("test1"),
-				check.That(data.ResourceName).Key("tags.ENV").HasValue("prod"),
 			),
 		},
+		data.ImportStep(),
 	})
 }
 
@@ -142,18 +123,16 @@ func TestAccKustoCluster_sku(t *testing.T) {
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("sku.0.name").HasValue("Dev(No SLA)_Standard_D11_v2"),
-				check.That(data.ResourceName).Key("sku.0.capacity").HasValue("1"),
 			),
 		},
+		data.ImportStep(),
 		{
 			Config: r.skuUpdate(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("sku.0.name").HasValue("Standard_D11_v2"),
-				check.That(data.ResourceName).Key("sku.0.capacity").HasValue("2"),
 			),
 		},
+		data.ImportStep(),
 	})
 }
 
@@ -166,10 +145,9 @@ func TestAccKustoCluster_zones(t *testing.T) {
 			Config: r.withZones(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("zones.#").HasValue("1"),
-				check.That(data.ResourceName).Key("zones.0").HasValue("1"),
 			),
 		},
+		data.ImportStep(),
 	})
 }
 
@@ -182,9 +160,6 @@ func TestAccKustoCluster_identitySystemAssigned(t *testing.T) {
 			Config: r.identitySystemAssigned(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("identity.0.type").HasValue("SystemAssigned"),
-				check.That(data.ResourceName).Key("identity.0.identity_ids.#").HasValue("0"),
-				check.That(data.ResourceName).Key("identity.0.principal_id").IsUUID(),
 			),
 		},
 		data.ImportStep(),
@@ -200,11 +175,9 @@ func TestAccKustoCluster_UserAssignedIdentity(t *testing.T) {
 			Config: r.userAssignedIdentity(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("identity.0.type").HasValue("UserAssigned"),
-				check.That(data.ResourceName).Key("identity.0.identity_ids.#").HasValue("1"),
-				check.That(data.ResourceName).Key("identity.0.principal_id").HasValue(""),
 			),
 		},
+		data.ImportStep(),
 	})
 }
 
@@ -217,11 +190,9 @@ func TestAccKustoCluster_multipleAssignedIdentity(t *testing.T) {
 			Config: r.multipleAssignedIdentity(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("identity.0.type").HasValue("SystemAssigned, UserAssigned"),
-				check.That(data.ResourceName).Key("identity.0.identity_ids.#").HasValue("1"),
-				check.That(data.ResourceName).Key("identity.0.principal_id").IsUUID(),
 			),
 		},
+		data.ImportStep(),
 	})
 }
 
@@ -234,9 +205,6 @@ func TestAccKustoCluster_optimizedAutoScale(t *testing.T) {
 			Config: r.optimizedAutoScale(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("optimized_auto_scale.#").HasValue("1"),
-				check.That(data.ResourceName).Key("optimized_auto_scale.0.minimum_instances").HasValue("2"),
-				check.That(data.ResourceName).Key("optimized_auto_scale.0.maximum_instances").HasValue("3"),
 			),
 		},
 		data.ImportStep(),
@@ -244,9 +212,6 @@ func TestAccKustoCluster_optimizedAutoScale(t *testing.T) {
 			Config: r.optimizedAutoScaleUpdate(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("optimized_auto_scale.#").HasValue("1"),
-				check.That(data.ResourceName).Key("optimized_auto_scale.0.minimum_instances").HasValue("3"),
-				check.That(data.ResourceName).Key("optimized_auto_scale.0.maximum_instances").HasValue("4"),
 			),
 		},
 		data.ImportStep(),
@@ -334,12 +299,35 @@ func TestAccKustoCluster_newSkus(t *testing.T) {
 			Config: r.newSkus(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("sku.0.name").HasValue("Standard_L8s_v3"),
-				check.That(data.ResourceName).Key("allowed_fqdns.#").HasValue("1"),
-				check.That(data.ResourceName).Key("allowed_fqdns.0").HasValue("255.255.255.0/24"),
-				check.That(data.ResourceName).Key("allowed_ip_ranges.#").HasValue("1"),
-				check.That(data.ResourceName).Key("allowed_ip_ranges.0").HasValue("0.0.0.0/0"),
-				check.That(data.ResourceName).Key("outbound_network_access_restricted").HasValue("true"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccKustoCluster_removeLanguageExtension(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kusto_cluster", "test")
+	r := KustoClusterResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicHyperVSupportedSku(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basicHyperVSupportedSku(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
@@ -357,13 +345,7 @@ func (KustoClusterResource) Exists(ctx context.Context, clients *clients.Client,
 		return nil, fmt.Errorf("retrieving %s: %v", id.String(), err)
 	}
 
-	if resp.Model == nil {
-		return nil, fmt.Errorf("response model is empty")
-	}
-
-	exists := resp.Model.Properties != nil
-
-	return &exists, nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (KustoClusterResource) basic(data acceptance.TestData) string {
@@ -389,6 +371,29 @@ resource "azurerm_kusto_cluster" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }
 
+func (KustoClusterResource) basicHyperVSupportedSku(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_kusto_cluster" "test" {
+  name                = "acctestkc%s"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku {
+    name     = "Standard_L8s_v3"
+    capacity = 2
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}
+
 func (KustoClusterResource) complete(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -404,13 +409,19 @@ resource "azurerm_kusto_cluster" "test" {
   name                               = "acctestkc%s"
   location                           = azurerm_resource_group.test.location
   resource_group_name                = azurerm_resource_group.test.name
-  allowed_fqdns                      = ["255.255.255.0/24"]
+  allowed_fqdns                      = ["example.blob.core.windows.net"]
   allowed_ip_ranges                  = ["0.0.0.0/0"]
   public_network_access_enabled      = false
   public_ip_type                     = "DualStack"
   outbound_network_access_restricted = true
+  
+  language_extensions {
+    name  = "PYTHON"
+    image = "Python3_6_5"
+  }
+
   sku {
-    name     = "Standard_D13_v2"
+    name     = "Standard_L8s_v3"
     capacity = 2
   }
 }

--- a/website/docs/r/kusto_cluster.html.markdown
+++ b/website/docs/r/kusto_cluster.html.markdown
@@ -14,12 +14,12 @@ Manages a Kusto (also known as Azure Data Explorer) Cluster
 
 ```hcl
 resource "azurerm_resource_group" "example" {
-  name     = "my-kusto-cluster-rg"
+  name     = "example"
   location = "West Europe"
 }
 
 resource "azurerm_kusto_cluster" "example" {
-  name                = "kustocluster"
+  name                = "example"
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
 
@@ -46,33 +46,33 @@ The following arguments are supported:
 
 * `sku` - (Required) A `sku` block as defined below.
 
-* `allowed_fqdns` - (Optional) List of allowed FQDNs(Fully Qualified Domain Name) for egress from Cluster.
+---
+
+* `allowed_fqdns` - (Optional) List of allowed FQDNs (Fully Qualified Domain Name) for egress from Cluster.
 
 * `allowed_ip_ranges` - (Optional) The list of ips in the format of CIDR allowed to connect to the cluster.
+
+* `auto_stop_enabled` - (Optional) Specifies if the cluster could be automatically stopped (due to lack of data or no activity for many days). Defaults to `true`.
+
+* `disk_encryption_enabled` - (Optional) Specifies if the cluster's disks are encrypted. Defaults to `false`.
 
 * `double_encryption_enabled` - (Optional) Is the cluster's double encryption enabled? Changing this forces a new resource to be created.
 
 * `identity` - (Optional) An `identity` block as defined below.
 
-* `auto_stop_enabled` - (Optional) Specifies if the cluster could be automatically stopped (due to lack of data or no activity for many days). Defaults to `true`.
+* `language_extensions` - (Optional) A `language_extensions` block as defined below.
 
-* `disk_encryption_enabled` - (Optional) Specifies if the cluster's disks are encrypted.
+* `optimized_auto_scale` - (Optional) An `optimized_auto_scale` block as defined below.
 
-* `streaming_ingestion_enabled` - (Optional) Specifies if the streaming ingest is enabled.
+* `outbound_network_access_restricted` - (Optional) Whether to restrict outbound network access. Defaults to `false`.
 
 * `public_ip_type` - (Optional) Indicates what public IP type to create - IPv4 (default), or DualStack (both IPv4 and IPv6). Defaults to `IPv4`.
 
 * `public_network_access_enabled` - (Optional) Is the public network access enabled? Defaults to `true`.
 
-* `outbound_network_access_restricted` - (Optional) Whether to restrict outbound network access. Value is optional but if passed in, must be `true` or `false`, default is `false`.
+* `purge_enabled` - (Optional) Specifies if the purge operations are enabled. Defaults to `false`.
 
-* `purge_enabled` - (Optional) Specifies if the purge operations are enabled.
-
-* `language_extensions` - (Optional) An list of `language_extensions` to enable. Valid values are: `PYTHON`, `PYTHON_3.10.8` and `R`. `PYTHON` is used to specify Python 3.6.5 image and `PYTHON_3.10.8` is used to specify Python 3.10.8 image. Note that `PYTHON_3.10.8` is only available in skus which support nested virtualization.
-
-~> **Note:** In `v4.0.0` and later version of the AzureRM Provider, `language_extensions` will be changed to a list of `language_extension` block. In each block, `name` and `image` are required. `name` is the name of the language extension, possible values are `PYTHON`, `R`. `image` is the image of the language extension, possible values are `Python3_6_5`, `Python3_10_8` and `R`.
-
-* `optimized_auto_scale` - (Optional) An `optimized_auto_scale` block as defined below.
+* `streaming_ingestion_enabled` - (Optional) Specifies if the streaming ingest is enabled. Defaults to `false`.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
@@ -81,16 +81,6 @@ The following arguments are supported:
 ~> **Note:** In v3.0 of `azurerm` a new or updated Kusto Cluster will only allow your own tenant by default. Explicit configuration of this setting will change from `trusted_external_tenants = ["MyTenantOnly"]` to `trusted_external_tenants = []`.
 
 * `zones` - (Optional) Specifies a list of Availability Zones in which this Kusto Cluster should be located. Changing this forces a new Kusto Cluster to be created.
-
----
-
-A `sku` block supports the following:
-
-* `name` - (Required) The name of the SKU. Possible values are `Dev(No SLA)_Standard_D11_v2`, `Dev(No SLA)_Standard_E2a_v4`, `Standard_D14_v2`, `Standard_D11_v2`, `Standard_D16d_v5`, `Standard_D13_v2`, `Standard_D12_v2`, `Standard_DS14_v2+4TB_PS`, `Standard_DS14_v2+3TB_PS`, `Standard_DS13_v2+1TB_PS`, `Standard_DS13_v2+2TB_PS`, `Standard_D32d_v5`, `Standard_D32d_v4`, `Standard_EC8ads_v5`, `Standard_EC8as_v5+1TB_PS`, `Standard_EC8as_v5+2TB_PS`, `Standard_EC16ads_v5`, `Standard_EC16as_v5+4TB_PS`, `Standard_EC16as_v5+3TB_PS`, `Standard_E80ids_v4`, `Standard_E8a_v4`, `Standard_E8ads_v5`, `Standard_E8as_v5+1TB_PS`, `Standard_E8as_v5+2TB_PS`, `Standard_E8as_v4+1TB_PS`, `Standard_E8as_v4+2TB_PS`, `Standard_E8d_v5`, `Standard_E8d_v4`, `Standard_E8s_v5+1TB_PS`, `Standard_E8s_v5+2TB_PS`, `Standard_E8s_v4+1TB_PS`, `Standard_E8s_v4+2TB_PS`, `Standard_E4a_v4`, `Standard_E4ads_v5`, `Standard_E4d_v5`, `Standard_E4d_v4`, `Standard_E16a_v4`, `Standard_E16ads_v5`, `Standard_E16as_v5+4TB_PS`, `Standard_E16as_v5+3TB_PS`, `Standard_E16as_v4+4TB_PS`, `Standard_E16as_v4+3TB_PS`, `Standard_E16d_v5`, `Standard_E16d_v4`, `Standard_E16s_v5+4TB_PS`, `Standard_E16s_v5+3TB_PS`, `Standard_E16s_v4+4TB_PS`, `Standard_E16s_v4+3TB_PS`, `Standard_E64i_v3`, `Standard_E2a_v4`, `Standard_E2ads_v5`, `Standard_E2d_v5`, `Standard_E2d_v4`, `Standard_L8as_v3`, `Standard_L8s`, `Standard_L8s_v3`, `Standard_L8s_v2`, `Standard_L4s`, `Standard_L16as_v3`, `Standard_L16s`, `Standard_L16s_v3`, `Standard_L16s_v2`, `Standard_L32as_v3` and `Standard_L32s_v3`.
-* `capacity` - (Optional) Specifies the node count for the cluster. Boundaries depend on the SKU name.
-
-~> **Note:** If no `optimized_auto_scale` block is defined, then the capacity is required.
-~> **Note:** If an `optimized_auto_scale` block is defined and no capacity is set, then the capacity is initially set to the value of `minimum_instances`.
 
 ---
 
@@ -104,11 +94,31 @@ An `identity` block supports the following:
 
 ---
 
-A `optimized_auto_scale` block supports the following:
+A `language_extensions` block supports the following:
 
-* `minimum_instances` - (Required) The minimum number of allowed instances. Must between `0` and `1000`.
+* `name` - (Required) The name of the language extension. Possible values are `PYTHON` and `R`. 
 
-* `maximum_instances` - (Required) The maximum number of allowed instances. Must between `0` and `1000`.
+* `image` - (Required) The language extension image. Possible values are `Python3_11_7`, `Python3_11_7_DL`, `Python3_10_8`, `Python3_10_8_DL`, `Python3_6_5`, `PythonCustomImage`, and `R`.
+
+---
+
+An `optimized_auto_scale` block supports the following:
+
+* `minimum_instances` - (Required) The minimum number of allowed instances. Possible values range between `0` and `1000`.
+
+* `maximum_instances` - (Required) The maximum number of allowed instances. Possible values range between `0` and `1000`.
+
+---
+
+A `sku` block supports the following:
+
+* `name` - (Required) The name of the SKU. Possible values are `Dev(No SLA)_Standard_D11_v2`, `Dev(No SLA)_Standard_E2a_v4`, `Standard_D14_v2`, `Standard_D11_v2`, `Standard_D16d_v5`, `Standard_D13_v2`, `Standard_D12_v2`, `Standard_DS14_v2+4TB_PS`, `Standard_DS14_v2+3TB_PS`, `Standard_DS13_v2+1TB_PS`, `Standard_DS13_v2+2TB_PS`, `Standard_D32d_v5`, `Standard_D32d_v4`, `Standard_EC8ads_v5`, `Standard_EC8as_v5+1TB_PS`, `Standard_EC8as_v5+2TB_PS`, `Standard_EC16ads_v5`, `Standard_EC16as_v5+4TB_PS`, `Standard_EC16as_v5+3TB_PS`, `Standard_E80ids_v4`, `Standard_E8a_v4`, `Standard_E8ads_v5`, `Standard_E8as_v5+1TB_PS`, `Standard_E8as_v5+2TB_PS`, `Standard_E8as_v4+1TB_PS`, `Standard_E8as_v4+2TB_PS`, `Standard_E8d_v5`, `Standard_E8d_v4`, `Standard_E8s_v5+1TB_PS`, `Standard_E8s_v5+2TB_PS`, `Standard_E8s_v4+1TB_PS`, `Standard_E8s_v4+2TB_PS`, `Standard_E4a_v4`, `Standard_E4ads_v5`, `Standard_E4d_v5`, `Standard_E4d_v4`, `Standard_E16a_v4`, `Standard_E16ads_v5`, `Standard_E16as_v5+4TB_PS`, `Standard_E16as_v5+3TB_PS`, `Standard_E16as_v4+4TB_PS`, `Standard_E16as_v4+3TB_PS`, `Standard_E16d_v5`, `Standard_E16d_v4`, `Standard_E16s_v5+4TB_PS`, `Standard_E16s_v5+3TB_PS`, `Standard_E16s_v4+4TB_PS`, `Standard_E16s_v4+3TB_PS`, `Standard_E64i_v3`, `Standard_E2a_v4`, `Standard_E2ads_v5`, `Standard_E2d_v5`, `Standard_E2d_v4`, `Standard_L8as_v3`, `Standard_L8s`, `Standard_L8s_v3`, `Standard_L8s_v2`, `Standard_L4s`, `Standard_L16as_v3`, `Standard_L16s`, `Standard_L16s_v3`, `Standard_L16s_v2`, `Standard_L32as_v3` and `Standard_L32s_v3`.
+
+* `capacity` - (Optional) Specifies the node count for the cluster. Boundaries depend on the SKU name.
+
+~> **Note:** If no `optimized_auto_scale` block is defined, then the capacity is required.
+
+~> **Note:** If an `optimized_auto_scale` block is defined and no capacity is set, then the capacity is initially set to the value of `minimum_instances`.
 
 ## Attributes Reference
 


### PR DESCRIPTION

<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

- Fixes update func so `language_extensions` can be removed
- General clean up


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

New test result:
```
=== RUN   TestAccKustoCluster_removeLanguageExtension
=== PAUSE TestAccKustoCluster_removeLanguageExtension
=== CONT  TestAccKustoCluster_removeLanguageExtension
--- PASS: TestAccKustoCluster_removeLanguageExtension (2760.72s)
```

Running remaining tests...


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
