### PR TITLE
`azurerm_iothub` - support for `data_residency_enabled` property

### DIFF
--- a/.teamcity/components/settings.kt
+++ b/.teamcity/components/settings.kt
@@ -111,7 +111,7 @@ var serviceTestConfigurationOverrides = mapOf(
         "iotcentral" to testConfiguration(locationOverride = LocationConfiguration("westeurope", "southeastasia", "eastus2", false)),
 
         // IoT Hub Device Update is only available in certain locations
-        "iothub" to testConfiguration(locationOverride = LocationConfiguration("eastus", "eastus2", "westus2", false)),
+        "iothub" to testConfiguration(locationOverride = LocationConfiguration("eastus", "brazilSouth", "westus2", false)),
 
         // load balancer global tire Public IP is only available in
         "loadbalancer" to testConfiguration(locationOverride = LocationConfiguration("westeurope", "eastus2", "westus", false)),

--- a/internal/services/iothub/iothub_resource.go
+++ b/internal/services/iothub/iothub_resource.go
@@ -604,6 +604,12 @@ func resourceIotHub() *pluginsdk.Resource {
 				Optional: true,
 			},
 
+			"data_residency_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				ForceNew: true,
+			},
+
 			"type": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
@@ -747,6 +753,10 @@ func resourceIotHubCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 			enabled = devices.PublicNetworkAccessEnabled
 		}
 		props.Properties.PublicNetworkAccess = enabled
+	}
+
+	if v, ok := d.GetOk("data_residency_enabled"); ok {
+		props.Properties.EnableDataResidency = pointer.FromBool(v.(bool))
 	}
 
 	retention, retentionOk := d.GetOk("event_hub_retention_in_days")
@@ -900,6 +910,12 @@ func resourceIotHubUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 				enabled = devices.PublicNetworkAccessEnabled
 			}
 			prop.PublicNetworkAccess = enabled
+		}
+	}
+
+	if d.HasChange("data_residency_enabled") {
+		if v, ok := d.GetOk("data_residency_enabled"); ok {
+			prop.EnableDataResidency = pointer.FromBool(v.(bool))
 		}
 	}
 
@@ -1072,6 +1088,10 @@ func resourceIotHubRead(d *pluginsdk.ResourceData, meta interface{}) error {
 
 		if enabled := properties.PublicNetworkAccess; enabled != "" {
 			d.Set("public_network_access_enabled", enabled == devices.PublicNetworkAccessEnabled)
+		}
+
+		if properties.EnableDataResidency != nil {
+			d.Set("data_residency_enabled", pointer.ToBool(properties.EnableDataResidency))
 		}
 
 		cloudToDevice := flattenIoTHubCloudToDevice(properties.CloudToDevice)

--- a/internal/services/iothub/iothub_resource_test.go
+++ b/internal/services/iothub/iothub_resource_test.go
@@ -2346,5 +2346,5 @@ resource "azurerm_iothub" "test" {
     purpose = "testing"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Secondary, data.RandomInteger)
 }

--- a/website/docs/r/iothub.html.markdown
+++ b/website/docs/r/iothub.html.markdown
@@ -171,6 +171,8 @@ The following arguments are supported:
 
 * `min_tls_version` - (Optional) Specifies the minimum TLS version to support for this hub. The only valid value is `1.2`. Changing this forces a new resource to be created.
 
+* `data_residency_enabled` - (Optional) Specifies whether data residency is enabled. When data residency is enabled, disaster recovery is disabled.
+
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ---


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

`data_residency_enabled` property is added to `azurerm_iothub` in this PR. Region in which `data_residency_enabled` can be set to `true` is added and applied in acceptance test.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] ~(For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.~


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_IOTHUB/554324?buildTab=overview
<img width="949" height="360" alt="image" src="https://github.com/user-attachments/assets/58c3916f-cfc3-4c83-bf5e-2847290e99d4" />


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_iothub` - support for the `data_residency_enabled` property [GH-31269]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #31269


## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
