### PR TITLE
Revert "`azurerm_kubernetes_cluster`, `azurerm_kubernetes_cluster_node_pool` - support for the `undrainable_node_behavior` and `max_unavailable` properties"

### DIFF
--- a/internal/services/containers/kubernetes_cluster_data_source.go
+++ b/internal/services/containers/kubernetes_cluster_data_source.go
@@ -1454,20 +1454,12 @@ func flattenKubernetesClusterDataSourceUpgradeSettings(input *managedclusters.Ag
 		values["max_surge"] = *input.MaxSurge
 	}
 
-	if input.MaxUnavailable != nil {
-		values["max_unavailable"] = *input.MaxUnavailable
-	}
-
 	if input.DrainTimeoutInMinutes != nil {
 		values["drain_timeout_in_minutes"] = *input.DrainTimeoutInMinutes
 	}
 
 	if input.NodeSoakDurationInMinutes != nil {
 		values["node_soak_duration_in_minutes"] = *input.NodeSoakDurationInMinutes
-	}
-
-	if input.UndrainableNodeBehavior != nil {
-		values["undrainable_node_behavior"] = string(*input.UndrainableNodeBehavior)
 	}
 
 	return []interface{}{values}

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -553,14 +553,14 @@ func TestAccKubernetesClusterNodePool_upgradeSettings(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.upgradeSettings(data, `10%`, 10, 5, "Cordon", "0%"),
+			Config: r.upgradeSettings(data, 35, 18),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config: r.upgradeSettings(data, `0%`, 15, 8, "Schedule", "25%"),
+			Config: r.upgradeSettings(data, 5, 0),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -2156,8 +2156,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
 `, r.templateConfig(data))
 }
 
-func (r KubernetesClusterNodePoolResource) upgradeSettings(data acceptance.TestData, maxSurge string, drainTimeout int, nodeSoakDuration int, undrainableBehavior string, maxUnavailable string) string {
+func (r KubernetesClusterNodePoolResource) upgradeSettings(data acceptance.TestData, drainTimeout int, nodeSoakDuration int) string {
 	template := r.templateConfig(data)
+
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -2171,14 +2172,12 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   vm_size               = "Standard_DS2_v2"
   node_count            = 3
   upgrade_settings {
-    max_surge                     = "%s"
+    max_surge                     = "10%%"
     drain_timeout_in_minutes      = %d
     node_soak_duration_in_minutes = %d
-    max_unavailable               = %q
-    undrainable_node_behavior     = %q
   }
 }
-`, template, maxSurge, drainTimeout, nodeSoakDuration, maxUnavailable, undrainableBehavior)
+`, template, drainTimeout, nodeSoakDuration)
 }
 
 func (r KubernetesClusterNodePoolResource) virtualNetworkAutomaticConfig(data acceptance.TestData) string {

--- a/internal/services/containers/kubernetes_cluster_resource_upgrade_test.go
+++ b/internal/services/containers/kubernetes_cluster_resource_upgrade_test.go
@@ -279,14 +279,14 @@ func TestAccKubernetesCluster_upgradeSettings(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.upgradeSettings(data, 10, 5, "Cordon"),
+			Config: r.upgradeSettings(data, 35, 18),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config: r.upgradeSettings(data, 15, 10, "Schedule"),
+			Config: r.upgradeSettings(data, 5, 0),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -295,7 +295,7 @@ func TestAccKubernetesCluster_upgradeSettings(t *testing.T) {
 	})
 }
 
-func (r KubernetesClusterResource) upgradeSettings(data acceptance.TestData, drainTimeout int, nodeSoak int, undrainableBehavior string) string {
+func (r KubernetesClusterResource) upgradeSettings(data acceptance.TestData, drainTimeout int, nodeSoakDuration int) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -320,7 +320,6 @@ resource "azurerm_kubernetes_cluster" "test" {
       max_surge                     = "10%%"
       drain_timeout_in_minutes      = %d
       node_soak_duration_in_minutes = %d
-      undrainable_node_behavior     = %q
     }
   }
 
@@ -328,7 +327,7 @@ resource "azurerm_kubernetes_cluster" "test" {
     type = "SystemAssigned"
   }
 }
-  `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, drainTimeout, nodeSoak, undrainableBehavior)
+  `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, drainTimeout, nodeSoakDuration)
 }
 
 func (KubernetesClusterResource) upgradeControlPlaneConfig(data acceptance.TestData, controlPlaneVersion string) string {

--- a/website/docs/d/kubernetes_cluster.html.markdown
+++ b/website/docs/d/kubernetes_cluster.html.markdown
@@ -180,10 +180,6 @@ A `upgrade_settings` block exports the following:
 
 * `max_surge` - The maximum number or percentage of nodes that will be added to the Node Pool size during an upgrade.
 
-* `max_unavailable` - The maximum number or percentage of nodes which can be unavailable during the upgrade.
-
-* `undrainable_node_behavior` - The action when a node is undrainable during upgrade. Possible values are `Cordon` and `Schedule`.
-
 ---
 
 A `key_management_service` block supports the following:

--- a/website/docs/d/kubernetes_cluster_node_pool.html.markdown
+++ b/website/docs/d/kubernetes_cluster_node_pool.html.markdown
@@ -100,10 +100,6 @@ A `upgrade_settings` block exports the following:
 
 * `max_surge` - The maximum number or percentage of nodes which will be added to the Node Pool size during an upgrade.
 
-* `max_unavailable` - The maximum number or percentage of nodes which can be unavailable during the upgrade.
-
-* `undrainable_node_behavior` - The action when a node is undrainable during upgrade. Possible values are `Cordon` and `Schedule`.
-
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -958,9 +958,6 @@ A `upgrade_settings` block supports the following:
 
 * `max_surge` - (Required) The maximum number or percentage of nodes which will be added to the Node Pool size during an upgrade.
 
-
-* `undrainable_node_behavior` - (Optional) Specifies the action when a node is undrainable during upgrade. Possible values are `Cordon` and `Schedule`.
-
 -> **Note:** If a percentage is provided, the number of surge nodes is calculated from the `node_count` value on the current cluster. Node surge can allow a cluster to have more nodes than `max_count` during an upgrade. Ensure that your cluster has enough [IP space](https://docs.microsoft.com/azure/aks/upgrade-cluster#customize-node-surge-upgrade) during an upgrade.
 
 ## Attributes Reference

--- a/website/docs/r/kubernetes_cluster_node_pool.html.markdown
+++ b/website/docs/r/kubernetes_cluster_node_pool.html.markdown
@@ -312,12 +312,6 @@ A `upgrade_settings` block supports the following:
 
 * `max_surge` - (Required) The maximum number or percentage of nodes which will be added to the Node Pool size during an upgrade.
 
-* `max_unavailable` - (Optional) The maximum number or percentage of nodes which can be unavailable during the upgrade. 
-
--> **Note:** `max_unavailable` conflicts with `max_surge`. Only one of them should be set. Using both with percentages that violate upgrade constraints is not supported.
-
-* `undrainable_node_behavior` - (Optional) Specifies the action when a node is undrainable during upgrade. Possible values are `Cordon` and `Schedule`.
-
 ---
 
 A `windows_profile` block supports the following:


### PR DESCRIPTION
Reverts hashicorp/terraform-provider-azurerm#30515

There's some conflicting information between the schema and the documentation, as we're trying to get this week's release out, we unfortunately don't have the time to properly re-review this change. As discussed internally, we're going to revert this change for now.
