### PR TITLE
Data Source: `azurerm_storage_blob` - Support `content`, `sensitive_content` and `is_content_sensitive`

### DIFF
--- a/website/docs/d/storage_blob.html.markdown
+++ b/website/docs/d/storage_blob.html.markdown
@@ -30,6 +30,8 @@ The following arguments are supported:
 
 * `storage_container_name` - The name of the Storage Container where the Blob exists.
 
+* `is_content_sensitive` - Whether the (human readable) content of this blob will be populated to `content` or `sensitive_content` (when set to `true`)? Defaults to `false`.
+
 ## Attributes Reference
 
 * `id` - The ID of the storage blob.
@@ -39,6 +41,13 @@ The following arguments are supported:
 * `type` - The type of the storage blob
 
 * `access_tier` - The access tier of the storage blob.
+
+* `content` - The content stored in the storage blob.
+
+* `sensitive_content` - The sensitive content stored in the storage blob.
+
+
+~> **Note:** `content`/`sensitive_content` is only populated when the `content_type` is one of `text/*`, `application/{json | ld+json | x-httpd-php | xhtml+xml | x-csh | x-sh | xml | atom+xml | x-sql | yaml}`.
 
 * `content_type` - The content type of the storage blob.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR adds a new attribute `is_content_sensitive` to the data source `azurerm_storage_blob`, based on:

1. Whether the `content_type` of the `azurerm_storge_blob` is a human readable (see the document for the full list of the supported mime types)?
2. Whether this attribute is `true` or `false`?

It will conditionally populate the content to `content` or `sensitive_content`.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

```shell
terraform-provider-azurerm on  storage_blob_ds_content via 🐹 v1.25.4 took 45s
💤 TF_ACC=1 go test -v -run=TestAccDataSourceStorageBlob_ ./internal/services/storage
=== RUN   TestAccDataSourceStorageBlob_basic
=== PAUSE TestAccDataSourceStorageBlob_basic
=== RUN   TestAccDataSourceStorageBlob_humanReadableContent
=== PAUSE TestAccDataSourceStorageBlob_humanReadableContent
=== CONT  TestAccDataSourceStorageBlob_basic
=== CONT  TestAccDataSourceStorageBlob_humanReadableContent
--- PASS: TestAccDataSourceStorageBlob_basic (167.95s)
--- PASS: TestAccDataSourceStorageBlob_humanReadableContent (182.38s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/storage       182.540s
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #31347


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
