### PR TITLE
`azurerm_kubernetes_cluster` - add `policy` property to `network_profile.advanced_networking` block

### DIFF
--- a/internal/services/containers/kubernetes_cluster_network_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_network_resource_test.go
@@ -101,6 +101,84 @@ func TestAccKubernetesCluster_advancedNetworkingNetworkDataplane(t *testing.T) {
 	})
 }
 
+func TestAccKubernetesCluster_advancedNetworkingPolicies(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
+	r := KubernetesClusterResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			// `policy` unset: the API defaults it to `FQDN` when security is enabled
+			Config: r.advancedNetworkingWithPolicies(data, ""),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("network_profile.0.advanced_networking.0.policy").HasValue("FQDN"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.advancedNetworkingWithPolicies(data, "L7"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			// omitting `policy` retains the value currently set on the cluster
+			Config: r.advancedNetworkingWithPolicies(data, ""),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("network_profile.0.advanced_networking.0.policy").HasValue("L7"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.advancedNetworkingWithPoliciesRemoved(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.advancedNetworkingWithPolicies(data, "FQDN"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.advancedNetworkingWithPolicies(data, "None"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccKubernetesCluster_advancedNetworkingPoliciesRequiresSecurity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
+	r := KubernetesClusterResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config:      r.advancedNetworkingWithPoliciesSecurityDisabled(data, "L7"),
+			ExpectError: regexp.MustCompile("`network_profile.0.advanced_networking.0.policy` can only be set to `FQDN` or `L7` when `network_profile.0.advanced_networking.0.security_enabled` is set to `true`"),
+		},
+	})
+}
+
+func TestAccKubernetesCluster_advancedNetworkingPoliciesConflictsWithIstio(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
+	r := KubernetesClusterResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config:      r.advancedNetworkingWithPoliciesAndIstio(data, "L7"),
+			ExpectError: regexp.MustCompile("`network_profile.0.advanced_networking.0.policy` cannot be set to `L7` when `service_mesh_profile.0.mode` is set to `Istio`"),
+		},
+	})
+}
+
 func TestAccKubernetesCluster_serviceMeshProfile(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
 	r := KubernetesClusterResource{}
@@ -1567,6 +1645,277 @@ resource "azurerm_kubernetes_cluster" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, networkPlugin)
+}
+
+func (KubernetesClusterResource) advancedNetworkingWithPolicies(data acceptance.TestData, advancedNetworkPolicies string) string {
+	policy := ""
+	if advancedNetworkPolicies != "" {
+		policy = fmt.Sprintf(`policy                = "%s"`, advancedNetworkPolicies)
+	}
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%[1]d"
+  address_space       = ["10.0.0.0/8"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctestsubnet%[1]d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.1.0.0/16"]
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%[1]d"
+
+  linux_profile {
+    admin_username = "acctestuser%[1]d"
+
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
+  }
+
+  default_node_pool {
+    name           = "default"
+    node_count     = 2
+    vm_size        = "Standard_DS2_v2"
+    vnet_subnet_id = azurerm_subnet.test.id
+    upgrade_settings {
+      max_surge = "10%%"
+    }
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  network_profile {
+    network_plugin     = "azure"
+    network_data_plane = "cilium"
+
+    advanced_networking {
+      observability_enabled = true
+      security_enabled      = true
+      %[3]s
+    }
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, policy)
+}
+
+func (KubernetesClusterResource) advancedNetworkingWithPoliciesRemoved(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%[1]d"
+  address_space       = ["10.0.0.0/8"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctestsubnet%[1]d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.1.0.0/16"]
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%[1]d"
+
+  linux_profile {
+    admin_username = "acctestuser%[1]d"
+
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
+  }
+
+  default_node_pool {
+    name           = "default"
+    node_count     = 2
+    vm_size        = "Standard_DS2_v2"
+    vnet_subnet_id = azurerm_subnet.test.id
+    upgrade_settings {
+      max_surge = "10%%"
+    }
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  network_profile {
+    network_plugin     = "azure"
+    network_data_plane = "cilium"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (KubernetesClusterResource) advancedNetworkingWithPoliciesSecurityDisabled(data acceptance.TestData, advancedNetworkPolicies string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%[1]d"
+  address_space       = ["10.0.0.0/8"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctestsubnet%[1]d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.1.0.0/16"]
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%[1]d"
+
+  linux_profile {
+    admin_username = "acctestuser%[1]d"
+
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
+  }
+
+  default_node_pool {
+    name           = "default"
+    node_count     = 2
+    vm_size        = "Standard_DS2_v2"
+    vnet_subnet_id = azurerm_subnet.test.id
+    upgrade_settings {
+      max_surge = "10%%"
+    }
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  network_profile {
+    network_plugin     = "azure"
+    network_data_plane = "cilium"
+
+    advanced_networking {
+      observability_enabled = true
+      security_enabled      = false
+      policy                = "%[3]s"
+    }
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, advancedNetworkPolicies)
+}
+
+func (KubernetesClusterResource) advancedNetworkingWithPoliciesAndIstio(data acceptance.TestData, advancedNetworkPolicies string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%[1]d"
+  address_space       = ["10.0.0.0/8"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctestsubnet%[1]d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.1.0.0/16"]
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%[1]d"
+
+  linux_profile {
+    admin_username = "acctestuser%[1]d"
+
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
+  }
+
+  default_node_pool {
+    name           = "default"
+    node_count     = 2
+    vm_size        = "Standard_DS2_v2"
+    vnet_subnet_id = azurerm_subnet.test.id
+    upgrade_settings {
+      max_surge = "10%%"
+    }
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  network_profile {
+    network_plugin     = "azure"
+    network_data_plane = "cilium"
+
+    advanced_networking {
+      observability_enabled = true
+      security_enabled      = true
+      policy                = "%[3]s"
+    }
+  }
+
+  service_mesh_profile {
+    mode      = "Istio"
+    revisions = ["asm-1-28"]
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, advancedNetworkPolicies)
 }
 
 func (KubernetesClusterResource) serviceMeshProfile(data acceptance.TestData, internalIngressEnabled bool, externalIngressEnabled bool) string {

--- a/internal/services/containers/kubernetes_cluster_network_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_network_resource_test.go
@@ -101,6 +101,84 @@ func TestAccKubernetesCluster_advancedNetworkingNetworkDataplane(t *testing.T) {
 	})
 }
 
+func TestAccKubernetesCluster_advancedNetworkingPolicies(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
+	r := KubernetesClusterResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			// `policy` unset: the API defaults it to `FQDN` when security is enabled
+			Config: r.advancedNetworkingWithPolicies(data, ""),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("network_profile.0.advanced_networking.0.policy").HasValue("FQDN"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.advancedNetworkingWithPolicies(data, "L7"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			// omitting `policy` retains the value currently set on the cluster
+			Config: r.advancedNetworkingWithPolicies(data, ""),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("network_profile.0.advanced_networking.0.policy").HasValue("L7"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.advancedNetworkingWithPoliciesRemoved(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.advancedNetworkingWithPolicies(data, "FQDN"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.advancedNetworkingWithPolicies(data, "None"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccKubernetesCluster_advancedNetworkingPoliciesRequiresSecurity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
+	r := KubernetesClusterResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config:      r.advancedNetworkingWithPoliciesSecurityDisabled(data, "L7"),
+			ExpectError: regexp.MustCompile("`network_profile.0.advanced_networking.0.policy` can only be set to `FQDN` or `L7` when `network_profile.0.advanced_networking.0.security_enabled` is set to `true`"),
+		},
+	})
+}
+
+func TestAccKubernetesCluster_advancedNetworkingPoliciesConflictsWithIstio(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
+	r := KubernetesClusterResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config:      r.advancedNetworkingWithPoliciesAndIstio(data, "L7"),
+			ExpectError: regexp.MustCompile("`network_profile.0.advanced_networking.0.policy` cannot be set to `L7` when `service_mesh_profile.0.mode` is set to `Istio`"),
+		},
+	})
+}
+
 func TestAccKubernetesCluster_serviceMeshProfile(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
 	r := KubernetesClusterResource{}
@@ -1567,6 +1645,297 @@ resource "azurerm_kubernetes_cluster" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, networkPlugin)
+}
+
+func (KubernetesClusterResource) advancedNetworkingWithPolicies(data acceptance.TestData, advancedNetworkPolicies string) string {
+	policy := ""
+	if advancedNetworkPolicies != "" {
+		policy = fmt.Sprintf(`policy                = "%s"`, advancedNetworkPolicies)
+	}
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%[1]d"
+  address_space       = ["10.0.0.0/8"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctestsubnet%[1]d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.1.0.0/16"]
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%[1]d"
+
+  linux_profile {
+    admin_username = "acctestuser%[1]d"
+
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
+  }
+
+  default_node_pool {
+    name           = "default"
+    node_count     = 2
+    vm_size        = "Standard_DS2_v2"
+    vnet_subnet_id = azurerm_subnet.test.id
+    upgrade_settings {
+      max_surge = "10%%"
+    }
+  }
+
+  node_provisioning_profile {
+    mode               = "Manual"
+    default_node_pools = "Auto"
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  network_profile {
+    network_plugin     = "azure"
+    network_data_plane = "cilium"
+
+    advanced_networking {
+      observability_enabled = true
+      security_enabled      = true
+      %[3]s
+    }
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, policy)
+}
+
+func (KubernetesClusterResource) advancedNetworkingWithPoliciesRemoved(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%[1]d"
+  address_space       = ["10.0.0.0/8"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctestsubnet%[1]d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.1.0.0/16"]
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%[1]d"
+
+  linux_profile {
+    admin_username = "acctestuser%[1]d"
+
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
+  }
+
+  default_node_pool {
+    name           = "default"
+    node_count     = 2
+    vm_size        = "Standard_DS2_v2"
+    vnet_subnet_id = azurerm_subnet.test.id
+    upgrade_settings {
+      max_surge = "10%%"
+    }
+  }
+
+  node_provisioning_profile {
+    mode               = "Manual"
+    default_node_pools = "Auto"
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  network_profile {
+    network_plugin     = "azure"
+    network_data_plane = "cilium"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (KubernetesClusterResource) advancedNetworkingWithPoliciesSecurityDisabled(data acceptance.TestData, advancedNetworkPolicies string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%[1]d"
+  address_space       = ["10.0.0.0/8"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctestsubnet%[1]d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.1.0.0/16"]
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%[1]d"
+
+  linux_profile {
+    admin_username = "acctestuser%[1]d"
+
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
+  }
+
+  default_node_pool {
+    name           = "default"
+    node_count     = 2
+    vm_size        = "Standard_DS2_v2"
+    vnet_subnet_id = azurerm_subnet.test.id
+    upgrade_settings {
+      max_surge = "10%%"
+    }
+  }
+
+  node_provisioning_profile {
+    mode               = "Manual"
+    default_node_pools = "Auto"
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  network_profile {
+    network_plugin     = "azure"
+    network_data_plane = "cilium"
+
+    advanced_networking {
+      observability_enabled = true
+      security_enabled      = false
+      policy                = "%[3]s"
+    }
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, advancedNetworkPolicies)
+}
+
+func (KubernetesClusterResource) advancedNetworkingWithPoliciesAndIstio(data acceptance.TestData, advancedNetworkPolicies string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%[1]d"
+  address_space       = ["10.0.0.0/8"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctestsubnet%[1]d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.1.0.0/16"]
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%[1]d"
+
+  linux_profile {
+    admin_username = "acctestuser%[1]d"
+
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
+  }
+
+  default_node_pool {
+    name           = "default"
+    node_count     = 2
+    vm_size        = "Standard_DS2_v2"
+    vnet_subnet_id = azurerm_subnet.test.id
+    upgrade_settings {
+      max_surge = "10%%"
+    }
+  }
+
+  node_provisioning_profile {
+    mode               = "Manual"
+    default_node_pools = "Auto"
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  network_profile {
+    network_plugin     = "azure"
+    network_data_plane = "cilium"
+
+    advanced_networking {
+      observability_enabled = true
+      security_enabled      = true
+      policy                = "%[3]s"
+    }
+  }
+
+  service_mesh_profile {
+    mode      = "Istio"
+    revisions = ["asm-1-28"]
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, advancedNetworkPolicies)
 }
 
 func (KubernetesClusterResource) serviceMeshProfile(data acceptance.TestData, internalIngressEnabled bool, externalIngressEnabled bool) string {

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -206,6 +206,16 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 							return fmt.Errorf("when `network_profile.0.advanced_networking` has `security_enabled` set to `true`, `network_profile.0.network_plugin` must be set to `%s`", managedclusters.NetworkPluginAzure)
 						}
 					}
+					advancedNetworkPolicies := d.Get("network_profile.0.advanced_networking.0.policy").(string)
+					if !securityEnabled && kubernetesClusterAdvancedNetworkingPolicySetInConfig(d) &&
+						(advancedNetworkPolicies == string(managedclusters.AdvancedNetworkPoliciesFQDN) || advancedNetworkPolicies == string(managedclusters.AdvancedNetworkPoliciesLSeven)) {
+						return fmt.Errorf("`network_profile.0.advanced_networking.0.policy` can only be set to `%s` or `%s` when `network_profile.0.advanced_networking.0.security_enabled` is set to `true`", managedclusters.AdvancedNetworkPoliciesFQDN, managedclusters.AdvancedNetworkPoliciesLSeven)
+					}
+					if securityEnabled && advancedNetworkPolicies == string(managedclusters.AdvancedNetworkPoliciesLSeven) {
+						if mode := d.Get("service_mesh_profile.0.mode").(string); mode == string(managedclusters.ServiceMeshModeIstio) {
+							return fmt.Errorf("`network_profile.0.advanced_networking.0.policy` cannot be set to `%s` when `service_mesh_profile.0.mode` is set to `%s`", managedclusters.AdvancedNetworkPoliciesLSeven, managedclusters.ServiceMeshModeIstio)
+						}
+					}
 				}
 				return nil
 			},
@@ -1392,6 +1402,12 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 										Optional:     true,
 										Default:      false,
 										AtLeastOneOf: []string{"network_profile.0.advanced_networking.0.observability_enabled", "network_profile.0.advanced_networking.0.security_enabled"},
+									},
+									"policy": {
+										Type:         pluginsdk.TypeString,
+										Optional:     true,
+										Computed:     true,
+										ValidateFunc: validation.StringInSlice(managedclusters.PossibleValuesForAdvancedNetworkPolicies(), false),
 									},
 								},
 							},
@@ -3752,6 +3768,24 @@ func expandKubernetesClusterNetworkProfile(input []interface{}, d *pluginsdk.Res
 	return &networkProfile, nil
 }
 
+// kubernetesClusterAdvancedNetworkingPolicySetInConfig reports whether `network_profile.0.advanced_networking.0.policy`
+// is explicitly set in the configuration, distinguishing it from a Computed value carried over from state.
+func kubernetesClusterAdvancedNetworkingPolicySetInConfig(d *schema.ResourceDiff) bool {
+	rawConfig := d.GetRawConfig()
+	if !rawConfig.IsKnown() || rawConfig.IsNull() {
+		return false
+	}
+	rawNetworkProfiles := rawConfig.AsValueMap()["network_profile"]
+	if !rawNetworkProfiles.IsKnown() || rawNetworkProfiles.IsNull() || rawNetworkProfiles.LengthInt() == 0 {
+		return false
+	}
+	rawAdvancedNetworkings := rawNetworkProfiles.AsValueSlice()[0].AsValueMap()["advanced_networking"]
+	if !rawAdvancedNetworkings.IsKnown() || rawAdvancedNetworkings.IsNull() || rawAdvancedNetworkings.LengthInt() == 0 {
+		return false
+	}
+	return !rawAdvancedNetworkings.AsValueSlice()[0].AsValueMap()["policy"].IsNull()
+}
+
 func expandKubernetesClusterAdvancedNetworking(input []interface{}, d *pluginsdk.ResourceData) *managedclusters.AdvancedNetworking {
 	if len(input) == 0 || input[0] == nil {
 		o, n := d.GetChange("network_profile.0.advanced_networking")
@@ -3762,7 +3796,8 @@ func expandKubernetesClusterAdvancedNetworking(input []interface{}, d *pluginsdk
 					Enabled: pointer.To(false),
 				},
 				Security: &managedclusters.AdvancedNetworkingSecurity{
-					Enabled: pointer.To(false),
+					Enabled:                 pointer.To(false),
+					AdvancedNetworkPolicies: pointer.To(managedclusters.AdvancedNetworkPoliciesNone),
 				},
 			}
 		}
@@ -3773,14 +3808,26 @@ func expandKubernetesClusterAdvancedNetworking(input []interface{}, d *pluginsdk
 	observabilityEnabled := config["observability_enabled"].(bool)
 	securityEnabled := config["security_enabled"].(bool)
 
+	// When security is disabled the API forces the policy to `None`, so send that explicitly rather than
+	// relaying a Computed value from state. When security is enabled and no value is known, leave the
+	// field unset so the API applies its default (`FQDN`).
+	var advancedNetworkPolicies *managedclusters.AdvancedNetworkPolicies
+	if !securityEnabled {
+		advancedNetworkPolicies = pointer.To(managedclusters.AdvancedNetworkPoliciesNone)
+	} else if v := config["policy"].(string); v != "" {
+		advancedNetworkPolicies = pointer.ToEnum[managedclusters.AdvancedNetworkPolicies](v)
+	}
+	security := &managedclusters.AdvancedNetworkingSecurity{
+		Enabled:                 pointer.To(securityEnabled),
+		AdvancedNetworkPolicies: advancedNetworkPolicies,
+	}
+
 	return &managedclusters.AdvancedNetworking{
 		Enabled: pointer.To(true),
 		Observability: &managedclusters.AdvancedNetworkingObservability{
 			Enabled: pointer.To(observabilityEnabled),
 		},
-		Security: &managedclusters.AdvancedNetworkingSecurity{
-			Enabled: pointer.To(securityEnabled),
-		},
+		Security: security,
 	}
 }
 
@@ -3795,14 +3842,19 @@ func flattenKubernetesClusterAdvancedNetworking(advancedNetworking *managedclust
 	}
 
 	securityEnabled := false
+	advancedNetworkPolicies := ""
 	if advancedNetworking.Security != nil {
 		securityEnabled = pointer.From(advancedNetworking.Security.Enabled)
+		if advancedNetworking.Security.AdvancedNetworkPolicies != nil {
+			advancedNetworkPolicies = string(*advancedNetworking.Security.AdvancedNetworkPolicies)
+		}
 	}
 
 	return []interface{}{
 		map[string]interface{}{
 			"observability_enabled": observabilityEnabled,
 			"security_enabled":      securityEnabled,
+			"policy":                advancedNetworkPolicies,
 		},
 	}
 }

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -204,6 +204,16 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 							return fmt.Errorf("when `network_profile.0.advanced_networking` has `security_enabled` set to `true`, `network_profile.0.network_plugin` must be set to `%s`", managedclusters.NetworkPluginAzure)
 						}
 					}
+					advancedNetworkPolicies := d.Get("network_profile.0.advanced_networking.0.policy").(string)
+					if !securityEnabled && kubernetesClusterAdvancedNetworkingPolicySetInConfig(d) &&
+						(advancedNetworkPolicies == string(managedclusters.AdvancedNetworkPoliciesFQDN) || advancedNetworkPolicies == string(managedclusters.AdvancedNetworkPoliciesLSeven)) {
+						return fmt.Errorf("`network_profile.0.advanced_networking.0.policy` can only be set to `%s` or `%s` when `network_profile.0.advanced_networking.0.security_enabled` is set to `true`", managedclusters.AdvancedNetworkPoliciesFQDN, managedclusters.AdvancedNetworkPoliciesLSeven)
+					}
+					if securityEnabled && advancedNetworkPolicies == string(managedclusters.AdvancedNetworkPoliciesLSeven) {
+						if mode := d.Get("service_mesh_profile.0.mode").(string); mode == string(managedclusters.ServiceMeshModeIstio) {
+							return fmt.Errorf("`network_profile.0.advanced_networking.0.policy` cannot be set to `%s` when `service_mesh_profile.0.mode` is set to `%s`", managedclusters.AdvancedNetworkPoliciesLSeven, managedclusters.ServiceMeshModeIstio)
+						}
+					}
 				}
 				return nil
 			},
@@ -1390,6 +1400,12 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 										Optional:     true,
 										Default:      false,
 										AtLeastOneOf: []string{"network_profile.0.advanced_networking.0.observability_enabled", "network_profile.0.advanced_networking.0.security_enabled"},
+									},
+									"policy": {
+										Type:         pluginsdk.TypeString,
+										Optional:     true,
+										Computed:     true,
+										ValidateFunc: validation.StringInSlice(managedclusters.PossibleValuesForAdvancedNetworkPolicies(), false),
 									},
 								},
 							},
@@ -3691,6 +3707,24 @@ func expandKubernetesClusterNetworkProfile(input []interface{}, d *pluginsdk.Res
 	return &networkProfile, nil
 }
 
+// kubernetesClusterAdvancedNetworkingPolicySetInConfig reports whether `network_profile.0.advanced_networking.0.policy`
+// is explicitly set in the configuration, distinguishing it from a Computed value carried over from state.
+func kubernetesClusterAdvancedNetworkingPolicySetInConfig(d *schema.ResourceDiff) bool {
+	rawConfig := d.GetRawConfig()
+	if !rawConfig.IsKnown() || rawConfig.IsNull() {
+		return false
+	}
+	rawNetworkProfiles := rawConfig.AsValueMap()["network_profile"]
+	if !rawNetworkProfiles.IsKnown() || rawNetworkProfiles.IsNull() || rawNetworkProfiles.LengthInt() == 0 {
+		return false
+	}
+	rawAdvancedNetworkings := rawNetworkProfiles.AsValueSlice()[0].AsValueMap()["advanced_networking"]
+	if !rawAdvancedNetworkings.IsKnown() || rawAdvancedNetworkings.IsNull() || rawAdvancedNetworkings.LengthInt() == 0 {
+		return false
+	}
+	return !rawAdvancedNetworkings.AsValueSlice()[0].AsValueMap()["policy"].IsNull()
+}
+
 func expandKubernetesClusterAdvancedNetworking(input []interface{}, d *pluginsdk.ResourceData) *managedclusters.AdvancedNetworking {
 	if len(input) == 0 || input[0] == nil {
 		o, n := d.GetChange("network_profile.0.advanced_networking")
@@ -3701,7 +3735,8 @@ func expandKubernetesClusterAdvancedNetworking(input []interface{}, d *pluginsdk
 					Enabled: pointer.To(false),
 				},
 				Security: &managedclusters.AdvancedNetworkingSecurity{
-					Enabled: pointer.To(false),
+					Enabled:                 pointer.To(false),
+					AdvancedNetworkPolicies: pointer.To(managedclusters.AdvancedNetworkPoliciesNone),
 				},
 			}
 		}
@@ -3712,14 +3747,26 @@ func expandKubernetesClusterAdvancedNetworking(input []interface{}, d *pluginsdk
 	observabilityEnabled := config["observability_enabled"].(bool)
 	securityEnabled := config["security_enabled"].(bool)
 
+	// When security is disabled the API forces the policy to `None`, so send that explicitly rather than
+	// relaying a Computed value from state. When security is enabled and no value is known, leave the
+	// field unset so the API applies its default (`FQDN`).
+	var advancedNetworkPolicies *managedclusters.AdvancedNetworkPolicies
+	if !securityEnabled {
+		advancedNetworkPolicies = pointer.To(managedclusters.AdvancedNetworkPoliciesNone)
+	} else if v := config["policy"].(string); v != "" {
+		advancedNetworkPolicies = pointer.ToEnum[managedclusters.AdvancedNetworkPolicies](v)
+	}
+	security := &managedclusters.AdvancedNetworkingSecurity{
+		Enabled:                 pointer.To(securityEnabled),
+		AdvancedNetworkPolicies: advancedNetworkPolicies,
+	}
+
 	return &managedclusters.AdvancedNetworking{
 		Enabled: pointer.To(true),
 		Observability: &managedclusters.AdvancedNetworkingObservability{
 			Enabled: pointer.To(observabilityEnabled),
 		},
-		Security: &managedclusters.AdvancedNetworkingSecurity{
-			Enabled: pointer.To(securityEnabled),
-		},
+		Security: security,
 	}
 }
 
@@ -3734,14 +3781,19 @@ func flattenKubernetesClusterAdvancedNetworking(advancedNetworking *managedclust
 	}
 
 	securityEnabled := false
+	advancedNetworkPolicies := ""
 	if advancedNetworking.Security != nil {
 		securityEnabled = pointer.From(advancedNetworking.Security.Enabled)
+		if advancedNetworking.Security.AdvancedNetworkPolicies != nil {
+			advancedNetworkPolicies = string(*advancedNetworking.Security.AdvancedNetworkPolicies)
+		}
 	}
 
 	return []interface{}{
 		map[string]interface{}{
 			"observability_enabled": observabilityEnabled,
 			"security_enabled":      securityEnabled,
+			"policy":                advancedNetworkPolicies,
 		},
 	}
 }

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -738,6 +738,8 @@ An `advanced_networking` block supports the following:
 
 * `security_enabled` - (Optional) Is security enabled? Defaults to `false`. This can only be enabled (set to `true`) when `network_plugin` is set to `azure` and `network_data_plane` is set to `cilium`.
 
+* `policy` - (Optional) Specifies the advanced network policy applied to the cluster. Possible values are `FQDN`, `L7` and `None`. When `security_enabled` is set to `true` and `policy` is not specified, the API defaults this to `FQDN`; set it to `None` to disable advanced network policy enforcement. `FQDN` and `L7` can only be set when `security_enabled` is set to `true`. `L7` cannot be set when `service_mesh_profile` `mode` is set to `Istio`.
+
 ---
 
 A `load_balancer_profile` block supports the following:


### PR DESCRIPTION
The `advanced_networking` block currently exposes `observability_enabled` and
`security_enabled`, but not the advanced network policy mode that Advanced
Container Networking Services (ACNS) security applies — enabling security
always yields the service default, with no way to select L7 policy enforcement
or disable policy enforcement from Terraform.

This PR adds the `policy` property to the `network_profile.advanced_networking`
block, mapping to the `AdvancedNetworkingSecurity.AdvancedNetworkPolicies`
field on the `managedclusters` API.

The API treats `advancedNetworkPolicies` as a tri-state field with a
service-side default: when `security_enabled` is `true` and the field is
unset, the service defaults it to `FQDN`; when security is disabled, the
service normalizes it to `None`. The schema models this directly:

- **Schema**: `policy` is `Optional` + `Computed` with possible values `FQDN`,
  `L7` and `None`. When omitted, the service-applied value flows into state,
  so clusters that already have `security_enabled = true` keep their current
  policy with no diff on provider upgrade. `None` is exposed as an explicit
  value because omission cannot express it: an unset `policy` on a
  security-enabled cluster is defaulted by the API to `FQDN`, so disabling
  enforcement requires `policy = "None"`.
- **Validation**: `FQDN` and `L7` can only be configured when
  `security_enabled` is `true`. The check applies only when `policy` is
  explicitly set in the configuration (via `GetRawConfig`), so a `Computed`
  value carried over from state does not block disabling security — the
  provider sends `None` in that case, matching the API's own normalization.
  `L7` cannot be combined with a `service_mesh_profile` in `Istio` mode;
  `FQDN` with Istio is allowed, matching the API.
- **Disable paths**: when `security_enabled` is `false` or the
  `advanced_networking` block is removed entirely, an explicit `None` is sent
  so a previously configured policy is reset rather than left for the API to
  retain.
- **Tests**: acceptance coverage for the service-side `FQDN` default, updating
  `FQDN` → `L7`, omitting `policy` (current value is retained), removing the
  `advanced_networking` block entirely, re-adding it, explicitly disabling
  with `None`, and the negative cases (`L7` without `security_enabled`, `L7`
  with Istio).
- **Documentation**: the `policy` argument and its preconditions added to the
  `azurerm_kubernetes_cluster` documentation.

<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

See above.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

Validated two ways against a dev-override build of the provider:

**Plan-time matrix** (10 cases): `FQDN`/`L7`/`None` plan cleanly with security
enabled; explicit `None` is accepted with security disabled; explicit `L7`
without `security_enabled` is rejected; `L7` with Istio is rejected while
`FQDN` with Istio plans cleanly; `security_enabled = true` with a non-cilium
data plane is still rejected; invalid values are rejected by schema validation
listing `["FQDN" "L7" "None"]`.

**Apply-time lifecycle** against the live API (`2025-10-01`), mirroring the
`TestAccKubernetesCluster_advancedNetworkingPolicies` steps, with
`TF_LOG=DEBUG` confirming the request and response bodies at each step:

| Step | Observed |
|---|---|
| create with `security_enabled = true`, `policy` omitted | request omits `advancedNetworkPolicies`; API defaults it to `FQDN`; state = `FQDN` |
| plan with the same config | empty — no drift from the Computed value |
| `policy = "L7"` | request and response carry `L7`; state = `L7` |
| plan with `policy` omitted | empty — current value retained |
| `security_enabled = false` with computed `L7` in state | no validation error; request sends `None`; state = `None` |
| `security_enabled = true` again | `None` retained — the state value is sent explicitly, so the API default does not re-fire |
| `advanced_networking` block removed | disable request carries an explicit `advancedNetworkPolicies: None`; block removed from state |
| block re-added with `policy = "FQDN"` | state = `FQDN` |


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

* `azurerm_kubernetes_cluster` - support for the `policy` property in the `network_profile.advanced_networking` block [GH-31506]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

N/A


## AI Assistance Disclosure

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->
AI was used for code generation and test authoring; all changes were reviewed before submission.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE]
> If this PR changes meaningfully during the course of review please update the title and description as required.
