### PR TITLE
Revert "`azurerm_subnet` - support `sharing_scope` property"

### DIFF
--- a/internal/services/network/subnet_resource_test.go
+++ b/internal/services/network/subnet_resource_test.go
@@ -415,49 +415,6 @@ func TestAccSubnet_serviceEndpointPolicy(t *testing.T) {
 	})
 }
 
-func TestAccSubnet_sharingScope(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_subnet", "test")
-	r := SubnetResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.sharingScope(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-	})
-}
-
-func TestAccSubnet_sharingScopeUpdated(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_subnet", "test")
-	r := SubnetResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.basic(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.sharingScope(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.basic(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-	})
-}
-
 func TestAccSubnet_updateAddressPrefix(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_subnet", "test")
 	r := SubnetResource{}
@@ -1066,21 +1023,6 @@ resource "azurerm_subnet" "import" {
   address_prefixes     = azurerm_subnet.test.address_prefixes
 }
 `, r.basic(data))
-}
-
-func (r SubnetResource) sharingScope(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-%s
-
-resource "azurerm_subnet" "test" {
-  name                            = "internal"
-  resource_group_name             = azurerm_resource_group.test.name
-  virtual_network_name            = azurerm_virtual_network.test.name
-  address_prefixes                = ["10.0.2.0/24"]
-  default_outbound_access_enabled = false
-  sharing_scope                   = "Tenant"
-}
-`, r.template(data))
 }
 
 func (r SubnetResource) serviceEndpoints(data acceptance.TestData) string {

--- a/website/docs/r/subnet.html.markdown
+++ b/website/docs/r/subnet.html.markdown
@@ -85,10 +85,6 @@ The following arguments are supported:
 
 -> **Note:** When configuring Azure Private Link service, the explicit setting `private_link_service_network_policies_enabled` must be set to `false` in the subnet since Private Link Service does not support network policies like user-defined Routes and Network Security Groups. This setting only affects the Private Link service. For other resources in the subnet, access is controlled based on the Network Security Group which can be configured using the `azurerm_subnet_network_security_group_association` resource. See more details from [Manage network policies for Private Link Services](https://learn.microsoft.com/en-gb/azure/private-link/disable-private-link-service-network-policy?tabs=private-link-network-policy-powershell).
 
-* `sharing_scope` - (Optional) The sharing scope of the subnet. Possible value is `Tenant`. This property cannot be set if `default_outbound_access_enabled` is set to `true`.
-
-!> **Note:** The `sharing_scope` property is in limited preview and only for users who have been specifically onboarded by the Azure Network Product team for testing. It is not intended for general production use. If you have not been onboarded, you should omit this in your Terraform virtual network configurations. This guidance will be reviewed and updated in 2026.
-
 * `service_endpoints` - (Optional) The list of Service endpoints to associate with the subnet. Possible values include: `Microsoft.AzureActiveDirectory`, `Microsoft.AzureCosmosDB`, `Microsoft.ContainerRegistry`, `Microsoft.EventHub`, `Microsoft.KeyVault`, `Microsoft.ServiceBus`, `Microsoft.Sql`, `Microsoft.Storage`, `Microsoft.Storage.Global` and `Microsoft.Web`.
 
 -> **Note:** In order to use `Microsoft.Storage.Global` service endpoint (which allows access to virtual networks in other regions), you must enable the `AllowGlobalTagsForStorage` feature in your subscription. This is currently a preview feature, please see the [official documentation](https://learn.microsoft.com/en-us/azure/storage/common/storage-network-security?tabs=azure-cli#enabling-access-to-virtual-networks-in-other-regions-preview) for more information.


### PR DESCRIPTION
Reverts hashicorp/terraform-provider-azurerm#30316

Feature is in private preview, we're unable to support this in the provider at this time