### PR TITLE
Revert "`azurerm_role_assignment`: check role assignment exits for 409 error"

### DIFF
--- a/internal/services/authorization/role_assignment_resource_test.go
+++ b/internal/services/authorization/role_assignment_resource_test.go
@@ -6,7 +6,6 @@ package authorization_test
 import (
 	"context"
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/google/uuid"
@@ -74,30 +73,6 @@ func TestAccRoleAssignment_requiresImport(t *testing.T) {
 		{
 			Config:      r.requiresImportConfig(id),
 			ExpectError: acceptance.RequiresImportError("azurerm_role_assignment"),
-		},
-	})
-}
-
-func TestAccRoleAssignment_requiresImportAdvanced(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_role_assignment", "test")
-	id := uuid.New().String()
-
-	r := RoleAssignmentResource{}
-
-	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.roleNameConfig(id),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		{
-			Config:      r.requiresImportConfigWithoutName(id),
-			ExpectError: acceptance.RequiresImportError("azurerm_role_assignment"),
-		},
-		{
-			Config:      r.requiresImportConfigDupError(id, uuid.New().String()),
-			ExpectError: regexp.MustCompile("role assignment `.*` already exists with a different name:"),
 		},
 	})
 }
@@ -414,31 +389,6 @@ resource "azurerm_role_assignment" "import" {
   principal_id         = azurerm_role_assignment.test.principal_id
 }
 `, RoleAssignmentResource{}.roleNameConfig(id))
-}
-
-func (RoleAssignmentResource) requiresImportConfigWithoutName(id string) string {
-	return fmt.Sprintf(`
-%s
-
-resource "azurerm_role_assignment" "import" {
-  scope                = azurerm_role_assignment.test.scope
-  role_definition_name = azurerm_role_assignment.test.role_definition_name
-  principal_id         = azurerm_role_assignment.test.principal_id
-}
-`, RoleAssignmentResource{}.roleNameConfig(id))
-}
-
-func (RoleAssignmentResource) requiresImportConfigDupError(id, dupID string) string {
-	return fmt.Sprintf(`
-%s
-
-resource "azurerm_role_assignment" "import" {
-  name                 = "%s"
-  scope                = azurerm_role_assignment.test.scope
-  role_definition_name = azurerm_role_assignment.test.role_definition_name
-  principal_id         = azurerm_role_assignment.test.principal_id
-}
-`, RoleAssignmentResource{}.roleNameConfig(id), dupID)
 }
 
 func (RoleAssignmentResource) dataActionsConfig(id string) string {


### PR DESCRIPTION
The test is failing and will need to be fixed before looking at this again

```
=== RUN   TestAccRoleAssignment_requiresImportAdvanced
    testcase.go:180: Step 3/3, expected an error with pattern, no match on: Error running apply: exit status 1
        Error: role assignment of `/subscriptions/*******/providers/Microsoft.Authorization/roleAssignments/ee93ec5b-2c50-43d7-a4ec-486f5568ea7d` already exists with a different id, modify the role assignment name and import with the exists id: `/subscriptions/*******/providers/Microsoft.Authorization/roleAssignments/182f3fa8-3f7d-4b47-bd83-d71c3ac8a9ce`
          with azurerm_role_assignment.import,
          on terraform_plugin_test.tf line 47, in resource "azurerm_role_assignment" "import":
          47: resource "azurerm_role_assignment" "import" {
--- FAIL: TestAccRoleAssignment_requiresImportAdvanced (75.00s)
```