### PR TITLE
various -  fix flawed testing methodology on some resource names

### DIFF
--- a/internal/services/frontdoor/validate/front_door_waf_name_test.go
+++ b/internal/services/frontdoor/validate/front_door_waf_name_test.go
@@ -88,5 +88,9 @@ func TestAccFrontDoorFirewallPolicy_validateName(t *testing.T) {
 		if tc.ExpectError && !hasError {
 			t.Fatalf("Expected the FrontDoor WAF Name to trigger a validation error for '%s'", tc.Name)
 		}
+
+		if !tc.ExpectError && hasError {
+			t.Fatalf("Encountered unexpected validation error for FrontDoor WAF Name '%s'", tc.Input)
+		}
 	}
 }

--- a/internal/services/keyvault/validate/nested_item_name_test.go
+++ b/internal/services/keyvault/validate/nested_item_name_test.go
@@ -52,5 +52,9 @@ func TestNestedItemName(t *testing.T) {
 		if tc.ExpectError && !hasError {
 			t.Fatalf("Expected the Key Vault Nested Item Name to trigger a validation error for '%s'", tc.Input)
 		}
+
+		if !tc.ExpectError && hasError {
+			t.Fatalf("Encountered unexpected validation error for Key Vault Nested Item Name '%s'", tc.Input)
+		}
 	}
 }

--- a/internal/services/keyvault/validate/vault_name_test.go
+++ b/internal/services/keyvault/validate/vault_name_test.go
@@ -61,5 +61,9 @@ func TestValidateVaultName(t *testing.T) {
 		if tc.ExpectError && !hasError {
 			t.Fatalf("Expected the Key Vault Name to trigger a validation error for '%s'", tc.Input)
 		}
+
+		if !tc.ExpectError && hasError {
+			t.Fatalf("Encountered unexpected validation error for Key Vault Name '%s'", tc.Input)
+		}
 	}
 }

--- a/internal/services/network/validate/hub_route_table_name_test.go
+++ b/internal/services/network/validate/hub_route_table_name_test.go
@@ -37,5 +37,9 @@ func TestHubRouteTableName(t *testing.T) {
 		if tc.ExpectError && !hasError {
 			t.Fatalf("Expected the Virtual Hub Route Table Name to trigger a validation error for '%s'", tc.Input)
 		}
+
+		if !tc.ExpectError && hasError {
+			t.Fatalf("Encountered unexpected validation error for Virtual Hub Route Table Name '%s'", tc.Input)
+		}
 	}
 }

--- a/internal/services/network/validate/ip_traffic_port_test.go
+++ b/internal/services/network/validate/ip_traffic_port_test.go
@@ -85,5 +85,9 @@ func TestIpTrafficPort(t *testing.T) {
 		if tc.ExpectError && !hasError {
 			t.Fatalf("Expected the IP Traffic Port to trigger a validation error for '%s'", tc.Input)
 		}
+
+		if !tc.ExpectError && hasError {
+			t.Fatalf("Encountered unexpected validation error for IP Traffic Port '%s'", tc.Input)
+		}
 	}
 }

--- a/internal/services/network/validate/number_of_ip_addresses_test.go
+++ b/internal/services/network/validate/number_of_ip_addresses_test.go
@@ -58,5 +58,9 @@ func TestNumberOfIpAddresses(t *testing.T) {
 		if tc.ExpectError && !hasError {
 			t.Fatalf("Expected NumberOfIpAddresses to trigger a validation error for '%s'", tc.Input)
 		}
+
+		if !tc.ExpectError && hasError {
+			t.Fatalf("Encountered unexpected validation error for NumberOfIpAddresses '%s'", tc.Input)
+		}
 	}
 }

--- a/internal/services/network/validate/policy_group_name.go
+++ b/internal/services/network/validate/policy_group_name.go
@@ -15,7 +15,7 @@ func PolicyGroupName(i interface{}, k string) (warnings []string, errors []error
 		return nil, []error{fmt.Errorf("expected type of %q to be string", k)}
 	}
 
-	if m, _ := validate.RegExHelper(i, k, `^[a-zA-Z][a-zA-Z.-_]{0,78}[a-zA-Z_]{0,1}$`); !m {
+	if m, _ := validate.RegExHelper(i, k, `^[a-zA-Z][a-zA-Z.\-_]{0,78}[a-zA-Z_]{0,1}$`); !m {
 		return nil, []error{fmt.Errorf(`%q must be between 1 and 80 characters in length, must begin with a letter, end with a letter or underscore and contain only letters, periods, underscores and hyphens, got %q`, k, v)}
 	}
 

--- a/internal/services/network/validate/policy_group_name_test.go
+++ b/internal/services/network/validate/policy_group_name_test.go
@@ -54,5 +54,9 @@ func TestPolicyGroupName(t *testing.T) {
 		if tc.ExpectError && !hasError {
 			t.Fatalf("Expected the Policy Group Name to trigger a validation error for '%s'", tc.Input)
 		}
+
+		if !tc.ExpectError && hasError {
+			t.Fatalf("Encountered unexpected validation error for Policy Group Name '%s'", tc.Input)
+		}
 	}
 }

--- a/internal/services/network/validate/route_map_name_test.go
+++ b/internal/services/network/validate/route_map_name_test.go
@@ -46,5 +46,9 @@ func TestValidateRouteMapName(t *testing.T) {
 		if tc.ExpectError && !hasError {
 			t.Fatalf("Expected the Route Map Name to trigger a validation error for '%s'", tc.Input)
 		}
+
+		if !tc.ExpectError && hasError {
+			t.Fatalf("Encountered unexpected validation error for Route Map Name '%s'", tc.Input)
+		}
 	}
 }


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

8 separate resource names' testing methodologies were unable to error on an erroring test case that was not intended to raise an error.
This additionally masked the fact that the regex for `virtual_network_gateway` `policy_group` blocks' names was incorrectly escaped.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->
