### PR TITLE
`azurerm[_management_group]_policy_set_definition` - fix update for `policy_definition_reference`

### DIFF
--- a/internal/sdk/raw_config.go
+++ b/internal/sdk/raw_config.go
@@ -35,7 +35,7 @@ func (rmd ResourceMetaData) GetRawConfig() (cty.Value, error) {
 // This method is experimental and not meant for general use.
 // Pull requests using this method, by authors not part of the HashiCorp AzureRM Provider team, will be declined at this time.
 func (rmd ResourceMetaData) GetRawConfigAt(key string) (cty.Value, error) {
-	ctyPath := constructPath(key)
+	ctyPath := ConstructCtyPath(key)
 
 	msg := "retrieving value at path `%s`: %+v"
 
@@ -139,13 +139,13 @@ func asValueMap(val cty.Value) (map[string]cty.Value, error) {
 	return val.AsValueMap(), nil
 }
 
-// constructPath takes a string and converts it to a `cty.Path` for use with `GetRawConfigAt`
+// ConstructCtyPath takes a string and converts it to a `cty.Path` for use with `GetRawConfigAt`
 // e.g. `identity.0.type`
 //
 // Note:
 // This function is experimental and not meant for general use.
 // Pull requests using this function, by authors not part of the HashiCorp AzureRM Provider team, will be declined at this time.
-func constructPath(key string) cty.Path {
+func ConstructCtyPath(key string) cty.Path {
 	p := cty.Path{}
 
 	for _, segment := range strings.Split(key, ".") {

--- a/internal/services/policy/management_group_policy_set_definition_resource.go
+++ b/internal/services/policy/management_group_policy_set_definition_resource.go
@@ -160,7 +160,7 @@ func (r ManagementGroupPolicySetDefinitionResource) Create() sdk.ResourceFunc {
 			}
 
 			if len(model.PolicyDefinitionReference) > 0 {
-				expandedDefinitions, err := expandPolicyDefinitionReference(model.PolicyDefinitionReference)
+				expandedDefinitions, err := expandPolicyDefinitionReference(model.PolicyDefinitionReference, metadata)
 				if err != nil {
 					return fmt.Errorf("expanding `policy_definition_reference`: %+v", err)
 				}
@@ -306,7 +306,7 @@ func (r ManagementGroupPolicySetDefinitionResource) Update() sdk.ResourceFunc {
 			}
 
 			if metadata.ResourceData.HasChange("policy_definition_reference") {
-				expandedDefinitions, err := expandPolicyDefinitionReference(config.PolicyDefinitionReference)
+				expandedDefinitions, err := expandPolicyDefinitionReference(config.PolicyDefinitionReference, metadata)
 				if err != nil {
 					return fmt.Errorf("expanding `policy_definition_reference`: %+v", err)
 				}

--- a/internal/services/policy/management_group_policy_set_definition_resource_test.go
+++ b/internal/services/policy/management_group_policy_set_definition_resource_test.go
@@ -142,6 +142,35 @@ func TestAccManagementGroupPolicySetDefinition_removeParameter(t *testing.T) {
 	})
 }
 
+func TestAccManagementGroupPolicySetDefinition_updateMultiplePolicyDefinitionReferences(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_management_group_policy_set_definition", "test")
+	r := ManagementGroupPolicySetDefinitionResourceTest{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.multipleReferences(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.multipleReferencesUpdate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.multipleReferences(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (ManagementGroupPolicySetDefinitionResourceTest) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := policysetdefinitions.ParseProviders2PolicySetDefinitionID(state.ID)
 	if err != nil {
@@ -337,6 +366,52 @@ VALUES
 `, r.template(data), data.RandomInteger, version)
 }
 
+func (r ManagementGroupPolicySetDefinitionResourceTest) multipleReferences(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_management_group_policy_set_definition" "test" {
+  name                = "acctestMGPSD-%[2]d"
+  policy_type         = "Custom"
+  display_name        = "Test Initiative"
+  management_group_id = azurerm_management_group.test.id
+
+  policy_definition_reference {
+    policy_definition_id = data.azurerm_policy_definition_built_in.policyReference1.id
+  }
+
+  policy_definition_reference {
+    policy_definition_id = data.azurerm_policy_definition_built_in.policyReference2.id
+  }
+
+  policy_definition_reference {
+    policy_definition_id = data.azurerm_policy_definition_built_in.policyReference3.id
+  }
+}
+`, r.templateMultiplePolicies(data), data.RandomInteger)
+}
+
+func (r ManagementGroupPolicySetDefinitionResourceTest) multipleReferencesUpdate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_management_group_policy_set_definition" "test" {
+  name                = "acctestMGPSD-%[2]d"
+  policy_type         = "Custom"
+  display_name        = "Test Initiative"
+  management_group_id = azurerm_management_group.test.id
+
+  policy_definition_reference {
+    policy_definition_id = data.azurerm_policy_definition_built_in.policyReference1.id
+  }
+
+  policy_definition_reference {
+    policy_definition_id = data.azurerm_policy_definition_built_in.policyReference3.id
+  }
+}
+`, r.templateMultiplePolicies(data), data.RandomInteger)
+}
+
 func (r ManagementGroupPolicySetDefinitionResourceTest) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -380,6 +455,30 @@ POLICY_RULE
     }
   }
 PARAMETERS
+}
+`, data.RandomInteger)
+}
+
+func (ManagementGroupPolicySetDefinitionResourceTest) templateMultiplePolicies(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_management_group" "test" {
+  display_name = "acctestmg-%[1]d"
+}
+
+data "azurerm_policy_definition_built_in" "policyReference1" {
+  display_name = "App Service apps should require FTPS only"
+}
+
+data "azurerm_policy_definition_built_in" "policyReference2" {
+  display_name = "Storage accounts should restrict network access"
+}
+
+data "azurerm_policy_definition_built_in" "policyReference3" {
+  display_name = "Function apps should require FTPS only"
 }
 `, data.RandomInteger)
 }

--- a/internal/services/policy/policy_set_definition_resource_test.go
+++ b/internal/services/policy/policy_set_definition_resource_test.go
@@ -330,6 +330,35 @@ func TestAccAzureRMPolicySetDefinition_removeParameter(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMPolicySetDefinition_updateMultiplePolicyDefinitionReferences(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_policy_set_definition", "test")
+	r := PolicySetDefinitionResourceTest{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.multipleReferences(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.multipleReferencesUpdate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.multipleReferences(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (r PolicySetDefinitionResourceTest) builtIn(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -932,6 +961,50 @@ VALUES
 `, r.template(data), data.RandomInteger, version)
 }
 
+func (r PolicySetDefinitionResourceTest) multipleReferences(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_policy_set_definition" "test" {
+  name         = "acctestPSD-%[2]d"
+  policy_type  = "Custom"
+  display_name = "Test Initiative"
+
+  policy_definition_reference {
+    policy_definition_id = data.azurerm_policy_definition_built_in.policyReference1.id
+  }
+
+  policy_definition_reference {
+    policy_definition_id = data.azurerm_policy_definition_built_in.policyReference2.id
+  }
+
+  policy_definition_reference {
+    policy_definition_id = data.azurerm_policy_definition_built_in.policyReference3.id
+  }
+}
+`, r.templateMultiplePolicies(), data.RandomInteger)
+}
+
+func (r PolicySetDefinitionResourceTest) multipleReferencesUpdate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_policy_set_definition" "test" {
+  name         = "acctestPSD-%[2]d"
+  policy_type  = "Custom"
+  display_name = "Test Initiative"
+
+  policy_definition_reference {
+    policy_definition_id = data.azurerm_policy_definition_built_in.policyReference1.id
+  }
+
+  policy_definition_reference {
+    policy_definition_id = data.azurerm_policy_definition_built_in.policyReference3.id
+  }
+}
+`, r.templateMultiplePolicies(), data.RandomInteger)
+}
+
 func (r PolicySetDefinitionResourceTest) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -972,6 +1045,26 @@ POLICY_RULE
 PARAMETERS
 }
 `, data.RandomInteger)
+}
+
+func (PolicySetDefinitionResourceTest) templateMultiplePolicies() string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_policy_definition_built_in" "policyReference1" {
+  display_name = "App Service apps should require FTPS only"
+}
+
+data "azurerm_policy_definition_built_in" "policyReference2" {
+  display_name = "Storage accounts should restrict network access"
+}
+
+data "azurerm_policy_definition_built_in" "policyReference3" {
+  display_name = "Function apps should require FTPS only"
+}
+`)
 }
 
 func (r PolicySetDefinitionResourceTest) templateNoParameter(data acceptance.TestData) string {

--- a/internal/services/policy/policy_set_definition_resource_test.go
+++ b/internal/services/policy/policy_set_definition_resource_test.go
@@ -1048,7 +1048,7 @@ PARAMETERS
 }
 
 func (PolicySetDefinitionResourceTest) templateMultiplePolicies() string {
-	return fmt.Sprintf(`
+	return `
 provider "azurerm" {
   features {}
 }
@@ -1064,7 +1064,7 @@ data "azurerm_policy_definition_built_in" "policyReference2" {
 data "azurerm_policy_definition_built_in" "policyReference3" {
   display_name = "Function apps should require FTPS only"
 }
-`)
+`
 }
 
 func (r PolicySetDefinitionResourceTest) templateNoParameter(data acceptance.TestData) string {

--- a/internal/tf/pluginsdk/convert.go
+++ b/internal/tf/pluginsdk/convert.go
@@ -9,7 +9,7 @@ import (
 )
 
 // GoValueFromTerraformValue returns a pointer to the Native Go value for the provided input cty.Value
-// If the input value is null, a nil pointer for the type is returned.
+// If the input value is null, a pointer to the zero-value for the type is returned.
 // This is a generics function, usage requires supplying the expected type.
 // e.g. out, err := GoValueFromTerraformValue[string](someVal)
 // NOTE: This helper is experimental and should only be used by Hashicorp maintainers until further notice


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This resolves an issue with the version not matching the `policy_definition_id` when `policy_definition_reference` blocks were added/removed.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

4.0 testing:
<img width="330" height="149" alt="image" src="https://github.com/user-attachments/assets/f9605f8b-b934-441e-b1ae-b042ad93d0ee" />

5.0 beta testing:
<img width="334" height="146" alt="image" src="https://github.com/user-attachments/assets/bc45a806-4bf8-4c54-b672-305a1b4ec83d" />

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
