### PR TITLE
`azurerm_data_factory` - fix `global_parameter.#.value` JSON parsing in property expansion

### DIFF
--- a/internal/services/datafactory/data_factory_resource.go
+++ b/internal/services/datafactory/data_factory_resource.go
@@ -477,6 +477,13 @@ func expandDataFactoryGlobalParameters(input []interface{}) (*map[string]factori
 			Type:  factories.GlobalParameterType(v["type"].(string)),
 			Value: v["value"].(string),
 		}
+
+		if result[name].Type == factories.GlobalParameterTypeArray || result[name].Type == factories.GlobalParameterTypeObject {
+			resultValue := result[name]
+			if err := json.Unmarshal([]byte(v["value"].(string)), &resultValue.Value); err == nil {
+				result[name] = resultValue
+			}
+		}
 	}
 	return &result, nil
 }


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

`azurerm_data_factory` `global_parameter.#.value` which contains JSON payload when `global_parameter.#.type` is `Array` or `Object` is not parsed correctly when `global_parameter` is expanded. This causes JSON payload to be sent in string form when REST API request is carried out. To reproduce the issue, one of the methods is to apply the Terraform configuration below.

```hcl
provider "azurerm" {
  features {}
}

resource "azurerm_resource_group" "test" {
  name     = "REDACTED"
  location = "southeastasia"
}

resource "azurerm_data_factory" "test" {
  name                = "REDACTED"
  location            = azurerm_resource_group.test.location
  resource_group_name = azurerm_resource_group.test.name

  global_parameter {
    name  = "objectVal"
    type  = "Object"
    value = jsonencode({ hello : "world" })
  }
}
```

From the JSON view in portal, it can be seen that instead of the correct JSON format, the `value` is in string format of `"{\"hello\":\"world\"}"`.

```json
{
    "name": "REDACTED",
    "id": "/subscriptions/REDACTED/resourceGroups/REDACTED/providers/Microsoft.DataFactory/factories/REDACTED",
    "type": "Microsoft.DataFactory/factories",
    "properties": {
        "provisioningState": "Succeeded",
        "createTime": "REDACTED",
        "version": "2018-06-01",
        "factoryStatistics": {
            "totalResourceCount": 0,
            "maxAllowedResourceCount": 0,
            "factorySizeInGbUnits": 0,
            "maxAllowedFactorySizeInGbUnits": 0
        },
        "globalParameters": {
            "objectVal": {
                "type": "Object",
                "value": "{\"hello\":\"world\"}"
            }
        },
        "publicNetworkAccess": "Enabled",
        "trustModeClaimForMi": {
            "value": "Disabled",
            "editable": true
        }
    },
    "eTag": "\"REDACTED\"",
    "location": "southeastasia",
    "tags": {}
}
```

To fix the issue, JSON parsing is applied during `global_parameter` expansion. This generates the correct `value` property in the JSON format shown below.

```json
...
"value": {
  "hello": "world"
}
...
```


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] ~I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).~
- [ ] ~I have written new tests for my resource or datasource changes & updated any relevant documentation.~
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] ~(For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.~


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

The failed tests are either intermittent or pre-existing from `main` branch run.
https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_DATAFACTORY/649271?buildTab=overview
<img width="960" height="670" alt="image" src="https://github.com/user-attachments/assets/55eef56f-a607-4652-93a8-9ab52457ef08" />
<img width="948" height="243" alt="image" src="https://github.com/user-attachments/assets/8c382e80-bb80-46c8-948a-21e83d2d956d" />


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_data_factory` - fix `global_parameter.#.value` JSON parsing in property expansion


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #30927 


## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
