### PR TITLE
feat: kubernetes_cluster readd vnet integration feature, add validation and fix runCommand failed test

### DIFF
--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -3172,15 +3172,25 @@ func flattenKubernetesClusterAPIAccessProfile(profile *managedclusters.ManagedCl
 		return []interface{}{}
 	}
 
-	apiServerAuthorizedIPRanges := utils.FlattenStringSlice(profile.AuthorizedIPRanges)
-	enableVnetIntegration := pointer.From(profile.EnableVnetIntegration)
-	subnetId := pointer.From(profile.SubnetId)
+	result := map[string]interface{}{}
 
-	return []interface{}{map[string]interface{}{
-		"authorized_ip_ranges":                apiServerAuthorizedIPRanges,
-		"virtual_network_integration_enabled": enableVnetIntegration,
-		"subnet_id":                           subnetId,
-	}}
+	if profile.AuthorizedIPRanges != nil && len(*profile.AuthorizedIPRanges) > 0 {
+		result["authorized_ip_ranges"] = utils.FlattenStringSlice(profile.AuthorizedIPRanges)
+	}
+
+	if profile.EnableVnetIntegration != nil {
+		result["virtual_network_integration_enabled"] = *profile.EnableVnetIntegration
+	}
+
+	if profile.SubnetId != nil {
+		result["subnet_id"] = *profile.SubnetId
+	}
+
+	if len(result) == 0 {
+		return []interface{}{}
+	}
+
+	return []interface{}{result}
 }
 
 func expandKubernetesClusterWorkloadAutoscalerProfile(input []interface{}, d *pluginsdk.ResourceData) *managedclusters.ManagedClusterWorkloadAutoScalerProfile {

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -154,6 +154,16 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 								ValidateFunc: validate.CIDR,
 							},
 						},
+						"virtual_network_integration_enabled": {
+							Type:     pluginsdk.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
+						"subnet_id": {
+							Type:         pluginsdk.TypeString,
+							Optional:     true,
+							ValidateFunc: commonids.ValidateSubnetID,
+						},
 					},
 				},
 			},
@@ -2520,14 +2530,6 @@ func resourceKubernetesClusterUpdate(d *pluginsdk.ResourceData, meta interface{}
 
 			tempAgentProfile := agentProfile
 			tempAgentProfile.Name = &temporaryNodePoolName
-
-			if tempAgentProfile.Properties != nil {
-				tempAgentProfile.Properties.NodeImageVersion = nil
-			}
-			if agentProfile.Properties != nil {
-				agentProfile.Properties.NodeImageVersion = nil
-			}
-
 			// if the temp node pool already exists due to a previous failure, don't bother spinning it up
 			if tempExisting.Model == nil {
 				if err := retryNodePoolCreation(ctx, nodePoolsClient, tempNodePoolId, tempAgentProfile); err != nil {
@@ -3154,21 +3156,31 @@ func expandKubernetesClusterAPIAccessProfile(d *pluginsdk.ResourceData) *managed
 		}
 	}
 
+	apiAccessProfile.EnableVnetIntegration = pointer.To(config["virtual_network_integration_enabled"].(bool))
+
+	if v, ok := config["subnet_id"]; ok {
+		if s := v.(string); s != "" {
+			apiAccessProfile.SubnetId = pointer.To(s)
+		}
+	}
+
 	return apiAccessProfile
 }
 
 func flattenKubernetesClusterAPIAccessProfile(profile *managedclusters.ManagedClusterAPIServerAccessProfile) []interface{} {
-	if profile == nil || profile.AuthorizedIPRanges == nil {
+	if profile == nil {
 		return []interface{}{}
 	}
 
 	apiServerAuthorizedIPRanges := utils.FlattenStringSlice(profile.AuthorizedIPRanges)
+	enableVnetIntegration := pointer.From(profile.EnableVnetIntegration)
+	subnetId := pointer.From(profile.SubnetId)
 
-	return []interface{}{
-		map[string]interface{}{
-			"authorized_ip_ranges": apiServerAuthorizedIPRanges,
-		},
-	}
+	return []interface{}{map[string]interface{}{
+		"authorized_ip_ranges":                apiServerAuthorizedIPRanges,
+		"virtual_network_integration_enabled": enableVnetIntegration,
+		"subnet_id":                           subnetId,
+	}}
 }
 
 func expandKubernetesClusterWorkloadAutoscalerProfile(input []interface{}, d *pluginsdk.ResourceData) *managedclusters.ManagedClusterWorkloadAutoScalerProfile {

--- a/internal/services/containers/kubernetes_cluster_validate.go
+++ b/internal/services/containers/kubernetes_cluster_validate.go
@@ -56,6 +56,22 @@ func validateKubernetesCluster(d *pluginsdk.ResourceData, cluster *managedcluste
 		}
 	}
 
+	// Validate API Server Access Profile
+	if v, exists := d.GetOk("api_server_access_profile"); exists {
+		rawProfiles := v.([]interface{})
+
+		if len(rawProfiles) != 0 {
+			profile := rawProfiles[0].(map[string]interface{})
+
+			virtualNetworkIntegrationEnabled := profile["virtual_network_integration_enabled"].(bool)
+			subnetId := profile["subnet_id"].(string)
+
+			if virtualNetworkIntegrationEnabled && subnetId == "" {
+				return fmt.Errorf("`subnet_id` is required when `virtual_network_integration_enabled` is set to `true`")
+			}
+		}
+	}
+
 	// @tombuildsstuff: As of 2020-03-30 it's no longer possible to create a cluster using a Service Principal
 	// for authentication (albeit this worked on 2020-03-27 via API version 2019-10-01 :shrug:). However it's
 	// possible to rotate the Service Principal for an existing Cluster - so this needs to be supported via

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -286,6 +286,10 @@ An `api_server_access_profile` block supports the following:
 
 * `authorized_ip_ranges` - (Optional) Set of authorized IP ranges to allow access to API server, e.g. ["198.51.100.0/24"].
 
+* `subnet_id` - (Optional) The ID of the Subnet where the API server endpoint is delegated to.
+
+* `virtual_network_integration_enabled` - (Optional) Should API Server VNet Integration be enabled? Defaults to `false`.
+
 ---
 
 An `auto_scaler_profile` block supports the following:


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

- readding #30516 
- adding rename from #30549
- fixing flattenKubernetesClusterAPIAccessProfile that caused runCommand test to fail
- adding validation and test for subnet_id when virtual_network_integration_enabled is set to true


tested runCommand, apiServerVnetIntegrationMissingSubnetId and apiServerVnetIntegration

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `kubernetes_cluster` - add virtual_network_integration_enabled to api_server_access_profile after it getting promoted to GA


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #30505

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
