### PR TITLE
[TestCase] `azurerm_*_cost_management_export` - Update `container_id`

### DIFF
--- a/internal/services/costmanagement/export_resource_base.go
+++ b/internal/services/costmanagement/export_resource_base.go
@@ -69,9 +69,10 @@ func (br costManagementExportBaseResource) arguments(fields map[string]*pluginsd
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
 					"container_id": {
-						Type:     pluginsdk.TypeString,
-						Required: true,
-						ForceNew: true,
+						Type:         pluginsdk.TypeString,
+						Required:     true,
+						ForceNew:     true,
+						ValidateFunc: commonids.ValidateStorageContainerID,
 					},
 					"root_folder_path": {
 						Type:         pluginsdk.TypeString,

--- a/internal/services/costmanagement/export_resource_base.go
+++ b/internal/services/costmanagement/export_resource_base.go
@@ -69,10 +69,9 @@ func (br costManagementExportBaseResource) arguments(fields map[string]*pluginsd
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
 					"container_id": {
-						Type:         pluginsdk.TypeString,
-						Required:     true,
-						ForceNew:     true,
-						ValidateFunc: commonids.ValidateStorageContainerID,
+						Type:     pluginsdk.TypeString,
+						Required: true,
+						ForceNew: true,
 					},
 					"root_folder_path": {
 						Type:         pluginsdk.TypeString,

--- a/internal/services/costmanagement/resource_group_cost_management_export_resource_test.go
+++ b/internal/services/costmanagement/resource_group_cost_management_export_resource_test.go
@@ -129,7 +129,7 @@ resource "azurerm_resource_group_cost_management_export" "test" {
   recurrence_period_end_date   = "%sT00:00:00Z"
 
   export_data_storage_location {
-    container_id     = azurerm_storage_container.test.id
+    container_id     = "${azurerm_storage_account.test.id}/blobServices/default/containers/${azurerm_storage_container.test.name}"
     root_folder_path = "/root"
   }
   export_data_options {
@@ -174,7 +174,7 @@ resource "azurerm_resource_group_cost_management_export" "test" {
   file_format                  = "Csv"
 
   export_data_storage_location {
-    container_id     = azurerm_storage_container.test.id
+    container_id     = "${azurerm_storage_account.test.id}/blobServices/default/containers/${azurerm_storage_container.test.name}"
     root_folder_path = "/root"
   }
   export_data_options {
@@ -198,7 +198,7 @@ resource "azurerm_resource_group_cost_management_export" "import" {
   recurrence_period_end_date   = azurerm_resource_group_cost_management_export.test.recurrence_period_start_date
 
   export_data_storage_location {
-    container_id     = azurerm_storage_container.test.id
+    container_id     = "${azurerm_storage_account.test.id}/blobServices/default/containers/${azurerm_storage_container.test.name}"
     root_folder_path = "/root"
   }
 

--- a/internal/services/costmanagement/subscription_cost_management_export_resource_test.go
+++ b/internal/services/costmanagement/subscription_cost_management_export_resource_test.go
@@ -134,7 +134,7 @@ resource "azurerm_subscription_cost_management_export" "test" {
   recurrence_period_end_date   = "%sT00:00:00Z"
 
   export_data_storage_location {
-    container_id     = azurerm_storage_container.test.id
+    container_id     = "${azurerm_storage_account.test.id}/blobServices/default/containers/${azurerm_storage_container.test.name}"
     root_folder_path = "/root"
   }
 
@@ -184,7 +184,7 @@ resource "azurerm_subscription_cost_management_export" "test" {
   recurrence_period_end_date   = "%sT00:00:00Z"
 
   export_data_storage_location {
-    container_id     = azurerm_storage_container.test.id
+    container_id     = "${azurerm_storage_account.test.id}/blobServices/default/containers/${azurerm_storage_container.test.name}"
     root_folder_path = "/root"
   }
 
@@ -209,7 +209,7 @@ resource "azurerm_subscription_cost_management_export" "import" {
   recurrence_period_end_date   = azurerm_subscription_cost_management_export.test.recurrence_period_start_date
 
   export_data_storage_location {
-    container_id     = azurerm_storage_container.test.id
+    container_id     = "${azurerm_storage_account.test.id}/blobServices/default/containers/${azurerm_storage_container.test.name}"
     root_folder_path = "/root"
   }
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description
Recently, I noticed that testcases related with cost management export resource are failed on teamcity daily run. The root cause is that resource_manager_id of azurerm_storage_container is deprecated in favor of id. See more details from https://github.com/hashicorp/terraform-provider-azurerm/pull/30632. The container_id of azurerm_*_cost_management_export requires the ID of the resource. So, we have to update the container_id in the test case.

The example of id of azurerm_storage_container: https://xxxxx.blob.core.windows.net/xxxxx

The example of resource_manager_id of azurerm_storage_container: /subscriptions/xxxx/resourceGroups/xxxx/providers/Microsoft.Storage/storageAccounts/xxxx/blobServices/default/containers/xxxx

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

--- PASS: TestAccResourceGroupCostManagementExport_basic (250.26s)
--- PASS: TestAccResourceGroupCostManagementExport_update (433.49s)
--- PASS: TestAccResourceGroupCostManagementExport_requiresImport (207.36s)
--- PASS: TestAccSubscriptionCostManagementExport_basic (252.88s)
--- PASS: TestAccSubscriptionCostManagementExport_update (465.29s)
--- PASS: TestAccSubscriptionCostManagementExport_requiresImport (232.88s)


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* [TestCase] `azurerm_resource_group_cost_management_export` - Update `container_id`


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
