### PR TITLE
`azurerm_container_app`, `azurerm_container_app_job`: fix perpetual diffs in env and secret blocks due to ordering sensitivity

### DIFF
--- a/internal/services/containerapps/container_app_job_resource.go
+++ b/internal/services/containerapps/container_app_job_resource.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/containerapps/helpers"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/containerapps/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/containerapps/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -50,6 +51,7 @@ type ContainerAppJobModel struct {
 }
 
 var _ sdk.ResourceWithUpdate = ContainerAppJobResource{}
+var _ sdk.ResourceWithStateMigration = ContainerAppJobResource{}
 
 func (r ContainerAppJobResource) ModelObject() interface{} {
 	return &ContainerAppJobModel{}
@@ -220,6 +222,15 @@ func (r ContainerAppJobResource) Attributes() map[string]*schema.Schema {
 	}
 }
 
+func (r ContainerAppJobResource) StateUpgraders() sdk.StateUpgradeData {
+	return sdk.StateUpgradeData{
+		SchemaVersion: 1,
+		Upgraders: map[int]pluginsdk.StateUpgrade{
+			0: migration.ContainerAppJobV0ToV1{},
+		},
+	}
+}
+
 func (r ContainerAppJobResource) Create() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
 		Timeout: 30 * time.Minute,
@@ -322,6 +333,10 @@ func (r ContainerAppJobResource) Read() sdk.ResourceFunc {
 			}
 
 			var state ContainerAppJobModel
+			var priorState ContainerAppJobModel
+			if err := metadata.Decode(&priorState); err != nil {
+				return err
+			}
 
 			state.Name = id.JobName
 			state.ResourceGroup = id.ResourceGroupName
@@ -371,6 +386,7 @@ func (r ContainerAppJobResource) Read() sdk.ResourceFunc {
 				return fmt.Errorf("listing secrets for %s: %+v", *id, err)
 			}
 			state.Secrets = helpers.FlattenContainerAppJobSecrets(secretResp.Model)
+			state.Secrets = helpers.PreserveContainerAppSecretValues(state.Secrets, priorState.Secrets)
 
 			return metadata.Encode(&state)
 		},

--- a/internal/services/containerapps/container_app_resource.go
+++ b/internal/services/containerapps/container_app_resource.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/managedenvironments"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/containerapps/helpers"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/containerapps/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/containerapps/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -53,6 +54,8 @@ type ContainerAppModel struct {
 var _ sdk.ResourceWithUpdate = ContainerAppResource{}
 
 var _ sdk.ResourceWithCustomizeDiff = ContainerAppResource{}
+
+var _ sdk.ResourceWithStateMigration = ContainerAppResource{}
 
 func (r ContainerAppResource) ModelObject() interface{} {
 	return &ContainerAppModel{}
@@ -258,6 +261,10 @@ func (r ContainerAppResource) Read() sdk.ResourceFunc {
 			}
 
 			var state ContainerAppModel
+			var priorState ContainerAppModel
+			if err := metadata.Decode(&priorState); err != nil {
+				return err
+			}
 
 			state.Name = id.ContainerAppName
 			state.ResourceGroup = id.ResourceGroupName
@@ -303,6 +310,7 @@ func (r ContainerAppResource) Read() sdk.ResourceFunc {
 			}
 
 			state.Secrets = helpers.FlattenContainerAppSecrets(secretsResp.Model)
+			state.Secrets = helpers.PreserveContainerAppSecretValues(state.Secrets, priorState.Secrets)
 
 			return metadata.Encode(&state)
 		},
@@ -468,6 +476,15 @@ func (r ContainerAppResource) CustomizeDiff() sdk.ResourceFunc {
 				}
 			}
 			return nil
+		},
+	}
+}
+
+func (r ContainerAppResource) StateUpgraders() sdk.StateUpgradeData {
+	return sdk.StateUpgradeData{
+		SchemaVersion: 1,
+		Upgraders: map[int]pluginsdk.StateUpgrade{
+			0: migration.ContainerAppV0ToV1{},
 		},
 	}
 }

--- a/internal/services/containerapps/container_app_resource_test.go
+++ b/internal/services/containerapps/container_app_resource_test.go
@@ -454,6 +454,25 @@ func TestAccContainerAppResource_secretRemove(t *testing.T) {
 	})
 }
 
+func TestAccContainerAppResource_envAndSecretStability(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_app", "test")
+	r := ContainerAppResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.envAndSecretOrderA(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		{
+			Config:             r.envAndSecretOrderB(data),
+			PlanOnly:           true,
+			ExpectNonEmptyPlan: false,
+		},
+	})
+}
+
 func TestAccContainerAppResource_scaleRules(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_container_app", "test")
 	r := ContainerAppResource{}
@@ -2995,6 +3014,90 @@ resource "azurerm_container_app" "test" {
   secret {
     name  = "pickle"
     value = "morty"
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r ContainerAppResource) envAndSecretOrderA(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_container_app" "test" {
+  name                         = "acctest-capp-%[2]d"
+  resource_group_name          = azurerm_resource_group.test.name
+  container_app_environment_id = azurerm_container_app_environment.test.id
+  revision_mode                = "Single"
+
+  template {
+    container {
+      name   = "acctest-cont-%[2]d"
+      image  = "jackofallops/azure-containerapps-python-acctest:v0.0.1"
+      cpu    = 0.25
+      memory = "0.5Gi"
+
+      env {
+        name  = "ALPHA"
+        value = "one"
+      }
+
+      env {
+        name  = "BETA"
+        value = "two"
+      }
+    }
+  }
+
+  secret {
+    name  = "first"
+    value = "one"
+  }
+
+  secret {
+    name  = "second"
+    value = "two"
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r ContainerAppResource) envAndSecretOrderB(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_container_app" "test" {
+  name                         = "acctest-capp-%[2]d"
+  resource_group_name          = azurerm_resource_group.test.name
+  container_app_environment_id = azurerm_container_app_environment.test.id
+  revision_mode                = "Single"
+
+  template {
+    container {
+      name   = "acctest-cont-%[2]d"
+      image  = "jackofallops/azure-containerapps-python-acctest:v0.0.1"
+      cpu    = 0.25
+      memory = "0.5Gi"
+
+      env {
+        name  = "BETA"
+        value = "two"
+      }
+
+      env {
+        name  = "ALPHA"
+        value = "one"
+      }
+    }
+  }
+
+  secret {
+    name  = "second"
+    value = "two"
+  }
+
+  secret {
+    name  = "first"
+    value = "one"
   }
 }
 `, r.template(data), data.RandomInteger)

--- a/internal/services/containerapps/helpers/container_app_job.go
+++ b/internal/services/containerapps/helpers/container_app_job.go
@@ -1018,12 +1018,15 @@ func FlattenContainerAppJobSecrets(input *jobs.JobSecretsCollection) []Secret {
 	result := make([]Secret, 0)
 
 	for _, v := range input.Value {
+		keyVaultSecretId := strings.TrimSpace(pointer.From(v.KeyVaultURL))
+		identity := strings.TrimSpace(pointer.From(v.Identity))
+
 		secret := Secret{
-			Identity:         pointer.From(v.Identity),
-			KeyVaultSecretId: pointer.From(v.KeyVaultURL),
+			Identity:         identity,
+			KeyVaultSecretId: keyVaultSecretId,
 			Name:             pointer.From(v.Name),
 		}
-		if v.KeyVaultURL == nil {
+		if keyVaultSecretId == "" {
 			secret.Value = pointer.From(v.Value)
 		}
 		result = append(result, secret)

--- a/internal/services/containerapps/helpers/container_apps.go
+++ b/internal/services/containerapps/helpers/container_apps.go
@@ -1848,9 +1848,9 @@ type ContainerEnvVar struct {
 
 func ContainerEnvVarSchema() *pluginsdk.Schema {
 	return &pluginsdk.Schema{
-		Type:     pluginsdk.TypeList,
-		MinItems: 1,
+		Type:     pluginsdk.TypeSet,
 		Optional: true,
+		Set:      containerEnvVarHash,
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
 				"name": {
@@ -1861,14 +1861,34 @@ func ContainerEnvVarSchema() *pluginsdk.Schema {
 				},
 
 				"value": {
-					Type:        pluginsdk.TypeString,
-					Optional:    true,
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					DiffSuppressFunc: func(k, oldValue, newValue string, d *pluginsdk.ResourceData) bool {
+						secretNamePath := strings.TrimSuffix(k, ".value") + ".secret_name"
+						if secretName, ok := d.Get(secretNamePath).(string); ok && secretName != "" {
+							return true
+						}
+
+						return false
+					},
 					Description: "The value for this environment variable. **NOTE:** This value is ignored if `secret_name` is used",
 				},
 
 				"secret_name": {
-					Type:        pluginsdk.TypeString,
-					Optional:    true,
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					DiffSuppressFunc: func(k, oldValue, newValue string, d *pluginsdk.ResourceData) bool {
+						if strings.TrimSpace(oldValue) == "" && strings.TrimSpace(newValue) == "" {
+							return true
+						}
+
+						valuePath := strings.TrimSuffix(k, ".secret_name") + ".value"
+						if value, ok := d.Get(valuePath).(string); ok && value != "" {
+							return true
+						}
+
+						return false
+					},
 					Description: "The name of the secret that contains the value for this environment variable.",
 				},
 			},
@@ -1878,8 +1898,9 @@ func ContainerEnvVarSchema() *pluginsdk.Schema {
 
 func ContainerEnvVarSchemaComputed() *pluginsdk.Schema {
 	return &pluginsdk.Schema{
-		Type:     pluginsdk.TypeList,
+		Type:     pluginsdk.TypeSet,
 		Computed: true,
+		Set:      containerEnvVarHash,
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
 				"name": {
@@ -2850,16 +2871,56 @@ type Secret struct {
 	Value            string `tfschema:"value"`
 }
 
+func containerEnvVarHash(input interface{}) int {
+	if input == nil {
+		return 0
+	}
+
+	v, ok := input.(map[string]interface{})
+	if !ok {
+		return 0
+	}
+
+	name, _ := v["name"].(string)
+	secretName, _ := v["secret_name"].(string)
+	value, _ := v["value"].(string)
+
+	if secretName != "" {
+		return pluginsdk.HashString(strings.Join([]string{name, "secret", secretName}, "\x00"))
+	}
+
+	return pluginsdk.HashString(strings.Join([]string{name, "value", value}, "\x00"))
+}
+
+func containerSecretHash(input interface{}) int {
+	if input == nil {
+		return 0
+	}
+
+	v, ok := input.(map[string]interface{})
+	if !ok {
+		return 0
+	}
+
+	name, _ := v["name"].(string)
+
+	return pluginsdk.HashString(name)
+}
+
 func SecretsSchema() *pluginsdk.Schema {
 	s := &pluginsdk.Schema{
-		Type:      pluginsdk.TypeSet,
-		Optional:  true,
-		Sensitive: true,
+		Type:     pluginsdk.TypeSet,
+		Optional: true,
+		Set:      containerSecretHash,
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
 				"identity": {
 					Type:     pluginsdk.TypeString,
 					Optional: true,
+					Default:  "",
+					DiffSuppressFunc: func(k, oldValue, newValue string, d *pluginsdk.ResourceData) bool {
+						return strings.EqualFold(oldValue, newValue)
+					},
 					ValidateFunc: validation.Any(
 						commonids.ValidateUserAssignedIdentityID,
 						validation.StringInSlice([]string{"System"}, false),
@@ -2870,6 +2931,7 @@ func SecretsSchema() *pluginsdk.Schema {
 				"key_vault_secret_id": {
 					Type:         pluginsdk.TypeString,
 					Optional:     true,
+					Default:      "",
 					ValidateFunc: keyvault.ValidateNestedItemID(keyvault.VersionTypeAny, keyvault.NestedItemTypeSecret),
 					Description:  "The Key Vault Secret ID. Could be either one of `id` or `versionless_id`.",
 				},
@@ -2884,6 +2946,7 @@ func SecretsSchema() *pluginsdk.Schema {
 				"value": {
 					Type:        pluginsdk.TypeString,
 					Optional:    true,
+					Default:     "",
 					Sensitive:   true,
 					Description: "The value for this secret.",
 				},
@@ -2903,6 +2966,7 @@ func SecretsDataSourceSchema() *pluginsdk.Schema {
 		Type:      pluginsdk.TypeSet,
 		Computed:  true,
 		Sensitive: true,
+		Set:       containerSecretHash,
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
 				"identity": {
@@ -3010,15 +3074,57 @@ func FlattenContainerAppSecrets(input *containerapps.SecretsCollection) []Secret
 	}
 	result := make([]Secret, 0)
 	for _, v := range input.Value {
+		keyVaultSecretId := strings.TrimSpace(pointer.From(v.KeyVaultURL))
+		identity := strings.TrimSpace(pointer.From(v.Identity))
+
 		secret := Secret{
-			Identity:         pointer.From(v.Identity),
-			KeyVaultSecretId: pointer.From(v.KeyVaultURL),
+			Identity:         identity,
+			KeyVaultSecretId: keyVaultSecretId,
 			Name:             pointer.From(v.Name),
 		}
-		if v.KeyVaultURL == nil {
+		if keyVaultSecretId == "" {
 			secret.Value = pointer.From(v.Value)
 		}
 		result = append(result, secret)
+	}
+
+	return result
+}
+
+func PreserveContainerAppSecretValues(current []Secret, prior []Secret) []Secret {
+	if len(current) == 0 || len(prior) == 0 {
+		return current
+	}
+
+	priorValuesByName := make(map[string]string, len(prior))
+	for _, v := range prior {
+		if strings.TrimSpace(v.Name) == "" {
+			continue
+		}
+		if strings.TrimSpace(v.KeyVaultSecretId) != "" {
+			continue
+		}
+		if v.Value == "" {
+			continue
+		}
+
+		priorValuesByName[v.Name] = v.Value
+	}
+
+	result := make([]Secret, len(current))
+	copy(result, current)
+
+	for i := range result {
+		if strings.TrimSpace(result[i].KeyVaultSecretId) != "" {
+			continue
+		}
+		if result[i].Value != "" {
+			continue
+		}
+
+		if priorValue, ok := priorValuesByName[result[i].Name]; ok {
+			result[i].Value = priorValue
+		}
 	}
 
 	return result

--- a/internal/services/containerapps/helpers/container_apps_test.go
+++ b/internal/services/containerapps/helpers/container_apps_test.go
@@ -5,6 +5,9 @@ package helpers
 
 import (
 	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerapps"
 )
 
 func TestValidateContainerAppRegistry(t *testing.T) {
@@ -65,5 +68,108 @@ func TestValidateContainerAppRegistry(t *testing.T) {
 		if tc.Valid != valid {
 			t.Fatalf("Expected %t but got %t for %s", tc.Valid, valid, tc.Input)
 		}
+	}
+}
+
+func TestContainerEnvVarHashIdenticalEntries(t *testing.T) {
+	a := map[string]interface{}{"name": "LOREM_VAR", "value": "ipsum"}
+	b := map[string]interface{}{"name": "LOREM_VAR", "value": "ipsum"}
+	if containerEnvVarHash(a) != containerEnvVarHash(b) {
+		t.Fatal("expected equal hashes for identical entries")
+	}
+}
+
+func TestContainerEnvVarHashDifferentValues(t *testing.T) {
+	a := map[string]interface{}{"name": "LOREM_VAR", "value": "ipsum"}
+	b := map[string]interface{}{"name": "LOREM_VAR", "value": "dolor"}
+	if containerEnvVarHash(a) == containerEnvVarHash(b) {
+		t.Fatal("expected different hashes for different values")
+	}
+}
+
+func TestContainerEnvVarHashValueVsSecret(t *testing.T) {
+	a := map[string]interface{}{"name": "LOREM_VAR", "value": "ipsum"}
+	b := map[string]interface{}{"name": "LOREM_VAR", "secret_name": "sit-amet"}
+	if containerEnvVarHash(a) == containerEnvVarHash(b) {
+		t.Fatal("expected different hashes for value-backed vs secret-backed")
+	}
+}
+
+func TestContainerEnvVarHashValueEqualsSecretName(t *testing.T) {
+	a := map[string]interface{}{"name": "LOREM_VAR", "value": "consectetur", "secret_name": ""}
+	b := map[string]interface{}{"name": "LOREM_VAR", "value": "", "secret_name": "consectetur"}
+	if containerEnvVarHash(a) == containerEnvVarHash(b) {
+		t.Fatal("expected different hashes when value equals secret_name")
+	}
+}
+
+func TestContainerEnvVarHashDifferentSecretNames(t *testing.T) {
+	a := map[string]interface{}{"name": "LOREM_VAR", "secret_name": "adipiscing"}
+	b := map[string]interface{}{"name": "LOREM_VAR", "secret_name": "elit-sed"}
+	if containerEnvVarHash(a) == containerEnvVarHash(b) {
+		t.Fatal("expected different hashes for different secret_name values")
+	}
+}
+
+func TestContainerEnvVarHashDifferentNames(t *testing.T) {
+	a := map[string]interface{}{"name": "LOREM_VAR", "value": "ipsum"}
+	b := map[string]interface{}{"name": "DOLOR_VAR", "value": "ipsum"}
+	if containerEnvVarHash(a) == containerEnvVarHash(b) {
+		t.Fatal("expected different hashes for different names")
+	}
+}
+
+func TestContainerEnvVarHashCaseSensitive(t *testing.T) {
+	a := map[string]interface{}{"name": "LOREM_VAR", "value": "ipsum"}
+	b := map[string]interface{}{"name": "lorem_var", "value": "ipsum"}
+	if containerEnvVarHash(a) == containerEnvVarHash(b) {
+		t.Fatal("expected different hashes for different name casing")
+	}
+}
+
+func TestContainerSecretHashSameNameDifferentValue(t *testing.T) {
+	a := map[string]interface{}{"name": "lorem-secret", "value": "ipsum"}
+	b := map[string]interface{}{"name": "lorem-secret", "value": "dolor"}
+	if containerSecretHash(a) != containerSecretHash(b) {
+		t.Fatal("expected equal hashes — secret identity is name-only")
+	}
+}
+
+func TestContainerSecretHashDifferentNames(t *testing.T) {
+	a := map[string]interface{}{"name": "lorem-secret"}
+	b := map[string]interface{}{"name": "ipsum-secret"}
+	if containerSecretHash(a) == containerSecretHash(b) {
+		t.Fatal("expected different hashes for different secret names")
+	}
+}
+
+func TestFlattenContainerAppSecretsNormalizesBlankKeyVaultURL(t *testing.T) {
+	result := FlattenContainerAppSecrets(&containerapps.SecretsCollection{
+		Value: []containerapps.ContainerAppSecret{
+			{Name: pointer.To("lorem-secret"), KeyVaultURL: pointer.To(""), Value: pointer.To("ipsum")},
+		},
+	})
+	if len(result) != 1 || result[0].KeyVaultSecretId != "" || result[0].Value != "ipsum" {
+		t.Fatalf("expected value-backed secret with blank key_vault_secret_id, got %+v", result)
+	}
+}
+
+func TestPreserveContainerAppSecretValues(t *testing.T) {
+	current := []Secret{
+		{Name: "lorem-secret", Value: ""},
+		{Name: "dolor-secret", KeyVaultSecretId: "https://vault.example.net/secrets/amet", Value: ""},
+	}
+	prior := []Secret{
+		{Name: "lorem-secret", Value: "consectetur"},
+		{Name: "dolor-secret", KeyVaultSecretId: "https://vault.example.net/secrets/amet", Value: "ignored"},
+	}
+
+	result := PreserveContainerAppSecretValues(current, prior)
+
+	if result[0].Value != "consectetur" {
+		t.Fatalf("expected value-backed secret to be preserved, got %q", result[0].Value)
+	}
+	if result[1].Value != "" {
+		t.Fatalf("expected key-vault-backed secret value to stay empty, got %q", result[1].Value)
 	}
 }

--- a/internal/services/containerapps/migration/container_app_job_v0_to_v1.go
+++ b/internal/services/containerapps/migration/container_app_job_v0_to_v1.go
@@ -1,0 +1,718 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package migration
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type ContainerAppJobV0ToV1 struct{}
+
+func jobEnvSchemaV0() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		MinItems: 1,
+		Optional: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"name": {
+					Type:     pluginsdk.TypeString,
+					Required: true,
+				},
+				"value": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+				},
+				"secret_name": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+				},
+			},
+		},
+	}
+}
+
+func jobSecretSchemaV0() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:      pluginsdk.TypeSet,
+		Optional:  true,
+		Sensitive: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"identity": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+				},
+				"key_vault_secret_id": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+				},
+				"name": {
+					Type:     pluginsdk.TypeString,
+					Required: true,
+				},
+				"value": {
+					Type:      pluginsdk.TypeString,
+					Optional:  true,
+					Sensitive: true,
+				},
+			},
+		},
+	}
+}
+
+// jobProbeHeaderSchemaV0 returns the inlined header schema shared by all probe types.
+func jobProbeHeaderSchemaV0() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"name": {
+					Type:     pluginsdk.TypeString,
+					Required: true,
+				},
+				"value": {
+					Type:     pluginsdk.TypeString,
+					Required: true,
+				},
+			},
+		},
+	}
+}
+
+// jobLivenessProbeSchemaV0 returns the inlined liveness_probe schema at v0.
+func jobLivenessProbeSchemaV0() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		MinItems: 1,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"transport": {
+					Type:     pluginsdk.TypeString,
+					Required: true,
+				},
+				"port": {
+					Type:     pluginsdk.TypeInt,
+					Required: true,
+				},
+				"host": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+				},
+				"path": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+				"header": jobProbeHeaderSchemaV0(),
+				"initial_delay": {
+					Type:     pluginsdk.TypeInt,
+					Optional: true,
+					Default:  1,
+				},
+				"interval_seconds": {
+					Type:     pluginsdk.TypeInt,
+					Optional: true,
+					Default:  10,
+				},
+				"timeout": {
+					Type:     pluginsdk.TypeInt,
+					Optional: true,
+					Default:  1,
+				},
+				"failure_count_threshold": {
+					Type:     pluginsdk.TypeInt,
+					Optional: true,
+					Default:  3,
+				},
+				"termination_grace_period_seconds": {
+					Type:     pluginsdk.TypeInt,
+					Computed: true,
+				},
+			},
+		},
+	}
+}
+
+// jobReadinessProbeSchemaV0 returns the inlined readiness_probe schema at v0.
+func jobReadinessProbeSchemaV0() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		MinItems: 1,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"transport": {
+					Type:     pluginsdk.TypeString,
+					Required: true,
+				},
+				"port": {
+					Type:     pluginsdk.TypeInt,
+					Required: true,
+				},
+				"host": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+				},
+				"path": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+				"header": jobProbeHeaderSchemaV0(),
+				"initial_delay": {
+					Type:     pluginsdk.TypeInt,
+					Optional: true,
+					Default:  0,
+				},
+				"interval_seconds": {
+					Type:     pluginsdk.TypeInt,
+					Optional: true,
+					Default:  10,
+				},
+				"timeout": {
+					Type:     pluginsdk.TypeInt,
+					Optional: true,
+					Default:  1,
+				},
+				"failure_count_threshold": {
+					Type:     pluginsdk.TypeInt,
+					Optional: true,
+					Default:  3,
+				},
+				"success_count_threshold": {
+					Type:     pluginsdk.TypeInt,
+					Optional: true,
+					Default:  3,
+				},
+			},
+		},
+	}
+}
+
+// jobStartupProbeSchemaV0 returns the inlined startup_probe schema at v0.
+func jobStartupProbeSchemaV0() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		MinItems: 1,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"transport": {
+					Type:     pluginsdk.TypeString,
+					Required: true,
+				},
+				"port": {
+					Type:     pluginsdk.TypeInt,
+					Required: true,
+				},
+				"host": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+				},
+				"path": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+				"header": jobProbeHeaderSchemaV0(),
+				"initial_delay": {
+					Type:     pluginsdk.TypeInt,
+					Optional: true,
+					Default:  0,
+				},
+				"interval_seconds": {
+					Type:     pluginsdk.TypeInt,
+					Optional: true,
+					Default:  10,
+				},
+				"timeout": {
+					Type:     pluginsdk.TypeInt,
+					Optional: true,
+					Default:  1,
+				},
+				"failure_count_threshold": {
+					Type:     pluginsdk.TypeInt,
+					Optional: true,
+					Default:  3,
+				},
+				"termination_grace_period_seconds": {
+					Type:     pluginsdk.TypeInt,
+					Computed: true,
+				},
+			},
+		},
+	}
+}
+
+// jobVolumeMountSchemaV0 returns the inlined volume_mounts schema at v0.
+func jobVolumeMountSchemaV0() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"name": {
+					Type:     pluginsdk.TypeString,
+					Required: true,
+				},
+				"path": {
+					Type:     pluginsdk.TypeString,
+					Required: true,
+				},
+				"sub_path": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+				},
+			},
+		},
+	}
+}
+
+// jobScaleRuleAuthSchemaV0 returns the inlined authentication schema for scale rules.
+func jobScaleRuleAuthSchemaV0() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		MinItems: 1,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"secret_name": {
+					Type:     pluginsdk.TypeString,
+					Required: true,
+				},
+				"trigger_parameter": {
+					Type:     pluginsdk.TypeString,
+					Required: true,
+				},
+			},
+		},
+	}
+}
+
+func (ContainerAppJobV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+		},
+
+		"resource_group_name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+		},
+
+		"location": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+		},
+
+		"container_app_environment_id": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+		},
+
+		"workload_profile_name": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+		},
+
+		"template": {
+			Type:     pluginsdk.TypeList,
+			Required: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"container": {
+						Type:     pluginsdk.TypeList,
+						Required: true,
+						MinItems: 1,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"name": {
+									Type:     pluginsdk.TypeString,
+									Required: true,
+								},
+								"image": {
+									Type:     pluginsdk.TypeString,
+									Required: true,
+								},
+								"cpu": {
+									Type:     pluginsdk.TypeFloat,
+									Required: true,
+								},
+								"memory": {
+									Type:     pluginsdk.TypeString,
+									Required: true,
+								},
+								"ephemeral_storage": {
+									Type:     pluginsdk.TypeString,
+									Computed: true,
+								},
+								"env": jobEnvSchemaV0(),
+								"args": {
+									Type:     pluginsdk.TypeList,
+									Optional: true,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+								"command": {
+									Type:     pluginsdk.TypeList,
+									Optional: true,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+								"liveness_probe":  jobLivenessProbeSchemaV0(),
+								"readiness_probe": jobReadinessProbeSchemaV0(),
+								"startup_probe":   jobStartupProbeSchemaV0(),
+								"volume_mounts":   jobVolumeMountSchemaV0(),
+							},
+						},
+					},
+
+					"init_container": {
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						MinItems: 1,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"name": {
+									Type:     pluginsdk.TypeString,
+									Required: true,
+								},
+								"image": {
+									Type:     pluginsdk.TypeString,
+									Required: true,
+								},
+								"cpu": {
+									Type:     pluginsdk.TypeFloat,
+									Optional: true,
+								},
+								"memory": {
+									Type:     pluginsdk.TypeString,
+									Optional: true,
+								},
+								"ephemeral_storage": {
+									Type:     pluginsdk.TypeString,
+									Computed: true,
+								},
+								"env": jobEnvSchemaV0(),
+								"args": {
+									Type:     pluginsdk.TypeList,
+									Optional: true,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+								"command": {
+									Type:     pluginsdk.TypeList,
+									Optional: true,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+								"volume_mounts": jobVolumeMountSchemaV0(),
+							},
+						},
+					},
+
+					"volume": {
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						MinItems: 1,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"name": {
+									Type:     pluginsdk.TypeString,
+									Required: true,
+								},
+								"storage_type": {
+									Type:     pluginsdk.TypeString,
+									Optional: true,
+									Default:  "EmptyDir",
+								},
+								"storage_name": {
+									Type:     pluginsdk.TypeString,
+									Optional: true,
+								},
+								"mount_options": {
+									Type:     pluginsdk.TypeString,
+									Optional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+
+		"secret": jobSecretSchemaV0(),
+
+		"registry": {
+			Type:     pluginsdk.TypeList,
+			MinItems: 1,
+			Optional: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"server": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+					},
+					"username": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+					},
+					"password_secret_name": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+					},
+					"identity": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+					},
+				},
+			},
+		},
+
+		"identity": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"type": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+					},
+					"identity_ids": {
+						Type:     pluginsdk.TypeSet,
+						Optional: true,
+						Elem: &pluginsdk.Schema{
+							Type: pluginsdk.TypeString,
+						},
+					},
+					"principal_id": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+					"tenant_id": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+				},
+			},
+		},
+
+		"tags": {
+			Type:     pluginsdk.TypeMap,
+			Optional: true,
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+			},
+		},
+
+		"outbound_ip_addresses": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+			},
+		},
+
+		"id": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Computed: true,
+		},
+
+		"replica_timeout_in_seconds": {
+			Type:     pluginsdk.TypeInt,
+			Required: true,
+		},
+
+		"replica_retry_limit": {
+			Type:     pluginsdk.TypeInt,
+			Optional: true,
+		},
+
+		"event_trigger_config": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"parallelism": {
+						Type:     pluginsdk.TypeInt,
+						Optional: true,
+					},
+					"replica_completion_count": {
+						Type:     pluginsdk.TypeInt,
+						Optional: true,
+					},
+					"scale": {
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"max_executions": {
+									Type:     pluginsdk.TypeInt,
+									Optional: true,
+									Default:  100,
+								},
+								"min_executions": {
+									Type:     pluginsdk.TypeInt,
+									Optional: true,
+									Default:  0,
+								},
+								"polling_interval_in_seconds": {
+									Type:     pluginsdk.TypeInt,
+									Optional: true,
+									Default:  30,
+								},
+								"rules": {
+									Type:     pluginsdk.TypeList,
+									Optional: true,
+									Elem: &pluginsdk.Resource{
+										Schema: map[string]*pluginsdk.Schema{
+											"name": {
+												Type:     pluginsdk.TypeString,
+												Required: true,
+											},
+											"metadata": {
+												Type:     pluginsdk.TypeMap,
+												Required: true,
+												Elem: &pluginsdk.Schema{
+													Type: pluginsdk.TypeString,
+												},
+											},
+											"custom_rule_type": {
+												Type:     pluginsdk.TypeString,
+												Required: true,
+											},
+											"authentication": jobScaleRuleAuthSchemaV0(),
+											"identity_id": {
+												Type:     pluginsdk.TypeString,
+												Optional: true,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+
+		"schedule_trigger_config": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"cron_expression": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+					},
+					"parallelism": {
+						Type:     pluginsdk.TypeInt,
+						Optional: true,
+					},
+					"replica_completion_count": {
+						Type:     pluginsdk.TypeInt,
+						Optional: true,
+					},
+				},
+			},
+		},
+
+		"manual_trigger_config": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"parallelism": {
+						Type:     pluginsdk.TypeInt,
+						Optional: true,
+					},
+					"replica_completion_count": {
+						Type:     pluginsdk.TypeInt,
+						Optional: true,
+					},
+				},
+			},
+		},
+
+		"event_stream_endpoint": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+	}
+}
+
+func (ContainerAppJobV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		normalizeJobEnvVars(rawState)
+		normalizeJobSecrets(rawState)
+		return rawState, nil
+	}
+}
+
+func normalizeJobEnvVars(rawState map[string]interface{}) {
+	templates, _ := rawState["template"].([]interface{})
+	for _, tmpl := range templates {
+		tmplMap, ok := tmpl.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		for _, key := range []string{"container", "init_container"} {
+			containers, _ := tmplMap[key].([]interface{})
+			for _, c := range containers {
+				cMap, ok := c.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				envs, _ := cMap["env"].([]interface{})
+				for _, e := range envs {
+					eMap, ok := e.(map[string]interface{})
+					if !ok {
+						continue
+					}
+					if eMap["value"] == nil {
+						eMap["value"] = ""
+					}
+					if eMap["secret_name"] == nil {
+						eMap["secret_name"] = ""
+					}
+				}
+			}
+		}
+	}
+}
+
+func normalizeJobSecrets(rawState map[string]interface{}) {
+	secrets, _ := rawState["secret"].([]interface{})
+	for _, s := range secrets {
+		sMap, ok := s.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if sMap["identity"] == nil {
+			sMap["identity"] = ""
+		}
+		if sMap["key_vault_secret_id"] == nil {
+			sMap["key_vault_secret_id"] = ""
+		}
+		if sMap["value"] == nil {
+			sMap["value"] = ""
+		}
+	}
+}

--- a/internal/services/containerapps/migration/container_app_v0_to_v1.go
+++ b/internal/services/containerapps/migration/container_app_v0_to_v1.go
@@ -1,0 +1,940 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package migration
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type ContainerAppV0ToV1 struct{}
+
+func envSchemaV0() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		MinItems: 1,
+		Optional: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"name": {
+					Type:     pluginsdk.TypeString,
+					Required: true,
+				},
+				"value": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+				},
+				"secret_name": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+				},
+			},
+		},
+	}
+}
+
+func secretSchemaV0() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:      pluginsdk.TypeSet,
+		Optional:  true,
+		Sensitive: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"identity": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+				},
+				"key_vault_secret_id": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+				},
+				"name": {
+					Type:     pluginsdk.TypeString,
+					Required: true,
+				},
+				"value": {
+					Type:      pluginsdk.TypeString,
+					Optional:  true,
+					Sensitive: true,
+				},
+			},
+		},
+	}
+}
+
+// probeHeaderSchemaV0 returns the inlined header schema shared by all probe types.
+func probeHeaderSchemaV0() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"name": {
+					Type:     pluginsdk.TypeString,
+					Required: true,
+				},
+				"value": {
+					Type:     pluginsdk.TypeString,
+					Required: true,
+				},
+			},
+		},
+	}
+}
+
+// livenessProbeSchemaV0 returns the inlined liveness_probe schema at v0.
+func livenessProbeSchemaV0() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		MinItems: 1,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"transport": {
+					Type:     pluginsdk.TypeString,
+					Required: true,
+				},
+				"port": {
+					Type:     pluginsdk.TypeInt,
+					Required: true,
+				},
+				"host": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+				},
+				"path": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+				"header": probeHeaderSchemaV0(),
+				"initial_delay": {
+					Type:     pluginsdk.TypeInt,
+					Optional: true,
+					Default:  1,
+				},
+				"interval_seconds": {
+					Type:     pluginsdk.TypeInt,
+					Optional: true,
+					Default:  10,
+				},
+				"timeout": {
+					Type:     pluginsdk.TypeInt,
+					Optional: true,
+					Default:  1,
+				},
+				"failure_count_threshold": {
+					Type:     pluginsdk.TypeInt,
+					Optional: true,
+					Default:  3,
+				},
+				"termination_grace_period_seconds": {
+					Type:     pluginsdk.TypeInt,
+					Computed: true,
+				},
+			},
+		},
+	}
+}
+
+// readinessProbeSchemaV0 returns the inlined readiness_probe schema at v0.
+func readinessProbeSchemaV0() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		MinItems: 1,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"transport": {
+					Type:     pluginsdk.TypeString,
+					Required: true,
+				},
+				"port": {
+					Type:     pluginsdk.TypeInt,
+					Required: true,
+				},
+				"host": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+				},
+				"path": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+				"header": probeHeaderSchemaV0(),
+				"initial_delay": {
+					Type:     pluginsdk.TypeInt,
+					Optional: true,
+					Default:  0,
+				},
+				"interval_seconds": {
+					Type:     pluginsdk.TypeInt,
+					Optional: true,
+					Default:  10,
+				},
+				"timeout": {
+					Type:     pluginsdk.TypeInt,
+					Optional: true,
+					Default:  1,
+				},
+				"failure_count_threshold": {
+					Type:     pluginsdk.TypeInt,
+					Optional: true,
+					Default:  3,
+				},
+				"success_count_threshold": {
+					Type:     pluginsdk.TypeInt,
+					Optional: true,
+					Default:  3,
+				},
+			},
+		},
+	}
+}
+
+// startupProbeSchemaV0 returns the inlined startup_probe schema at v0.
+func startupProbeSchemaV0() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		MinItems: 1,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"transport": {
+					Type:     pluginsdk.TypeString,
+					Required: true,
+				},
+				"port": {
+					Type:     pluginsdk.TypeInt,
+					Required: true,
+				},
+				"host": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+				},
+				"path": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+				"header": probeHeaderSchemaV0(),
+				"initial_delay": {
+					Type:     pluginsdk.TypeInt,
+					Optional: true,
+					Default:  0,
+				},
+				"interval_seconds": {
+					Type:     pluginsdk.TypeInt,
+					Optional: true,
+					Default:  10,
+				},
+				"timeout": {
+					Type:     pluginsdk.TypeInt,
+					Optional: true,
+					Default:  1,
+				},
+				"failure_count_threshold": {
+					Type:     pluginsdk.TypeInt,
+					Optional: true,
+					Default:  3,
+				},
+				"termination_grace_period_seconds": {
+					Type:     pluginsdk.TypeInt,
+					Computed: true,
+				},
+			},
+		},
+	}
+}
+
+// volumeMountSchemaV0 returns the inlined volume_mounts schema at v0.
+func volumeMountSchemaV0() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"name": {
+					Type:     pluginsdk.TypeString,
+					Required: true,
+				},
+				"path": {
+					Type:     pluginsdk.TypeString,
+					Required: true,
+				},
+				"sub_path": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+				},
+			},
+		},
+	}
+}
+
+// scaleRuleAuthSchemaV0 returns the inlined authentication schema shared by scale rules.
+func scaleRuleAuthSchemaV0() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		MinItems: 1,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"secret_name": {
+					Type:     pluginsdk.TypeString,
+					Required: true,
+				},
+				"trigger_parameter": {
+					Type:     pluginsdk.TypeString,
+					Required: true,
+				},
+			},
+		},
+	}
+}
+
+// httpScaleRuleAuthSchemaV0 is the same as scaleRuleAuthSchemaV0 but trigger_parameter is Optional.
+func httpScaleRuleAuthSchemaV0() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		MinItems: 1,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"secret_name": {
+					Type:     pluginsdk.TypeString,
+					Required: true,
+				},
+				"trigger_parameter": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+				},
+			},
+		},
+	}
+}
+
+func (ContainerAppV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+		},
+
+		"resource_group_name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+		},
+
+		"location": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"container_app_environment_id": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+		},
+
+		"workload_profile_name": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+		},
+
+		"template": {
+			Type:     pluginsdk.TypeList,
+			MaxItems: 1,
+			Required: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"container": {
+						Type:     pluginsdk.TypeList,
+						Required: true,
+						MinItems: 1,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"name": {
+									Type:     pluginsdk.TypeString,
+									Required: true,
+								},
+								"image": {
+									Type:     pluginsdk.TypeString,
+									Required: true,
+								},
+								"cpu": {
+									Type:     pluginsdk.TypeFloat,
+									Required: true,
+								},
+								"memory": {
+									Type:     pluginsdk.TypeString,
+									Required: true,
+								},
+								"ephemeral_storage": {
+									Type:     pluginsdk.TypeString,
+									Computed: true,
+								},
+								"env": envSchemaV0(),
+								"args": {
+									Type:     pluginsdk.TypeList,
+									Optional: true,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+								"command": {
+									Type:     pluginsdk.TypeList,
+									Optional: true,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+								"liveness_probe":  livenessProbeSchemaV0(),
+								"readiness_probe": readinessProbeSchemaV0(),
+								"startup_probe":   startupProbeSchemaV0(),
+								"volume_mounts":   volumeMountSchemaV0(),
+							},
+						},
+					},
+
+					"init_container": {
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						MinItems: 1,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"name": {
+									Type:     pluginsdk.TypeString,
+									Required: true,
+								},
+								"image": {
+									Type:     pluginsdk.TypeString,
+									Required: true,
+								},
+								"cpu": {
+									Type:     pluginsdk.TypeFloat,
+									Optional: true,
+								},
+								"memory": {
+									Type:     pluginsdk.TypeString,
+									Optional: true,
+								},
+								"ephemeral_storage": {
+									Type:     pluginsdk.TypeString,
+									Computed: true,
+								},
+								"env": envSchemaV0(),
+								"args": {
+									Type:     pluginsdk.TypeList,
+									Optional: true,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+								"command": {
+									Type:     pluginsdk.TypeList,
+									Optional: true,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+								"volume_mounts": volumeMountSchemaV0(),
+							},
+						},
+					},
+
+					"min_replicas": {
+						Type:     pluginsdk.TypeInt,
+						Optional: true,
+						Default:  0,
+					},
+					"max_replicas": {
+						Type:     pluginsdk.TypeInt,
+						Optional: true,
+						Default:  10,
+					},
+					"cooldown_period_in_seconds": {
+						Type:     pluginsdk.TypeInt,
+						Optional: true,
+						Default:  300,
+					},
+					"polling_interval_in_seconds": {
+						Type:     pluginsdk.TypeInt,
+						Optional: true,
+						Default:  30,
+					},
+
+					"azure_queue_scale_rule": {
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"name": {
+									Type:     pluginsdk.TypeString,
+									Required: true,
+								},
+								"queue_length": {
+									Type:     pluginsdk.TypeInt,
+									Required: true,
+								},
+								"queue_name": {
+									Type:     pluginsdk.TypeString,
+									Required: true,
+								},
+								"authentication": scaleRuleAuthSchemaV0(),
+							},
+						},
+					},
+
+					"custom_scale_rule": {
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"name": {
+									Type:     pluginsdk.TypeString,
+									Required: true,
+								},
+								"metadata": {
+									Type:     pluginsdk.TypeMap,
+									Required: true,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+								"custom_rule_type": {
+									Type:     pluginsdk.TypeString,
+									Required: true,
+								},
+								"authentication": scaleRuleAuthSchemaV0(),
+								"identity_id": {
+									Type:     pluginsdk.TypeString,
+									Optional: true,
+								},
+							},
+						},
+					},
+
+					"http_scale_rule": {
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"name": {
+									Type:     pluginsdk.TypeString,
+									Required: true,
+								},
+								"concurrent_requests": {
+									Type:     pluginsdk.TypeString,
+									Required: true,
+								},
+								"authentication": httpScaleRuleAuthSchemaV0(),
+							},
+						},
+					},
+
+					"tcp_scale_rule": {
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"name": {
+									Type:     pluginsdk.TypeString,
+									Required: true,
+								},
+								"concurrent_requests": {
+									Type:     pluginsdk.TypeString,
+									Required: true,
+								},
+								"authentication": httpScaleRuleAuthSchemaV0(),
+							},
+						},
+					},
+
+					"volume": {
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						MinItems: 1,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"name": {
+									Type:     pluginsdk.TypeString,
+									Required: true,
+								},
+								"storage_type": {
+									Type:     pluginsdk.TypeString,
+									Optional: true,
+									Default:  "EmptyDir",
+								},
+								"storage_name": {
+									Type:     pluginsdk.TypeString,
+									Optional: true,
+								},
+								"mount_options": {
+									Type:     pluginsdk.TypeString,
+									Optional: true,
+								},
+							},
+						},
+					},
+
+					"revision_suffix": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						Computed: true,
+					},
+
+					"termination_grace_period_seconds": {
+						Type:     pluginsdk.TypeInt,
+						Optional: true,
+						Default:  0,
+					},
+				},
+			},
+		},
+
+		"secret": secretSchemaV0(),
+
+		"registry": {
+			Type:     pluginsdk.TypeList,
+			MinItems: 1,
+			Optional: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"server": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+					},
+					"username": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+					},
+					"password_secret_name": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+					},
+					"identity": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+					},
+				},
+			},
+		},
+
+		"identity": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"type": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+					},
+					"identity_ids": {
+						Type:     pluginsdk.TypeSet,
+						Optional: true,
+						Elem: &pluginsdk.Schema{
+							Type: pluginsdk.TypeString,
+						},
+					},
+					"principal_id": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+					"tenant_id": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+				},
+			},
+		},
+
+		"tags": {
+			Type:     pluginsdk.TypeMap,
+			Optional: true,
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+			},
+		},
+
+		"outbound_ip_addresses": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+			},
+		},
+
+		"id": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Computed: true,
+		},
+
+		"revision_mode": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+		},
+
+		"ingress": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"allow_insecure_connections": {
+						Type:     pluginsdk.TypeBool,
+						Optional: true,
+						Default:  false,
+					},
+					"external_enabled": {
+						Type:     pluginsdk.TypeBool,
+						Optional: true,
+						Default:  false,
+					},
+					"custom_domain": {
+						Type:     pluginsdk.TypeList,
+						Computed: true,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"certificate_binding_type": {
+									Type:     pluginsdk.TypeString,
+									Computed: true,
+								},
+								"certificate_id": {
+									Type:     pluginsdk.TypeString,
+									Computed: true,
+								},
+								"name": {
+									Type:     pluginsdk.TypeString,
+									Computed: true,
+								},
+							},
+						},
+					},
+					"cors": {
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						MaxItems: 1,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"allowed_origins": {
+									Type:     pluginsdk.TypeList,
+									Required: true,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+								"allow_credentials_enabled": {
+									Type:     pluginsdk.TypeBool,
+									Optional: true,
+									Default:  false,
+								},
+								"allowed_headers": {
+									Type:     pluginsdk.TypeList,
+									Optional: true,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+								"allowed_methods": {
+									Type:     pluginsdk.TypeList,
+									Optional: true,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+								"exposed_headers": {
+									Type:     pluginsdk.TypeList,
+									Optional: true,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+								"max_age_in_seconds": {
+									Type:     pluginsdk.TypeInt,
+									Optional: true,
+								},
+							},
+						},
+					},
+					"fqdn": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+					"ip_security_restriction": {
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"action": {
+									Type:     pluginsdk.TypeString,
+									Required: true,
+								},
+								"description": {
+									Type:     pluginsdk.TypeString,
+									Optional: true,
+								},
+								"ip_address_range": {
+									Type:     pluginsdk.TypeString,
+									Required: true,
+								},
+								"name": {
+									Type:     pluginsdk.TypeString,
+									Required: true,
+								},
+							},
+						},
+					},
+					"target_port": {
+						Type:     pluginsdk.TypeInt,
+						Required: true,
+					},
+					"exposed_port": {
+						Type:     pluginsdk.TypeInt,
+						Optional: true,
+					},
+					"traffic_weight": {
+						Type:     pluginsdk.TypeList,
+						Required: true,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"label": {
+									Type:     pluginsdk.TypeString,
+									Optional: true,
+								},
+								"revision_suffix": {
+									Type:     pluginsdk.TypeString,
+									Optional: true,
+								},
+								"latest_revision": {
+									Type:     pluginsdk.TypeBool,
+									Optional: true,
+									Default:  false,
+								},
+								"percentage": {
+									Type:     pluginsdk.TypeInt,
+									Required: true,
+								},
+							},
+						},
+					},
+					"transport": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						Default:  "auto",
+					},
+					"client_certificate_mode": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+					},
+				},
+			},
+		},
+
+		"dapr": {
+			Type:     pluginsdk.TypeList,
+			MaxItems: 1,
+			Optional: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"app_id": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+					},
+					"app_port": {
+						Type:     pluginsdk.TypeInt,
+						Optional: true,
+					},
+					"app_protocol": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						Default:  "http",
+					},
+				},
+			},
+		},
+
+		"max_inactive_revisions": {
+			Type:     pluginsdk.TypeInt,
+			Optional: true,
+		},
+
+		"latest_revision_name": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"latest_revision_fqdn": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"custom_domain_verification_id": {
+			Type:      pluginsdk.TypeString,
+			Computed:  true,
+			Sensitive: true,
+		},
+	}
+}
+
+func (ContainerAppV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		normalizeEnvVars(rawState)
+		normalizeSecrets(rawState)
+		return rawState, nil
+	}
+}
+
+func normalizeEnvVars(rawState map[string]interface{}) {
+	templates, _ := rawState["template"].([]interface{})
+	for _, tmpl := range templates {
+		tmplMap, ok := tmpl.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		for _, key := range []string{"container", "init_container"} {
+			containers, _ := tmplMap[key].([]interface{})
+			for _, c := range containers {
+				cMap, ok := c.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				envs, _ := cMap["env"].([]interface{})
+				for _, e := range envs {
+					eMap, ok := e.(map[string]interface{})
+					if !ok {
+						continue
+					}
+					if eMap["value"] == nil {
+						eMap["value"] = ""
+					}
+					if eMap["secret_name"] == nil {
+						eMap["secret_name"] = ""
+					}
+				}
+			}
+		}
+	}
+}
+
+func normalizeSecrets(rawState map[string]interface{}) {
+	secrets, _ := rawState["secret"].([]interface{})
+	for _, s := range secrets {
+		sMap, ok := s.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if sMap["identity"] == nil {
+			sMap["identity"] = ""
+		}
+		if sMap["key_vault_secret_id"] == nil {
+			sMap["key_vault_secret_id"] = ""
+		}
+		if sMap["value"] == nil {
+			sMap["value"] = ""
+		}
+	}
+}


### PR DESCRIPTION
<!--  All Submissions -->
## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review
## Description
<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 
If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->
Both `azurerm_container_app` and `azurerm_container_app_job` produce noisy remove/re-add diffs on every `terraform plan` for `env` and `secret` blocks, even when nothing has changed. The root causes are:
1. **`env` uses `TypeList`** — any reordering by the API (or in HCL) causes index-based churn across all entries.
2. **`secret` optional fields lack `Default:""`** — Terraform stores `null` in state but reads back `""`, causing the full set to be replaced every plan.
3. **Set-level `Sensitive` on `secret`** — prevents Terraform from showing which secret changed, making diffs unreadable.
4. **API doesn't return secret plain-text values** — every refresh loses stored values without explicit preservation.
This PR fixes all four issues by:
- Converting `env` from `TypeList` to `TypeSet` with a custom hash function (keyed on name + type discriminator + value/secret_name).
- Adding `Default:""` to all optional string fields in the `secret` schema to eliminate null-vs-empty diffs.
- Moving `Sensitive` from the set level to only the `secret.value` field.
- Adding `DiffSuppressFunc` on `env.value`/`env.secret_name` (cross-field irrelevance) and `secret.identity` (case-insensitive Azure resource IDs).
- Adding `PreserveContainerAppSecretValues` to carry forward prior state values that the API doesn't return.
- Adding a v0→v1 state migration that normalizes `nil` to `""` for fields that gained defaults.
A one-time state migration runs automatically on upgrade. Users can persist it with `terraform apply -refresh-only`.
## PR Checklist
- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: "`resource_name_here` - description of change e.g. adding property `new_property_name_here`"
<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->
## Changes to existing Resource / Data Source
- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [x] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.
## Testing 
- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)
<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 
For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->
Unit tests cover hash functions (including collision resistance between value-backed and secret-backed env vars), `FlattenContainerAppSecrets` blank KeyVaultURL normalization, and `PreserveContainerAppSecretValues` carry-forward logic.
State migration tested manually by building the provider from the commit prior to this change, applying a configuration with multiple env vars and secrets, then upgrading to this branch and verifying:
- `terraform plan` shows no unexpected diffs
- `terraform plan -refresh=false` shows no diffs
- `terraform state show` reflects the migrated state
- `terraform apply -refresh-only -auto-approve` persists the migration cleanly
## Change Log
Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).
<!-- Replace the changelog example below with your entry. One resource per line. -->
* `azurerm_container_app` - fix perpetual diffs in `env` and `secret` blocks due to ordering sensitivity [GH-29743] [GH-31376]
* `azurerm_container_app_job` - fix perpetual diffs in `env` and `secret` blocks due to ordering sensitivity.
<!-- What type of PR is this? -->
This is a (please select all that apply):
- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change
## Related Issue(s)
Fixes #29743
Fixes #31376
## AI Assistance Disclosure
<!-- 
IMPORTANT!
If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.
If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)
If responses to this pull request are/will be generated using AI, disclose this as well.
-->
- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs
<!-- extent of AI usage can be described here -->
AI (Claude) was used to help with code generation, test writing, debugging and wording this PR description.
All changes were reviewed, edited and tested manually against real Azure infrastructure.
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan
If a change needs to be reverted, we will publish an updated version of the provider.
## Changes to Security Controls
Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
No changes to security controls. The only security-adjacent change is moving `Sensitive` from the set level to the individual `secret.value` field, which preserves the same protection while improving plan readability.
> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.