### PR TITLE
`azurerm_mssql_server` - add poller for eventual consistency

### DIFF
--- a/internal/services/mssql/custompollers/mssql_server_availability_poller.go
+++ b/internal/services/mssql/custompollers/mssql_server_availability_poller.go
@@ -1,0 +1,64 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package custompollers
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-08-01-preview/servers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+)
+
+var _ pollers.PollerType = &MsSqlServerAvailabilityPoller{}
+
+type MsSqlServerAvailabilityPoller struct {
+	client       *servers.ServersClient
+	id           commonids.SqlServerId
+	successCount int
+}
+
+const msSqlServerAvailabilitySuccessCount = 3
+
+func NewMsSqlServerAvailabilityPoller(client *servers.ServersClient, id commonids.SqlServerId) *MsSqlServerAvailabilityPoller {
+	return &MsSqlServerAvailabilityPoller{
+		client:       client,
+		id:           id,
+		successCount: msSqlServerAvailabilitySuccessCount,
+	}
+}
+
+func (p *MsSqlServerAvailabilityPoller) Poll(ctx context.Context) (*pollers.PollResult, error) {
+	resp, err := p.client.Get(ctx, p.id, servers.DefaultGetOperationOptions())
+	if err != nil {
+		if response.WasNotFound(resp.HttpResponse) {
+			p.successCount = msSqlServerAvailabilitySuccessCount
+			return &pollers.PollResult{
+				Status:       pollers.PollingStatusInProgress,
+				PollInterval: 5 * time.Second,
+			}, nil
+		}
+
+		return &pollers.PollResult{
+			Status:       pollers.PollingStatusFailed,
+			PollInterval: 5 * time.Second,
+		}, fmt.Errorf("retrieving %s: %+v", p.id, err)
+	}
+
+	if p.successCount > 1 {
+		p.successCount--
+		return &pollers.PollResult{
+			Status:       pollers.PollingStatusInProgress,
+			PollInterval: 5 * time.Second,
+		}, nil
+	}
+
+	return &pollers.PollResult{
+		Status:       pollers.PollingStatusSucceeded,
+		PollInterval: 5 * time.Second,
+	}, nil
+}

--- a/internal/services/mssql/mssql_server_resource.go
+++ b/internal/services/mssql/mssql_server_resource.go
@@ -346,7 +346,7 @@ func resourceMsSqlServerCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 	pollerType := custompollers.NewMsSqlServerAvailabilityPoller(client, id)
 	poller := pollers.NewPoller(pollerType, 5*time.Second, pollers.DefaultNumberOfDroppedConnectionsToAllow)
 	if err = poller.PollUntilDone(ctx); err != nil {
-		return fmt.Errorf("[DEBUG] waiting for %s to be able to be queried: %+v", id, err)
+		return fmt.Errorf("waiting for %s to be able to be queried: %w", id, err)
 	}
 
 	connection := serverconnectionpolicies.ServerConnectionPolicy{

--- a/internal/services/mssql/mssql_server_resource.go
+++ b/internal/services/mssql/mssql_server_resource.go
@@ -342,6 +342,13 @@ func resourceMsSqlServerCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 		return err
 	}
 
+	log.Printf("[DEBUG] Waiting for %s to be able to be queried", id)
+	pollerType := custompollers.NewMsSqlServerAvailabilityPoller(client, id)
+	poller := pollers.NewPoller(pollerType, 5*time.Second, pollers.DefaultNumberOfDroppedConnectionsToAllow)
+	if err = poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("[DEBUG] waiting for %s to be able to be queried: %+v", id, err)
+	}
+
 	connection := serverconnectionpolicies.ServerConnectionPolicy{
 		Properties: &serverconnectionpolicies.ServerConnectionPolicyProperties{
 			ConnectionType: serverconnectionpolicies.ServerConnectionType(d.Get("connection_policy").(string)),


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

After the mssql creation successfully, the connection creation might fail due to eventual consistency. Thus adding a poller to check its consistency.

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<img width="1027" height="701" alt="image" src="https://github.com/user-attachments/assets/662792d9-846f-4cf3-b622-3bc8b7acfaeb" />
The failure is also happening on main branch, which is not caused by this change.

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_mssql_server` - add poller for eventual consistency [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #32313


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
