### PR TITLE
`azurerm_postgresql_flexible_server` : fix acctests failure

### DIFF
--- a/internal/services/postgres/postgresql_flexible_server_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_resource.go
@@ -692,7 +692,20 @@ func resourcePostgresqlFlexibleServerRead(d *pluginsdk.ResourceData, meta interf
 			d.Set("zone", props.AvailabilityZone)
 			d.Set("version", pointer.From(props.Version))
 			d.Set("fqdn", props.FullyQualifiedDomainName)
-			d.Set("source_server_id", props.SourceServerResourceId)
+
+			// According to the API spec, `sourceServerResourceId`(`source_server_id`) is only returned by the Azure REST API
+			// when `create_mode` is 'Replica'. For other create modes, this field is not returned, which is intended behavior of the API.
+			// Therefore, we populate this field from the API response if present; otherwise, we read the value from the configuration.
+			sourceResourceId := pointer.From(props.SourceServerResourceId)
+			if sourceResourceId == "" {
+				sourceResourceId = d.Get("source_server_id").(string)
+			}
+			d.Set("source_server_id", sourceResourceId)
+
+			// `pointInTimeUTC` has "x-ms-mutability": ["create"], so it's only used at creation.
+			// Without "read," it's not persisted in the resource model and won't appear in GET responses.
+			// So read it from the configuration.
+			d.Set("point_in_time_restore_time_in_utc", d.Get("point_in_time_restore_time_in_utc").(string))
 
 			// Currently, `replicationRole` is set to `Primary` when `createMode` is `Replica` and `replicationRole` is updated to `None`. Service team confirmed it should be set to `None` for this scenario. See more details from https://github.com/Azure/azure-rest-api-specs/issues/22499
 			d.Set("replication_role", d.Get("replication_role").(string))


### PR DESCRIPTION
The following acceptance tests are failing due to changes to `source_server_id` introduced in PR [#30350](https://github.com/hashicorp/terraform-provider-azurerm/pull/30350):

- [TestAccPostgresqlFlexibleServer_geoRestore](https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_POSTGRES/452871?buildTab=tests&status=failed&name=TestAccPostgresqlFlexibleServer_geoRestore&expandedTest=build%3A%28id%3A452871%29%2Cid%3A2000000102)
- [TestAccPostgresqlFlexibleServer_pointInTimeRestore](https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_POSTGRES/452871?buildTab=tests&status=failed&name=TestAccPostgresqlFlexibleServer_pointInTimeRestore&expandedTest=build%3A%28id%3A452871%29%2Cid%3A2000000090)
- [TestAccPostgresqlFlexibleServer_replica](https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_POSTGRES/452871?buildTab=tests&status=failed&name=TestAccPostgresqlFlexibleServer_replica&expandedTest=build%3A%28id%3A452871%29%2Cid%3A2000000097)

According to the [description](https://github.com/Azure/azure-rest-api-specs/blob/0202b86915d236c7a625c64215374b056b75ae25/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/stable/2024-08-01/FlexibleServers.json#L570) of `sourceServerResourceId`：
_"Identifier of the flexible server to be used as the source of the new flexible server. Required when 'createMode' is 'PointInTimeRestore', 'GeoRestore', 'Replica', or 'ReviveDropped'. This property is returned only when the target flexible server is a read replica."_

This PR updates the logic to set `source_server_id` from the API when available, or fall back to the configuration otherwise, in order to fix the test failures and address GH [#30497](https://github.com/hashicorp/terraform-provider-azurerm/issues/30479).

Additionally, it fixes the `point_in_time_restore_time_in_utc` issue mentioned in GH [#30497](https://github.com/hashicorp/terraform-provider-azurerm/issues/30479). Since `pointInTimeUTC` has "x-ms-mutability": ["create"], it is only used during creation. Without "read", it is not persisted in the resource model and therefore does not appear in GET responses. As a result, the value is now read from the configuration.

Test Results:
<img width="419" height="481" alt="image" src="https://github.com/user-attachments/assets/dc4e0634-edc7-4ced-aa73-a3b8518636f4" />

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [X] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #30479

