### PR TITLE
`azurerm_data_factory_pipeline` - rename `moniter_metrics_after_duration` property to `monitor_metrics_after_duration` 

### DIFF
--- a/internal/services/datafactory/data_factory_pipeline_resource.go
+++ b/internal/services/datafactory/data_factory_pipeline_resource.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/datafactory/2018-06-01/pipelines"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/datafactory/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -23,7 +24,7 @@ import (
 )
 
 func resourceDataFactoryPipeline() *pluginsdk.Resource {
-	return &pluginsdk.Resource{
+	resource := &pluginsdk.Resource{
 		Create: resourceDataFactoryPipelineCreateUpdate,
 		Read:   resourceDataFactoryPipelineRead,
 		Update: resourceDataFactoryPipelineCreateUpdate,
@@ -104,12 +105,33 @@ func resourceDataFactoryPipeline() *pluginsdk.Resource {
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
 
-			"moniter_metrics_after_duration": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
+			"monitor_metrics_after_duration": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
 			},
 		},
 	}
+
+	if !features.FivePointOh() {
+		resource.Schema["moniter_metrics_after_duration"] = &pluginsdk.Schema{
+			Type:          pluginsdk.TypeString,
+			Optional:      true,
+			Computed:      true,
+			ValidateFunc:  validation.StringIsNotEmpty,
+			ConflictsWith: []string{"monitor_metrics_after_duration"},
+			Deprecated:    "`moniter_metrics_after_duration` has been deprecated in favour of `monitor_metrics_after_duration` and will be removed in v5.0 of the AzureRM Provider",
+		}
+		resource.Schema["monitor_metrics_after_duration"] = &pluginsdk.Schema{
+			Type:          pluginsdk.TypeString,
+			Optional:      true,
+			Computed:      true,
+			ValidateFunc:  validation.StringIsNotEmpty,
+			ConflictsWith: []string{"moniter_metrics_after_duration"},
+		}
+	}
+
+	return resource
 }
 
 func resourceDataFactoryPipelineCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
@@ -187,11 +209,21 @@ func resourceDataFactoryPipelineCreateUpdate(d *pluginsdk.ResourceData, meta int
 		payload.Properties.Concurrency = pointer.To(int64(v.(int)))
 	}
 
-	if v, ok := d.GetOk("moniter_metrics_after_duration"); ok {
+	if v, ok := d.GetOk("monitor_metrics_after_duration"); ok {
 		payload.Properties.Policy = &pipelines.PipelinePolicy{
 			ElapsedTimeMetric: &pipelines.PipelineElapsedTimeMetricPolicy{
 				Duration: pointer.To(v),
 			},
+		}
+	}
+
+	if !features.FivePointOh() {
+		if !pluginsdk.IsExplicitlyNullInConfig(d, "moniter_metrics_after_duration") {
+			payload.Properties.Policy = &pipelines.PipelinePolicy{
+				ElapsedTimeMetric: &pipelines.PipelineElapsedTimeMetricPolicy{
+					Duration: pointer.To(d.Get("moniter_metrics_after_duration")),
+				},
+			}
 		}
 	}
 
@@ -258,7 +290,11 @@ func resourceDataFactoryPipelineRead(d *pluginsdk.ResourceData, meta interface{}
 				elapsedTimeMetricDuration = v
 			}
 		}
-		d.Set("moniter_metrics_after_duration", elapsedTimeMetricDuration)
+
+		d.Set("monitor_metrics_after_duration", elapsedTimeMetricDuration)
+		if !features.FivePointOh() {
+			d.Set("moniter_metrics_after_duration", elapsedTimeMetricDuration)
+		}
 
 		if folder := props.Folder; folder != nil {
 			d.Set("folder", pointer.From(folder.Name))

--- a/internal/services/datafactory/data_factory_pipeline_resource.go
+++ b/internal/services/datafactory/data_factory_pipeline_resource.go
@@ -115,16 +115,18 @@ func resourceDataFactoryPipeline() *pluginsdk.Resource {
 
 	if !features.FivePointOh() {
 		resource.Schema["moniter_metrics_after_duration"] = &pluginsdk.Schema{
-			Type:          pluginsdk.TypeString,
-			Optional:      true,
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			// NOTE: O+C as the value might be changed during read from renamed property
 			Computed:      true,
 			ValidateFunc:  validation.StringIsNotEmpty,
 			ConflictsWith: []string{"monitor_metrics_after_duration"},
 			Deprecated:    "`moniter_metrics_after_duration` has been deprecated in favour of `monitor_metrics_after_duration` and will be removed in v5.0 of the AzureRM Provider",
 		}
 		resource.Schema["monitor_metrics_after_duration"] = &pluginsdk.Schema{
-			Type:          pluginsdk.TypeString,
-			Optional:      true,
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			// NOTE: O+C as the value might be changed during read from renamed property
 			Computed:      true,
 			ValidateFunc:  validation.StringIsNotEmpty,
 			ConflictsWith: []string{"moniter_metrics_after_duration"},

--- a/internal/services/datafactory/data_factory_pipeline_resource.go
+++ b/internal/services/datafactory/data_factory_pipeline_resource.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/datafactory/2018-06-01/pipelines"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/datafactory/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -23,7 +24,7 @@ import (
 )
 
 func resourceDataFactoryPipeline() *pluginsdk.Resource {
-	return &pluginsdk.Resource{
+	resource := &pluginsdk.Resource{
 		Create: resourceDataFactoryPipelineCreateUpdate,
 		Read:   resourceDataFactoryPipelineRead,
 		Update: resourceDataFactoryPipelineCreateUpdate,
@@ -104,12 +105,33 @@ func resourceDataFactoryPipeline() *pluginsdk.Resource {
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
 
-			"moniter_metrics_after_duration": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
+			"monitor_metrics_after_duration": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
 			},
 		},
 	}
+
+	if !features.FivePointOh() {
+		resource.Schema["moniter_metrics_after_duration"] = &pluginsdk.Schema{
+			Type:          pluginsdk.TypeString,
+			Optional:      true,
+			Computed:      true,
+			ValidateFunc:  validation.StringIsNotEmpty,
+			ConflictsWith: []string{"monitor_metrics_after_duration"},
+			Deprecated:    "`moniter_metrics_after_duration` has been deprecated in favour of `monitor_metrics_after_duration` and will be removed in v5.0 of the AzureRM Provider",
+		}
+		resource.Schema["monitor_metrics_after_duration"] = &pluginsdk.Schema{
+			Type:          pluginsdk.TypeString,
+			Optional:      true,
+			Computed:      true,
+			ValidateFunc:  validation.StringIsNotEmpty,
+			ConflictsWith: []string{"moniter_metrics_after_duration"},
+		}
+	}
+
+	return resource
 }
 
 func resourceDataFactoryPipelineCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
@@ -189,11 +211,21 @@ func resourceDataFactoryPipelineCreateUpdate(d *pluginsdk.ResourceData, meta int
 		payload.Properties.Concurrency = pointer.To(int64(v.(int)))
 	}
 
-	if v, ok := d.GetOk("moniter_metrics_after_duration"); ok {
+	if v, ok := d.GetOk("monitor_metrics_after_duration"); ok {
 		payload.Properties.Policy = &pipelines.PipelinePolicy{
 			ElapsedTimeMetric: &pipelines.PipelineElapsedTimeMetricPolicy{
 				Duration: pointer.To(v),
 			},
+		}
+	}
+
+	if !features.FivePointOh() {
+		if !pluginsdk.IsExplicitlyNullInConfig(d, "moniter_metrics_after_duration") {
+			payload.Properties.Policy = &pipelines.PipelinePolicy{
+				ElapsedTimeMetric: &pipelines.PipelineElapsedTimeMetricPolicy{
+					Duration: pointer.To(d.Get("moniter_metrics_after_duration")),
+				},
+			}
 		}
 	}
 
@@ -260,7 +292,11 @@ func resourceDataFactoryPipelineRead(d *pluginsdk.ResourceData, meta interface{}
 				elapsedTimeMetricDuration = v
 			}
 		}
-		d.Set("moniter_metrics_after_duration", elapsedTimeMetricDuration)
+
+		d.Set("monitor_metrics_after_duration", elapsedTimeMetricDuration)
+		if !features.FivePointOh() {
+			d.Set("moniter_metrics_after_duration", elapsedTimeMetricDuration)
+		}
 
 		if folder := props.Folder; folder != nil {
 			d.Set("folder", pointer.From(folder.Name))

--- a/internal/services/datafactory/data_factory_pipeline_resource.go
+++ b/internal/services/datafactory/data_factory_pipeline_resource.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/datafactory/2018-06-01/pipelines"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/datafactory/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -113,26 +112,6 @@ func resourceDataFactoryPipeline() *pluginsdk.Resource {
 		},
 	}
 
-	if !features.FivePointOh() {
-		resource.Schema["moniter_metrics_after_duration"] = &pluginsdk.Schema{
-			Type:     pluginsdk.TypeString,
-			Optional: true,
-			// NOTE: O+C as the value might be changed during read from renamed property
-			Computed:      true,
-			ValidateFunc:  validation.StringIsNotEmpty,
-			ConflictsWith: []string{"monitor_metrics_after_duration"},
-			Deprecated:    "`moniter_metrics_after_duration` has been deprecated in favour of `monitor_metrics_after_duration` and will be removed in v5.0 of the AzureRM Provider",
-		}
-		resource.Schema["monitor_metrics_after_duration"] = &pluginsdk.Schema{
-			Type:     pluginsdk.TypeString,
-			Optional: true,
-			// NOTE: O+C as the value might be changed during read from renamed property
-			Computed:      true,
-			ValidateFunc:  validation.StringIsNotEmpty,
-			ConflictsWith: []string{"moniter_metrics_after_duration"},
-		}
-	}
-
 	return resource
 }
 
@@ -221,16 +200,6 @@ func resourceDataFactoryPipelineCreateUpdate(d *pluginsdk.ResourceData, meta int
 		}
 	}
 
-	if !features.FivePointOh() {
-		if !pluginsdk.IsExplicitlyNullInConfig(d, "moniter_metrics_after_duration") {
-			payload.Properties.Policy = &pipelines.PipelinePolicy{
-				ElapsedTimeMetric: &pipelines.PipelineElapsedTimeMetricPolicy{
-					Duration: pointer.To(d.Get("moniter_metrics_after_duration")),
-				},
-			}
-		}
-	}
-
 	if v, ok := d.GetOk("folder"); ok {
 		payload.Properties.Folder = &pipelines.PipelineFolder{
 			Name: pointer.To(v.(string)),
@@ -296,9 +265,6 @@ func resourceDataFactoryPipelineRead(d *pluginsdk.ResourceData, meta interface{}
 		}
 
 		d.Set("monitor_metrics_after_duration", elapsedTimeMetricDuration)
-		if !features.FivePointOh() {
-			d.Set("moniter_metrics_after_duration", elapsedTimeMetricDuration)
-		}
 
 		if folder := props.Folder; folder != nil {
 			d.Set("folder", pointer.From(folder.Name))

--- a/internal/services/datafactory/data_factory_pipeline_resource_test.go
+++ b/internal/services/datafactory/data_factory_pipeline_resource_test.go
@@ -77,35 +77,6 @@ func TestAccDataFactoryPipeline_update(t *testing.T) {
 	})
 }
 
-func TestAccDataFactoryPipeline_migrateDeprecatedToNewField(t *testing.T) {
-	if features.FivePointOh() {
-		t.Skip("skipping since `moniter_metrics_after_duration` is removed in 5.0")
-	}
-
-	data := acceptance.BuildTestData(t, "azurerm_data_factory_pipeline", "test")
-	r := PipelineResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.monitorMetricsDeprecated(data, "00:01:00"),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("moniter_metrics_after_duration").HasValue("00:01:00"),
-				check.That(data.ResourceName).Key("monitor_metrics_after_duration").HasValue("00:01:00"),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.monitorMetricsNew(data, "00:02:00"),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("monitor_metrics_after_duration").HasValue("00:02:00"),
-			),
-		},
-		data.ImportStep(),
-	})
-}
-
 func TestAccDataFactoryPipeline_activities(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_data_factory_pipeline", "test")
 	r := PipelineResource{}
@@ -424,30 +395,6 @@ resource "azurerm_data_factory_pipeline" "test" {
 JSON
 }
 `, r.template(data), data.RandomInteger, headerBlock)
-}
-
-func (r PipelineResource) monitorMetricsDeprecated(data acceptance.TestData, duration string) string {
-	return fmt.Sprintf(`
-%[1]s
-
-resource "azurerm_data_factory_pipeline" "test" {
-  name                           = "acctest%[2]d"
-  data_factory_id                = azurerm_data_factory.test.id
-  moniter_metrics_after_duration = %[3]q
-}
-`, r.template(data), data.RandomInteger, duration)
-}
-
-func (r PipelineResource) monitorMetricsNew(data acceptance.TestData, duration string) string {
-	return fmt.Sprintf(`
-%[1]s
-
-resource "azurerm_data_factory_pipeline" "test" {
-  name                           = "acctest%[2]d"
-  data_factory_id                = azurerm_data_factory.test.id
-  monitor_metrics_after_duration = %[3]q
-}
-`, r.template(data), data.RandomInteger, duration)
 }
 
 func (r PipelineResource) activitiesUpdated(data acceptance.TestData) string {

--- a/internal/services/datafactory/data_factory_pipeline_resource_test.go
+++ b/internal/services/datafactory/data_factory_pipeline_resource_test.go
@@ -273,20 +273,15 @@ JSON
 }
 
 func (r PipelineResource) update(data acceptance.TestData) string {
-	metricsFieldName := "monitor_metrics_after_duration"
-	if !features.FivePointOh() {
-		metricsFieldName = "moniter_metrics_after_duration"
-	}
-
 	return fmt.Sprintf(`
 %[1]s
 
 resource "azurerm_data_factory_pipeline" "test" {
-  name            = "acctest%[2]d"
-  data_factory_id = azurerm_data_factory.test.id
-  annotations     = ["test1", "test2"]
-  description     = "updated description"
-  %[3]s           = "00:02:00"
+  name                           = "acctest%[2]d"
+  data_factory_id                = azurerm_data_factory.test.id
+  annotations                    = ["test1", "test2"]
+  description                    = "updated description"
+  monitor_metrics_after_duration = "00:02:00"
 
   parameters = {
     test  = "testparameter"
@@ -324,7 +319,7 @@ resource "azurerm_data_factory_pipeline" "test" {
 ]
 JSON
 }
-`, r.template(data), data.RandomInteger, metricsFieldName)
+`, r.template(data), data.RandomInteger)
 }
 
 func (r PipelineResource) activities(data acceptance.TestData) string {

--- a/internal/services/datafactory/data_factory_pipeline_resource_test.go
+++ b/internal/services/datafactory/data_factory_pipeline_resource_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
@@ -184,6 +185,94 @@ resource "azurerm_data_factory_pipeline" "test" {
 }
 
 func (PipelineResource) complete(data acceptance.TestData) string {
+	if !features.FivePointOh() {
+		return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-df-%d"
+  location = "%s"
+}
+
+resource "azurerm_data_factory" "test" {
+  name                = "acctestdfv2%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_data_factory_pipeline" "test" {
+  name                           = "acctest%d"
+  data_factory_id                = azurerm_data_factory.test.id
+  annotations                    = ["test1", "test2", "test3"]
+  description                    = "test description"
+  moniter_metrics_after_duration = "00:01:00"
+
+  parameters = {
+    test = "testparameter"
+  }
+
+  variables = {
+    foo = "test1"
+    bar = "test2"
+  }
+
+  activities_json = <<JSON
+[
+  {
+    "name": "test append variable",
+    "type": "AppendVariable",
+    "dependsOn": [],
+    "userProperties": [],
+    "typeProperties": {
+      "variableName": "bob",
+      "value": "something"
+    }
+  },
+  {
+    "name": "test web activity",
+    "type": "WebActivity",
+    "dependsOn": [],
+    "userProperties": [],
+    "typeProperties": {
+	  "url": "https://test.com",
+	  "method": "POST",
+      "headers": {
+        "authorization": {
+          "value": "foo",
+          "type": "Expression"
+        },
+        "content_type": "application/x-www-form-urlencoded"
+      }
+    }
+  },
+  {
+    "name": "test filter",
+    "type": "Filter",
+    "dependsOn": [
+      {
+        "activity": "Filter something",
+        "dependencyConditions": ["Succeeded"]
+      }
+    ],
+    "userProperties": [],
+    "typeProperties": {
+      "items": {
+        "value": "@json(activity('Filter Something').output.response)",
+        "type": "Expression"
+      },
+      "condition": {
+        "value": "@equals(coalesce(item().Authorised, 0), 1)",
+        "type": "Expression"
+      }
+    }
+  }
+]
+JSON
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+	}
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -201,10 +290,11 @@ resource "azurerm_data_factory" "test" {
 }
 
 resource "azurerm_data_factory_pipeline" "test" {
-  name            = "acctest%d"
-  data_factory_id = azurerm_data_factory.test.id
-  annotations     = ["test1", "test2", "test3"]
-  description     = "test description"
+  name                           = "acctest%d"
+  data_factory_id                = azurerm_data_factory.test.id
+  annotations                    = ["test1", "test2", "test3"]
+  description                    = "test description"
+  monitor_metrics_after_duration = "00:01:00"
 
   parameters = {
     test = "testparameter"
@@ -289,10 +379,11 @@ resource "azurerm_data_factory" "test" {
 }
 
 resource "azurerm_data_factory_pipeline" "test" {
-  name            = "acctest%d"
-  data_factory_id = azurerm_data_factory.test.id
-  annotations     = ["test1", "test2"]
-  description     = "updated description"
+  name                           = "acctest%d"
+  data_factory_id                = azurerm_data_factory.test.id
+  annotations                    = ["test1", "test2"]
+  description                    = "updated description"
+  monitor_metrics_after_duration = "00:02:00"
 
   parameters = {
     test  = "testparameter"

--- a/internal/services/datafactory/data_factory_pipeline_resource_test.go
+++ b/internal/services/datafactory/data_factory_pipeline_resource_test.go
@@ -77,6 +77,35 @@ func TestAccDataFactoryPipeline_update(t *testing.T) {
 	})
 }
 
+func TestAccDataFactoryPipeline_migrateDeprecatedToNewField(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("skipping since `moniter_metrics_after_duration` is removed in 5.0")
+	}
+
+	data := acceptance.BuildTestData(t, "azurerm_data_factory_pipeline", "test")
+	r := PipelineResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.monitorMetricsDeprecated(data, "00:01:00"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("moniter_metrics_after_duration").HasValue("00:01:00"),
+				check.That(data.ResourceName).Key("monitor_metrics_after_duration").HasValue("00:01:00"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.monitorMetricsNew(data, "00:02:00"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("monitor_metrics_after_duration").HasValue("00:02:00"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccDataFactoryPipeline_activities(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_data_factory_pipeline", "test")
 	r := PipelineResource{}
@@ -160,7 +189,7 @@ func (t PipelineResource) appendVariableActivityNameIs(expected string) func(inp
 	}
 }
 
-func (PipelineResource) basic(data acceptance.TestData) string {
+func (PipelineResource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -177,124 +206,35 @@ resource "azurerm_data_factory" "test" {
   resource_group_name = azurerm_resource_group.test.name
 }
 
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (r PipelineResource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
 resource "azurerm_data_factory_pipeline" "test" {
-  name            = "acctest%d"
+  name            = "acctest%[2]d"
   data_factory_id = azurerm_data_factory.test.id
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+`, r.template(data), data.RandomInteger)
 }
 
-func (PipelineResource) complete(data acceptance.TestData) string {
+func (r PipelineResource) complete(data acceptance.TestData) string {
+	metricsFieldName := "monitor_metrics_after_duration"
 	if !features.FivePointOh() {
-		return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-df-%d"
-  location = "%s"
-}
-
-resource "azurerm_data_factory" "test" {
-  name                = "acctestdfv2%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-}
-
-resource "azurerm_data_factory_pipeline" "test" {
-  name                           = "acctest%d"
-  data_factory_id                = azurerm_data_factory.test.id
-  annotations                    = ["test1", "test2", "test3"]
-  description                    = "test description"
-  moniter_metrics_after_duration = "00:01:00"
-
-  parameters = {
-    test = "testparameter"
-  }
-
-  variables = {
-    foo = "test1"
-    bar = "test2"
-  }
-
-  activities_json = <<JSON
-[
-  {
-    "name": "test append variable",
-    "type": "AppendVariable",
-    "dependsOn": [],
-    "userProperties": [],
-    "typeProperties": {
-      "variableName": "bob",
-      "value": "something"
-    }
-  },
-  {
-    "name": "test web activity",
-    "type": "WebActivity",
-    "dependsOn": [],
-    "userProperties": [],
-    "typeProperties": {
-	  "url": "https://test.com",
-	  "method": "POST",
-      "headers": {
-        "authorization": {
-          "value": "foo",
-          "type": "Expression"
-        },
-        "content_type": "application/x-www-form-urlencoded"
-      }
-    }
-  },
-  {
-    "name": "test filter",
-    "type": "Filter",
-    "dependsOn": [
-      {
-        "activity": "Filter something",
-        "dependencyConditions": ["Succeeded"]
-      }
-    ],
-    "userProperties": [],
-    "typeProperties": {
-      "items": {
-        "value": "@json(activity('Filter Something').output.response)",
-        "type": "Expression"
-      },
-      "condition": {
-        "value": "@equals(coalesce(item().Authorised, 0), 1)",
-        "type": "Expression"
-      }
-    }
-  }
-]
-JSON
-}
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+		metricsFieldName = "moniter_metrics_after_duration"
 	}
+
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-df-%d"
-  location = "%s"
-}
-
-resource "azurerm_data_factory" "test" {
-  name                = "acctestdfv2%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-}
+%[1]s
 
 resource "azurerm_data_factory_pipeline" "test" {
-  name                           = "acctest%d"
-  data_factory_id                = azurerm_data_factory.test.id
-  annotations                    = ["test1", "test2", "test3"]
-  description                    = "test description"
-  monitor_metrics_after_duration = "00:01:00"
+  name            = "acctest%[2]d"
+  data_factory_id = azurerm_data_factory.test.id
+  annotations     = ["test1", "test2", "test3"]
+  description     = "test description"
+  %[3]s           = "00:01:00"
 
   parameters = {
     test = "testparameter"
@@ -358,32 +298,24 @@ resource "azurerm_data_factory_pipeline" "test" {
 ]
 JSON
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+`, r.template(data), data.RandomInteger, metricsFieldName)
 }
 
-func (PipelineResource) update(data acceptance.TestData) string {
+func (r PipelineResource) update(data acceptance.TestData) string {
+	metricsFieldName := "monitor_metrics_after_duration"
+	if !features.FivePointOh() {
+		metricsFieldName = "moniter_metrics_after_duration"
+	}
+
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-df-%d"
-  location = "%s"
-}
-
-resource "azurerm_data_factory" "test" {
-  name                = "acctestdfv2%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-}
+%[1]s
 
 resource "azurerm_data_factory_pipeline" "test" {
-  name                           = "acctest%d"
-  data_factory_id                = azurerm_data_factory.test.id
-  annotations                    = ["test1", "test2"]
-  description                    = "updated description"
-  monitor_metrics_after_duration = "00:02:00"
+  name            = "acctest%[2]d"
+  data_factory_id = azurerm_data_factory.test.id
+  annotations     = ["test1", "test2"]
+  description     = "updated description"
+  %[3]s           = "00:02:00"
 
   parameters = {
     test  = "testparameter"
@@ -421,28 +353,15 @@ resource "azurerm_data_factory_pipeline" "test" {
 ]
 JSON
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+`, r.template(data), data.RandomInteger, metricsFieldName)
 }
 
-func (PipelineResource) activities(data acceptance.TestData) string {
+func (r PipelineResource) activities(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_data_factory" "test" {
-  name                = "acctestdfv2%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-}
+%[1]s
 
 resource "azurerm_data_factory_pipeline" "test" {
-  name            = "acctest%d"
+  name            = "acctest%[2]d"
   data_factory_id = azurerm_data_factory.test.id
   variables = {
     "bob" = "item1"
@@ -462,10 +381,10 @@ resource "azurerm_data_factory_pipeline" "test" {
 ]
 JSON
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+`, r.template(data), data.RandomInteger)
 }
 
-func (PipelineResource) webActivityHeaders(data acceptance.TestData, withHeader bool) string {
+func (r PipelineResource) webActivityHeaders(data acceptance.TestData, withHeader bool) string {
 	headerBlock := `
       "headers": {
         "authorization": {
@@ -480,23 +399,10 @@ func (PipelineResource) webActivityHeaders(data acceptance.TestData, withHeader 
 	}
 
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_data_factory" "test" {
-  name                = "acctestdfv2%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-}
+%[1]s
 
 resource "azurerm_data_factory_pipeline" "test" {
-  name            = "acctest%d"
+  name            = "acctest%[2]d"
   data_factory_id = azurerm_data_factory.test.id
   variables = {
     "bob" = "item1"
@@ -509,7 +415,7 @@ resource "azurerm_data_factory_pipeline" "test" {
     "dependsOn": [],
     "userProperties": [],
     "typeProperties": {
-    %s
+    %[3]s
 	  "url": "https://test.com",
 	  "method": "POST"
     }
@@ -517,28 +423,39 @@ resource "azurerm_data_factory_pipeline" "test" {
 ]
 JSON
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, headerBlock)
+`, r.template(data), data.RandomInteger, headerBlock)
 }
 
-func (PipelineResource) activitiesUpdated(data acceptance.TestData) string {
+func (r PipelineResource) monitorMetricsDeprecated(data acceptance.TestData, duration string) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_data_factory" "test" {
-  name                = "acctestdfv2%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-}
+%[1]s
 
 resource "azurerm_data_factory_pipeline" "test" {
-  name            = "acctest%d"
+  name                           = "acctest%[2]d"
+  data_factory_id                = azurerm_data_factory.test.id
+  moniter_metrics_after_duration = %[3]q
+}
+`, r.template(data), data.RandomInteger, duration)
+}
+
+func (r PipelineResource) monitorMetricsNew(data acceptance.TestData, duration string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_data_factory_pipeline" "test" {
+  name                           = "acctest%[2]d"
+  data_factory_id                = azurerm_data_factory.test.id
+  monitor_metrics_after_duration = %[3]q
+}
+`, r.template(data), data.RandomInteger, duration)
+}
+
+func (r PipelineResource) activitiesUpdated(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_data_factory_pipeline" "test" {
+  name            = "acctest%[2]d"
   data_factory_id = azurerm_data_factory.test.id
   variables = {
     "bob" = "item1"
@@ -558,5 +475,5 @@ resource "azurerm_data_factory_pipeline" "test" {
 ]
 JSON
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+`, r.template(data), data.RandomInteger)
 }

--- a/internal/services/datafactory/data_factory_pipeline_resource_test.go
+++ b/internal/services/datafactory/data_factory_pipeline_resource_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
@@ -192,20 +191,15 @@ resource "azurerm_data_factory_pipeline" "test" {
 }
 
 func (r PipelineResource) complete(data acceptance.TestData) string {
-	metricsFieldName := "monitor_metrics_after_duration"
-	if !features.FivePointOh() {
-		metricsFieldName = "moniter_metrics_after_duration"
-	}
-
 	return fmt.Sprintf(`
 %[1]s
 
 resource "azurerm_data_factory_pipeline" "test" {
-  name            = "acctest%[2]d"
-  data_factory_id = azurerm_data_factory.test.id
-  annotations     = ["test1", "test2", "test3"]
-  description     = "test description"
-  %[3]s           = "00:01:00"
+  name                           = "acctest%[2]d"
+  data_factory_id                = azurerm_data_factory.test.id
+  annotations                    = ["test1", "test2", "test3"]
+  description                    = "test description"
+  monitor_metrics_after_duration = "00:01:00"
 
   parameters = {
     test = "testparameter"
@@ -269,7 +263,7 @@ resource "azurerm_data_factory_pipeline" "test" {
 ]
 JSON
 }
-`, r.template(data), data.RandomInteger, metricsFieldName)
+`, r.template(data), data.RandomInteger)
 }
 
 func (r PipelineResource) update(data acceptance.TestData) string {

--- a/website/docs/5.0-upgrade-guide.html.markdown
+++ b/website/docs/5.0-upgrade-guide.html.markdown
@@ -352,6 +352,10 @@ Please follow the format in the example below for listing breaking changes in re
 
 * Validation for `rbac_authorization.resource_id` has been changed to validate for an integration runtime resource ID (case-sensitive) rather than validating for a non-empty string.
 
+### `azurerm_data_factory_pipeline`
+
+* The deprecated `moniter_metrics_after_duration` property has been removed in favour of the `monitor_metrics_after_duration` property.
+
 ### `azurerm_eventgrid_event_subscription`
 
 * Validation for `azure_function.function_id` has been changed to validate for an Azure Function resource ID (case-sensitive) rather than validating for an Azure resource ID.

--- a/website/docs/5.0-upgrade-guide.html.markdown
+++ b/website/docs/5.0-upgrade-guide.html.markdown
@@ -463,6 +463,10 @@ Please follow the format in the example below for listing breaking changes in re
 
 * Validation for `rbac_authorization.resource_id` has been changed to validate for an integration runtime resource ID (case-sensitive) rather than validating for a non-empty string.
 
+### `azurerm_data_factory_pipeline`
+
+* The deprecated `moniter_metrics_after_duration` property has been removed in favour of the `monitor_metrics_after_duration` property.
+  
 ### `azurerm_dedicated_host`
 
 * The `license_type` property no longer accepts `None` as a value. Omitting the property sets `None` in the request.
@@ -470,7 +474,7 @@ Please follow the format in the example below for listing breaking changes in re
 ### `azurerm_disk_encryption_set`
 
 * The deprecated `managed_hsm_key_id` property has been removed in favour of the `key_vault_key_id` property.
-
+  
 ### `azurerm_eventgrid_event_subscription`
 
 * Validation for `azure_function.function_id` has been changed to validate for an Azure Function resource ID (case-sensitive) rather than validating for an Azure resource ID.

--- a/website/docs/r/data_factory_pipeline.html.markdown
+++ b/website/docs/r/data_factory_pipeline.html.markdown
@@ -72,7 +72,7 @@ The following arguments are supported:
 
 * `folder` - (Optional) The folder that this Pipeline is in. If not specified, the Pipeline will appear at the root level.
 
-* `moniter_metrics_after_duration` - (Optional) The TimeSpan value after which an Azure Monitoring Metric is fired.
+* `monitor_metrics_after_duration` - (Optional) The TimeSpan value after which an Azure Monitoring Metric is fired.
 
 * `parameters` - (Optional) A map of parameters to associate with the Data Factory Pipeline.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR is to resolve #32137. Rename the `moniter_metrics_after_duration` to `monitor_metrics_after_duration` 

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”

<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.

## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

<img width="449" height="317" alt="image" src="https://github.com/user-attachments/assets/ed879892-de56-4aa3-a170-03a63cad6467" />

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_data_factory_pipeline` - the `moniter_metrics_after_duration` property has been deprecated in favour of `monitor_metrics_after_duration` and will be removed in v5.0 [GH-32177]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [x] Breaking Change


## Related Issue(s)

Fixes #32137


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
