### PR TITLE
`azurerm_kubernetes_cluster_node_pool` - validate `node_taints` format at plan time

### DIFF
--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -296,7 +296,8 @@ func resourceKubernetesClusterNodePoolSchema() map[string]*pluginsdk.Schema {
 			Type:     pluginsdk.TypeList,
 			Optional: true,
 			Elem: &pluginsdk.Schema{
-				Type: pluginsdk.TypeString,
+				Type:         pluginsdk.TypeString,
+				ValidateFunc: containerValidate.KubernetesNodeTaint,
 			},
 		},
 

--- a/internal/services/containers/validate/kubernetes.go
+++ b/internal/services/containers/validate/kubernetes.go
@@ -62,6 +62,29 @@ func KubernetesDNSPrefix(i interface{}, k string) (warnings []string, errors []e
 	return warnings, errors
 }
 
+func KubernetesNodeTaint(i interface{}, k string) (warnings []string, errors []error) {
+	v, ok := i.(string)
+	if !ok {
+		return nil, []error{fmt.Errorf("expected type of %q to be string", k)}
+	}
+
+	parts := strings.Split(v, ":")
+	if len(parts) != 2 {
+		errors = append(errors, fmt.Errorf("%q must be in the format `key[=value]:effect`, got %q", k, v))
+		return
+	}
+	if parts[0] == "" {
+		errors = append(errors, fmt.Errorf("the key portion of %q cannot be empty, got %q", k, v))
+	}
+	switch parts[1] {
+	case "NoSchedule", "PreferNoSchedule", "NoExecute":
+	default:
+		errors = append(errors, fmt.Errorf("the effect of %q must be one of `NoSchedule`, `PreferNoSchedule` or `NoExecute`, got %q", k, parts[1]))
+	}
+
+	return
+}
+
 func KubernetesGitRepositoryUrl() pluginsdk.SchemaValidateFunc {
 	return func(i interface{}, k string) ([]string, []error) {
 		v, ok := i.(string)

--- a/internal/services/containers/validate/kubernetes_test.go
+++ b/internal/services/containers/validate/kubernetes_test.go
@@ -165,6 +165,66 @@ func TestKubernetesDNSPrefix(t *testing.T) {
 	}
 }
 
+func TestKubernetesNodeTaint(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+		{
+			Input: "",
+			Valid: false,
+		},
+		{
+			Input: "key=value:NoSchedule",
+			Valid: true,
+		},
+		{
+			Input: "key:NoSchedule",
+			Valid: true,
+		},
+		{
+			Input: "example.com/key=value:PreferNoSchedule",
+			Valid: true,
+		},
+		{
+			Input: "key=value:NoExecute",
+			Valid: true,
+		},
+		{
+			// missing `=` between key and value, taken from #31386
+			Input: "project:dcp-prd:NoSchedule",
+			Valid: false,
+		},
+		{
+			Input: "key=value",
+			Valid: false,
+		},
+		{
+			Input: ":NoSchedule",
+			Valid: false,
+		},
+		{
+			Input: "key=value:Bogus",
+			Valid: false,
+		},
+		{
+			Input: "key=value:noSchedule",
+			Valid: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Input, func(t *testing.T) {
+			_, errors := KubernetesNodeTaint(tc.Input, "test")
+			valid := len(errors) == 0
+
+			if tc.Valid != valid {
+				t.Fatalf("Expected %t but got %t for %q: %+v", tc.Valid, valid, tc.Input, errors)
+			}
+		})
+	}
+}
+
 func TestKubernetesGitRepositoryUrl(t *testing.T) {
 	cases := []struct {
 		Input string


### PR DESCRIPTION
## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

The `node_taints` element on `azurerm_kubernetes_cluster_node_pool` had no validation, so a malformed taint (for example missing the `=` between key and value) was only caught by the AKS API at apply time, after a node pool create attempt. The error from Azure is `invalid taint spec` and points users to https://aka.ms/node-taints.

This adds a `KubernetesNodeTaint` validator alongside the other Kubernetes validators in `internal/services/containers/validate/kubernetes.go` and wires it onto the schema element. The validator checks the taint splits cleanly on a single `:`, that the key portion is non-empty, and that the effect is one of `NoSchedule`, `PreferNoSchedule` or `NoExecute`. It deliberately does not enforce the full Kubernetes label key/value character set so the Azure API stays the final arbiter on those.

## Testing

Unit tests added next to the existing `TestKubernetes*` tests, including the exact malformed taint from the linked issue (`project:dcp-prd:NoSchedule`).

```
$ go test -count=1 -v -run 'TestKubernetesNodeTaint' ./internal/services/containers/validate/
=== RUN   TestKubernetesNodeTaint
--- PASS: TestKubernetesNodeTaint (0.00s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/containers/validate
```

The existing acceptance tests for this resource (`TestAccKubernetesClusterNodePool_nodeTaints`, etc.) use `key=value:NoSchedule` configurations which the new validator accepts; running them is best-effort for the maintainer since they create real AKS clusters.

## Change Log

* `azurerm_kubernetes_cluster_node_pool` - validate the format of `node_taints` entries to fail fast on malformed values [GH-00000]

This is a:

- [x] Bug Fix

## Related Issue(s)

Fixes #31386

## AI Assistance Disclosure

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

Claude Code was used to confirm the AKS taint format against Microsoft Learn, draft the validator and tests, and draft this PR description. The change was reviewed by the contributor before submission.

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

No changes to security controls.