### PR TITLE
`azurerm_mongo_cluster` - fix `administrator_password` restriction

### DIFF
--- a/internal/services/mongocluster/mongo_cluster_resource.go
+++ b/internal/services/mongocluster/mongo_cluster_resource.go
@@ -724,28 +724,28 @@ func (r MongoClusterResource) CustomizeDiff() sdk.ResourceFunc {
 
 			switch state.CreateMode {
 			case string(mongoclusters.CreateModeDefault):
-				if state.AdministratorUserName == "" {
-					return fmt.Errorf("`administrator_username` is required when `create_mode` is %s", string(mongoclusters.CreateModeDefault))
+				if isNativeAuthRequired(metadata) && state.AdministratorUserName == "" {
+					return fmt.Errorf("`administrator_username` is required when `authentication_methods` contains `NativeAuth` or is not configured")
 				}
 
 				if state.ComputeTier == "" {
-					return fmt.Errorf("`compute_tier` is required when `create_mode` is %s", string(mongoclusters.CreateModeDefault))
+					return fmt.Errorf("`compute_tier` is required when `create_mode` is `%s`", string(mongoclusters.CreateModeDefault))
 				}
 
 				if state.StorageSizeInGb == 0 {
-					return fmt.Errorf("`storage_size_in_gb` is required when `create_mode` is %s", string(mongoclusters.CreateModeDefault))
+					return fmt.Errorf("`storage_size_in_gb` is required when `create_mode` is `%s`", string(mongoclusters.CreateModeDefault))
 				}
 
 				if state.HighAvailabilityMode == "" {
-					return fmt.Errorf("`high_availability_mode` is required when `create_mode` is %s", string(mongoclusters.CreateModeDefault))
+					return fmt.Errorf("`high_availability_mode` is required when `create_mode` is `%s`", string(mongoclusters.CreateModeDefault))
 				}
 
 				if state.ShardCount == 0 {
-					return fmt.Errorf("`shard_count` is required when `create_mode` is %s", string(mongoclusters.CreateModeDefault))
+					return fmt.Errorf("`shard_count` is required when `create_mode` is `%s`", string(mongoclusters.CreateModeDefault))
 				}
 
 				if state.Version == "" {
-					return fmt.Errorf("`version` is required when `create_mode` is %s", string(mongoclusters.CreateModeDefault))
+					return fmt.Errorf("`version` is required when `create_mode` is `%s`", string(mongoclusters.CreateModeDefault))
 				}
 			case string(mongoclusters.CreateModeGeoReplica):
 				if state.SourceLocation == "" {
@@ -953,4 +953,20 @@ func flattenMongoClusterAuthConfig(input *mongoclusters.AuthConfigProperties) []
 	}
 
 	return results
+}
+
+func isNativeAuthRequired(metadata sdk.ResourceMetaData) bool {
+	authMethodsRaw := metadata.ResourceDiff.GetRawConfig().AsValueMap()["authentication_methods"]
+	nativeAuthRequired := false
+	if authMethodsRaw.IsNull() || !authMethodsRaw.IsKnown() {
+		nativeAuthRequired = true
+	} else {
+		for _, v := range authMethodsRaw.AsValueSet().Values() {
+			if v.AsString() == string(mongoclusters.AuthenticationModeNativeAuth) {
+				nativeAuthRequired = true
+				break
+			}
+		}
+	}
+	return nativeAuthRequired
 }

--- a/internal/services/mongocluster/mongo_cluster_resource.go
+++ b/internal/services/mongocluster/mongo_cluster_resource.go
@@ -5,6 +5,7 @@ package mongocluster
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"regexp"
@@ -725,7 +726,7 @@ func (r MongoClusterResource) CustomizeDiff() sdk.ResourceFunc {
 			switch state.CreateMode {
 			case string(mongoclusters.CreateModeDefault):
 				if isNativeAuthRequired(metadata) && state.AdministratorUserName == "" {
-					return fmt.Errorf("`administrator_username` is required when `authentication_methods` contains `NativeAuth` or is not configured")
+					return errors.New("`administrator_username` is required when `authentication_methods` contains `NativeAuth` or is not configured")
 				}
 
 				if state.ComputeTier == "" {

--- a/internal/services/mongocluster/mongo_cluster_resource.go
+++ b/internal/services/mongocluster/mongo_cluster_resource.go
@@ -958,16 +958,26 @@ func flattenMongoClusterAuthConfig(input *mongoclusters.AuthConfigProperties) []
 
 func isNativeAuthRequired(metadata sdk.ResourceMetaData) bool {
 	authMethodsRaw := metadata.ResourceDiff.GetRawConfig().AsValueMap()["authentication_methods"]
-	nativeAuthRequired := false
-	if authMethodsRaw.IsNull() || !authMethodsRaw.IsKnown() {
-		nativeAuthRequired = true
-	} else {
-		for _, v := range authMethodsRaw.AsValueSet().Values() {
-			if v.AsString() == string(mongoclusters.AuthenticationModeNativeAuth) {
-				nativeAuthRequired = true
-				break
-			}
+	if !authMethodsRaw.IsKnown() {
+		return false
+	}
+	if authMethodsRaw.IsNull() {
+		return true
+	}
+
+	authMethods := authMethodsRaw.AsValueSet().Values()
+	if len(authMethods) == 0 {
+		return true
+	}
+
+	for _, v := range authMethods {
+		if !v.IsKnown() {
+			continue
+		}
+		if v.AsString() == string(mongoclusters.AuthenticationModeNativeAuth) {
+			return true
 		}
 	}
-	return nativeAuthRequired
+
+	return false
 }

--- a/internal/services/mongocluster/mongo_cluster_resource_test.go
+++ b/internal/services/mongocluster/mongo_cluster_resource_test.go
@@ -167,6 +167,21 @@ func TestAccMongoCluster_dataApiModeEnabled(t *testing.T) {
 	})
 }
 
+func TestAccMongoCluster_entraIdOnly(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_mongo_cluster", "test")
+	r := MongoClusterResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.entraIdOnly(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("create_mode"),
+	})
+}
+
 func (r MongoClusterResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := mongoclusters.ParseMongoClusterID(state.ID)
 	if err != nil {
@@ -442,6 +457,24 @@ resource "azurerm_mongo_cluster" "test" {
   data_api_mode_enabled  = true
 }
 `, r.template(data, data.Locations.Ternary), data.RandomInteger)
+}
+
+func (r MongoClusterResource) entraIdOnly(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_mongo_cluster" "test" {
+  name                   = "acctest-mc%d"
+  resource_group_name    = azurerm_resource_group.test.name
+  location               = azurerm_resource_group.test.location
+  shard_count            = "1"
+  compute_tier           = "M30"
+  high_availability_mode = "Disabled"
+  storage_size_in_gb     = "32"
+  version                = "7.0"
+  authentication_methods = ["MicrosoftEntraID"]
+}
+`, r.template(data, data.Locations.Primary), data.RandomInteger)
 }
 
 func (r MongoClusterResource) template(data acceptance.TestData, location string) string {

--- a/internal/services/mongocluster/mongo_cluster_resource_test.go
+++ b/internal/services/mongocluster/mongo_cluster_resource_test.go
@@ -6,6 +6,7 @@ package mongocluster_test
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -179,6 +180,27 @@ func TestAccMongoCluster_entraIdOnly(t *testing.T) {
 			),
 		},
 		data.ImportStep("create_mode"),
+	})
+}
+
+func TestAccMongoCluster_authenticationMethodsValidation(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_mongo_cluster", "test")
+	r := MongoClusterResource{}
+	expectedError := regexp.MustCompile("`administrator_username` is required when `authentication_methods` contains `NativeAuth` or is not configured")
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config:      r.withoutAdministrator(data, ""),
+			ExpectError: expectedError,
+		},
+		{
+			Config:      r.withoutAdministrator(data, "  authentication_methods = []"),
+			ExpectError: expectedError,
+		},
+		{
+			Config:      r.withoutAdministrator(data, `  authentication_methods = ["NativeAuth"]`),
+			ExpectError: expectedError,
+		},
 	})
 }
 
@@ -463,6 +485,10 @@ func (r MongoClusterResource) entraIdOnly(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
+resource "terraform_data" "authentication_method" {
+  input = "MicrosoftEntraID"
+}
+
 resource "azurerm_mongo_cluster" "test" {
   name                   = "acctest-mc%d"
   resource_group_name    = azurerm_resource_group.test.name
@@ -472,9 +498,27 @@ resource "azurerm_mongo_cluster" "test" {
   high_availability_mode = "Disabled"
   storage_size_in_gb     = "32"
   version                = "7.0"
-  authentication_methods = ["MicrosoftEntraID"]
+  authentication_methods = [terraform_data.authentication_method.output]
 }
 `, r.template(data, data.Locations.Primary), data.RandomInteger)
+}
+
+func (r MongoClusterResource) withoutAdministrator(data acceptance.TestData, authenticationMethods string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_mongo_cluster" "test" {
+  name                   = "acctest-mc%d"
+  resource_group_name    = azurerm_resource_group.test.name
+  location               = azurerm_resource_group.test.location
+  shard_count            = "1"
+  compute_tier           = "M30"
+  high_availability_mode = "Disabled"
+  storage_size_in_gb     = "32"
+  version                = "7.0"
+%s
+}
+`, r.template(data, data.Locations.Primary), data.RandomInteger, authenticationMethods)
 }
 
 func (r MongoClusterResource) template(data acceptance.TestData, location string) string {

--- a/internal/services/mongocluster/mongo_cluster_resource_test.go
+++ b/internal/services/mongocluster/mongo_cluster_resource_test.go
@@ -485,10 +485,6 @@ func (r MongoClusterResource) entraIdOnly(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
-resource "terraform_data" "authentication_method" {
-  input = "MicrosoftEntraID"
-}
-
 resource "azurerm_mongo_cluster" "test" {
   name                   = "acctest-mc%d"
   resource_group_name    = azurerm_resource_group.test.name
@@ -498,7 +494,7 @@ resource "azurerm_mongo_cluster" "test" {
   high_availability_mode = "Disabled"
   storage_size_in_gb     = "32"
   version                = "7.0"
-  authentication_methods = [terraform_data.authentication_method.output]
+  authentication_methods = ["MicrosoftEntraID"]
 }
 `, r.template(data, data.Locations.Primary), data.RandomInteger)
 }

--- a/website/docs/r/mongo_cluster.html.markdown
+++ b/website/docs/r/mongo_cluster.html.markdown
@@ -45,6 +45,8 @@ The following arguments are supported:
 
 * `administrator_username` - (Optional) The administrator username of the MongoDB Cluster. Changing this forces a new resource to be created.
 
+~> **Note:** `administrator_username` is required when `authentication_methods` contains `NativeAuth` or is not configured.
+
 * `create_mode` - (Optional) The creation mode for the MongoDB Cluster. Possible values are `Default`, `GeoReplica` and `PointInTimeRestore`. Defaults to `Default`. Changing this forces a new resource to be created.
 
 * `customer_managed_key` - (Optional) A `customer_managed_key` block as defined below. Changing this forces a new resource to be created.


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

1. Relax the restriction for always requiring `administrator_password` with `Default` create mode: now `administrator_password` is only required when `authentication_methods` is not present or contains `NativeAuth`
2. `MicrosoftEntraID` can be the stand-alone authentication method now

**NOTE**: `MicrosoftEntraID`-only authentication is not well supported in the portal: this is only achievable by using API/Terraform. The portal for authentication setting is like the following screenshot when only `MicrosoftEntraID` authentication is enabled. 

<img width="902" height="192" alt="auth" src="https://github.com/user-attachments/assets/25bf5c27-773f-4dc8-9eab-03fe37c20783" />


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

<img width="581" height="853" alt="image" src="https://github.com/user-attachments/assets/eb6b009e-ea2d-494d-ac1e-268e3558d95d" />

**Note**: the failed `TestAccMongoClusterFreeTier` test is transient due to limitation of number of free-tier cluster

Update 2026-7-23
<img width="493" height="885" alt="image" src="https://github.com/user-attachments/assets/55f0e230-98e0-441e-9196-f852ccbd383e" />

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_mongo_cluster` - fix `administrator_password` restriction [GH-32092]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #32023


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
