### PR TITLE
`azurerm_api_management` - add plan-time catch for `certificate` property when V2 SKU is used

### DIFF
--- a/internal/services/apimanagement/api_management_resource.go
+++ b/internal/services/apimanagement/api_management_resource.go
@@ -103,6 +103,14 @@ func resourceApiManagementService() *pluginsdk.Resource {
 			pluginsdk.ForceNewIfChange("sku_name", func(ctx context.Context, old, new, meta interface{}) bool {
 				return (strings.Contains(old.(string), "V2") && !strings.Contains(new.(string), "V2")) || (strings.Contains(new.(string), "V2") && !strings.Contains(old.(string), "V2"))
 			}),
+
+			pluginsdk.CustomizeDiffShim(func(ctx context.Context, d *pluginsdk.ResourceDiff, _ interface{}) error {
+				if skuName := d.Get("sku_name").(string); strings.Contains(skuName, "V2") && len(d.Get("certificate").([]interface{})) > 0 {
+					return fmt.Errorf("`certificate` cannot be set when V2 SKU is used (`sku_name` is `%s`). Please use `azurerm_api_management_certificate` instead", skuName)
+				}
+
+				return nil
+			}),
 		),
 	}
 }

--- a/website/docs/r/api_management.html.markdown
+++ b/website/docs/r/api_management.html.markdown
@@ -141,11 +141,6 @@ A `certificate` block supports the following:
 
 A `delegation` block supports the following:
 
-
----
-
-A `delegation` block supports the following:
-
 * `subscriptions_enabled` - (Optional) Should subscription requests be delegated to an external url? Defaults to `false`.
 
 * `user_registration_enabled` - (Optional) Should user registration requests be delegated to an external url? Defaults to `false`.

--- a/website/docs/r/api_management.html.markdown
+++ b/website/docs/r/api_management.html.markdown
@@ -135,6 +135,13 @@ A `certificate` block supports the following:
 
 * `certificate_password` - (Optional) The password for the certificate.
 
+~> **Note:** `certificate` cannot be set when V2 SKU is used (`sku_name` contains `V2`). Please use `azurerm_api_management_certificate` resource instead.
+
+---
+
+A `delegation` block supports the following:
+
+
 ---
 
 A `delegation` block supports the following:


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

When `azurerm_api_management` resource V2 SKU is used, `certificate` property cannot be set as mentioned in #31708 . Instead, `azurerm_api_management_certificate` resource has to applied. Plan-time catch is added to fix the prevent the `certificate` configuration when V2 SKU is used.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] ~I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).~
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] ~(For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.~


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_APIMANAGEMENT/617812?buildTab=tests&status=failed&expandedTest=build%3A%28id%3A617812%29%2Cid%3A2000000181
<img width="962" height="584" alt="image" src="https://github.com/user-attachments/assets/f6e65c42-a6a7-46da-8cfe-1754d2884117" />
<img width="958" height="667" alt="image" src="https://github.com/user-attachments/assets/8ef60a48-9998-4313-892f-c1f289624a82" />
<img width="963" height="281" alt="image" src="https://github.com/user-attachments/assets/3d5a7bc9-104e-41c0-8b1e-12cee8a0269b" />

The failed tests are pre-existing from main branch. As this is a rerun, the change is listed in the [first run](https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_APIMANAGEMENT/613603?buildTab=changes&expandRevisionsSection=true).


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_api_management` - add plan time catch for `certificate` when V2 SKU is used


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #31708 


## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
