### PR TITLE
`azurerm_data_factory_linked_service_sftp` - Add MFA auth type

### DIFF
--- a/internal/services/datafactory/data_factory_linked_service_sftp_resource.go
+++ b/internal/services/datafactory/data_factory_linked_service_sftp_resource.go
@@ -6,6 +6,7 @@ package datafactory
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -125,13 +126,13 @@ func resourceDataFactoryLinkedServiceSFTP() *pluginsdk.Resource {
 				Type:          pluginsdk.TypeString,
 				Optional:      true,
 				Sensitive:     true,
-				ConflictsWith: []string{"password", "key_vault_password", "key_vault_private_key_passphrase"},
+				ConflictsWith: []string{"key_vault_private_key_passphrase"},
 			},
 
 			"key_vault_private_key_passphrase": {
 				Type:          pluginsdk.TypeList,
 				Optional:      true,
-				ConflictsWith: []string{"password", "key_vault_password", "private_key_passphrase"},
+				ConflictsWith: []string{"private_key_passphrase"},
 				MaxItems:      1,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
@@ -151,16 +152,17 @@ func resourceDataFactoryLinkedServiceSFTP() *pluginsdk.Resource {
 			},
 
 			"password": {
-				Type:         pluginsdk.TypeString,
-				Optional:     true,
-				Sensitive:    true,
-				ValidateFunc: validation.StringIsNotEmpty,
-				ExactlyOneOf: []string{"password", "key_vault_password", "private_key_content_base64", "key_vault_private_key_content_base64", "private_key_path"},
+				Type:          pluginsdk.TypeString,
+				Optional:      true,
+				Sensitive:     true,
+				ValidateFunc:  validation.StringIsNotEmpty,
+				ConflictsWith: []string{"key_vault_password"},
 			},
 
 			"key_vault_password": {
-				Type:     pluginsdk.TypeList,
-				Optional: true,
+				Type:          pluginsdk.TypeList,
+				Optional:      true,
+				ConflictsWith: []string{"password"},
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
 						"linked_service_name": {
@@ -179,16 +181,18 @@ func resourceDataFactoryLinkedServiceSFTP() *pluginsdk.Resource {
 			},
 
 			"private_key_content_base64": {
-				Type:         pluginsdk.TypeString,
-				Optional:     true,
-				Sensitive:    true,
-				ValidateFunc: validation.StringIsBase64,
+				Type:          pluginsdk.TypeString,
+				Optional:      true,
+				Sensitive:     true,
+				ValidateFunc:  validation.StringIsBase64,
+				ConflictsWith: []string{"key_vault_private_key_content_base64", "private_key_path"},
 			},
 
 			"key_vault_private_key_content_base64": {
-				Type:     pluginsdk.TypeList,
-				Optional: true,
-				MaxItems: 1,
+				Type:          pluginsdk.TypeList,
+				Optional:      true,
+				MaxItems:      1,
+				ConflictsWith: []string{"private_key_content_base64", "private_key_path"},
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
 						"linked_service_name": {
@@ -207,8 +211,9 @@ func resourceDataFactoryLinkedServiceSFTP() *pluginsdk.Resource {
 			},
 
 			"private_key_path": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
+				Type:          pluginsdk.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"key_vault_private_key_content_base64", "private_key_content_base64"},
 			},
 
 			"skip_host_key_validation": {
@@ -221,6 +226,7 @@ func resourceDataFactoryLinkedServiceSFTP() *pluginsdk.Resource {
 				authCombinations := map[string]string{
 					"private_key_content_base64":           string(datafactory.SftpAuthenticationTypeSSHPublicKey),
 					"key_vault_private_key_content_base64": string(datafactory.SftpAuthenticationTypeSSHPublicKey),
+					"key_vault_private_key_passphrase":     string(datafactory.SftpAuthenticationTypeSSHPublicKey),
 					"private_key_path":                     string(datafactory.SftpAuthenticationTypeSSHPublicKey),
 					"password":                             string(datafactory.SftpAuthenticationTypeBasic),
 					"key_vault_password":                   string(datafactory.SftpAuthenticationTypeBasic),
@@ -228,8 +234,8 @@ func resourceDataFactoryLinkedServiceSFTP() *pluginsdk.Resource {
 
 				for keyType, authType := range authCombinations {
 					if _, ok := d.GetOk(keyType); ok {
-						if d.Get("authentication_type").(string) != authType {
-							return fmt.Errorf("`authentication_type` must be `%s` when `%s` is defined", authType, keyType)
+						if !slices.Contains([]string{authType, string(datafactory.SftpAuthenticationTypeMultiFactor)}, d.Get("authentication_type").(string)) {
+							return fmt.Errorf("when `%s` is defined, `authentication_type` must be `%s` or `%s`", keyType, authType, datafactory.SftpAuthenticationTypeMultiFactor)
 						}
 					}
 				}

--- a/internal/services/datafactory/data_factory_linked_service_sftp_resource_test.go
+++ b/internal/services/datafactory/data_factory_linked_service_sftp_resource_test.go
@@ -118,7 +118,7 @@ func TestAccDataFactoryLinkedServiceSFTP_mfa(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("private_key_content_base64", "private_key_passphrase"),
+		data.ImportStep("private_key_content_base64", "private_key_passphrase", "password"),
 	})
 }
 

--- a/internal/services/datafactory/data_factory_linked_service_sftp_resource_test.go
+++ b/internal/services/datafactory/data_factory_linked_service_sftp_resource_test.go
@@ -107,6 +107,21 @@ func TestAccDataFactoryLinkedServiceSFTP_keyVaultReference(t *testing.T) {
 	})
 }
 
+func TestAccDataFactoryLinkedServiceSFTP_mfa(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_data_factory_linked_service_sftp", "test")
+	r := LinkedServiceSFTPResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.mfa(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("private_key_content_base64", "private_key_passphrase"),
+	})
+}
+
 func (LinkedServiceSFTPResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.LinkedServiceID(state.ID)
 	if err != nil {
@@ -268,6 +283,32 @@ resource "azurerm_data_factory_linked_service_sftp" "test" {
   key_vault_password {
     linked_service_name = azurerm_data_factory_linked_service_key_vault.test.name
     secret_name         = "password"
+  }
+}
+`, r.template(data), r.keyKeyVault(data), data.RandomInteger)
+}
+
+func (r LinkedServiceSFTPResource) mfa(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+%[2]s
+resource "azurerm_data_factory_linked_service_sftp" "test" {
+  name                = "acctestlssftp%[3]d"
+  data_factory_id     = azurerm_data_factory.test.id
+  authentication_type = "MultiFactor"
+  host                = "http://www.bing.com"
+  port                = 22
+  username            = "foo"
+  password            = "bar"
+
+  key_vault_private_key_content_base64 {
+    linked_service_name = azurerm_data_factory_linked_service_key_vault.test.name
+    secret_name         = "private_key_content_base64"
+  }
+
+  key_vault_private_key_passphrase {
+    linked_service_name = azurerm_data_factory_linked_service_key_vault.test.name
+    secret_name         = "private_key_passphrase"
   }
 }
 `, r.template(data), r.keyKeyVault(data), data.RandomInteger)


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

`azurerm_data_factory_linked_service_sftp` - In the Azure spec, this resource supports three authentication types:

1. "Basic": inputs are username and password
2. "SshPublicKey": inputs are a private key and optionally, if the key requires it, the key's passphrase
3. "MultiFactor": the sum of "Basic" and "SshPublicKey"

The provider currently only accepts "Basic" and "SshPublicKey" as valid inputs for "authentication_type". This PR expands the validation to match Azure, i.e. also allowing "MultiFactor".

In addition to revising the validation on the "authentication_type" property, the existing validation (mainly the custom diff, but also property-level validation) required adjusting. It was implemented with the expectation that only "Basic" or "SshPublicKey" would be supported. Because these two types share no inputs, the provider could return a validation error if one's input was provided, but the other type was being used.

The "MultiFactor" type is the sum of the two types' requirements, so the method above could no longer be used. The critical change is:

```go
if _, ok := d.GetOk(keyType); ok {
	if d.Get("authentication_type").(string) != authType {
		return fmt.Errorf("`authentication_type` must be `%s` when `%s` is defined", authType, keyType)
```
had to become
```go
if _, ok := d.GetOk(keyType); ok {
	if !slices.Contains([]string{authType, "MultiFactor")}, d.Get("authentication_type").(string)) {
		return fmt.Errorf("when `%s` is defined, `authentication_type` must be `%s` or `MultiFactor`", keyType, authType)
```

Many of the authentication inputs can be provided via multiple (mutually exclusive) arguments, e.g. "password" and "key_vault_password". This PR addresses a few minor gaps in the validation to reflect the mutual exclusivity.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.
For example: "`resource_name_here` - description of change e.g. adding property `new_property_name_here`"

## Testing

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<img width="1203" height="623" alt="image" src="https://github.com/user-attachments/assets/3ec44a93-edf3-4311-a0a7-ff07afd03327" />

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).
* `azurerm_data_factory_linked_service_sftp` - * `azurerm_data_factory_linked_service_sftp` - Add MFA auth type` [GH-30466] [GH-30466]

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change

## Related Issue(s)
Fixes #

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan
If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls
Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE]
> If this PR changes meaningfully during the course of review please update the title and description as required.