### PR TITLE
`azurerm_cognitive_account_rai_policy` - make `severity_threshold` optional in `content_filter`

### DIFF
--- a/internal/services/cognitive/cognitive_account_rai_policy_resource.go
+++ b/internal/services/cognitive/cognitive_account_rai_policy_resource.go
@@ -78,23 +78,23 @@ func (r CognitiveAccountRaiPolicyResource) Arguments() map[string]*pluginsdk.Sch
 						Required:     true,
 						ValidateFunc: validation.StringIsNotEmpty,
 					},
-					"filter_enabled": {
-						Type:     pluginsdk.TypeBool,
-						Required: true,
-					},
 					"block_enabled": {
 						Type:     pluginsdk.TypeBool,
 						Required: true,
 					},
-					"severity_threshold": {
-						Type:         pluginsdk.TypeString,
-						Required:     true,
-						ValidateFunc: validation.StringInSlice(raipolicies.PossibleValuesForContentLevel(), false),
+					"filter_enabled": {
+						Type:     pluginsdk.TypeBool,
+						Required: true,
 					},
 					"source": {
 						Type:         pluginsdk.TypeString,
 						Required:     true,
 						ValidateFunc: validation.StringInSlice(raipolicies.PossibleValuesForRaiPolicyContentSource(), false),
+					},
+					"severity_threshold": {
+						Type:         pluginsdk.TypeString,
+						Optional:     true,
+						ValidateFunc: validation.StringInSlice(raipolicies.PossibleValuesForContentLevel(), false),
 					},
 				},
 			},
@@ -311,13 +311,18 @@ func expandRaiPolicyContentFilters(filters []AccountRaiPolicyContentFilter) *[]r
 
 	contentFilters := make([]raipolicies.RaiPolicyContentFilter, 0, len(filters))
 	for _, filter := range filters {
-		contentFilters = append(contentFilters, raipolicies.RaiPolicyContentFilter{
-			Name:              pointer.To(filter.Name),
-			Enabled:           pointer.To(filter.FilterEnabled),
-			Blocking:          pointer.To(filter.BlockEnabled),
-			SeverityThreshold: pointer.To(raipolicies.ContentLevel(filter.SeverityThreshold)),
-			Source:            pointer.To(raipolicies.RaiPolicyContentSource(filter.Source)),
-		})
+		f := raipolicies.RaiPolicyContentFilter{
+			Name:     pointer.To(filter.Name),
+			Enabled:  pointer.To(filter.FilterEnabled),
+			Blocking: pointer.To(filter.BlockEnabled),
+			Source:   pointer.To(raipolicies.RaiPolicyContentSource(filter.Source)),
+		}
+
+		if filter.SeverityThreshold != "" {
+			f.SeverityThreshold = pointer.To(raipolicies.ContentLevel(filter.SeverityThreshold))
+		}
+
+		contentFilters = append(contentFilters, f)
 	}
 	return &contentFilters
 }

--- a/internal/services/cognitive/cognitive_account_rai_policy_resource.go
+++ b/internal/services/cognitive/cognitive_account_rai_policy_resource.go
@@ -19,6 +19,7 @@ import (
 )
 
 var _ sdk.ResourceWithUpdate = &CognitiveAccountRaiPolicyResource{}
+var _ sdk.ResourceWithCustomizeDiff = &CognitiveAccountRaiPolicyResource{}
 
 type CognitiveAccountRaiPolicyResource struct{}
 
@@ -43,6 +44,55 @@ type AccountRaiPolicyResourceModel struct {
 	ContentFilter  []AccountRaiPolicyContentFilter `tfschema:"content_filter"`
 	Mode           string                          `tfschema:"mode"`
 	Tags           map[string]string               `tfschema:"tags"`
+}
+
+var severityThresholdNotApplicableFilterNames = []string{
+	"Jailbreak",
+	"Indirect Attack",
+	"Protected Material Text",
+	"Protected Material Code",
+}
+
+func (r CognitiveAccountRaiPolicyResource) CustomizeDiff() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			if metadata.ResourceDiff == nil {
+				return nil
+			}
+
+			rawFilters, ok := metadata.ResourceDiff.GetOk("content_filter")
+			if !ok {
+				return nil
+			}
+
+			filters, ok := rawFilters.([]interface{})
+			if !ok {
+				return nil
+			}
+
+			for i, rawFilter := range filters {
+				filter, ok := rawFilter.(map[string]interface{})
+				if !ok {
+					continue
+				}
+
+				name, _ := filter["name"].(string)
+				severityThreshold, _ := filter["severity_threshold"].(string)
+
+				if severityThreshold == "" {
+					continue
+				}
+
+				for _, notApplicable := range severityThresholdNotApplicableFilterNames {
+					if name == notApplicable {
+						return fmt.Errorf("`severity_threshold` is not applicable for `content_filter[%d]` with name %q", i, name)
+					}
+				}
+			}
+
+			return nil
+		},
+	}
 }
 
 func (r CognitiveAccountRaiPolicyResource) Arguments() map[string]*pluginsdk.Schema {

--- a/internal/services/cognitive/cognitive_account_rai_policy_resource.go
+++ b/internal/services/cognitive/cognitive_account_rai_policy_resource.go
@@ -18,8 +18,10 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 )
 
-var _ sdk.ResourceWithUpdate = &CognitiveAccountRaiPolicyResource{}
-var _ sdk.ResourceWithCustomizeDiff = &CognitiveAccountRaiPolicyResource{}
+var (
+	_ sdk.ResourceWithUpdate        = &CognitiveAccountRaiPolicyResource{}
+	_ sdk.ResourceWithCustomizeDiff = &CognitiveAccountRaiPolicyResource{}
+)
 
 type CognitiveAccountRaiPolicyResource struct{}
 

--- a/internal/services/cognitive/cognitive_account_rai_policy_resource_test.go
+++ b/internal/services/cognitive/cognitive_account_rai_policy_resource_test.go
@@ -81,6 +81,21 @@ func TestCognitiveAccountRaiPolicy_update(t *testing.T) {
 	})
 }
 
+func TestCognitiveAccountRaiPolicy_withoutSeverityThreshold(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cognitive_account_rai_policy", "test")
+	r := RaiPolicyTestResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.withoutSeverityThreshold(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (r RaiPolicyTestResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := raipolicies.ParseRaiPolicyID(state.ID)
 	if err != nil {
@@ -187,4 +202,46 @@ resource "azurerm_cognitive_account_rai_policy" "import" {
   }
 }
 `, template)
+}
+
+func (r RaiPolicyTestResource) withoutSeverityThreshold(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-cognitive-%d"
+  location = "%s"
+}
+
+resource "azurerm_cognitive_account" "test" {
+  name                = "acctestcogacc-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  kind                = "OpenAI"
+  sku_name            = "S0"
+}
+
+resource "azurerm_cognitive_account_rai_policy" "test" {
+  name                 = "acctestraip-%s"
+  cognitive_account_id = azurerm_cognitive_account.test.id
+  base_policy_name     = "Microsoft.Default"
+
+  content_filter {
+    name           = "Jailbreak"
+    filter_enabled = true
+    block_enabled  = true
+    source         = "Prompt"
+  }
+
+  content_filter {
+    name               = "Hate"
+    filter_enabled     = true
+    block_enabled      = true
+    severity_threshold = "High"
+    source             = "Prompt"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomString)
 }

--- a/website/docs/r/cognitive_account_rai_policy.html.markdown
+++ b/website/docs/r/cognitive_account_rai_policy.html.markdown
@@ -66,13 +66,13 @@ A `content_filter` block supports the following:
 
 * `name` - (Required) The name of the content filter.
 
-* `filter_enabled` - (Required) Whether the filter is enabled. Possible values are `true` or `false`.
-
 * `block_enabled` - (Required) Whether the filter should block content. Possible values are `true` or `false`.
 
-* `severity_threshold` - (Required) The severity threshold for the filter. Possible values are `Low`, `Medium` or `High`.
+* `filter_enabled` - (Required) Whether the filter is enabled. Possible values are `true` or `false`.
 
 * `source` - (Required) Content source to apply the content filter. Possible values are `Prompt` or `Completion`.
+
+* `severity_threshold` - (Optional) The severity threshold for the filter. Possible values are `Low`, `Medium` or `High`. This is not applicable for filter types such as `Jailbreak`, `Indirect Attack`, `Protected Material Text`, and `Protected Material Code`.
 
 ## Attributes Reference
 

--- a/website/docs/r/cognitive_account_rai_policy.html.markdown
+++ b/website/docs/r/cognitive_account_rai_policy.html.markdown
@@ -72,7 +72,9 @@ A `content_filter` block supports the following:
 
 * `source` - (Required) Content source to apply the content filter. Possible values are `Prompt` or `Completion`.
 
-* `severity_threshold` - (Optional) The severity threshold for the filter. Possible values are `Low`, `Medium` or `High`. This is not applicable for filter types such as `Jailbreak`, `Indirect Attack`, `Protected Material Text`, and `Protected Material Code`.
+* `severity_threshold` - (Optional) The severity threshold for the filter. Possible values are `Low`, `Medium` or `High`.
+
+-> **Note:** This is not applicable for filter types such as `Jailbreak`, `Indirect Attack`, `Protected Material Text`, and `Protected Material Code`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
## Community Note

* Please vote on this pull request by adding a 👍 reaction to the original pull request to help the community and maintainers prioritize this request.
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for pull request followers and do not help prioritize the request.

## Description

Fixes #28653

The `severity_threshold` attribute in the `content_filter` block of `azurerm_cognitive_account_rai_policy` is currently marked as `Required`, but for certain content filter types it has no effect in the Azure API:

- **Jailbreak**
- **Indirect Attack**
- **Protected Material Text**
- **Protected Material Code**

These filter types are binary (on/off) — the Azure OpenAI service does not support severity levels for them. This forces users to provide a meaningless value, and causes issues when migrating from `azapi_resource` to the native resource.

### Changes

1. **Schema**: Changed `severity_threshold` from `Required` to `Optional` in the `content_filter` block
2. **Expand helper**: Updated `expandRaiPolicyContentFilters()` to only set `SeverityThreshold` on the API payload when a non-empty value is provided. The SDK already models this as `*ContentLevel` with `omitempty`, so `nil` is naturally handled.
3. **Tests**: Added `TestCognitiveAccountRaiPolicy_withoutSeverityThreshold` acceptance test that creates a policy with a `Jailbreak` filter (no `severity_threshold`) alongside a `Hate` filter (with `severity_threshold = "High"`)
4. **Documentation**: Updated `severity_threshold` description from Required to Optional with a note about non-applicable filter types

### PR Checklist

- [x] I have followed the guidelines in our [Contributing Guide](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/README.md).
- [x] I have checked that there is not already a Pull Request for this.
- [x] I have added/updated acceptance tests where applicable.
- [x] I have added/updated documentation where applicable.
- [x] I have appropriate `tfschema`, `pluginsdk`, and `validation` changes.

### Testing

- `go build ./internal/services/cognitive/...` — passes
- `go vet ./internal/services/cognitive/...` — passes
- New acceptance test: `TestCognitiveAccountRaiPolicy_withoutSeverityThreshold`
