### PR TITLE
New Resource: `azurerm_storage_mover_multi_cloud_connector_endpoint`

### DIFF
--- a/internal/services/storagemover/registration.go
+++ b/internal/services/storagemover/registration.go
@@ -46,6 +46,7 @@ func (r Registration) Resources() []sdk.Resource {
 		StorageMoverTargetEndpointResource{},
 		StorageMoverProjectResource{},
 		StorageMoverJobDefinitionResource{},
+		StorageMoverMultiCloudConnectorEndpointResource{},
 	}
 }
 

--- a/internal/services/storagemover/registration.go
+++ b/internal/services/storagemover/registration.go
@@ -40,13 +40,13 @@ func (r Registration) DataSources() []sdk.DataSource {
 // Resources returns a list of Resources supported by this Service
 func (r Registration) Resources() []sdk.Resource {
 	return []sdk.Resource{
-		StorageMoverResource{},
 		StorageMoverAgentResource{},
-		StorageMoverSourceEndpointResource{},
-		StorageMoverTargetEndpointResource{},
-		StorageMoverProjectResource{},
 		StorageMoverJobDefinitionResource{},
 		StorageMoverMultiCloudConnectorEndpointResource{},
+		StorageMoverProjectResource{},
+		StorageMoverResource{},
+		StorageMoverSourceEndpointResource{},
+		StorageMoverTargetEndpointResource{},
 	}
 }
 
@@ -71,6 +71,7 @@ func (r Registration) ListResources() []sdk.FrameworkListWrappedResource {
 		StorageMoverAgentListResource{},
 		StorageMoverJobDefinitionListResource{},
 		StorageMoverListResource{},
+		StorageMoverMultiCloudConnectorEndpointListResource{},
 		StorageMoverProjectListResource{},
 		StorageMoverSourceEndpointListResource{},
 	}

--- a/internal/services/storagemover/storage_mover_multi_cloud_connector_endpoint_resource.go
+++ b/internal/services/storagemover/storage_mover_multi_cloud_connector_endpoint_resource.go
@@ -1,0 +1,242 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package storagemover
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/storagemover/2025-07-01/endpoints"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/storagemover/2025-07-01/storagemovers"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+type StorageMoverMultiCloudConnectorEndpointModel struct {
+	Name                  string `tfschema:"name"`
+	StorageMoverId        string `tfschema:"storage_mover_id"`
+	MultiCloudConnectorId string `tfschema:"multi_cloud_connector_id"`
+	AwsS3BucketId         string `tfschema:"aws_s3_bucket_id"`
+	Description           string `tfschema:"description"`
+}
+
+type StorageMoverMultiCloudConnectorEndpointResource struct{}
+
+var _ sdk.ResourceWithUpdate = StorageMoverMultiCloudConnectorEndpointResource{}
+
+func (r StorageMoverMultiCloudConnectorEndpointResource) ResourceType() string {
+	return "azurerm_storage_mover_multi_cloud_connector_endpoint"
+}
+
+func (r StorageMoverMultiCloudConnectorEndpointResource) ModelObject() interface{} {
+	return &StorageMoverMultiCloudConnectorEndpointModel{}
+}
+
+func (r StorageMoverMultiCloudConnectorEndpointResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return endpoints.ValidateEndpointID
+}
+
+func (r StorageMoverMultiCloudConnectorEndpointResource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+			ValidateFunc: validation.StringMatch(
+				regexp.MustCompile(`^[0-9a-zA-Z][-_0-9a-zA-Z]{0,63}$`),
+				`The name must be between 1 and 64 characters in length, begin with a letter or number, and may contain letters, numbers, dashes and underscore.`,
+			),
+		},
+
+		"storage_mover_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: storagemovers.ValidateStorageMoverID,
+		},
+
+		"multi_cloud_connector_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: azure.ValidateResourceID,
+		},
+
+		"aws_s3_bucket_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: azure.ValidateResourceID,
+		},
+
+		"description": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+	}
+}
+
+func (r StorageMoverMultiCloudConnectorEndpointResource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{}
+}
+
+func (r StorageMoverMultiCloudConnectorEndpointResource) Create() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			var model StorageMoverMultiCloudConnectorEndpointModel
+			if err := metadata.Decode(&model); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			client := metadata.Client.StorageMover.EndpointsClient
+			storageMoverId, err := storagemovers.ParseStorageMoverID(model.StorageMoverId)
+			if err != nil {
+				return err
+			}
+
+			id := endpoints.NewEndpointID(storageMoverId.SubscriptionId, storageMoverId.ResourceGroupName, storageMoverId.StorageMoverName, model.Name)
+			existing, err := client.Get(ctx, id)
+			if err != nil && !response.WasNotFound(existing.HttpResponse) {
+				return fmt.Errorf("checking for existing %s: %+v", id, err)
+			}
+
+			if !response.WasNotFound(existing.HttpResponse) {
+				return metadata.ResourceRequiresImport(r.ResourceType(), id)
+			}
+
+			endpointProperties := endpoints.AzureMultiCloudConnectorEndpointProperties{
+				MultiCloudConnectorId: model.MultiCloudConnectorId,
+				AwsS3BucketId:         model.AwsS3BucketId,
+			}
+
+			if model.Description != "" {
+				endpointProperties.Description = pointer.To(model.Description)
+			}
+
+			properties := endpoints.Endpoint{
+				Properties: endpointProperties,
+			}
+
+			if _, err := client.CreateOrUpdate(ctx, id, properties); err != nil {
+				return fmt.Errorf("creating %s: %+v", id, err)
+			}
+
+			metadata.SetID(id)
+			return nil
+		},
+	}
+}
+
+func (r StorageMoverMultiCloudConnectorEndpointResource) Update() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.StorageMover.EndpointsClient
+
+			id, err := endpoints.ParseEndpointID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			var model StorageMoverMultiCloudConnectorEndpointModel
+			if err := metadata.Decode(&model); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			resp, err := client.Get(ctx, *id)
+			if err != nil {
+				return fmt.Errorf("retrieving %s: %+v", *id, err)
+			}
+
+			properties := resp.Model
+			if properties == nil {
+				return fmt.Errorf("retrieving %s: model was nil", *id)
+			}
+
+			if metadata.ResourceData.HasChange("description") {
+				if v, ok := properties.Properties.(endpoints.AzureMultiCloudConnectorEndpointProperties); ok {
+					v.Description = pointer.To(model.Description)
+					properties.Properties = v
+				}
+			}
+
+			if _, err := client.CreateOrUpdate(ctx, *id, *properties); err != nil {
+				return fmt.Errorf("updating %s: %+v", *id, err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func (r StorageMoverMultiCloudConnectorEndpointResource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.StorageMover.EndpointsClient
+
+			id, err := endpoints.ParseEndpointID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.Get(ctx, *id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return metadata.MarkAsGone(id)
+				}
+
+				return fmt.Errorf("retrieving %s: %+v", *id, err)
+			}
+
+			state := StorageMoverMultiCloudConnectorEndpointModel{
+				Name:           id.EndpointName,
+				StorageMoverId: storagemovers.NewStorageMoverID(id.SubscriptionId, id.ResourceGroupName, id.StorageMoverName).ID(),
+			}
+
+			if model := resp.Model; model != nil {
+				if v, ok := model.Properties.(endpoints.AzureMultiCloudConnectorEndpointProperties); ok {
+					state.MultiCloudConnectorId = v.MultiCloudConnectorId
+					state.AwsS3BucketId = v.AwsS3BucketId
+
+					des := ""
+					if v.Description != nil {
+						des = *v.Description
+					}
+					state.Description = des
+				}
+			}
+
+			return metadata.Encode(&state)
+		},
+	}
+}
+
+func (r StorageMoverMultiCloudConnectorEndpointResource) Delete() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.StorageMover.EndpointsClient
+
+			id, err := endpoints.ParseEndpointID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			if err := client.DeleteThenPoll(ctx, *id); err != nil {
+				return fmt.Errorf("deleting %s: %+v", id, err)
+			}
+
+			return nil
+		},
+	}
+}

--- a/internal/services/storagemover/storage_mover_multi_cloud_connector_endpoint_resource.go
+++ b/internal/services/storagemover/storage_mover_multi_cloud_connector_endpoint_resource.go
@@ -79,7 +79,7 @@ func (r StorageMoverMultiCloudConnectorEndpointResource) Arguments() map[string]
 		"description": {
 			Type:         pluginsdk.TypeString,
 			Optional:     true,
-			ValidateFunc: validation.StringIsNotEmpty,
+			ValidateFunc: validation.StringLenBetween(0, 1024),
 		},
 	}
 }
@@ -159,7 +159,7 @@ func (r StorageMoverMultiCloudConnectorEndpointResource) Update() sdk.ResourceFu
 
 			properties := resp.Model
 			if properties == nil {
-				return fmt.Errorf("retrieving %s: model was nil", *id)
+				return fmt.Errorf("retrieving %s: `model` was nil", *id)
 			}
 
 			if metadata.ResourceData.HasChange("description") {
@@ -207,12 +207,7 @@ func (r StorageMoverMultiCloudConnectorEndpointResource) Read() sdk.ResourceFunc
 				if v, ok := model.Properties.(endpoints.AzureMultiCloudConnectorEndpointProperties); ok {
 					state.MultiCloudConnectorId = v.MultiCloudConnectorId
 					state.AwsS3BucketId = v.AwsS3BucketId
-
-					des := ""
-					if v.Description != nil {
-						des = *v.Description
-					}
-					state.Description = des
+					state.Description = pointer.From(v.Description)
 				}
 			}
 

--- a/internal/services/storagemover/storage_mover_multi_cloud_connector_endpoint_resource.go
+++ b/internal/services/storagemover/storage_mover_multi_cloud_connector_endpoint_resource.go
@@ -14,8 +14,8 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storagemover/2025-07-01/endpoints"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storagemover/2025-07-01/storagemovers"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storagemover/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 )
@@ -74,14 +74,14 @@ func (r StorageMoverMultiCloudConnectorEndpointResource) Arguments() map[string]
 			Type:         pluginsdk.TypeString,
 			Required:     true,
 			ForceNew:     true,
-			ValidateFunc: azure.ValidateResourceID,
+			ValidateFunc: validate.MultiCloudConnectorARMResourceID,
 		},
 
 		"aws_s3_bucket_id": {
 			Type:         pluginsdk.TypeString,
 			Required:     true,
 			ForceNew:     true,
-			ValidateFunc: azure.ValidateResourceID,
+			ValidateFunc: validate.AwsS3BucketARMResourceID,
 		},
 
 		"description": {

--- a/internal/services/storagemover/storage_mover_multi_cloud_connector_endpoint_resource.go
+++ b/internal/services/storagemover/storage_mover_multi_cloud_connector_endpoint_resource.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storagemover/2025-07-01/endpoints"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storagemover/2025-07-01/storagemovers"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
@@ -29,7 +30,10 @@ type StorageMoverMultiCloudConnectorEndpointModel struct {
 
 type StorageMoverMultiCloudConnectorEndpointResource struct{}
 
-var _ sdk.ResourceWithUpdate = StorageMoverMultiCloudConnectorEndpointResource{}
+var (
+	_ sdk.ResourceWithUpdate   = StorageMoverMultiCloudConnectorEndpointResource{}
+	_ sdk.ResourceWithIdentity = StorageMoverMultiCloudConnectorEndpointResource{}
+)
 
 func (r StorageMoverMultiCloudConnectorEndpointResource) ResourceType() string {
 	return "azurerm_storage_mover_multi_cloud_connector_endpoint"
@@ -41,6 +45,10 @@ func (r StorageMoverMultiCloudConnectorEndpointResource) ModelObject() interface
 
 func (r StorageMoverMultiCloudConnectorEndpointResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
 	return endpoints.ValidateEndpointID
+}
+
+func (r StorageMoverMultiCloudConnectorEndpointResource) Identity() resourceids.ResourceId {
+	return &endpoints.EndpointId{}
 }
 
 func (r StorageMoverMultiCloudConnectorEndpointResource) Arguments() map[string]*pluginsdk.Schema {
@@ -106,7 +114,7 @@ func (r StorageMoverMultiCloudConnectorEndpointResource) Create() sdk.ResourceFu
 			id := endpoints.NewEndpointID(storageMoverId.SubscriptionId, storageMoverId.ResourceGroupName, storageMoverId.StorageMoverName, model.Name)
 			existing, err := client.Get(ctx, id)
 			if err != nil && !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for existing %s: %+v", id, err)
+				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
 			}
 
 			if !response.WasNotFound(existing.HttpResponse) {
@@ -131,7 +139,10 @@ func (r StorageMoverMultiCloudConnectorEndpointResource) Create() sdk.ResourceFu
 			}
 
 			metadata.SetID(id)
-			return nil
+			if err := pluginsdk.SetResourceIdentityData(metadata.ResourceData, &id); err != nil {
+				return err
+			}
+			return metadata.Encode(&model)
 		},
 	}
 }
@@ -211,6 +222,9 @@ func (r StorageMoverMultiCloudConnectorEndpointResource) Read() sdk.ResourceFunc
 				}
 			}
 
+			if err := pluginsdk.SetResourceIdentityData(metadata.ResourceData, id); err != nil {
+				return err
+			}
 			return metadata.Encode(&state)
 		},
 	}

--- a/internal/services/storagemover/storage_mover_multi_cloud_connector_endpoint_resource.go
+++ b/internal/services/storagemover/storage_mover_multi_cloud_connector_endpoint_resource.go
@@ -112,13 +112,15 @@ func (r StorageMoverMultiCloudConnectorEndpointResource) Create() sdk.ResourceFu
 			}
 
 			id := endpoints.NewEndpointID(storageMoverId.SubscriptionId, storageMoverId.ResourceGroupName, storageMoverId.StorageMoverName, model.Name)
-			existing, err := client.Get(ctx, id)
-			if err != nil && !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
-			}
+			if !metadata.Client.Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+				existing, err := client.Get(ctx, id)
+				if err != nil && !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+				}
 
-			if !response.WasNotFound(existing.HttpResponse) {
-				return metadata.ResourceRequiresImport(r.ResourceType(), id)
+				if !response.WasNotFound(existing.HttpResponse) {
+					return metadata.ResourceRequiresImport(r.ResourceType(), id)
+				}
 			}
 
 			endpointProperties := endpoints.AzureMultiCloudConnectorEndpointProperties{

--- a/internal/services/storagemover/storage_mover_multi_cloud_connector_endpoint_resource.go
+++ b/internal/services/storagemover/storage_mover_multi_cloud_connector_endpoint_resource.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2014, 2025
 // SPDX-License-Identifier: MPL-2.0
 
 package storagemover
@@ -211,25 +211,29 @@ func (r StorageMoverMultiCloudConnectorEndpointResource) Read() sdk.ResourceFunc
 				return fmt.Errorf("retrieving %s: %+v", *id, err)
 			}
 
-			state := StorageMoverMultiCloudConnectorEndpointModel{
-				Name:           id.EndpointName,
-				StorageMoverId: storagemovers.NewStorageMoverID(id.SubscriptionId, id.ResourceGroupName, id.StorageMoverName).ID(),
-			}
-
-			if model := resp.Model; model != nil {
-				if v, ok := model.Properties.(endpoints.AzureMultiCloudConnectorEndpointProperties); ok {
-					state.MultiCloudConnectorId = v.MultiCloudConnectorId
-					state.AwsS3BucketId = v.AwsS3BucketId
-					state.Description = pointer.From(v.Description)
-				}
-			}
-
-			if err := pluginsdk.SetResourceIdentityData(metadata.ResourceData, id); err != nil {
-				return err
-			}
-			return metadata.Encode(&state)
+			return r.flatten(metadata, id, resp.Model)
 		},
 	}
+}
+
+func (r StorageMoverMultiCloudConnectorEndpointResource) flatten(metadata sdk.ResourceMetaData, id *endpoints.EndpointId, model *endpoints.Endpoint) error {
+	state := StorageMoverMultiCloudConnectorEndpointModel{
+		Name:           id.EndpointName,
+		StorageMoverId: storagemovers.NewStorageMoverID(id.SubscriptionId, id.ResourceGroupName, id.StorageMoverName).ID(),
+	}
+
+	if model != nil {
+		if v, ok := model.Properties.(endpoints.AzureMultiCloudConnectorEndpointProperties); ok {
+			state.MultiCloudConnectorId = v.MultiCloudConnectorId
+			state.AwsS3BucketId = v.AwsS3BucketId
+			state.Description = pointer.From(v.Description)
+		}
+	}
+
+	if err := pluginsdk.SetResourceIdentityData(metadata.ResourceData, id); err != nil {
+		return err
+	}
+	return metadata.Encode(&state)
 }
 
 func (r StorageMoverMultiCloudConnectorEndpointResource) Delete() sdk.ResourceFunc {

--- a/internal/services/storagemover/storage_mover_multi_cloud_connector_endpoint_resource_identity_test.go
+++ b/internal/services/storagemover/storage_mover_multi_cloud_connector_endpoint_resource_identity_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2014, 2025
 // SPDX-License-Identifier: MPL-2.0
 
 package storagemover_test

--- a/internal/services/storagemover/storage_mover_multi_cloud_connector_endpoint_resource_identity_test.go
+++ b/internal/services/storagemover/storage_mover_multi_cloud_connector_endpoint_resource_identity_test.go
@@ -1,0 +1,47 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package storagemover_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
+)
+
+func TestAccStorageMoverMultiCloudConnectorEndpoint_resourceIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_mover_multi_cloud_connector_endpoint", "test")
+	r := StorageMoverMultiCloudConnectorEndpointTestResource{}
+
+	multiCloudConnectorId := os.Getenv("ARM_TEST_MULTI_CLOUD_CONNECTOR_ID")
+	awsS3BucketId := os.Getenv("ARM_TEST_AWS_S3_BUCKET_ID")
+	if multiCloudConnectorId == "" || awsS3BucketId == "" {
+		t.Skip("Skipping as ARM_TEST_MULTI_CLOUD_CONNECTOR_ID and/or ARM_TEST_AWS_S3_BUCKET_ID are not set")
+	}
+
+	checkedFields := map[string]struct{}{
+		"name":                {},
+		"resource_group_name": {},
+		"storage_mover_name":  {},
+		"subscription_id":     {},
+	}
+
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data, multiCloudConnectorId, awsS3BucketId),
+			ConfigStateChecks: []statecheck.StateCheck{
+				customstatecheck.ExpectAllIdentityFieldsAreChecked("azurerm_storage_mover_multi_cloud_connector_endpoint.test", checkedFields),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_storage_mover_multi_cloud_connector_endpoint.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_mover_multi_cloud_connector_endpoint.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("storage_mover_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_mover_multi_cloud_connector_endpoint.test", tfjsonpath.New("storage_mover_name"), tfjsonpath.New("storage_mover_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_mover_multi_cloud_connector_endpoint.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("storage_mover_id")),
+			},
+		},
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
+}

--- a/internal/services/storagemover/storage_mover_multi_cloud_connector_endpoint_resource_list.go
+++ b/internal/services/storagemover/storage_mover_multi_cloud_connector_endpoint_resource_list.go
@@ -1,0 +1,109 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package storagemover
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-azure-helpers/framework/typehelpers"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/storagemover/2025-07-01/endpoints"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/storagemover/2025-07-01/storagemovers"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-framework/list/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type StorageMoverMultiCloudConnectorEndpointListResource struct{}
+
+type StorageMoverMultiCloudConnectorEndpointListModel struct {
+	StorageMoverId types.String `tfsdk:"storage_mover_id"`
+}
+
+var _ sdk.FrameworkListWrappedResource = new(StorageMoverMultiCloudConnectorEndpointListResource)
+
+func (StorageMoverMultiCloudConnectorEndpointListResource) Metadata(_ context.Context, _ resource.MetadataRequest, response *resource.MetadataResponse) {
+	response.TypeName = StorageMoverMultiCloudConnectorEndpointResource{}.ResourceType()
+}
+
+func (StorageMoverMultiCloudConnectorEndpointListResource) ResourceFunc() *pluginsdk.Resource {
+	return sdk.WrappedResource(StorageMoverMultiCloudConnectorEndpointResource{})
+}
+
+func (StorageMoverMultiCloudConnectorEndpointListResource) ListResourceConfigSchema(_ context.Context, _ list.ListResourceSchemaRequest, response *list.ListResourceSchemaResponse) {
+	response.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"storage_mover_id": schema.StringAttribute{
+				Required: true,
+				Validators: []validator.String{
+					typehelpers.WrappedStringValidator{Func: storagemovers.ValidateStorageMoverID},
+				},
+			},
+		},
+	}
+}
+
+func (StorageMoverMultiCloudConnectorEndpointListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream, metadata sdk.ResourceMetadata) {
+	client := metadata.Client.StorageMover.EndpointsClient
+
+	var data StorageMoverMultiCloudConnectorEndpointListModel
+	diags := request.Config.Get(ctx, &data)
+	if diags.HasError() {
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+
+	storageMoverID, err := storagemovers.ParseStorageMoverID(data.StorageMoverId.ValueString())
+	if err != nil {
+		sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("parsing Storage Mover ID for `%s`", StorageMoverMultiCloudConnectorEndpointResource{}.ResourceType()), err)
+		return
+	}
+
+	resp, err := client.ListComplete(ctx, endpoints.NewStorageMoverID(storageMoverID.SubscriptionId, storageMoverID.ResourceGroupName, storageMoverID.StorageMoverName))
+	if err != nil {
+		sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("listing `%s`", StorageMoverMultiCloudConnectorEndpointResource{}.ResourceType()), err)
+		return
+	}
+
+	resource := StorageMoverMultiCloudConnectorEndpointResource{}
+	stream.Results = func(push func(list.ListResult) bool) {
+		for _, item := range resp.Items {
+			if _, ok := item.Properties.(endpoints.AzureMultiCloudConnectorEndpointProperties); !ok {
+				continue
+			}
+
+			result := request.NewListResult(ctx)
+			result.DisplayName = pointer.From(item.Name)
+
+			id, err := endpoints.ParseEndpointIDInsensitively(pointer.From(item.Id))
+			if err != nil {
+				sdk.SetErrorDiagnosticAndPushListResult(result, push, "parsing Storage Mover Multi-Cloud Connector Endpoint ID", err)
+				return
+			}
+
+			meta := sdk.NewResourceMetaData(metadata.Client, resource)
+			meta.SetID(id)
+
+			if err := resource.flatten(meta, id, &item); err != nil {
+				sdk.SetErrorDiagnosticAndPushListResult(result, push, fmt.Sprintf("encoding `%s` resource data", resource.ResourceType()), err)
+				return
+			}
+
+			sdk.EncodeListResult(ctx, meta.ResourceData, &result)
+			if result.Diagnostics.HasError() {
+				push(result)
+				return
+			}
+
+			if !push(result) {
+				return
+			}
+		}
+	}
+}

--- a/internal/services/storagemover/storage_mover_multi_cloud_connector_endpoint_resource_list_test.go
+++ b/internal/services/storagemover/storage_mover_multi_cloud_connector_endpoint_resource_list_test.go
@@ -1,0 +1,84 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package storagemover_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
+)
+
+func TestAccStorageMoverMultiCloudConnectorEndpoint_list(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_mover_multi_cloud_connector_endpoint", "testlist")
+	r := StorageMoverMultiCloudConnectorEndpointTestResource{}
+	resourceName := fmt.Sprintf("acctest-smmcce-%d", data.RandomInteger)
+	storageMoverName := fmt.Sprintf("acctest-ssm-%d", data.RandomInteger)
+	resourceGroupName := fmt.Sprintf("acctest-rg-%d", data.RandomInteger)
+
+	multiCloudConnectorId := os.Getenv("ARM_TEST_MULTI_CLOUD_CONNECTOR_ID")
+	awsS3BucketId := os.Getenv("ARM_TEST_AWS_S3_BUCKET_ID")
+	if multiCloudConnectorId == "" || awsS3BucketId == "" {
+		t.Skip("Skipping as ARM_TEST_MULTI_CLOUD_CONNECTOR_ID and/or ARM_TEST_AWS_S3_BUCKET_ID are not set")
+	}
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []resource.TestStep{
+			{Config: r.listConfig(data, multiCloudConnectorId, awsS3BucketId)},
+			{
+				Query:  true,
+				Config: r.listQuery(),
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectLength("azurerm_storage_mover_multi_cloud_connector_endpoint.list", 1),
+					querycheck.ExpectIdentity("azurerm_storage_mover_multi_cloud_connector_endpoint.list", map[string]knownvalue.Check{
+						"name":                knownvalue.StringExact(resourceName),
+						"resource_group_name": knownvalue.StringExact(resourceGroupName),
+						"storage_mover_name":  knownvalue.StringExact(storageMoverName),
+						"subscription_id":     knownvalue.StringExact(data.Subscriptions.Primary),
+					}),
+				},
+			},
+		},
+	})
+}
+
+func (r StorageMoverMultiCloudConnectorEndpointTestResource) listConfig(data acceptance.TestData, multiCloudConnectorId, awsS3BucketId string) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_storage_mover_multi_cloud_connector_endpoint" "test" {
+  name                     = "acctest-smmcce-%d"
+  storage_mover_id         = azurerm_storage_mover.test.id
+  multi_cloud_connector_id = "%s"
+  aws_s3_bucket_id         = "%s"
+}
+`, template, data.RandomInteger, multiCloudConnectorId, awsS3BucketId)
+}
+
+func (r StorageMoverMultiCloudConnectorEndpointTestResource) listQuery() string {
+	return `
+list "azurerm_storage_mover_multi_cloud_connector_endpoint" "list" {
+  provider = azurerm
+  config {
+    storage_mover_id = azurerm_storage_mover.test.id
+  }
+}
+`
+}

--- a/internal/services/storagemover/storage_mover_multi_cloud_connector_endpoint_resource_test.go
+++ b/internal/services/storagemover/storage_mover_multi_cloud_connector_endpoint_resource_test.go
@@ -1,0 +1,216 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package storagemover_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/storagemover/2025-07-01/endpoints"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type StorageMoverMultiCloudConnectorEndpointTestResource struct{}
+
+func TestAccStorageMoverMultiCloudConnectorEndpoint_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_mover_multi_cloud_connector_endpoint", "test")
+	r := StorageMoverMultiCloudConnectorEndpointTestResource{}
+
+	multiCloudConnectorId := os.Getenv("ARM_TEST_MULTI_CLOUD_CONNECTOR_ID")
+	awsS3BucketId := os.Getenv("ARM_TEST_AWS_S3_BUCKET_ID")
+	if multiCloudConnectorId == "" || awsS3BucketId == "" {
+		t.Skip("Skipping as ARM_TEST_MULTI_CLOUD_CONNECTOR_ID and/or ARM_TEST_AWS_S3_BUCKET_ID are not set")
+	}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data, multiCloudConnectorId, awsS3BucketId),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccStorageMoverMultiCloudConnectorEndpoint_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_mover_multi_cloud_connector_endpoint", "test")
+	r := StorageMoverMultiCloudConnectorEndpointTestResource{}
+
+	multiCloudConnectorId := os.Getenv("ARM_TEST_MULTI_CLOUD_CONNECTOR_ID")
+	awsS3BucketId := os.Getenv("ARM_TEST_AWS_S3_BUCKET_ID")
+	if multiCloudConnectorId == "" || awsS3BucketId == "" {
+		t.Skip("Skipping as ARM_TEST_MULTI_CLOUD_CONNECTOR_ID and/or ARM_TEST_AWS_S3_BUCKET_ID are not set")
+	}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data, multiCloudConnectorId, awsS3BucketId),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(func(data acceptance.TestData) string {
+			return r.requiresImport(data, multiCloudConnectorId, awsS3BucketId)
+		}),
+	})
+}
+
+func TestAccStorageMoverMultiCloudConnectorEndpoint_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_mover_multi_cloud_connector_endpoint", "test")
+	r := StorageMoverMultiCloudConnectorEndpointTestResource{}
+
+	multiCloudConnectorId := os.Getenv("ARM_TEST_MULTI_CLOUD_CONNECTOR_ID")
+	awsS3BucketId := os.Getenv("ARM_TEST_AWS_S3_BUCKET_ID")
+	if multiCloudConnectorId == "" || awsS3BucketId == "" {
+		t.Skip("Skipping as ARM_TEST_MULTI_CLOUD_CONNECTOR_ID and/or ARM_TEST_AWS_S3_BUCKET_ID are not set")
+	}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data, multiCloudConnectorId, awsS3BucketId),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccStorageMoverMultiCloudConnectorEndpoint_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_mover_multi_cloud_connector_endpoint", "test")
+	r := StorageMoverMultiCloudConnectorEndpointTestResource{}
+
+	multiCloudConnectorId := os.Getenv("ARM_TEST_MULTI_CLOUD_CONNECTOR_ID")
+	awsS3BucketId := os.Getenv("ARM_TEST_AWS_S3_BUCKET_ID")
+	if multiCloudConnectorId == "" || awsS3BucketId == "" {
+		t.Skip("Skipping as ARM_TEST_MULTI_CLOUD_CONNECTOR_ID and/or ARM_TEST_AWS_S3_BUCKET_ID are not set")
+	}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data, multiCloudConnectorId, awsS3BucketId),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.update(data, multiCloudConnectorId, awsS3BucketId),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (r StorageMoverMultiCloudConnectorEndpointTestResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := endpoints.ParseEndpointID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	client := clients.StorageMover.EndpointsClient
+	resp, err := client.Get(ctx, *id)
+	if err != nil {
+		if response.WasNotFound(resp.HttpResponse) {
+			return pointer.To(false), nil
+		}
+		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+	return pointer.To(resp.Model != nil), nil
+}
+
+func (r StorageMoverMultiCloudConnectorEndpointTestResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctest-rg-%d"
+  location = "%s"
+}
+
+resource "azurerm_storage_mover" "test" {
+  name                = "acctest-ssm-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (r StorageMoverMultiCloudConnectorEndpointTestResource) basic(data acceptance.TestData, multiCloudConnectorId, awsS3BucketId string) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_storage_mover_multi_cloud_connector_endpoint" "test" {
+  name                     = "acctest-smmcce-%d"
+  storage_mover_id         = azurerm_storage_mover.test.id
+  multi_cloud_connector_id = "%s"
+  aws_s3_bucket_id         = "%s"
+}
+`, template, data.RandomInteger, multiCloudConnectorId, awsS3BucketId)
+}
+
+func (r StorageMoverMultiCloudConnectorEndpointTestResource) requiresImport(data acceptance.TestData, multiCloudConnectorId, awsS3BucketId string) string {
+	config := r.basic(data, multiCloudConnectorId, awsS3BucketId)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_storage_mover_multi_cloud_connector_endpoint" "import" {
+  name                     = azurerm_storage_mover_multi_cloud_connector_endpoint.test.name
+  storage_mover_id         = azurerm_storage_mover.test.id
+  multi_cloud_connector_id = azurerm_storage_mover_multi_cloud_connector_endpoint.test.multi_cloud_connector_id
+  aws_s3_bucket_id         = azurerm_storage_mover_multi_cloud_connector_endpoint.test.aws_s3_bucket_id
+}
+`, config)
+}
+
+func (r StorageMoverMultiCloudConnectorEndpointTestResource) complete(data acceptance.TestData, multiCloudConnectorId, awsS3BucketId string) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_storage_mover_multi_cloud_connector_endpoint" "test" {
+  name                     = "acctest-smmcce-%d"
+  storage_mover_id         = azurerm_storage_mover.test.id
+  multi_cloud_connector_id = "%s"
+  aws_s3_bucket_id         = "%s"
+  description              = "Example Multi-Cloud Connector Endpoint Description"
+}
+`, template, data.RandomInteger, multiCloudConnectorId, awsS3BucketId)
+}
+
+func (r StorageMoverMultiCloudConnectorEndpointTestResource) update(data acceptance.TestData, multiCloudConnectorId, awsS3BucketId string) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_storage_mover_multi_cloud_connector_endpoint" "test" {
+  name                     = "acctest-smmcce-%d"
+  storage_mover_id         = azurerm_storage_mover.test.id
+  multi_cloud_connector_id = "%s"
+  aws_s3_bucket_id         = "%s"
+  description              = "Updated Multi-Cloud Connector Endpoint Description"
+}
+`, template, data.RandomInteger, multiCloudConnectorId, awsS3BucketId)
+}

--- a/internal/services/storagemover/storage_mover_multi_cloud_connector_endpoint_resource_test.go
+++ b/internal/services/storagemover/storage_mover_multi_cloud_connector_endpoint_resource_test.go
@@ -1,6 +1,14 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
+// Acceptance tests for this resource require real Azure resources that are not created by these tests:
+//   - ARM_TEST_MULTI_CLOUD_CONNECTOR_ID — resource ID of a Microsoft.HybridConnectivity/publicCloudConnectors instance
+//   - ARM_TEST_AWS_S3_BUCKET_ID — resource ID of a Microsoft.AwsConnector/s3Buckets instance linked for cloud-to-cloud migration
+//
+// Create those prerequisites in the portal or via ARM as described in
+// https://learn.microsoft.com/azure/storage-mover/cloud-to-cloud-migration
+// then export the two IDs into the environment before running TF_ACC for this package.
+
 package storagemover_test
 
 import (

--- a/internal/services/storagemover/storage_mover_multi_cloud_connector_endpoint_resource_test.go
+++ b/internal/services/storagemover/storage_mover_multi_cloud_connector_endpoint_resource_test.go
@@ -1,9 +1,9 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2014, 2025
 // SPDX-License-Identifier: MPL-2.0
 
 // Acceptance tests for this resource require real Azure resources that are not created by these tests:
-//   - ARM_TEST_MULTI_CLOUD_CONNECTOR_ID — resource ID of a Microsoft.HybridConnectivity/publicCloudConnectors instance
-//   - ARM_TEST_AWS_S3_BUCKET_ID — resource ID of a Microsoft.AwsConnector/s3Buckets instance linked for cloud-to-cloud migration
+//   - ARM_TEST_MULTI_CLOUD_CONNECTOR_ID - resource ID of a Microsoft.HybridConnectivity/publicCloudConnectors instance
+//   - ARM_TEST_AWS_S3_BUCKET_ID - resource ID of a Microsoft.AwsConnector/s3Buckets instance linked for cloud-to-cloud migration
 //
 // Create those prerequisites in the portal or via ARM as described in
 // https://learn.microsoft.com/azure/storage-mover/cloud-to-cloud-migration

--- a/internal/services/storagemover/validate/multi_cloud_connector_arm_resource_id.go
+++ b/internal/services/storagemover/validate/multi_cloud_connector_arm_resource_id.go
@@ -1,0 +1,40 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package validate
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+)
+
+// MultiCloudConnectorARMResourceID validates a full ARM resource ID for a Hybrid Connectivity public cloud connector.
+// See https://learn.microsoft.com/rest/api/storagemover/endpoints/create-or-update
+func MultiCloudConnectorARMResourceID(i interface{}, k string) (warnings []string, errors []error) {
+	warnings, errors = azure.ValidateResourceID(i, k)
+	if len(errors) > 0 {
+		return warnings, errors
+	}
+
+	id := strings.ToLower(i.(string))
+	if !strings.Contains(id, "/providers/microsoft.hybridconnectivity/publiccloudconnectors/") {
+		errors = append(errors, fmt.Errorf("%q must be the resource ID of a Microsoft.HybridConnectivity/publicCloudConnectors resource", k))
+	}
+	return warnings, errors
+}
+
+// AwsS3BucketARMResourceID validates a full ARM resource ID for an AWS S3 bucket resource exposed through Microsoft.AwsConnector.
+func AwsS3BucketARMResourceID(i interface{}, k string) (warnings []string, errors []error) {
+	warnings, errors = azure.ValidateResourceID(i, k)
+	if len(errors) > 0 {
+		return warnings, errors
+	}
+
+	id := strings.ToLower(i.(string))
+	if !strings.Contains(id, "/providers/microsoft.awsconnector/s3buckets/") {
+		errors = append(errors, fmt.Errorf("%q must be the resource ID of a Microsoft.AwsConnector/s3Buckets resource", k))
+	}
+	return warnings, errors
+}

--- a/internal/services/storagemover/validate/multi_cloud_connector_arm_resource_id.go
+++ b/internal/services/storagemover/validate/multi_cloud_connector_arm_resource_id.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2014, 2025
 // SPDX-License-Identifier: MPL-2.0
 
 package validate
@@ -10,8 +10,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 )
 
-// MultiCloudConnectorARMResourceID validates a full ARM resource ID for a Hybrid Connectivity public cloud connector.
-// See https://learn.microsoft.com/rest/api/storagemover/endpoints/create-or-update
 func MultiCloudConnectorARMResourceID(i interface{}, k string) (warnings []string, errors []error) {
 	warnings, errors = azure.ValidateResourceID(i, k)
 	if len(errors) > 0 {
@@ -25,7 +23,6 @@ func MultiCloudConnectorARMResourceID(i interface{}, k string) (warnings []strin
 	return warnings, errors
 }
 
-// AwsS3BucketARMResourceID validates a full ARM resource ID for an AWS S3 bucket resource exposed through Microsoft.AwsConnector.
 func AwsS3BucketARMResourceID(i interface{}, k string) (warnings []string, errors []error) {
 	warnings, errors = azure.ValidateResourceID(i, k)
 	if len(errors) > 0 {

--- a/internal/services/storagemover/validate/multi_cloud_connector_arm_resource_id_test.go
+++ b/internal/services/storagemover/validate/multi_cloud_connector_arm_resource_id_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2014, 2025
 // SPDX-License-Identifier: MPL-2.0
 
 package validate

--- a/internal/services/storagemover/validate/multi_cloud_connector_arm_resource_id_test.go
+++ b/internal/services/storagemover/validate/multi_cloud_connector_arm_resource_id_test.go
@@ -1,0 +1,36 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package validate
+
+import "testing"
+
+func TestMultiCloudConnectorARMResourceID(t *testing.T) {
+	t.Parallel()
+
+	valid := "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.HybridConnectivity/publicCloudConnectors/c1"
+	_, errs := MultiCloudConnectorARMResourceID(valid, "multi_cloud_connector_id")
+	if len(errs) > 0 {
+		t.Fatalf("expected valid id, got %v", errs)
+	}
+
+	_, errs = MultiCloudConnectorARMResourceID("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/sa", "multi_cloud_connector_id")
+	if len(errs) == 0 {
+		t.Fatal("expected error for wrong resource type")
+	}
+}
+
+func TestAwsS3BucketARMResourceID(t *testing.T) {
+	t.Parallel()
+
+	valid := "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.AwsConnector/s3Buckets/b1"
+	_, errs := AwsS3BucketARMResourceID(valid, "aws_s3_bucket_id")
+	if len(errs) > 0 {
+		t.Fatalf("expected valid id, got %v", errs)
+	}
+
+	_, errs = AwsS3BucketARMResourceID("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/sa", "aws_s3_bucket_id")
+	if len(errs) == 0 {
+		t.Fatal("expected error for wrong resource type")
+	}
+}

--- a/website/docs/list-resources/storage_mover_multi_cloud_connector_endpoint.html.markdown
+++ b/website/docs/list-resources/storage_mover_multi_cloud_connector_endpoint.html.markdown
@@ -1,0 +1,30 @@
+---
+subcategory: "Storage Mover"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_storage_mover_multi_cloud_connector_endpoint"
+description: |-
+  Lists Storage Mover Multi-Cloud Connector Endpoint resources.
+---
+
+# List resource: azurerm_storage_mover_multi_cloud_connector_endpoint
+
+Lists Storage Mover Multi-Cloud Connector Endpoint resources.
+
+## Example Usage
+
+### List Multi-Cloud Connector Endpoints in a Storage Mover
+
+```hcl
+list "azurerm_storage_mover_multi_cloud_connector_endpoint" "example" {
+  provider = azurerm
+  config {
+    storage_mover_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example-rg/providers/Microsoft.StorageMover/storageMovers/example-mover"
+  }
+}
+```
+
+## Argument Reference
+
+This list resource supports the following arguments:
+
+* `storage_mover_id` - (Required) The ID of the Storage Mover to query.

--- a/website/docs/r/storage_mover_multi_cloud_connector_endpoint.html.markdown
+++ b/website/docs/r/storage_mover_multi_cloud_connector_endpoint.html.markdown
@@ -1,0 +1,77 @@
+---
+subcategory: "Storage Mover"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_storage_mover_multi_cloud_connector_endpoint"
+description: |-
+  Manages a Storage Mover Multi-Cloud Connector Endpoint.
+---
+
+# azurerm_storage_mover_multi_cloud_connector_endpoint
+
+Manages a Storage Mover Multi-Cloud Connector Endpoint for migrating data from AWS S3 to Azure.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_storage_mover" "example" {
+  name                = "example-ssm"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = "West Europe"
+}
+
+resource "azurerm_storage_mover_multi_cloud_connector_endpoint" "example" {
+  name                     = "example-mcce"
+  storage_mover_id         = azurerm_storage_mover.example.id
+  multi_cloud_connector_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example-rg/providers/Microsoft.HybridConnectivity/publicCloudConnectors/example-connector"
+  aws_s3_bucket_id         = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aws-rg/providers/Microsoft.AWSConnector/s3Buckets/example-bucket"
+  description              = "Example Multi-Cloud Connector Endpoint"
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Specifies the name which should be used for this Storage Mover Multi-Cloud Connector Endpoint. Changing this forces a new resource to be created.
+
+* `storage_mover_id` - (Required) Specifies the ID of the Storage Mover for this Multi-Cloud Connector Endpoint. Changing this forces a new resource to be created.
+
+* `multi_cloud_connector_id` - (Required) Specifies the resource ID of the Public Cloud Connector in the format `/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridConnectivity/publicCloudConnectors/{publicCloudConnectorName}`. Changing this forces a new resource to be created.
+
+* `aws_s3_bucket_id` - (Required) Specifies the resource ID of the AWS S3 Bucket in the format `/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/s3Buckets/{s3BucketName}`. Changing this forces a new resource to be created.
+
+* `description` - (Optional) Specifies a description for the Storage Mover Multi-Cloud Connector Endpoint.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the Storage Mover Multi-Cloud Connector Endpoint.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/configure#define-operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Storage Mover Multi-Cloud Connector Endpoint.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Storage Mover Multi-Cloud Connector Endpoint.
+* `update` - (Defaults to 30 minutes) Used when updating the Storage Mover Multi-Cloud Connector Endpoint.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Storage Mover Multi-Cloud Connector Endpoint.
+
+## Import
+
+Storage Mover Multi-Cloud Connector Endpoint can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_storage_mover_multi_cloud_connector_endpoint.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1/providers/Microsoft.StorageMover/storageMovers/storageMover1/endpoints/endpoint1
+```
+
+## API Providers
+<!-- This section is generated, changes will be overwritten -->
+This resource uses the following Azure API Providers:
+
+* `Microsoft.StorageMover` - 2025-07-01

--- a/website/docs/r/storage_mover_multi_cloud_connector_endpoint.html.markdown
+++ b/website/docs/r/storage_mover_multi_cloud_connector_endpoint.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # azurerm_storage_mover_multi_cloud_connector_endpoint
 
-Manages a Storage Mover Multi-Cloud Connector Endpoint for migrating data from AWS S3 to Azure.
+Manages a Storage Mover **Target Endpoint** of type Multi-Cloud Connector for [cloud-to-cloud migration](https://learn.microsoft.com/azure/storage-mover/cloud-to-cloud-migration) from AWS S3 to Azure. In the Azure portal this appears under **Storage Mover** → your storage mover → **Endpoints** when creating an endpoint that uses a multi-cloud connector and AWS S3 bucket.
 
 ## Example Usage
 
@@ -28,7 +28,7 @@ resource "azurerm_storage_mover_multi_cloud_connector_endpoint" "example" {
   name                     = "example-mcce"
   storage_mover_id         = azurerm_storage_mover.example.id
   multi_cloud_connector_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example-rg/providers/Microsoft.HybridConnectivity/publicCloudConnectors/example-connector"
-  aws_s3_bucket_id         = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aws-rg/providers/Microsoft.AWSConnector/s3Buckets/example-bucket"
+  aws_s3_bucket_id         = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aws-rg/providers/Microsoft.AwsConnector/s3Buckets/example-bucket"
   description              = "Example Multi-Cloud Connector Endpoint"
 }
 ```


### PR DESCRIPTION
This PR adds a new resource `azurerm_storage_mover_multi_cloud_connector_endpoint` for managing Storage Mover Multi-Cloud Connector Endpoints, enabling data migration from AWS S3 to Azure.

<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This PR introduces the `azurerm_storage_mover_multi_cloud_connector_endpoint` resource, which allows users to create endpoints for migrating data from AWS S3 buckets to Azure using Azure Storage Mover's Multi-Cloud Connector capability.

**Properties:**
- `name` - (Required) The name of the endpoint
- `storage_mover_id` - (Required) The ID of the Storage Mover
- `multi_cloud_connector_id` - (Required) The resource ID of the Multi-Cloud Connector
- `aws_s3_bucket_id` - (Required) The resource ID of the AWS S3 bucket
- `description` - (Optional) A description for the endpoint

This resource uses API version `2025-07-01`.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 


## New Resource

- [x] I have added an explanation of what my resource does and why it should be included in the provider.
- [x] I have written acceptance tests & documentation for my resource.
- [x] I have successfully run acceptance tests with my changes locally.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass.

Acceptance tests pass for the new resource.


## Change Log

* **New Resource:** `azurerm_storage_mover_multi_cloud_connector_endpoint` [GH-31588]


This is a (please select all that apply):

- [ ] Bug Fix
- [x] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

N/A


## AI Assistance Disclosure

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

AI was used to assist with code generation, documentation, and test implementation.


## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

No changes to security controls in this pull request.