### PR TITLE
`azurerm_netapp_volume` - support for new property `mount_target`

### DIFF
--- a/internal/services/netapp/netapp_account_encryption_resource_test.go
+++ b/internal/services/netapp/netapp_account_encryption_resource_test.go
@@ -200,10 +200,6 @@ resource "azurerm_user_assigned_identity" "test" {
   name                = "user-assigned-identity-%[2]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-
-  tags = {
-    "CreatedOnDate" = "2022-07-08T23:50:21Z"
-  }
 }
 
 data "azurerm_client_config" "current" {

--- a/internal/services/netapp/netapp_volume_data_source.go
+++ b/internal/services/netapp/netapp_volume_data_source.go
@@ -5,7 +5,6 @@ package netapp
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"strings"
 	"time"
 
@@ -15,6 +14,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/netapp/2025-06-01/volumes"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/netapp/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"

--- a/internal/services/netapp/netapp_volume_data_source_test.go
+++ b/internal/services/netapp/netapp_volume_data_source_test.go
@@ -27,7 +27,7 @@ func TestAccDataSourceNetAppVolume_basic(t *testing.T) {
 				check.That(data.ResourceName).Key("network_features").HasValue("Basic"),
 				check.That(data.ResourceName).Key("storage_quota_in_gb").Exists(),
 				check.That(data.ResourceName).Key("protocols.0").Exists(),
-				check.That(data.ResourceName).Key("mount_ip_addresses.#").HasValue("1"),
+				check.That(data.ResourceName).Key("mount_target.#").HasValue("1"),
 				check.That(data.ResourceName).Key("encryption_key_source").HasValue("Microsoft.NetApp"),
 				check.That(data.ResourceName).Key("large_volume_enabled").HasValue("false"),
 			),

--- a/internal/services/netapp/netapp_volume_resource_test.go
+++ b/internal/services/netapp/netapp_volume_resource_test.go
@@ -370,7 +370,7 @@ func TestAccNetAppVolume_largeVolume(t *testing.T) {
 			Config: r.largeVolume(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("storage_quota_in_gb").HasValue("105472"),
+				check.That(data.ResourceName).Key("storage_quota_in_gb").HasValue("51200"),
 				check.That(data.ResourceName).Key("large_volume_enabled").HasValue("true"),
 			),
 		},
@@ -1531,7 +1531,7 @@ resource "azurerm_netapp_volume" "test" {
   volume_path          = "my-unique-file-path-%d"
   service_level        = "Standard"
   subnet_id            = azurerm_subnet.test.id
-  storage_quota_in_gb  = 105472
+  storage_quota_in_gb  = 51200
   large_volume_enabled = true
   throughput_in_mibps  = 1640
 }
@@ -1588,7 +1588,7 @@ resource "azurerm_netapp_pool" "test" {
   size_in_tb          = "%d"
   qos_type            = "Manual"
 }
-`, r.templateProviderFeatureFlags(), data.RandomInteger, overriddenlocations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, 120)
+`, r.templateProviderFeatureFlags(), data.RandomInteger, overriddenlocations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, 25)
 }
 
 func (r NetAppVolumeResource) templateForCrossRegionReplication(data acceptance.TestData) string {

--- a/internal/services/netapp/netapp_volume_resource_test.go
+++ b/internal/services/netapp/netapp_volume_resource_test.go
@@ -354,7 +354,7 @@ func TestAccNetAppVolume_complete(t *testing.T) {
 				check.That(data.ResourceName).Key("export_policy_rule.#").HasValue("3"),
 				check.That(data.ResourceName).Key("tags.%").HasValue("3"),
 				check.That(data.ResourceName).Key("tags.FoO").HasValue("BaR"),
-				check.That(data.ResourceName).Key("mount_ip_addresses.#").HasValue("1"),
+				check.That(data.ResourceName).Key("mount_target.#").HasValue("1"),
 			),
 		},
 		data.ImportStep(),

--- a/website/docs/5.0-upgrade-guide.html.markdown
+++ b/website/docs/5.0-upgrade-guide.html.markdown
@@ -370,6 +370,8 @@ Please follow the format in the example below for listing breaking changes in re
 
 * The deprecated `export_policy_rule.protocols_enabled` property has been removed in favour of the `export_policy_rule.protocol` property.
 
+* The deprecated `mount_ip_addresses` property has been removed in favour of the `mount_target` property.
+
 ### `azurerm_network_watcher_flow_log`
 
 * The deprecated `network_security_group_id` property has been removed in favour of the `target_resource_id` property.
@@ -523,6 +525,10 @@ Please follow the format in the example below for listing breaking changes in da
 ### `azurerm_logic_app_standard`
 
 * The deprecated `site_config.public_network_access_enabled` property has been removed and superseded by the `public_network_access` property.
+
+### `azurerm_netapp_volume`
+
+* The deprecated `mount_ip_addresses` property has been removed in favour of the `mount_target` property.
 
 ### `azurerm_nginx_configuration`
 

--- a/website/docs/d/netapp_volume.html.markdown
+++ b/website/docs/d/netapp_volume.html.markdown
@@ -45,7 +45,7 @@ The following attributes are exported:
   
 * `zone` - The Availability Zone in which the Volume is located.
 
-* `mount_ip_addresses` - A list of IPv4 Addresses which should be used to mount the volume.
+* `mount_target` - One or more `mount_target` blocks as defined below.
 
 * `protocols` - A list of protocol types enabled on volume.
 
@@ -96,6 +96,12 @@ A `data_protection_backup_policy` block supports the following:
 * `policy_enabled` - Backup policy is enabled or not.
 
 ---
+
+A `mount_target` block exports the following:
+
+* `ip_address` - The IP address of the mount target.
+
+* `smb_server_fqdn` - The SMB server's Fully Qualified Domain Name (FQDN).
 
 ## Timeouts
 

--- a/website/docs/r/netapp_volume.html.markdown
+++ b/website/docs/r/netapp_volume.html.markdown
@@ -301,7 +301,15 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `id` - The ID of the NetApp Volume.
 
-* `mount_ip_addresses` - A list of IPv4 Addresses which should be used to mount the volume.
+* `mount_target` - One or more `mount_target` blocks as defined below.
+
+---
+
+A `mount_target` block exports the following:
+
+* `ip_address` - The IP address of the mount target.
+
+* `smb_server_fqdn` - The SMB server's Fully Qualified Domain Name (FQDN).
 
 ## Timeouts
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description
This PR is to support new property [`mount_target`](https://github.com/Azure/azure-rest-api-specs/blob/e96c24570a484cff13d153fb472f812878866a39/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/stable/2025-09-01/netapp.json#L12238) for Netapp Volume.
<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

```
--- PASS: TestAccDataSourceNetAppVolume_backupPolicy (1291.40s)
--- PASS: TestAccDataSourceNetAppVolume_basic (878.30s)
--- PASS: TestAccNetAppVolume_protocolsEnabled (1016.13s)
--- PASS: TestAccNetAppVolume_backupPolicy (1675.81s)
--- PASS: TestAccNetAppVolume_backupPolicyUpdate (1434.37s)
--- PASS: TestAccNetAppVolume_basic (1118.77s)
--- PASS: TestAccNetAppVolume_availabilityZone (881.91s)
--- PASS: TestAccNetAppVolume_nfsv41 (1147.43s)
--- PASS: TestAccNetAppVolume_standardNetworkFeature (854.27s)
--- PASS: TestAccNetAppVolume_createFromSnapshotInAnotherPool (1172.32s)
--- PASS: TestAccNetAppVolume_snapshotPolicyUpdate (1519.04s)
--- PASS: TestAccNetAppVolume_snapshotPolicy (1598.12s)
--- PASS: TestAccNetAppVolume_shortTermClone (1901.49s)
--- PASS: TestAccNetAppVolume_requiresImport (1774.15s)
--- PASS: TestAccNetAppVolume_crossRegionReplication (2437.65s)
--- PASS: TestAccNetAppVolume_crossZoneReplication (2685.13s)
--- PASS: TestAccNetAppVolume_crossZoneRegionReplication (2974.74s)
--- PASS: TestAccNetAppVolume_complete (1548.58s)
--- PASS: TestAccNetAppVolume_update (1203.07s)
--- PASS: TestAccNetAppVolume_updateExportPolicyRule (1441.53s)
--- PASS: TestAccNetAppVolume_volEncryptionCmkUserAssigned (1023.76s)
--- PASS: TestAccNetAppVolume_volEncryptionCmkSystemAssigned (1493.03s)
--- PASS: TestAccNetAppVolume_coolAccess (1384.26s)
--- PASS: TestAccNetAppVolume_protocolConversion (1209.96s)
--- PASS: TestAccNetAppVolume_serviceLevelUpdate (1716.91s)
--- PASS: TestAccNetAppVolume_nfsv3SnapshotDirectoryVisibleTrue (1208.48s)
--- PASS: TestAccNetAppVolume_nfsv3SnapshotDirectoryVisibleFalse (1218.25s)
--- PASS: TestAccNetAppVolume_nfsv3FromSnapshot (1106.07s)
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_netapp_volume` - support for new property `mount_target`


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/31171


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
