### PR TITLE
`azurerm_linux_virtual_machine_scale_set`, `azurerm_windows_virtual_machine_scale_set` - support `automatic_zone_rebalancing_enabled`

### DIFF
--- a/internal/services/compute/linux_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_resource.go
@@ -440,7 +440,7 @@ func resourceLinuxVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData, meta i
 		props.Properties.SpotRestorePolicy = spotRestorePolicy
 	}
 
-	props.Properties.ResiliencyPolicy = ExpandVirtualMachineScaleSetResiliency(true, d.Get("automatic_zone_rebalancing_enabled").(bool), d.Get("resilient_vm_creation_enabled").(bool), d.Get("resilient_vm_deletion_enabled").(bool))
+	props.Properties.ResiliencyPolicy = ExpandVirtualMachineScaleSetResiliency(d.Get("automatic_zone_rebalancing_enabled").(bool), d.Get("resilient_vm_creation_enabled").(bool), d.Get("resilient_vm_deletion_enabled").(bool))
 
 	if len(zones) > 0 {
 		props.Zones = &zones
@@ -713,7 +713,7 @@ func resourceLinuxVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData, meta i
 		automaticZoneRebalancingEnabled := d.Get("automatic_zone_rebalancing_enabled").(bool)
 		resilientVMCreationEnabled := d.Get("resilient_vm_creation_enabled").(bool)
 		resilientVMDeletionEnabled := d.Get("resilient_vm_deletion_enabled").(bool)
-		updateProps.ResiliencyPolicy = ExpandVirtualMachineScaleSetResiliency(false, automaticZoneRebalancingEnabled, resilientVMCreationEnabled, resilientVMDeletionEnabled)
+		updateProps.ResiliencyPolicy = ExpandVirtualMachineScaleSetResiliencyUpdate(d.HasChange("automatic_zone_rebalancing_enabled"), automaticZoneRebalancingEnabled, resilientVMCreationEnabled, resilientVMDeletionEnabled)
 	}
 
 	if d.HasChange("termination_notification") {

--- a/internal/services/compute/linux_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_resource.go
@@ -440,7 +440,7 @@ func resourceLinuxVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData, meta i
 		props.Properties.SpotRestorePolicy = spotRestorePolicy
 	}
 
-	props.Properties.ResiliencyPolicy = ExpandVirtualMachineScaleSetResiliency(d.Get("automatic_zone_rebalancing_enabled").(bool), d.Get("resilient_vm_creation_enabled").(bool), d.Get("resilient_vm_deletion_enabled").(bool))
+	props.Properties.ResiliencyPolicy = ExpandVirtualMachineScaleSetResiliency(true, d.Get("automatic_zone_rebalancing_enabled").(bool), d.Get("resilient_vm_creation_enabled").(bool), d.Get("resilient_vm_deletion_enabled").(bool))
 
 	if len(zones) > 0 {
 		props.Zones = &zones
@@ -713,7 +713,7 @@ func resourceLinuxVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData, meta i
 		automaticZoneRebalancingEnabled := d.Get("automatic_zone_rebalancing_enabled").(bool)
 		resilientVMCreationEnabled := d.Get("resilient_vm_creation_enabled").(bool)
 		resilientVMDeletionEnabled := d.Get("resilient_vm_deletion_enabled").(bool)
-		updateProps.ResiliencyPolicy = ExpandVirtualMachineScaleSetResiliency(automaticZoneRebalancingEnabled, resilientVMCreationEnabled, resilientVMDeletionEnabled)
+		updateProps.ResiliencyPolicy = ExpandVirtualMachineScaleSetResiliency(false, automaticZoneRebalancingEnabled, resilientVMCreationEnabled, resilientVMDeletionEnabled)
 	}
 
 	if d.HasChange("termination_notification") {

--- a/internal/services/compute/linux_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_resource.go
@@ -440,7 +440,7 @@ func resourceLinuxVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData, meta i
 		props.Properties.SpotRestorePolicy = spotRestorePolicy
 	}
 
-	props.Properties.ResiliencyPolicy = ExpandVirtualMachineScaleSetResiliency(d.Get("resilient_vm_creation_enabled").(bool), d.Get("resilient_vm_deletion_enabled").(bool))
+	props.Properties.ResiliencyPolicy = ExpandVirtualMachineScaleSetResiliency(d.Get("automatic_zone_rebalancing_enabled").(bool), d.Get("resilient_vm_creation_enabled").(bool), d.Get("resilient_vm_deletion_enabled").(bool))
 
 	if len(zones) > 0 {
 		props.Zones = &zones
@@ -709,10 +709,11 @@ func resourceLinuxVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData, meta i
 		}
 	}
 
-	if d.HasChanges("resilient_vm_creation_enabled", "resilient_vm_deletion_enabled") {
+	if d.HasChanges("automatic_zone_rebalancing_enabled", "resilient_vm_creation_enabled", "resilient_vm_deletion_enabled") {
+		automaticZoneRebalancingEnabled := d.Get("automatic_zone_rebalancing_enabled").(bool)
 		resilientVMCreationEnabled := d.Get("resilient_vm_creation_enabled").(bool)
 		resilientVMDeletionEnabled := d.Get("resilient_vm_deletion_enabled").(bool)
-		updateProps.ResiliencyPolicy = ExpandVirtualMachineScaleSetResiliency(resilientVMCreationEnabled, resilientVMDeletionEnabled)
+		updateProps.ResiliencyPolicy = ExpandVirtualMachineScaleSetResiliency(automaticZoneRebalancingEnabled, resilientVMCreationEnabled, resilientVMDeletionEnabled)
 	}
 
 	if d.HasChange("termination_notification") {
@@ -922,7 +923,8 @@ func resourceLinuxVirtualMachineScaleSetRead(d *pluginsdk.ResourceData, meta int
 				d.Set("spot_restore", FlattenVirtualMachineScaleSetSpotRestorePolicy(props.SpotRestorePolicy))
 			}
 
-			resilientVMCreationEnabled, resilientVMDeletionEnabled := FlattenVirtualMachineScaleSetResiliency(props.ResiliencyPolicy)
+			automaticZoneRebalancingEnabled, resilientVMCreationEnabled, resilientVMDeletionEnabled := FlattenVirtualMachineScaleSetResiliency(props.ResiliencyPolicy)
+			d.Set("automatic_zone_rebalancing_enabled", automaticZoneRebalancingEnabled)
 			d.Set("resilient_vm_creation_enabled", resilientVMCreationEnabled)
 			d.Set("resilient_vm_deletion_enabled", resilientVMDeletionEnabled)
 
@@ -1207,6 +1209,12 @@ func resourceLinuxVirtualMachineScaleSetSchema() map[string]*pluginsdk.Schema {
 		"automatic_os_upgrade_policy": VirtualMachineScaleSetAutomatedOSUpgradePolicySchema(),
 
 		"automatic_instance_repair": VirtualMachineScaleSetAutomaticRepairsPolicySchema(),
+
+		"automatic_zone_rebalancing_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Default:  false,
+		},
 
 		"boot_diagnostics": bootDiagnosticsSchema(),
 

--- a/internal/services/compute/linux_virtual_machine_scale_set_resource_resiliency_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_resource_resiliency_test.go
@@ -99,14 +99,14 @@ func (r LinuxVirtualMachineScaleSetResource) automaticZoneRebalancing(data accep
 %s
 
 resource "azurerm_linux_virtual_machine_scale_set" "test" {
-  name                = "acctestvmss-%d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  sku                 = "Standard_F2ads_v7"
-  instances           = 2
-  admin_username      = "adminuser"
-  disable_password_authentication = true
-  zones               = ["1", "2"]
+  name                               = "acctestvmss-%d"
+  resource_group_name                = azurerm_resource_group.test.name
+  location                           = azurerm_resource_group.test.location
+  sku                                = "Standard_F2ads_v7"
+  instances                          = 2
+  admin_username                     = "adminuser"
+  disable_password_authentication    = true
+  zones                              = ["1", "2"]
   automatic_zone_rebalancing_enabled = %t
 
   source_image_reference {

--- a/internal/services/compute/linux_virtual_machine_scale_set_resource_resiliency_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_resource_resiliency_test.go
@@ -11,6 +11,35 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 )
 
+func TestAccLinuxVirtualMachineScaleSet_resiliency_automaticZoneRebalancing(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine_scale_set", "test")
+	r := LinuxVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.automaticZoneRebalancing(data, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			Config: r.automaticZoneRebalancing(data, false),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			Config: r.automaticZoneRebalancing(data, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
 func TestAccLinuxVirtualMachineScaleSet_resiliency_vmCreationOnly(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine_scale_set", "test")
 	data.Locations.Primary = "eastus2" // Resiliency policies are only supported in specific regions
@@ -63,6 +92,64 @@ func TestAccLinuxVirtualMachineScaleSet_resiliency_update(t *testing.T) {
 		},
 		data.ImportStep("admin_password"),
 	})
+}
+
+func (r LinuxVirtualMachineScaleSetResource) automaticZoneRebalancing(data acceptance.TestData, automaticZoneRebalancingEnabled bool) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_linux_virtual_machine_scale_set" "test" {
+  name                = "acctestvmss-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  sku                 = "Standard_F2ads_v7"
+  instances           = 2
+  admin_username      = "adminuser"
+  disable_password_authentication = true
+  zones               = ["1", "2"]
+  automatic_zone_rebalancing_enabled = %t
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "0001-com-ubuntu-server-jammy"
+    sku       = "22_04-lts-gen2"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  extension {
+    name                       = "HealthExtension"
+    publisher                  = "Microsoft.ManagedServices"
+    type                       = "ApplicationHealthLinux"
+    type_handler_version       = "1.0"
+    auto_upgrade_minor_version = true
+    settings = jsonencode({
+      protocol = "https"
+      port     = 443
+    })
+  }
+
+  network_interface {
+    name    = "example"
+    primary = true
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurerm_subnet.test.id
+    }
+  }
+}
+`, r.template(data), data.RandomInteger, automaticZoneRebalancingEnabled)
 }
 
 func (r LinuxVirtualMachineScaleSetResource) resiliencyVMPolicies(data acceptance.TestData, vmCreationEnabled, vmDeletionEnabled bool) string {

--- a/internal/services/compute/virtual_machine_scale_set.go
+++ b/internal/services/compute/virtual_machine_scale_set.go
@@ -378,13 +378,16 @@ func FlattenVirtualMachineScaleSetSpotRestorePolicy(input *virtualmachinescalese
 	}
 }
 
-func ExpandVirtualMachineScaleSetResiliency(automaticZoneRebalancingEnabled, resilientVMCreationEnabled, resilientVMDeletionEnabled bool) *virtualmachinescalesets.ResiliencyPolicy {
+func ExpandVirtualMachineScaleSetResiliency(newResouce, automaticZoneRebalancingEnabled, resilientVMCreationEnabled, resilientVMDeletionEnabled bool) *virtualmachinescalesets.ResiliencyPolicy {
 	result := &virtualmachinescalesets.ResiliencyPolicy{}
 
-	result.AutomaticZoneRebalancingPolicy = &virtualmachinescalesets.AutomaticZoneRebalancingPolicy{
-		Enabled:           pointer.To(automaticZoneRebalancingEnabled),
-		RebalanceBehavior: pointer.To(virtualmachinescalesets.RebalanceBehaviorCreateBeforeDelete),
-		RebalanceStrategy: pointer.To(virtualmachinescalesets.RebalanceStrategyRecreate),
+	// Skip sending AutomaticZoneRebalancingPolicy on create when disabled, because the API requires the feature to be registered in the subscription and will return an error otherwise. On update, always send it to allow disabling.
+	if !newResouce || automaticZoneRebalancingEnabled {
+		result.AutomaticZoneRebalancingPolicy = &virtualmachinescalesets.AutomaticZoneRebalancingPolicy{
+			Enabled:           pointer.To(automaticZoneRebalancingEnabled),
+			RebalanceBehavior: pointer.To(virtualmachinescalesets.RebalanceBehaviorCreateBeforeDelete),
+			RebalanceStrategy: pointer.To(virtualmachinescalesets.RebalanceStrategyRecreate),
+		}
 	}
 
 	result.ResilientVMCreationPolicy = &virtualmachinescalesets.ResilientVMCreationPolicy{

--- a/internal/services/compute/virtual_machine_scale_set.go
+++ b/internal/services/compute/virtual_machine_scale_set.go
@@ -378,10 +378,14 @@ func FlattenVirtualMachineScaleSetSpotRestorePolicy(input *virtualmachinescalese
 	}
 }
 
-func ExpandVirtualMachineScaleSetResiliency(resilientVMCreationEnabled, resilientVMDeletionEnabled bool) *virtualmachinescalesets.ResiliencyPolicy {
-	// Note: AutomaticZoneRebalancingPolicy is excluded as it's in private preview and
-	// has been removed from the schema to prevent API errors.
+func ExpandVirtualMachineScaleSetResiliency(automaticZoneRebalancingEnabled, resilientVMCreationEnabled, resilientVMDeletionEnabled bool) *virtualmachinescalesets.ResiliencyPolicy {
 	result := &virtualmachinescalesets.ResiliencyPolicy{}
+
+	result.AutomaticZoneRebalancingPolicy = &virtualmachinescalesets.AutomaticZoneRebalancingPolicy{
+		Enabled:           pointer.To(automaticZoneRebalancingEnabled),
+		RebalanceBehavior: pointer.To(virtualmachinescalesets.RebalanceBehaviorCreateBeforeDelete),
+		RebalanceStrategy: pointer.To(virtualmachinescalesets.RebalanceStrategyRecreate),
+	}
 
 	result.ResilientVMCreationPolicy = &virtualmachinescalesets.ResilientVMCreationPolicy{
 		Enabled: pointer.To(resilientVMCreationEnabled),
@@ -394,10 +398,13 @@ func ExpandVirtualMachineScaleSetResiliency(resilientVMCreationEnabled, resilien
 	return result
 }
 
-func FlattenVirtualMachineScaleSetResiliency(input *virtualmachinescalesets.ResiliencyPolicy) (resilientVMCreationEnabled, resilientVMDeletionEnabled bool) {
+func FlattenVirtualMachineScaleSetResiliency(input *virtualmachinescalesets.ResiliencyPolicy) (automaticZoneRebalancingEnabled, resilientVMCreationEnabled, resilientVMDeletionEnabled bool) {
 	if input == nil {
-		// No ResiliencyPolicy - don't set these fields in state for backward compatibility
-		return resilientVMCreationEnabled, resilientVMDeletionEnabled
+		return automaticZoneRebalancingEnabled, resilientVMCreationEnabled, resilientVMDeletionEnabled
+	}
+
+	if automaticZoneRebalancing := input.AutomaticZoneRebalancingPolicy; automaticZoneRebalancing != nil {
+		automaticZoneRebalancingEnabled = pointer.From(automaticZoneRebalancing.Enabled)
 	}
 
 	if vmCreation := input.ResilientVMCreationPolicy; vmCreation != nil {

--- a/internal/services/compute/virtual_machine_scale_set.go
+++ b/internal/services/compute/virtual_machine_scale_set.go
@@ -378,11 +378,34 @@ func FlattenVirtualMachineScaleSetSpotRestorePolicy(input *virtualmachinescalese
 	}
 }
 
-func ExpandVirtualMachineScaleSetResiliency(newResouce, automaticZoneRebalancingEnabled, resilientVMCreationEnabled, resilientVMDeletionEnabled bool) *virtualmachinescalesets.ResiliencyPolicy {
+func ExpandVirtualMachineScaleSetResiliency(automaticZoneRebalancingEnabled, resilientVMCreationEnabled, resilientVMDeletionEnabled bool) *virtualmachinescalesets.ResiliencyPolicy {
 	result := &virtualmachinescalesets.ResiliencyPolicy{}
 
-	// Skip sending AutomaticZoneRebalancingPolicy on create when disabled, because the API requires the feature to be registered in the subscription and will return an error otherwise. On update, always send it to allow disabling.
-	if !newResouce || automaticZoneRebalancingEnabled {
+	// Skip sending AutomaticZoneRebalancingPolicy on create when disabled, because the API requires the feature to be registered in the subscription and will return an error otherwise.
+	if automaticZoneRebalancingEnabled {
+		result.AutomaticZoneRebalancingPolicy = &virtualmachinescalesets.AutomaticZoneRebalancingPolicy{
+			Enabled:           pointer.To(automaticZoneRebalancingEnabled),
+			RebalanceBehavior: pointer.To(virtualmachinescalesets.RebalanceBehaviorCreateBeforeDelete),
+			RebalanceStrategy: pointer.To(virtualmachinescalesets.RebalanceStrategyRecreate),
+		}
+	}
+
+	result.ResilientVMCreationPolicy = &virtualmachinescalesets.ResilientVMCreationPolicy{
+		Enabled: pointer.To(resilientVMCreationEnabled),
+	}
+
+	result.ResilientVMDeletionPolicy = &virtualmachinescalesets.ResilientVMDeletionPolicy{
+		Enabled: pointer.To(resilientVMDeletionEnabled),
+	}
+
+	return result
+}
+
+func ExpandVirtualMachineScaleSetResiliencyUpdate(automaticZoneRebalancingConfigIsChanged, automaticZoneRebalancingEnabled, resilientVMCreationEnabled, resilientVMDeletionEnabled bool) *virtualmachinescalesets.ResiliencyPolicy {
+	result := &virtualmachinescalesets.ResiliencyPolicy{}
+
+	// Only include AutomaticZoneRebalancingPolicy in the update payload if the setting has changed, to avoid hitting the same API error as create when the feature isn't registered, while still allowing users to disable it after it's been enabled.
+	if automaticZoneRebalancingConfigIsChanged {
 		result.AutomaticZoneRebalancingPolicy = &virtualmachinescalesets.AutomaticZoneRebalancingPolicy{
 			Enabled:           pointer.To(automaticZoneRebalancingEnabled),
 			RebalanceBehavior: pointer.To(virtualmachinescalesets.RebalanceBehaviorCreateBeforeDelete),

--- a/internal/services/compute/windows_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_resource.go
@@ -447,7 +447,7 @@ func resourceWindowsVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData, meta
 		props.Properties.SpotRestorePolicy = spotRestorePolicy
 	}
 
-	props.Properties.ResiliencyPolicy = ExpandVirtualMachineScaleSetResiliency(true, d.Get("automatic_zone_rebalancing_enabled").(bool), d.Get("resilient_vm_creation_enabled").(bool), d.Get("resilient_vm_deletion_enabled").(bool))
+	props.Properties.ResiliencyPolicy = ExpandVirtualMachineScaleSetResiliency(d.Get("automatic_zone_rebalancing_enabled").(bool), d.Get("resilient_vm_creation_enabled").(bool), d.Get("resilient_vm_deletion_enabled").(bool))
 
 	if len(zones) > 0 {
 		props.Zones = &zones
@@ -727,7 +727,7 @@ func resourceWindowsVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData, meta
 		automaticZoneRebalancingEnabled := d.Get("automatic_zone_rebalancing_enabled").(bool)
 		resilientVMCreationEnabled := d.Get("resilient_vm_creation_enabled").(bool)
 		resilientVMDeletionEnabled := d.Get("resilient_vm_deletion_enabled").(bool)
-		updateProps.ResiliencyPolicy = ExpandVirtualMachineScaleSetResiliency(false, automaticZoneRebalancingEnabled, resilientVMCreationEnabled, resilientVMDeletionEnabled)
+		updateProps.ResiliencyPolicy = ExpandVirtualMachineScaleSetResiliencyUpdate(d.HasChange("automatic_zone_rebalancing_enabled"), automaticZoneRebalancingEnabled, resilientVMCreationEnabled, resilientVMDeletionEnabled)
 	}
 
 	if d.HasChange("termination_notification") {

--- a/internal/services/compute/windows_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_resource.go
@@ -447,7 +447,7 @@ func resourceWindowsVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData, meta
 		props.Properties.SpotRestorePolicy = spotRestorePolicy
 	}
 
-	props.Properties.ResiliencyPolicy = ExpandVirtualMachineScaleSetResiliency(d.Get("automatic_zone_rebalancing_enabled").(bool), d.Get("resilient_vm_creation_enabled").(bool), d.Get("resilient_vm_deletion_enabled").(bool))
+	props.Properties.ResiliencyPolicy = ExpandVirtualMachineScaleSetResiliency(true, d.Get("automatic_zone_rebalancing_enabled").(bool), d.Get("resilient_vm_creation_enabled").(bool), d.Get("resilient_vm_deletion_enabled").(bool))
 
 	if len(zones) > 0 {
 		props.Zones = &zones
@@ -727,7 +727,7 @@ func resourceWindowsVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData, meta
 		automaticZoneRebalancingEnabled := d.Get("automatic_zone_rebalancing_enabled").(bool)
 		resilientVMCreationEnabled := d.Get("resilient_vm_creation_enabled").(bool)
 		resilientVMDeletionEnabled := d.Get("resilient_vm_deletion_enabled").(bool)
-		updateProps.ResiliencyPolicy = ExpandVirtualMachineScaleSetResiliency(automaticZoneRebalancingEnabled, resilientVMCreationEnabled, resilientVMDeletionEnabled)
+		updateProps.ResiliencyPolicy = ExpandVirtualMachineScaleSetResiliency(false, automaticZoneRebalancingEnabled, resilientVMCreationEnabled, resilientVMDeletionEnabled)
 	}
 
 	if d.HasChange("termination_notification") {

--- a/internal/services/compute/windows_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_resource.go
@@ -447,7 +447,7 @@ func resourceWindowsVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData, meta
 		props.Properties.SpotRestorePolicy = spotRestorePolicy
 	}
 
-	props.Properties.ResiliencyPolicy = ExpandVirtualMachineScaleSetResiliency(d.Get("resilient_vm_creation_enabled").(bool), d.Get("resilient_vm_deletion_enabled").(bool))
+	props.Properties.ResiliencyPolicy = ExpandVirtualMachineScaleSetResiliency(d.Get("automatic_zone_rebalancing_enabled").(bool), d.Get("resilient_vm_creation_enabled").(bool), d.Get("resilient_vm_deletion_enabled").(bool))
 
 	if len(zones) > 0 {
 		props.Zones = &zones
@@ -723,10 +723,11 @@ func resourceWindowsVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData, meta
 		}
 	}
 
-	if d.HasChanges("resilient_vm_creation_enabled", "resilient_vm_deletion_enabled") {
+	if d.HasChanges("automatic_zone_rebalancing_enabled", "resilient_vm_creation_enabled", "resilient_vm_deletion_enabled") {
+		automaticZoneRebalancingEnabled := d.Get("automatic_zone_rebalancing_enabled").(bool)
 		resilientVMCreationEnabled := d.Get("resilient_vm_creation_enabled").(bool)
 		resilientVMDeletionEnabled := d.Get("resilient_vm_deletion_enabled").(bool)
-		updateProps.ResiliencyPolicy = ExpandVirtualMachineScaleSetResiliency(resilientVMCreationEnabled, resilientVMDeletionEnabled)
+		updateProps.ResiliencyPolicy = ExpandVirtualMachineScaleSetResiliency(automaticZoneRebalancingEnabled, resilientVMCreationEnabled, resilientVMDeletionEnabled)
 	}
 
 	if d.HasChange("termination_notification") {
@@ -941,7 +942,8 @@ func resourceWindowsVirtualMachineScaleSetRead(d *pluginsdk.ResourceData, meta i
 				d.Set("spot_restore", FlattenVirtualMachineScaleSetSpotRestorePolicy(props.SpotRestorePolicy))
 			}
 
-			resilientVMCreationEnabled, resilientVMDeletionEnabled := FlattenVirtualMachineScaleSetResiliency(props.ResiliencyPolicy)
+			automaticZoneRebalancingEnabled, resilientVMCreationEnabled, resilientVMDeletionEnabled := FlattenVirtualMachineScaleSetResiliency(props.ResiliencyPolicy)
+			d.Set("automatic_zone_rebalancing_enabled", automaticZoneRebalancingEnabled)
 			d.Set("resilient_vm_creation_enabled", resilientVMCreationEnabled)
 			d.Set("resilient_vm_deletion_enabled", resilientVMDeletionEnabled)
 
@@ -1233,6 +1235,12 @@ func resourceWindowsVirtualMachineScaleSetSchema() map[string]*pluginsdk.Schema 
 		"automatic_os_upgrade_policy": VirtualMachineScaleSetAutomatedOSUpgradePolicySchema(),
 
 		"automatic_instance_repair": VirtualMachineScaleSetAutomaticRepairsPolicySchema(),
+
+		"automatic_zone_rebalancing_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Default:  false,
+		},
 
 		"boot_diagnostics": bootDiagnosticsSchema(),
 

--- a/internal/services/compute/windows_virtual_machine_scale_set_resource_resiliency_test.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_resource_resiliency_test.go
@@ -100,15 +100,15 @@ func (r WindowsVirtualMachineScaleSetResource) automaticZoneRebalancing(data acc
 %s
 
 resource "azurerm_windows_virtual_machine_scale_set" "test" {
-  name                = "acctestvmss-%d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  sku                 = "Standard_F2ads_v7"
-  instances           = 2
-  admin_username      = "adminuser"
-  admin_password      = "P@ssword1234!"
-  computer_name_prefix = "vm-"
-  zones               = ["1", "2"]
+  name                               = "acctestvmss-%d"
+  resource_group_name                = azurerm_resource_group.test.name
+  location                           = azurerm_resource_group.test.location
+  sku                                = "Standard_F2ads_v7"
+  instances                          = 2
+  admin_username                     = "adminuser"
+  admin_password                     = "P@ssword1234!"
+  computer_name_prefix               = "vm-"
+  zones                              = ["1", "2"]
   automatic_zone_rebalancing_enabled = %t
 
   source_image_reference {

--- a/internal/services/compute/windows_virtual_machine_scale_set_resource_resiliency_test.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_resource_resiliency_test.go
@@ -11,6 +11,35 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 )
 
+func TestAccWindowsVirtualMachineScaleSet_resiliency_automaticZoneRebalancing(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine_scale_set", "test")
+	r := WindowsVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.automaticZoneRebalancing(data, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			Config: r.automaticZoneRebalancing(data, false),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			Config: r.automaticZoneRebalancing(data, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
 func TestAccWindowsVirtualMachineScaleSet_resiliency_vmCreationOnly(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine_scale_set", "test")
 	data.Locations.Primary = "eastus2" // Resiliency policies are only supported in specific regions
@@ -64,6 +93,61 @@ func TestAccWindowsVirtualMachineScaleSet_resiliency_update(t *testing.T) {
 		},
 		data.ImportStep("admin_password"),
 	})
+}
+
+func (r WindowsVirtualMachineScaleSetResource) automaticZoneRebalancing(data acceptance.TestData, automaticZoneRebalancingEnabled bool) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine_scale_set" "test" {
+  name                = "acctestvmss-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  sku                 = "Standard_F2ads_v7"
+  instances           = 2
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+  computer_name_prefix = "vm-"
+  zones               = ["1", "2"]
+  automatic_zone_rebalancing_enabled = %t
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2019-datacenter-gensecond"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name    = "example"
+    primary = true
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurerm_subnet.test.id
+    }
+  }
+
+  extension {
+    name                       = "HealthExtension"
+    publisher                  = "Microsoft.ManagedServices"
+    type                       = "ApplicationHealthWindows"
+    type_handler_version       = "1.0"
+    auto_upgrade_minor_version = true
+    settings = jsonencode({
+      protocol    = "https"
+      port        = 443
+      requestPath = "/"
+    })
+  }
+}
+`, r.template(data), data.RandomInteger, automaticZoneRebalancingEnabled)
 }
 
 func (r WindowsVirtualMachineScaleSetResource) resiliencyVMPolicies(data acceptance.TestData, vmCreationEnabled, vmDeletionEnabled bool) string {

--- a/website/docs/r/linux_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/linux_virtual_machine_scale_set.html.markdown
@@ -128,6 +128,10 @@ resource "azurerm_linux_virtual_machine_scale_set" "example" {
 
 -> **Note:** For more information about Automatic Instance Repair, please refer to the [product documentation](https://docs.microsoft.com/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-automatic-instance-repairs).
 
+* `automatic_zone_rebalancing_enabled` - (Optional) Whether to enable automatic zone balance. Defaults to `false`.
+
+-> **Note:** For more information about automatic zone balance, please refer to the [product documentation](https://learn.microsoft.com/azure/virtual-machine-scale-sets/auto-zone-balance-overview).
+
 * `boot_diagnostics` - (Optional) A `boot_diagnostics` block as defined below.
 
 * `capacity_reservation_group_id` - (Optional) Specifies the ID of the Capacity Reservation Group which the Virtual Machine Scale Set should be allocated to. Changing this forces a new resource to be created.

--- a/website/docs/r/windows_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/windows_virtual_machine_scale_set.html.markdown
@@ -117,6 +117,10 @@ resource "azurerm_windows_virtual_machine_scale_set" "example" {
 
 -> **Note:** For more information about Automatic Instance Repair, please refer to [this doc](https://docs.microsoft.com/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-automatic-instance-repairs).
 
+* `automatic_zone_rebalancing_enabled` - (Optional) Whether to enable automatic zone balance. Defaults to `false`.
+
+-> **Note:** For more information about automatic zone balance, please refer to the [product documentation](https://learn.microsoft.com/azure/virtual-machine-scale-sets/auto-zone-balance-overview).
+
 * `boot_diagnostics` - (Optional) A `boot_diagnostics` block as defined below.
 
 * `capacity_reservation_group_id` - (Optional) Specifies the ID of the Capacity Reservation Group which the Virtual Machine Scale Set should be allocated to. Changing this forces a new resource to be created.


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR supports [Automatic zone balance](https://learn.microsoft.com/en-us/azure/virtual-machine-scale-sets/auto-zone-balance-overview) feature for uniform VMSS. Though it's still in public preview stage, it will be GA soon and the service team has confirmed there won't exist any API interface change.

**Note:** Please follow the official [Prerequisites](https://learn.microsoft.com/en-us/azure/virtual-machine-scale-sets/auto-zone-balance-enable?tabs=portal-1%2Crest-api-2%2Ccli#prerequisites) before you start using this feature.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

<img width="755" height="52" alt="image" src="https://github.com/user-attachments/assets/7741c4b6-4988-45e6-ba4d-7765eced262a" />

--- PASS: TestAccLinuxVirtualMachineScaleSet_resiliency_automaticZoneRebalancing (712.55s)
--- PASS: TestAccWindowsVirtualMachineScaleSet_resiliency_automaticZoneRebalancing (659.73s)

Note: 
1. Newly failed testcases pass after re-running
2. Newly added testcases cannot pass because the subscription of the team city does not register `AutomaticVMSSZoneRebalancing` feature

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_linux_virtual_machine_scale_set`, `azurerm_windows_virtual_machine_scale_set` - support `automatic_zone_rebalancing_enabled`


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
