### PR TITLE
`azurerm_mssql_managed_instance_start_stop_schedule` - update `schedule` from `TypeList` to `TypeSet`

### DIFF
--- a/internal/services/mssqlmanagedinstance/migration/managed_instance_start_stop_schedule_v0_to_v1.go
+++ b/internal/services/mssqlmanagedinstance/migration/managed_instance_start_stop_schedule_v0_to_v1.go
@@ -1,0 +1,110 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package migration
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+var _ pluginsdk.StateUpgrade = MsSqlManagedInstanceStartStopScheduleV0ToV1{}
+
+type MsSqlManagedInstanceStartStopScheduleV0ToV1 struct{}
+
+func (MsSqlManagedInstanceStartStopScheduleV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"managed_instance_id": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"description": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+		},
+
+		"schedule": {
+			Type:     pluginsdk.TypeList,
+			Required: true,
+			MinItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"start_day": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+					},
+
+					"start_time": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+					},
+
+					"stop_day": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+					},
+
+					"stop_time": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+					},
+				},
+			},
+		},
+
+		"timezone_id": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Default:  "UTC",
+		},
+
+		"next_execution_time": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"next_run_action": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+	}
+}
+
+func (MsSqlManagedInstanceStartStopScheduleV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		if schedules, ok := rawState["schedule"].([]interface{}); ok {
+			rawState["schedule"] = pluginsdk.NewSet(pluginsdk.HashResource(startStopScheduleItemSchema()), schedules)
+		}
+
+		return rawState, nil
+	}
+}
+
+func startStopScheduleItemSchema() *pluginsdk.Resource {
+	return &pluginsdk.Resource{
+		Schema: map[string]*pluginsdk.Schema{
+			"start_day": {
+				Type:     pluginsdk.TypeString,
+				Required: true,
+			},
+
+			"start_time": {
+				Type:     pluginsdk.TypeString,
+				Required: true,
+			},
+
+			"stop_day": {
+				Type:     pluginsdk.TypeString,
+				Required: true,
+			},
+
+			"stop_time": {
+				Type:     pluginsdk.TypeString,
+				Required: true,
+			},
+		},
+	}
+}

--- a/internal/services/mssqlmanagedinstance/migration/managed_instance_start_stop_schedule_v0_to_v1.go
+++ b/internal/services/mssqlmanagedinstance/migration/managed_instance_start_stop_schedule_v0_to_v1.go
@@ -75,36 +75,6 @@ func (MsSqlManagedInstanceStartStopScheduleV0ToV1) Schema() map[string]*pluginsd
 
 func (MsSqlManagedInstanceStartStopScheduleV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
 	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-		if schedules, ok := rawState["schedule"].([]interface{}); ok {
-			rawState["schedule"] = pluginsdk.NewSet(pluginsdk.HashResource(startStopScheduleItemSchema()), schedules)
-		}
-
 		return rawState, nil
-	}
-}
-
-func startStopScheduleItemSchema() *pluginsdk.Resource {
-	return &pluginsdk.Resource{
-		Schema: map[string]*pluginsdk.Schema{
-			"start_day": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-			},
-
-			"start_time": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-			},
-
-			"stop_day": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-			},
-
-			"stop_time": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-			},
-		},
 	}
 }

--- a/internal/services/mssqlmanagedinstance/migration/managed_instance_start_stop_schedule_v0_to_v1.go
+++ b/internal/services/mssqlmanagedinstance/migration/managed_instance_start_stop_schedule_v0_to_v1.go
@@ -18,7 +18,6 @@ func (MsSqlManagedInstanceStartStopScheduleV0ToV1) Schema() map[string]*pluginsd
 		"managed_instance_id": {
 			Type:     pluginsdk.TypeString,
 			Required: true,
-			ForceNew: true,
 		},
 
 		"description": {
@@ -29,7 +28,6 @@ func (MsSqlManagedInstanceStartStopScheduleV0ToV1) Schema() map[string]*pluginsd
 		"schedule": {
 			Type:     pluginsdk.TypeList,
 			Required: true,
-			MinItems: 1,
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
 					"start_day": {
@@ -58,7 +56,6 @@ func (MsSqlManagedInstanceStartStopScheduleV0ToV1) Schema() map[string]*pluginsd
 		"timezone_id": {
 			Type:     pluginsdk.TypeString,
 			Optional: true,
-			Default:  "UTC",
 		},
 
 		"next_execution_time": {

--- a/internal/services/mssqlmanagedinstance/migration/managed_instance_start_stop_schedule_v0_to_v1_test.go
+++ b/internal/services/mssqlmanagedinstance/migration/managed_instance_start_stop_schedule_v0_to_v1_test.go
@@ -1,0 +1,38 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package migration
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+func TestMsSqlManagedInstanceStartStopScheduleV0ToV1(t *testing.T) {
+	input := map[string]interface{}{
+		"managed_instance_id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Sql/managedInstances/instance1",
+		"schedule": []interface{}{
+			map[string]interface{}{
+				"start_day":  "Wednesday",
+				"start_time": "11:00",
+				"stop_day":   "Wednesday",
+				"stop_time":  "23:00",
+			},
+		},
+		"timezone_id": "UTC",
+	}
+
+	actual, err := MsSqlManagedInstanceStartStopScheduleV0ToV1{}.UpgradeFunc()(context.TODO(), input, nil)
+	if err != nil {
+		t.Fatalf("expected no error but got: %+v", err)
+	}
+
+	if _, ok := actual["schedule"].([]interface{}); !ok {
+		t.Fatalf("expected schedule to remain a JSON-serializable slice, got %T", actual["schedule"])
+	}
+
+	if _, err := json.Marshal(actual); err != nil {
+		t.Fatalf("expected upgraded state to be JSON serializable, got: %+v", err)
+	}
+}

--- a/internal/services/mssqlmanagedinstance/mssql_managed_instance_start_stop_schedule_resource.go
+++ b/internal/services/mssqlmanagedinstance/mssql_managed_instance_start_stop_schedule_resource.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	schedule "github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-08-01-preview/startstopmanagedinstanceschedules"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/mssqlmanagedinstance/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/mssqlmanagedinstance/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/mssqlmanagedinstance/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -37,7 +38,10 @@ type ScheduleItemModel struct {
 
 type MsSqlManagedInstanceStartStopScheduleResource struct{}
 
-var _ sdk.ResourceWithUpdate = MsSqlManagedInstanceStartStopScheduleResource{}
+var (
+	_ sdk.ResourceWithUpdate         = MsSqlManagedInstanceStartStopScheduleResource{}
+	_ sdk.ResourceWithStateMigration = MsSqlManagedInstanceStartStopScheduleResource{}
+)
 
 func (r MsSqlManagedInstanceStartStopScheduleResource) ResourceType() string {
 	return "azurerm_mssql_managed_instance_start_stop_schedule"
@@ -49,6 +53,15 @@ func (r MsSqlManagedInstanceStartStopScheduleResource) ModelObject() interface{}
 
 func (r MsSqlManagedInstanceStartStopScheduleResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
 	return validate.ManagedInstanceStartStopScheduleID
+}
+
+func (r MsSqlManagedInstanceStartStopScheduleResource) StateUpgraders() sdk.StateUpgradeData {
+	return sdk.StateUpgradeData{
+		SchemaVersion: 1,
+		Upgraders: map[int]pluginsdk.StateUpgrade{
+			0: migration.MsSqlManagedInstanceStartStopScheduleV0ToV1{},
+		},
+	}
 }
 
 func (r MsSqlManagedInstanceStartStopScheduleResource) Arguments() map[string]*pluginsdk.Schema {
@@ -66,7 +79,7 @@ func (r MsSqlManagedInstanceStartStopScheduleResource) Arguments() map[string]*p
 		},
 
 		"schedule": {
-			Type:     pluginsdk.TypeList,
+			Type:     pluginsdk.TypeSet,
 			Required: true,
 			MinItems: 1,
 			Elem: &pluginsdk.Resource{

--- a/internal/services/mssqlmanagedinstance/mssql_managed_instance_start_stop_schedule_resource_test.go
+++ b/internal/services/mssqlmanagedinstance/mssql_managed_instance_start_stop_schedule_resource_test.go
@@ -126,10 +126,24 @@ resource "azurerm_mssql_managed_instance_start_stop_schedule" "test" {
   description         = "test description"
   timezone_id         = "Central European Standard Time"
   schedule {
+    start_day  = "Monday"
+    start_time = "08:00"
+    stop_day   = "Monday"
+    stop_time  = "20:00"
+  }
+
+  schedule {
     start_day  = "Wednesday"
     start_time = "11:00"
     stop_day   = "Wednesday"
     stop_time  = "23:00"
+  }
+
+  schedule {
+    start_day  = "Friday"
+    start_time = "09:00"
+    stop_day   = "Friday"
+    stop_time  = "21:00"
   }
 }
 `, r.template(data))
@@ -143,6 +157,12 @@ resource "azurerm_mssql_managed_instance_start_stop_schedule" "test" {
   description         = "updated test description"
   timezone_id         = "Central European Standard Time"
   schedule {
+    start_day  = "Monday"
+    start_time = "08:00"
+    stop_day   = "Monday"
+    stop_time  = "20:00"
+  }
+  schedule {
     start_day  = "Wednesday"
     start_time = "10:00"
     stop_day   = "Wednesday"
@@ -153,6 +173,12 @@ resource "azurerm_mssql_managed_instance_start_stop_schedule" "test" {
     start_time = "11:00"
     stop_day   = "Thursday"
     stop_time  = "23:00"
+  }
+  schedule {
+    start_day  = "Friday"
+    start_time = "09:00"
+    stop_day   = "Friday"
+    stop_time  = "21:00"
   }
 }
 `, r.template(data))
@@ -165,10 +191,10 @@ func (r sqlManagedInstanceStartStopScheduleResource) requiresImport(data accepta
 resource "azurerm_mssql_managed_instance_start_stop_schedule" "import" {
   managed_instance_id = azurerm_mssql_managed_instance_start_stop_schedule.test.managed_instance_id
   schedule {
-    start_day  = azurerm_mssql_managed_instance_start_stop_schedule.test.schedule.0.start_day
-    start_time = azurerm_mssql_managed_instance_start_stop_schedule.test.schedule.0.start_time
-    stop_day   = azurerm_mssql_managed_instance_start_stop_schedule.test.schedule.0.stop_day
-    stop_time  = azurerm_mssql_managed_instance_start_stop_schedule.test.schedule.0.stop_time
+    start_day  = "Wednesday"
+    start_time = "11:00"
+    stop_day   = "Wednesday"
+    stop_time  = "23:00"
   }
 }
 `, r.basic(data))


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

The service returns a re-ordered `schedule`, which causes diff. So updating to use `TypeSet`

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [x] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<img width="1086" height="990" alt="image" src="https://github.com/user-attachments/assets/58eec5fe-61e5-406c-a723-b61813870450" />



manual test for state migration:
1. created the resource with current released AzureRM provider
2. use the local build AzureRM provider from this branch
>No changes. Your infrastructure matches the configuration.

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_mssql_managed_instance_start_stop_schedule` - update `schedule` from `TypeList` to `TypeSet` [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #32340


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

Used AI to review and anaylyze

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
