### PR TITLE
`azurerm_kusto_cluster` - support for the `callout_policy` block

### DIFF
--- a/internal/services/kusto/kusto_cluster_resource.go
+++ b/internal/services/kusto/kusto_cluster_resource.go
@@ -953,21 +953,15 @@ func expandKustoClusterCalloutPolicies(input []interface{}) *[]clusters.CalloutP
 
 func flattenKustoClusterCalloutPolicies(input *[]clusters.CalloutPolicy) []interface{} {
 	if input == nil {
-		return []interface{}{}
+		return make([]interface{}, 0)
 	}
 
 	output := make([]interface{}, 0)
 	for _, policy := range *input {
 		policyMap := map[string]interface{}{}
-		if policy.CalloutType != nil {
-			policyMap["callout_type"] = string(*policy.CalloutType)
-		}
-		if policy.CalloutUriRegex != nil {
-			policyMap["callout_uri_regex"] = *policy.CalloutUriRegex
-		}
-		if policy.OutboundAccess != nil {
-			policyMap["outbound_access"] = string(*policy.OutboundAccess)
-		}
+		policyMap["callout_type"] = string(pointer.From(policy.CalloutType))
+		policyMap["callout_uri_regex"] = pointer.From(policy.CalloutUriRegex)
+		policyMap["outbound_access"] = string(pointer.From(policy.OutboundAccess))
 		output = append(output, policyMap)
 	}
 

--- a/internal/services/kusto/kusto_cluster_resource.go
+++ b/internal/services/kusto/kusto_cluster_resource.go
@@ -941,9 +941,9 @@ func expandKustoClusterCalloutPolicies(input []interface{}) *[]clusters.CalloutP
 	for _, item := range input {
 		policyMap := item.(map[string]interface{})
 		policy := clusters.CalloutPolicy{
-			CalloutType:     pointer.To(clusters.CalloutType(policyMap["callout_type"].(string))),
+			CalloutType:     pointer.ToEnum[clusters.CalloutType](policyMap["callout_type"].(string)),
 			CalloutUriRegex: pointer.To(policyMap["callout_uri_regex"].(string)),
-			OutboundAccess:  pointer.To(clusters.OutboundAccess(policyMap["outbound_access"].(string))),
+			OutboundAccess:  pointer.ToEnum[clusters.OutboundAccess](policyMap["outbound_access"].(string)),
 		}
 		policies = append(policies, policy)
 	}
@@ -959,9 +959,9 @@ func flattenKustoClusterCalloutPolicies(input *[]clusters.CalloutPolicy) []inter
 	output := make([]interface{}, 0)
 	for _, policy := range *input {
 		policyMap := map[string]interface{}{}
-		policyMap["callout_type"] = string(pointer.From(policy.CalloutType))
+		policyMap["callout_type"] = pointer.FromEnum(policy.CalloutType)
 		policyMap["callout_uri_regex"] = pointer.From(policy.CalloutUriRegex)
-		policyMap["outbound_access"] = string(pointer.From(policy.OutboundAccess))
+		policyMap["outbound_access"] = pointer.FromEnum(policy.OutboundAccess)
 		output = append(output, policyMap)
 	}
 

--- a/internal/services/kusto/kusto_cluster_resource_test.go
+++ b/internal/services/kusto/kusto_cluster_resource_test.go
@@ -315,10 +315,6 @@ func TestAccKustoCluster_calloutPolicy(t *testing.T) {
 			Config: r.calloutPolicy(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("callout_policy.#").HasValue("1"),
-				check.That(data.ResourceName).Key("callout_policy.0.callout_type").HasValue("kusto"),
-				check.That(data.ResourceName).Key("callout_policy.0.callout_uri_regex").HasValue(".*\\.kusto\\.windows\\.net"),
-				check.That(data.ResourceName).Key("callout_policy.0.outbound_access").HasValue("Allow"),
 			),
 		},
 		data.ImportStep(),
@@ -334,7 +330,6 @@ func TestAccKustoCluster_calloutPolicyMultiple(t *testing.T) {
 			Config: r.calloutPolicyMultiple(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("callout_policy.#").HasValue("3"),
 			),
 		},
 		data.ImportStep(),
@@ -350,7 +345,6 @@ func TestAccKustoCluster_calloutPolicyUpdate(t *testing.T) {
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("callout_policy.#").HasValue("0"),
 			),
 		},
 		data.ImportStep(),
@@ -358,7 +352,6 @@ func TestAccKustoCluster_calloutPolicyUpdate(t *testing.T) {
 			Config: r.calloutPolicy(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("callout_policy.#").HasValue("1"),
 			),
 		},
 		data.ImportStep(),
@@ -366,8 +359,6 @@ func TestAccKustoCluster_calloutPolicyUpdate(t *testing.T) {
 			Config: r.calloutPolicyUpdate(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("callout_policy.#").HasValue("1"),
-				check.That(data.ResourceName).Key("callout_policy.0.callout_type").HasValue("webapi"),
 			),
 		},
 		data.ImportStep(),
@@ -375,7 +366,6 @@ func TestAccKustoCluster_calloutPolicyUpdate(t *testing.T) {
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("callout_policy.#").HasValue("0"),
 			),
 		},
 		data.ImportStep(),

--- a/website/docs/r/kusto_cluster.html.markdown
+++ b/website/docs/r/kusto_cluster.html.markdown
@@ -102,7 +102,7 @@ A `callout_policy` block supports the following:
 
 * `callout_uri_regex` - (Required) A regular expression or the callout URI.
 
-* `outbound_access` - (Required) Whether outbound access is permitted for the specified service with the URI pattern? Possible values are `Allow` and `Deny`.
+* `outbound_access` - (Required) Whether outbound access is permitted for the specified service with the URI pattern. Possible values are `Allow` and `Deny`.
 
 ---
 

--- a/website/docs/r/kusto_cluster.html.markdown
+++ b/website/docs/r/kusto_cluster.html.markdown
@@ -102,7 +102,7 @@ A `callout_policy` block supports the following:
 
 * `callout_uri_regex` - (Required) A regular expression or the callout URI.
 
-* `outbound_access` - (Required) Indicates whether outbound access is permitted for the specified URI pattern. Possible values are `Allow` and `Deny`.
+* `outbound_access` - (Required) Whether outbound access is permitted for the specified service with the URI pattern? Possible values are `Allow` and `Deny`.
 
 ---
 

--- a/website/docs/r/kusto_cluster.html.markdown
+++ b/website/docs/r/kusto_cluster.html.markdown
@@ -54,6 +54,8 @@ The following arguments are supported:
 
 * `auto_stop_enabled` - (Optional) Specifies if the cluster could be automatically stopped (due to lack of data or no activity for many days). Defaults to `true`.
 
+* `callout_policy` - (Optional) A `callout_policy` block as defined below.
+
 * `disk_encryption_enabled` - (Optional) Specifies if the cluster's disks are encrypted. Defaults to `false`.
 
 * `double_encryption_enabled` - (Optional) Is the cluster's double encryption enabled? Changing this forces a new resource to be created.
@@ -91,6 +93,16 @@ An `identity` block supports the following:
 * `identity_ids` - (Optional) Specifies a list of User Assigned Managed Identity IDs to be assigned to this Kusto Cluster.
 
 ~> **Note:** This is required when `type` is set to `UserAssigned` or `SystemAssigned, UserAssigned`.
+
+---
+
+A `callout_policy` block supports the following:
+
+* `callout_type` - (Required) The type of callout service. Possible values are `azure_digital_twins`, `azure_openai`, `cosmosdb`, `external_data`, `genevametrics`, `kusto`, `mysql`, `postgresql`, `sandbox_artifacts`, `sql`, and `webapi`.
+
+* `callout_uri_regex` - (Required) A regular expression or FQDN pattern for the callout URI.
+
+* `outbound_access` - (Required) Indicates whether outbound access is permitted for the specified URI pattern. Possible values are `Allow` and `Deny`.
 
 ---
 

--- a/website/docs/r/kusto_cluster.html.markdown
+++ b/website/docs/r/kusto_cluster.html.markdown
@@ -100,7 +100,7 @@ A `callout_policy` block supports the following:
 
 * `callout_type` - (Required) The type of callout service. Possible values are `azure_digital_twins`, `azure_openai`, `cosmosdb`, `external_data`, `genevametrics`, `kusto`, `mysql`, `postgresql`, `sandbox_artifacts`, `sql`, and `webapi`.
 
-* `callout_uri_regex` - (Required) A regular expression or FQDN pattern for the callout URI.
+* `callout_uri_regex` - (Required) A regular expression or the callout URI.
 
 * `outbound_access` - (Required) Indicates whether outbound access is permitted for the specified URI pattern. Possible values are `Allow` and `Deny`.
 


### PR DESCRIPTION
## Community Note
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This PR adds support for the `callout_policy` block on the `azurerm_kusto_cluster` resource. Callout policies allow users to control egress from their Kusto (Azure Data Explorer) cluster by specifying which external services can be accessed and under what URI patterns.

Each `callout_policy` block supports:
- `callout_type` - The type of callout service (e.g., `kusto`, `sql`, `cosmosdb`, `webapi`, etc.)
- `callout_uri_regex` - A regular expression or FQDN pattern for the callout URI
- `outbound_access` - Whether to `Allow` or `Deny` outbound access for the specified pattern

This feature enables users to implement fine-grained network security controls for their Kusto clusters.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- N/A (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass.

New test cases added:
- `TestAccKustoCluster_calloutPolicy` - Tests basic single callout policy configuration
- `TestAccKustoCluster_calloutPolicyMultiple` - Tests multiple callout policies
- `TestAccKustoCluster_calloutPolicyUpdate` - Tests adding, updating, and removing callout policies

TC Run:

<img width="632" height="501" alt="image" src="https://github.com/user-attachments/assets/237218d4-04fe-4b91-844b-7b874f2a8b25" />
Failed test cases in above results are not related to this PR.

## Change Log

* `azurerm_kusto_cluster` - support for the `callout_policy` block [GH-31370]


This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

This contribution was made with AI assistance for code generation, test creation, and documentation updates.


## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

No changes to security controls. This PR adds support for configuring callout policies which is a security feature that allows users to control egress from their Kusto clusters.
