### PR TITLE
`azurerm_mysql_flexible_server` - fix failing acceptance test

### DIFF
--- a/internal/services/mysql/mysql_flexible_server_resource_test.go
+++ b/internal/services/mysql/mysql_flexible_server_resource_test.go
@@ -505,12 +505,12 @@ func TestAccMySqlFlexibleServer_writeOnlyPassword(t *testing.T) {
 		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
 		Steps: []resource.TestStep{
 			{
-				Config: r.writeOnlyPassword(data, "a-secret-from-kv", 1),
+				Config: r.writeOnlyPassword(data, "A-secret-from-kv", 1),
 				Check:  check.That(data.ResourceName).ExistsInAzure(r),
 			},
 			data.ImportStep("administrator_password_wo_version"),
 			{
-				Config: r.writeOnlyPassword(data, "a-secret-from-kv-updated", 2),
+				Config: r.writeOnlyPassword(data, "A-secret-from-kv-updated", 2),
 				Check:  check.That(data.ResourceName).ExistsInAzure(r),
 			},
 			data.ImportStep("administrator_password_wo_version"),
@@ -534,7 +534,7 @@ func TestAccMySqlFlexibleServer_updateToWriteOnlyPassword(t *testing.T) {
 			},
 			data.ImportStep("administrator_password"),
 			{
-				Config: r.writeOnlyPassword(data, "a-secret-from-kv", 1),
+				Config: r.writeOnlyPassword(data, "A-secret-from-kv", 1),
 				Check:  check.That(data.ResourceName).ExistsInAzure(r),
 			},
 			data.ImportStep("administrator_password", "administrator_password_wo_version"),


### PR DESCRIPTION
- Fix acceptance test [TestAccMySqlFlexibleServer_writeOnlyPassword](https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_MYSQL/450331?buildTab=tests&status=failed&expandedTest=build%3A%28id%3A450331%29%2Cid%3A2000000030) and [TestAccMySqlFlexibleServer_updateToWriteOnlyPassword](https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_MYSQL/450331?buildTab=tests&status=failed&expandedTest=build%3A%28id%3A450331%29%2Cid%3A2000000032) failure.


- Test Results:

<img width="526" height="435" alt="image" src="https://github.com/user-attachments/assets/7dbc494b-cc50-4d9a-8656-338075c1d38b" />

