### PR TITLE
`azurerm_kubernetes_cluster_node_pool` - fix tests

### DIFF
--- a/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -1705,11 +1705,11 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   vm_size               = "Standard_DS2_v2"
   node_count            = 1
 
-  tags = {
-    environment = "Staging"
-  }
   upgrade_settings {
     max_surge = "10%%"
+  }
+  tags = {
+    environment = "Staging"
   }
 }
 `, r.templateConfig(data))

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -1311,6 +1311,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   auto_scaling_enabled  = true
   min_count             = 1
   max_count             = 3
+  upgrade_settings {
+    max_surge = "10%%"
+  }
 }
 `, r.templateConfig(data))
 }
@@ -1330,6 +1333,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   auto_scaling_enabled  = true
   min_count             = %d
   max_count             = %d
+  upgrade_settings {
+    max_surge = "10%%"
+  }
 }
 `, r.templateConfig(data), min, max)
 }
@@ -1370,6 +1376,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
   vm_size               = "Standard_DS2_v2"
   node_count            = 1
+  upgrade_settings {
+    max_surge = "10%%"
+  }
 
   kubelet_config {
     cpu_manager_policy        = "static"
@@ -1462,6 +1471,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
   vm_size               = "Standard_DS2_v2"
   node_count            = 1
+  upgrade_settings {
+    max_surge = "10%%"
+  }
 
   kubelet_config {
     cpu_manager_policy    = "static"
@@ -1595,6 +1607,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   node_count            = 1
   vnet_subnet_id        = azurerm_subnet.test.id
   zones                 = ["1"]
+  upgrade_settings {
+    max_surge = "10%%"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
@@ -1669,6 +1684,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   vm_size                       = "Standard_D2s_v3"
   node_count                    = 1
   capacity_reservation_group_id = azurerm_capacity_reservation.test.capacity_reservation_group_id
+  upgrade_settings {
+    max_surge = "10%%"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary)
 }
@@ -1689,6 +1707,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
 
   tags = {
     environment = "Staging"
+  }
+  upgrade_settings {
+    max_surge = "10%%"
   }
 }
 `, r.templateConfig(data))
@@ -1712,6 +1733,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
     ignore_changes = [
       node_count,
     ]
+  }
+  upgrade_settings {
+    max_surge = "10%%"
   }
 }
 `, r.templateConfig(data))
@@ -1740,6 +1764,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
       node_count,
     ]
   }
+  upgrade_settings {
+    max_surge = "10%%"
+  }
 }
 `, r.templateConfig(data))
 }
@@ -1757,6 +1784,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "first" {
   kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
   vm_size               = "Standard_DS2_v2"
   node_count            = 1
+  upgrade_settings {
+    max_surge = "10%%"
+  }
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "second" {
@@ -1764,6 +1794,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "second" {
   kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
   vm_size               = "Standard_F2s_v2"
   node_count            = 1
+  upgrade_settings {
+    max_surge = "10%%"
+  }
 }
 `, r.templateConfig(data))
 }
@@ -1781,6 +1814,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "first" {
   kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
   vm_size               = "Standard_DS2_v2"
   node_count            = %d
+  upgrade_settings {
+    max_surge = "10%%"
+  }
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "second" {
@@ -1788,6 +1824,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "second" {
   kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
   vm_size               = "Standard_F2s_v2"
   node_count            = %d
+  upgrade_settings {
+    max_surge = "10%%"
+  }
 }
 `, r.templateConfig(data), numberOfAgents, numberOfAgents)
 }
@@ -1805,6 +1844,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
   vm_size               = "Standard_DS2_v2"
   node_count            = %d
+  upgrade_settings {
+    max_surge = "10%%"
+  }
 }
 `, r.templateConfig(data), numberOfAgents)
 }
@@ -1844,6 +1886,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   vm_size               = "Standard_DS2_v2"
   node_count            = 1
   mode                  = "System"
+  upgrade_settings {
+    max_surge = "10%%"
+  }
 }
 `, r.templateConfig(data))
 }
@@ -1862,6 +1907,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   vm_size               = "Standard_DS2_v2"
   node_count            = 1
   mode                  = "User"
+  upgrade_settings {
+    max_surge = "10%%"
+  }
 }
 `, r.templateConfig(data))
 }
@@ -1881,6 +1929,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "autoscale" {
   auto_scaling_enabled  = true
   min_count             = 1
   max_count             = 3
+  upgrade_settings {
+    max_surge = "10%%"
+  }
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "manual" {
@@ -1888,6 +1939,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "manual" {
   kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
   vm_size               = "Standard_F2s_v2"
   node_count            = %d
+  upgrade_settings {
+    max_surge = "10%%"
+  }
 }
 `, r.templateConfig(data), numberOfAgents)
 }
@@ -1912,6 +1966,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   node_count            = 1
   node_labels = {
 %s
+  }
+  upgrade_settings {
+    max_surge = "10%%"
   }
 }
 `, r.templateConfig(data), labelsStr)
@@ -1938,6 +1995,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   node_taints = [
 %s
   ]
+  upgrade_settings {
+    max_surge = "10%%"
+  }
 }
 `, r.templateConfig(data), taintsStr)
 }
@@ -1964,6 +2024,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   node_count               = 1
   node_public_ip_enabled   = true
   node_public_ip_prefix_id = azurerm_public_ip_prefix.test.id
+  upgrade_settings {
+    max_surge = "10%%"
+  }
 }
 `, r.templateConfig(data), data.RandomInteger)
 }
@@ -2034,6 +2097,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   node_count            = 1
   pod_subnet_id         = azurerm_subnet.podsubnet.id
   vnet_subnet_id        = azurerm_subnet.nodesubnet.id
+  upgrade_settings {
+    max_surge = "10%%"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
@@ -2065,6 +2131,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   vm_size               = "Standard_DS2_v2"
   node_count            = 1
   os_disk_size_gb       = 100
+  upgrade_settings {
+    max_surge = "10%%"
+  }
 }
 `, r.templateConfig(data))
 }
@@ -2109,6 +2178,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   vm_size                      = "Standard_DS2_v2"
   node_count                   = 1
   proximity_placement_group_id = azurerm_proximity_placement_group.test.id
+  upgrade_settings {
+    max_surge = "10%%"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
@@ -2126,6 +2198,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   node_count            = 1
   os_disk_size_gb       = 100
   os_disk_type          = "Ephemeral"
+  upgrade_settings {
+    max_surge = "10%%"
+  }
 }
 `, r.templateConfig(data))
 }
@@ -2152,6 +2227,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   node_taints = [
     "kubernetes.azure.com/scalesetpriority=spot:NoSchedule"
   ]
+  upgrade_settings {
+    max_surge = "10%%"
+  }
 }
 `, r.templateConfig(data))
 }
@@ -2196,6 +2274,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   min_count             = 1
   max_count             = 3
   vnet_subnet_id        = azurerm_subnet.test.id
+  upgrade_settings {
+    max_surge = "10%%"
+  }
 }
 `, r.templateVirtualNetworkConfig(data))
 }
@@ -2214,6 +2295,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   vm_size               = "Standard_DS2_v2"
   node_count            = 1
   vnet_subnet_id        = azurerm_subnet.test.id
+  upgrade_settings {
+    max_surge = "10%%"
+  }
 }
 `, r.templateVirtualNetworkConfig(data))
 }
@@ -2239,6 +2323,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   vm_size               = "Standard_DS2_v2"
   node_count            = 1
   vnet_subnet_id        = azurerm_subnet.test2.id
+  upgrade_settings {
+    max_surge = "10%%"
+  }
 }
 `, r.templateVirtualNetworkConfig(data), data.RandomInteger)
 }
@@ -2259,6 +2346,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   os_type               = "Windows"
   tags = {
     Os = "Windows"
+  }
+  upgrade_settings {
+    max_surge = "10%%"
   }
 }
 `, r.templateWindowsConfig(data))
@@ -2282,6 +2372,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   tags = {
     Os = "Windows"
   }
+  upgrade_settings {
+    max_surge = "10%%"
+  }
 }
 `, r.templateWindowsConfig(data))
 }
@@ -2304,6 +2397,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   tags = {
     Os = "Windows"
   }
+  upgrade_settings {
+    max_surge = "10%%"
+  }
 }
 `, r.templateWindowsConfig(data))
 }
@@ -2321,6 +2417,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "linux" {
   kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
   vm_size               = "Standard_DS2_v2"
   node_count            = 1
+  upgrade_settings {
+    max_surge = "10%%"
+  }
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "windows" {
@@ -2329,6 +2428,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "windows" {
   vm_size               = "Standard_DS2_v2"
   node_count            = 1
   os_type               = "Windows"
+  upgrade_settings {
+    max_surge = "10%%"
+  }
 }
 `, r.templateWindowsConfig(data))
 }
@@ -2463,6 +2565,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   min_count             = 0
   max_count             = 3
   node_count            = 0
+  upgrade_settings {
+    max_surge = "10%%"
+  }
 }
 `, r.templateConfig(data))
 }
@@ -2481,6 +2586,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   vm_size                 = "Standard_DS2_v2"
   host_encryption_enabled = true
   node_count              = 1
+  upgrade_settings {
+    max_surge = "10%%"
+  }
 }
 `, r.templateConfig(data))
 }
@@ -2501,6 +2609,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   min_count             = 1
   max_count             = 399
   node_count            = 1
+  upgrade_settings {
+    max_surge = "10%%"
+  }
 }
 `, r.templateConfig(data))
 }
@@ -2521,6 +2632,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   min_count             = 1
   max_count             = 1
   node_count            = 1
+  upgrade_settings {
+    max_surge = "10%%"
+  }
 }
 `, r.templateConfig(data))
 }
@@ -2540,6 +2654,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   node_count            = 3
   fips_enabled          = true
   kubelet_disk_type     = "OS"
+  upgrade_settings {
+    max_surge = "10%%"
+  }
 }
 `, r.templateConfig(data))
 }
@@ -2577,6 +2694,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   temporary_name_for_rotation = "temporal"
   ultra_ssd_enabled           = %t
   zones                       = ["1", "2", "3"]
+  upgrade_settings {
+    max_surge = "10%%"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, ultraSSDEnabled)
 }
@@ -2612,6 +2732,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
   vm_size               = "Standard_D2s_v3"
   os_sku                = "%s"
+  upgrade_settings {
+    max_surge = "10%%"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, osSku)
 }
@@ -2682,6 +2805,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   vm_size               = "Standard_D2s_v3"
   node_count            = 1
   host_group_id         = azurerm_dedicated_host_group.test.id
+  upgrade_settings {
+    max_surge = "10%%"
+  }
 
   depends_on = [
     azurerm_role_assignment.test,
@@ -2706,6 +2832,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   auto_scaling_enabled  = %t
   min_count             = %d
   max_count             = %d
+  upgrade_settings {
+    max_surge = "10%%"
+  }
 }
 `, r.templateConfig(data), enableAutoScaling, minCount, maxCount)
 }
@@ -2741,6 +2870,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
   vm_size               = "Standard_D2s_v3"
   scale_down_mode       = "%s"
+  upgrade_settings {
+    max_surge = "10%%"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, scaleDownMode)
 }
@@ -2776,6 +2908,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
   vm_size               = "Standard_D2s_v3"
   workload_runtime      = "%s"
+  upgrade_settings {
+    max_surge = "10%%"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, workloadRuntime)
 }
@@ -2821,6 +2956,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   os_sku                = "Windows2019"
   windows_profile {
     outbound_nat_enabled = true
+  }
+  upgrade_settings {
+    max_surge = "10%%"
   }
 }
 `, data.Locations.Primary, data.RandomInteger)
@@ -2870,6 +3008,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
     node_public_ip_tags = {
       RoutingPreference = "Internet"
     }
+  }
+  upgrade_settings {
+    max_surge = "10%%"
   }
 }
  `, data.Locations.Primary, data.RandomInteger)
@@ -2926,6 +3067,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
       RoutingPreference = "Internet"
     }
   }
+  upgrade_settings {
+    max_surge = "10%%"
+  }
 }
  `, data.Locations.Primary, data.RandomInteger)
 }
@@ -2963,6 +3107,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "source" {
   name                  = "source"
   kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
   vm_size               = "Standard_D2s_v3"
+  upgrade_settings {
+    max_surge = "10%%"
+  }
 }
  `, data.Locations.Primary, data.RandomInteger)
 }
@@ -3000,6 +3147,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "source" {
   name                  = "source"
   kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
   vm_size               = "Standard_D2s_v3"
+  upgrade_settings {
+    max_surge = "10%%"
+  }
 }
 
 data "azurerm_kubernetes_node_pool_snapshot" "test" {
@@ -3013,6 +3163,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   vm_size               = "Standard_DS2_v2"
   node_count            = 1
   snapshot_id           = data.azurerm_kubernetes_node_pool_snapshot.test.id
+  upgrade_settings {
+    max_surge = "10%%"
+  }
   depends_on = [
     azurerm_kubernetes_cluster_node_pool.source
   ]
@@ -3054,6 +3207,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
   vm_size               = "Standard_NC24ads_A100_v4"
   gpu_instance          = "MIG1g"
+  upgrade_settings {
+    max_surge = "10%%"
+  }
 }
  `, data.Locations.Primary, data.RandomInteger)
 }
@@ -3092,6 +3248,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
   vm_size               = "Standard_NC24ads_A100_v4"
   gpu_driver            = "Install"
+  upgrade_settings {
+    max_surge = "10%%"
+  }
 }
  `, data.Locations.Primary, data.RandomInteger)
 }
@@ -3169,6 +3328,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "test1" {
   vnet_subnet_id        = azurerm_subnet.test[0].id
   pod_subnet_id         = azurerm_subnet.test[1].id
   zones                 = ["1"]
+  upgrade_settings {
+    max_surge = "10%%"
+  }
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "test2" {
@@ -3179,6 +3341,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "test2" {
   vnet_subnet_id        = azurerm_subnet.test[2].id
   pod_subnet_id         = azurerm_subnet.test[3].id
   zones                 = ["1"]
+  upgrade_settings {
+    max_surge = "10%%"
+  }
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "test3" {
@@ -3189,6 +3354,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "test3" {
   vnet_subnet_id        = azurerm_subnet.test[4].id
   pod_subnet_id         = azurerm_subnet.test[5].id
   zones                 = ["1"]
+  upgrade_settings {
+    max_surge = "10%%"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
@@ -3224,6 +3392,9 @@ resource "azurerm_kubernetes_cluster" "test" {
 resource "azurerm_kubernetes_cluster_node_pool" "test" {
   name                  = "internal"
   kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
+  upgrade_settings {
+    max_surge = "10%%"
+  }
 }
  `, data.Locations.Primary, data.RandomInteger)
 }
@@ -3300,6 +3471,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "pool1" {
   node_count            = 1
   pod_subnet_id         = azurerm_subnet.podsubnet.id
   vnet_subnet_id        = azurerm_subnet.nodesubnet.id
+  upgrade_settings {
+    max_surge = "10%%"
+  }
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "pool2" {
@@ -3309,9 +3483,11 @@ resource "azurerm_kubernetes_cluster_node_pool" "pool2" {
   node_count            = 1
   pod_subnet_id         = azurerm_subnet.podsubnet.id
   vnet_subnet_id        = azurerm_subnet.nodesubnet.id
+  upgrade_settings {
+    max_surge = "10%%"
+  }
 }
-`,
-		data.RandomInteger,     // resource_group name
+`, data.RandomInteger, // resource_group name
 		data.Locations.Primary, // resource_group location
 		data.RandomInteger,     // virtual_network name
 		data.RandomInteger,     // kubernetes_cluster name

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -2604,7 +2604,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   vm_size               = "Standard_DS2_v2"
   auto_scaling_enabled  = true
   min_count             = 1
-  max_count             = 399
+  max_count             = 250
   node_count            = 1
   upgrade_settings {
     max_surge = "10%%"
@@ -3204,6 +3204,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
   vm_size               = "Standard_NC24ads_A100_v4"
   gpu_instance          = "MIG1g"
+  gpu_driver            = "Install"
   upgrade_settings {
     max_surge = "10%%"
   }

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -2227,9 +2227,6 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   node_taints = [
     "kubernetes.azure.com/scalesetpriority=spot:NoSchedule"
   ]
-  upgrade_settings {
-    max_surge = "10%%"
-  }
 }
 `, r.templateConfig(data))
 }

--- a/internal/services/containers/kubernetes_cluster_resource_upgrade_test.go
+++ b/internal/services/containers/kubernetes_cluster_resource_upgrade_test.go
@@ -409,6 +409,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   vm_size               = "Standard_DS2_v2"
   node_count            = 1
   orchestrator_version  = %q
+  upgrade_settings {
+    max_surge = "10%%"
+  }
 }
 `, r.upgradeControlPlaneDefaultNodePoolConfig(data, controlPlaneVersion, defaultNodePoolVersion), customNodePoolVersion)
 }
@@ -432,6 +435,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   node_taints = [
     "kubernetes.azure.com/scalesetpriority=spot:NoSchedule"
   ]
+  upgrade_settings {
+    max_surge = "10%%"
+  }
 }
 `, r.upgradeControlPlaneDefaultNodePoolConfig(data, controlPlaneVersion, defaultNodePoolVersion), customNodePoolVersion)
 }

--- a/internal/services/containers/kubernetes_node_pool_snapshot_data_source_test.go
+++ b/internal/services/containers/kubernetes_node_pool_snapshot_data_source_test.go
@@ -121,6 +121,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "source" {
   name                  = "source"
   kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
   vm_size               = "Standard_D2s_v3"
+  upgrade_settings {
+    max_surge = "10%%"
+  }
 }
  `, data.Locations.Primary, data.RandomInteger)
 }
@@ -158,6 +161,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "source" {
   name                  = "source"
   kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
   vm_size               = "Standard_D2s_v3"
+  upgrade_settings {
+    max_surge = "10%%"
+  }
 }
 
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)
<img width="1130" height="895" alt="image" src="https://github.com/user-attachments/assets/974f49e9-06db-459f-a8f5-11fdb6ff4a9b" />

<img width="1124" height="418" alt="image" src="https://github.com/user-attachments/assets/ef57aa63-92d5-4003-905b-96cfb9703215" />

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
