### PR TITLE
`azurerm_network_watcher_flow_log` - `target_resource_id` is no longer `ForceNew`

### DIFF
--- a/internal/services/network/network_watcher_flow_log_resource.go
+++ b/internal/services/network/network_watcher_flow_log_resource.go
@@ -4,6 +4,8 @@
 package network
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"log"
 	"time"
@@ -22,12 +24,12 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceNetworkWatcherFlowLog() *pluginsdk.Resource {
@@ -74,7 +76,6 @@ func resourceNetworkWatcherFlowLog() *pluginsdk.Resource {
 
 			"target_resource_id": {
 				Type:     pluginsdk.TypeString,
-				ForceNew: true,
 				Required: true,
 				ValidateFunc: validation.Any(
 					networksecuritygroups.ValidateNetworkSecurityGroupID,
@@ -175,6 +176,23 @@ func resourceNetworkWatcherFlowLog() *pluginsdk.Resource {
 
 			"tags": commonschema.Tags(),
 		},
+
+		CustomizeDiff: func(_ context.Context, d *pluginsdk.ResourceDiff, _ any) error {
+			if d.Id() == "" {
+				targetResourceId := d.Get("target_resource_id").(string)
+				if !features.FivePointOh() {
+					if v, ok := d.GetOk("network_security_group_id"); ok && v.(string) != "" {
+						targetResourceId = v.(string)
+					}
+				}
+
+				if _, err := networksecuritygroups.ParseNetworkSecurityGroupID(targetResourceId); err == nil {
+					return errors.New("creation of new NSG flow logs is no longer supported by Azure as of June 30, 2025. NSG flow logs will be retired on September 30, 2027. For more information, see https://learn.microsoft.com/azure/network-watcher/nsg-flow-logs-migrate")
+				}
+			}
+
+			return nil
+		},
 	}
 
 	if !features.FivePointOh() {
@@ -216,23 +234,6 @@ func resourceNetworkWatcherFlowLogCreate(d *pluginsdk.ResourceData, meta interfa
 
 	id := flowlogs.NewFlowLogID(subscriptionId, d.Get("resource_group_name").(string), d.Get("network_watcher_name").(string), d.Get("name").(string))
 
-	targetResourceId := ""
-
-	if !features.FivePointOh() {
-		if v, ok := d.GetOk("network_security_group_id"); ok && v.(string) != "" {
-			targetResourceId = v.(string)
-		}
-	}
-
-	if v, ok := d.GetOk("target_resource_id"); ok && v.(string) != "" {
-		targetResourceId = v.(string)
-	}
-
-	// For newly created resources, the "name" is required, it is set as Optional and Computed is merely for the existing ones for the sake of backward compatibility.
-	if id.NetworkWatcherName == "" {
-		return fmt.Errorf("`name` is required for Network Watcher Flow Log")
-	}
-
 	existing, err := client.Get(ctx, id)
 	if err != nil {
 		if !response.WasNotFound(existing.HttpResponse) {
@@ -243,6 +244,8 @@ func resourceNetworkWatcherFlowLogCreate(d *pluginsdk.ResourceData, meta interfa
 	if !response.WasNotFound(existing.HttpResponse) {
 		return tf.ImportAsExistsError("azurerm_network_watcher_flow_log", id.ID())
 	}
+
+	targetResourceId := d.Get("target_resource_id").(string)
 
 	locks.ByID(targetResourceId)
 	defer locks.UnlockByID(targetResourceId)
@@ -262,7 +265,7 @@ func resourceNetworkWatcherFlowLogCreate(d *pluginsdk.ResourceData, meta interfa
 	}
 
 	parameters := flowlogs.FlowLog{
-		Location: utils.String(location.Normalize(loc)),
+		Location: pointer.To(location.Normalize(loc)),
 		Properties: &flowlogs.FlowLogPropertiesFormat{
 			TargetResourceId: targetResourceId,
 			StorageId:        d.Get("storage_account_id").(string),
@@ -317,16 +320,12 @@ func resourceNetworkWatcherFlowLogUpdate(d *pluginsdk.ResourceData, meta interfa
 
 	payload := existing.Model
 
-	targetResourceId := ""
-
+	targetResourceId := d.Get("target_resource_id").(string)
 	if !features.FivePointOh() {
-		if v, ok := d.GetOk("network_security_group_id"); ok && v.(string) != "" {
-			targetResourceId = v.(string)
+		// Need to use RawConfig here since both properties are computed and a `Get`/`GetOk` may return the previously computed value
+		if rawVal, diags := d.GetRawConfigAt(sdk.ConstructCtyPath("network_security_group_id")); !diags.HasError() && !rawVal.IsNull() {
+			targetResourceId = rawVal.AsString()
 		}
-	}
-
-	if v, ok := d.GetOk("target_resource_id"); ok && v.(string) != "" {
-		targetResourceId = v.(string)
 	}
 
 	locks.ByID(targetResourceId)
@@ -360,6 +359,10 @@ func resourceNetworkWatcherFlowLogUpdate(d *pluginsdk.ResourceData, meta interfa
 
 	if d.HasChange("tags") {
 		payload.Tags = tags.Expand(d.Get("tags").(map[string]interface{}))
+	}
+
+	if d.HasChange("target_resource_id") || (!features.FivePointOh() && d.HasChange("network_security_group_id")) {
+		payload.Properties.TargetResourceId = targetResourceId
 	}
 
 	if err := client.CreateOrUpdateThenPoll(ctx, *id, *payload); err != nil {
@@ -430,8 +433,14 @@ func resourceNetworkWatcherFlowLogRead(d *pluginsdk.ResourceData, meta interface
 				targetResourceId = nicId.ID()
 			}
 
-			if !features.FivePointOh() && targetIsNSG {
-				d.Set("network_security_group_id", targetResourceId)
+			if !features.FivePointOh() {
+				if targetIsNSG {
+					d.Set("network_security_group_id", targetResourceId)
+				} else {
+					// If `network_security_group_id` was previously set, and target is no longer an NSG
+					// ensure we remove `network_security_group_id` from state
+					d.Set("network_security_group_id", nil)
+				}
 			}
 
 			d.Set("target_resource_id", targetResourceId)
@@ -573,9 +582,9 @@ func expandNetworkWatcherFlowLogTrafficAnalytics(d *pluginsdk.ResourceData) *flo
 	return &flowlogs.TrafficAnalyticsProperties{
 		NetworkWatcherFlowAnalyticsConfiguration: &flowlogs.TrafficAnalyticsConfigurationProperties{
 			Enabled:                  pointer.To(enabled),
-			WorkspaceId:              utils.String(workspaceID),
-			WorkspaceRegion:          utils.String(workspaceRegion),
-			WorkspaceResourceId:      utils.String(workspaceResourceID),
+			WorkspaceId:              pointer.To(workspaceID),
+			WorkspaceRegion:          pointer.To(workspaceRegion),
+			WorkspaceResourceId:      pointer.To(workspaceResourceID),
 			TrafficAnalyticsInterval: pointer.To(int64(interval)),
 		},
 	}

--- a/internal/services/network/network_watcher_flow_log_resource_test.go
+++ b/internal/services/network/network_watcher_flow_log_resource_test.go
@@ -6,6 +6,7 @@ package network_test
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -25,7 +26,7 @@ func testAccNetworkWatcherFlowLog_basic(t *testing.T) {
 
 	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.basicConfig(data),
+			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -34,18 +35,46 @@ func testAccNetworkWatcherFlowLog_basic(t *testing.T) {
 	})
 }
 
-func testAccNetworkWatcherFlowLog_basicWithVirtualNetwork(t *testing.T) {
+func testAccNetworkWatcherFlowLog_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_network_watcher_flow_log", "test")
 	r := NetworkWatcherFlowLogResource{}
 
 	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.basicConfigWithVirtualNetwork(data),
+			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
+		{
+			// turns out while you can't create with an NSG, you can create a new flow log
+			// and update it to an NSG, so we'll include that in the test for now ¯\_(ツ)_/¯
+			Config: r.basicWithNSG(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func testAccNetworkWatcherFlowLog_cannotCreateNewWithNSG(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_network_watcher_flow_log", "test")
+	r := NetworkWatcherFlowLogResource{}
+
+	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
+		{
+			Config:      r.basicWithNSG(data),
+			ExpectError: regexp.MustCompile("creation of new NSG flow logs is no longer supported by Azure as of June 30, 2025."),
+		},
 	})
 }
 
@@ -85,7 +114,7 @@ func testAccNetworkWatcherFlowLog_requiresImport(t *testing.T) {
 
 	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.basicConfig(data),
+			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -125,7 +154,7 @@ func testAccNetworkWatcherFlowLog_reenabled(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			Config: r.basicConfig(data),
+			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -140,7 +169,7 @@ func testAccNetworkWatcherFlowLog_retentionPolicy(t *testing.T) {
 
 	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.basicConfig(data),
+			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -184,7 +213,7 @@ func testAccNetworkWatcherFlowLog_trafficAnalytics(t *testing.T) {
 
 	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.basicConfig(data),
+			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -218,8 +247,9 @@ func testAccNetworkWatcherFlowLog_trafficAnalytics(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
+		data.ImportStep(),
 		{
-			Config: r.basicConfig(data),
+			Config: r.basicIgnoreUnmanaged(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -287,7 +317,7 @@ func testAccNetworkWatcherFlowLog_tags(t *testing.T) {
 	})
 }
 
-func (t NetworkWatcherFlowLogResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+func (r NetworkWatcherFlowLogResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := flowlogs.ParseFlowLogID(state.ID)
 	if err != nil {
 		return nil, err
@@ -301,31 +331,41 @@ func (t NetworkWatcherFlowLogResource) Exists(ctx context.Context, clients *clie
 	return pointer.To(resp.Model != nil), nil
 }
 
-func (NetworkWatcherFlowLogResource) prerequisites(data acceptance.TestData) string {
+func (NetworkWatcherFlowLogResource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-watcher-%d"
-  location = "%s"
+  name     = "acctestRG-watcher-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_network_security_group" "test" {
-  name                = "acctestNSG%d"
+  name                = "acctestNSG%[1]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
 }
 
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvn-%[1]d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctestsubnet-%[1]d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.1.0/24"]
+}
+
 resource "azurerm_network_watcher" "test" {
-  name                = "acctest-NW-%d"
+  name                = "acctest-NW-%[1]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
 }
 
 resource "azurerm_storage_account" "test" {
-  name                = "acctestsa%d"
+  name                = "acctestsa%[3]d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
 
@@ -334,18 +374,22 @@ resource "azurerm_storage_account" "test" {
   account_replication_type   = "LRS"
   https_traffic_only_enabled = true
 }
-`, data.RandomIntOfLength(10), data.Locations.Primary, data.RandomIntOfLength(10), data.RandomInteger, data.RandomInteger%1000000)
+`, data.RandomIntOfLength(10), data.Locations.Primary, data.RandomInteger%1000000)
 }
 
-func (r NetworkWatcherFlowLogResource) basicConfig(data acceptance.TestData) string {
+func (r NetworkWatcherFlowLogResource) basicWithNSG(data acceptance.TestData) string {
 	if !features.FivePointOh() {
 		return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 %s
 
 resource "azurerm_network_watcher_flow_log" "test" {
   network_watcher_name = azurerm_network_watcher.test.name
   resource_group_name  = azurerm_resource_group.test.name
-  name                 = "flowlog-%d"
+  name                 = "flowlog-%[2]d"
 
   network_security_group_id = azurerm_network_security_group.test.id
   storage_account_id        = azurerm_storage_account.test.id
@@ -356,15 +400,19 @@ resource "azurerm_network_watcher_flow_log" "test" {
     days    = 0
   }
 }
-`, r.prerequisites(data), data.RandomInteger)
+`, r.template(data), data.RandomInteger)
 	}
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 %s
 
 resource "azurerm_network_watcher_flow_log" "test" {
   network_watcher_name = azurerm_network_watcher.test.name
   resource_group_name  = azurerm_resource_group.test.name
-  name                 = "flowlog-%d"
+  name                 = "flowlog-%[2]d"
 
   target_resource_id = azurerm_network_security_group.test.id
   storage_account_id = azurerm_storage_account.test.id
@@ -375,51 +423,21 @@ resource "azurerm_network_watcher_flow_log" "test" {
     days    = 0
   }
 }
-`, r.prerequisites(data), data.RandomInteger)
+`, r.template(data), data.RandomInteger)
 }
 
-func (r NetworkWatcherFlowLogResource) basicConfigWithVirtualNetwork(data acceptance.TestData) string {
-	if !features.FivePointOh() {
-		return fmt.Sprintf(`
-%s
-
-resource "azurerm_virtual_network" "test" {
-  name                = "acctestvn-%d"
-  address_space       = ["10.0.0.0/16"]
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-}
-
-resource "azurerm_network_watcher_flow_log" "test" {
-  network_watcher_name = azurerm_network_watcher.test.name
-  resource_group_name  = azurerm_resource_group.test.name
-  name                 = "flowlog-%d"
-
-  target_resource_id = azurerm_virtual_network.test.id
-  storage_account_id = azurerm_storage_account.test.id
-  enabled            = true
-
-  retention_policy {
-    enabled = false
-    days    = 0
-  }
-}
-`, r.prerequisites(data), data.RandomInteger, data.RandomInteger)
-	}
+func (r NetworkWatcherFlowLogResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-%s
-
-resource "azurerm_virtual_network" "test" {
-  name                = "acctestvn-%d"
-  address_space       = ["10.0.0.0/16"]
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
+provider "azurerm" {
+  features {}
 }
+
+%s
 
 resource "azurerm_network_watcher_flow_log" "test" {
   network_watcher_name = azurerm_network_watcher.test.name
   resource_group_name  = azurerm_resource_group.test.name
-  name                 = "flowlog-%d"
+  name                 = "flowlog-%[2]d"
 
   target_resource_id = azurerm_virtual_network.test.id
   storage_account_id = azurerm_storage_account.test.id
@@ -430,31 +448,51 @@ resource "azurerm_network_watcher_flow_log" "test" {
     days    = 0
   }
 }
-`, r.prerequisites(data), data.RandomInteger, data.RandomInteger)
+`, r.template(data), data.RandomInteger)
+}
+
+func (r NetworkWatcherFlowLogResource) basicIgnoreUnmanaged(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    resource_group {
+      # "azurerm_log_analytics_workspace" leaves behind unmanaged resources created by Azure
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}
+
+%s
+
+resource "azurerm_network_watcher_flow_log" "test" {
+  network_watcher_name = azurerm_network_watcher.test.name
+  resource_group_name  = azurerm_resource_group.test.name
+  name                 = "flowlog-%[2]d"
+
+  target_resource_id = azurerm_virtual_network.test.id
+  storage_account_id = azurerm_storage_account.test.id
+  enabled            = true
+
+  retention_policy {
+    enabled = false
+    days    = 0
+  }
+}
+`, r.template(data), data.RandomInteger)
 }
 
 func (r NetworkWatcherFlowLogResource) basicConfigWithSubnet(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 %s
-
-resource "azurerm_virtual_network" "test" {
-  name                = "acctestvn-%d"
-  address_space       = ["10.0.0.0/16"]
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-}
-
-resource "azurerm_subnet" "test" {
-  name                 = "acctestsubnet-%d"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes     = ["10.0.1.0/24"]
-}
 
 resource "azurerm_network_watcher_flow_log" "test" {
   network_watcher_name = azurerm_network_watcher.test.name
   resource_group_name  = azurerm_resource_group.test.name
-  name                 = "flowlog-%d"
+  name                 = "flowlog-%[2]d"
 
   target_resource_id = azurerm_subnet.test.id
   storage_account_id = azurerm_storage_account.test.id
@@ -465,29 +503,19 @@ resource "azurerm_network_watcher_flow_log" "test" {
     days    = 0
   }
 }
-`, r.prerequisites(data), data.RandomInteger, data.RandomInteger, data.RandomInteger)
+`, r.template(data), data.RandomInteger)
 }
 
 func (r NetworkWatcherFlowLogResource) basicConfigWithNIC(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 %s
 
-resource "azurerm_virtual_network" "test" {
-  name                = "acctestvn-%d"
-  address_space       = ["10.0.0.0/16"]
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-}
-
-resource "azurerm_subnet" "test" {
-  name                 = "acctestsubnet-%d"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes     = ["10.0.1.0/24"]
-}
-
 resource "azurerm_network_interface" "test" {
-  name                = "acctestnic-%d"
+  name                = "acctestnic-%[2]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
 
@@ -498,10 +526,36 @@ resource "azurerm_network_interface" "test" {
   }
 }
 
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctestVM-%[2]d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  admin_password                  = "T@rraf0rmTest"
+  disable_password_authentication = false
+
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "0001-com-ubuntu-server-jammy"
+    sku       = "22_04-lts"
+    version   = "latest"
+  }
+}
+
 resource "azurerm_network_watcher_flow_log" "test" {
   network_watcher_name = azurerm_network_watcher.test.name
   resource_group_name  = azurerm_resource_group.test.name
-  name                 = "flowlog-%d"
+  name                 = "flowlog-%[2]d"
 
   target_resource_id = azurerm_network_interface.test.id
   storage_account_id = azurerm_storage_account.test.id
@@ -512,30 +566,10 @@ resource "azurerm_network_watcher_flow_log" "test" {
     days    = 0
   }
 }
-`, r.prerequisites(data), data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+`, r.template(data), data.RandomInteger)
 }
 
 func (r NetworkWatcherFlowLogResource) requiresImport(data acceptance.TestData) string {
-	if !features.FivePointOh() {
-		return fmt.Sprintf(`
-%s
-
-resource "azurerm_network_watcher_flow_log" "import" {
-  network_watcher_name = azurerm_network_watcher_flow_log.test.network_watcher_name
-  resource_group_name  = azurerm_network_watcher_flow_log.test.resource_group_name
-  name                 = azurerm_network_watcher_flow_log.test.name
-
-  network_security_group_id = azurerm_network_watcher_flow_log.test.target_resource_id
-  storage_account_id        = azurerm_network_watcher_flow_log.test.storage_account_id
-  enabled                   = azurerm_network_watcher_flow_log.test.enabled
-
-  retention_policy {
-    enabled = false
-    days    = 0
-  }
-}
-`, r.basicConfig(data))
-	}
 	return fmt.Sprintf(`
 %s
 
@@ -553,31 +587,15 @@ resource "azurerm_network_watcher_flow_log" "import" {
     days    = 0
   }
 }
-`, r.basicConfig(data))
+`, r.basic(data))
 }
 
 func (r NetworkWatcherFlowLogResource) retentionPolicyConfig(data acceptance.TestData) string {
-	if !features.FivePointOh() {
-		return fmt.Sprintf(`
-%s
-
-resource "azurerm_network_watcher_flow_log" "test" {
-  network_watcher_name = azurerm_network_watcher.test.name
-  resource_group_name  = azurerm_resource_group.test.name
-  name                 = "flowlog-%d"
-
-  network_security_group_id = azurerm_network_security_group.test.id
-  storage_account_id        = azurerm_storage_account.test.id
-  enabled                   = true
-
-  retention_policy {
-    enabled = true
-    days    = 7
-  }
-}
-`, r.prerequisites(data), data.RandomInteger)
-	}
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 %s
 
 resource "azurerm_network_watcher_flow_log" "test" {
@@ -585,7 +603,7 @@ resource "azurerm_network_watcher_flow_log" "test" {
   resource_group_name  = azurerm_resource_group.test.name
   name                 = "flowlog-%d"
 
-  target_resource_id = azurerm_network_security_group.test.id
+  target_resource_id = azurerm_virtual_network.test.id
   storage_account_id = azurerm_storage_account.test.id
   enabled            = true
 
@@ -594,42 +612,15 @@ resource "azurerm_network_watcher_flow_log" "test" {
     days    = 7
   }
 }
-`, r.prerequisites(data), data.RandomInteger)
+`, r.template(data), data.RandomInteger)
 }
 
 func (r NetworkWatcherFlowLogResource) retentionPolicyConfigUpdateStorageAccount(data acceptance.TestData) string {
-	if !features.FivePointOh() {
-		return fmt.Sprintf(`
-%s
-
-resource "azurerm_storage_account" "testb" {
-  name                = "acctestsab%d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-
-  account_tier               = "Standard"
-  account_kind               = "StorageV2"
-  account_replication_type   = "LRS"
-  https_traffic_only_enabled = true
-}
-
-resource "azurerm_network_watcher_flow_log" "test" {
-  network_watcher_name = azurerm_network_watcher.test.name
-  resource_group_name  = azurerm_resource_group.test.name
-  name                 = "flowlog-%d"
-
-  network_security_group_id = azurerm_network_security_group.test.id
-  storage_account_id        = azurerm_storage_account.testb.id
-  enabled                   = true
-
-  retention_policy {
-    enabled = true
-    days    = 7
-  }
-}
-`, r.prerequisites(data), data.RandomInteger%1000000+1, data.RandomInteger)
-	}
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 %s
 
 resource "azurerm_storage_account" "testb" {
@@ -648,7 +639,7 @@ resource "azurerm_network_watcher_flow_log" "test" {
   resource_group_name  = azurerm_resource_group.test.name
   name                 = "flowlog-%d"
 
-  target_resource_id = azurerm_network_security_group.test.id
+  target_resource_id = azurerm_virtual_network.test.id
   storage_account_id = azurerm_storage_account.testb.id
   enabled            = true
 
@@ -657,32 +648,15 @@ resource "azurerm_network_watcher_flow_log" "test" {
     days    = 7
   }
 }
-`, r.prerequisites(data), data.RandomInteger%1000000+1, data.RandomInteger)
+`, r.template(data), data.RandomInteger%1000000+1, data.RandomInteger)
 }
 
 func (r NetworkWatcherFlowLogResource) disabledConfig(data acceptance.TestData) string {
-	if !features.FivePointOh() {
-		return fmt.Sprintf(`
-%s
-
-resource "azurerm_network_watcher_flow_log" "test" {
-  network_watcher_name = azurerm_network_watcher.test.name
-  resource_group_name  = azurerm_resource_group.test.name
-  name                 = "flowlog-%d"
-  location             = azurerm_network_watcher.test.location
-
-  network_security_group_id = azurerm_network_security_group.test.id
-  storage_account_id        = azurerm_storage_account.test.id
-  enabled                   = false
-
-  retention_policy {
-    enabled = true
-    days    = 7
-  }
-}
-`, r.prerequisites(data), data.RandomInteger)
-	}
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 %s
 
 resource "azurerm_network_watcher_flow_log" "test" {
@@ -691,7 +665,7 @@ resource "azurerm_network_watcher_flow_log" "test" {
   name                 = "flowlog-%d"
   location             = azurerm_network_watcher.test.location
 
-  target_resource_id = azurerm_network_security_group.test.id
+  target_resource_id = azurerm_virtual_network.test.id
   storage_account_id = azurerm_storage_account.test.id
   enabled            = false
 
@@ -700,46 +674,20 @@ resource "azurerm_network_watcher_flow_log" "test" {
     days    = 7
   }
 }
-`, r.prerequisites(data), data.RandomInteger)
+`, r.template(data), data.RandomInteger)
 }
 
 func (r NetworkWatcherFlowLogResource) TrafficAnalyticsEnabledConfig(data acceptance.TestData) string {
-	if !features.FivePointOh() {
-		return fmt.Sprintf(`
-%s
-
-resource "azurerm_log_analytics_workspace" "test" {
-  name                = "acctestLAW-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  sku                 = "PerGB2018"
-}
-
-resource "azurerm_network_watcher_flow_log" "test" {
-  network_watcher_name = azurerm_network_watcher.test.name
-  resource_group_name  = azurerm_resource_group.test.name
-  name                 = "flowlog-%d"
-  location             = azurerm_network_watcher.test.location
-
-  network_security_group_id = azurerm_network_security_group.test.id
-  storage_account_id        = azurerm_storage_account.test.id
-  enabled                   = true
-
-  retention_policy {
-    enabled = true
-    days    = 7
-  }
-
-  traffic_analytics {
-    enabled               = true
-    workspace_id          = azurerm_log_analytics_workspace.test.workspace_id
-    workspace_region      = azurerm_log_analytics_workspace.test.location
-    workspace_resource_id = azurerm_log_analytics_workspace.test.id
-  }
-}
-`, r.prerequisites(data), data.RandomInteger, data.RandomInteger)
-	}
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    resource_group {
+      # "azurerm_log_analytics_workspace" leaves behind unmanaged resources created by Azure
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}
+
 %s
 
 resource "azurerm_log_analytics_workspace" "test" {
@@ -755,7 +703,7 @@ resource "azurerm_network_watcher_flow_log" "test" {
   name                 = "flowlog-%d"
   location             = azurerm_network_watcher.test.location
 
-  target_resource_id = azurerm_network_security_group.test.id
+  target_resource_id = azurerm_virtual_network.test.id
   storage_account_id = azurerm_storage_account.test.id
   enabled            = true
 
@@ -771,47 +719,20 @@ resource "azurerm_network_watcher_flow_log" "test" {
     workspace_resource_id = azurerm_log_analytics_workspace.test.id
   }
 }
-`, r.prerequisites(data), data.RandomInteger, data.RandomInteger)
+`, r.template(data), data.RandomInteger, data.RandomInteger)
 }
 
 func (r NetworkWatcherFlowLogResource) TrafficAnalyticsUpdateInterval(data acceptance.TestData) string {
-	if !features.FivePointOh() {
-		return fmt.Sprintf(`
-%s
-
-resource "azurerm_log_analytics_workspace" "test" {
-  name                = "acctestLAW-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  sku                 = "PerGB2018"
-}
-
-resource "azurerm_network_watcher_flow_log" "test" {
-  network_watcher_name = azurerm_network_watcher.test.name
-  resource_group_name  = azurerm_resource_group.test.name
-  name                 = "flowlog-%d"
-  location             = azurerm_network_watcher.test.location
-
-  network_security_group_id = azurerm_network_security_group.test.id
-  storage_account_id        = azurerm_storage_account.test.id
-  enabled                   = true
-
-  retention_policy {
-    enabled = true
-    days    = 7
-  }
-
-  traffic_analytics {
-    enabled               = true
-    workspace_id          = azurerm_log_analytics_workspace.test.workspace_id
-    workspace_region      = azurerm_log_analytics_workspace.test.location
-    workspace_resource_id = azurerm_log_analytics_workspace.test.id
-    interval_in_minutes   = 10
-  }
-}
-`, r.prerequisites(data), data.RandomInteger, data.RandomInteger)
-	}
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    resource_group {
+      # "azurerm_log_analytics_workspace" leaves behind unmanaged resources created by Azure
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}
+
 %s
 
 resource "azurerm_log_analytics_workspace" "test" {
@@ -827,7 +748,7 @@ resource "azurerm_network_watcher_flow_log" "test" {
   name                 = "flowlog-%d"
   location             = azurerm_network_watcher.test.location
 
-  target_resource_id = azurerm_network_security_group.test.id
+  target_resource_id = azurerm_virtual_network.test.id
   storage_account_id = azurerm_storage_account.test.id
   enabled            = true
 
@@ -844,47 +765,20 @@ resource "azurerm_network_watcher_flow_log" "test" {
     interval_in_minutes   = 10
   }
 }
-`, r.prerequisites(data), data.RandomInteger, data.RandomInteger)
+`, r.template(data), data.RandomInteger, data.RandomInteger)
 }
 
 func (r NetworkWatcherFlowLogResource) TrafficAnalyticsDisabledConfig(data acceptance.TestData) string {
-	if !features.FivePointOh() {
-		return fmt.Sprintf(`
-%s
-
-resource "azurerm_log_analytics_workspace" "test" {
-  name                = "acctestLAW-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  sku                 = "PerGB2018"
-}
-
-resource "azurerm_network_watcher_flow_log" "test" {
-  network_watcher_name = azurerm_network_watcher.test.name
-  resource_group_name  = azurerm_resource_group.test.name
-  name                 = "flowlog-%d"
-  location             = azurerm_network_watcher.test.location
-
-  network_security_group_id = azurerm_network_security_group.test.id
-  storage_account_id        = azurerm_storage_account.test.id
-  enabled                   = true
-
-  retention_policy {
-    enabled = true
-    days    = 7
-  }
-
-  traffic_analytics {
-    enabled               = false
-    workspace_id          = azurerm_log_analytics_workspace.test.workspace_id
-    workspace_region      = azurerm_log_analytics_workspace.test.location
-    workspace_resource_id = azurerm_log_analytics_workspace.test.id
-  }
-}
-`, r.prerequisites(data), data.RandomInteger, data.RandomInteger)
-	}
-
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    resource_group {
+      # "azurerm_log_analytics_workspace" leaves behind unmanaged resources created by Azure
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}
+
 %s
 
 resource "azurerm_log_analytics_workspace" "test" {
@@ -900,7 +794,7 @@ resource "azurerm_network_watcher_flow_log" "test" {
   name                 = "flowlog-%d"
   location             = azurerm_network_watcher.test.location
 
-  target_resource_id = azurerm_network_security_group.test.id
+  target_resource_id = azurerm_virtual_network.test.id
   storage_account_id = azurerm_storage_account.test.id
   enabled            = true
 
@@ -916,47 +810,20 @@ resource "azurerm_network_watcher_flow_log" "test" {
     workspace_resource_id = azurerm_log_analytics_workspace.test.id
   }
 }
-`, r.prerequisites(data), data.RandomInteger, data.RandomInteger)
+`, r.template(data), data.RandomInteger, data.RandomInteger)
 }
 
 func (r NetworkWatcherFlowLogResource) versionConfig(data acceptance.TestData, version int) string {
-	if !features.FivePointOh() {
-		return fmt.Sprintf(`
-%s
-
-resource "azurerm_log_analytics_workspace" "test" {
-  name                = "acctestLAW-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  sku                 = "PerGB2018"
-}
-
-resource "azurerm_network_watcher_flow_log" "test" {
-  network_watcher_name = azurerm_network_watcher.test.name
-  resource_group_name  = azurerm_resource_group.test.name
-  name                 = "flowlog-%d"
-  location             = azurerm_network_watcher.test.location
-
-  network_security_group_id = azurerm_network_security_group.test.id
-  storage_account_id        = azurerm_storage_account.test.id
-  enabled                   = true
-  version                   = %d
-
-  retention_policy {
-    enabled = true
-    days    = 7
-  }
-
-  traffic_analytics {
-    enabled               = true
-    workspace_id          = azurerm_log_analytics_workspace.test.workspace_id
-    workspace_region      = azurerm_log_analytics_workspace.test.location
-    workspace_resource_id = azurerm_log_analytics_workspace.test.id
-  }
-}
-`, r.prerequisites(data), data.RandomInteger, data.RandomInteger, version)
-	}
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    resource_group {
+      # "azurerm_log_analytics_workspace" leaves behind unmanaged resources created by Azure
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}
+
 %s
 
 resource "azurerm_log_analytics_workspace" "test" {
@@ -972,7 +839,7 @@ resource "azurerm_network_watcher_flow_log" "test" {
   name                 = "flowlog-%d"
   location             = azurerm_network_watcher.test.location
 
-  target_resource_id = azurerm_network_security_group.test.id
+  target_resource_id = azurerm_virtual_network.test.id
   storage_account_id = azurerm_storage_account.test.id
   enabled            = true
   version            = %d
@@ -989,32 +856,15 @@ resource "azurerm_network_watcher_flow_log" "test" {
     workspace_resource_id = azurerm_log_analytics_workspace.test.id
   }
 }
-`, r.prerequisites(data), data.RandomInteger, data.RandomInteger, version)
+`, r.template(data), data.RandomInteger, data.RandomInteger, version)
 }
 
 func (r NetworkWatcherFlowLogResource) location(data acceptance.TestData) string {
-	if !features.FivePointOh() {
-		return fmt.Sprintf(`
-%s
-
-resource "azurerm_network_watcher_flow_log" "test" {
-  network_watcher_name = azurerm_network_watcher.test.name
-  resource_group_name  = azurerm_resource_group.test.name
-  name                 = "flowlog-%d"
-  location             = azurerm_resource_group.test.location
-
-  network_security_group_id = azurerm_network_security_group.test.id
-  storage_account_id        = azurerm_storage_account.test.id
-  enabled                   = true
-
-  retention_policy {
-    enabled = false
-    days    = 0
-  }
-}
-`, r.prerequisites(data), data.RandomInteger)
-	}
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 %s
 
 resource "azurerm_network_watcher_flow_log" "test" {
@@ -1023,7 +873,7 @@ resource "azurerm_network_watcher_flow_log" "test" {
   name                 = "flowlog-%d"
   location             = azurerm_resource_group.test.location
 
-  target_resource_id = azurerm_network_security_group.test.id
+  target_resource_id = azurerm_virtual_network.test.id
   storage_account_id = azurerm_storage_account.test.id
   enabled            = true
 
@@ -1032,35 +882,15 @@ resource "azurerm_network_watcher_flow_log" "test" {
     days    = 0
   }
 }
-`, r.prerequisites(data), data.RandomInteger)
+`, r.template(data), data.RandomInteger)
 }
 
 func (r NetworkWatcherFlowLogResource) tags(data acceptance.TestData, v string) string {
-	if !features.FivePointOh() {
-		return fmt.Sprintf(`
-%s
-
-resource "azurerm_network_watcher_flow_log" "test" {
-  network_watcher_name = azurerm_network_watcher.test.name
-  resource_group_name  = azurerm_resource_group.test.name
-  name                 = "flowlog-%d"
-
-  network_security_group_id = azurerm_network_security_group.test.id
-  storage_account_id        = azurerm_storage_account.test.id
-  enabled                   = true
-
-  retention_policy {
-    enabled = false
-    days    = 0
-  }
-
-  tags = {
-    env = "%s"
-  }
-}
-`, r.prerequisites(data), data.RandomInteger, v)
-	}
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
 %s
 
 resource "azurerm_network_watcher_flow_log" "test" {
@@ -1068,7 +898,7 @@ resource "azurerm_network_watcher_flow_log" "test" {
   resource_group_name  = azurerm_resource_group.test.name
   name                 = "flowlog-%d"
 
-  target_resource_id = azurerm_network_security_group.test.id
+  target_resource_id = azurerm_virtual_network.test.id
   storage_account_id = azurerm_storage_account.test.id
   enabled            = true
 
@@ -1081,5 +911,5 @@ resource "azurerm_network_watcher_flow_log" "test" {
     env = "%s"
   }
 }
-`, r.prerequisites(data), data.RandomInteger, v)
+`, r.template(data), data.RandomInteger, v)
 }

--- a/internal/services/network/network_watcher_resource_test.go
+++ b/internal/services/network/network_watcher_resource_test.go
@@ -77,8 +77,7 @@ func TestAccNetworkWatcher(t *testing.T) {
 			"machineScope":               testAccVirtualMachineScaleSetPacketCapture_machineScope,
 		},
 		"FlowLog": {
-			"basic":                   testAccNetworkWatcherFlowLog_basic,
-			"basicWithVirtualNetwork": testAccNetworkWatcherFlowLog_basicWithVirtualNetwork,
+			"basicWithVirtualNetwork": testAccNetworkWatcherFlowLog_basic,
 			"basicWithSubnet":         testAccNetworkWatcherFlowLog_basicWithSubnet,
 			"basicWithNIC":            testAccNetworkWatcherFlowLog_basicWithNIC,
 			"requiresImport":          testAccNetworkWatcherFlowLog_requiresImport,
@@ -90,6 +89,8 @@ func TestAccNetworkWatcher(t *testing.T) {
 			"version":                 testAccNetworkWatcherFlowLog_version,
 			"location":                testAccNetworkWatcherFlowLog_location,
 			"tags":                    testAccNetworkWatcherFlowLog_tags,
+			"cannotCreateNewWithNSG":  testAccNetworkWatcherFlowLog_cannotCreateNewWithNSG,
+			"update":                  testAccNetworkWatcherFlowLog_update,
 		},
 	}
 

--- a/website/docs/r/network_watcher_flow_log.html.markdown
+++ b/website/docs/r/network_watcher_flow_log.html.markdown
@@ -85,13 +85,17 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) The name of the resource group in which the Network Watcher was deployed. Changing this forces a new resource to be created.
 
-* `target_resource_id` - (Required) The ID of the Resource for which to enable flow logs for. Changing this forces a new resource to be created.
+* `target_resource_id` - (Required) The ID of the Resource for which to enable flow logs for.
+
+~> **Note:** As of July 30, 2025, it is no longer possible to create new flow logs for Network Security Groups.
 
 * `storage_account_id` - (Required) The ID of the Storage Account where flow logs are stored.
 
 * `enabled` - (Required) Should Network Flow Logging be Enabled?
 
 * `retention_policy` - (Required) A `retention_policy` block as documented below.
+
+---
 
 * `location` - (Optional) The location where the Network Watcher Flow Log resides. Changing this forces a new resource to be created. Defaults to the `location` of the Network Watcher.
 
@@ -106,6 +110,7 @@ The following arguments are supported:
 The `retention_policy` block supports the following:
 
 * `enabled` - (Required) Boolean flag to enable/disable retention.
+
 * `days` - (Required) The number of days to retain flow log records.
  
 ---
@@ -113,9 +118,13 @@ The `retention_policy` block supports the following:
 The `traffic_analytics` block supports the following:
 
 * `enabled` - (Required) Boolean flag to enable/disable traffic analytics.
+
 * `workspace_id` - (Required) The resource GUID of the attached workspace.
+
 * `workspace_region` - (Required) The location of the attached workspace.
+
 * `workspace_resource_id` - (Required) The resource ID of the attached workspace.
+
 * `interval_in_minutes` - (Optional) How frequently service should do flow analytics in minutes. Defaults to `60`.
 
 ## Attributes Reference


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

`target_resource_id` and `network_security_group_id` were made O+C without ForceNew set due to the deprecation, causing an issue where updates to these properties didn't apply (no ForceNew, and no logic in update to actually handle the change) leading to a perpetual diff of the same change.

Changes:

- `target_resource_id` is no longer `ForceNew` and can be updated, added logic to update func
- added `CustomizeDiff` to prevent creation of `azurerm_network_watcher_flow_log` resources with an NSG as the target, this functionality has been deprecated by Azure and the API returns an error if you try to do so
- Updated most test configs to use VNets as the target instead of an NSG, added an update test, and fixed other tests.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

Note: I ran these locally so I could limit the tests specifically to the modified resource. These are tested sequentially, bundled with all other tests that provision an `azurerm_network_watcher` resource

4.0 tests:

```
        --- PASS: TestAccNetworkWatcher/FlowLog/update (291.20s)
        --- PASS: TestAccNetworkWatcher/FlowLog/basicWithVirtualNetwork (174.12s)
        --- PASS: TestAccNetworkWatcher/FlowLog/basicWithSubnet (187.82s)
        --- PASS: TestAccNetworkWatcher/FlowLog/basicWithNIC (271.31s)
        --- PASS: TestAccNetworkWatcher/FlowLog/updateStorageAccount (302.91s)
        --- PASS: TestAccNetworkWatcher/FlowLog/version (314.58s)
        --- PASS: TestAccNetworkWatcher/FlowLog/location (176.99s)
        --- PASS: TestAccNetworkWatcher/FlowLog/requiresImport (179.66s)
        --- PASS: TestAccNetworkWatcher/FlowLog/disabled (176.89s)
        --- PASS: TestAccNetworkWatcher/FlowLog/reenabled (218.77s)
        --- PASS: TestAccNetworkWatcher/FlowLog/retentionPolicy (215.07s)
        --- PASS: TestAccNetworkWatcher/FlowLog/trafficAnalytics (483.47s)
        --- PASS: TestAccNetworkWatcher/FlowLog/tags (220.45s)
        --- PASS: TestAccNetworkWatcher/FlowLog/cannotCreateNewWithNSG (143.48s)
```

5.0 tests:

```
        --- PASS: TestAccNetworkWatcher/FlowLog/basicWithNIC (194.19s)
        --- PASS: TestAccNetworkWatcher/FlowLog/disabled (121.41s)
        --- PASS: TestAccNetworkWatcher/FlowLog/trafficAnalytics (419.83s)
        --- PASS: TestAccNetworkWatcher/FlowLog/version (248.67s)
        --- PASS: TestAccNetworkWatcher/FlowLog/location (157.64s)
        --- PASS: TestAccNetworkWatcher/FlowLog/requiresImport (122.31s)
        --- PASS: TestAccNetworkWatcher/FlowLog/reenabled (200.00s)
        --- PASS: TestAccNetworkWatcher/FlowLog/retentionPolicy (161.12s)
        --- PASS: TestAccNetworkWatcher/FlowLog/updateStorageAccount (176.50s)
        --- PASS: TestAccNetworkWatcher/FlowLog/tags (170.58s)
        --- PASS: TestAccNetworkWatcher/FlowLog/cannotCreateNewWithNSG (93.69s)
        --- PASS: TestAccNetworkWatcher/FlowLog/update (190.31s)
        --- PASS: TestAccNetworkWatcher/FlowLog/basicWithVirtualNetwork (117.41s)
        --- PASS: TestAccNetworkWatcher/FlowLog/basicWithSubnet (128.71s)
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #30567
Fixes #28792


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
