### PR TITLE
`azurerm_kubernetes_cluster` and `azurerm_kubernetes_cluster_node_pool` - support `local_dns_profile`

### DIFF
--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -228,7 +228,7 @@ func resourceKubernetesClusterNodePoolSchema() map[string]*pluginsdk.Schema {
 
 		"linux_os_config": schemaNodePoolLinuxOSConfig(),
 
-		"local_dns_profile": schemaNodePoolResourceLocalDNSProfile(),
+		"local_dns_profile": schemaNodePoolLocalDNSProfile(),
 
 		"fips_enabled": {
 			Type:     pluginsdk.TypeBool,
@@ -1966,10 +1966,6 @@ func flattenAgentPoolNetworkProfileNodePublicIPTags(input *[]agentpools.IPTag) m
 	}
 
 	return out
-}
-
-func schemaNodePoolResourceLocalDNSProfile() *pluginsdk.Schema {
-	return schemaNodePoolLocalDNSProfile()
 }
 
 func expandAgentPoolLocalDNSProfile(input []interface{}) *agentpools.LocalDNSProfile {

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -90,6 +90,9 @@ func resourceKubernetesClusterNodePool() *pluginsdk.Resource {
 				return old != "" && new == ""
 			}),
 			func(ctx context.Context, d *pluginsdk.ResourceDiff, meta interface{}) error {
+				return validateNodePoolLocalDNSProfileRawConfig(d)
+			},
+			func(ctx context.Context, d *pluginsdk.ResourceDiff, meta interface{}) error {
 				priority := d.Get("priority").(string)
 				isSpot := priority == string(agentpools.ScaleSetPrioritySpot)
 
@@ -1966,11 +1969,7 @@ func flattenAgentPoolNetworkProfileNodePublicIPTags(input *[]agentpools.IPTag) m
 }
 
 func schemaNodePoolResourceLocalDNSProfile() *pluginsdk.Schema {
-	return schemaNodePoolLocalDNSProfile([]string{
-		"local_dns_profile.0.kube_dns_override",
-		"local_dns_profile.0.mode",
-		"local_dns_profile.0.vnet_dns_override",
-	})
+	return schemaNodePoolLocalDNSProfile()
 }
 
 func expandAgentPoolLocalDNSProfile(input []interface{}) *agentpools.LocalDNSProfile {

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -225,6 +225,8 @@ func resourceKubernetesClusterNodePoolSchema() map[string]*pluginsdk.Schema {
 
 		"linux_os_config": schemaNodePoolLinuxOSConfig(),
 
+		"local_dns_profile": schemaNodePoolResourceLocalDNSProfile(),
+
 		"fips_enabled": {
 			Type:     pluginsdk.TypeBool,
 			Optional: true,
@@ -744,6 +746,10 @@ func resourceKubernetesClusterNodePoolCreate(d *pluginsdk.ResourceData, meta int
 		profile.NetworkProfile = expandAgentPoolNetworkProfile(networkProfile)
 	}
 
+	if localDNSProfile := d.Get("local_dns_profile").([]interface{}); len(localDNSProfile) > 0 {
+		profile.LocalDNSProfile = expandAgentPoolLocalDNSProfile(localDNSProfile)
+	}
+
 	if snapshotId := d.Get("snapshot_id").(string); snapshotId != "" {
 		profile.CreationData = &agentpools.CreationData{
 			SourceResourceId: pointer.To(snapshotId),
@@ -971,6 +977,10 @@ func resourceKubernetesClusterNodePoolUpdate(d *pluginsdk.ResourceData, meta int
 
 	if d.HasChange("node_network_profile") {
 		props.NetworkProfile = expandAgentPoolNetworkProfile(d.Get("node_network_profile").([]interface{}))
+	}
+
+	if d.HasChange("local_dns_profile") {
+		props.LocalDNSProfile = expandAgentPoolLocalDNSProfile(d.Get("local_dns_profile").([]interface{}))
 	}
 
 	if d.HasChange("zones") {
@@ -1283,6 +1293,10 @@ func resourceKubernetesClusterNodePoolRead(d *pluginsdk.ResourceData, meta inter
 
 		if err := d.Set("node_network_profile", flattenAgentPoolNetworkProfile(props.NetworkProfile)); err != nil {
 			return fmt.Errorf("setting `node_network_profile`: %+v", err)
+		}
+
+		if err := d.Set("local_dns_profile", flattenAgentPoolLocalDNSProfile(props.LocalDNSProfile)); err != nil {
+			return fmt.Errorf("setting `local_dns_profile`: %+v", err)
 		}
 	}
 
@@ -1949,4 +1963,113 @@ func flattenAgentPoolNetworkProfileNodePublicIPTags(input *[]agentpools.IPTag) m
 	}
 
 	return out
+}
+
+func schemaNodePoolResourceLocalDNSProfile() *pluginsdk.Schema {
+	return schemaNodePoolLocalDNSProfile([]string{
+		"local_dns_profile.0.kube_dns_override",
+		"local_dns_profile.0.mode",
+		"local_dns_profile.0.vnet_dns_override",
+	})
+}
+
+func expandAgentPoolLocalDNSProfile(input []interface{}) *agentpools.LocalDNSProfile {
+	if len(input) == 0 || input[0] == nil {
+		return nil
+	}
+
+	raw := input[0].(map[string]interface{})
+	result := &agentpools.LocalDNSProfile{}
+
+	if v := raw["mode"].(string); v != "" {
+		result.Mode = pointer.ToEnum[agentpools.LocalDNSMode](v)
+	}
+
+	if v, ok := raw["kube_dns_override"].(*pluginsdk.Set); ok && v != nil {
+		result.KubeDNSOverrides = expandAgentPoolLocalDNSOverrides(v.List())
+	}
+	if v, ok := raw["vnet_dns_override"].(*pluginsdk.Set); ok && v != nil {
+		result.VnetDNSOverrides = expandAgentPoolLocalDNSOverrides(v.List())
+	}
+
+	return result
+}
+
+func expandAgentPoolLocalDNSOverrides(input []interface{}) *map[string]agentpools.LocalDNSOverride {
+	if len(input) == 0 {
+		return nil
+	}
+
+	result := make(map[string]agentpools.LocalDNSOverride)
+	for _, item := range input {
+		raw := item.(map[string]interface{})
+		domain := raw["domain"].(string)
+		override := agentpools.LocalDNSOverride{}
+
+		if v := raw["serve_stale"].(string); v != "" {
+			override.ServeStale = pointer.ToEnum[agentpools.LocalDNSServeStale](v)
+		}
+		if v := raw["serve_stale_duration"].(int); v > 0 {
+			override.ServeStaleDurationInSeconds = pointer.To(int64(v))
+		}
+		if v := raw["query_logging"].(string); v != "" {
+			override.QueryLogging = pointer.ToEnum[agentpools.LocalDNSQueryLogging](v)
+		}
+		if v := raw["protocol"].(string); v != "" {
+			override.Protocol = pointer.ToEnum[agentpools.LocalDNSProtocol](v)
+		}
+		if v := raw["forward_destination"].(string); v != "" {
+			override.ForwardDestination = pointer.ToEnum[agentpools.LocalDNSForwardDestination](v)
+		}
+		if v := raw["forward_policy"].(string); v != "" {
+			override.ForwardPolicy = pointer.ToEnum[agentpools.LocalDNSForwardPolicy](v)
+		}
+		if v := raw["max_concurrent"].(int); v > 0 {
+			override.MaxConcurrent = pointer.To(int64(v))
+		}
+		if v := raw["cache_duration_in_seconds"].(int); v > 0 {
+			override.CacheDurationInSeconds = pointer.To(int64(v))
+		}
+
+		result[domain] = override
+	}
+
+	return &result
+}
+
+func flattenAgentPoolLocalDNSProfile(input *agentpools.LocalDNSProfile) []interface{} {
+	if input == nil || (input.Mode == nil && (input.VnetDNSOverrides == nil || len(*input.VnetDNSOverrides) == 0) && (input.KubeDNSOverrides == nil || len(*input.KubeDNSOverrides) == 0)) {
+		return []interface{}{}
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"mode":              string(pointer.From(input.Mode)),
+			"vnet_dns_override": flattenAgentPoolLocalDNSOverrides(input.VnetDNSOverrides),
+			"kube_dns_override": flattenAgentPoolLocalDNSOverrides(input.KubeDNSOverrides),
+		},
+	}
+}
+
+func flattenAgentPoolLocalDNSOverrides(input *map[string]agentpools.LocalDNSOverride) []interface{} {
+	if input == nil {
+		return []interface{}{}
+	}
+
+	results := make([]interface{}, 0)
+	for domain, override := range *input {
+		results = append(results, map[string]interface{}{
+			"domain":                    domain,
+			"serve_stale":               string(pointer.From(override.ServeStale)),
+			"serve_stale_duration":      int(pointer.From(override.ServeStaleDurationInSeconds)),
+			"query_logging":             string(pointer.From(override.QueryLogging)),
+			"protocol":                  string(pointer.From(override.Protocol)),
+			"forward_destination":       string(pointer.From(override.ForwardDestination)),
+			"forward_policy":            string(pointer.From(override.ForwardPolicy)),
+			"max_concurrent":            int(pointer.From(override.MaxConcurrent)),
+			"cache_duration_in_seconds": int(pointer.From(override.CacheDurationInSeconds)),
+		})
+	}
+
+	return results
 }

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -4356,6 +4356,11 @@ resource "azurerm_kubernetes_cluster" "test" {
     }
   }
 
+  node_provisioning_profile {
+    mode               = "Manual"
+    default_node_pools = "Auto"
+  }
+
   identity {
     type = "SystemAssigned"
   }
@@ -4465,6 +4470,11 @@ resource "azurerm_kubernetes_cluster" "test" {
     upgrade_settings {
       max_surge = "10%%%%"
     }
+  }
+
+  node_provisioning_profile {
+    mode               = "Manual"
+    default_node_pools = "Auto"
   }
 
   identity {

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -4498,18 +4498,6 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
     }
 
     vnet_dns_override {
-      domain                    = "mycustom.local"
-      serve_stale               = "Verify"
-      serve_stale_duration      = 3600
-      query_logging             = "Error"
-      protocol                  = "PreferUDP"
-      forward_destination       = "VnetDNS"
-      forward_policy            = "RoundRobin"
-      max_concurrent            = 2000
-      cache_duration_in_seconds = 7200
-    }
-
-    vnet_dns_override {
       domain                    = "cluster.local"
       serve_stale               = "Verify"
       serve_stale_duration      = 3600

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -1496,6 +1496,43 @@ func TestAccKubernetesClusterNodePool_VMSizeOmitted(t *testing.T) {
 	})
 }
 
+func TestAccKubernetesClusterNodePool_localDNSProfile(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster_node_pool", "test")
+	r := KubernetesClusterNodePoolResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.localDNSProfile(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccKubernetesClusterNodePool_localDNSProfileUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster_node_pool", "test")
+	r := KubernetesClusterNodePoolResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.localDNSProfile(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.localDNSProfileUpdated(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (r KubernetesClusterNodePoolResource) autoScaleConfig(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -4273,6 +4310,240 @@ resource "azurerm_kubernetes_cluster_node_pool" "pool2" {
   vnet_subnet_id        = azurerm_subnet.nodesubnet2.id
   upgrade_settings {
     max_surge = "10%%"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (KubernetesClusterNodePoolResource) localDNSProfile(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%[1]d"
+  address_space       = ["10.1.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctestsubnet%[1]d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.1.0.0/24"]
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%[1]d"
+
+  default_node_pool {
+    name           = "default"
+    node_count     = 1
+    vm_size        = "Standard_D4s_v3"
+    vnet_subnet_id = azurerm_subnet.test.id
+    upgrade_settings {
+      max_surge = "10%%%%"
+    }
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+resource "azurerm_kubernetes_cluster_node_pool" "test" {
+  name                  = "acctestnp"
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
+  vm_size               = "Standard_D4s_v3"
+  node_count            = 1
+  vnet_subnet_id        = azurerm_subnet.test.id
+  upgrade_settings {
+    max_surge = "10%%"
+  }
+
+  local_dns_profile {
+    mode = "Required"
+
+    vnet_dns_override {
+      domain                    = "."
+      serve_stale               = "Verify"
+      serve_stale_duration      = 3600
+      query_logging             = "Error"
+      protocol                  = "PreferUDP"
+      forward_destination       = "VnetDNS"
+      forward_policy            = "Sequential"
+      max_concurrent            = 1000
+      cache_duration_in_seconds = 3600
+    }
+
+    vnet_dns_override {
+      domain                    = "cluster.local"
+      serve_stale               = "Verify"
+      serve_stale_duration      = 3600
+      query_logging             = "Error"
+      protocol                  = "PreferUDP"
+      forward_destination       = "ClusterCoreDNS"
+      forward_policy            = "Sequential"
+      max_concurrent            = 1000
+      cache_duration_in_seconds = 3600
+    }
+
+    kube_dns_override {
+      domain                    = "cluster.local"
+      serve_stale               = "Verify"
+      serve_stale_duration      = 3600
+      query_logging             = "Error"
+      protocol                  = "PreferUDP"
+      forward_destination       = "ClusterCoreDNS"
+      forward_policy            = "Sequential"
+      max_concurrent            = 1000
+      cache_duration_in_seconds = 3600
+    }
+
+    kube_dns_override {
+      domain                    = "."
+      serve_stale               = "Verify"
+      serve_stale_duration      = 3600
+      query_logging             = "Error"
+      protocol                  = "PreferUDP"
+      forward_destination       = "ClusterCoreDNS"
+      forward_policy            = "Sequential"
+      max_concurrent            = 1000
+      cache_duration_in_seconds = 3600
+    }
+  }
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (KubernetesClusterNodePoolResource) localDNSProfileUpdated(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%[1]d"
+  address_space       = ["10.1.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctestsubnet%[1]d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.1.0.0/24"]
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%[1]d"
+
+  default_node_pool {
+    name           = "default"
+    node_count     = 1
+    vm_size        = "Standard_D4s_v3"
+    vnet_subnet_id = azurerm_subnet.test.id
+    upgrade_settings {
+      max_surge = "10%%%%"
+    }
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+resource "azurerm_kubernetes_cluster_node_pool" "test" {
+  name                  = "acctestnp"
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
+  vm_size               = "Standard_D4s_v3"
+  node_count            = 1
+  vnet_subnet_id        = azurerm_subnet.test.id
+  upgrade_settings {
+    max_surge = "10%%"
+  }
+
+  local_dns_profile {
+    mode = "Required"
+
+    vnet_dns_override {
+      domain                    = "."
+      serve_stale               = "Verify"
+      serve_stale_duration      = 3600
+      query_logging             = "Error"
+      protocol                  = "PreferUDP"
+      forward_destination       = "VnetDNS"
+      forward_policy            = "RoundRobin"
+      max_concurrent            = 2000
+      cache_duration_in_seconds = 7200
+    }
+
+    vnet_dns_override {
+      domain                    = "mycustom.local"
+      serve_stale               = "Verify"
+      serve_stale_duration      = 3600
+      query_logging             = "Error"
+      protocol                  = "PreferUDP"
+      forward_destination       = "VnetDNS"
+      forward_policy            = "RoundRobin"
+      max_concurrent            = 2000
+      cache_duration_in_seconds = 7200
+    }
+
+    vnet_dns_override {
+      domain                    = "cluster.local"
+      serve_stale               = "Verify"
+      serve_stale_duration      = 3600
+      query_logging             = "Error"
+      protocol                  = "PreferUDP"
+      forward_destination       = "ClusterCoreDNS"
+      forward_policy            = "RoundRobin"
+      max_concurrent            = 2000
+      cache_duration_in_seconds = 7200
+    }
+
+    kube_dns_override {
+      domain                    = "cluster.local"
+      serve_stale               = "Immediate"
+      serve_stale_duration      = 3600
+      query_logging             = "Log"
+      protocol                  = "ForceTCP"
+      forward_destination       = "ClusterCoreDNS"
+      forward_policy            = "RoundRobin"
+      max_concurrent            = 2000
+      cache_duration_in_seconds = 7200
+    }
+
+    kube_dns_override {
+      domain                    = "."
+      serve_stale               = "Immediate"
+      serve_stale_duration      = 3600
+      query_logging             = "Log"
+      protocol                  = "ForceTCP"
+      forward_destination       = "ClusterCoreDNS"
+      forward_policy            = "RoundRobin"
+      max_concurrent            = 2000
+      cache_duration_in_seconds = 7200
+    }
   }
 }
 `, data.RandomInteger, data.Locations.Primary)

--- a/internal/services/containers/kubernetes_cluster_other_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_other_resource_test.go
@@ -4298,6 +4298,11 @@ resource "azurerm_kubernetes_cluster" "test" {
     }
   }
 
+  node_provisioning_profile {
+    mode               = "Manual"
+    default_node_pools = "Auto"
+  }
+
   identity {
     type = "SystemAssigned"
   }
@@ -4397,6 +4402,11 @@ resource "azurerm_kubernetes_cluster" "test" {
         cache_duration_in_seconds = 7200
       }
     }
+  }
+
+  node_provisioning_profile {
+    mode               = "Manual"
+    default_node_pools = "Auto"
   }
 
   identity {

--- a/internal/services/containers/kubernetes_cluster_other_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_other_resource_test.go
@@ -1269,6 +1269,43 @@ func TestAccKubernetesCluster_aiToolchainOperatorProfileToggle(t *testing.T) {
 	})
 }
 
+func TestAccKubernetesCluster_localDNSProfile(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
+	r := KubernetesClusterResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.localDNSProfile(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("default_node_pool.0.temporary_name_for_rotation"),
+	})
+}
+
+func TestAccKubernetesCluster_localDNSProfileUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
+	r := KubernetesClusterResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.localDNSProfile(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("default_node_pool.0.temporary_name_for_rotation"),
+		{
+			Config: r.localDNSProfileUpdated(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("default_node_pool.0.temporary_name_for_rotation"),
+	})
+}
+
 func (KubernetesClusterResource) sameSize(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -4165,4 +4202,206 @@ resource "azurerm_kubernetes_cluster" "test" {
   }
 }
   `, data.RandomInteger, data.Locations.Primary, enabled, currentKubernetesVersion)
+}
+
+func (KubernetesClusterResource) localDNSProfile(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%[1]d"
+  address_space       = ["10.1.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctestsubnet%[1]d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.1.0.0/24"]
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%[1]d"
+
+  default_node_pool {
+    name                        = "default"
+    node_count                  = 1
+    vm_size                     = "Standard_D4s_v3"
+    vnet_subnet_id              = azurerm_subnet.test.id
+    temporary_name_for_rotation = "temp"
+    upgrade_settings {
+      max_surge = "10%%"
+    }
+
+    local_dns_profile {
+      mode = "Required"
+
+      vnet_dns_override {
+        domain                    = "."
+        serve_stale               = "Verify"
+        serve_stale_duration      = 3600
+        query_logging             = "Error"
+        protocol                  = "PreferUDP"
+        forward_destination       = "VnetDNS"
+        forward_policy            = "Sequential"
+        max_concurrent            = 1000
+        cache_duration_in_seconds = 3600
+      }
+
+      vnet_dns_override {
+        domain                    = "cluster.local"
+        serve_stale               = "Verify"
+        serve_stale_duration      = 3600
+        query_logging             = "Error"
+        protocol                  = "PreferUDP"
+        forward_destination       = "ClusterCoreDNS"
+        forward_policy            = "Sequential"
+        max_concurrent            = 1000
+        cache_duration_in_seconds = 3600
+      }
+
+      kube_dns_override {
+        domain                    = "cluster.local"
+        serve_stale               = "Verify"
+        serve_stale_duration      = 3600
+        query_logging             = "Error"
+        protocol                  = "PreferUDP"
+        forward_destination       = "ClusterCoreDNS"
+        forward_policy            = "Sequential"
+        max_concurrent            = 1000
+        cache_duration_in_seconds = 3600
+      }
+
+      kube_dns_override {
+        domain                    = "."
+        serve_stale               = "Verify"
+        serve_stale_duration      = 3600
+        query_logging             = "Error"
+        protocol                  = "PreferUDP"
+        forward_destination       = "ClusterCoreDNS"
+        forward_policy            = "Sequential"
+        max_concurrent            = 1000
+        cache_duration_in_seconds = 3600
+      }
+    }
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (KubernetesClusterResource) localDNSProfileUpdated(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%[1]d"
+  address_space       = ["10.1.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctestsubnet%[1]d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.1.0.0/24"]
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%[1]d"
+
+  default_node_pool {
+    name                        = "default"
+    node_count                  = 1
+    vm_size                     = "Standard_D4s_v3"
+    vnet_subnet_id              = azurerm_subnet.test.id
+    temporary_name_for_rotation = "temp"
+    upgrade_settings {
+      max_surge = "10%%"
+    }
+
+    local_dns_profile {
+      mode = "Required"
+
+      vnet_dns_override {
+        domain                    = "."
+        serve_stale               = "Verify"
+        serve_stale_duration      = 3600
+        query_logging             = "Error"
+        protocol                  = "PreferUDP"
+        forward_destination       = "VnetDNS"
+        forward_policy            = "RoundRobin"
+        max_concurrent            = 2000
+        cache_duration_in_seconds = 7200
+      }
+
+      vnet_dns_override {
+        domain                    = "cluster.local"
+        serve_stale               = "Verify"
+        serve_stale_duration      = 3600
+        query_logging             = "Error"
+        protocol                  = "PreferUDP"
+        forward_destination       = "ClusterCoreDNS"
+        forward_policy            = "RoundRobin"
+        max_concurrent            = 2000
+        cache_duration_in_seconds = 7200
+      }
+
+      kube_dns_override {
+        domain                    = "cluster.local"
+        serve_stale               = "Verify"
+        serve_stale_duration      = 3600
+        query_logging             = "Error"
+        protocol                  = "PreferUDP"
+        forward_destination       = "ClusterCoreDNS"
+        forward_policy            = "RoundRobin"
+        max_concurrent            = 2000
+        cache_duration_in_seconds = 7200
+      }
+
+      kube_dns_override {
+        domain                    = "."
+        serve_stale               = "Verify"
+        serve_stale_duration      = 3600
+        query_logging             = "Error"
+        protocol                  = "PreferUDP"
+        forward_destination       = "ClusterCoreDNS"
+        forward_policy            = "RoundRobin"
+        max_concurrent            = 2000
+        cache_duration_in_seconds = 7200
+      }
+    }
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary)
 }

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -88,6 +88,9 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 			pluginsdk.ForceNewIfChange("api_server_access_profile.0.subnet_id", func(ctx context.Context, old, new, meta interface{}) bool {
 				return old != "" && new == ""
 			}),
+			func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+				return validateDefaultNodePoolLocalDNSProfileRawConfig(d)
+			},
 			pluginsdk.ForceNewIf("default_node_pool.0.name", func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) bool {
 				old, new := d.GetChange("default_node_pool.0.name")
 				defaultName := d.Get("default_node_pool.0.name")

--- a/internal/services/containers/kubernetes_nodepool.go
+++ b/internal/services/containers/kubernetes_nodepool.go
@@ -708,7 +708,6 @@ func schemaLocalDNSOverride() *pluginsdk.Schema {
 	return &pluginsdk.Schema{
 		Type:     pluginsdk.TypeSet,
 		Optional: true,
-		Set:      localDNSOverrideHash,
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
 				"domain": {
@@ -775,16 +774,6 @@ func schemaLocalDNSOverride() *pluginsdk.Schema {
 			},
 		},
 	}
-}
-
-func localDNSOverrideHash(v interface{}) int {
-	if m, ok := v.(map[string]interface{}); ok {
-		if domain, ok := m["domain"].(string); ok {
-			return pluginsdk.HashString(domain)
-		}
-	}
-
-	return 0
 }
 
 func validateDefaultNodePoolLocalDNSProfileRawConfig(d *pluginsdk.ResourceDiff) error {

--- a/internal/services/containers/kubernetes_nodepool.go
+++ b/internal/services/containers/kubernetes_nodepool.go
@@ -281,6 +281,8 @@ func SchemaDefaultNodePool() *pluginsdk.Schema {
 						Type:     pluginsdk.TypeBool,
 						Optional: true,
 					},
+
+					"local_dns_profile": schemaDefaultNodePoolLocalDNSProfile(),
 				}
 			}(),
 		},
@@ -675,6 +677,101 @@ func schemaNodePoolNetworkProfile() *pluginsdk.Schema {
 	}
 }
 
+func schemaDefaultNodePoolLocalDNSProfile() *pluginsdk.Schema {
+	return schemaNodePoolLocalDNSProfile([]string{
+		"default_node_pool.0.local_dns_profile.0.kube_dns_override",
+		"default_node_pool.0.local_dns_profile.0.mode",
+		"default_node_pool.0.local_dns_profile.0.vnet_dns_override",
+	})
+}
+
+func schemaNodePoolLocalDNSProfile(atLeastOneOf []string) *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"kube_dns_override": schemaLocalDNSOverride(atLeastOneOf),
+
+				"mode": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringInSlice(managedclusters.PossibleValuesForLocalDNSMode(), false),
+					AtLeastOneOf: atLeastOneOf,
+				},
+
+				"vnet_dns_override": schemaLocalDNSOverride(atLeastOneOf),
+			},
+		},
+	}
+}
+
+func schemaLocalDNSOverride(atLeastOneOf []string) *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:         pluginsdk.TypeSet,
+		Optional:     true,
+		AtLeastOneOf: atLeastOneOf,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"domain": {
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+
+				"cache_duration_in_seconds": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					ValidateFunc: validation.IntAtLeast(1),
+				},
+
+				"forward_destination": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringInSlice(managedclusters.PossibleValuesForLocalDNSForwardDestination(), false),
+				},
+
+				"forward_policy": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringInSlice(managedclusters.PossibleValuesForLocalDNSForwardPolicy(), false),
+				},
+
+				"max_concurrent": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					ValidateFunc: validation.IntAtLeast(1),
+				},
+
+				"protocol": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringInSlice(managedclusters.PossibleValuesForLocalDNSProtocol(), false),
+				},
+
+				"query_logging": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringInSlice(managedclusters.PossibleValuesForLocalDNSQueryLogging(), false),
+				},
+
+				"serve_stale": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringInSlice(managedclusters.PossibleValuesForLocalDNSServeStale(), false),
+				},
+
+				"serve_stale_duration": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					ValidateFunc: validation.IntAtLeast(1),
+				},
+			},
+		},
+	}
+}
+
 func upgradeSettingsSchemaClusterDefaultNodePool() *pluginsdk.Schema {
 	return &pluginsdk.Schema{
 		Type:     pluginsdk.TypeList,
@@ -848,7 +945,56 @@ func ConvertDefaultNodePoolToAgentPool(input *[]managedclusters.ManagedClusterAg
 		agentpool.Properties.GpuInstanceProfile = pointer.To(agentpools.GPUInstanceProfile(*defaultCluster.GpuInstanceProfile))
 	}
 
+	if localDNS := defaultCluster.LocalDNSProfile; localDNS != nil {
+		converted := agentpools.LocalDNSProfile{}
+		if localDNS.Mode != nil {
+			converted.Mode = pointer.ToEnum[agentpools.LocalDNSMode](pointer.FromEnum(localDNS.Mode))
+		}
+		if localDNS.State != nil {
+			converted.State = pointer.ToEnum[agentpools.LocalDNSState](pointer.FromEnum(localDNS.State))
+		}
+		if localDNS.VnetDNSOverrides != nil {
+			overrides := make(map[string]agentpools.LocalDNSOverride)
+			for k, v := range *localDNS.VnetDNSOverrides {
+				overrides[k] = convertClusterLocalDNSOverrideToAgentPool(v)
+			}
+			converted.VnetDNSOverrides = &overrides
+		}
+		if localDNS.KubeDNSOverrides != nil {
+			overrides := make(map[string]agentpools.LocalDNSOverride)
+			for k, v := range *localDNS.KubeDNSOverrides {
+				overrides[k] = convertClusterLocalDNSOverrideToAgentPool(v)
+			}
+			converted.KubeDNSOverrides = &overrides
+		}
+		agentpool.Properties.LocalDNSProfile = &converted
+	}
+
 	return agentpool
+}
+
+func convertClusterLocalDNSOverrideToAgentPool(input managedclusters.LocalDNSOverride) agentpools.LocalDNSOverride {
+	result := agentpools.LocalDNSOverride{
+		CacheDurationInSeconds:      input.CacheDurationInSeconds,
+		MaxConcurrent:               input.MaxConcurrent,
+		ServeStaleDurationInSeconds: input.ServeStaleDurationInSeconds,
+	}
+	if input.ForwardDestination != nil {
+		result.ForwardDestination = pointer.ToEnum[agentpools.LocalDNSForwardDestination](pointer.FromEnum(input.ForwardDestination))
+	}
+	if input.ForwardPolicy != nil {
+		result.ForwardPolicy = pointer.ToEnum[agentpools.LocalDNSForwardPolicy](pointer.FromEnum(input.ForwardPolicy))
+	}
+	if input.Protocol != nil {
+		result.Protocol = pointer.ToEnum[agentpools.LocalDNSProtocol](pointer.FromEnum(input.Protocol))
+	}
+	if input.QueryLogging != nil {
+		result.QueryLogging = pointer.ToEnum[agentpools.LocalDNSQueryLogging](pointer.FromEnum(input.QueryLogging))
+	}
+	if input.ServeStale != nil {
+		result.ServeStale = pointer.ToEnum[agentpools.LocalDNSServeStale](pointer.FromEnum(input.ServeStale))
+	}
+	return result
 }
 
 func ExpandDefaultNodePool(d *pluginsdk.ResourceData) (*[]managedclusters.ManagedClusterAgentPoolProfile, error) {
@@ -1041,6 +1187,10 @@ func ExpandDefaultNodePool(d *pluginsdk.ResourceData) (*[]managedclusters.Manage
 
 	if networkProfile := raw["node_network_profile"].([]interface{}); len(networkProfile) > 0 {
 		profile.NetworkProfile = expandClusterPoolNetworkProfile(networkProfile)
+	}
+
+	if localDNSProfile := raw["local_dns_profile"].([]interface{}); len(localDNSProfile) > 0 {
+		profile.LocalDNSProfile = expandClusterNodePoolLocalDNSProfile(localDNSProfile)
 	}
 
 	return &[]managedclusters.ManagedClusterAgentPoolProfile{
@@ -1443,6 +1593,7 @@ func FlattenDefaultNodePool(input *[]managedclusters.ManagedClusterAgentPoolProf
 		"only_critical_addons_enabled":  criticalAddonsEnabled,
 		"kubelet_config":                flattenClusterNodePoolKubeletConfig(agentPool.KubeletConfig),
 		"linux_os_config":               linuxOSConfig,
+		"local_dns_profile":             flattenClusterNodePoolLocalDNSProfile(agentPool.LocalDNSProfile),
 		"zones":                         zones.FlattenUntyped(agentPool.AvailabilityZones),
 		"capacity_reservation_group_id": capacityReservationGroupId,
 	}
@@ -1968,4 +2119,105 @@ func flattenClusterPoolNetworkProfileNodePublicIPTags(input *[]managedclusters.I
 	}
 
 	return out
+}
+
+func expandClusterNodePoolLocalDNSProfile(input []interface{}) *managedclusters.LocalDNSProfile {
+	if len(input) == 0 || input[0] == nil {
+		return nil
+	}
+
+	raw := input[0].(map[string]interface{})
+	result := &managedclusters.LocalDNSProfile{}
+
+	if v := raw["mode"].(string); v != "" {
+		result.Mode = pointer.ToEnum[managedclusters.LocalDNSMode](v)
+	}
+
+	if v, ok := raw["kube_dns_override"].(*pluginsdk.Set); ok && v != nil {
+		result.KubeDNSOverrides = expandClusterLocalDNSOverrides(v.List())
+	}
+	if v, ok := raw["vnet_dns_override"].(*pluginsdk.Set); ok && v != nil {
+		result.VnetDNSOverrides = expandClusterLocalDNSOverrides(v.List())
+	}
+
+	return result
+}
+
+func expandClusterLocalDNSOverrides(input []interface{}) *map[string]managedclusters.LocalDNSOverride {
+	if len(input) == 0 {
+		return nil
+	}
+
+	result := make(map[string]managedclusters.LocalDNSOverride)
+	for _, item := range input {
+		raw := item.(map[string]interface{})
+		domain := raw["domain"].(string)
+		override := managedclusters.LocalDNSOverride{}
+
+		if v := raw["serve_stale"].(string); v != "" {
+			override.ServeStale = pointer.ToEnum[managedclusters.LocalDNSServeStale](v)
+		}
+		if v := raw["serve_stale_duration"].(int); v > 0 {
+			override.ServeStaleDurationInSeconds = pointer.To(int64(v))
+		}
+		if v := raw["query_logging"].(string); v != "" {
+			override.QueryLogging = pointer.ToEnum[managedclusters.LocalDNSQueryLogging](v)
+		}
+		if v := raw["protocol"].(string); v != "" {
+			override.Protocol = pointer.ToEnum[managedclusters.LocalDNSProtocol](v)
+		}
+		if v := raw["forward_destination"].(string); v != "" {
+			override.ForwardDestination = pointer.ToEnum[managedclusters.LocalDNSForwardDestination](v)
+		}
+		if v := raw["forward_policy"].(string); v != "" {
+			override.ForwardPolicy = pointer.ToEnum[managedclusters.LocalDNSForwardPolicy](v)
+		}
+		if v := raw["max_concurrent"].(int); v > 0 {
+			override.MaxConcurrent = pointer.To(int64(v))
+		}
+		if v := raw["cache_duration_in_seconds"].(int); v > 0 {
+			override.CacheDurationInSeconds = pointer.To(int64(v))
+		}
+
+		result[domain] = override
+	}
+
+	return &result
+}
+
+func flattenClusterNodePoolLocalDNSProfile(input *managedclusters.LocalDNSProfile) []interface{} {
+	if input == nil || (input.Mode == nil && (input.VnetDNSOverrides == nil || len(*input.VnetDNSOverrides) == 0) && (input.KubeDNSOverrides == nil || len(*input.KubeDNSOverrides) == 0)) {
+		return []interface{}{}
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"mode":              string(pointer.From(input.Mode)),
+			"vnet_dns_override": flattenClusterLocalDNSOverrides(input.VnetDNSOverrides),
+			"kube_dns_override": flattenClusterLocalDNSOverrides(input.KubeDNSOverrides),
+		},
+	}
+}
+
+func flattenClusterLocalDNSOverrides(input *map[string]managedclusters.LocalDNSOverride) []interface{} {
+	if input == nil {
+		return []interface{}{}
+	}
+
+	results := make([]interface{}, 0)
+	for domain, override := range *input {
+		results = append(results, map[string]interface{}{
+			"domain":                    domain,
+			"serve_stale":               string(pointer.From(override.ServeStale)),
+			"serve_stale_duration":      int(pointer.From(override.ServeStaleDurationInSeconds)),
+			"query_logging":             string(pointer.From(override.QueryLogging)),
+			"protocol":                  string(pointer.From(override.Protocol)),
+			"forward_destination":       string(pointer.From(override.ForwardDestination)),
+			"forward_policy":            string(pointer.From(override.ForwardPolicy)),
+			"max_concurrent":            int(pointer.From(override.MaxConcurrent)),
+			"cache_duration_in_seconds": int(pointer.From(override.CacheDurationInSeconds)),
+		})
+	}
+
+	return results
 }

--- a/internal/services/containers/kubernetes_nodepool.go
+++ b/internal/services/containers/kubernetes_nodepool.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2025-10-01/snapshots"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/applicationsecuritygroups"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-11-01/publicipprefixes"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	computeValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/validate"
@@ -678,40 +679,36 @@ func schemaNodePoolNetworkProfile() *pluginsdk.Schema {
 }
 
 func schemaDefaultNodePoolLocalDNSProfile() *pluginsdk.Schema {
-	return schemaNodePoolLocalDNSProfile([]string{
-		"default_node_pool.0.local_dns_profile.0.kube_dns_override",
-		"default_node_pool.0.local_dns_profile.0.mode",
-		"default_node_pool.0.local_dns_profile.0.vnet_dns_override",
-	})
+	return schemaNodePoolLocalDNSProfile()
 }
 
-func schemaNodePoolLocalDNSProfile(atLeastOneOf []string) *pluginsdk.Schema {
+func schemaNodePoolLocalDNSProfile() *pluginsdk.Schema {
 	return &pluginsdk.Schema{
 		Type:     pluginsdk.TypeList,
 		Optional: true,
 		MaxItems: 1,
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
-				"kube_dns_override": schemaLocalDNSOverride(atLeastOneOf),
+				"kube_dns_override": schemaLocalDNSOverride(),
 
 				"mode": {
 					Type:         pluginsdk.TypeString,
 					Optional:     true,
+					Default:      string(managedclusters.LocalDNSModePreferred),
 					ValidateFunc: validation.StringInSlice(managedclusters.PossibleValuesForLocalDNSMode(), false),
-					AtLeastOneOf: atLeastOneOf,
 				},
 
-				"vnet_dns_override": schemaLocalDNSOverride(atLeastOneOf),
+				"vnet_dns_override": schemaLocalDNSOverride(),
 			},
 		},
 	}
 }
 
-func schemaLocalDNSOverride(atLeastOneOf []string) *pluginsdk.Schema {
+func schemaLocalDNSOverride() *pluginsdk.Schema {
 	return &pluginsdk.Schema{
-		Type:         pluginsdk.TypeSet,
-		Optional:     true,
-		AtLeastOneOf: atLeastOneOf,
+		Type:     pluginsdk.TypeSet,
+		Optional: true,
+		Set:      localDNSOverrideHash,
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
 				"domain": {
@@ -723,53 +720,167 @@ func schemaLocalDNSOverride(atLeastOneOf []string) *pluginsdk.Schema {
 				"cache_duration_in_seconds": {
 					Type:         pluginsdk.TypeInt,
 					Optional:     true,
+					Default:      3600,
 					ValidateFunc: validation.IntAtLeast(1),
 				},
 
 				"forward_destination": {
 					Type:         pluginsdk.TypeString,
 					Optional:     true,
+					Default:      string(managedclusters.LocalDNSForwardDestinationClusterCoreDNS),
 					ValidateFunc: validation.StringInSlice(managedclusters.PossibleValuesForLocalDNSForwardDestination(), false),
 				},
 
 				"forward_policy": {
 					Type:         pluginsdk.TypeString,
 					Optional:     true,
+					Default:      string(managedclusters.LocalDNSForwardPolicySequential),
 					ValidateFunc: validation.StringInSlice(managedclusters.PossibleValuesForLocalDNSForwardPolicy(), false),
 				},
 
 				"max_concurrent": {
 					Type:         pluginsdk.TypeInt,
 					Optional:     true,
+					Default:      1000,
 					ValidateFunc: validation.IntAtLeast(1),
 				},
 
 				"protocol": {
 					Type:         pluginsdk.TypeString,
 					Optional:     true,
+					Default:      string(managedclusters.LocalDNSProtocolPreferUDP),
 					ValidateFunc: validation.StringInSlice(managedclusters.PossibleValuesForLocalDNSProtocol(), false),
 				},
 
 				"query_logging": {
 					Type:         pluginsdk.TypeString,
 					Optional:     true,
+					Default:      string(managedclusters.LocalDNSQueryLoggingError),
 					ValidateFunc: validation.StringInSlice(managedclusters.PossibleValuesForLocalDNSQueryLogging(), false),
 				},
 
 				"serve_stale": {
 					Type:         pluginsdk.TypeString,
 					Optional:     true,
+					Default:      string(managedclusters.LocalDNSServeStaleImmediate),
 					ValidateFunc: validation.StringInSlice(managedclusters.PossibleValuesForLocalDNSServeStale(), false),
 				},
 
 				"serve_stale_duration": {
 					Type:         pluginsdk.TypeInt,
 					Optional:     true,
+					Default:      3600,
 					ValidateFunc: validation.IntAtLeast(1),
 				},
 			},
 		},
 	}
+}
+
+func localDNSOverrideHash(v interface{}) int {
+	if m, ok := v.(map[string]interface{}); ok {
+		if domain, ok := m["domain"].(string); ok {
+			return pluginsdk.HashString(domain)
+		}
+	}
+
+	return 0
+}
+
+func validateDefaultNodePoolLocalDNSProfileRawConfig(d *pluginsdk.ResourceDiff) error {
+	rawConfig := d.GetRawConfig()
+	if !localDNSRawValueCanIterate(rawConfig) {
+		return nil
+	}
+
+	defaultNodePoolRaw, ok := rawConfig.AsValueMap()["default_node_pool"]
+	if !ok {
+		return nil
+	}
+
+	for _, defaultNodePool := range localDNSRawValueSlice(defaultNodePoolRaw) {
+		if !localDNSRawValueCanIterate(defaultNodePool) {
+			continue
+		}
+
+		localDNSProfileRaw, ok := defaultNodePool.AsValueMap()["local_dns_profile"]
+		if !ok {
+			continue
+		}
+
+		if err := validateLocalDNSProfileRawConfig(localDNSProfileRaw, "default_node_pool.local_dns_profile"); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func validateNodePoolLocalDNSProfileRawConfig(d *pluginsdk.ResourceDiff) error {
+	rawConfig := d.GetRawConfig()
+	if !localDNSRawValueCanIterate(rawConfig) {
+		return nil
+	}
+
+	localDNSProfileRaw, ok := rawConfig.AsValueMap()["local_dns_profile"]
+	if !ok {
+		return nil
+	}
+
+	return validateLocalDNSProfileRawConfig(localDNSProfileRaw, "local_dns_profile")
+}
+
+func validateLocalDNSProfileRawConfig(input cty.Value, path string) error {
+	for _, localDNSProfileRaw := range localDNSRawValueSlice(input) {
+		if !localDNSRawValueCanIterate(localDNSProfileRaw) {
+			continue
+		}
+
+		localDNSProfile := localDNSProfileRaw.AsValueMap()
+		for _, key := range []string{"kube_dns_override", "vnet_dns_override"} {
+			if raw, ok := localDNSProfile[key]; ok {
+				if err := validateLocalDNSOverrideRawConfig(raw, fmt.Sprintf("%s.%s", path, key)); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func validateLocalDNSOverrideRawConfig(input cty.Value, path string) error {
+	seen := make(map[string]struct{})
+	for _, overrideRaw := range localDNSRawValueSlice(input) {
+		if !localDNSRawValueCanIterate(overrideRaw) {
+			continue
+		}
+
+		domainRaw, ok := overrideRaw.AsValueMap()["domain"]
+		if !ok || domainRaw.IsNull() || !domainRaw.IsKnown() {
+			continue
+		}
+
+		domain := domainRaw.AsString()
+		if _, ok := seen[domain]; ok {
+			return fmt.Errorf("duplicate `domain` value %q was found in `%s`; each domain must be specified only once", domain, path)
+		}
+		seen[domain] = struct{}{}
+	}
+
+	return nil
+}
+
+func localDNSRawValueSlice(input cty.Value) []cty.Value {
+	if !localDNSRawValueCanIterate(input) {
+		return nil
+	}
+
+	return input.AsValueSlice()
+}
+
+func localDNSRawValueCanIterate(input cty.Value) bool {
+	return !input.IsNull() && input.IsKnown() && input.CanIterateElements()
 }
 
 func upgradeSettingsSchemaClusterDefaultNodePool() *pluginsdk.Schema {

--- a/internal/services/containers/kubernetes_nodepool.go
+++ b/internal/services/containers/kubernetes_nodepool.go
@@ -283,7 +283,7 @@ func SchemaDefaultNodePool() *pluginsdk.Schema {
 						Optional: true,
 					},
 
-					"local_dns_profile": schemaDefaultNodePoolLocalDNSProfile(),
+					"local_dns_profile": schemaNodePoolLocalDNSProfile(),
 				}
 			}(),
 		},
@@ -678,10 +678,6 @@ func schemaNodePoolNetworkProfile() *pluginsdk.Schema {
 	}
 }
 
-func schemaDefaultNodePoolLocalDNSProfile() *pluginsdk.Schema {
-	return schemaNodePoolLocalDNSProfile()
-}
-
 func schemaNodePoolLocalDNSProfile() *pluginsdk.Schema {
 	return &pluginsdk.Schema{
 		Type:     pluginsdk.TypeList,
@@ -777,6 +773,9 @@ func schemaLocalDNSOverride() *pluginsdk.Schema {
 }
 
 func validateDefaultNodePoolLocalDNSProfileRawConfig(d *pluginsdk.ResourceDiff) error {
+	// The override schema uses the SDK's full-block set hash so changing settings
+	// under an existing domain still produces a diff. Raw config validation keeps
+	// the API's domain-keyed uniqueness rule without rejecting unknown domains.
 	rawConfig := d.GetRawConfig()
 	if !localDNSRawValueCanIterate(rawConfig) {
 		return nil

--- a/internal/services/containers/kubernetes_nodepool_test.go
+++ b/internal/services/containers/kubernetes_nodepool_test.go
@@ -1,0 +1,42 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package containers
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestSchemaLocalDNSOverrideHashIncludesSettings(t *testing.T) {
+	localDNSOverride := schemaLocalDNSOverride()
+
+	localDNSOverrides := localDNSOverride.ZeroValue().(*schema.Set)
+	localDNSOverrides.Add(map[string]interface{}{
+		"domain":                    ".",
+		"cache_duration_in_seconds": 3600,
+		"forward_destination":       "VnetDNS",
+		"forward_policy":            "Sequential",
+		"max_concurrent":            1000,
+		"protocol":                  "PreferUDP",
+		"query_logging":             "Error",
+		"serve_stale":               "Verify",
+		"serve_stale_duration":      3600,
+	})
+	localDNSOverrides.Add(map[string]interface{}{
+		"domain":                    ".",
+		"cache_duration_in_seconds": 7200,
+		"forward_destination":       "VnetDNS",
+		"forward_policy":            "RoundRobin",
+		"max_concurrent":            2000,
+		"protocol":                  "PreferUDP",
+		"query_logging":             "Error",
+		"serve_stale":               "Verify",
+		"serve_stale_duration":      3600,
+	})
+
+	if localDNSOverrides.Len() != 2 {
+		t.Fatalf("expected two local DNS override hashes, got %d", localDNSOverrides.Len())
+	}
+}

--- a/internal/services/containers/kubernetes_nodepool_test.go
+++ b/internal/services/containers/kubernetes_nodepool_test.go
@@ -6,6 +6,7 @@ package containers
 import (
 	"testing"
 
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -38,5 +39,35 @@ func TestSchemaLocalDNSOverrideHashIncludesSettings(t *testing.T) {
 
 	if localDNSOverrides.Len() != 2 {
 		t.Fatalf("expected two local DNS override hashes, got %d", localDNSOverrides.Len())
+	}
+}
+
+func TestValidateLocalDNSOverrideRawConfigSkipsUnknownDomain(t *testing.T) {
+	input := cty.ListVal([]cty.Value{
+		cty.ObjectVal(map[string]cty.Value{
+			"domain": cty.UnknownVal(cty.String),
+		}),
+		cty.ObjectVal(map[string]cty.Value{
+			"domain": cty.UnknownVal(cty.String),
+		}),
+	})
+
+	if err := validateLocalDNSOverrideRawConfig(input, "local_dns_profile.kube_dns_override"); err != nil {
+		t.Fatalf("expected unknown domains to be skipped, got %q", err)
+	}
+}
+
+func TestValidateLocalDNSOverrideRawConfigRejectsDuplicateDomain(t *testing.T) {
+	input := cty.ListVal([]cty.Value{
+		cty.ObjectVal(map[string]cty.Value{
+			"domain": cty.StringVal("example.com"),
+		}),
+		cty.ObjectVal(map[string]cty.Value{
+			"domain": cty.StringVal("example.com"),
+		}),
+	})
+
+	if err := validateLocalDNSOverrideRawConfig(input, "local_dns_profile.kube_dns_override"); err == nil {
+		t.Fatal("expected duplicate domain validation error")
 	}
 }

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -403,6 +403,8 @@ A `default_node_pool` block supports the following:
 
 * `linux_os_config` - (Optional) A `linux_os_config` block as defined below. `temporary_name_for_rotation` must be specified when changing this block.
 
+* `local_dns_profile` - (Optional) A `local_dns_profile` block as defined below. Configures the LocalDNS feature which deploys a DNS proxy on each node for low-latency DNS resolution.
+
 * `fips_enabled` - (Optional) Should the nodes in this Node Pool have Federal Information Processing Standard enabled? `temporary_name_for_rotation` must be specified when changing this block.
 
 * `kubelet_disk_type` - (Optional) The type of disk used by kubelet. Possible values are `OS` and `Temporary`. `temporary_name_for_rotation` must be specified when changing this block.
@@ -550,6 +552,40 @@ A `linux_os_config` block supports the following:
 * `transparent_huge_page_defrag` - (Optional) specifies the defrag configuration for Transparent Huge Page. Possible values are `always`, `defer`, `defer+madvise`, `madvise` and `never`.
 
 * `transparent_huge_page` - (Optional) Specifies the Transparent Huge Page configuration. Possible values are `always`, `madvise` and `never`.
+
+---
+
+A `local_dns_profile` block supports the following:
+
+At least one of `kube_dns_override`, `mode` or `vnet_dns_override` must be specified.
+
+* `kube_dns_override` - (Optional) One or more `kube_dns_override` blocks as defined below. Configures DNS overrides for Kubernetes DNS resolution.
+
+* `mode` - (Optional) The mode for the LocalDNS feature. Possible values are `Required`, `Preferred` and `Disabled`.
+
+* `vnet_dns_override` - (Optional) One or more `vnet_dns_override` blocks as defined below. Configures DNS overrides for VNet DNS resolution.
+
+---
+
+A `kube_dns_override` and `vnet_dns_override` block supports the following:
+
+* `domain` - (Required) The domain name to configure DNS overrides for. This is used as the map key in the API payload (e.g. `"."` or `"cluster.local"`).
+
+* `cache_duration_in_seconds` - (Optional) The duration in seconds to cache DNS responses. This value must be at least `1`.
+
+* `forward_destination` - (Optional) The forward destination for DNS queries. Possible values are `ClusterCoreDNS` and `VnetDNS`.
+
+* `forward_policy` - (Optional) The forwarding policy. Possible values are `Random`, `RoundRobin` and `Sequential`.
+
+* `max_concurrent` - (Optional) The maximum number of concurrent DNS queries. This value must be at least `1`.
+
+* `protocol` - (Optional) The DNS protocol to use. Possible values are `ForceTCP` and `PreferUDP`.
+
+* `query_logging` - (Optional) The query logging configuration. Possible values are `Error` and `Log`.
+
+* `serve_stale` - (Optional) The serve stale configuration. Possible values are `Disable`, `Immediate` and `Verify`.
+
+* `serve_stale_duration` - (Optional) The serve stale duration in seconds. This value must be at least `1`.
 
 ---
 

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -557,11 +557,9 @@ A `linux_os_config` block supports the following:
 
 A `local_dns_profile` block supports the following:
 
-At least one of `kube_dns_override`, `mode` or `vnet_dns_override` must be specified.
-
 * `kube_dns_override` - (Optional) One or more `kube_dns_override` blocks as defined below. Configures DNS overrides for Kubernetes DNS resolution.
 
-* `mode` - (Optional) The mode for the LocalDNS feature. Possible values are `Required`, `Preferred` and `Disabled`.
+* `mode` - (Optional) The mode for the LocalDNS feature. Possible values are `Required`, `Preferred` and `Disabled`. Defaults to `Preferred`.
 
 * `vnet_dns_override` - (Optional) One or more `vnet_dns_override` blocks as defined below. Configures DNS overrides for VNet DNS resolution.
 
@@ -571,21 +569,21 @@ A `kube_dns_override` and `vnet_dns_override` block supports the following:
 
 * `domain` - (Required) The domain name to configure DNS overrides for. This is used as the map key in the API payload (e.g. `"."` or `"cluster.local"`).
 
-* `cache_duration_in_seconds` - (Optional) The duration in seconds to cache DNS responses. This value must be at least `1`.
+* `cache_duration_in_seconds` - (Optional) The duration in seconds to cache DNS responses. This value must be at least `1`. Defaults to `3600`.
 
-* `forward_destination` - (Optional) The forward destination for DNS queries. Possible values are `ClusterCoreDNS` and `VnetDNS`.
+* `forward_destination` - (Optional) The forward destination for DNS queries. Possible values are `ClusterCoreDNS` and `VnetDNS`. Defaults to `ClusterCoreDNS`.
 
-* `forward_policy` - (Optional) The forwarding policy. Possible values are `Random`, `RoundRobin` and `Sequential`.
+* `forward_policy` - (Optional) The forwarding policy. Possible values are `Random`, `RoundRobin` and `Sequential`. Defaults to `Sequential`.
 
-* `max_concurrent` - (Optional) The maximum number of concurrent DNS queries. This value must be at least `1`.
+* `max_concurrent` - (Optional) The maximum number of concurrent DNS queries. This value must be at least `1`. Defaults to `1000`.
 
-* `protocol` - (Optional) The DNS protocol to use. Possible values are `ForceTCP` and `PreferUDP`.
+* `protocol` - (Optional) The DNS protocol to use. Possible values are `ForceTCP` and `PreferUDP`. Defaults to `PreferUDP`.
 
-* `query_logging` - (Optional) The query logging configuration. Possible values are `Error` and `Log`.
+* `query_logging` - (Optional) The query logging configuration. Possible values are `Error` and `Log`. Defaults to `Error`.
 
-* `serve_stale` - (Optional) The serve stale configuration. Possible values are `Disable`, `Immediate` and `Verify`.
+* `serve_stale` - (Optional) The serve stale configuration. Possible values are `Disable`, `Immediate` and `Verify`. Defaults to `Immediate`.
 
-* `serve_stale_duration` - (Optional) The serve stale duration in seconds. This value must be at least `1`.
+* `serve_stale_duration` - (Optional) The serve stale duration in seconds. This value must be at least `1`. Defaults to `3600`.
 
 ---
 

--- a/website/docs/r/kubernetes_cluster_node_pool.html.markdown
+++ b/website/docs/r/kubernetes_cluster_node_pool.html.markdown
@@ -226,11 +226,9 @@ A `linux_os_config` block supports the following:
 
 A `local_dns_profile` block supports the following:
 
-At least one of `kube_dns_override`, `mode` or `vnet_dns_override` must be specified.
-
 * `kube_dns_override` - (Optional) One or more `kube_dns_override` blocks as defined below. Configures DNS overrides for Kubernetes DNS resolution.
 
-* `mode` - (Optional) The mode for the LocalDNS feature. Possible values are `Required`, `Preferred` and `Disabled`.
+* `mode` - (Optional) The mode for the LocalDNS feature. Possible values are `Required`, `Preferred` and `Disabled`. Defaults to `Preferred`.
 
 * `vnet_dns_override` - (Optional) One or more `vnet_dns_override` blocks as defined below. Configures DNS overrides for VNet DNS resolution.
 
@@ -240,21 +238,21 @@ A `kube_dns_override` and `vnet_dns_override` block supports the following:
 
 * `domain` - (Required) The domain name to configure DNS overrides for. This is used as the map key in the API payload (e.g. `"."` or `"cluster.local"`).
 
-* `cache_duration_in_seconds` - (Optional) The duration in seconds to cache DNS responses. This value must be at least `1`.
+* `cache_duration_in_seconds` - (Optional) The duration in seconds to cache DNS responses. This value must be at least `1`. Defaults to `3600`.
 
-* `forward_destination` - (Optional) The forward destination for DNS queries. Possible values are `ClusterCoreDNS` and `VnetDNS`.
+* `forward_destination` - (Optional) The forward destination for DNS queries. Possible values are `ClusterCoreDNS` and `VnetDNS`. Defaults to `ClusterCoreDNS`.
 
-* `forward_policy` - (Optional) The forwarding policy. Possible values are `Random`, `RoundRobin` and `Sequential`.
+* `forward_policy` - (Optional) The forwarding policy. Possible values are `Random`, `RoundRobin` and `Sequential`. Defaults to `Sequential`.
 
-* `max_concurrent` - (Optional) The maximum number of concurrent DNS queries. This value must be at least `1`.
+* `max_concurrent` - (Optional) The maximum number of concurrent DNS queries. This value must be at least `1`. Defaults to `1000`.
 
-* `protocol` - (Optional) The DNS protocol to use. Possible values are `ForceTCP` and `PreferUDP`.
+* `protocol` - (Optional) The DNS protocol to use. Possible values are `ForceTCP` and `PreferUDP`. Defaults to `PreferUDP`.
 
-* `query_logging` - (Optional) The query logging configuration. Possible values are `Error` and `Log`.
+* `query_logging` - (Optional) The query logging configuration. Possible values are `Error` and `Log`. Defaults to `Error`.
 
-* `serve_stale` - (Optional) The serve stale configuration. Possible values are `Disable`, `Immediate` and `Verify`.
+* `serve_stale` - (Optional) The serve stale configuration. Possible values are `Disable`, `Immediate` and `Verify`. Defaults to `Immediate`.
 
-* `serve_stale_duration` - (Optional) The serve stale duration in seconds. This value must be at least `1`.
+* `serve_stale_duration` - (Optional) The serve stale duration in seconds. This value must be at least `1`. Defaults to `3600`.
 
 ---
 

--- a/website/docs/r/kubernetes_cluster_node_pool.html.markdown
+++ b/website/docs/r/kubernetes_cluster_node_pool.html.markdown
@@ -92,6 +92,8 @@ The following arguments are supported:
 
 * `linux_os_config` - (Optional) A `linux_os_config` block as defined below. Changing this requires specifying `temporary_name_for_rotation`.
 
+* `local_dns_profile` - (Optional) A `local_dns_profile` block as defined below. Configures the LocalDNS feature which deploys a DNS proxy on each node for low-latency DNS resolution.
+
 * `fips_enabled` - (Optional) Should the nodes in this Node Pool have Federal Information Processing Standard enabled? Changing this property requires specifying `temporary_name_for_rotation`.
 
 ~> **Note:** FIPS support is in Public Preview - more information and details on how to opt into the Preview can be found in [this article](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#add-a-fips-enabled-node-pool-preview).
@@ -219,6 +221,40 @@ A `linux_os_config` block supports the following:
 * `transparent_huge_page_defrag` - (Optional) specifies the defrag configuration for Transparent Huge Page. Possible values are `always`, `defer`, `defer+madvise`, `madvise` and `never`. 
 
 * `transparent_huge_page` - (Optional) Specifies the Transparent Huge Page configuration. Possible values are `always`, `madvise` and `never`.
+
+---
+
+A `local_dns_profile` block supports the following:
+
+At least one of `kube_dns_override`, `mode` or `vnet_dns_override` must be specified.
+
+* `kube_dns_override` - (Optional) One or more `kube_dns_override` blocks as defined below. Configures DNS overrides for Kubernetes DNS resolution.
+
+* `mode` - (Optional) The mode for the LocalDNS feature. Possible values are `Required`, `Preferred` and `Disabled`.
+
+* `vnet_dns_override` - (Optional) One or more `vnet_dns_override` blocks as defined below. Configures DNS overrides for VNet DNS resolution.
+
+---
+
+A `kube_dns_override` and `vnet_dns_override` block supports the following:
+
+* `domain` - (Required) The domain name to configure DNS overrides for. This is used as the map key in the API payload (e.g. `"."` or `"cluster.local"`).
+
+* `cache_duration_in_seconds` - (Optional) The duration in seconds to cache DNS responses. This value must be at least `1`.
+
+* `forward_destination` - (Optional) The forward destination for DNS queries. Possible values are `ClusterCoreDNS` and `VnetDNS`.
+
+* `forward_policy` - (Optional) The forwarding policy. Possible values are `Random`, `RoundRobin` and `Sequential`.
+
+* `max_concurrent` - (Optional) The maximum number of concurrent DNS queries. This value must be at least `1`.
+
+* `protocol` - (Optional) The DNS protocol to use. Possible values are `ForceTCP` and `PreferUDP`.
+
+* `query_logging` - (Optional) The query logging configuration. Possible values are `Error` and `Log`.
+
+* `serve_stale` - (Optional) The serve stale configuration. Possible values are `Disable`, `Immediate` and `Verify`.
+
+* `serve_stale_duration` - (Optional) The serve stale duration in seconds. This value must be at least `1`.
 
 ---
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This PR adds support for the `local_dns_profile` block on AKS node pools through:

* `azurerm_kubernetes_cluster.default_node_pool.local_dns_profile`
* `azurerm_kubernetes_cluster_node_pool.local_dns_profile`

The new block maps the AKS LocalDNS profile fields exposed by the `2026-05-01` Container Service API, including the LocalDNS mode plus VNet and Kubernetes DNS override maps. The implementation wires the field through create, update, read, import flattening, acceptance tests, and resource documentation.

Feature guide: [Configure LocalDNS in Azure Kubernetes Service (AKS)](https://learn.microsoft.com/en-us/azure/aks/localdns-custom). The guide covers Azure CLI configuration with `--localdns-config`; this PR adds Terraform support through the AKS API.

Portal check (16 September 2026): I found no LocalDNS controls in the AKS Standard creation wizard, including the default and additional node-pool forms, Networking and Advanced tabs. I could not check existing-cluster editing because no clusters were listed; the Portal also reported subscription lookup errors. This was a limited UI check, so I am not claiming that configuration is CLI-only.

This is a Harry-authored replacement for closed PR #31987. During the duplicate PR check I found open PR #32348, which appears to overlap this feature.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

### Current May API validation - 16 September 2026

Head `f44971b5` merges main's `2026-05-01` API without changing Local DNS feature logic. Three unit tests, full containers compilation, pinned formatting, fixture checks and diff-scoped lint (zero issues) passed locally.

May-API acceptance: [TeamCity 753393](https://hashicorp.teamcity.com/build/753393) finished on 16 September 2026 at 00:55:17 UTC: **18 passed, 0 failed, 0 ignored, 0 muted** on merge `a597d620` (head `f44971b5`). The selected Local DNS and shared-path cases completed, including harness teardown; all 15 requested runtime settings matched. This is focused coverage, not full-suite or beta coverage. No dedicated Local DNS remove/disable/re-enable stages or separate Azure resource inventory were performed.

### Historical acceptance - older API

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

September 11 Azure acceptance: [TeamCity 743433](https://hashicorp.teamcity.com/build/743433) passed **18/18 cases**, with no failures, ignored or muted tests, on pinned merge `9a6c35e3404d` (base `f485f47e9c6d` + head `96fde554dfc2`), not later main revisions. Coverage includes Local DNS create/update/import for both pool types, four shared Linux/kubelet cases, and selected network/scaling controls. Profile removal and mode transitions are not covered.

[TeamCity 743434](https://hashicorp.teamcity.com/build/743434) also passed **3/3 scaling controls** on exact base `f485f47e9c6d`, with no failures, ignored or muted tests. The three previously unattributed scaling failures no longer reproduce in these focused PR/base runs; their original causes remain unknown.

The [older broad run 702696](https://hashicorp.teamcity.com/build/702696) remains **270 passed, 24 failed and 4 ignored**; focused passes do not make it green. Historical beta run 702697 could not be independently verified because its metadata returned 404. The screenshot and link below are historical.

<img width="954" height="321" alt="image" src="https://github.com/user-attachments/assets/fef33e4b-0650-4c88-b88d-d268ab5387e4" />
https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_CONTAINERS/679661?buildTab=tests&name=_localDNSProfile

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/31342


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

AI assistance was used to port the implementation from the closed PR, resolve conflicts against current `main`, draft documentation/test updates, run validation commands, and prepare this PR description.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

No changes to security controls.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.



