### PR TITLE
`azurerm_container_app_environment` - fix GPU consumption workload profiles sending unsupported `MinimumCount`/`MaximumCount`

### DIFF
--- a/internal/services/containerapps/helpers/container_app_environment.go
+++ b/internal/services/containerapps/helpers/container_app_environment.go
@@ -4,6 +4,8 @@
 package helpers
 
 import (
+	"strings"
+
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/managedenvironments"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -97,6 +99,11 @@ func WorkloadProfileSchema() *pluginsdk.Schema {
 	}
 }
 
+func isConsumptionProfileType(workloadProfileType string) bool {
+	return strings.EqualFold(workloadProfileType, string(WorkloadProfileSkuConsumption)) ||
+		strings.HasPrefix(strings.ToLower(workloadProfileType), "consumption-gpu")
+}
+
 func ExpandWorkloadProfiles(input []WorkloadProfileModel) *[]managedenvironments.WorkloadProfile {
 	if len(input) == 0 {
 		return nil
@@ -106,15 +113,13 @@ func ExpandWorkloadProfiles(input []WorkloadProfileModel) *[]managedenvironments
 
 	for _, v := range input {
 		r := managedenvironments.WorkloadProfile{
-			Name: v.Name,
+			Name:                v.Name,
+			WorkloadProfileType: v.WorkloadProfileType,
 		}
 
-		if v.Name != string(WorkloadProfileSkuConsumption) {
-			r.WorkloadProfileType = v.WorkloadProfileType
+		if !isConsumptionProfileType(v.WorkloadProfileType) {
 			r.MaximumCount = pointer.To(v.MaximumCount)
 			r.MinimumCount = pointer.To(v.MinimumCount)
-		} else {
-			r.WorkloadProfileType = string(WorkloadProfileSkuConsumption)
 		}
 
 		result = append(result, r)

--- a/internal/services/containerapps/helpers/container_app_environment_test.go
+++ b/internal/services/containerapps/helpers/container_app_environment_test.go
@@ -1,0 +1,90 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package helpers
+
+import (
+	"testing"
+)
+
+func TestIsConsumptionProfileType(t *testing.T) {
+	cases := []struct {
+		Input    string
+		Expected bool
+	}{
+		{Input: "Consumption", Expected: true},
+		{Input: "consumption", Expected: true},
+		{Input: "Consumption-GPU-NC8as-T4", Expected: true},
+		{Input: "Consumption-GPU-NC24-A100", Expected: true},
+		{Input: "consumption-gpu-nc8as-t4", Expected: true},
+		{Input: "D4", Expected: false},
+		{Input: "E4", Expected: false},
+		{Input: "NC24-A100", Expected: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Input, func(t *testing.T) {
+			result := isConsumptionProfileType(tc.Input)
+			if result != tc.Expected {
+				t.Fatalf("expected %v for %q, got %v", tc.Expected, tc.Input, result)
+			}
+		})
+	}
+}
+
+func TestExpandWorkloadProfiles_ConsumptionGPU(t *testing.T) {
+	input := []WorkloadProfileModel{
+		{
+			Name:                "Consumption",
+			WorkloadProfileType: "Consumption",
+		},
+		{
+			Name:                "Consump-GPU-T4",
+			WorkloadProfileType: "Consumption-GPU-NC8as-T4",
+		},
+		{
+			Name:                "E4-01",
+			WorkloadProfileType: "E4",
+			MaximumCount:        2,
+			MinimumCount:        0,
+		},
+	}
+
+	result := ExpandWorkloadProfiles(input)
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	profiles := *result
+	if len(profiles) != 3 {
+		t.Fatalf("expected 3 profiles, got %d", len(profiles))
+	}
+
+	// Consumption profile should not have MinimumCount/MaximumCount
+	if profiles[0].MinimumCount != nil {
+		t.Errorf("Consumption profile should not have MinimumCount, got %v", *profiles[0].MinimumCount)
+	}
+	if profiles[0].MaximumCount != nil {
+		t.Errorf("Consumption profile should not have MaximumCount, got %v", *profiles[0].MaximumCount)
+	}
+
+	// GPU Consumption profile should not have MinimumCount/MaximumCount
+	if profiles[1].MinimumCount != nil {
+		t.Errorf("GPU Consumption profile should not have MinimumCount, got %v", *profiles[1].MinimumCount)
+	}
+	if profiles[1].MaximumCount != nil {
+		t.Errorf("GPU Consumption profile should not have MaximumCount, got %v", *profiles[1].MaximumCount)
+	}
+
+	// Dedicated profile should have MinimumCount/MaximumCount
+	if profiles[2].MinimumCount == nil {
+		t.Error("E4 profile should have MinimumCount")
+	} else if *profiles[2].MinimumCount != 0 {
+		t.Errorf("expected MinimumCount 0, got %d", *profiles[2].MinimumCount)
+	}
+	if profiles[2].MaximumCount == nil {
+		t.Error("E4 profile should have MaximumCount")
+	} else if *profiles[2].MaximumCount != 2 {
+		t.Errorf("expected MaximumCount 2, got %d", *profiles[2].MaximumCount)
+	}
+}

--- a/website/docs/r/container_app_environment.html.markdown
+++ b/website/docs/r/container_app_environment.html.markdown
@@ -99,6 +99,8 @@ A `workload_profile` block supports the following:
 
 * `minimum_count` - (Optional) The minimum number of instances of workload profile that can be deployed in the Container App Environment.
 
+~> **Note:** The `maximum_count` and `minimum_count` properties are not supported for Consumption-based workload profiles (i.e. `Consumption`, `Consumption-GPU-NC24-A100`, and `Consumption-GPU-NC8as-T4`).
+
 ---
 
 An `identity` block supports the following:


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

GPU consumption workload profiles (e.g. `Consumption-GPU-NC8as-T4`) do not support `MinimumCount` or `MaximumCount` in the Azure API. Previously, the provider unconditionally sent these fields for all consumption workload profiles, causing an API error when creating a Container App Environment with GPU consumption workload profiles.

This fix skips sending `MinimumCount` and `MaximumCount` for GPU consumption workload profiles, matching the API's requirements. Documentation has been updated to clarify that `minimum_count` and `maximum_count` are not supported for consumption workload profiles.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.


## Testing

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass.

Unit tests were added and pass locally. Manual end-to-end testing was performed by deploying a Container App Environment with a GPU consumption workload profile (`Consumption-GPU-NC8as-T4`) in Azure. Prior to the fix, this resulted in an API error. After the fix, the environment was created successfully.


## Change Log

* `azurerm_container_app_environment` - fix GPU consumption workload profiles sending unsupported `MinimumCount`/`MaximumCount` [GH-31763]


This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #31763


## AI Assistance Disclosure

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

Claude Code was used to assist with implementing the fix, writing tests, and documentation updates.


## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

No changes to security controls.