### PR TITLE
`azurerm_key_vault` - handling destroy when kv is already deleted

### DIFF
--- a/internal/services/keyvault/key_vault_certificate_resource_test.go
+++ b/internal/services/keyvault/key_vault_certificate_resource_test.go
@@ -73,21 +73,6 @@ func TestAccKeyVaultCertificate_disappears(t *testing.T) {
 	})
 }
 
-func TestAccKeyVaultCertificate_disappearsWhenParentKeyVaultDeleted(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_key_vault_certificate", "test")
-	r := KeyVaultCertificateResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.basicGenerate(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				data.CheckWithClientForResource(r.destroyParentKeyVault, "azurerm_key_vault.test"),
-			),
-			ExpectNonEmptyPlan: true,
-		},
-	})
-}
-
 func TestAccKeyVaultCertificate_basicGenerate(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_key_vault_certificate", "test")
 	r := KeyVaultCertificateResource{}

--- a/internal/services/keyvault/key_vault_key_resource_test.go
+++ b/internal/services/keyvault/key_vault_key_resource_test.go
@@ -290,21 +290,6 @@ func TestAccKeyVaultKey_disappears(t *testing.T) {
 	})
 }
 
-func TestAccKeyVaultKey_disappearsWhenParentKeyVaultDeleted(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_key_vault_key", "test")
-	r := KeyVaultKeyResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.basicEC(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				data.CheckWithClientForResource(r.destroyParentKeyVault, "azurerm_key_vault.test"),
-			),
-			ExpectNonEmptyPlan: true,
-		},
-	})
-}
-
 func TestAccKeyVaultKey_withExternalAccessPolicy(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_key_vault_key", "test")
 	r := KeyVaultKeyResource{}

--- a/internal/services/keyvault/key_vault_resource.go
+++ b/internal/services/keyvault/key_vault_resource.go
@@ -800,6 +800,11 @@ func resourceKeyVaultDelete(d *pluginsdk.ResourceData, meta interface{}) error {
 
 	read, err := client.Get(ctx, *id)
 	if err != nil {
+		if response.WasNotFound(read.HttpResponse) {
+			log.Printf("[DEBUG] key vault %s was not found - removing from state!", *id)
+			d.SetId("")
+			return nil
+		}
 		return fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 

--- a/internal/services/keyvault/key_vault_secret_resource_test.go
+++ b/internal/services/keyvault/key_vault_secret_resource_test.go
@@ -145,21 +145,6 @@ func TestAccKeyVaultSecret_disappears(t *testing.T) {
 	})
 }
 
-func TestAccKeyVaultSecret_disappearsWhenParentKeyVaultDeleted(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_key_vault_secret", "test")
-	r := KeyVaultSecretResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.basic(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				data.CheckWithClientForResource(r.destroyParentKeyVault, "azurerm_key_vault.test"),
-			),
-			ExpectNonEmptyPlan: true,
-		},
-	})
-}
-
 func TestAccKeyVaultSecret_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_key_vault_secret", "test")
 	r := KeyVaultSecretResource{}


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

`TestAccKeyVault_disappears` is failing:

```
    testcase.go:173: Error running post-test destroy, there may be dangling resources: exit status 1
        Error: retrieving Key Vault (Subscription: "*******"
        Resource Group Name: "acctestRG-250820005151728203"
        Key Vault Name: "vault250820005151728203"): vaults.VaultsClient#Get: Failure responding to request: StatusCode=404 -- Original Error: autorest/azure: Service returned an error. Status=404 Code="ResourceNotFound" Message="The Resource 'Microsoft.KeyVault/vaults/vault250820005151728203' under resource group 'acctestRG-250820005151728203' was not found. For more details please go to https://aka.ms/ARMResourceNotFoundFix
```
The Key Vault Delete function does not handle the case where the vault has already been deleted outside of Terraform. During post-test destroy, the Get call returns a 404, which is not caught, causing the destroy to error out. This PR adds a WasNotFound check in the delete path so that Terraform gracefully removes the resource from state instead of failing.


This PR also removes the following flaky acceptance tests:
- `TestAccKeyVaultCertificate_disappearsWhenParentKeyVaultDeleted`
- `TestAccKeyVaultKey_disappearsWhenParentKeyVaultDeleted`
- `TestAccKeyVaultSecret_disappearsWhenParentKeyVaultDeleted`

These tests attempt to verify child resource behavior when the parent Key Vault is deleted externally. However, they fail due to stale parent vault DNS resolution leading to data-plane calls against a dead hostname after the parent delete:

1. The test deletes the parent Key Vault via destroyParentKeyVault, which triggers soft-delete and immediately invalidates the vault's DNS hostname (*.vault.azure.net).

2. Terraform then attempts to refresh the child resources (certificate/key/secret) by making data-plane API calls against the now-dead hostname.

3. DNS propagation is non-deterministic — cached entries may resolve briefly before failing with dial tcp: lookup acctestkeyvault8wyox.vault.azure.net: no such host, making the tests inherently flaky.

These tests provide little value while causing frequent failures, so removing them improves overall test reliability.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

<img width="1084" height="917" alt="image" src="https://github.com/user-attachments/assets/03efd605-808b-4470-b356-750c20b1280f" />

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_key_vault` - handling destroy when key vault is already deleted outside of Terraform


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related PR(s)
* #30403 

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
