### PR TITLE
`azurerm_netapp_account` - adding property `nfsv4_id_domain`

### DIFF
--- a/examples/netapp/nfsv41_id_domain/README.md
+++ b/examples/netapp/nfsv41_id_domain/README.md
@@ -1,0 +1,11 @@
+## Example: NetApp Account with NFSv4.1 ID Domain
+
+This example demonstrates how to configure a NetApp Account with NFSv4.1 ID domain functionality for proper user and group name mapping in NFSv4.1 protocols.
+
+### Variables
+
+* `prefix` - (Required) The prefix used for all resources in this example.
+
+* `location` - (Required) The Azure Region in which the resources in this example should be created.
+
+* `nfsv4_id_domain` - (Required) The NFSv4 ID domain for user and group name mapping.

--- a/examples/netapp/nfsv41_id_domain/main.tf
+++ b/examples/netapp/nfsv41_id_domain/main.tf
@@ -1,0 +1,99 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~>4.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+# Create Resource Group
+resource "azurerm_resource_group" "example" {
+  name     = "${var.prefix}-resources"
+  location = var.location
+}
+
+# Create NetApp Account with NFSv4.1 ID Domain
+resource "azurerm_netapp_account" "example" {
+  name                = "${var.prefix}-netapp-account"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  nfsv4_id_domain     = var.nfsv4_id_domain
+
+  tags = {
+    purpose = "NFSv4.1 ID Domain Example"
+  }
+}
+
+# Create NetApp Pool
+resource "azurerm_netapp_pool" "example" {
+  name                = "${var.prefix}-netapp-pool"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  account_name        = azurerm_netapp_account.example.name
+  service_level       = "Standard"
+  size_in_tb          = 4
+}
+
+# Create Virtual Network
+resource "azurerm_virtual_network" "example" {
+  name                = "${var.prefix}-vnet"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  address_space       = ["10.0.0.0/16"]
+}
+
+# Create Subnet
+resource "azurerm_subnet" "example" {
+  name                 = "${var.prefix}-subnet"
+  resource_group_name  = azurerm_resource_group.example.name
+  virtual_network_name = azurerm_virtual_network.example.name
+  address_prefixes     = ["10.0.1.0/24"]
+
+  delegation {
+    name = "netapp"
+
+    service_delegation {
+      name    = "Microsoft.Netapp/volumes"
+      actions = ["Microsoft.Network/networkinterfaces/*", "Microsoft.Network/virtualNetworks/subnets/join/action"]
+    }
+  }
+}
+
+# Create NetApp Volume with NFSv4.1
+resource "azurerm_netapp_volume" "example" {
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  name                = "${var.prefix}-netapp-volume"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  account_name        = azurerm_netapp_account.example.name
+  pool_name           = azurerm_netapp_pool.example.name
+  volume_path         = "${var.prefix}-my-unique-file-path"
+  service_level       = "Standard"
+  subnet_id           = azurerm_subnet.example.id
+  protocols           = ["NFSv4.1"]
+  storage_quota_in_gb = 100
+
+  export_policy_rule {
+    rule_index          = 1
+    allowed_clients     = ["0.0.0.0/0"]
+    protocols_enabled   = ["NFSv4.1"]
+    unix_read_only      = false
+    unix_read_write     = true
+    root_access_enabled = true
+  }
+
+  tags = {
+    purpose = "NFSv4.1 Volume Example"
+  }
+}

--- a/examples/netapp/nfsv41_id_domain/variables.tf
+++ b/examples/netapp/nfsv41_id_domain/variables.tf
@@ -1,0 +1,20 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+variable "prefix" {
+  description = "The prefix which should be used for all resources in this example"
+  type        = string
+  default     = "nfsv41-id-domain"
+}
+
+variable "location" {
+  description = "The Azure Region in which all resources in this example should be created."
+  type        = string
+  default     = "WestUS3"
+}
+
+variable "nfsv4_id_domain" {
+  description = "The NFSv4 ID domain for the NetApp account"
+  type        = string
+  default     = "example.com"
+}

--- a/internal/services/netapp/netapp_account_data_source.go
+++ b/internal/services/netapp/netapp_account_data_source.go
@@ -40,6 +40,12 @@ func dataSourceNetAppAccount() *pluginsdk.Resource {
 
 			"identity": commonschema.SystemOrUserAssignedIdentityOptional(),
 
+			"nfsv4_id_domain": {
+				Type:        pluginsdk.TypeString,
+				Computed:    true,
+				Description: "The NFSv4 ID domain for this NetApp Account.",
+			},
+
 			"tags": commonschema.TagsDataSource(),
 		},
 	}
@@ -67,6 +73,10 @@ func dataSourceNetAppAccountRead(d *pluginsdk.ResourceData, meta interface{}) er
 
 	if model := resp.Model; model != nil {
 		d.Set("location", location.NormalizeNilable(&model.Location))
+
+		if properties := model.Properties; properties != nil {
+			d.Set("nfsv4_id_domain", properties.NfsV4IDDomain)
+		}
 
 		identity, err := identity.FlattenLegacySystemAndUserAssignedMap(model.Identity)
 		if err != nil {

--- a/internal/services/netapp/netapp_account_data_source_test.go
+++ b/internal/services/netapp/netapp_account_data_source_test.go
@@ -44,6 +44,22 @@ func TestAccDataSourceNetAppAccount_systemAssignedManagedIdentity(t *testing.T) 
 	})
 }
 
+func TestAccDataSourceNetAppAccount_nfsv4IdDomain(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_netapp_account", "test")
+	r := NetAppAccountDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.nfsv4IdDomainConfig(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("resource_group_name").Exists(),
+				check.That(data.ResourceName).Key("name").Exists(),
+				check.That(data.ResourceName).Key("nfsv4_id_domain").HasValue("example.com"),
+			),
+		},
+	})
+}
+
 func (r NetAppAccountDataSource) basicConfig(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
@@ -64,4 +80,15 @@ data "azurerm_netapp_account" "test" {
   name                = azurerm_netapp_account.test.name
 }
 `, NetAppAccountResource{}.systemAssignedManagedIdentity(data))
+}
+
+func (r NetAppAccountDataSource) nfsv4IdDomainConfig(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_netapp_account" "test" {
+  resource_group_name = azurerm_netapp_account.test.resource_group_name
+  name                = azurerm_netapp_account.test.name
+}
+`, NetAppAccountResource{}.nfsv4IdDomainConfig(data))
 }

--- a/internal/services/netapp/netapp_account_resource_test.go
+++ b/internal/services/netapp/netapp_account_resource_test.go
@@ -186,6 +186,51 @@ func TestAccNetAppAccount_updateManagedIdentity(t *testing.T) {
 	})
 }
 
+func TestAccNetAppAccount_nfsv4IdDomain(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_netapp_account", "test")
+	r := NetAppAccountResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.nfsv4IdDomainConfig(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("nfsv4_id_domain").HasValue("example.com"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccNetAppAccount_nfsv4IdDomainUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_netapp_account", "test")
+	r := NetAppAccountResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicConfig(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		{
+			Config: r.nfsv4IdDomainConfig(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("nfsv4_id_domain").HasValue("example.com"),
+			),
+		},
+		{
+			Config: r.nfsv4IdDomainUpdateConfig(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("nfsv4_id_domain").HasValue("updated.example.com"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (t NetAppAccountResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := netappaccounts.ParseNetAppAccountID(state.ID)
 	if err != nil {
@@ -347,4 +392,38 @@ resource "azurerm_resource_group" "test" {
 
 
 `, data.RandomInteger, data.Locations.Primary)
+}
+
+func (NetAppAccountResource) nfsv4IdDomainConfig(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_netapp_account" "test" {
+  name                = "acctest-NetAppAccount-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  nfsv4_id_domain     = "example.com"
+
+  tags = {
+    CreatedOnDate = "2022-07-08T23:50:21Z"
+  }
+}
+`, NetAppAccountResource{}.template(data), data.RandomInteger)
+}
+
+func (NetAppAccountResource) nfsv4IdDomainUpdateConfig(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_netapp_account" "test" {
+  name                = "acctest-NetAppAccount-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  nfsv4_id_domain     = "updated.example.com"
+
+  tags = {
+    CreatedOnDate = "2022-07-08T23:50:21Z"
+  }
+}
+`, NetAppAccountResource{}.template(data), data.RandomInteger)
 }

--- a/website/docs/d/netapp_account.html.markdown
+++ b/website/docs/d/netapp_account.html.markdown
@@ -37,6 +37,8 @@ The following attributes are exported:
 
 * `location` - The Azure Region where the NetApp Account exists.
 
+* `nfsv4_id_domain` - The NFSv4.1 ID domain used for user and group name to UID and GID mappings.
+
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:

--- a/website/docs/r/netapp_account.html.markdown
+++ b/website/docs/r/netapp_account.html.markdown
@@ -33,6 +33,7 @@ resource "azurerm_netapp_account" "example" {
   name                = "netappaccount"
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
+  nfsv4_id_domain     = "example.com"
 
   active_directory {
     username            = "aduser"
@@ -62,6 +63,8 @@ The following arguments are supported:
 * `resource_group_name` - (Required) The name of the resource group where the NetApp Account should be created. Changing this forces a new resource to be created.
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
+
+* `nfsv4_id_domain` - (Optional) The NFSv4 ID domain for this NetApp Account.
 
 * `active_directory` - (Optional) A `active_directory` block as defined below.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This PR implements support for `nfsv4_id_domain` property in `netapp_account` resource.

## PR Checklist

- [X] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [X] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [X] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [X] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [X] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”

## Testing 

- [X] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

### Test outputs

```
Acceptance Tests
================

Resource
--------

==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
egrep: warning: egrep is obsolescent; using grep -E
egrep: warning: egrep is obsolescent; using grep -E
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/netapp -parallel 1 -run=TestAccNetAppAccount -count=1 -timeout 1200m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccNetAppAccountEncryptionDataSource_basic
=== PAUSE TestAccNetAppAccountEncryptionDataSource_basic
=== RUN   TestAccNetAppAccountEncryption_cmkSystemAssigned
=== PAUSE TestAccNetAppAccountEncryption_cmkSystemAssigned
=== RUN   TestAccNetAppAccountEncryption_cmkUserAssigned
=== PAUSE TestAccNetAppAccountEncryption_cmkUserAssigned
=== RUN   TestAccNetAppAccountEncryption_updateKey
=== PAUSE TestAccNetAppAccountEncryption_updateKey
=== RUN   TestAccNetAppAccountResource
=== RUN   TestAccNetAppAccountResource/Resource
=== RUN   TestAccNetAppAccountResource/Resource/basic
=== PAUSE TestAccNetAppAccountResource/Resource/basic
=== CONT  TestAccNetAppAccountResource/Resource/basic
=== RUN   TestAccNetAppAccountResource/Resource#01
=== RUN   TestAccNetAppAccountResource/Resource#01/requiresImport
=== PAUSE TestAccNetAppAccountResource/Resource#01/requiresImport
=== CONT  TestAccNetAppAccountResource/Resource#01/requiresImport
=== RUN   TestAccNetAppAccountResource/Resource#02
=== RUN   TestAccNetAppAccountResource/Resource#02/complete
=== PAUSE TestAccNetAppAccountResource/Resource#02/complete
=== CONT  TestAccNetAppAccountResource/Resource#02/complete
=== RUN   TestAccNetAppAccountResource/Resource#03
=== RUN   TestAccNetAppAccountResource/Resource#03/update
=== PAUSE TestAccNetAppAccountResource/Resource#03/update
=== CONT  TestAccNetAppAccountResource/Resource#03/update
--- PASS: TestAccNetAppAccountResource (537.65s)
    --- PASS: TestAccNetAppAccountResource/Resource (0.00s)
        --- PASS: TestAccNetAppAccountResource/Resource/basic (142.06s)
    --- PASS: TestAccNetAppAccountResource/Resource#01 (0.00s)
        --- PASS: TestAccNetAppAccountResource/Resource#01/requiresImport (114.06s)
    --- PASS: TestAccNetAppAccountResource/Resource#02 (0.00s)
        --- PASS: TestAccNetAppAccountResource/Resource#02/complete (121.33s)
    --- PASS: TestAccNetAppAccountResource/Resource#03 (0.00s)
        --- PASS: TestAccNetAppAccountResource/Resource#03/update (160.20s)
=== RUN   TestAccNetAppAccount_systemAssignedManagedIdentity
=== PAUSE TestAccNetAppAccount_systemAssignedManagedIdentity
=== RUN   TestAccNetAppAccount_userAssignedManagedIdentity
=== PAUSE TestAccNetAppAccount_userAssignedManagedIdentity
=== RUN   TestAccNetAppAccount_updateManagedIdentity
=== PAUSE TestAccNetAppAccount_updateManagedIdentity
=== RUN   TestAccNetAppAccount_nfsv4IdDomain
=== PAUSE TestAccNetAppAccount_nfsv4IdDomain
=== RUN   TestAccNetAppAccount_nfsv4IdDomainUpdate
=== PAUSE TestAccNetAppAccount_nfsv4IdDomainUpdate
=== CONT  TestAccNetAppAccountEncryptionDataSource_basic
--- PASS: TestAccNetAppAccountEncryptionDataSource_basic (348.53s)
=== CONT  TestAccNetAppAccount_userAssignedManagedIdentity
=== CONT  TestAccNetAppAccount_nfsv4IdDomainUpdate
--- PASS: TestAccNetAppAccount_userAssignedManagedIdentity (140.98s)
--- PASS: TestAccNetAppAccount_nfsv4IdDomainUpdate (192.08s)
=== CONT  TestAccNetAppAccount_nfsv4IdDomain
--- PASS: TestAccNetAppAccount_nfsv4IdDomain (117.91s)
=== CONT  TestAccNetAppAccount_updateManagedIdentity
=== CONT  TestAccNetAppAccountEncryption_updateKey
--- PASS: TestAccNetAppAccount_updateManagedIdentity (194.29s)
--- PASS: TestAccNetAppAccountEncryption_updateKey (515.63s)
=== CONT  TestAccNetAppAccount_systemAssignedManagedIdentity
--- PASS: TestAccNetAppAccount_systemAssignedManagedIdentity (120.51s)
=== CONT  TestAccNetAppAccountEncryption_cmkUserAssigned
--- PASS: TestAccNetAppAccountEncryption_cmkUserAssigned (368.81s)
=== CONT  TestAccNetAppAccountEncryption_cmkSystemAssigned
--- PASS: TestAccNetAppAccountEncryption_cmkSystemAssigned (380.97s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/netapp        2917.391s

Data Source
-----------

TESTTIMEOUT='1200m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
egrep: warning: egrep is obsolescent; using grep -E
egrep: warning: egrep is obsolescent; using grep -E
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/netapp -parallel 1 -run=TestAccDataSourceNetAppAccount -count=1 -timeout 1200m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccDataSourceNetAppAccount_basic
=== PAUSE TestAccDataSourceNetAppAccount_basic
=== RUN   TestAccDataSourceNetAppAccount_systemAssignedManagedIdentity
=== PAUSE TestAccDataSourceNetAppAccount_systemAssignedManagedIdentity
=== RUN   TestAccDataSourceNetAppAccount_nfsv4IdDomain
=== PAUSE TestAccDataSourceNetAppAccount_nfsv4IdDomain
=== CONT  TestAccDataSourceNetAppAccount_basic
--- PASS: TestAccDataSourceNetAppAccount_basic (109.04s)
=== CONT  TestAccDataSourceNetAppAccount_nfsv4IdDomain
--- PASS: TestAccDataSourceNetAppAccount_nfsv4IdDomain (100.68s)
=== CONT  TestAccDataSourceNetAppAccount_systemAssignedManagedIdentity
--- PASS: TestAccDataSourceNetAppAccount_systemAssignedManagedIdentity (98.54s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/netapp        308.303s

Terraform Configuration
=======================

Terraform apply
---------------

azurerm_netapp_volume.example: Still creating... [07m10s elapsed]
azurerm_netapp_volume.example: Still creating... [07m20s elapsed]
azurerm_netapp_volume.example: Still creating... [07m30s elapsed]
azurerm_netapp_volume.example: Still creating... [07m40s elapsed]
azurerm_netapp_volume.example: Still creating... [07m50s elapsed]
azurerm_netapp_volume.example: Creation complete after 7m51s [id=/subscriptions/66bc9830-19b6-4987-94d2-0e487be7aa47/resourceGroups/nfsv41-id-domain-resources/providers/Microsoft.NetApp/netAppAccounts/nfsv41-id-domain-netapp-account/capacityPools/nfsv41-id-domain-netapp-pool/volumes/nfsv41-id-domain-netapp-volume]
╷
│ Warning: Argument is deprecated
│
│   with azurerm_netapp_volume.example,
│   on main.tf line 90, in resource "azurerm_netapp_volume" "example":
│   90:     protocols_enabled   = ["NFSv4.1"]
│
│ this property has been deprecated in favour of `export_policy_rule.protocol` and will be removed in version 5.0 of the Provider.
╵

Apply complete! Resources: 6 added, 0 changed, 0 destroyed.

Terraform plan
--------------

╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - hashicorp/azurerm in /home/pmarques/go/src/github.com/hashicorp/terraform-provider-azurerm
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
azurerm_resource_group.example: Refreshing state... [id=/subscriptions/66bc9830-19b6-4987-94d2-0e487be7aa47/resourceGroups/nfsv41-id-domain-resources]
azurerm_netapp_account.example: Refreshing state... [id=/subscriptions/66bc9830-19b6-4987-94d2-0e487be7aa47/resourceGroups/nfsv41-id-domain-resources/providers/Microsoft.NetApp/netAppAccounts/nfsv41-id-domain-netapp-account]
azurerm_virtual_network.example: Refreshing state... [id=/subscriptions/66bc9830-19b6-4987-94d2-0e487be7aa47/resourceGroups/nfsv41-id-domain-resources/providers/Microsoft.Network/virtualNetworks/nfsv41-id-domain-vnet]
azurerm_netapp_pool.example: Refreshing state... [id=/subscriptions/66bc9830-19b6-4987-94d2-0e487be7aa47/resourceGroups/nfsv41-id-domain-resources/providers/Microsoft.NetApp/netAppAccounts/nfsv41-id-domain-netapp-account/capacityPools/nfsv41-id-domain-netapp-pool]
azurerm_subnet.example: Refreshing state... [id=/subscriptions/66bc9830-19b6-4987-94d2-0e487be7aa47/resourceGroups/nfsv41-id-domain-resources/providers/Microsoft.Network/virtualNetworks/nfsv41-id-domain-vnet/subnets/nfsv41-id-domain-subnet]
azurerm_netapp_volume.example: Refreshing state... [id=/subscriptions/66bc9830-19b6-4987-94d2-0e487be7aa47/resourceGroups/nfsv41-id-domain-resources/providers/Microsoft.NetApp/netAppAccounts/nfsv41-id-domain-netapp-account/capacityPools/nfsv41-id-domain-netapp-pool/volumes/nfsv41-id-domain-netapp-volume]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
╷
│ Warning: Argument is deprecated
│
│   with azurerm_netapp_volume.example,
│   on main.tf line 94, in resource "azurerm_netapp_volume" "example":
│   94:     protocols_enabled   = ["NFSv4.1"]
│
│ this property has been deprecated in favour of `export_policy_rule.protocol` and will be removed in version 5.0 of the Provider.
╵
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

* `azurerm_netapp_account` - support for new property called `nfsv4_id_domain`

This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [X] Enhancement
- [ ] Breaking Change

