### PR TITLE
`azurerm_storage_account` - fix read to allow disabling the dataplane on existing resource that does not require it #30625

### DIFF
--- a/internal/services/storage/storage_account_resource_test.go
+++ b/internal/services/storage/storage_account_resource_test.go
@@ -1968,6 +1968,21 @@ func TestAccStorageAccount_noDataPlane(t *testing.T) {
 			),
 		},
 		data.ImportStep(),
+		// #30625: ensure we can disable/enable dataplane if it is not required for the resource
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.noDataPlane(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
 	})
 }
 


### PR DESCRIPTION
## Community Note

* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

Fix for #30625

The check when dataplane is disabled is based on if there are any value(s) for the `queue_properties` or `static_website` attributes.

However those 2 attributes are computed attributes which means if the storage account resource is applied at least once with dataplane enabled those 2 attributes will get a non nil value (containing the defaults set by Azure).

Then disabling the dataplane leads to an error because the provider supposes the user wants to modify those attributes as they are present in the state.

This PR fixes the issue (i.e. allows the disablement of a previously enabled dataplane) by removing those at refresh time when dataplane is disabled. Then at diff time only the inputs from the users will be used for the check, meaning the error will be thrown only on the intended case where someone tries to manage those attributes with dataplane disabled.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”

## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally.

## Change Log

* `azurerm_storage_account` - fix read to allow disabling the dataplane on existing resource that does not require it [GH-30625]

This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #30625