### PR TITLE
`azurerm_kusto_cluster` - rename `language_extensions` to `language_extension`

### DIFF
--- a/internal/services/kusto/kusto_cluster_resource.go
+++ b/internal/services/kusto/kusto_cluster_resource.go
@@ -6,7 +6,6 @@ package kusto
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"log"
 	"strings"
 	"time"
@@ -25,6 +24,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/kusto/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/kusto/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -323,7 +323,6 @@ func resourceKustoCluster() *pluginsdk.Resource {
 						return err
 					}
 				}
-
 			}
 
 			return nil
@@ -574,7 +573,6 @@ func resourceKustoClusterUpdate(d *pluginsdk.ResourceData, meta interface{}) err
 			// While the `CustomizeDiff` does update `*ResourceDiff` with the updated (empty) value, it doesn't seem to propagate through to the `*ResourceData` in `Update()`
 			if !hasError && !rawLanguageExtensions.IsNull() && rawLanguageExtensions.IsKnown() && !rawLanguageExtension.IsNull() && rawLanguageExtension.IsKnown() {
 				if len(rawLanguageExtensions.AsValueSlice()) == 0 && len(rawLanguageExtension.AsValueSlice()) == 0 {
-
 					props.LanguageExtensions = expandKustoClusterLanguageExtensionList(make([]any, 0))
 				}
 			}

--- a/internal/services/kusto/kusto_cluster_resource_test.go
+++ b/internal/services/kusto/kusto_cluster_resource_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
@@ -305,7 +306,7 @@ func TestAccKustoCluster_newSkus(t *testing.T) {
 	})
 }
 
-func TestAccKustoCluster_removeLanguageExtension(t *testing.T) {
+func TestAccKustoCluster_languageExtension(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_kusto_cluster", "test")
 	r := KustoClusterResource{}
 
@@ -325,13 +326,69 @@ func TestAccKustoCluster_removeLanguageExtension(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
+			Config: r.multipleLanguageExtensions(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basicHyperVSupportedSku(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				r.checkLanguageExtensions(data)...,
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccKustoCluster_languageExtensionsDeprecated(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as the `language_extensions` block was removed in 5.0")
+	}
+
+	data := acceptance.BuildTestData(t, "azurerm_kusto_cluster", "test")
+	r := KustoClusterResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
 			Config: r.basicHyperVSupportedSku(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
+		{
+			Config: r.multipleLanguageExtensionsDeprecated(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basicHyperVSupportedSku(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				r.checkLanguageExtensions(data)...,
+			),
+		},
+		data.ImportStep(),
 	})
+}
+
+func (r KustoClusterResource) checkLanguageExtensions(data acceptance.TestData) []pluginsdk.TestCheckFunc {
+	if !features.FivePointOh() {
+		// When removing this in 5.0, inline the `check.That(data.ResourceName).ExistsInAzure(r),` check in the TestStep
+		// and remove this method entirely.
+		return []pluginsdk.TestCheckFunc{
+			check.That(data.ResourceName).ExistsInAzure(r),
+			// While in 4.x this is O+C, so we want to ensure these blocks are empty
+			check.That(data.ResourceName).Key("language_extension.#").HasValue("0"),
+			check.That(data.ResourceName).Key("language_extensions.#").HasValue("0"),
+		}
+	}
+	return []pluginsdk.TestCheckFunc{
+		check.That(data.ResourceName).ExistsInAzure(r),
+	}
 }
 
 func (KustoClusterResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
@@ -414,6 +471,84 @@ resource "azurerm_kusto_cluster" "test" {
   public_network_access_enabled      = false
   public_ip_type                     = "DualStack"
   outbound_network_access_restricted = true
+
+  language_extension {
+    name  = "PYTHON"
+    image = "Python3_6_5"
+  }
+
+  sku {
+    name     = "Standard_L8s_v3"
+    capacity = 2
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}
+
+func (KustoClusterResource) multipleLanguageExtensions(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_kusto_cluster" "test" {
+  name                               = "acctestkc%s"
+  location                           = azurerm_resource_group.test.location
+  resource_group_name                = azurerm_resource_group.test.name
+  allowed_fqdns                      = ["example.blob.core.windows.net"]
+  allowed_ip_ranges                  = ["0.0.0.0/0"]
+  public_network_access_enabled      = false
+  public_ip_type                     = "DualStack"
+  outbound_network_access_restricted = true
+
+  language_extension {
+    name  = "R"
+    image = "R"
+  }
+
+  language_extension {
+    name  = "PYTHON"
+    image = "Python3_6_5"
+  }
+
+  sku {
+    name     = "Standard_L8s_v3"
+    capacity = 2
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}
+
+func (KustoClusterResource) multipleLanguageExtensionsDeprecated(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_kusto_cluster" "test" {
+  name                               = "acctestkc%s"
+  location                           = azurerm_resource_group.test.location
+  resource_group_name                = azurerm_resource_group.test.name
+  allowed_fqdns                      = ["example.blob.core.windows.net"]
+  allowed_ip_ranges                  = ["0.0.0.0/0"]
+  public_network_access_enabled      = false
+  public_ip_type                     = "DualStack"
+  outbound_network_access_restricted = true
+
+  language_extensions {
+    name  = "R"
+    image = "R"
+  }
 
   language_extensions {
     name  = "PYTHON"

--- a/website/docs/5.0-upgrade-guide.html.markdown
+++ b/website/docs/5.0-upgrade-guide.html.markdown
@@ -259,18 +259,19 @@ Please follow the format in the example below for listing breaking changes in re
 
 * The deprecated `linux_os_config.transparent_huge_page_enabled` property has been removed in favour of the `linux_os_config.transparent_huge_page` property.
 
-### `azurerm_kusto_eventgrid_data_connection`
-
-* The deprecated `eventgrid_resource_id` property has been removed in favour of the `eventgrid_event_subscription_id` property.
-* The deprecated `managed_identity_resource_id` property has been removed in favour of the `managed_identity_id` property.
-
 ### `azurerm_kusto_attached_database_configuration`
 
 * The deprecated `cluster_resource_id` property has been removed in favour of the `cluster_id` property.
 
 ### `azurerm_kusto_cluster`
 
+* The deprecated `language_extensions` property has been removed in favour of the `language_extension` property.
 * The deprecated `virtual_network_configuration` block has been removed as it is no longer supported by the resource.
+
+### `azurerm_kusto_eventgrid_data_connection`
+
+* The deprecated `eventgrid_resource_id` property has been removed in favour of the `eventgrid_event_subscription_id` property.
+* The deprecated `managed_identity_resource_id` property has been removed in favour of the `managed_identity_id` property.
 
 ### `azurerm_lb`
 

--- a/website/docs/r/kusto_cluster.html.markdown
+++ b/website/docs/r/kusto_cluster.html.markdown
@@ -60,7 +60,7 @@ The following arguments are supported:
 
 * `identity` - (Optional) An `identity` block as defined below.
 
-* `language_extensions` - (Optional) A `language_extensions` block as defined below.
+* `language_extension` - (Optional) A `language_extension` block as defined below.
 
 * `optimized_auto_scale` - (Optional) An `optimized_auto_scale` block as defined below.
 
@@ -94,7 +94,7 @@ An `identity` block supports the following:
 
 ---
 
-A `language_extensions` block supports the following:
+A `language_extension` block supports the following:
 
 * `name` - (Required) The name of the language extension. Possible values are `PYTHON` and `R`. 
 


### PR DESCRIPTION
Renaming block as documented previously

<img width="614" height="145" alt="image" src="https://github.com/user-attachments/assets/ca53d66a-ccdd-4798-a305-0bc4876b306a" />

Tests:

4.0:
<img width="480" height="151" alt="image" src="https://github.com/user-attachments/assets/15db5fb9-ae4f-4323-baf4-ed65bedea576" />

Single failure was a transient error, succeeded in the 5.0 run
<img width="391" height="37" alt="image" src="https://github.com/user-attachments/assets/9e1c3020-c186-48bf-b735-ba75af96bd63" />

<img width="398" height="34" alt="image" src="https://github.com/user-attachments/assets/1fc45759-0d92-4953-873e-94855da7858d" />


5.0:
<img width="488" height="146" alt="image" src="https://github.com/user-attachments/assets/8c0b2d22-3aa2-4cd6-8c90-d5fbe0cd9b38" />
