### PR TITLE
`azurerm_*_policy_assignment` - `override.kind` can now be configured

### DIFF
--- a/internal/services/policy/assignment_resource_base.go
+++ b/internal/services/policy/assignment_resource_base.go
@@ -430,7 +430,6 @@ func (br assignmentBaseResource) arguments(fields map[string]*pluginsdk.Schema) 
 								"kind": {
 									Type:     pluginsdk.TypeString,
 									Optional: true,
-									Computed: true,
 									Default:  policyassignments.SelectorKindPolicyDefinitionReferenceId,
 									ValidateFunc: validation.StringInSlice([]string{
 										string(policyassignments.SelectorKindPolicyDefinitionReferenceId),

--- a/internal/services/policy/assignment_resource_base.go
+++ b/internal/services/policy/assignment_resource_base.go
@@ -427,12 +427,15 @@ func (br assignmentBaseResource) arguments(fields map[string]*pluginsdk.Schema) 
 									},
 								},
 
-								// The supported selector kinds in a policy effect override are 'PolicyDefinitionReferenceId'.
-								// https://learn.microsoft.com/en-us/azure/governance/policy/concepts/assignment-structure#overrides-preview
-								// so make kind as computed for selector of override
 								"kind": {
 									Type:     pluginsdk.TypeString,
+									Optional: true,
 									Computed: true,
+									Default:  policyassignments.SelectorKindPolicyDefinitionReferenceId,
+									ValidateFunc: validation.StringInSlice([]string{
+										string(policyassignments.SelectorKindPolicyDefinitionReferenceId),
+										string(policyassignments.SelectorKindResourceLocation),
+									}, false),
 								},
 
 								"not_in": {
@@ -566,7 +569,7 @@ func (br assignmentBaseResource) expandOverrides(overrides []interface{}) *[]pol
 			var item policyassignments.Override
 			item.Value = pointer.To(m["value"].(string))
 			item.Kind = pointer.To(policyassignments.OverrideKindPolicyEffect)
-			item.Selectors = br.expandSelectors(m["selectors"].([]interface{}), true)
+			item.Selectors = br.expandSelectors(m["selectors"].([]interface{}))
 			res = append(res, item)
 		}
 	}
@@ -590,7 +593,7 @@ func (br assignmentBaseResource) expandStringSlice(in interface{}) (res []string
 	return res
 }
 
-func (br assignmentBaseResource) expandSelectors(i []interface{}, isOverride bool) *[]policyassignments.Selector {
+func (br assignmentBaseResource) expandSelectors(i []interface{}) *[]policyassignments.Selector {
 	if len(i) == 0 {
 		return nil
 	}
@@ -599,11 +602,7 @@ func (br assignmentBaseResource) expandSelectors(i []interface{}, isOverride boo
 	for _, v := range i {
 		if m, ok := v.(map[string]interface{}); ok {
 			var item policyassignments.Selector
-			if isOverride {
-				item.Kind = pointer.To(policyassignments.SelectorKindPolicyDefinitionReferenceId)
-			} else {
-				item.Kind = pointer.To(policyassignments.SelectorKind(m["kind"].(string)))
-			}
+			item.Kind = pointer.To(policyassignments.SelectorKind(m["kind"].(string)))
 			if in := br.expandStringSlice(m["in"]); len(in) > 0 {
 				item.In = pointer.To(in)
 			}
@@ -627,7 +626,7 @@ func (br assignmentBaseResource) expandResourceSelectors(rs []interface{}) *[]po
 		if m, ok := v.(map[string]interface{}); ok {
 			var item policyassignments.ResourceSelector
 			item.Name = pointer.To(m["name"].(string))
-			item.Selectors = br.expandSelectors(m["selectors"].([]interface{}), false)
+			item.Selectors = br.expandSelectors(m["selectors"].([]interface{}))
 			res = append(res, item)
 		}
 	}

--- a/internal/services/policy/policy_virtual_machine_configuration_assignment_resource_test.go
+++ b/internal/services/policy/policy_virtual_machine_configuration_assignment_resource_test.go
@@ -227,7 +227,7 @@ resource "azurerm_policy_virtual_machine_configuration_assignment" "test" {
   configuration {
     version         = "1.1.1.1"
     assignment_type = "ApplyAndAutoCorrect"
-    content_hash    = "testcontenthash"
+    content_hash    = upper("db4d5cd43c59c756f9beb1f029c858bc341587bf75332288270a26493565f058")
     content_uri     = "https://testcontenturi/package"
 
     parameter {
@@ -251,7 +251,7 @@ resource "azurerm_policy_virtual_machine_configuration_assignment" "test" {
   configuration {
     version         = "1.1.1.1"
     assignment_type = "Audit"
-    content_hash    = "testcontenthash2"
+    content_hash    = upper("cde01f651f3a3055834753d42d73b44e2a505844ac34f9ccc35d3d6dfffcb2e4")
     content_uri     = "https://testcontenturi/package2"
 
     parameter {

--- a/website/docs/r/management_group_policy_assignment.html.markdown
+++ b/website/docs/r/management_group_policy_assignment.html.markdown
@@ -78,7 +78,7 @@ The following arguments are supported:
 
 * `parameters` - (Optional) A JSON mapping of any Parameters for this Policy.
 
-* `overrides` - (Optional) One or more `overrides` blocks as defined below. More detail about `overrides` and `resource_selectors` see [policy assignment structure](https://learn.microsoft.com/en-us/azure/governance/policy/concepts/assignment-structure#resource-selectors-preview)
+* `overrides` - (Optional) One or more `overrides` blocks as defined below. More detail about `overrides` and `resource_selectors` see [policy assignment structure](https://learn.microsoft.com/en-us/azure/governance/policy/concepts/assignment-structure)
 
 * `resource_selectors` - (Optional) One or more `resource_selectors` blocks as defined below to filter polices by resource properties.
 

--- a/website/docs/r/management_group_policy_assignment.html.markdown
+++ b/website/docs/r/management_group_policy_assignment.html.markdown
@@ -114,6 +114,8 @@ A `override_selector` block supports the following:
 
 * `in` - (Optional) Specify the list of policy reference id values to filter in. Cannot be used with `not_in`.
 
+* `kind` - (Optional) Specifies which characteristic will narrow down the set of evaluated resources. Possible values are `resourceLocation`, and `policyDefinitionReferenceId`. Defaults to `policyDefinitionReferenceId`.
+
 * `not_in` - (Optional) Specify the list of policy reference id values to filter out. Cannot be used with `in`.
 
 ---

--- a/website/docs/r/policy_virtual_machine_configuration_assignment.html.markdown
+++ b/website/docs/r/policy_virtual_machine_configuration_assignment.html.markdown
@@ -136,6 +136,8 @@ A `configuration` block supports the following:
 
 * `content_hash` - (Optional) The content hash for the Guest Configuration package.
 
+~> **Note:** The value for `content_hash` should be the SH256SUM for the zip file in the `content_uri` and must be in upper case. 
+
 * `content_uri` - (Optional) The content URI where the Guest Configuration package is stored.
 
 ~> **Note:** When deploying a Custom Guest Configuration package the `content_hash` and `content_uri` fields must be defined. For Built-in Guest Configuration packages, such as the `AzureWindowsBaseline` package, the `content_hash` and `content_uri` should not be defined, rather these fields will be returned after the Built-in Guest Configuration package has been provisioned. For more information on guest configuration assignments please see the [product documentation](https://docs.microsoft.com/azure/governance/policy/concepts/guest-configuration-assignments).

--- a/website/docs/r/resource_group_policy_assignment.html.markdown
+++ b/website/docs/r/resource_group_policy_assignment.html.markdown
@@ -89,7 +89,7 @@ The following arguments are supported:
 
 * `parameters` - (Optional) A JSON mapping of any Parameters for this Policy.
 
-* `overrides` - (Optional) One or more `overrides` blocks as defined below. More detail about `overrides` and `resource_selectors` see [policy assignment structure](https://learn.microsoft.com/en-us/azure/governance/policy/concepts/assignment-structure#resource-selectors-preview)
+* `overrides` - (Optional) One or more `overrides` blocks as defined below. More detail about `overrides` and `resource_selectors` see [policy assignment structure](https://learn.microsoft.com/en-us/azure/governance/policy/concepts/assignment-structure)
 
 * `resource_selectors` - (Optional) One or more `resource_selectors` blocks as defined below to filter polices by resource properties.
 

--- a/website/docs/r/resource_group_policy_assignment.html.markdown
+++ b/website/docs/r/resource_group_policy_assignment.html.markdown
@@ -125,6 +125,8 @@ A `override_selector` block supports the following:
 
 * `in` - (Optional) Specify the list of policy reference id values to filter in. Cannot be used with `not_in`.
 
+* `kind` - (Optional) Specifies which characteristic will narrow down the set of evaluated resources. Possible values are `resourceLocation`, and `policyDefinitionReferenceId`. Defaults to `policyDefinitionReferenceId`.
+
 * `not_in` - (Optional) Specify the list of policy reference id values to filter out. Cannot be used with `in`.
 
 ---

--- a/website/docs/r/resource_policy_assignment.html.markdown
+++ b/website/docs/r/resource_policy_assignment.html.markdown
@@ -116,6 +116,8 @@ A `override_selector` block supports the following:
 
 * `in` - (Optional) Specify the list of policy reference id values to filter in. Cannot be used with `not_in`.
 
+* `kind` - (Optional) Specifies which characteristic will narrow down the set of evaluated resources. Possible values are `resourceLocation`, and `policyDefinitionReferenceId`. Defaults to `policyDefinitionReferenceId`.
+
 * `not_in` - (Optional) Specify the list of policy reference id values to filter out. Cannot be used with `in`.
 
 ---

--- a/website/docs/r/resource_policy_assignment.html.markdown
+++ b/website/docs/r/resource_policy_assignment.html.markdown
@@ -80,7 +80,7 @@ The following arguments are supported:
 
 * `parameters` - (Optional) A JSON mapping of any Parameters for this Policy.
 
-* `overrides` - (Optional) One or more `overrides` blocks as defined below. More detail about `overrides` and `resource_selectors` see [policy assignment structure](https://learn.microsoft.com/en-us/azure/governance/policy/concepts/assignment-structure#resource-selectors-preview)
+* `overrides` - (Optional) One or more `overrides` blocks as defined below. More detail about `overrides` and `resource_selectors` see [policy assignment structure](https://learn.microsoft.com/en-us/azure/governance/policy/concepts/assignment-structure)
 
 * `resource_selectors` - (Optional) One or more `resource_selectors` blocks as defined below to filter polices by resource properties.
 

--- a/website/docs/r/subscription_policy_assignment.html.markdown
+++ b/website/docs/r/subscription_policy_assignment.html.markdown
@@ -75,7 +75,7 @@ The following arguments are supported:
 
 * `parameters` - (Optional) A JSON mapping of any Parameters for this Policy.
 
-* `overrides` - (Optional) One or more `overrides` blocks as defined below. More detail about `overrides` and `resource_selectors` see [policy assignment structure](https://learn.microsoft.com/en-us/azure/governance/policy/concepts/assignment-structure#resource-selectors-preview)
+* `overrides` - (Optional) One or more `overrides` blocks as defined below. More detail about `overrides` and `resource_selectors` see [policy assignment structure](https://learn.microsoft.com/en-us/azure/governance/policy/concepts/assignment-structure)
 
 * `resource_selectors` - (Optional) One or more `resource_selectors` blocks as defined below to filter polices by resource properties.
 
@@ -110,6 +110,8 @@ A `overrides` block supports the following:
 A `override_selector` block supports the following:
 
 * `in` - (Optional) Specify the list of policy reference id values to filter in. Cannot be used with `not_in`.
+
+* `kind` - (Optional) Specifies which characteristic will narrow down the set of evaluated resources. Possible values are `resourceLocation`, and `policyDefinitionReferenceId`. Defaults to `policyDefinitionReferenceId`.
 
 * `not_in` - (Optional) Specify the list of policy reference id values to filter out. Cannot be used with `in`.
 


### PR DESCRIPTION

Since preview, the `kind` value for policy assignments has been updated to accept an additional value, so this property have now been made configurable, where previously it was `Computed` only.  To maintain backwards compatibility, this property now defaults to the previously hard-coded value of `policyDefinitionReferenceId`.

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_management_group_policy_assignment` - `override.kind` can now be configured
* `azurerm_resource_group_policy_assignment` - `override.kind` can now be configured
* `azurerm_resource_policy_assignment` - `override.kind` can now be configured
* `azurerm_subscription_policy_assignment` - `override.kind` can now be configured


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
