### PR TITLE
Testing: fix resource identity tests for storage service

### DIFF
--- a/internal/services/storage/storage_encryption_scope_resource.go
+++ b/internal/services/storage/storage_encryption_scope_resource.go
@@ -23,7 +23,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
-//go:generate go run ../../tools/generator-tests resourceidentity -resource-name storage_encryption_scope -service-package-name storage -properties "encryption_scope_name:name" -compare-values "subscription_id:storage_account_id,resource_group_name:storage_account_id,storage_account_name:storage_account_id" -test-name "keyVaultKey"
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name storage_encryption_scope -service-package-name storage -properties "name" -compare-values "subscription_id:storage_account_id,resource_group_name:storage_account_id,storage_account_name:storage_account_id" -test-name "keyVaultKey"
 
 func resourceStorageEncryptionScope() *pluginsdk.Resource {
 	return &pluginsdk.Resource{

--- a/internal/services/storage/storage_encryption_scope_resource_identity_gen_test.go
+++ b/internal/services/storage/storage_encryption_scope_resource_identity_gen_test.go
@@ -30,7 +30,7 @@ func TestAccStorageEncryptionScope_resourceIdentity(t *testing.T) {
 			{
 				Config: r.keyVaultKey(data),
 				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_storage_encryption_scope.test", tfjsonpath.New("encryption_scope_name"), tfjsonpath.New("name")),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_storage_encryption_scope.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
 					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_encryption_scope.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("storage_account_id")),
 					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_encryption_scope.test", tfjsonpath.New("storage_account_name"), tfjsonpath.New("storage_account_id")),
 					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_encryption_scope.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("storage_account_id")),

--- a/internal/services/storage/storage_sync_cloud_endpoint_resource.go
+++ b/internal/services/storage/storage_sync_cloud_endpoint_resource.go
@@ -22,7 +22,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
-//go:generate go run ../../tools/generator-tests resourceidentity -resource-name storage_sync_cloud_endpoint -service-package-name storage -properties "cloud_endpoint_name:name" -compare-values "subscription_id:storage_sync_group_id,resource_group_name:storage_sync_group_id,storage_sync_service_name:storage_sync_group_id,sync_group_name:storage_sync_group_id"
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name storage_sync_cloud_endpoint -service-package-name storage -properties "name" -compare-values "subscription_id:storage_sync_group_id,resource_group_name:storage_sync_group_id,storage_sync_service_name:storage_sync_group_id,sync_group_name:storage_sync_group_id"
 
 func resourceStorageSyncCloudEndpoint() *pluginsdk.Resource {
 	return &pluginsdk.Resource{

--- a/internal/services/storage/storage_sync_cloud_endpoint_resource_identity_gen_test.go
+++ b/internal/services/storage/storage_sync_cloud_endpoint_resource_identity_gen_test.go
@@ -30,7 +30,7 @@ func TestAccStorageSyncCloudEndpoint_resourceIdentity(t *testing.T) {
 			{
 				Config: r.basic(data),
 				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_storage_sync_cloud_endpoint.test", tfjsonpath.New("cloud_endpoint_name"), tfjsonpath.New("name")),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_storage_sync_cloud_endpoint.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
 					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_sync_cloud_endpoint.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("storage_sync_group_id")),
 					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_sync_cloud_endpoint.test", tfjsonpath.New("storage_sync_service_name"), tfjsonpath.New("storage_sync_group_id")),
 					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_sync_cloud_endpoint.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("storage_sync_group_id")),


### PR DESCRIPTION
Looks like these were missed during the change to our identity schema generator where the last segment is changed to `name` rather than `<something>_name`

<img width="464" height="88" alt="image" src="https://github.com/user-attachments/assets/d09d588e-fd9d-432a-9734-2e771738441e" />
