### PR TITLE
`azurerm_kubernetes_cluster` - rename `vnet_integration_enabled` to `virtual_network_integration_enabled`

### DIFF
--- a/internal/services/containers/kubernetes_cluster_network_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_network_resource_test.go
@@ -4260,8 +4260,8 @@ resource "azurerm_kubernetes_cluster" "test" {
   }
 
   api_server_access_profile {
-    vnet_integration_enabled = true
-    subnet_id                = azurerm_subnet.test.id
+    virtual_network_integration_enabled = true
+    subnet_id                           = azurerm_subnet.test.id
   }
 }
 `, data.Locations.Primary, data.RandomInteger)

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -154,7 +154,7 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 								ValidateFunc: validate.CIDR,
 							},
 						},
-						"vnet_integration_enabled": {
+						"virtual_network_integration_enabled": {
 							Type:     pluginsdk.TypeBool,
 							Optional: true,
 							Default:  false,
@@ -3164,7 +3164,7 @@ func expandKubernetesClusterAPIAccessProfile(d *pluginsdk.ResourceData) *managed
 		}
 	}
 
-	apiAccessProfile.EnableVnetIntegration = pointer.To(config["vnet_integration_enabled"].(bool))
+	apiAccessProfile.EnableVnetIntegration = pointer.To(config["virtual_network_integration_enabled"].(bool))
 
 	if v, ok := config["subnet_id"]; ok {
 		if s := v.(string); s != "" {
@@ -3185,9 +3185,9 @@ func flattenKubernetesClusterAPIAccessProfile(profile *managedclusters.ManagedCl
 	subnetId := pointer.From(profile.SubnetId)
 
 	return []interface{}{map[string]interface{}{
-		"authorized_ip_ranges":     apiServerAuthorizedIPRanges,
-		"vnet_integration_enabled": enableVnetIntegration,
-		"subnet_id":                subnetId,
+		"authorized_ip_ranges":                apiServerAuthorizedIPRanges,
+		"virtual_network_integration_enabled": enableVnetIntegration,
+		"subnet_id":                           subnetId,
 	}}
 }
 

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -288,7 +288,7 @@ An `api_server_access_profile` block supports the following:
 
 * `subnet_id` - (Optional) The ID of the Subnet where the API server endpoint is delegated to.
 
-* `vnet_integration_enabled` - (Optional) Should API Server VNet Integration be enabled? Defaults to `false`.
+* `virtual_network_integration_enabled` - (Optional) Whether Virtual Network Integration is enabled for the API server. Defaults to `false`.
 
 ---
 


### PR DESCRIPTION
Following our [naming guide](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/reference-naming.md?plain=1#L13), new properties should use complete words rather than abbreviating things like `vm`, `vnet`, `rg`, etc.

This property has not been released yet, so there is no need to wrap this in a feature flag for 5.0.

original PR for reference #30516