### PR TITLE
`azurerm_container_registry`: Support `azuread_authentication_as_arm_policy_enabled`, `role_assignment_mode` and `network_rule_bypass_allowed_for_tasks`

### DIFF
--- a/internal/services/containers/container_registry_resource.go
+++ b/internal/services/containers/container_registry_resource.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
-	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
@@ -382,24 +381,6 @@ func resourceContainerRegistryCreate(d *pluginsdk.ResourceData, meta interface{}
 		if !response.WasNotFound(existing.HttpResponse) {
 			return tf.ImportAsExistsError("azurerm_container_registry", id.ID())
 		}
-	}
-
-	sId := commonids.NewSubscriptionID(subscriptionId)
-	availabilityRequest := registries.RegistryNameCheckRequest{
-		Name: id.RegistryName,
-		Type: "Microsoft.ContainerRegistry/registries",
-	}
-	resp, err := client.CheckNameAvailability(ctx, sId, availabilityRequest)
-	if err != nil {
-		return fmt.Errorf("checking if the name %q was available: %+v", id.RegistryName, err)
-	}
-
-	if resp.Model == nil && resp.Model.NameAvailable == nil {
-		return fmt.Errorf("checking name availability for %s: model was nil", id)
-	}
-
-	if available := *resp.Model.NameAvailable; !available {
-		return fmt.Errorf("the name %q used for the Container Registry needs to be globally unique and isn't available: %s", id.RegistryName, *resp.Model.Message)
 	}
 
 	sku := d.Get("sku").(string)

--- a/internal/services/containers/container_registry_resource_test.go
+++ b/internal/services/containers/container_registry_resource_test.go
@@ -491,15 +491,16 @@ resource "azurerm_container_registry" "test" {
     type = "SystemAssigned"
   }
 
-  public_network_access_enabled = false
-  quarantine_policy_enabled     = true
-  retention_policy_in_days      = 10
-  trust_policy_enabled          = true
-  export_policy_enabled         = false
-  anonymous_pull_enabled        = true
-  data_endpoint_enabled         = true
-
-  network_rule_bypass_option = "None"
+  public_network_access_enabled                = false
+  quarantine_policy_enabled                    = true
+  retention_policy_in_days                     = 10
+  trust_policy_enabled                         = true
+  export_policy_enabled                        = false
+  azuread_authentication_as_arm_policy_enabled = false
+  anonymous_pull_enabled                       = true
+  data_endpoint_enabled                        = true
+  network_rule_bypass_option                   = "None"
+  role_assignment_mode                         = "AbacRepositoryPermissions"
 
   tags = {
     environment = "production"
@@ -540,15 +541,16 @@ resource "azurerm_container_registry" "test" {
     ]
   }
 
-  public_network_access_enabled = true
-  quarantine_policy_enabled     = false
-  retention_policy_in_days      = 15
-  trust_policy_enabled          = false
-  export_policy_enabled         = true
-  anonymous_pull_enabled        = false
-  data_endpoint_enabled         = false
-
-  network_rule_bypass_option = "AzureServices"
+  public_network_access_enabled                = true
+  quarantine_policy_enabled                    = false
+  retention_policy_in_days                     = 15
+  trust_policy_enabled                         = false
+  export_policy_enabled                        = true
+  azuread_authentication_as_arm_policy_enabled = true
+  anonymous_pull_enabled                       = false
+  data_endpoint_enabled                        = false
+  network_rule_bypass_option                   = "AzureServices"
+  role_assignment_mode                         = "LegacyRegistryPermissions"
 
   tags = {
     environment = "production"

--- a/internal/services/containers/container_registry_resource_test.go
+++ b/internal/services/containers/container_registry_resource_test.go
@@ -500,6 +500,7 @@ resource "azurerm_container_registry" "test" {
   anonymous_pull_enabled                       = true
   data_endpoint_enabled                        = true
   network_rule_bypass_option                   = "None"
+  network_rule_bypass_for_tasks_enabled        = true
   role_assignment_mode                         = "AbacRepositoryPermissions"
 
   tags = {
@@ -550,6 +551,7 @@ resource "azurerm_container_registry" "test" {
   anonymous_pull_enabled                       = false
   data_endpoint_enabled                        = false
   network_rule_bypass_option                   = "AzureServices"
+  network_rule_bypass_for_tasks_enabled        = false
   role_assignment_mode                         = "LegacyRegistryPermissions"
 
   tags = {

--- a/website/docs/r/container_registry.html.markdown
+++ b/website/docs/r/container_registry.html.markdown
@@ -168,6 +168,8 @@ The following arguments are supported:
 
 * `export_policy_enabled` - (Optional) Boolean value that indicates whether export policy is enabled. Defaults to `true`. In order to set it to `false`, make sure the `public_network_access_enabled` is also set to `false`.
 
+* `azuread_authentication_as_arm_policy_enabled` - (Optional) Whether to use Azure Resource Manager audience token for this Container Registry? Defaults to `true`.
+
 ~> **Note:** `quarantine_policy_enabled`, `retention_policy_in_days`, `trust_policy_enabled`, `export_policy_enabled` and `zone_redundancy_enabled` are only supported on resources with the `Premium` SKU.
 
 * `identity` - (Optional) An `identity` block as defined below.
@@ -179,6 +181,8 @@ The following arguments are supported:
 * `data_endpoint_enabled` - (Optional) Whether to enable dedicated data endpoints for this Container Registry? This is only supported on resources with the `Premium` SKU.
 
 * `network_rule_bypass_option` - (Optional) Whether to allow trusted Azure services to access a network-restricted Container Registry? Possible values are `None` and `AzureServices`. Defaults to `AzureServices`.
+
+* `role_assignment_mode` - (Optional) The role assignment mode of this Container Registry. Possible values are `AbacRepositoryPermissions` and `LegacyRegistryPermissions`. Defaults to `LegacyRegistryPermissions`.
 
 ---
 

--- a/website/docs/r/container_registry.html.markdown
+++ b/website/docs/r/container_registry.html.markdown
@@ -182,6 +182,8 @@ The following arguments are supported:
 
 * `network_rule_bypass_option` - (Optional) Whether to allow trusted Azure services to access a network-restricted Container Registry? Possible values are `None` and `AzureServices`. Defaults to `AzureServices`.
 
+* `network_rule_bypass_for_tasks_enabled` - (Optional) Whether to allow Container Registry Tasks to access a network-restricted Container Registry? Defaults to `false`.
+
 * `role_assignment_mode` - (Optional) The role assignment mode of this Container Registry. Possible values are `AbacRepositoryPermissions` and `LegacyRegistryPermissions`. Defaults to `LegacyRegistryPermissions`.
 
 ---


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

After upgrading the API version of ACR to 2025-11-01, there are a few new properties introduced:

- `network_rule_bypass_allowed_for_tasks`: This is a new policy setting being introduced allowing customers to opt-in to network bypass for tasks. See: https://learn.microsoft.com/en-us/azure/container-registry/manage-network-bypass-policy-for-tasks. ~Whilst, there is an issue with this attribute (https://github.com/Azure/azure-rest-api-specs/issues/40126), so I didn't support it in this PR until the issue is resolved.~
- `azuread_authentication_as_arm_policy_enabled`: Microsoft Entra tokens are used when registry users authenticate with Azure Container Registry (ACR). By default, Azure Container Registry (ACR) accepts Microsoft Entra tokens with an audience scope set for Azure Resource Manager (ARM), a control plane management layer for managing Azure resources. See: https://learn.microsoft.com/en-us/azure/container-registry/container-registry-disable-authentication-as-arm
- `role_assignment_mode`: See: https://techcommunity.microsoft.com/blog/appsonazureblog/azure-container-registry-repository-permissions-with-attribute-based-access-cont/4467182

The default values are set per the API behavior (manually checked) and API spec definition.

Additionally, I've removed the checkNameAvailability API call during the Create function, which has no obvious benefit and is now failing with 503:

```
{
  "error": {
    "code": "ServiceUnavailable",
    "message": "Unable to perform post/subscriptions/checkNameAvailability. Please try after some time."
  },
  "status": "Failed"
}
```

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [x] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

```shell
💤 TF_ACC=1 go test -v -run='TestAccContainerRegistry_update' ./internal/services/containers
=== RUN   TestAccContainerRegistry_update
=== PAUSE TestAccContainerRegistry_update
=== CONT  TestAccContainerRegistry_update
--- PASS: TestAccContainerRegistry_update (215.76s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/containers    215.779s

```


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #29599


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
