### PR TITLE
`azurerm_virtual_network` & `azurerm_subnet` - Add `network_identifier` to `service_endpoint` field

### DIFF
--- a/internal/services/appservice/linux_function_app_resource_test.go
+++ b/internal/services/appservice/linux_function_app_resource_test.go
@@ -4638,9 +4638,9 @@ resource "azurerm_subnet" "test" {
     }
   }
 
-  service_endpoints = [
-    "Microsoft.Storage"
-  ]
+  service_endpoint {
+    service = "Microsoft.Storage"
+  }
 }
 
 resource "azurerm_storage_account_network_rules" "test" {

--- a/internal/services/appservice/linux_function_app_slot_resource_test.go
+++ b/internal/services/appservice/linux_function_app_slot_resource_test.go
@@ -3551,9 +3551,9 @@ resource "azurerm_subnet" "test" {
     }
   }
 
-  service_endpoints = [
-    "Microsoft.Storage"
-  ]
+  service_endpoint {
+    service = "Microsoft.Storage"
+  }
 }
 
 resource "azurerm_storage_account_network_rules" "test" {

--- a/internal/services/appservice/linux_web_app_resource_test.go
+++ b/internal/services/appservice/linux_web_app_resource_test.go
@@ -3950,9 +3950,9 @@ resource "azurerm_subnet" "test" {
     }
   }
 
-  service_endpoints = [
-    "Microsoft.Storage"
-  ]
+  service_endpoint {
+    service = "Microsoft.Storage"
+  }
 }
 
 resource "azurerm_storage_account" "test" {

--- a/internal/services/appservice/linux_web_app_slot_resource_test.go
+++ b/internal/services/appservice/linux_web_app_slot_resource_test.go
@@ -3190,9 +3190,9 @@ resource "azurerm_subnet" "test" {
     }
   }
 
-  service_endpoints = [
-    "Microsoft.Storage"
-  ]
+  service_endpoint {
+    service = "Microsoft.Storage"
+  }
 }
 
 resource "azurerm_storage_account" "test" {

--- a/internal/services/appservice/windows_function_app_resource_test.go
+++ b/internal/services/appservice/windows_function_app_resource_test.go
@@ -3937,9 +3937,9 @@ resource "azurerm_subnet" "test" {
     }
   }
 
-  service_endpoints = [
-    "Microsoft.Storage"
-  ]
+  service_endpoint {
+    service = "Microsoft.Storage"
+  }
 }
 
 resource "azurerm_storage_account_network_rules" "test" {

--- a/internal/services/appservice/windows_function_app_slot_resource_test.go
+++ b/internal/services/appservice/windows_function_app_slot_resource_test.go
@@ -3253,9 +3253,9 @@ resource "azurerm_subnet" "test" {
     }
   }
 
-  service_endpoints = [
-    "Microsoft.Storage"
-  ]
+  service_endpoint {
+    service = "Microsoft.Storage"
+  }
 }
 
 resource "azurerm_storage_account_network_rules" "test" {

--- a/internal/services/appservice/windows_web_app_resource_test.go
+++ b/internal/services/appservice/windows_web_app_resource_test.go
@@ -4193,9 +4193,9 @@ resource "azurerm_subnet" "test" {
     }
   }
 
-  service_endpoints = [
-    "Microsoft.Storage"
-  ]
+  service_endpoint {
+    service = "Microsoft.Storage"
+  }
 }
 
 resource "azurerm_storage_account" "test" {

--- a/internal/services/appservice/windows_web_app_slot_resource_test.go
+++ b/internal/services/appservice/windows_web_app_slot_resource_test.go
@@ -2931,9 +2931,9 @@ resource "azurerm_subnet" "test" {
     }
   }
 
-  service_endpoints = [
-    "Microsoft.Storage"
-  ]
+  service_endpoint {
+    service = "Microsoft.Storage"
+  }
 }
 
 resource "azurerm_storage_account" "test" {

--- a/internal/services/cognitive/ai_services_resource_test.go
+++ b/internal/services/cognitive/ai_services_resource_test.go
@@ -436,7 +436,9 @@ resource "azurerm_subnet" "test_a" {
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.0.2.0/24"]
-  service_endpoints    = ["Microsoft.CognitiveServices"]
+  service_endpoint {
+    service = "Microsoft.CognitiveServices"
+  }
 }
 
 resource "azurerm_subnet" "test_b" {
@@ -444,7 +446,9 @@ resource "azurerm_subnet" "test_b" {
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.0.4.0/24"]
-  service_endpoints    = ["Microsoft.CognitiveServices"]
+  service_endpoint {
+    service = "Microsoft.CognitiveServices"
+  }
 }
 
 resource "azurerm_ai_services" "test" {
@@ -547,7 +551,9 @@ resource "azurerm_subnet" "test_a" {
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.0.2.0/24"]
-  service_endpoints    = ["Microsoft.CognitiveServices"]
+  service_endpoint {
+    service = "Microsoft.CognitiveServices"
+  }
 }
 
 resource "azurerm_subnet" "test_b" {
@@ -555,7 +561,9 @@ resource "azurerm_subnet" "test_b" {
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.0.4.0/24"]
-  service_endpoints    = ["Microsoft.CognitiveServices"]
+  service_endpoint {
+    service = "Microsoft.CognitiveServices"
+  }
 }
 
 resource "azurerm_ai_services" "test" {
@@ -922,7 +930,9 @@ resource "azurerm_subnet" "test_a" {
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.0.2.0/24"]
-  service_endpoints    = ["Microsoft.CognitiveServices"]
+  service_endpoint {
+    service = "Microsoft.CognitiveServices"
+  }
 }
 
 resource "azurerm_subnet" "test_b" {
@@ -930,7 +940,9 @@ resource "azurerm_subnet" "test_b" {
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.0.4.0/24"]
-  service_endpoints    = ["Microsoft.CognitiveServices"]
+  service_endpoint {
+    service = "Microsoft.CognitiveServices"
+  }
 }
 `, r.template(data), data.RandomInteger)
 }

--- a/internal/services/cognitive/cognitive_account_data_source_test.go
+++ b/internal/services/cognitive/cognitive_account_data_source_test.go
@@ -212,7 +212,9 @@ resource "azurerm_subnet" "test_a" {
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.0.2.0/24"]
-  service_endpoints    = ["Microsoft.CognitiveServices"]
+  service_endpoint {
+    service = "Microsoft.CognitiveServices"
+  }
 }
 
 resource "azurerm_subnet" "test_b" {
@@ -220,7 +222,9 @@ resource "azurerm_subnet" "test_b" {
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.0.4.0/24"]
-  service_endpoints    = ["Microsoft.CognitiveServices"]
+  service_endpoint {
+    service = "Microsoft.CognitiveServices"
+  }
 }
 
 resource "azurerm_subnet" "test_agent" {

--- a/internal/services/cognitive/cognitive_account_resource_test.go
+++ b/internal/services/cognitive/cognitive_account_resource_test.go
@@ -1325,7 +1325,9 @@ resource "azurerm_subnet" "test_a" {
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.0.2.0/24"]
-  service_endpoints    = ["Microsoft.CognitiveServices"]
+  service_endpoint {
+    service = "Microsoft.CognitiveServices"
+  }
 }
 
 resource "azurerm_subnet" "test_b" {
@@ -1333,7 +1335,9 @@ resource "azurerm_subnet" "test_b" {
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.0.4.0/24"]
-  service_endpoints    = ["Microsoft.CognitiveServices"]
+  service_endpoint {
+    service = "Microsoft.CognitiveServices"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
@@ -1657,7 +1661,9 @@ resource "azurerm_subnet" "test_a" {
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.0.2.0/24"]
-  service_endpoints    = ["Microsoft.CognitiveServices"]
+  service_endpoint {
+    service = "Microsoft.CognitiveServices"
+  }
 }
 
 resource "azurerm_subnet" "test_b" {
@@ -1665,7 +1671,9 @@ resource "azurerm_subnet" "test_b" {
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.0.4.0/24"]
-  service_endpoints    = ["Microsoft.CognitiveServices"]
+  service_endpoint {
+    service = "Microsoft.CognitiveServices"
+  }
 }
 
 resource "azurerm_cognitive_account" "test" {

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -3910,11 +3910,17 @@ resource "azurerm_subnet" "test" {
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.1.${count.index}.0/24"]
-  service_endpoints = [
-    "Microsoft.Storage.Global",
-    "Microsoft.AzureActiveDirectory",
-    "Microsoft.KeyVault"
-  ]
+  service_endpoint {
+    service = "Microsoft.Storage.Global"
+  }
+
+  service_endpoint {
+    service = "Microsoft.AzureActiveDirectory"
+  }
+
+  service_endpoint {
+    service = "Microsoft.KeyVault"
+  }
 
   lifecycle {
     # AKS automatically configures subnet delegations when the subnets are assigned

--- a/internal/services/cosmos/cosmosdb_account_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_account_resource_test.go
@@ -1680,7 +1680,9 @@ resource "azurerm_subnet" "subnet1" {
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.0.1.0/24"]
-  service_endpoints    = ["Microsoft.AzureCosmosDB"]
+  service_endpoint {
+    service = "Microsoft.AzureCosmosDB"
+  }
 }
 
 resource "azurerm_subnet" "subnet2" {
@@ -1688,7 +1690,9 @@ resource "azurerm_subnet" "subnet2" {
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.0.2.0/24"]
-  service_endpoints    = ["Microsoft.AzureCosmosDB"]
+  service_endpoint {
+    service = "Microsoft.AzureCosmosDB"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary)
 }
@@ -2480,11 +2484,13 @@ resource "azurerm_subnet" "subnet1" {
 }
 
 resource "azurerm_subnet" "subnet2" {
-  name                                          = "acctest-SN2-%[1]d-2"
-  resource_group_name                           = azurerm_resource_group.test.name
-  virtual_network_name                          = azurerm_virtual_network.test.name
-  address_prefixes                              = ["10.0.2.0/24"]
-  service_endpoints                             = ["Microsoft.AzureCosmosDB"]
+  name                 = "acctest-SN2-%[1]d-2"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.2.0/24"]
+  service_endpoint {
+    service = "Microsoft.AzureCosmosDB"
+  }
   private_endpoint_network_policies             = "Disabled"
   private_link_service_network_policies_enabled = false
 }

--- a/internal/services/elasticsan/elastic_san_volume_group_resource_test.go
+++ b/internal/services/elasticsan/elastic_san_volume_group_resource_test.go
@@ -419,7 +419,9 @@ resource "azurerm_subnet" "test" {
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.0.1.0/24"]
-  service_endpoints    = ["Microsoft.Storage.Global"]
+  service_endpoint {
+    service = "Microsoft.Storage.Global"
+  }
 
 }
 
@@ -522,7 +524,9 @@ resource "azurerm_subnet" "test" {
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.0.1.0/24"]
-  service_endpoints    = ["Microsoft.Storage.Global"]
+  service_endpoint {
+    service = "Microsoft.Storage.Global"
+  }
 
 }
 
@@ -625,7 +629,9 @@ resource "azurerm_subnet" "test" {
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.0.1.0/24"]
-  service_endpoints    = ["Microsoft.Storage.Global"]
+  service_endpoint {
+    service = "Microsoft.Storage.Global"
+  }
 
 }
 
@@ -634,7 +640,9 @@ resource "azurerm_subnet" "test2" {
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.0.2.0/24"]
-  service_endpoints    = ["Microsoft.Storage.Global"]
+  service_endpoint {
+    service = "Microsoft.Storage.Global"
+  }
 
 }
 

--- a/internal/services/eventhub/eventhub_namespace_resource_test.go
+++ b/internal/services/eventhub/eventhub_namespace_resource_test.go
@@ -856,7 +856,9 @@ resource "azurerm_subnet" "test" {
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.0.1.0/24"]
-  service_endpoints    = ["Microsoft.EventHub"]
+  service_endpoint {
+    service = "Microsoft.EventHub"
+  }
 }
 
 resource "azurerm_virtual_network" "test2" {
@@ -871,7 +873,9 @@ resource "azurerm_subnet" "test2" {
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test2.name
   address_prefixes     = ["10.1.1.0/24"]
-  service_endpoints    = ["Microsoft.EventHub"]
+  service_endpoint {
+    service = "Microsoft.EventHub"
+  }
 }
 
 resource "azurerm_eventhub_namespace" "test" {

--- a/internal/services/keyvault/key_vault_resource_test.go
+++ b/internal/services/keyvault/key_vault_resource_test.go
@@ -566,7 +566,9 @@ resource "azurerm_subnet" "test_a" {
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.0.2.0/24"]
-  service_endpoints    = ["Microsoft.KeyVault"]
+  service_endpoint {
+    service = "Microsoft.KeyVault"
+  }
 }
 
 resource "azurerm_subnet" "test_b" {
@@ -574,7 +576,9 @@ resource "azurerm_subnet" "test_b" {
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.0.4.0/24"]
-  service_endpoints    = ["Microsoft.KeyVault"]
+  service_endpoint {
+    service = "Microsoft.KeyVault"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }

--- a/internal/services/managedhsm/key_vault_managed_hardware_security_module_resource_test.go
+++ b/internal/services/managedhsm/key_vault_managed_hardware_security_module_resource_test.go
@@ -345,7 +345,9 @@ resource "azurerm_subnet" "test_a" {
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.0.2.0/24"]
-  service_endpoints    = ["Microsoft.KeyVault"]
+  service_endpoint {
+    service = "Microsoft.KeyVault"
+  }
 }
 
 resource "azurerm_key_vault_managed_hardware_security_module" "test" {

--- a/internal/services/mssql/mssql_database_extended_auditing_policy_resource_test.go
+++ b/internal/services/mssql/mssql_database_extended_auditing_policy_resource_test.go
@@ -510,10 +510,6 @@ resource "azurerm_mssql_server_extended_auditing_policy" "test" {
     azurerm_storage_account.test,
   ]
 }
-
-
-
-
 `, data.RandomInteger, data.Locations.Primary, data.RandomString, data.Client().SubscriptionID)
 }
 

--- a/internal/services/mssql/mssql_database_extended_auditing_policy_resource_test.go
+++ b/internal/services/mssql/mssql_database_extended_auditing_policy_resource_test.go
@@ -430,11 +430,17 @@ resource "azurerm_virtual_network" "test" {
 }
 
 resource "azurerm_subnet" "test" {
-  name                              = "acctestsubnet%[1]d"
-  resource_group_name               = azurerm_resource_group.test.name
-  virtual_network_name              = azurerm_virtual_network.test.name
-  address_prefixes                  = ["10.0.2.0/24"]
-  service_endpoints                 = ["Microsoft.Storage", "Microsoft.Sql"]
+  name                 = "acctestsubnet%[1]d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.2.0/24"]
+  service_endpoint {
+    service = "Microsoft.Storage"
+  }
+
+  service_endpoint {
+    service = "Microsoft.Sql"
+  }
   private_endpoint_network_policies = "Disabled"
 }
 

--- a/internal/services/mssql/mssql_server_extended_auditing_policy_resource_test.go
+++ b/internal/services/mssql/mssql_server_extended_auditing_policy_resource_test.go
@@ -350,7 +350,9 @@ resource "azurerm_subnet" "test" {
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.0.2.0/24"]
-  service_endpoints    = ["Microsoft.Storage"]
+  service_endpoint {
+    service = "Microsoft.Storage"
+  }
 }
 
 resource "azurerm_storage_account" "test" {

--- a/internal/services/mssql/mssql_server_microsoft_support_auditing_policy_resource_test.go
+++ b/internal/services/mssql/mssql_server_microsoft_support_auditing_policy_resource_test.go
@@ -288,7 +288,9 @@ resource "azurerm_subnet" "test" {
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.0.2.0/24"]
-  service_endpoints    = ["Microsoft.Storage"]
+  service_endpoint {
+    service = "Microsoft.Storage"
+  }
 }
 
 resource "azurerm_storage_account" "test" {

--- a/internal/services/mssql/mssql_virtual_network_rule_resource_test.go
+++ b/internal/services/mssql/mssql_virtual_network_rule_resource_test.go
@@ -125,7 +125,9 @@ resource "azurerm_subnet" "test1" {
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.7.28.0/25"]
-  service_endpoints    = ["Microsoft.Sql"]
+  service_endpoint {
+    service = "Microsoft.Sql"
+  }
 }
 
 resource "azurerm_subnet" "test2" {
@@ -133,7 +135,9 @@ resource "azurerm_subnet" "test2" {
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.7.28.128/25"]
-  service_endpoints    = ["Microsoft.Sql"]
+  service_endpoint {
+    service = "Microsoft.Sql"
+  }
 }
 
 resource "azurerm_subnet" "test3" {

--- a/internal/services/mysql/mysql_flexible_server_resource_test.go
+++ b/internal/services/mysql/mysql_flexible_server_resource_test.go
@@ -768,7 +768,9 @@ resource "azurerm_subnet" "test" {
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.0.2.0/24"]
-  service_endpoints    = ["Microsoft.Storage"]
+  service_endpoint {
+    service = "Microsoft.Storage"
+  }
 
   delegation {
     name = "fs"
@@ -853,7 +855,9 @@ resource "azurerm_subnet" "test" {
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.0.2.0/24"]
-  service_endpoints    = ["Microsoft.Storage"]
+  service_endpoint {
+    service = "Microsoft.Storage"
+  }
 
   delegation {
     name = "fs"

--- a/internal/services/network/subnet_data_source.go
+++ b/internal/services/network/subnet_data_source.go
@@ -85,26 +85,9 @@ func dataSourceSubnet() *pluginsdk.Resource {
 		resource.Schema["service_endpoints"] = &pluginsdk.Schema{
 			Type:       pluginsdk.TypeList,
 			Computed:   true,
-			Deprecated: "The `service_endpoints` property has been superseded by the `service_endpoint` block and will be removed in v5.0 of the AzureRM Provider.",
+			Deprecated: "The `service_endpoints` list of strings will be replaced by a `service_endpoints` block in v5.0 of the AzureRM Provider.",
 			Elem: &pluginsdk.Schema{
 				Type: pluginsdk.TypeString,
-			},
-		}
-
-		resource.Schema["service_endpoint"] = &pluginsdk.Schema{
-			Type:     pluginsdk.TypeList,
-			Computed: true,
-			Elem: &pluginsdk.Resource{
-				Schema: map[string]*pluginsdk.Schema{
-					"service": {
-						Type:     pluginsdk.TypeString,
-						Computed: true,
-					},
-					"network_identifier": {
-						Type:     pluginsdk.TypeString,
-						Computed: true,
-					},
-				},
 			},
 		}
 	} else {
@@ -183,17 +166,12 @@ func dataSourceSubnetRead(d *pluginsdk.ResourceData, meta interface{}) error {
 			}
 			d.Set("route_table_id", routeTableId)
 
-			serviceEndpoint := flattenSubnetServiceEndpoint(props.ServiceEndpoints)
 			if !features.FivePointOh() {
-				serviceEndpoints := flattenSubnetServiceEndpoints(props.ServiceEndpoints)
-				if err := d.Set("service_endpoints", serviceEndpoints); err != nil {
+				if err := d.Set("service_endpoints", flattenSubnetServiceEndpoints(props.ServiceEndpoints)); err != nil {
 					return fmt.Errorf("setting `service_endpoints`: %+v", err)
 				}
-				if err := d.Set("service_endpoint", serviceEndpoint); err != nil {
-					return fmt.Errorf("setting `service_endpoint`: %+v", err)
-				}
 			} else {
-				if err := d.Set("service_endpoints", serviceEndpoint); err != nil {
+				if err := d.Set("service_endpoints", flattenSubnetServiceEndpoint(props.ServiceEndpoints)); err != nil {
 					return fmt.Errorf("setting `service_endpoints`: %+v", err)
 				}
 			}

--- a/internal/services/network/subnet_data_source.go
+++ b/internal/services/network/subnet_data_source.go
@@ -64,23 +64,6 @@ func dataSourceSubnet() *pluginsdk.Resource {
 				Computed: true,
 			},
 
-			"service_endpoint": {
-				Type:     pluginsdk.TypeList,
-				Computed: true,
-				Elem: &pluginsdk.Resource{
-					Schema: map[string]*pluginsdk.Schema{
-						"service": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
-						"network_identifier": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
-					},
-				},
-			},
-
 			"default_outbound_access_enabled": {
 				Type:     pluginsdk.TypeBool,
 				Computed: true,
@@ -105,6 +88,40 @@ func dataSourceSubnet() *pluginsdk.Resource {
 			Deprecated: "The `service_endpoints` property has been superseded by the `service_endpoint` block and will be removed in v5.0 of the AzureRM Provider.",
 			Elem: &pluginsdk.Schema{
 				Type: pluginsdk.TypeString,
+			},
+		}
+
+		resource.Schema["service_endpoint"] = &pluginsdk.Schema{
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"service": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+					"network_identifier": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+				},
+			},
+		}
+	} else {
+		resource.Schema["service_endpoints"] = &pluginsdk.Schema{
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"service": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+					"network_identifier": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+				},
 			},
 		}
 	}
@@ -166,16 +183,19 @@ func dataSourceSubnetRead(d *pluginsdk.ResourceData, meta interface{}) error {
 			}
 			d.Set("route_table_id", routeTableId)
 
-			serviceEndpoints := flattenSubnetServiceEndpoints(props.ServiceEndpoints)
+			serviceEndpoint := flattenSubnetServiceEndpoint(props.ServiceEndpoints)
 			if !features.FivePointOh() {
+				serviceEndpoints := flattenSubnetServiceEndpoints(props.ServiceEndpoints)
 				if err := d.Set("service_endpoints", serviceEndpoints); err != nil {
 					return fmt.Errorf("setting `service_endpoints`: %+v", err)
 				}
-			}
-
-			serviceEndpoint := flattenSubnetServiceEndpoint(props.ServiceEndpoints)
-			if err := d.Set("service_endpoint", serviceEndpoint); err != nil {
-				return fmt.Errorf("setting `service_endpoint`: %+v", err)
+				if err := d.Set("service_endpoint", serviceEndpoint); err != nil {
+					return fmt.Errorf("setting `service_endpoint`: %+v", err)
+				}
+			} else {
+				if err := d.Set("service_endpoints", serviceEndpoint); err != nil {
+					return fmt.Errorf("setting `service_endpoints`: %+v", err)
+				}
 			}
 		}
 	}

--- a/internal/services/network/subnet_data_source.go
+++ b/internal/services/network/subnet_data_source.go
@@ -78,21 +78,21 @@ func dataSourceSubnet() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeBool,
 				Computed: true,
 			},
-		},
-	}
 
-	resource.Schema["service_endpoints"] = &pluginsdk.Schema{
-		Type:     pluginsdk.TypeList,
-		Computed: true,
-		Elem: &pluginsdk.Resource{
-			Schema: map[string]*pluginsdk.Schema{
-				"service": {
-					Type:     pluginsdk.TypeString,
-					Computed: true,
-				},
-				"network_identifier": {
-					Type:     pluginsdk.TypeString,
-					Computed: true,
+			"service_endpoints": {
+				Type:     pluginsdk.TypeList,
+				Computed: true,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"service": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+						"network_identifier": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+					},
 				},
 			},
 		},

--- a/internal/services/network/subnet_data_source.go
+++ b/internal/services/network/subnet_data_source.go
@@ -64,10 +64,28 @@ func dataSourceSubnet() *pluginsdk.Resource {
 			},
 
 			"service_endpoints": {
-				Type:     pluginsdk.TypeList,
-				Computed: true,
+				Type:       pluginsdk.TypeList,
+				Computed:   true,
+				Deprecated: "The `service_endpoints` property has been superseded by the `service_endpoint` block and will be removed in a future version of the provider.",
 				Elem: &pluginsdk.Schema{
 					Type: pluginsdk.TypeString,
+				},
+			},
+
+			"service_endpoint": {
+				Type:     pluginsdk.TypeList,
+				Computed: true,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"service": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+						"network_identifier": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+					},
 				},
 			},
 
@@ -146,6 +164,11 @@ func dataSourceSubnetRead(d *pluginsdk.ResourceData, meta interface{}) error {
 			serviceEndpoints := flattenSubnetServiceEndpoints(props.ServiceEndpoints)
 			if err := d.Set("service_endpoints", serviceEndpoints); err != nil {
 				return fmt.Errorf("setting `service_endpoints`: %+v", err)
+			}
+
+			serviceEndpoint := flattenSubnetServiceEndpoint(props.ServiceEndpoints)
+			if err := d.Set("service_endpoint", serviceEndpoint); err != nil {
+				return fmt.Errorf("setting `service_endpoint`: %+v", err)
 			}
 		}
 	}

--- a/internal/services/network/subnet_data_source.go
+++ b/internal/services/network/subnet_data_source.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/subnets"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
@@ -20,7 +21,7 @@ import (
 )
 
 func dataSourceSubnet() *pluginsdk.Resource {
-	return &pluginsdk.Resource{
+	resource := &pluginsdk.Resource{
 		Read: dataSourceSubnetRead,
 
 		Timeouts: &pluginsdk.ResourceTimeout{
@@ -63,15 +64,6 @@ func dataSourceSubnet() *pluginsdk.Resource {
 				Computed: true,
 			},
 
-			"service_endpoints": {
-				Type:       pluginsdk.TypeList,
-				Computed:   true,
-				Deprecated: "The `service_endpoints` property has been superseded by the `service_endpoint` block and will be removed in a future version of the provider.",
-				Elem: &pluginsdk.Schema{
-					Type: pluginsdk.TypeString,
-				},
-			},
-
 			"service_endpoint": {
 				Type:     pluginsdk.TypeList,
 				Computed: true,
@@ -105,6 +97,19 @@ func dataSourceSubnet() *pluginsdk.Resource {
 			},
 		},
 	}
+
+	if !features.FivePointOh() {
+		resource.Schema["service_endpoints"] = &pluginsdk.Schema{
+			Type:       pluginsdk.TypeList,
+			Computed:   true,
+			Deprecated: "The `service_endpoints` property has been superseded by the `service_endpoint` block and will be removed in v5.0 of the AzureRM Provider.",
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+			},
+		}
+	}
+
+	return resource
 }
 
 func dataSourceSubnetRead(d *pluginsdk.ResourceData, meta interface{}) error {
@@ -162,8 +167,10 @@ func dataSourceSubnetRead(d *pluginsdk.ResourceData, meta interface{}) error {
 			d.Set("route_table_id", routeTableId)
 
 			serviceEndpoints := flattenSubnetServiceEndpoints(props.ServiceEndpoints)
-			if err := d.Set("service_endpoints", serviceEndpoints); err != nil {
-				return fmt.Errorf("setting `service_endpoints`: %+v", err)
+			if !features.FivePointOh() {
+				if err := d.Set("service_endpoints", serviceEndpoints); err != nil {
+					return fmt.Errorf("setting `service_endpoints`: %+v", err)
+				}
 			}
 
 			serviceEndpoint := flattenSubnetServiceEndpoint(props.ServiceEndpoints)

--- a/internal/services/network/subnet_data_source.go
+++ b/internal/services/network/subnet_data_source.go
@@ -81,6 +81,23 @@ func dataSourceSubnet() *pluginsdk.Resource {
 		},
 	}
 
+	resource.Schema["service_endpoints"] = &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Computed: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"service": {
+					Type:     pluginsdk.TypeString,
+					Computed: true,
+				},
+				"network_identifier": {
+					Type:     pluginsdk.TypeString,
+					Computed: true,
+				},
+			},
+		},
+	}
+
 	if !features.FivePointOh() {
 		resource.Schema["service_endpoints"] = &pluginsdk.Schema{
 			Type:       pluginsdk.TypeList,
@@ -88,23 +105,6 @@ func dataSourceSubnet() *pluginsdk.Resource {
 			Deprecated: "The `service_endpoints` list of strings will be replaced by a `service_endpoints` block in v5.0 of the AzureRM Provider.",
 			Elem: &pluginsdk.Schema{
 				Type: pluginsdk.TypeString,
-			},
-		}
-	} else {
-		resource.Schema["service_endpoints"] = &pluginsdk.Schema{
-			Type:     pluginsdk.TypeList,
-			Computed: true,
-			Elem: &pluginsdk.Resource{
-				Schema: map[string]*pluginsdk.Schema{
-					"service": {
-						Type:     pluginsdk.TypeString,
-						Computed: true,
-					},
-					"network_identifier": {
-						Type:     pluginsdk.TypeString,
-						Computed: true,
-					},
-				},
 			},
 		}
 	}

--- a/internal/services/network/subnet_data_source.go
+++ b/internal/services/network/subnet_data_source.go
@@ -20,7 +20,7 @@ import (
 )
 
 func dataSourceSubnet() *pluginsdk.Resource {
-	resource := &pluginsdk.Resource{
+	return &pluginsdk.Resource{
 		Read: dataSourceSubnetRead,
 
 		Timeouts: &pluginsdk.ResourceTimeout{
@@ -78,7 +78,7 @@ func dataSourceSubnet() *pluginsdk.Resource {
 				Computed: true,
 			},
 
-			"service_endpoints": {
+			"service_endpoint": {
 				Type:     pluginsdk.TypeList,
 				Computed: true,
 				Elem: &pluginsdk.Resource{
@@ -96,8 +96,6 @@ func dataSourceSubnet() *pluginsdk.Resource {
 			},
 		},
 	}
-
-	return resource
 }
 
 func dataSourceSubnetRead(d *pluginsdk.ResourceData, meta interface{}) error {
@@ -154,8 +152,8 @@ func dataSourceSubnetRead(d *pluginsdk.ResourceData, meta interface{}) error {
 			}
 			d.Set("route_table_id", routeTableId)
 
-			if err := d.Set("service_endpoints", flattenSubnetServiceEndpoint(props.ServiceEndpoints)); err != nil {
-				return fmt.Errorf("setting `service_endpoints`: %+v", err)
+			if err := d.Set("service_endpoint", flattenSubnetServiceEndpoint(props.ServiceEndpoints)); err != nil {
+				return fmt.Errorf("setting `service_endpoint`: %+v", err)
 			}
 		}
 	}

--- a/internal/services/network/subnet_data_source.go
+++ b/internal/services/network/subnet_data_source.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/subnets"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
@@ -98,17 +97,6 @@ func dataSourceSubnet() *pluginsdk.Resource {
 		},
 	}
 
-	if !features.FivePointOh() {
-		resource.Schema["service_endpoints"] = &pluginsdk.Schema{
-			Type:       pluginsdk.TypeList,
-			Computed:   true,
-			Deprecated: "The `service_endpoints` list of strings will be replaced by a `service_endpoints` block in v5.0 of the AzureRM Provider.",
-			Elem: &pluginsdk.Schema{
-				Type: pluginsdk.TypeString,
-			},
-		}
-	}
-
 	return resource
 }
 
@@ -166,14 +154,8 @@ func dataSourceSubnetRead(d *pluginsdk.ResourceData, meta interface{}) error {
 			}
 			d.Set("route_table_id", routeTableId)
 
-			if !features.FivePointOh() {
-				if err := d.Set("service_endpoints", flattenSubnetServiceEndpoints(props.ServiceEndpoints)); err != nil {
-					return fmt.Errorf("setting `service_endpoints`: %+v", err)
-				}
-			} else {
-				if err := d.Set("service_endpoints", flattenSubnetServiceEndpoint(props.ServiceEndpoints)); err != nil {
-					return fmt.Errorf("setting `service_endpoints`: %+v", err)
-				}
+			if err := d.Set("service_endpoints", flattenSubnetServiceEndpoint(props.ServiceEndpoints)); err != nil {
+				return fmt.Errorf("setting `service_endpoints`: %+v", err)
 			}
 		}
 	}

--- a/internal/services/network/subnet_data_source_test.go
+++ b/internal/services/network/subnet_data_source_test.go
@@ -102,7 +102,7 @@ func TestAccDataSourceSubnet_serviceEndpoints(t *testing.T) {
 
 	data.DataSourceTest(t, []acceptance.TestStep{
 		{
-			Config: r.serviceEndpoint(data),
+			Config: r.serviceEndpoints(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("name").Exists(),
 				check.That(data.ResourceName).Key("resource_group_name").Exists(),
@@ -110,7 +110,27 @@ func TestAccDataSourceSubnet_serviceEndpoints(t *testing.T) {
 				check.That(data.ResourceName).Key("address_prefixes.#").Exists(),
 				check.That(data.ResourceName).Key("network_security_group_id").HasValue(""),
 				check.That(data.ResourceName).Key("route_table_id").HasValue(""),
-				check.That(data.ResourceName).Key("service_endpoints.#").HasValue("2"),
+				check.That(data.ResourceName).Key("service_endpoint.#").HasValue("2"),
+				check.That(data.ResourceName).Key("service_endpoint.0.service").Exists(),
+			),
+		},
+	})
+}
+
+func TestAccDataSourceSubnet_serviceEndpointsWithNetworkIdentifier(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_subnet", "test")
+	r := SubnetDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.serviceEndpointsWithNetworkIdentifier(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("name").Exists(),
+				check.That(data.ResourceName).Key("resource_group_name").Exists(),
+				check.That(data.ResourceName).Key("virtual_network_name").Exists(),
+				check.That(data.ResourceName).Key("service_endpoint.#").HasValue("1"),
+				check.That(data.ResourceName).Key("service_endpoint.0.service").HasValue("Microsoft.Storage"),
+				check.That(data.ResourceName).Key("service_endpoint.0.network_identifier").IsSet(),
 			),
 		},
 	})

--- a/internal/services/network/subnet_data_source_test.go
+++ b/internal/services/network/subnet_data_source_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 )
 
 type SubnetDataSource struct{}
@@ -257,18 +256,6 @@ data "azurerm_subnet" "test" {
 }
 
 func (SubnetDataSource) serviceEndpoints(data acceptance.TestData) string {
-	if !features.FivePointOh() {
-		return fmt.Sprintf(`
-%s
-
-data "azurerm_subnet" "test" {
-  name                 = azurerm_subnet.test.name
-  virtual_network_name = azurerm_subnet.test.virtual_network_name
-  resource_group_name  = azurerm_subnet.test.resource_group_name
-}
-`, SubnetResource{}.serviceEndpointsUpdated(data))
-	}
-
 	return fmt.Sprintf(`
 %s
 

--- a/internal/services/network/subnet_data_source_test.go
+++ b/internal/services/network/subnet_data_source_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 )
 
 type SubnetDataSource struct{}
@@ -256,7 +257,8 @@ data "azurerm_subnet" "test" {
 }
 
 func (SubnetDataSource) serviceEndpoint(data acceptance.TestData) string {
-	return fmt.Sprintf(`
+	if !features.FivePointOh() {
+		return fmt.Sprintf(`
 %s
 
 data "azurerm_subnet" "test" {
@@ -265,6 +267,29 @@ data "azurerm_subnet" "test" {
   resource_group_name  = azurerm_subnet.test.resource_group_name
 }
 `, SubnetResource{}.serviceEndpointsUpdated(data))
+	}
+
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_subnet" "test" {
+  name                 = azurerm_subnet.test.name
+  virtual_network_name = azurerm_subnet.test.virtual_network_name
+  resource_group_name  = azurerm_subnet.test.resource_group_name
+}
+`, SubnetResource{}.serviceEndpointBlockUpdated(data))
+}
+
+func (SubnetDataSource) serviceEndpointWithNetworkIdentifier(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_subnet" "test" {
+  name                 = azurerm_subnet.test.name
+  virtual_network_name = azurerm_subnet.test.virtual_network_name
+  resource_group_name  = azurerm_subnet.test.resource_group_name
+}
+`, SubnetResource{}.serviceEndpointWithNetworkIdentifier(data))
 }
 
 func (SubnetDataSource) template(data acceptance.TestData) string {

--- a/internal/services/network/subnet_data_source_test.go
+++ b/internal/services/network/subnet_data_source_test.go
@@ -256,7 +256,7 @@ data "azurerm_subnet" "test" {
 `, r.routeTableDependencies(data))
 }
 
-func (SubnetDataSource) serviceEndpoint(data acceptance.TestData) string {
+func (SubnetDataSource) serviceEndpoints(data acceptance.TestData) string {
 	if !features.FivePointOh() {
 		return fmt.Sprintf(`
 %s
@@ -280,7 +280,7 @@ data "azurerm_subnet" "test" {
 `, SubnetResource{}.serviceEndpointBlockUpdated(data))
 }
 
-func (SubnetDataSource) serviceEndpointWithNetworkIdentifier(data acceptance.TestData) string {
+func (SubnetDataSource) serviceEndpointsWithNetworkIdentifier(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 

--- a/internal/services/network/subnet_resource.go
+++ b/internal/services/network/subnet_resource.go
@@ -26,7 +26,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -362,21 +361,6 @@ func resourceSubnet() *pluginsdk.Resource {
 				Computed: true,
 			},
 		},
-	}
-
-	if !features.FivePointOh() {
-		resource.Schema["service_endpoints"] = &pluginsdk.Schema{
-			Type:     pluginsdk.TypeSet,
-			Optional: true,
-			// NOTE: O+C to allow the deprecated `service_endpoints` property and `service_endpoint` block to coexist in v4
-			Computed:      true,
-			Elem:          &pluginsdk.Schema{Type: pluginsdk.TypeString},
-			Set:           pluginsdk.HashString,
-			Deprecated:    "The `service_endpoints` property has been superseded by the `service_endpoint` block and will be removed in v5.0 of the AzureRM Provider.",
-			ConflictsWith: []string{"service_endpoint"},
-		}
-		resource.Schema["service_endpoint"].ConflictsWith = []string{"service_endpoints"}
-		resource.Schema["service_endpoint"].Computed = true
 	}
 
 	return resource
@@ -776,13 +760,6 @@ func resourceSubnetFlatten(d *pluginsdk.ResourceData, id commonids.SubnetId, sub
 			d.Set("private_endpoint_network_policies", string(pointer.From(props.PrivateEndpointNetworkPolicies)))
 			d.Set("private_link_service_network_policies_enabled", flattenSubnetNetworkPolicy(string(pointer.From(props.PrivateLinkServiceNetworkPolicies))))
 			d.Set("sharing_scope", pointer.FromEnum(props.SharingScope))
-
-			if !features.FivePointOh() {
-				serviceEndpoints := flattenSubnetServiceEndpoints(props.ServiceEndpoints)
-				if err := d.Set("service_endpoints", serviceEndpoints); err != nil {
-					return fmt.Errorf("setting `service_endpoints`: %+v", err)
-				}
-			}
 
 			serviceEndpoint := flattenSubnetServiceEndpoint(props.ServiceEndpoints)
 			if err := d.Set("service_endpoint", serviceEndpoint); err != nil {

--- a/internal/services/network/subnet_resource.go
+++ b/internal/services/network/subnet_resource.go
@@ -181,14 +181,24 @@ func resourceSubnet() *pluginsdk.Resource {
 			"service_endpoint": {
 				Type:     pluginsdk.TypeList,
 				Optional: true,
-				// NOTE: O+C to allow the deprecated `service_endpoints` property and `service_endpoint` block to coexist in v4
-				Computed: true,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
 						"service": {
-							Type:         pluginsdk.TypeString,
-							Required:     true,
-							ValidateFunc: validation.StringIsNotEmpty,
+							Type:     pluginsdk.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"Microsoft.AzureActiveDirectory",
+								"Microsoft.AzureCosmosDB",
+								"Microsoft.CognitiveServices",
+								"Microsoft.ContainerRegistry",
+								"Microsoft.EventHub",
+								"Microsoft.KeyVault",
+								"Microsoft.ServiceBus",
+								"Microsoft.Sql",
+								"Microsoft.Storage",
+								"Microsoft.Storage.Global",
+								"Microsoft.Web",
+							}, false),
 						},
 						"network_identifier": {
 							Type:         pluginsdk.TypeString,
@@ -366,6 +376,8 @@ func resourceSubnet() *pluginsdk.Resource {
 			ConflictsWith: []string{"service_endpoint"},
 		}
 		resource.Schema["service_endpoint"].ConflictsWith = []string{"service_endpoints"}
+		// NOTE: O+C to allow the deprecated `service_endpoints` property and `service_endpoint` block to coexist in v4
+		resource.Schema["service_endpoint"].Computed = true
 	}
 
 	return resource
@@ -896,13 +908,12 @@ func expandSubnetServiceEndpoint(input []interface{}) *[]subnets.ServiceEndpoint
 
 	for _, item := range input {
 		v := item.(map[string]interface{})
-		svc := v["service"].(string)
 		endpoint := subnets.ServiceEndpointPropertiesFormat{
-			Service: &svc,
+			Service: pointer.To(v["service"].(string)),
 		}
 		if networkIdentifier := v["network_identifier"].(string); networkIdentifier != "" {
 			endpoint.NetworkIdentifier = &subnets.SubResource{
-				Id: &networkIdentifier,
+				Id: pointer.To(networkIdentifier),
 			}
 		}
 		endpoints = append(endpoints, endpoint)
@@ -919,13 +930,12 @@ func flattenSubnetServiceEndpoint(serviceEndpoints *[]subnets.ServiceEndpointPro
 	}
 
 	for _, endpoint := range *serviceEndpoints {
-		item := map[string]interface{}{}
-		if endpoint.Service != nil {
-			item["service"] = *endpoint.Service
+		item := map[string]interface{}{
+			"service": pointer.From(endpoint.Service),
 		}
 		networkIdentifier := ""
-		if endpoint.NetworkIdentifier != nil && endpoint.NetworkIdentifier.Id != nil {
-			networkIdentifier = *endpoint.NetworkIdentifier.Id
+		if endpoint.NetworkIdentifier != nil {
+			networkIdentifier = pointer.From(endpoint.NetworkIdentifier.Id)
 		}
 		item["network_identifier"] = networkIdentifier
 		endpoints = append(endpoints, item)

--- a/internal/services/network/subnet_resource.go
+++ b/internal/services/network/subnet_resource.go
@@ -26,6 +26,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -112,7 +113,7 @@ var subnetDelegationServiceNames = []string{
 }
 
 func resourceSubnet() *pluginsdk.Resource {
-	return &pluginsdk.Resource{
+	resource := &pluginsdk.Resource{
 		Create:   resourceSubnetCreate,
 		Read:     resourceSubnetRead,
 		Update:   resourceSubnetUpdate,
@@ -177,18 +178,11 @@ func resourceSubnet() *pluginsdk.Resource {
 				},
 			},
 
-			"service_endpoints": {
-				Type:          pluginsdk.TypeSet,
-				Optional:      true,
-				Elem:          &pluginsdk.Schema{Type: pluginsdk.TypeString},
-				Set:           pluginsdk.HashString,
-				Deprecated:    "The `service_endpoints` property has been superseded by the `service_endpoint` block and will be removed in a future version of the provider.",
-				ConflictsWith: []string{"service_endpoint"},
-			},
-
 			"service_endpoint": {
 				Type:     pluginsdk.TypeList,
 				Optional: true,
+				// NOTE: O+C to allow the deprecated `service_endpoints` property and `service_endpoint` block to coexist in v4
+				Computed: true,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
 						"service": {
@@ -203,7 +197,6 @@ func resourceSubnet() *pluginsdk.Resource {
 						},
 					},
 				},
-				ConflictsWith: []string{"service_endpoints"},
 			},
 
 			"service_endpoint_policy_ids": {
@@ -360,6 +353,22 @@ func resourceSubnet() *pluginsdk.Resource {
 			},
 		},
 	}
+
+	if !features.FivePointOh() {
+		resource.Schema["service_endpoints"] = &pluginsdk.Schema{
+			Type:     pluginsdk.TypeSet,
+			Optional: true,
+			// NOTE: O+C to allow the deprecated `service_endpoints` property and `service_endpoint` block to coexist in v4
+			Computed:      true,
+			Elem:          &pluginsdk.Schema{Type: pluginsdk.TypeString},
+			Set:           pluginsdk.HashString,
+			Deprecated:    "The `service_endpoints` property has been superseded by the `service_endpoint` block and will be removed in v5.0 of the AzureRM Provider.",
+			ConflictsWith: []string{"service_endpoint"},
+		}
+		resource.Schema["service_endpoint"].ConflictsWith = []string{"service_endpoints"}
+	}
+
+	return resource
 }
 
 func resourceSubnetCreate(d *pluginsdk.ResourceData, meta interface{}) error {
@@ -757,16 +766,16 @@ func resourceSubnetFlatten(d *pluginsdk.ResourceData, id commonids.SubnetId, sub
 			d.Set("private_link_service_network_policies_enabled", flattenSubnetNetworkPolicy(string(pointer.From(props.PrivateLinkServiceNetworkPolicies))))
 			d.Set("sharing_scope", pointer.FromEnum(props.SharingScope))
 
-			if len(d.Get("service_endpoints").(*pluginsdk.Set).List()) > 0 {
+			if !features.FivePointOh() {
 				serviceEndpoints := flattenSubnetServiceEndpoints(props.ServiceEndpoints)
 				if err := d.Set("service_endpoints", serviceEndpoints); err != nil {
 					return fmt.Errorf("setting `service_endpoints`: %+v", err)
 				}
-			} else {
-				serviceEndpoint := flattenSubnetServiceEndpoint(props.ServiceEndpoints)
-				if err := d.Set("service_endpoint", serviceEndpoint); err != nil {
-					return fmt.Errorf("setting `service_endpoint`: %+v", err)
-				}
+			}
+
+			serviceEndpoint := flattenSubnetServiceEndpoint(props.ServiceEndpoints)
+			if err := d.Set("service_endpoint", serviceEndpoint); err != nil {
+				return fmt.Errorf("setting `service_endpoint`: %+v", err)
 			}
 
 			serviceEndpointPolicies := flattenSubnetServiceEndpointPolicies(props.ServiceEndpointPolicies)

--- a/internal/services/network/subnet_resource.go
+++ b/internal/services/network/subnet_resource.go
@@ -411,7 +411,7 @@ func resourceSubnetCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 			IPamPoolPrefixAllocations:         expandSubnetIPAddressPool(d.Get("ip_address_pool").([]interface{})),
 			PrivateEndpointNetworkPolicies:    pointer.ToEnum[subnets.VirtualNetworkPrivateEndpointNetworkPolicies](d.Get("private_endpoint_network_policies").(string)),
 			PrivateLinkServiceNetworkPolicies: expandSubnetNetworkPolicy(d.Get("private_link_service_network_policies_enabled").(bool)),
-			ServiceEndpoints:                  expandSubnetServiceEndpoints(d.Get("service_endpoints").(*pluginsdk.Set).List()),
+			ServiceEndpoints:                  expandSubnetServiceEndpoint(d.Get("service_endpoint").([]interface{})),
 			ServiceEndpointPolicies:           expandSubnetServiceEndpointPolicies(d.Get("service_endpoint_policy_ids").(*pluginsdk.Set).List()),
 			SharingScope:                      pointer.ToEnum[subnets.SharingScope](d.Get("sharing_scope").(string)),
 
@@ -617,13 +617,8 @@ func resourceSubnetUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 		props.SharingScope = pointer.ToEnum[subnets.SharingScope](d.Get("sharing_scope").(string))
 	}
 
-	if d.HasChange("service_endpoints") {
-		props.ServiceEndpoints = expandSubnetServiceEndpoints(d.Get("service_endpoints").(*pluginsdk.Set).List())
-	}
-
 	if d.HasChange("service_endpoint") {
-		serviceEndpointRaw := d.Get("service_endpoint").([]interface{})
-		props.ServiceEndpoints = expandSubnetServiceEndpoint(serviceEndpointRaw)
+		props.ServiceEndpoints = expandSubnetServiceEndpoint(d.Get("service_endpoint").([]interface{}))
 	}
 
 	if d.HasChange("service_endpoint_policy_ids") {
@@ -748,8 +743,7 @@ func resourceSubnetFlatten(d *pluginsdk.ResourceData, id commonids.SubnetId, sub
 			d.Set("private_link_service_network_policies_enabled", flattenSubnetNetworkPolicy(string(pointer.From(props.PrivateLinkServiceNetworkPolicies))))
 			d.Set("sharing_scope", pointer.FromEnum(props.SharingScope))
 
-			serviceEndpoint := flattenSubnetServiceEndpoint(props.ServiceEndpoints)
-			if err := d.Set("service_endpoint", serviceEndpoint); err != nil {
+			if err := d.Set("service_endpoint", flattenSubnetServiceEndpoint(props.ServiceEndpoints)); err != nil {
 				return fmt.Errorf("setting `service_endpoint`: %+v", err)
 			}
 
@@ -833,37 +827,6 @@ func expandSubnetRouteTableID(d *pluginsdk.ResourceData) (*subnets.RouteTable, e
 	return &subnets.RouteTable{
 		Id: pointer.To(wo.AsString()),
 	}, nil
-}
-
-func expandSubnetServiceEndpoints(input []interface{}) *[]subnets.ServiceEndpointPropertiesFormat {
-	endpoints := make([]subnets.ServiceEndpointPropertiesFormat, 0)
-
-	for _, svcEndpointRaw := range input {
-		if svc, ok := svcEndpointRaw.(string); ok {
-			endpoint := subnets.ServiceEndpointPropertiesFormat{
-				Service: &svc,
-			}
-			endpoints = append(endpoints, endpoint)
-		}
-	}
-
-	return &endpoints
-}
-
-func flattenSubnetServiceEndpoints(serviceEndpoints *[]subnets.ServiceEndpointPropertiesFormat) []interface{} {
-	endpoints := make([]interface{}, 0)
-
-	if serviceEndpoints == nil {
-		return endpoints
-	}
-
-	for _, endpoint := range *serviceEndpoints {
-		if endpoint.Service != nil {
-			endpoints = append(endpoints, *endpoint.Service)
-		}
-	}
-
-	return endpoints
 }
 
 func expandSubnetServiceEndpoint(input []interface{}) *[]subnets.ServiceEndpointPropertiesFormat {

--- a/internal/services/network/subnet_resource.go
+++ b/internal/services/network/subnet_resource.go
@@ -28,6 +28,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
@@ -112,7 +113,7 @@ var subnetDelegationServiceNames = []string{
 }
 
 func resourceSubnet() *pluginsdk.Resource {
-	resource := &pluginsdk.Resource{
+	return &pluginsdk.Resource{
 		Create:   resourceSubnetCreate,
 		Read:     resourceSubnetRead,
 		Update:   resourceSubnetUpdate,
@@ -183,21 +184,9 @@ func resourceSubnet() *pluginsdk.Resource {
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
 						"service": {
-							Type:     pluginsdk.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								"Microsoft.AzureActiveDirectory",
-								"Microsoft.AzureCosmosDB",
-								"Microsoft.CognitiveServices",
-								"Microsoft.ContainerRegistry",
-								"Microsoft.EventHub",
-								"Microsoft.KeyVault",
-								"Microsoft.ServiceBus",
-								"Microsoft.Sql",
-								"Microsoft.Storage",
-								"Microsoft.Storage.Global",
-								"Microsoft.Web",
-							}, false),
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validate.SubnetServiceEndpointName(),
 						},
 						"network_identifier": {
 							Type:         pluginsdk.TypeString,
@@ -362,8 +351,6 @@ func resourceSubnet() *pluginsdk.Resource {
 			},
 		},
 	}
-
-	return resource
 }
 
 func resourceSubnetCreate(d *pluginsdk.ResourceData, meta interface{}) error {
@@ -909,11 +896,9 @@ func flattenSubnetServiceEndpoint(serviceEndpoints *[]subnets.ServiceEndpointPro
 		item := map[string]interface{}{
 			"service": pointer.From(endpoint.Service),
 		}
-		networkIdentifier := ""
 		if endpoint.NetworkIdentifier != nil {
-			networkIdentifier = pointer.From(endpoint.NetworkIdentifier.Id)
+			item["network_identifier"] = pointer.From(endpoint.NetworkIdentifier.Id)
 		}
-		item["network_identifier"] = networkIdentifier
 		endpoints = append(endpoints, item)
 	}
 

--- a/internal/services/network/subnet_resource.go
+++ b/internal/services/network/subnet_resource.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/subnets"
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
@@ -177,10 +178,32 @@ func resourceSubnet() *pluginsdk.Resource {
 			},
 
 			"service_endpoints": {
-				Type:     pluginsdk.TypeSet,
+				Type:          pluginsdk.TypeSet,
+				Optional:      true,
+				Elem:          &pluginsdk.Schema{Type: pluginsdk.TypeString},
+				Set:           pluginsdk.HashString,
+				Deprecated:    "The `service_endpoints` property has been superseded by the `service_endpoint` block and will be removed in a future version of the provider.",
+				ConflictsWith: []string{"service_endpoint"},
+			},
+
+			"service_endpoint": {
+				Type:     pluginsdk.TypeList,
 				Optional: true,
-				Elem:     &pluginsdk.Schema{Type: pluginsdk.TypeString},
-				Set:      pluginsdk.HashString,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"service": {
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+						"network_identifier": {
+							Type:         pluginsdk.TypeString,
+							Optional:     true,
+							ValidateFunc: azure.ValidateResourceID,
+						},
+					},
+				},
+				ConflictsWith: []string{"service_endpoints"},
 			},
 
 			"service_endpoint_policy_ids": {
@@ -607,6 +630,11 @@ func resourceSubnetUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 		props.ServiceEndpoints = expandSubnetServiceEndpoints(d.Get("service_endpoints").(*pluginsdk.Set).List())
 	}
 
+	if d.HasChange("service_endpoint") {
+		serviceEndpointRaw := d.Get("service_endpoint").([]interface{})
+		props.ServiceEndpoints = expandSubnetServiceEndpoint(serviceEndpointRaw)
+	}
+
 	if d.HasChange("service_endpoint_policy_ids") {
 		props.ServiceEndpointPolicies = expandSubnetServiceEndpointPolicies(d.Get("service_endpoint_policy_ids").(*pluginsdk.Set).List())
 	}
@@ -729,9 +757,16 @@ func resourceSubnetFlatten(d *pluginsdk.ResourceData, id commonids.SubnetId, sub
 			d.Set("private_link_service_network_policies_enabled", flattenSubnetNetworkPolicy(string(pointer.From(props.PrivateLinkServiceNetworkPolicies))))
 			d.Set("sharing_scope", pointer.FromEnum(props.SharingScope))
 
-			serviceEndpoints := flattenSubnetServiceEndpoints(props.ServiceEndpoints)
-			if err := d.Set("service_endpoints", serviceEndpoints); err != nil {
-				return fmt.Errorf("setting `service_endpoints`: %+v", err)
+			if len(d.Get("service_endpoints").(*pluginsdk.Set).List()) > 0 {
+				serviceEndpoints := flattenSubnetServiceEndpoints(props.ServiceEndpoints)
+				if err := d.Set("service_endpoints", serviceEndpoints); err != nil {
+					return fmt.Errorf("setting `service_endpoints`: %+v", err)
+				}
+			} else {
+				serviceEndpoint := flattenSubnetServiceEndpoint(props.ServiceEndpoints)
+				if err := d.Set("service_endpoint", serviceEndpoint); err != nil {
+					return fmt.Errorf("setting `service_endpoint`: %+v", err)
+				}
 			}
 
 			serviceEndpointPolicies := flattenSubnetServiceEndpointPolicies(props.ServiceEndpointPolicies)
@@ -842,6 +877,49 @@ func flattenSubnetServiceEndpoints(serviceEndpoints *[]subnets.ServiceEndpointPr
 		if endpoint.Service != nil {
 			endpoints = append(endpoints, *endpoint.Service)
 		}
+	}
+
+	return endpoints
+}
+
+func expandSubnetServiceEndpoint(input []interface{}) *[]subnets.ServiceEndpointPropertiesFormat {
+	endpoints := make([]subnets.ServiceEndpointPropertiesFormat, 0)
+
+	for _, item := range input {
+		v := item.(map[string]interface{})
+		svc := v["service"].(string)
+		endpoint := subnets.ServiceEndpointPropertiesFormat{
+			Service: &svc,
+		}
+		if networkIdentifier := v["network_identifier"].(string); networkIdentifier != "" {
+			endpoint.NetworkIdentifier = &subnets.SubResource{
+				Id: &networkIdentifier,
+			}
+		}
+		endpoints = append(endpoints, endpoint)
+	}
+
+	return &endpoints
+}
+
+func flattenSubnetServiceEndpoint(serviceEndpoints *[]subnets.ServiceEndpointPropertiesFormat) []interface{} {
+	endpoints := make([]interface{}, 0)
+
+	if serviceEndpoints == nil {
+		return endpoints
+	}
+
+	for _, endpoint := range *serviceEndpoints {
+		item := map[string]interface{}{}
+		if endpoint.Service != nil {
+			item["service"] = *endpoint.Service
+		}
+		networkIdentifier := ""
+		if endpoint.NetworkIdentifier != nil && endpoint.NetworkIdentifier.Id != nil {
+			networkIdentifier = *endpoint.NetworkIdentifier.Id
+		}
+		item["network_identifier"] = networkIdentifier
+		endpoints = append(endpoints, item)
 	}
 
 	return endpoints

--- a/internal/services/network/subnet_resource.go
+++ b/internal/services/network/subnet_resource.go
@@ -376,7 +376,6 @@ func resourceSubnet() *pluginsdk.Resource {
 			ConflictsWith: []string{"service_endpoint"},
 		}
 		resource.Schema["service_endpoint"].ConflictsWith = []string{"service_endpoints"}
-		// NOTE: O+C to allow the deprecated `service_endpoints` property and `service_endpoint` block to coexist in v4
 		resource.Schema["service_endpoint"].Computed = true
 	}
 

--- a/internal/services/network/subnet_resource_test.go
+++ b/internal/services/network/subnet_resource_test.go
@@ -506,7 +506,8 @@ func TestAccSubnet_serviceEndpointBlock(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			Config: r.serviceEndpointBlock(data),
+			// remove them
+			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),

--- a/internal/services/network/subnet_resource_test.go
+++ b/internal/services/network/subnet_resource_test.go
@@ -497,14 +497,14 @@ func TestAccSubnet_serviceEndpoints(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("service_endpoints", "service_endpoint"),
 		{
 			Config: r.serviceEndpointsUpdated(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("service_endpoints", "service_endpoint"),
 		{
 			// remove them
 			Config: r.basic(data),
@@ -517,6 +517,48 @@ func TestAccSubnet_serviceEndpoints(t *testing.T) {
 			Config: r.serviceEndpoints(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("service_endpoints", "service_endpoint"),
+	})
+}
+
+func TestAccSubnet_serviceEndpointBlock(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_subnet", "test")
+	r := SubnetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.serviceEndpointBlock(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("service_endpoint.0.service").HasValue("Microsoft.Sql"),
+				check.That(data.ResourceName).Key("service_endpoint.#").HasValue("1"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.serviceEndpointBlockUpdated(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("service_endpoint.#").HasValue("2"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccSubnet_serviceEndpointWithNetworkIdentifier(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_subnet", "test")
+	r := SubnetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.serviceEndpointWithNetworkIdentifier(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("service_endpoint.0.service").HasValue("Microsoft.Storage"),
+				check.That(data.ResourceName).Key("service_endpoint.0.network_identifier").IsSet(),
 			),
 		},
 		data.ImportStep(),
@@ -534,14 +576,14 @@ func TestAccSubnet_serviceEndpointPolicy(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("service_endpoints", "service_endpoint"),
 		{
 			Config: r.serviceEndpointPolicyUpdate(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("service_endpoints", "service_endpoint"),
 		{
 			Config: r.serviceEndpointPolicyBasic(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -1443,6 +1485,70 @@ resource "azurerm_subnet" "test2" {
   service_endpoints    = ["Microsoft.Sql", "Microsoft.Storage"]
 }
 `, r.template(data))
+}
+
+func (r SubnetResource) serviceEndpointBlock(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_subnet" "test" {
+  name                 = "internal"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.2.0/24"]
+
+  service_endpoint {
+    service = "Microsoft.Sql"
+  }
+}
+`, r.template(data))
+}
+
+func (r SubnetResource) serviceEndpointBlockUpdated(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_subnet" "test" {
+  name                 = "internal"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.2.0/24"]
+
+  service_endpoint {
+    service = "Microsoft.Sql"
+  }
+
+  service_endpoint {
+    service = "Microsoft.Storage"
+  }
+}
+`, r.template(data))
+}
+
+func (r SubnetResource) serviceEndpointWithNetworkIdentifier(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_public_ip" "test" {
+  name                = "acctestpip-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "internal"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.2.0/24"]
+
+  service_endpoint {
+    service            = "Microsoft.Storage"
+    network_identifier = azurerm_public_ip.test.id
+  }
+}
+`, r.template(data), data.RandomInteger)
 }
 
 func (r SubnetResource) serviceEndpointPolicyBasic(data acceptance.TestData) string {

--- a/internal/services/network/subnet_resource_test.go
+++ b/internal/services/network/subnet_resource_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
@@ -479,47 +478,6 @@ func TestAccSubnet_enablePrivateLinkServiceNetworkPolicies(t *testing.T) {
 		data.ImportStep(),
 		{
 			Config: r.enablePrivateLinkServiceNetworkPolicies(data, true),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-	})
-}
-
-func TestAccSubnet_serviceEndpoints(t *testing.T) {
-	if features.FivePointOh() {
-		t.Skip("Skipping as `service_endpoints` is removed in v5.0 of the provider")
-	}
-
-	data := acceptance.BuildTestData(t, "azurerm_subnet", "test")
-	r := SubnetResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.serviceEndpoints(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.serviceEndpointsUpdated(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			// remove them
-			Config: r.basic(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.serviceEndpoints(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -1442,50 +1400,6 @@ resource "azurerm_subnet" "test" {
 `, r.template(data))
 }
 
-func (r SubnetResource) serviceEndpoints(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-%s
-
-resource "azurerm_subnet" "test" {
-  name                 = "internal"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes     = ["10.0.2.0/24"]
-  service_endpoints    = ["Microsoft.Sql"]
-}
-
-resource "azurerm_subnet" "test2" {
-  name                 = "internal2"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes     = ["10.0.3.0/24"]
-  service_endpoints    = ["Microsoft.Sql"]
-}
-`, r.template(data))
-}
-
-func (r SubnetResource) serviceEndpointsUpdated(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-%s
-
-resource "azurerm_subnet" "test" {
-  name                 = "internal"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes     = ["10.0.2.0/24"]
-  service_endpoints    = ["Microsoft.Sql", "Microsoft.Storage"]
-}
-
-resource "azurerm_subnet" "test2" {
-  name                 = "internal2"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes     = ["10.0.3.0/24"]
-  service_endpoints    = ["Microsoft.Sql", "Microsoft.Storage"]
-}
-`, r.template(data))
-}
-
 func (r SubnetResource) serviceEndpointBlock(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
@@ -1570,13 +1484,6 @@ resource "azurerm_subnet" "test" {
 }
 
 func (r SubnetResource) serviceEndpointPolicyUpdate(data acceptance.TestData) string {
-	serviceEndpointConfig := `service_endpoints = ["Microsoft.Sql"]`
-	if features.FivePointOh() {
-		serviceEndpointConfig = `
-  service_endpoint {
-    service = "Microsoft.Sql"
-  }`
-	}
 	return fmt.Sprintf(`
 %s
 
@@ -1591,10 +1498,13 @@ resource "azurerm_subnet" "test" {
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.0.2.0/24"]
-  %s
+
+  service_endpoint {
+    service = "Microsoft.Sql"
+  }
   service_endpoint_policy_ids = [azurerm_subnet_service_endpoint_storage_policy.test.id]
 }
-`, r.template(data), data.RandomInteger, serviceEndpointConfig)
+`, r.template(data), data.RandomInteger)
 }
 
 func (r SubnetResource) updatedAddressPrefix(data acceptance.TestData) string {

--- a/internal/services/network/subnet_resource_test.go
+++ b/internal/services/network/subnet_resource_test.go
@@ -536,7 +536,7 @@ func TestAccSubnet_serviceEndpointBlock(t *testing.T) {
 				check.That(data.ResourceName).Key("service_endpoint.#").HasValue("1"),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("service_endpoints"),
 		{
 			Config: r.serviceEndpointBlockUpdated(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -544,15 +544,16 @@ func TestAccSubnet_serviceEndpointBlock(t *testing.T) {
 				check.That(data.ResourceName).Key("service_endpoint.#").HasValue("2"),
 			),
 		},
-		data.ImportStep(),
-	})
-}
-
-func TestAccSubnet_serviceEndpointWithNetworkIdentifier(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_subnet", "test")
-	r := SubnetResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
+		data.ImportStep("service_endpoints"),
+		{
+			Config: r.serviceEndpointBlock(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("service_endpoint.0.service").HasValue("Microsoft.Sql"),
+				check.That(data.ResourceName).Key("service_endpoint.#").HasValue("1"),
+			),
+		},
+		data.ImportStep("service_endpoints"),
 		{
 			Config: r.serviceEndpointWithNetworkIdentifier(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -561,7 +562,7 @@ func TestAccSubnet_serviceEndpointWithNetworkIdentifier(t *testing.T) {
 				check.That(data.ResourceName).Key("service_endpoint.0.network_identifier").IsSet(),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("service_endpoints"),
 	})
 }
 

--- a/internal/services/network/subnet_resource_test.go
+++ b/internal/services/network/subnet_resource_test.go
@@ -506,8 +506,7 @@ func TestAccSubnet_serviceEndpointBlock(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			// remove them
-			Config: r.basic(data),
+			Config: r.serviceEndpointBlockRemoved(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -1466,6 +1465,19 @@ resource "azurerm_subnet" "test" {
   service_endpoint {
     service = "Microsoft.Storage"
   }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r SubnetResource) serviceEndpointBlockRemoved(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctest-%d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.2.0/24"]
 }
 `, r.template(data), data.RandomInteger)
 }

--- a/internal/services/network/subnet_resource_test.go
+++ b/internal/services/network/subnet_resource_test.go
@@ -577,10 +577,6 @@ func TestAccSubnet_serviceEndpointBlock(t *testing.T) {
 }
 
 func TestAccSubnet_serviceEndpointPolicy(t *testing.T) {
-	if features.FivePointOh() {
-		t.Skip("Skipping as `service_endpoints` is removed in v5.0 of the provider")
-	}
-
 	data := acceptance.BuildTestData(t, "azurerm_subnet", "test")
 	r := SubnetResource{}
 
@@ -1586,6 +1582,13 @@ resource "azurerm_subnet" "test" {
 }
 
 func (r SubnetResource) serviceEndpointPolicyUpdate(data acceptance.TestData) string {
+	serviceEndpointConfig := `service_endpoints = ["Microsoft.Sql"]`
+	if features.FivePointOh() {
+		serviceEndpointConfig = `
+  service_endpoint {
+    service = "Microsoft.Sql"
+  }`
+	}
 	return fmt.Sprintf(`
 %s
 
@@ -1600,10 +1603,10 @@ resource "azurerm_subnet" "test" {
   resource_group_name         = azurerm_resource_group.test.name
   virtual_network_name        = azurerm_virtual_network.test.name
   address_prefixes            = ["10.0.2.0/24"]
-  service_endpoints           = ["Microsoft.Sql"]
+  %s
   service_endpoint_policy_ids = [azurerm_subnet_service_endpoint_storage_policy.test.id]
 }
-`, r.template(data), data.RandomInteger)
+`, r.template(data), data.RandomInteger, serviceEndpointConfig)
 }
 
 func (r SubnetResource) updatedAddressPrefix(data acceptance.TestData) string {

--- a/internal/services/network/subnet_resource_test.go
+++ b/internal/services/network/subnet_resource_test.go
@@ -532,47 +532,35 @@ func TestAccSubnet_serviceEndpointBlock(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_subnet", "test")
 	r := SubnetResource{}
 
-	ignoreFields := []string{}
-	if !features.FivePointOh() {
-		ignoreFields = append(ignoreFields, "service_endpoints")
-	}
-
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.serviceEndpointBlock(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("service_endpoint.0.service").HasValue("Microsoft.Sql"),
-				check.That(data.ResourceName).Key("service_endpoint.#").HasValue("1"),
 			),
 		},
-		data.ImportStep(ignoreFields...),
+		data.ImportStep(),
 		{
 			Config: r.serviceEndpointBlockUpdated(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("service_endpoint.#").HasValue("2"),
 			),
 		},
-		data.ImportStep(ignoreFields...),
+		data.ImportStep(),
 		{
 			Config: r.serviceEndpointBlock(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("service_endpoint.0.service").HasValue("Microsoft.Sql"),
-				check.That(data.ResourceName).Key("service_endpoint.#").HasValue("1"),
 			),
 		},
-		data.ImportStep(ignoreFields...),
+		data.ImportStep(),
 		{
 			Config: r.serviceEndpointWithNetworkIdentifier(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("service_endpoint.0.service").HasValue("Microsoft.Storage"),
-				check.That(data.ResourceName).Key("service_endpoint.0.network_identifier").IsSet(),
 			),
 		},
-		data.ImportStep(ignoreFields...),
+		data.ImportStep(),
 	})
 }
 
@@ -587,14 +575,14 @@ func TestAccSubnet_serviceEndpointPolicy(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("service_endpoints", "service_endpoint"),
+		data.ImportStep(),
 		{
 			Config: r.serviceEndpointPolicyUpdate(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("service_endpoints", "service_endpoint"),
+		data.ImportStep(),
 		{
 			Config: r.serviceEndpointPolicyBasic(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -1503,7 +1491,7 @@ func (r SubnetResource) serviceEndpointBlock(data acceptance.TestData) string {
 %s
 
 resource "azurerm_subnet" "test" {
-  name                 = "internal"
+  name                 = "acctest-%d"
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.0.2.0/24"]
@@ -1512,7 +1500,7 @@ resource "azurerm_subnet" "test" {
     service = "Microsoft.Sql"
   }
 }
-`, r.template(data))
+`, r.template(data), data.RandomInteger)
 }
 
 func (r SubnetResource) serviceEndpointBlockUpdated(data acceptance.TestData) string {
@@ -1520,7 +1508,7 @@ func (r SubnetResource) serviceEndpointBlockUpdated(data acceptance.TestData) st
 %s
 
 resource "azurerm_subnet" "test" {
-  name                 = "internal"
+  name                 = "acctest-%d"
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.0.2.0/24"]
@@ -1533,7 +1521,7 @@ resource "azurerm_subnet" "test" {
     service = "Microsoft.Storage"
   }
 }
-`, r.template(data))
+`, r.template(data), data.RandomInteger)
 }
 
 func (r SubnetResource) serviceEndpointWithNetworkIdentifier(data acceptance.TestData) string {
@@ -1549,7 +1537,7 @@ resource "azurerm_public_ip" "test" {
 }
 
 resource "azurerm_subnet" "test" {
-  name                 = "internal"
+  name                 = "acctest-%d"
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.0.2.0/24"]
@@ -1559,7 +1547,7 @@ resource "azurerm_subnet" "test" {
     network_identifier = azurerm_public_ip.test.id
   }
 }
-`, r.template(data), data.RandomInteger)
+`, r.template(data), data.RandomInteger, data.RandomInteger)
 }
 
 func (r SubnetResource) serviceEndpointPolicyBasic(data acceptance.TestData) string {
@@ -1599,10 +1587,10 @@ resource "azurerm_subnet_service_endpoint_storage_policy" "test" {
 }
 
 resource "azurerm_subnet" "test" {
-  name                        = "internal"
-  resource_group_name         = azurerm_resource_group.test.name
-  virtual_network_name        = azurerm_virtual_network.test.name
-  address_prefixes            = ["10.0.2.0/24"]
+  name                 = "internal"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.2.0/24"]
   %s
   service_endpoint_policy_ids = [azurerm_subnet_service_endpoint_storage_policy.test.id]
 }

--- a/internal/services/network/subnet_resource_test.go
+++ b/internal/services/network/subnet_resource_test.go
@@ -502,14 +502,14 @@ func TestAccSubnet_serviceEndpoints(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("service_endpoints", "service_endpoint"),
+		data.ImportStep(),
 		{
 			Config: r.serviceEndpointsUpdated(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("service_endpoints", "service_endpoint"),
+		data.ImportStep(),
 		{
 			// remove them
 			Config: r.basic(data),
@@ -524,7 +524,7 @@ func TestAccSubnet_serviceEndpoints(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("service_endpoints", "service_endpoint"),
+		data.ImportStep(),
 	})
 }
 

--- a/internal/services/network/subnet_resource_test.go
+++ b/internal/services/network/subnet_resource_test.go
@@ -523,6 +523,37 @@ func TestAccSubnet_serviceEndpointBlock(t *testing.T) {
 	})
 }
 
+func TestAccSubnet_serviceEndpointBlockMultiple(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_subnet", "test")
+	r := SubnetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.serviceEndpointBlockMultiple(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("service_endpoint.#").HasValue("3"),
+				check.That(data.ResourceName).Key("service_endpoint.0.service").HasValue("Microsoft.Sql"),
+				check.That(data.ResourceName).Key("service_endpoint.1.service").HasValue("Microsoft.Storage"),
+				check.That(data.ResourceName).Key("service_endpoint.2.service").HasValue("Microsoft.KeyVault"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.serviceEndpointBlockMultipleUpdated(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("service_endpoint.#").HasValue("3"),
+				check.That(data.ResourceName).Key("service_endpoint.0.service").HasValue("Microsoft.Sql"),
+				check.That(data.ResourceName).Key("service_endpoint.1.service").HasValue("Microsoft.Storage"),
+				check.That(data.ResourceName).Key("service_endpoint.1.network_identifier").Exists(),
+				check.That(data.ResourceName).Key("service_endpoint.2.service").HasValue("Microsoft.ServiceBus"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccSubnet_serviceEndpointPolicy(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_subnet", "test")
 	r := SubnetResource{}
@@ -1437,6 +1468,65 @@ resource "azurerm_subnet" "test" {
   }
 }
 `, r.template(data), data.RandomInteger)
+}
+
+func (r SubnetResource) serviceEndpointBlockMultiple(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctest-%d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.2.0/24"]
+
+  service_endpoint {
+    service = "Microsoft.Sql"
+  }
+
+  service_endpoint {
+    service = "Microsoft.Storage"
+  }
+
+  service_endpoint {
+    service = "Microsoft.KeyVault"
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r SubnetResource) serviceEndpointBlockMultipleUpdated(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_public_ip" "test" {
+  name                = "acctestpip-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctest-%d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.2.0/24"]
+
+  service_endpoint {
+    service = "Microsoft.Sql"
+  }
+
+  service_endpoint {
+    service            = "Microsoft.Storage"
+    network_identifier = azurerm_public_ip.test.id
+  }
+
+  service_endpoint {
+    service = "Microsoft.ServiceBus"
+  }
+}
+`, r.template(data), data.RandomInteger, data.RandomInteger)
 }
 
 func (r SubnetResource) serviceEndpointWithNetworkIdentifier(data acceptance.TestData) string {

--- a/internal/services/network/subnet_resource_test.go
+++ b/internal/services/network/subnet_resource_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
@@ -487,6 +488,10 @@ func TestAccSubnet_enablePrivateLinkServiceNetworkPolicies(t *testing.T) {
 }
 
 func TestAccSubnet_serviceEndpoints(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as `service_endpoints` is removed in v5.0 of the provider")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_subnet", "test")
 	r := SubnetResource{}
 
@@ -527,6 +532,11 @@ func TestAccSubnet_serviceEndpointBlock(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_subnet", "test")
 	r := SubnetResource{}
 
+	ignoreFields := []string{}
+	if !features.FivePointOh() {
+		ignoreFields = append(ignoreFields, "service_endpoints")
+	}
+
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.serviceEndpointBlock(data),
@@ -536,7 +546,7 @@ func TestAccSubnet_serviceEndpointBlock(t *testing.T) {
 				check.That(data.ResourceName).Key("service_endpoint.#").HasValue("1"),
 			),
 		},
-		data.ImportStep("service_endpoints"),
+		data.ImportStep(ignoreFields...),
 		{
 			Config: r.serviceEndpointBlockUpdated(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -544,7 +554,7 @@ func TestAccSubnet_serviceEndpointBlock(t *testing.T) {
 				check.That(data.ResourceName).Key("service_endpoint.#").HasValue("2"),
 			),
 		},
-		data.ImportStep("service_endpoints"),
+		data.ImportStep(ignoreFields...),
 		{
 			Config: r.serviceEndpointBlock(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -553,7 +563,7 @@ func TestAccSubnet_serviceEndpointBlock(t *testing.T) {
 				check.That(data.ResourceName).Key("service_endpoint.#").HasValue("1"),
 			),
 		},
-		data.ImportStep("service_endpoints"),
+		data.ImportStep(ignoreFields...),
 		{
 			Config: r.serviceEndpointWithNetworkIdentifier(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -562,11 +572,15 @@ func TestAccSubnet_serviceEndpointBlock(t *testing.T) {
 				check.That(data.ResourceName).Key("service_endpoint.0.network_identifier").IsSet(),
 			),
 		},
-		data.ImportStep("service_endpoints"),
+		data.ImportStep(ignoreFields...),
 	})
 }
 
 func TestAccSubnet_serviceEndpointPolicy(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as `service_endpoints` is removed in v5.0 of the provider")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_subnet", "test")
 	r := SubnetResource{}
 

--- a/internal/services/network/validate/subnet_service_endpoint_name.go
+++ b/internal/services/network/validate/subnet_service_endpoint_name.go
@@ -1,0 +1,25 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package validate
+
+import (
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+func SubnetServiceEndpointName() pluginsdk.SchemaValidateFunc {
+	return validation.StringInSlice([]string{
+		"Microsoft.AzureActiveDirectory",
+		"Microsoft.AzureCosmosDB",
+		"Microsoft.CognitiveServices",
+		"Microsoft.ContainerRegistry",
+		"Microsoft.EventHub",
+		"Microsoft.KeyVault",
+		"Microsoft.ServiceBus",
+		"Microsoft.Sql",
+		"Microsoft.Storage",
+		"Microsoft.Storage.Global",
+		"Microsoft.Web",
+	}, false)
+}

--- a/internal/services/network/validate/subnet_service_endpoint_name_test.go
+++ b/internal/services/network/validate/subnet_service_endpoint_name_test.go
@@ -1,0 +1,54 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package validate
+
+import (
+	"testing"
+)
+
+func TestSubnetServiceEndpointName(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected bool
+	}{
+		{
+			input:    "",
+			expected: false,
+		},
+		{
+			input:    "Microsoft.Storage",
+			expected: true,
+		},
+		{
+			input:    "Microsoft.Storage.Global",
+			expected: true,
+		},
+		{
+			input:    "Microsoft.CognitiveServices",
+			expected: true,
+		},
+		{
+			input:    "Microsoft.KeyVault",
+			expected: true,
+		},
+		{
+			input:    "microsoft.storage",
+			expected: false,
+		},
+		{
+			input:    "Microsoft.Test",
+			expected: false,
+		},
+	}
+
+	validateFunc := SubnetServiceEndpointName()
+
+	for _, tc := range tests {
+		_, errs := validateFunc(tc.input, "service")
+		ok := len(errs) == 0
+		if ok != tc.expected {
+			t.Fatalf("input %q: expected %t got %t", tc.input, tc.expected, ok)
+		}
+	}
+}

--- a/internal/services/network/virtual_hub_connection_resource_test.go
+++ b/internal/services/network/virtual_hub_connection_resource_test.go
@@ -497,17 +497,41 @@ resource "azurerm_subnet" "test" {
   private_endpoint_network_policies             = "Disabled"
   private_link_service_network_policies_enabled = true
 
-  service_endpoints = [
-    "Microsoft.AzureActiveDirectory",
-    "Microsoft.AzureCosmosDB",
-    "Microsoft.ContainerRegistry",
-    "Microsoft.EventHub",
-    "Microsoft.KeyVault",
-    "Microsoft.ServiceBus",
-    "Microsoft.Sql",
-    "Microsoft.Storage",
-    "Microsoft.Web",
-  ]
+  service_endpoint {
+    service = "Microsoft.AzureActiveDirectory"
+  }
+
+  service_endpoint {
+    service = "Microsoft.AzureCosmosDB"
+  }
+
+  service_endpoint {
+    service = "Microsoft.ContainerRegistry"
+  }
+
+  service_endpoint {
+    service = "Microsoft.EventHub"
+  }
+
+  service_endpoint {
+    service = "Microsoft.KeyVault"
+  }
+
+  service_endpoint {
+    service = "Microsoft.ServiceBus"
+  }
+
+  service_endpoint {
+    service = "Microsoft.Sql"
+  }
+
+  service_endpoint {
+    service = "Microsoft.Storage"
+  }
+
+  service_endpoint {
+    service = "Microsoft.Web"
+  }
 }
 
 resource "azurerm_virtual_wan" "test" {

--- a/internal/services/network/virtual_network_resource.go
+++ b/internal/services/network/virtual_network_resource.go
@@ -483,7 +483,7 @@ func resourceVirtualNetworkFlatten(d *pluginsdk.ResourceData, id commonids.Virtu
 				return fmt.Errorf("setting `encryption`: %+v", err)
 			}
 
-			subnet, err := flattenVirtualNetworkSubnets(props.Subnets, d)
+			subnet, err := flattenVirtualNetworkSubnets(props.Subnets)
 			if err != nil {
 				return fmt.Errorf("flattening `subnet`: %+v", err)
 			}
@@ -1027,7 +1027,7 @@ func flattenVirtualNetworkEncryption(encryption *virtualnetworks.VirtualNetworkE
 	}
 }
 
-func flattenVirtualNetworkSubnets(input *[]virtualnetworks.Subnet, d *pluginsdk.ResourceData) (*pluginsdk.Set, error) {
+func flattenVirtualNetworkSubnets(input *[]virtualnetworks.Subnet) (*pluginsdk.Set, error) {
 	results := &pluginsdk.Set{
 		F: resourceAzureSubnetHash,
 	}

--- a/internal/services/network/virtual_network_resource.go
+++ b/internal/services/network/virtual_network_resource.go
@@ -68,7 +68,7 @@ func resourceVirtualNetwork() *pluginsdk.Resource {
 }
 
 func resourceVirtualNetworkSchema() map[string]*pluginsdk.Schema {
-	schema := map[string]*pluginsdk.Schema{
+	resourceSchema := map[string]*pluginsdk.Schema{
 		"name": {
 			Type:         pluginsdk.TypeString,
 			Required:     true,
@@ -300,17 +300,27 @@ func resourceVirtualNetworkSchema() map[string]*pluginsdk.Schema {
 					},
 
 					"service_endpoint": {
-						Type:     pluginsdk.TypeList,
-						Optional: true,
-						// NOTE: O+C to allow the deprecated `service_endpoints` property and `service_endpoint` block to coexist in v4
-						Computed:   true,
+						Type:       pluginsdk.TypeList,
+						Optional:   true,
 						ConfigMode: pluginsdk.SchemaConfigModeAttr,
 						Elem: &pluginsdk.Resource{
 							Schema: map[string]*pluginsdk.Schema{
 								"service": {
-									Type:         pluginsdk.TypeString,
-									Required:     true,
-									ValidateFunc: validation.StringIsNotEmpty,
+									Type:     pluginsdk.TypeString,
+									Required: true,
+									ValidateFunc: validation.StringInSlice([]string{
+										"Microsoft.AzureActiveDirectory",
+										"Microsoft.AzureCosmosDB",
+										"Microsoft.CognitiveServices",
+										"Microsoft.ContainerRegistry",
+										"Microsoft.EventHub",
+										"Microsoft.KeyVault",
+										"Microsoft.ServiceBus",
+										"Microsoft.Sql",
+										"Microsoft.Storage",
+										"Microsoft.Storage.Global",
+										"Microsoft.Web",
+									}, false),
 								},
 								"network_identifier": {
 									Type:         pluginsdk.TypeString,
@@ -349,7 +359,7 @@ func resourceVirtualNetworkSchema() map[string]*pluginsdk.Schema {
 	}
 
 	if !features.FivePointOh() {
-		subnetSchema := schema["subnet"].Elem.(*pluginsdk.Resource).Schema
+		subnetSchema := resourceSchema["subnet"].Elem.(*pluginsdk.Resource).Schema
 		subnetSchema["service_endpoints"] = &pluginsdk.Schema{
 			Type:     pluginsdk.TypeSet,
 			Optional: true,
@@ -361,9 +371,11 @@ func resourceVirtualNetworkSchema() map[string]*pluginsdk.Schema {
 			},
 			Set: pluginsdk.HashString,
 		}
+		// NOTE: O+C to allow the deprecated `service_endpoints` property and `service_endpoint` block to coexist in v4
+		subnetSchema["service_endpoint"].Computed = true
 	}
 
-	return schema
+	return resourceSchema
 }
 
 func resourceVirtualNetworkCreate(d *pluginsdk.ResourceData, meta interface{}) error {
@@ -631,11 +643,11 @@ func resourceVirtualNetworkUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 	}
 
 	if d.HasChange("subnet") {
-		subnets, routeTables, err := expandVirtualNetworkSubnets(ctx, *client, d.Get("subnet").(*pluginsdk.Set).List(), *id, d)
+		subnetList, routeTables, err := expandVirtualNetworkSubnets(ctx, *client, d.Get("subnet").(*pluginsdk.Set).List(), *id, d)
 		if err != nil {
 			return fmt.Errorf("expanding `subnet`: %+v", err)
 		}
-		payload.Properties.Subnets = subnets
+		payload.Properties.Subnets = subnetList
 
 		locks.ByID(id.ID())
 		defer locks.UnlockByID(id.ID())
@@ -1139,10 +1151,7 @@ func flattenVirtualNetworkSubnets(input *[]virtualnetworks.Subnet, d *pluginsdk.
 					if !rawConfig.IsNull() && rawConfig.IsKnown() {
 						rawSubnets := rawConfig.AsValueMap()["subnet"]
 						if !rawSubnets.IsNull() && rawSubnets.IsKnown() {
-							name := ""
-							if subnet.Name != nil {
-								name = *subnet.Name
-							}
+							name := pointer.From(subnet.Name)
 							for _, rs := range rawSubnets.AsValueSlice() {
 								sm := rs.AsValueMap()
 								if sm["name"].IsKnown() && sm["name"].AsString() == name {
@@ -1350,13 +1359,12 @@ func expandVirtualNetworkSubnetServiceEndpoint(input []interface{}) *[]virtualne
 
 	for _, item := range input {
 		v := item.(map[string]interface{})
-		svc := v["service"].(string)
 		endpoint := virtualnetworks.ServiceEndpointPropertiesFormat{
-			Service: &svc,
+			Service: pointer.To(v["service"].(string)),
 		}
 		if networkIdentifier := v["network_identifier"].(string); networkIdentifier != "" {
 			endpoint.NetworkIdentifier = &virtualnetworks.SubResource{
-				Id: &networkIdentifier,
+				Id: pointer.To(networkIdentifier),
 			}
 		}
 		endpoints = append(endpoints, endpoint)
@@ -1373,13 +1381,12 @@ func flattenVirtualNetworkSubnetServiceEndpoint(serviceEndpoints *[]virtualnetwo
 	}
 
 	for _, endpoint := range *serviceEndpoints {
-		item := map[string]interface{}{}
-		if endpoint.Service != nil {
-			item["service"] = *endpoint.Service
+		item := map[string]interface{}{
+			"service": pointer.From(endpoint.Service),
 		}
 		networkIdentifier := ""
-		if endpoint.NetworkIdentifier != nil && endpoint.NetworkIdentifier.Id != nil {
-			networkIdentifier = *endpoint.NetworkIdentifier.Id
+		if endpoint.NetworkIdentifier != nil {
+			networkIdentifier = pointer.From(endpoint.NetworkIdentifier.Id)
 		}
 		item["network_identifier"] = networkIdentifier
 		endpoints = append(endpoints, item)

--- a/internal/services/network/virtual_network_resource.go
+++ b/internal/services/network/virtual_network_resource.go
@@ -371,7 +371,6 @@ func resourceVirtualNetworkSchema() map[string]*pluginsdk.Schema {
 			},
 			Set: pluginsdk.HashString,
 		}
-		// NOTE: O+C to allow the deprecated `service_endpoints` property and `service_endpoint` block to coexist in v4
 		subnetSchema["service_endpoint"].Computed = true
 	}
 
@@ -842,18 +841,7 @@ func expandVirtualNetworkSubnets(ctx context.Context, client virtualnetworks.Vir
 
 		subnetObj.Properties.ServiceEndpointPolicies = expandVirtualNetworkSubnetServiceEndpointPolicies(subnet["service_endpoint_policy_ids"].(*pluginsdk.Set).List())
 		if !features.FivePointOh() {
-			serviceEndpointsNull := true
-			rawSubnets := d.GetRawConfig().AsValueMap()["subnet"]
-			if !rawSubnets.IsNull() && rawSubnets.IsKnown() {
-				for _, rs := range rawSubnets.AsValueSlice() {
-					sm := rs.AsValueMap()
-					if sm["name"].IsKnown() && sm["name"].AsString() == name {
-						serviceEndpointsNull = sm["service_endpoints"].IsNull()
-						break
-					}
-				}
-			}
-			if !serviceEndpointsNull {
+			if virtualNetworkSubnetHasServiceEndpointsInConfig(d, name) {
 				serviceEndpointsRaw := subnet["service_endpoints"].(*pluginsdk.Set).List()
 				subnetObj.Properties.ServiceEndpoints = expandVirtualNetworkSubnetServiceEndpoints(serviceEndpointsRaw)
 			} else {
@@ -936,18 +924,7 @@ func expandVirtualNetworkProperties(ctx context.Context, client virtualnetworks.
 
 			subnetObj.Properties.ServiceEndpointPolicies = expandVirtualNetworkSubnetServiceEndpointPolicies(subnet["service_endpoint_policy_ids"].(*pluginsdk.Set).List())
 			if !features.FivePointOh() {
-				serviceEndpointsNull := true
-				rawSubnets := d.GetRawConfig().AsValueMap()["subnet"]
-				if !rawSubnets.IsNull() && rawSubnets.IsKnown() {
-					for _, rs := range rawSubnets.AsValueSlice() {
-						sm := rs.AsValueMap()
-						if sm["name"].IsKnown() && sm["name"].AsString() == name {
-							serviceEndpointsNull = sm["service_endpoints"].IsNull()
-							break
-						}
-					}
-				}
-				if !serviceEndpointsNull {
+				if virtualNetworkSubnetHasServiceEndpointsInConfig(d, name) {
 					serviceEndpointsRaw := subnet["service_endpoints"].(*pluginsdk.Set).List()
 					subnetObj.Properties.ServiceEndpoints = expandVirtualNetworkSubnetServiceEndpoints(serviceEndpointsRaw)
 				} else {
@@ -1146,22 +1123,7 @@ func flattenVirtualNetworkSubnets(input *[]virtualnetworks.Subnet, d *pluginsdk.
 				}
 				output["route_table_id"] = routeTableId
 				if !features.FivePointOh() {
-					serviceEndpointsInConfig := false
-					rawConfig := d.GetRawConfig()
-					if !rawConfig.IsNull() && rawConfig.IsKnown() {
-						rawSubnets := rawConfig.AsValueMap()["subnet"]
-						if !rawSubnets.IsNull() && rawSubnets.IsKnown() {
-							name := pointer.From(subnet.Name)
-							for _, rs := range rawSubnets.AsValueSlice() {
-								sm := rs.AsValueMap()
-								if sm["name"].IsKnown() && sm["name"].AsString() == name {
-									serviceEndpointsInConfig = !sm["service_endpoints"].IsNull()
-									break
-								}
-							}
-						}
-					}
-					if serviceEndpointsInConfig {
+					if virtualNetworkSubnetHasServiceEndpointsInConfig(d, pointer.From(subnet.Name)) {
 						output["service_endpoints"] = flattenVirtualNetworkSubnetServiceEndpoints(props.ServiceEndpoints)
 					}
 					output["service_endpoint"] = flattenVirtualNetworkSubnetServiceEndpoint(props.ServiceEndpoints)
@@ -1273,6 +1235,24 @@ func expandVirtualNetworkSubnetServiceEndpointPolicies(input []interface{}) *[]v
 		output = append(output, virtualnetworks.ServiceEndpointPolicy{Id: &policy})
 	}
 	return &output
+}
+
+func virtualNetworkSubnetHasServiceEndpointsInConfig(d *pluginsdk.ResourceData, subnetName string) bool {
+	rawConfig := d.GetRawConfig()
+	if rawConfig.IsNull() || !rawConfig.IsKnown() {
+		return false
+	}
+	rawSubnets := rawConfig.AsValueMap()["subnet"]
+	if rawSubnets.IsNull() || !rawSubnets.IsKnown() {
+		return false
+	}
+	for _, rs := range rawSubnets.AsValueSlice() {
+		sm := rs.AsValueMap()
+		if sm["name"].IsKnown() && sm["name"].AsString() == subnetName {
+			return !sm["service_endpoints"].IsNull()
+		}
+	}
+	return false
 }
 
 func expandVirtualNetworkSubnetServiceEndpoints(input []interface{}) *[]virtualnetworks.ServiceEndpointPropertiesFormat {

--- a/internal/services/network/virtual_network_resource.go
+++ b/internal/services/network/virtual_network_resource.go
@@ -30,6 +30,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
@@ -67,7 +68,7 @@ func resourceVirtualNetwork() *pluginsdk.Resource {
 }
 
 func resourceVirtualNetworkSchema() map[string]*pluginsdk.Schema {
-	return map[string]*pluginsdk.Schema{
+	schema := map[string]*pluginsdk.Schema{
 		"name": {
 			Type:         pluginsdk.TypeString,
 			Required:     true,
@@ -298,19 +299,11 @@ func resourceVirtualNetworkSchema() map[string]*pluginsdk.Schema {
 						Optional: true,
 					},
 
-					"service_endpoints": {
-						Type:       pluginsdk.TypeSet,
-						Optional:   true,
-						Deprecated: "The `service_endpoints` property has been superseded by the `service_endpoint` block and will be removed in a future version of the provider.",
-						Elem: &pluginsdk.Schema{
-							Type: pluginsdk.TypeString,
-						},
-						Set: pluginsdk.HashString,
-					},
-
 					"service_endpoint": {
-						Type:       pluginsdk.TypeList,
-						Optional:   true,
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						// NOTE: O+C to allow the deprecated `service_endpoints` property and `service_endpoint` block to coexist in v4
+						Computed:   true,
 						ConfigMode: pluginsdk.SchemaConfigModeAttr,
 						Elem: &pluginsdk.Resource{
 							Schema: map[string]*pluginsdk.Schema{
@@ -354,6 +347,23 @@ func resourceVirtualNetworkSchema() map[string]*pluginsdk.Schema {
 
 		"tags": commonschema.Tags(),
 	}
+
+	if !features.FivePointOh() {
+		subnetSchema := schema["subnet"].Elem.(*pluginsdk.Resource).Schema
+		subnetSchema["service_endpoints"] = &pluginsdk.Schema{
+			Type:     pluginsdk.TypeSet,
+			Optional: true,
+			// NOTE: O+C to allow the deprecated `service_endpoints` property and `service_endpoint` block to coexist in v4
+			Computed:   true,
+			Deprecated: "The `service_endpoints` property has been superseded by the `service_endpoint` block and will be removed in v5.0 of the AzureRM Provider.",
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+			},
+			Set: pluginsdk.HashString,
+		}
+	}
+
+	return schema
 }
 
 func resourceVirtualNetworkCreate(d *pluginsdk.ResourceData, meta interface{}) error {
@@ -495,10 +505,12 @@ func resourceVirtualNetworkFlatten(d *pluginsdk.ResourceData, id commonids.Virtu
 
 			configSubnets := d.Get("subnet").(*pluginsdk.Set).List()
 			oldFormatSubnets := make(map[string]bool)
-			for _, raw := range configSubnets {
-				s := raw.(map[string]interface{})
-				if endpoints := s["service_endpoints"].(*pluginsdk.Set).List(); len(endpoints) > 0 {
-					oldFormatSubnets[s["name"].(string)] = true
+			if !features.FivePointOh() {
+				for _, raw := range configSubnets {
+					s := raw.(map[string]interface{})
+					if endpoints := s["service_endpoints"].(*pluginsdk.Set).List(); len(endpoints) > 0 {
+						oldFormatSubnets[s["name"].(string)] = true
+					}
 				}
 			}
 
@@ -828,8 +840,12 @@ func expandVirtualNetworkSubnets(ctx context.Context, client virtualnetworks.Vir
 		}
 
 		subnetObj.Properties.ServiceEndpointPolicies = expandVirtualNetworkSubnetServiceEndpointPolicies(subnet["service_endpoint_policy_ids"].(*pluginsdk.Set).List())
-		if serviceEndpointsRaw := subnet["service_endpoints"].(*pluginsdk.Set).List(); len(serviceEndpointsRaw) > 0 {
-			subnetObj.Properties.ServiceEndpoints = expandVirtualNetworkSubnetServiceEndpoints(serviceEndpointsRaw)
+		if !features.FivePointOh() {
+			if serviceEndpointsRaw := subnet["service_endpoints"].(*pluginsdk.Set).List(); len(serviceEndpointsRaw) > 0 {
+				subnetObj.Properties.ServiceEndpoints = expandVirtualNetworkSubnetServiceEndpoints(serviceEndpointsRaw)
+			} else {
+				subnetObj.Properties.ServiceEndpoints = expandVirtualNetworkSubnetServiceEndpoint(subnet["service_endpoint"].([]interface{}))
+			}
 		} else {
 			subnetObj.Properties.ServiceEndpoints = expandVirtualNetworkSubnetServiceEndpoint(subnet["service_endpoint"].([]interface{}))
 		}
@@ -906,8 +922,12 @@ func expandVirtualNetworkProperties(ctx context.Context, client virtualnetworks.
 			}
 
 			subnetObj.Properties.ServiceEndpointPolicies = expandVirtualNetworkSubnetServiceEndpointPolicies(subnet["service_endpoint_policy_ids"].(*pluginsdk.Set).List())
-			if serviceEndpointsRaw := subnet["service_endpoints"].(*pluginsdk.Set).List(); len(serviceEndpointsRaw) > 0 {
-				subnetObj.Properties.ServiceEndpoints = expandVirtualNetworkSubnetServiceEndpoints(serviceEndpointsRaw)
+			if !features.FivePointOh() {
+				if serviceEndpointsRaw := subnet["service_endpoints"].(*pluginsdk.Set).List(); len(serviceEndpointsRaw) > 0 {
+					subnetObj.Properties.ServiceEndpoints = expandVirtualNetworkSubnetServiceEndpoints(serviceEndpointsRaw)
+				} else {
+					subnetObj.Properties.ServiceEndpoints = expandVirtualNetworkSubnetServiceEndpoint(subnet["service_endpoint"].([]interface{}))
+				}
 			} else {
 				subnetObj.Properties.ServiceEndpoints = expandVirtualNetworkSubnetServiceEndpoint(subnet["service_endpoint"].([]interface{}))
 			}
@@ -1100,11 +1120,15 @@ func flattenVirtualNetworkSubnets(input *[]virtualnetworks.Subnet, oldFormatSubn
 					routeTableId = id.ID()
 				}
 				output["route_table_id"] = routeTableId
-				if oldFormatSubnets[pointer.From(subnet.Name)] {
-					output["service_endpoints"] = flattenVirtualNetworkSubnetServiceEndpoints(props.ServiceEndpoints)
-					output["service_endpoint"] = make([]interface{}, 0)
+				if !features.FivePointOh() {
+					if oldFormatSubnets[pointer.From(subnet.Name)] {
+						output["service_endpoints"] = flattenVirtualNetworkSubnetServiceEndpoints(props.ServiceEndpoints)
+						output["service_endpoint"] = make([]interface{}, 0)
+					} else {
+						output["service_endpoints"] = pluginsdk.NewSet(pluginsdk.HashString, []interface{}{})
+						output["service_endpoint"] = flattenVirtualNetworkSubnetServiceEndpoint(props.ServiceEndpoints)
+					}
 				} else {
-					output["service_endpoints"] = pluginsdk.NewSet(pluginsdk.HashString, []interface{}{})
 					output["service_endpoint"] = flattenVirtualNetworkSubnetServiceEndpoint(props.ServiceEndpoints)
 				}
 				output["service_endpoint_policy_ids"] = flattenVirtualNetworkSubnetServiceEndpointPolicies(props.ServiceEndpointPolicies)

--- a/internal/services/network/virtual_network_resource.go
+++ b/internal/services/network/virtual_network_resource.go
@@ -27,6 +27,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/ipampools"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/virtualnetworks"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
@@ -298,12 +299,33 @@ func resourceVirtualNetworkSchema() map[string]*pluginsdk.Schema {
 					},
 
 					"service_endpoints": {
-						Type:     pluginsdk.TypeSet,
-						Optional: true,
+						Type:       pluginsdk.TypeSet,
+						Optional:   true,
+						Deprecated: "The `service_endpoints` property has been superseded by the `service_endpoint` block and will be removed in a future version of the provider.",
 						Elem: &pluginsdk.Schema{
 							Type: pluginsdk.TypeString,
 						},
 						Set: pluginsdk.HashString,
+					},
+
+					"service_endpoint": {
+						Type:       pluginsdk.TypeList,
+						Optional:   true,
+						ConfigMode: pluginsdk.SchemaConfigModeAttr,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"service": {
+									Type:         pluginsdk.TypeString,
+									Required:     true,
+									ValidateFunc: validation.StringIsNotEmpty,
+								},
+								"network_identifier": {
+									Type:         pluginsdk.TypeString,
+									Optional:     true,
+									ValidateFunc: azure.ValidateResourceID,
+								},
+							},
+						},
 					},
 
 					"service_endpoint_policy_ids": {
@@ -471,7 +493,16 @@ func resourceVirtualNetworkFlatten(d *pluginsdk.ResourceData, id commonids.Virtu
 				return fmt.Errorf("setting `encryption`: %+v", err)
 			}
 
-			subnet, err := flattenVirtualNetworkSubnets(props.Subnets)
+			configSubnets := d.Get("subnet").(*pluginsdk.Set).List()
+			oldFormatSubnets := make(map[string]bool)
+			for _, raw := range configSubnets {
+				s := raw.(map[string]interface{})
+				if endpoints := s["service_endpoints"].(*pluginsdk.Set).List(); len(endpoints) > 0 {
+					oldFormatSubnets[s["name"].(string)] = true
+				}
+			}
+
+			subnet, err := flattenVirtualNetworkSubnets(props.Subnets, oldFormatSubnets)
 			if err != nil {
 				return fmt.Errorf("flattening `subnet`: %+v", err)
 			}
@@ -797,7 +828,11 @@ func expandVirtualNetworkSubnets(ctx context.Context, client virtualnetworks.Vir
 		}
 
 		subnetObj.Properties.ServiceEndpointPolicies = expandVirtualNetworkSubnetServiceEndpointPolicies(subnet["service_endpoint_policy_ids"].(*pluginsdk.Set).List())
-		subnetObj.Properties.ServiceEndpoints = expandVirtualNetworkSubnetServiceEndpoints(subnet["service_endpoints"].(*pluginsdk.Set).List())
+		if serviceEndpointsRaw := subnet["service_endpoints"].(*pluginsdk.Set).List(); len(serviceEndpointsRaw) > 0 {
+			subnetObj.Properties.ServiceEndpoints = expandVirtualNetworkSubnetServiceEndpoints(serviceEndpointsRaw)
+		} else {
+			subnetObj.Properties.ServiceEndpoints = expandVirtualNetworkSubnetServiceEndpoint(subnet["service_endpoint"].([]interface{}))
+		}
 
 		if secGroup := subnet["security_group"].(string); secGroup != "" {
 			subnetObj.Properties.NetworkSecurityGroup = &virtualnetworks.NetworkSecurityGroup{
@@ -871,7 +906,11 @@ func expandVirtualNetworkProperties(ctx context.Context, client virtualnetworks.
 			}
 
 			subnetObj.Properties.ServiceEndpointPolicies = expandVirtualNetworkSubnetServiceEndpointPolicies(subnet["service_endpoint_policy_ids"].(*pluginsdk.Set).List())
-			subnetObj.Properties.ServiceEndpoints = expandVirtualNetworkSubnetServiceEndpoints(subnet["service_endpoints"].(*pluginsdk.Set).List())
+			if serviceEndpointsRaw := subnet["service_endpoints"].(*pluginsdk.Set).List(); len(serviceEndpointsRaw) > 0 {
+				subnetObj.Properties.ServiceEndpoints = expandVirtualNetworkSubnetServiceEndpoints(serviceEndpointsRaw)
+			} else {
+				subnetObj.Properties.ServiceEndpoints = expandVirtualNetworkSubnetServiceEndpoint(subnet["service_endpoint"].([]interface{}))
+			}
 
 			if secGroup := subnet["security_group"].(string); secGroup != "" {
 				subnetObj.Properties.NetworkSecurityGroup = &virtualnetworks.NetworkSecurityGroup{
@@ -1015,7 +1054,7 @@ func flattenVirtualNetworkEncryption(encryption *virtualnetworks.VirtualNetworkE
 	}
 }
 
-func flattenVirtualNetworkSubnets(input *[]virtualnetworks.Subnet) (*pluginsdk.Set, error) {
+func flattenVirtualNetworkSubnets(input *[]virtualnetworks.Subnet, oldFormatSubnets map[string]bool) (*pluginsdk.Set, error) {
 	results := &pluginsdk.Set{
 		F: resourceAzureSubnetHash,
 	}
@@ -1061,7 +1100,13 @@ func flattenVirtualNetworkSubnets(input *[]virtualnetworks.Subnet) (*pluginsdk.S
 					routeTableId = id.ID()
 				}
 				output["route_table_id"] = routeTableId
-				output["service_endpoints"] = flattenVirtualNetworkSubnetServiceEndpoints(props.ServiceEndpoints)
+				if oldFormatSubnets[pointer.From(subnet.Name)] {
+					output["service_endpoints"] = flattenVirtualNetworkSubnetServiceEndpoints(props.ServiceEndpoints)
+					output["service_endpoint"] = make([]interface{}, 0)
+				} else {
+					output["service_endpoints"] = pluginsdk.NewSet(pluginsdk.HashString, []interface{}{})
+					output["service_endpoint"] = flattenVirtualNetworkSubnetServiceEndpoint(props.ServiceEndpoints)
+				}
 				output["service_endpoint_policy_ids"] = flattenVirtualNetworkSubnetServiceEndpointPolicies(props.ServiceEndpointPolicies)
 			}
 
@@ -1243,6 +1288,49 @@ func flattenVirtualNetworkSubnetServiceEndpoints(serviceEndpoints *[]virtualnetw
 		if endpoint.Service != nil {
 			endpoints = append(endpoints, *endpoint.Service)
 		}
+	}
+
+	return endpoints
+}
+
+func expandVirtualNetworkSubnetServiceEndpoint(input []interface{}) *[]virtualnetworks.ServiceEndpointPropertiesFormat {
+	endpoints := make([]virtualnetworks.ServiceEndpointPropertiesFormat, 0)
+
+	for _, item := range input {
+		v := item.(map[string]interface{})
+		svc := v["service"].(string)
+		endpoint := virtualnetworks.ServiceEndpointPropertiesFormat{
+			Service: &svc,
+		}
+		if networkIdentifier := v["network_identifier"].(string); networkIdentifier != "" {
+			endpoint.NetworkIdentifier = &virtualnetworks.SubResource{
+				Id: &networkIdentifier,
+			}
+		}
+		endpoints = append(endpoints, endpoint)
+	}
+
+	return &endpoints
+}
+
+func flattenVirtualNetworkSubnetServiceEndpoint(serviceEndpoints *[]virtualnetworks.ServiceEndpointPropertiesFormat) []interface{} {
+	endpoints := make([]interface{}, 0)
+
+	if serviceEndpoints == nil {
+		return endpoints
+	}
+
+	for _, endpoint := range *serviceEndpoints {
+		item := map[string]interface{}{}
+		if endpoint.Service != nil {
+			item["service"] = *endpoint.Service
+		}
+		networkIdentifier := ""
+		if endpoint.NetworkIdentifier != nil && endpoint.NetworkIdentifier.Id != nil {
+			networkIdentifier = *endpoint.NetworkIdentifier.Id
+		}
+		item["network_identifier"] = networkIdentifier
+		endpoints = append(endpoints, item)
 	}
 
 	return endpoints

--- a/internal/services/network/virtual_network_resource.go
+++ b/internal/services/network/virtual_network_resource.go
@@ -67,7 +67,7 @@ func resourceVirtualNetwork() *pluginsdk.Resource {
 }
 
 func resourceVirtualNetworkSchema() map[string]*pluginsdk.Schema {
-	resourceSchema := map[string]*pluginsdk.Schema{
+	return map[string]*pluginsdk.Schema{
 		"name": {
 			Type:         pluginsdk.TypeString,
 			Required:     true,
@@ -305,21 +305,9 @@ func resourceVirtualNetworkSchema() map[string]*pluginsdk.Schema {
 						Elem: &pluginsdk.Resource{
 							Schema: map[string]*pluginsdk.Schema{
 								"service": {
-									Type:     pluginsdk.TypeString,
-									Required: true,
-									ValidateFunc: validation.StringInSlice([]string{
-										"Microsoft.AzureActiveDirectory",
-										"Microsoft.AzureCosmosDB",
-										"Microsoft.CognitiveServices",
-										"Microsoft.ContainerRegistry",
-										"Microsoft.EventHub",
-										"Microsoft.KeyVault",
-										"Microsoft.ServiceBus",
-										"Microsoft.Sql",
-										"Microsoft.Storage",
-										"Microsoft.Storage.Global",
-										"Microsoft.Web",
-									}, false),
+									Type:         pluginsdk.TypeString,
+									Required:     true,
+									ValidateFunc: validate.SubnetServiceEndpointName(),
 								},
 								"network_identifier": {
 									Type:         pluginsdk.TypeString,
@@ -356,8 +344,6 @@ func resourceVirtualNetworkSchema() map[string]*pluginsdk.Schema {
 
 		"tags": commonschema.Tags(),
 	}
-
-	return resourceSchema
 }
 
 func resourceVirtualNetworkCreate(d *pluginsdk.ResourceData, meta interface{}) error {
@@ -625,7 +611,7 @@ func resourceVirtualNetworkUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 	}
 
 	if d.HasChange("subnet") {
-		subnetList, routeTables, err := expandVirtualNetworkSubnets(ctx, *client, d.Get("subnet").(*pluginsdk.Set).List(), *id, d)
+		subnetList, routeTables, err := expandVirtualNetworkSubnets(ctx, *client, d.Get("subnet").(*pluginsdk.Set).List(), *id)
 		if err != nil {
 			return fmt.Errorf("expanding `subnet`: %+v", err)
 		}
@@ -754,7 +740,7 @@ func expandVirtualNetworkEncryption(input []interface{}) *virtualnetworks.Virtua
 	}
 }
 
-func expandVirtualNetworkSubnets(ctx context.Context, client virtualnetworks.VirtualNetworksClient, input []interface{}, id commonids.VirtualNetworkId, d *pluginsdk.ResourceData) (*[]virtualnetworks.Subnet, *[]string, error) {
+func expandVirtualNetworkSubnets(ctx context.Context, client virtualnetworks.VirtualNetworksClient, input []interface{}, id commonids.VirtualNetworkId) (*[]virtualnetworks.Subnet, *[]string, error) {
 	subnets := make([]virtualnetworks.Subnet, 0)
 	routeTables := make([]string, 0)
 
@@ -1273,11 +1259,9 @@ func flattenVirtualNetworkSubnetServiceEndpoint(serviceEndpoints *[]virtualnetwo
 		item := map[string]interface{}{
 			"service": pointer.From(endpoint.Service),
 		}
-		networkIdentifier := ""
 		if endpoint.NetworkIdentifier != nil {
-			networkIdentifier = pointer.From(endpoint.NetworkIdentifier.Id)
+			item["network_identifier"] = pointer.From(endpoint.NetworkIdentifier.Id)
 		}
-		item["network_identifier"] = networkIdentifier
 		endpoints = append(endpoints, item)
 	}
 

--- a/internal/services/network/virtual_network_resource.go
+++ b/internal/services/network/virtual_network_resource.go
@@ -30,7 +30,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
@@ -356,22 +355,6 @@ func resourceVirtualNetworkSchema() map[string]*pluginsdk.Schema {
 		},
 
 		"tags": commonschema.Tags(),
-	}
-
-	if !features.FivePointOh() {
-		subnetSchema := resourceSchema["subnet"].Elem.(*pluginsdk.Resource).Schema
-		subnetSchema["service_endpoints"] = &pluginsdk.Schema{
-			Type:     pluginsdk.TypeSet,
-			Optional: true,
-			// NOTE: O+C to allow the deprecated `service_endpoints` property and `service_endpoint` block to coexist in v4
-			Computed:   true,
-			Deprecated: "The `service_endpoints` property has been superseded by the `service_endpoint` block and will be removed in v5.0 of the AzureRM Provider.",
-			Elem: &pluginsdk.Schema{
-				Type: pluginsdk.TypeString,
-			},
-			Set: pluginsdk.HashString,
-		}
-		subnetSchema["service_endpoint"].Computed = true
 	}
 
 	return resourceSchema
@@ -840,16 +823,7 @@ func expandVirtualNetworkSubnets(ctx context.Context, client virtualnetworks.Vir
 		}
 
 		subnetObj.Properties.ServiceEndpointPolicies = expandVirtualNetworkSubnetServiceEndpointPolicies(subnet["service_endpoint_policy_ids"].(*pluginsdk.Set).List())
-		if !features.FivePointOh() {
-			if virtualNetworkSubnetHasServiceEndpointsInConfig(d, name) {
-				serviceEndpointsRaw := subnet["service_endpoints"].(*pluginsdk.Set).List()
-				subnetObj.Properties.ServiceEndpoints = expandVirtualNetworkSubnetServiceEndpoints(serviceEndpointsRaw)
-			} else {
-				subnetObj.Properties.ServiceEndpoints = expandVirtualNetworkSubnetServiceEndpoint(subnet["service_endpoint"].([]interface{}))
-			}
-		} else {
-			subnetObj.Properties.ServiceEndpoints = expandVirtualNetworkSubnetServiceEndpoint(subnet["service_endpoint"].([]interface{}))
-		}
+		subnetObj.Properties.ServiceEndpoints = expandVirtualNetworkSubnetServiceEndpoint(subnet["service_endpoint"].([]interface{}))
 
 		if secGroup := subnet["security_group"].(string); secGroup != "" {
 			subnetObj.Properties.NetworkSecurityGroup = &virtualnetworks.NetworkSecurityGroup{
@@ -923,16 +897,7 @@ func expandVirtualNetworkProperties(ctx context.Context, client virtualnetworks.
 			}
 
 			subnetObj.Properties.ServiceEndpointPolicies = expandVirtualNetworkSubnetServiceEndpointPolicies(subnet["service_endpoint_policy_ids"].(*pluginsdk.Set).List())
-			if !features.FivePointOh() {
-				if virtualNetworkSubnetHasServiceEndpointsInConfig(d, name) {
-					serviceEndpointsRaw := subnet["service_endpoints"].(*pluginsdk.Set).List()
-					subnetObj.Properties.ServiceEndpoints = expandVirtualNetworkSubnetServiceEndpoints(serviceEndpointsRaw)
-				} else {
-					subnetObj.Properties.ServiceEndpoints = expandVirtualNetworkSubnetServiceEndpoint(subnet["service_endpoint"].([]interface{}))
-				}
-			} else {
-				subnetObj.Properties.ServiceEndpoints = expandVirtualNetworkSubnetServiceEndpoint(subnet["service_endpoint"].([]interface{}))
-			}
+			subnetObj.Properties.ServiceEndpoints = expandVirtualNetworkSubnetServiceEndpoint(subnet["service_endpoint"].([]interface{}))
 
 			if secGroup := subnet["security_group"].(string); secGroup != "" {
 				subnetObj.Properties.NetworkSecurityGroup = &virtualnetworks.NetworkSecurityGroup{
@@ -1122,14 +1087,7 @@ func flattenVirtualNetworkSubnets(input *[]virtualnetworks.Subnet, d *pluginsdk.
 					routeTableId = id.ID()
 				}
 				output["route_table_id"] = routeTableId
-				if !features.FivePointOh() {
-					if virtualNetworkSubnetHasServiceEndpointsInConfig(d, pointer.From(subnet.Name)) {
-						output["service_endpoints"] = flattenVirtualNetworkSubnetServiceEndpoints(props.ServiceEndpoints)
-					}
-					output["service_endpoint"] = flattenVirtualNetworkSubnetServiceEndpoint(props.ServiceEndpoints)
-				} else {
-					output["service_endpoint"] = flattenVirtualNetworkSubnetServiceEndpoint(props.ServiceEndpoints)
-				}
+				output["service_endpoint"] = flattenVirtualNetworkSubnetServiceEndpoint(props.ServiceEndpoints)
 				output["service_endpoint_policy_ids"] = flattenVirtualNetworkSubnetServiceEndpointPolicies(props.ServiceEndpointPolicies)
 			}
 
@@ -1237,39 +1195,6 @@ func expandVirtualNetworkSubnetServiceEndpointPolicies(input []interface{}) *[]v
 	return &output
 }
 
-func virtualNetworkSubnetHasServiceEndpointsInConfig(d *pluginsdk.ResourceData, subnetName string) bool {
-	rawConfig := d.GetRawConfig()
-	if rawConfig.IsNull() || !rawConfig.IsKnown() {
-		return false
-	}
-	rawSubnets := rawConfig.AsValueMap()["subnet"]
-	if rawSubnets.IsNull() || !rawSubnets.IsKnown() {
-		return false
-	}
-	for _, rs := range rawSubnets.AsValueSlice() {
-		sm := rs.AsValueMap()
-		if sm["name"].IsKnown() && sm["name"].AsString() == subnetName {
-			return !sm["service_endpoints"].IsNull()
-		}
-	}
-	return false
-}
-
-func expandVirtualNetworkSubnetServiceEndpoints(input []interface{}) *[]virtualnetworks.ServiceEndpointPropertiesFormat {
-	endpoints := make([]virtualnetworks.ServiceEndpointPropertiesFormat, 0)
-
-	for _, svcEndpointRaw := range input {
-		if svc, ok := svcEndpointRaw.(string); ok {
-			endpoint := virtualnetworks.ServiceEndpointPropertiesFormat{
-				Service: &svc,
-			}
-			endpoints = append(endpoints, endpoint)
-		}
-	}
-
-	return &endpoints
-}
-
 func expandVirtualNetworkSubnetDelegation(input []interface{}) *[]virtualnetworks.Delegation {
 	retDelegations := make([]virtualnetworks.Delegation, 0)
 
@@ -1316,22 +1241,6 @@ func flattenVirtualNetworkSubnetServiceEndpointPolicies(input *[]virtualnetworks
 		output = append(output, id)
 	}
 	return output
-}
-
-func flattenVirtualNetworkSubnetServiceEndpoints(serviceEndpoints *[]virtualnetworks.ServiceEndpointPropertiesFormat) []interface{} {
-	endpoints := make([]interface{}, 0)
-
-	if serviceEndpoints == nil {
-		return endpoints
-	}
-
-	for _, endpoint := range *serviceEndpoints {
-		if endpoint.Service != nil {
-			endpoints = append(endpoints, *endpoint.Service)
-		}
-	}
-
-	return endpoints
 }
 
 func expandVirtualNetworkSubnetServiceEndpoint(input []interface{}) *[]virtualnetworks.ServiceEndpointPropertiesFormat {

--- a/internal/services/network/virtual_network_resource.go
+++ b/internal/services/network/virtual_network_resource.go
@@ -503,18 +503,7 @@ func resourceVirtualNetworkFlatten(d *pluginsdk.ResourceData, id commonids.Virtu
 				return fmt.Errorf("setting `encryption`: %+v", err)
 			}
 
-			configSubnets := d.Get("subnet").(*pluginsdk.Set).List()
-			oldFormatSubnets := make(map[string]bool)
-			if !features.FivePointOh() {
-				for _, raw := range configSubnets {
-					s := raw.(map[string]interface{})
-					if endpoints := s["service_endpoints"].(*pluginsdk.Set).List(); len(endpoints) > 0 {
-						oldFormatSubnets[s["name"].(string)] = true
-					}
-				}
-			}
-
-			subnet, err := flattenVirtualNetworkSubnets(props.Subnets, oldFormatSubnets)
+			subnet, err := flattenVirtualNetworkSubnets(props.Subnets, d)
 			if err != nil {
 				return fmt.Errorf("flattening `subnet`: %+v", err)
 			}
@@ -642,7 +631,7 @@ func resourceVirtualNetworkUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 	}
 
 	if d.HasChange("subnet") {
-		subnets, routeTables, err := expandVirtualNetworkSubnets(ctx, *client, d.Get("subnet").(*pluginsdk.Set).List(), *id)
+		subnets, routeTables, err := expandVirtualNetworkSubnets(ctx, *client, d.Get("subnet").(*pluginsdk.Set).List(), *id, d)
 		if err != nil {
 			return fmt.Errorf("expanding `subnet`: %+v", err)
 		}
@@ -771,7 +760,7 @@ func expandVirtualNetworkEncryption(input []interface{}) *virtualnetworks.Virtua
 	}
 }
 
-func expandVirtualNetworkSubnets(ctx context.Context, client virtualnetworks.VirtualNetworksClient, input []interface{}, id commonids.VirtualNetworkId) (*[]virtualnetworks.Subnet, *[]string, error) {
+func expandVirtualNetworkSubnets(ctx context.Context, client virtualnetworks.VirtualNetworksClient, input []interface{}, id commonids.VirtualNetworkId, d *pluginsdk.ResourceData) (*[]virtualnetworks.Subnet, *[]string, error) {
 	subnets := make([]virtualnetworks.Subnet, 0)
 	routeTables := make([]string, 0)
 
@@ -841,7 +830,19 @@ func expandVirtualNetworkSubnets(ctx context.Context, client virtualnetworks.Vir
 
 		subnetObj.Properties.ServiceEndpointPolicies = expandVirtualNetworkSubnetServiceEndpointPolicies(subnet["service_endpoint_policy_ids"].(*pluginsdk.Set).List())
 		if !features.FivePointOh() {
-			if serviceEndpointsRaw := subnet["service_endpoints"].(*pluginsdk.Set).List(); len(serviceEndpointsRaw) > 0 {
+			serviceEndpointsNull := true
+			rawSubnets := d.GetRawConfig().AsValueMap()["subnet"]
+			if !rawSubnets.IsNull() && rawSubnets.IsKnown() {
+				for _, rs := range rawSubnets.AsValueSlice() {
+					sm := rs.AsValueMap()
+					if sm["name"].IsKnown() && sm["name"].AsString() == name {
+						serviceEndpointsNull = sm["service_endpoints"].IsNull()
+						break
+					}
+				}
+			}
+			if !serviceEndpointsNull {
+				serviceEndpointsRaw := subnet["service_endpoints"].(*pluginsdk.Set).List()
 				subnetObj.Properties.ServiceEndpoints = expandVirtualNetworkSubnetServiceEndpoints(serviceEndpointsRaw)
 			} else {
 				subnetObj.Properties.ServiceEndpoints = expandVirtualNetworkSubnetServiceEndpoint(subnet["service_endpoint"].([]interface{}))
@@ -923,7 +924,19 @@ func expandVirtualNetworkProperties(ctx context.Context, client virtualnetworks.
 
 			subnetObj.Properties.ServiceEndpointPolicies = expandVirtualNetworkSubnetServiceEndpointPolicies(subnet["service_endpoint_policy_ids"].(*pluginsdk.Set).List())
 			if !features.FivePointOh() {
-				if serviceEndpointsRaw := subnet["service_endpoints"].(*pluginsdk.Set).List(); len(serviceEndpointsRaw) > 0 {
+				serviceEndpointsNull := true
+				rawSubnets := d.GetRawConfig().AsValueMap()["subnet"]
+				if !rawSubnets.IsNull() && rawSubnets.IsKnown() {
+					for _, rs := range rawSubnets.AsValueSlice() {
+						sm := rs.AsValueMap()
+						if sm["name"].IsKnown() && sm["name"].AsString() == name {
+							serviceEndpointsNull = sm["service_endpoints"].IsNull()
+							break
+						}
+					}
+				}
+				if !serviceEndpointsNull {
+					serviceEndpointsRaw := subnet["service_endpoints"].(*pluginsdk.Set).List()
 					subnetObj.Properties.ServiceEndpoints = expandVirtualNetworkSubnetServiceEndpoints(serviceEndpointsRaw)
 				} else {
 					subnetObj.Properties.ServiceEndpoints = expandVirtualNetworkSubnetServiceEndpoint(subnet["service_endpoint"].([]interface{}))
@@ -1074,7 +1087,7 @@ func flattenVirtualNetworkEncryption(encryption *virtualnetworks.VirtualNetworkE
 	}
 }
 
-func flattenVirtualNetworkSubnets(input *[]virtualnetworks.Subnet, oldFormatSubnets map[string]bool) (*pluginsdk.Set, error) {
+func flattenVirtualNetworkSubnets(input *[]virtualnetworks.Subnet, d *pluginsdk.ResourceData) (*pluginsdk.Set, error) {
 	results := &pluginsdk.Set{
 		F: resourceAzureSubnetHash,
 	}
@@ -1121,13 +1134,28 @@ func flattenVirtualNetworkSubnets(input *[]virtualnetworks.Subnet, oldFormatSubn
 				}
 				output["route_table_id"] = routeTableId
 				if !features.FivePointOh() {
-					if oldFormatSubnets[pointer.From(subnet.Name)] {
-						output["service_endpoints"] = flattenVirtualNetworkSubnetServiceEndpoints(props.ServiceEndpoints)
-						output["service_endpoint"] = make([]interface{}, 0)
-					} else {
-						output["service_endpoints"] = pluginsdk.NewSet(pluginsdk.HashString, []interface{}{})
-						output["service_endpoint"] = flattenVirtualNetworkSubnetServiceEndpoint(props.ServiceEndpoints)
+					serviceEndpointsInConfig := false
+					rawConfig := d.GetRawConfig()
+					if !rawConfig.IsNull() && rawConfig.IsKnown() {
+						rawSubnets := rawConfig.AsValueMap()["subnet"]
+						if !rawSubnets.IsNull() && rawSubnets.IsKnown() {
+							name := ""
+							if subnet.Name != nil {
+								name = *subnet.Name
+							}
+							for _, rs := range rawSubnets.AsValueSlice() {
+								sm := rs.AsValueMap()
+								if sm["name"].IsKnown() && sm["name"].AsString() == name {
+									serviceEndpointsInConfig = !sm["service_endpoints"].IsNull()
+									break
+								}
+							}
+						}
 					}
+					if serviceEndpointsInConfig {
+						output["service_endpoints"] = flattenVirtualNetworkSubnetServiceEndpoints(props.ServiceEndpoints)
+					}
+					output["service_endpoint"] = flattenVirtualNetworkSubnetServiceEndpoint(props.ServiceEndpoints)
 				} else {
 					output["service_endpoint"] = flattenVirtualNetworkSubnetServiceEndpoint(props.ServiceEndpoints)
 				}

--- a/internal/services/network/virtual_network_resource_test.go
+++ b/internal/services/network/virtual_network_resource_test.go
@@ -399,6 +399,43 @@ func TestAccVirtualNetwork_subnet(t *testing.T) {
 	})
 }
 
+func TestAccVirtualNetwork_serviceEndpointBlock(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_virtual_network", "test")
+	r := VirtualNetworkResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.serviceEndpointBlock(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.serviceEndpointBlockUpdated(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccVirtualNetwork_serviceEndpointWithNetworkIdentifier(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_virtual_network", "test")
+	r := VirtualNetworkResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.serviceEndpointWithNetworkIdentifier(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccVirtualNetwork_subnetRouteTable(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_virtual_network", "test")
 	r := VirtualNetworkResource{}
@@ -1175,4 +1212,104 @@ resource "azurerm_virtual_network" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary)
+}
+
+func (VirtualNetworkResource) serviceEndpointBlock(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  subnet {
+    name             = "subnet1"
+    address_prefixes = ["10.0.1.0/24"]
+
+    service_endpoint {
+      service = "Microsoft.Sql"
+    }
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (VirtualNetworkResource) serviceEndpointBlockUpdated(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  subnet {
+    name             = "subnet1"
+    address_prefixes = ["10.0.1.0/24"]
+
+    service_endpoint {
+      service = "Microsoft.Sql"
+    }
+
+    service_endpoint {
+      service = "Microsoft.Storage"
+    }
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (VirtualNetworkResource) serviceEndpointWithNetworkIdentifier(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_public_ip" "test" {
+  name                = "acctestpip-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  subnet {
+    name             = "subnet1"
+    address_prefixes = ["10.0.1.0/24"]
+
+    service_endpoint {
+      service            = "Microsoft.Storage"
+      network_identifier = azurerm_public_ip.test.id
+    }
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }

--- a/internal/services/network/virtual_network_resource_test.go
+++ b/internal/services/network/virtual_network_resource_test.go
@@ -418,14 +418,13 @@ func TestAccVirtualNetwork_serviceEndpointBlock(t *testing.T) {
 			),
 		},
 		data.ImportStep(),
-	})
-}
-
-func TestAccVirtualNetwork_serviceEndpointWithNetworkIdentifier(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_virtual_network", "test")
-	r := VirtualNetworkResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.serviceEndpointBlock(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
 		{
 			Config: r.serviceEndpointWithNetworkIdentifier(data),
 			Check: acceptance.ComposeTestCheckFunc(

--- a/internal/services/network/virtual_network_resource_test.go
+++ b/internal/services/network/virtual_network_resource_test.go
@@ -1057,7 +1057,7 @@ resource "azurerm_virtual_network" "test" {
     private_link_service_network_policies_enabled = false
     private_endpoint_network_policies             = "Enabled"
     %[3]s
-    service_endpoint_policy_ids                   = [azurerm_subnet_service_endpoint_storage_policy.test.id]
+    service_endpoint_policy_ids = [azurerm_subnet_service_endpoint_storage_policy.test.id]
 
     delegation {
       name = "nginx"
@@ -1075,7 +1075,7 @@ resource "azurerm_virtual_network" "test" {
     address_prefixes                              = ["10.0.2.0/24"]
     private_link_service_network_policies_enabled = false
     %[4]s
-    service_endpoint_policy_ids                   = [azurerm_subnet_service_endpoint_storage_policy.test.id]
+    service_endpoint_policy_ids = [azurerm_subnet_service_endpoint_storage_policy.test.id]
 
     delegation {
       name = "containers"

--- a/internal/services/network/virtual_network_resource_test.go
+++ b/internal/services/network/virtual_network_resource_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
@@ -1013,6 +1014,21 @@ resource "azurerm_virtual_network" "test" {
 }
 
 func (VirtualNetworkResource) subnet(data acceptance.TestData) string {
+	serviceEndpointSubnet1 := `service_endpoints = ["Microsoft.Sql", "Microsoft.Storage"]`
+	serviceEndpointSubnet2 := `service_endpoints = ["Microsoft.Storage"]`
+	if features.FivePointOh() {
+		serviceEndpointSubnet1 = `
+    service_endpoint {
+      service = "Microsoft.Sql"
+    }
+    service_endpoint {
+      service = "Microsoft.Storage"
+    }`
+		serviceEndpointSubnet2 = `
+    service_endpoint {
+      service = "Microsoft.Storage"
+    }`
+	}
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -1040,7 +1056,7 @@ resource "azurerm_virtual_network" "test" {
     address_prefixes                              = ["10.0.1.0/24", "ace:cab:deca::/64"]
     private_link_service_network_policies_enabled = false
     private_endpoint_network_policies             = "Enabled"
-    service_endpoints                             = ["Microsoft.Sql", "Microsoft.Storage"]
+    %[3]s
     service_endpoint_policy_ids                   = [azurerm_subnet_service_endpoint_storage_policy.test.id]
 
     delegation {
@@ -1058,7 +1074,7 @@ resource "azurerm_virtual_network" "test" {
     name                                          = "subnet2"
     address_prefixes                              = ["10.0.2.0/24"]
     private_link_service_network_policies_enabled = false
-    service_endpoints                             = ["Microsoft.Storage"]
+    %[4]s
     service_endpoint_policy_ids                   = [azurerm_subnet_service_endpoint_storage_policy.test.id]
 
     delegation {
@@ -1076,10 +1092,17 @@ resource "azurerm_virtual_network" "test" {
     environment = "Production"
   }
 }
-`, data.RandomInteger, data.Locations.Primary)
+`, data.RandomInteger, data.Locations.Primary, serviceEndpointSubnet1, serviceEndpointSubnet2)
 }
 
 func (VirtualNetworkResource) subnetUpdated(data acceptance.TestData) string {
+	serviceEndpointConfig := `service_endpoints = ["Microsoft.Storage"]`
+	if features.FivePointOh() {
+		serviceEndpointConfig = `
+    service_endpoint {
+      service = "Microsoft.Storage"
+    }`
+	}
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -1108,7 +1131,7 @@ resource "azurerm_virtual_network" "test" {
     default_outbound_access_enabled               = false
     private_link_service_network_policies_enabled = true
     private_endpoint_network_policies             = "Enabled"
-    service_endpoints                             = ["Microsoft.Storage"]
+    %[3]s
 
     delegation {
       name = "first"
@@ -1125,7 +1148,7 @@ resource "azurerm_virtual_network" "test" {
     environment = "Production"
   }
 }
-`, data.RandomInteger, data.Locations.Primary)
+`, data.RandomInteger, data.Locations.Primary, serviceEndpointConfig)
 }
 
 func (VirtualNetworkResource) subnetRouteTable(data acceptance.TestData) string {

--- a/internal/services/network/virtual_network_resource_test.go
+++ b/internal/services/network/virtual_network_resource_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
@@ -1014,21 +1013,17 @@ resource "azurerm_virtual_network" "test" {
 }
 
 func (VirtualNetworkResource) subnet(data acceptance.TestData) string {
-	serviceEndpointSubnet1 := `service_endpoints = ["Microsoft.Sql", "Microsoft.Storage"]`
-	serviceEndpointSubnet2 := `service_endpoints = ["Microsoft.Storage"]`
-	if features.FivePointOh() {
-		serviceEndpointSubnet1 = `
+	serviceEndpointSubnet1 := `
     service_endpoint {
       service = "Microsoft.Sql"
     }
     service_endpoint {
       service = "Microsoft.Storage"
     }`
-		serviceEndpointSubnet2 = `
+	serviceEndpointSubnet2 := `
     service_endpoint {
       service = "Microsoft.Storage"
     }`
-	}
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -1096,13 +1091,10 @@ resource "azurerm_virtual_network" "test" {
 }
 
 func (VirtualNetworkResource) subnetUpdated(data acceptance.TestData) string {
-	serviceEndpointConfig := `service_endpoints = ["Microsoft.Storage"]`
-	if features.FivePointOh() {
-		serviceEndpointConfig = `
+	serviceEndpointConfig := `
     service_endpoint {
       service = "Microsoft.Storage"
     }`
-	}
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}

--- a/internal/services/network/virtual_network_resource_test.go
+++ b/internal/services/network/virtual_network_resource_test.go
@@ -419,7 +419,8 @@ func TestAccVirtualNetwork_serviceEndpointBlock(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			Config: r.serviceEndpointBlock(data),
+			// remove them
+			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -1013,17 +1014,6 @@ resource "azurerm_virtual_network" "test" {
 }
 
 func (VirtualNetworkResource) subnet(data acceptance.TestData) string {
-	serviceEndpointSubnet1 := `
-    service_endpoint {
-      service = "Microsoft.Sql"
-    }
-    service_endpoint {
-      service = "Microsoft.Storage"
-    }`
-	serviceEndpointSubnet2 := `
-    service_endpoint {
-      service = "Microsoft.Storage"
-    }`
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -1051,7 +1041,13 @@ resource "azurerm_virtual_network" "test" {
     address_prefixes                              = ["10.0.1.0/24", "ace:cab:deca::/64"]
     private_link_service_network_policies_enabled = false
     private_endpoint_network_policies             = "Enabled"
-    %[3]s
+
+    service_endpoint {
+      service = "Microsoft.Sql"
+    }
+    service_endpoint {
+      service = "Microsoft.Storage"
+    }
     service_endpoint_policy_ids = [azurerm_subnet_service_endpoint_storage_policy.test.id]
 
     delegation {
@@ -1069,7 +1065,10 @@ resource "azurerm_virtual_network" "test" {
     name                                          = "subnet2"
     address_prefixes                              = ["10.0.2.0/24"]
     private_link_service_network_policies_enabled = false
-    %[4]s
+
+    service_endpoint {
+      service = "Microsoft.Storage"
+    }
     service_endpoint_policy_ids = [azurerm_subnet_service_endpoint_storage_policy.test.id]
 
     delegation {
@@ -1087,14 +1086,10 @@ resource "azurerm_virtual_network" "test" {
     environment = "Production"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, serviceEndpointSubnet1, serviceEndpointSubnet2)
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func (VirtualNetworkResource) subnetUpdated(data acceptance.TestData) string {
-	serviceEndpointConfig := `
-    service_endpoint {
-      service = "Microsoft.Storage"
-    }`
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -1123,7 +1118,10 @@ resource "azurerm_virtual_network" "test" {
     default_outbound_access_enabled               = false
     private_link_service_network_policies_enabled = true
     private_endpoint_network_policies             = "Enabled"
-    %[3]s
+
+    service_endpoint {
+      service = "Microsoft.Storage"
+    }
 
     delegation {
       name = "first"
@@ -1140,7 +1138,7 @@ resource "azurerm_virtual_network" "test" {
     environment = "Production"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, serviceEndpointConfig)
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func (VirtualNetworkResource) subnetRouteTable(data acceptance.TestData) string {

--- a/internal/services/postgres/postgresql_flexible_server_resource_test.go
+++ b/internal/services/postgres/postgresql_flexible_server_resource_test.go
@@ -978,7 +978,9 @@ resource "azurerm_subnet" "test" {
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.0.2.0/24"]
-  service_endpoints    = ["Microsoft.Storage"]
+  service_endpoint {
+    service = "Microsoft.Storage"
+  }
   delegation {
     name = "fs"
     service_delegation {
@@ -1054,7 +1056,9 @@ resource "azurerm_subnet" "test" {
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.0.2.0/24"]
-  service_endpoints    = ["Microsoft.Storage"]
+  service_endpoint {
+    service = "Microsoft.Storage"
+  }
   delegation {
     name = "fs"
     service_delegation {

--- a/internal/services/postgres/postgresql_flexible_server_virtual_endpoint_resource_test.go
+++ b/internal/services/postgres/postgresql_flexible_server_virtual_endpoint_resource_test.go
@@ -305,7 +305,9 @@ resource "azurerm_subnet" "primary" {
   resource_group_name  = azurerm_resource_group.primary.name
   virtual_network_name = azurerm_virtual_network.primary.name
   address_prefixes     = ["10.0.1.0/24"]
-  service_endpoints    = ["Microsoft.Storage"]
+  service_endpoint {
+    service = "Microsoft.Storage"
+  }
 
   delegation {
     name = "fs"
@@ -415,7 +417,9 @@ resource "azurerm_subnet" "secondary" {
   resource_group_name  = azurerm_resource_group.secondary.name
   virtual_network_name = azurerm_virtual_network.secondary.name
   address_prefixes     = ["11.0.1.0/24"]
-  service_endpoints    = ["Microsoft.Storage"]
+  service_endpoint {
+    service = "Microsoft.Storage"
+  }
 
   delegation {
     name = "fs"

--- a/internal/services/redhatopenshift/redhat_openshift_cluster_resource_test.go
+++ b/internal/services/redhatopenshift/redhat_openshift_cluster_resource_test.go
@@ -964,7 +964,13 @@ resource "azurerm_subnet" "main_subnet" {
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.0.0.0/23"]
-  service_endpoints    = ["Microsoft.Storage", "Microsoft.ContainerRegistry"]
+  service_endpoint {
+    service = "Microsoft.Storage"
+  }
+
+  service_endpoint {
+    service = "Microsoft.ContainerRegistry"
+  }
 
   private_link_service_network_policies_enabled = false
 }
@@ -974,7 +980,13 @@ resource "azurerm_subnet" "worker_subnet" {
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.0.2.0/23"]
-  service_endpoints    = ["Microsoft.Storage", "Microsoft.ContainerRegistry"]
+  service_endpoint {
+    service = "Microsoft.Storage"
+  }
+
+  service_endpoint {
+    service = "Microsoft.ContainerRegistry"
+  }
 }
  `, data.RandomInteger, data.Locations.Primary)
 }

--- a/internal/services/servicebus/servicebus_namespace_resource_test.go
+++ b/internal/services/servicebus/servicebus_namespace_resource_test.go
@@ -730,7 +730,9 @@ resource "azurerm_subnet" "test" {
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["172.17.0.0/24"]
 
-  service_endpoints = ["Microsoft.ServiceBus"]
+  service_endpoint {
+    service = "Microsoft.ServiceBus"
+  }
 }
 
 resource "azurerm_servicebus_namespace" "test" {
@@ -778,7 +780,9 @@ resource "azurerm_subnet" "test" {
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["172.17.0.0/24"]
 
-  service_endpoints = ["Microsoft.ServiceBus"]
+  service_endpoint {
+    service = "Microsoft.ServiceBus"
+  }
 }
 
 resource "azurerm_servicebus_namespace" "test" {
@@ -829,7 +833,9 @@ resource "azurerm_subnet" "test" {
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["172.17.0.0/24"]
 
-  service_endpoints = ["Microsoft.ServiceBus"]
+  service_endpoint {
+    service = "Microsoft.ServiceBus"
+  }
 }
 
 resource "azurerm_servicebus_namespace" "test" {

--- a/internal/services/serviceconnector/app_service_connection_resource_test.go
+++ b/internal/services/serviceconnector/app_service_connection_resource_test.go
@@ -450,7 +450,9 @@ resource "azurerm_subnet" "test1" {
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.0.1.0/24"]
-  service_endpoints    = ["Microsoft.AzureCosmosDB"]
+  service_endpoint {
+    service = "Microsoft.AzureCosmosDB"
+  }
 
   delegation {
     name = "delegation"

--- a/internal/services/storage/storage_account_network_rules_resource_test.go
+++ b/internal/services/storage/storage_account_network_rules_resource_test.go
@@ -236,7 +236,9 @@ resource "azurerm_subnet" "test" {
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.0.2.0/24"]
-  service_endpoints    = ["Microsoft.Storage"]
+  service_endpoint {
+    service = "Microsoft.Storage"
+  }
 }
 
 resource "azurerm_storage_account" "test" {
@@ -284,7 +286,9 @@ resource "azurerm_subnet" "test" {
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.0.2.0/24"]
-  service_endpoints    = ["Microsoft.Storage"]
+  service_endpoint {
+    service = "Microsoft.Storage"
+  }
 }
 
 resource "azurerm_storage_account" "test" {
@@ -332,7 +336,9 @@ resource "azurerm_subnet" "test" {
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.0.2.0/24"]
-  service_endpoints    = ["Microsoft.Storage"]
+  service_endpoint {
+    service = "Microsoft.Storage"
+  }
 }
 
 resource "azurerm_subnet" "test2" {
@@ -340,7 +346,9 @@ resource "azurerm_subnet" "test2" {
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.0.3.0/24"]
-  service_endpoints    = ["Microsoft.Storage"]
+  service_endpoint {
+    service = "Microsoft.Storage"
+  }
 }
 
 resource "azurerm_storage_account" "test" {

--- a/internal/services/storage/storage_account_resource_test.go
+++ b/internal/services/storage/storage_account_resource_test.go
@@ -2417,7 +2417,9 @@ resource "azurerm_subnet" "test" {
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.0.2.0/24"]
-  service_endpoints    = ["Microsoft.Storage"]
+  service_endpoint {
+    service = "Microsoft.Storage"
+  }
 }
 
 resource "azurerm_storage_account" "test" {
@@ -2809,7 +2811,9 @@ resource "azurerm_subnet" "test" {
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.0.2.0/24"]
-  service_endpoints    = ["Microsoft.Storage"]
+  service_endpoint {
+    service = "Microsoft.Storage"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary)
 }

--- a/internal/services/storagecache/hpc_cache_blob_nfs_target_resource_test.go
+++ b/internal/services/storagecache/hpc_cache_blob_nfs_target_resource_test.go
@@ -286,7 +286,9 @@ resource "azurerm_subnet" "test" {
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.0.2.0/24"]
-  service_endpoints    = ["Microsoft.Storage"]
+  service_endpoint {
+    service = "Microsoft.Storage"
+  }
 }
 
 data "azuread_service_principal" "test" {

--- a/internal/services/synapse/synapse_sql_pool_extended_auditing_policy_resource_test.go
+++ b/internal/services/synapse/synapse_sql_pool_extended_auditing_policy_resource_test.go
@@ -314,7 +314,9 @@ resource "azurerm_subnet" "test" {
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.0.2.0/24"]
-  service_endpoints    = ["Microsoft.Storage"]
+  service_endpoint {
+    service = "Microsoft.Storage"
+  }
 }
 
 resource "azurerm_storage_account_network_rules" "test" {

--- a/internal/services/synapse/synapse_workspace_extended_auditing_policy_resource_test.go
+++ b/internal/services/synapse/synapse_workspace_extended_auditing_policy_resource_test.go
@@ -306,7 +306,9 @@ resource "azurerm_subnet" "test" {
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.0.2.0/24"]
-  service_endpoints    = ["Microsoft.Storage"]
+  service_endpoint {
+    service = "Microsoft.Storage"
+  }
 }
 
 resource "azurerm_storage_account_network_rules" "test" {

--- a/internal/services/workloads/workloads_sap_single_node_virtual_instance_resource_test.go
+++ b/internal/services/workloads/workloads_sap_single_node_virtual_instance_resource_test.go
@@ -163,7 +163,9 @@ resource "azurerm_subnet" "test" {
   address_prefixes                              = ["10.0.2.0/24"]
   private_endpoint_network_policies             = "Disabled"
   private_link_service_network_policies_enabled = true
-  service_endpoints                             = ["Microsoft.Storage"]
+  service_endpoint {
+    service = "Microsoft.Storage"
+  }
 }
 
 resource "azurerm_resource_group" "app" {

--- a/internal/services/workloads/workloads_sap_three_tier_virtual_instance_resource_test.go
+++ b/internal/services/workloads/workloads_sap_three_tier_virtual_instance_resource_test.go
@@ -183,7 +183,9 @@ resource "azurerm_subnet" "test" {
   address_prefixes                              = ["10.0.2.0/24"]
   private_endpoint_network_policies             = "Disabled"
   private_link_service_network_policies_enabled = true
-  service_endpoints                             = ["Microsoft.Storage"]
+  service_endpoint {
+    service = "Microsoft.Storage"
+  }
 }
 
 resource "azurerm_resource_group" "app" {

--- a/website/docs/5.0-upgrade-guide.html.markdown
+++ b/website/docs/5.0-upgrade-guide.html.markdown
@@ -1028,6 +1028,16 @@ The `security_policies.firewall.association.domain.cdn_frontdoor_domain_id` prop
 
 * The deprecated `enable_bgp` property has been removed in favour of the `bgp_enabled` property.
 
+### `azurerm_subnet`
+
+* The deprecated `service_endpoints` property has been removed in favour of the `service_endpoint` block.
+
+### `azurerm_virtual_network`
+
+* The deprecated `subnet.service_endpoints` property has been removed in favour of the `subnet.service_endpoint` block.
+
+### `azurerm_mssql_virtual_machine`
+
 ### `azurerm_virtual_network_gateway_connection`
 
 * The deprecated `enable_bgp` property has been removed in favour of the `bgp_enabled` property.

--- a/website/docs/5.0-upgrade-guide.html.markdown
+++ b/website/docs/5.0-upgrade-guide.html.markdown
@@ -1020,6 +1020,10 @@ The `security_policies.firewall.association.domain.cdn_frontdoor_domain_id` prop
 
 * The `storage_table_id` property now requires a Resource Manager ID. The deprecated Data Plane URL format is no longer supported.
 
+### `azurerm_subnet`
+
+* The deprecated `service_endpoints` property has been removed in favour of the `service_endpoint` block.
+
 ### `azurerm_synapse_spark_pool`
 
 * The `spark_version` property no longer accepts `3.2` or `3.3` as a value.
@@ -1027,10 +1031,6 @@ The `security_policies.firewall.association.domain.cdn_frontdoor_domain_id` prop
 ### `azurerm_virtual_network_gateway`
 
 * The deprecated `enable_bgp` property has been removed in favour of the `bgp_enabled` property.
-
-### `azurerm_subnet`
-
-* The deprecated `service_endpoints` property has been removed in favour of the `service_endpoint` block.
 
 ### `azurerm_virtual_network`
 
@@ -1194,14 +1194,14 @@ The `security_policies.firewall.association.domain.cdn_frontdoor_domain_id` prop
 
 * The `storage_table_id` property now requires a Resource Manager ID. The deprecated Data Plane URL format is no longer supported.
 
+### `azurerm_subnet`
+
+* The deprecated `subnet.service_endpoints` property has been removed in favour of the `subnet.service_endpoint` block.
+
 ### `azurerm_virtual_machine_scale_set`
 
 * The `network_interface.enable_accelerated_networking` property has been removed in favour of the `network_interface.accelerated_networking_enabled` property.
 * The `network_interface.enable_ip_forwarding` property has been removed in favour of the `network_interface.ip_forwarding_enabled` property.
-
-### `azurerm_subnet`
-
-* The `service_endpoints` property has been updated from a list of strings to a block type containing `service` and `network_identifier` attributes.
 
 ### `azurerm_virtual_network_gateway`
 

--- a/website/docs/5.0-upgrade-guide.html.markdown
+++ b/website/docs/5.0-upgrade-guide.html.markdown
@@ -1199,6 +1199,10 @@ The `security_policies.firewall.association.domain.cdn_frontdoor_domain_id` prop
 * The `network_interface.enable_accelerated_networking` property has been removed in favour of the `network_interface.accelerated_networking_enabled` property.
 * The `network_interface.enable_ip_forwarding` property has been removed in favour of the `network_interface.ip_forwarding_enabled` property.
 
+### `azurerm_subnet`
+
+* The `service_endpoints` property has been updated from a list of strings to a block type containing `service` and `network_identifier` attributes.
+
 ### `azurerm_virtual_network_gateway`
 
 * The deprecated `enable_bgp` property has been removed in favour of the `bgp_enabled` property.

--- a/website/docs/d/subnet.html.markdown
+++ b/website/docs/d/subnet.html.markdown
@@ -36,7 +36,6 @@ output "subnet_id" {
 * `address_prefixes` - The address prefixes for the subnet.
 * `network_security_group_id` - The ID of the Network Security Group associated with the subnet.
 * `route_table_id` - The ID of the Route Table associated with this subnet.
-* `service_endpoints` - (**Deprecated**) A list of Service Endpoint names within this subnet. Superseded by `service_endpoint`.
 * `service_endpoint` - A list of `service_endpoint` blocks as defined below.
 * `default_outbound_access_enabled` - Is the default outbound access enabled for the subnet.
 * `private_endpoint_network_policies` - Enable or Disable network policies for the private endpoint on the subnet.

--- a/website/docs/d/subnet.html.markdown
+++ b/website/docs/d/subnet.html.markdown
@@ -36,18 +36,10 @@ output "subnet_id" {
 * `address_prefixes` - The address prefixes for the subnet.
 * `network_security_group_id` - The ID of the Network Security Group associated with the subnet.
 * `route_table_id` - The ID of the Route Table associated with this subnet.
-* `service_endpoint` - A list of `service_endpoint` blocks as defined below.
+* `service_endpoints` - A list of Service Endpoints within this subnet.
 * `default_outbound_access_enabled` - Is the default outbound access enabled for the subnet.
 * `private_endpoint_network_policies` - Enable or Disable network policies for the private endpoint on the subnet.
 * `private_link_service_network_policies_enabled` - Enable or Disable network policies for the private link service on the subnet.
-
----
-
-A `service_endpoint` block exports the following:
-
-* `service` - The Service endpoint name.
-
-* `network_identifier` - The ARM resource ID of the network identifier associated with the service endpoint.
 
 ## Timeouts
 

--- a/website/docs/d/subnet.html.markdown
+++ b/website/docs/d/subnet.html.markdown
@@ -36,10 +36,19 @@ output "subnet_id" {
 * `address_prefixes` - The address prefixes for the subnet.
 * `network_security_group_id` - The ID of the Network Security Group associated with the subnet.
 * `route_table_id` - The ID of the Route Table associated with this subnet.
-* `service_endpoints` - A list of Service Endpoints within this subnet.
+* `service_endpoints` - (**Deprecated**) A list of Service Endpoint names within this subnet. Superseded by `service_endpoint`.
+* `service_endpoint` - A list of `service_endpoint` blocks as defined below.
 * `default_outbound_access_enabled` - Is the default outbound access enabled for the subnet.
 * `private_endpoint_network_policies` - Enable or Disable network policies for the private endpoint on the subnet.
 * `private_link_service_network_policies_enabled` - Enable or Disable network policies for the private link service on the subnet.
+
+---
+
+A `service_endpoint` block exports the following:
+
+* `service` - The Service endpoint name.
+
+* `network_identifier` - The ARM resource ID of the network identifier associated with the service endpoint.
 
 ## Timeouts
 

--- a/website/docs/d/subnet.html.markdown
+++ b/website/docs/d/subnet.html.markdown
@@ -36,10 +36,17 @@ output "subnet_id" {
 * `address_prefixes` - The address prefixes for the subnet.
 * `network_security_group_id` - The ID of the Network Security Group associated with the subnet.
 * `route_table_id` - The ID of the Route Table associated with this subnet.
-* `service_endpoints` - A list of Service Endpoints within this subnet.
+* `service_endpoint` - A `service_endpoint` block as defined below.
 * `default_outbound_access_enabled` - Is the default outbound access enabled for the subnet.
 * `private_endpoint_network_policies` - Enable or Disable network policies for the private endpoint on the subnet.
 * `private_link_service_network_policies_enabled` - Enable or Disable network policies for the private link service on the subnet.
+
+---
+
+A `service_endpoint` block exports the following:
+
+* `service` - The type of the Service Endpoint.
+* `network_identifier` - The ID of the network resource associated with the Service Endpoint.
 
 ## Timeouts
 

--- a/website/docs/r/elastic_san_volume_group.html.markdown
+++ b/website/docs/r/elastic_san_volume_group.html.markdown
@@ -48,7 +48,9 @@ resource "azurerm_subnet" "example" {
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
   address_prefixes     = ["10.0.1.0/24"]
-  service_endpoints    = ["Microsoft.Storage.Global"]
+  service_endpoint {
+    service = "Microsoft.Storage.Global"
+  }
 
 }
 

--- a/website/docs/r/mssql_server_extended_auditing_policy.html.markdown
+++ b/website/docs/r/mssql_server_extended_auditing_policy.html.markdown
@@ -74,11 +74,17 @@ resource "azurerm_virtual_network" "example" {
 }
 
 resource "azurerm_subnet" "example" {
-  name                                           = "subnetname-1"
-  resource_group_name                            = azurerm_resource_group.example.name
-  virtual_network_name                           = azurerm_virtual_network.example.name
-  address_prefixes                               = ["10.0.2.0/24"]
-  service_endpoints                              = ["Microsoft.Sql", "Microsoft.Storage"]
+  name                 = "subnetname-1"
+  resource_group_name  = azurerm_resource_group.example.name
+  virtual_network_name = azurerm_virtual_network.example.name
+  address_prefixes     = ["10.0.2.0/24"]
+  service_endpoint {
+    service = "Microsoft.Sql"
+  }
+
+  service_endpoint {
+    service = "Microsoft.Storage"
+  }
   enforce_private_link_endpoint_network_policies = true
 }
 

--- a/website/docs/r/mssql_server_microsoft_support_auditing_policy.html.markdown
+++ b/website/docs/r/mssql_server_microsoft_support_auditing_policy.html.markdown
@@ -72,11 +72,17 @@ resource "azurerm_virtual_network" "example" {
 }
 
 resource "azurerm_subnet" "example" {
-  name                                           = "subnetname-1"
-  resource_group_name                            = azurerm_resource_group.example.name
-  virtual_network_name                           = azurerm_virtual_network.example.name
-  address_prefixes                               = ["10.0.2.0/24"]
-  service_endpoints                              = ["Microsoft.Sql", "Microsoft.Storage"]
+  name                 = "subnetname-1"
+  resource_group_name  = azurerm_resource_group.example.name
+  virtual_network_name = azurerm_virtual_network.example.name
+  address_prefixes     = ["10.0.2.0/24"]
+  service_endpoint {
+    service = "Microsoft.Sql"
+  }
+
+  service_endpoint {
+    service = "Microsoft.Storage"
+  }
   enforce_private_link_endpoint_network_policies = true
 }
 

--- a/website/docs/r/mssql_virtual_network_rule.html.markdown
+++ b/website/docs/r/mssql_virtual_network_rule.html.markdown
@@ -30,7 +30,9 @@ resource "azurerm_subnet" "example" {
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
   address_prefixes     = ["10.7.29.0/29"]
-  service_endpoints    = ["Microsoft.Sql"]
+  service_endpoint {
+    service = "Microsoft.Sql"
+  }
 }
 
 resource "azurerm_mssql_server" "example" {

--- a/website/docs/r/mysql_flexible_server.html.markdown
+++ b/website/docs/r/mysql_flexible_server.html.markdown
@@ -34,7 +34,9 @@ resource "azurerm_subnet" "example" {
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
   address_prefixes     = ["10.0.2.0/24"]
-  service_endpoints    = ["Microsoft.Storage"]
+  service_endpoint {
+    service = "Microsoft.Storage"
+  }
   delegation {
     name = "fs"
     service_delegation {

--- a/website/docs/r/postgresql_flexible_server.html.markdown
+++ b/website/docs/r/postgresql_flexible_server.html.markdown
@@ -34,7 +34,9 @@ resource "azurerm_subnet" "example" {
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
   address_prefixes     = ["10.0.2.0/24"]
-  service_endpoints    = ["Microsoft.Storage"]
+  service_endpoint {
+    service = "Microsoft.Storage"
+  }
   delegation {
     name = "fs"
     service_delegation {

--- a/website/docs/r/redhat_openshift_cluster.html.markdown
+++ b/website/docs/r/redhat_openshift_cluster.html.markdown
@@ -65,7 +65,13 @@ resource "azurerm_subnet" "main_subnet" {
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
   address_prefixes     = ["10.0.0.0/23"]
-  service_endpoints    = ["Microsoft.Storage", "Microsoft.ContainerRegistry"]
+  service_endpoint {
+    service = "Microsoft.Storage"
+  }
+
+  service_endpoint {
+    service = "Microsoft.ContainerRegistry"
+  }
 }
 
 resource "azurerm_subnet" "worker_subnet" {
@@ -73,7 +79,13 @@ resource "azurerm_subnet" "worker_subnet" {
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
   address_prefixes     = ["10.0.2.0/23"]
-  service_endpoints    = ["Microsoft.Storage", "Microsoft.ContainerRegistry"]
+  service_endpoint {
+    service = "Microsoft.Storage"
+  }
+
+  service_endpoint {
+    service = "Microsoft.ContainerRegistry"
+  }
 }
 
 resource "azurerm_redhat_openshift_cluster" "example" {

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -51,7 +51,13 @@ resource "azurerm_subnet" "example" {
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
   address_prefixes     = ["10.0.2.0/24"]
-  service_endpoints    = ["Microsoft.Sql", "Microsoft.Storage"]
+  service_endpoint {
+    service = "Microsoft.Sql"
+  }
+
+  service_endpoint {
+    service = "Microsoft.Storage"
+  }
 }
 
 resource "azurerm_storage_account" "example" {

--- a/website/docs/r/storage_account_network_rules.html.markdown
+++ b/website/docs/r/storage_account_network_rules.html.markdown
@@ -36,7 +36,9 @@ resource "azurerm_subnet" "example" {
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
   address_prefixes     = ["10.0.2.0/24"]
-  service_endpoints    = ["Microsoft.Storage"]
+  service_endpoint {
+    service = "Microsoft.Storage"
+  }
 }
 
 resource "azurerm_storage_account" "example" {

--- a/website/docs/r/subnet.html.markdown
+++ b/website/docs/r/subnet.html.markdown
@@ -89,11 +89,7 @@ The following arguments are supported:
 
 !> **Note:** The `sharing_scope` property is only available to users who have been explicitly registered and granted access by the Azure Networking Product Group.
 
-* `service_endpoints` - (Optional, **Deprecated**) The list of Service endpoints to associate with the subnet. Possible values include: `Microsoft.AzureActiveDirectory`, `Microsoft.AzureCosmosDB`, `Microsoft.ContainerRegistry`, `Microsoft.EventHub`, `Microsoft.KeyVault`, `Microsoft.ServiceBus`, `Microsoft.Sql`, `Microsoft.Storage`, `Microsoft.Storage.Global` and `Microsoft.Web`. This property has been superseded by the `service_endpoint` block and will be removed in a future version of the provider.
-
--> **Note:** In order to use `Microsoft.Storage.Global` service endpoint (which allows access to virtual networks in other regions), you must enable the `AllowGlobalTagsForStorage` feature in your subscription. This is currently a preview feature, please see the [official documentation](https://learn.microsoft.com/en-us/azure/storage/common/storage-network-security?tabs=azure-cli#enabling-access-to-virtual-networks-in-other-regions-preview) for more information.
-
-* `service_endpoint` - (Optional) One or more `service_endpoint` blocks as defined below. Conflicts with `service_endpoints`.
+* `service_endpoint` - (Optional) One or more `service_endpoint` blocks as defined below.
 
 * `service_endpoint_policy_ids` - (Optional) The list of IDs of Service Endpoint Policies to associate with the subnet.
 

--- a/website/docs/r/subnet.html.markdown
+++ b/website/docs/r/subnet.html.markdown
@@ -89,7 +89,7 @@ The following arguments are supported:
 
 !> **Note:** The `sharing_scope` property is only available to users who have been explicitly registered and granted access by the Azure Networking Product Group.
 
-* `service_endpoint` - (Optional) One or more `service_endpoint` blocks as defined below.
+* `service_endpoint` - (Optional) A `service_endpoint` as defined below.
 
 * `service_endpoint_policy_ids` - (Optional) The list of IDs of Service Endpoint Policies to associate with the subnet.
 
@@ -109,7 +109,7 @@ The following arguments are supported:
 
 A `service_endpoint` block supports the following:
 
-* `service` - (Required) The name of the Service endpoint to associate with the subnet. Possible values include: `Microsoft.AzureActiveDirectory`, `Microsoft.AzureCosmosDB`, `Microsoft.ContainerRegistry`, `Microsoft.EventHub`, `Microsoft.KeyVault`, `Microsoft.ServiceBus`, `Microsoft.Sql`, `Microsoft.Storage`, `Microsoft.Storage.Global` and `Microsoft.Web`.
+* `service` - (Required) The name of the Service endpoint to associate with the subnet. Possible values are `Microsoft.AzureActiveDirectory`, `Microsoft.AzureCosmosDB`, `Microsoft.CognitiveService`, `Microsoft.ContainerRegistry`, `Microsoft.EventHub`, `Microsoft.KeyVault`, `Microsoft.ServiceBus`, `Microsoft.Sql`, `Microsoft.Storage`, `Microsoft.Storage.Global`, and `Microsoft.Web`.
 
 * `network_identifier` - (Optional) The ARM resource ID of the network identifier to associate with the service endpoint.
 

--- a/website/docs/r/subnet.html.markdown
+++ b/website/docs/r/subnet.html.markdown
@@ -89,7 +89,7 @@ The following arguments are supported:
 
 !> **Note:** The `sharing_scope` property is only available to users who have been explicitly registered and granted access by the Azure Networking Product Group.
 
-* `service_endpoint` - (Optional) A `service_endpoint` as defined below.
+* `service_endpoint` - (Optional) A `service_endpoint` block as defined below.
 
 * `service_endpoint_policy_ids` - (Optional) The list of IDs of Service Endpoint Policies to associate with the subnet.
 

--- a/website/docs/r/subnet.html.markdown
+++ b/website/docs/r/subnet.html.markdown
@@ -89,9 +89,11 @@ The following arguments are supported:
 
 !> **Note:** The `sharing_scope` property is only available to users who have been explicitly registered and granted access by the Azure Networking Product Group.
 
-* `service_endpoints` - (Optional) The list of Service endpoints to associate with the subnet. Possible values include: `Microsoft.AzureActiveDirectory`, `Microsoft.AzureCosmosDB`, `Microsoft.ContainerRegistry`, `Microsoft.EventHub`, `Microsoft.KeyVault`, `Microsoft.ServiceBus`, `Microsoft.Sql`, `Microsoft.Storage`, `Microsoft.Storage.Global` and `Microsoft.Web`.
+* `service_endpoints` - (Optional, **Deprecated**) The list of Service endpoints to associate with the subnet. Possible values include: `Microsoft.AzureActiveDirectory`, `Microsoft.AzureCosmosDB`, `Microsoft.ContainerRegistry`, `Microsoft.EventHub`, `Microsoft.KeyVault`, `Microsoft.ServiceBus`, `Microsoft.Sql`, `Microsoft.Storage`, `Microsoft.Storage.Global` and `Microsoft.Web`. This property has been superseded by the `service_endpoint` block and will be removed in a future version of the provider.
 
 -> **Note:** In order to use `Microsoft.Storage.Global` service endpoint (which allows access to virtual networks in other regions), you must enable the `AllowGlobalTagsForStorage` feature in your subscription. This is currently a preview feature, please see the [official documentation](https://learn.microsoft.com/en-us/azure/storage/common/storage-network-security?tabs=azure-cli#enabling-access-to-virtual-networks-in-other-regions-preview) for more information.
+
+* `service_endpoint` - (Optional) One or more `service_endpoint` blocks as defined below. Conflicts with `service_endpoints`.
 
 * `service_endpoint_policy_ids` - (Optional) The list of IDs of Service Endpoint Policies to associate with the subnet.
 
@@ -106,6 +108,14 @@ The following arguments are supported:
 -> **Note:** This property is only meant for environments where Azure Policy requires Route Tables to be specified during Subnet creation/update. It is recommended to use the `azurerm_subnet_route_table_association` resource instead.
 
 * `route_table_id_wo_version` - (Optional) An integer that must be incremented whenever `route_table_id_wo` is updated. Required if `route_table_id_wo` is specified.
+
+---
+
+A `service_endpoint` block supports the following:
+
+* `service` - (Required) The name of the Service endpoint to associate with the subnet. Possible values include: `Microsoft.AzureActiveDirectory`, `Microsoft.AzureCosmosDB`, `Microsoft.ContainerRegistry`, `Microsoft.EventHub`, `Microsoft.KeyVault`, `Microsoft.ServiceBus`, `Microsoft.Sql`, `Microsoft.Storage`, `Microsoft.Storage.Global` and `Microsoft.Web`.
+
+* `network_identifier` - (Optional) The ARM resource ID of the network identifier to associate with the service endpoint.
 
 ---
 

--- a/website/docs/r/virtual_network.html.markdown
+++ b/website/docs/r/virtual_network.html.markdown
@@ -155,7 +155,7 @@ The `subnet` block supports:
 
 -> **Note:** If you declare the subnet inline inside `azurerm_virtual_network`, set `route_table_id` in that `subnet` block — do not also create an `azurerm_subnet_route_table_association` for the same subnet. The association resource is for when you manage the subnet as a separate `azurerm_subnet` resource.
 
-* `service_endpoint` - (Optional) One or more `service_endpoint` blocks as defined below.
+* `service_endpoint` - (Optional) A `service_endpoint` as defined below.
 
 * `service_endpoint_policy_ids` - (Optional) The list of IDs of Service Endpoint Policies to associate with the subnet.
 
@@ -163,7 +163,7 @@ The `subnet` block supports:
 
 A `service_endpoint` block supports the following:
 
-* `service` - (Required) The name of the Service endpoint to associate with the subnet. Possible values include: `Microsoft.AzureActiveDirectory`, `Microsoft.AzureCosmosDB`, `Microsoft.ContainerRegistry`, `Microsoft.EventHub`, `Microsoft.KeyVault`, `Microsoft.ServiceBus`, `Microsoft.Sql`, `Microsoft.Storage`, `Microsoft.Storage.Global` and `Microsoft.Web`.
+* `service` - (Required) The name of the Service endpoint to associate with the subnet. Possible values are `Microsoft.AzureActiveDirectory`, `Microsoft.AzureCosmosDB`, `Microsoft.CognitiveService`, `Microsoft.ContainerRegistry`, `Microsoft.EventHub`, `Microsoft.KeyVault`, `Microsoft.ServiceBus`, `Microsoft.Sql`, `Microsoft.Storage`, `Microsoft.Storage.Global`, and `Microsoft.Web`.
 
 * `network_identifier` - (Optional) The ARM resource ID of the network identifier to associate with the service endpoint.
 

--- a/website/docs/r/virtual_network.html.markdown
+++ b/website/docs/r/virtual_network.html.markdown
@@ -155,8 +155,6 @@ The `subnet` block supports:
 
 -> **Note:** If you declare the subnet inline inside `azurerm_virtual_network`, set `route_table_id` in that `subnet` block — do not also create an `azurerm_subnet_route_table_association` for the same subnet. The association resource is for when you manage the subnet as a separate `azurerm_subnet` resource.
 
-* `service_endpoints` - (Optional, **Deprecated**) The list of Service endpoints to associate with the subnet. Possible values include: `Microsoft.AzureActiveDirectory`, `Microsoft.AzureCosmosDB`, `Microsoft.ContainerRegistry`, `Microsoft.EventHub`, `Microsoft.KeyVault`, `Microsoft.ServiceBus`, `Microsoft.Sql`, `Microsoft.Storage`, `Microsoft.Storage.Global` and `Microsoft.Web`. This property has been superseded by the `service_endpoint` block and will be removed in a future version of the provider.
-
 * `service_endpoint` - (Optional) One or more `service_endpoint` blocks as defined below.
 
 * `service_endpoint_policy_ids` - (Optional) The list of IDs of Service Endpoint Policies to associate with the subnet.

--- a/website/docs/r/virtual_network.html.markdown
+++ b/website/docs/r/virtual_network.html.markdown
@@ -155,9 +155,19 @@ The `subnet` block supports:
 
 -> **Note:** If you declare the subnet inline inside `azurerm_virtual_network`, set `route_table_id` in that `subnet` block — do not also create an `azurerm_subnet_route_table_association` for the same subnet. The association resource is for when you manage the subnet as a separate `azurerm_subnet` resource.
 
-* `service_endpoints` - (Optional) The list of Service endpoints to associate with the subnet. Possible values include: `Microsoft.AzureActiveDirectory`, `Microsoft.AzureCosmosDB`, `Microsoft.ContainerRegistry`, `Microsoft.EventHub`, `Microsoft.KeyVault`, `Microsoft.ServiceBus`, `Microsoft.Sql`, `Microsoft.Storage`, `Microsoft.Storage.Global` and `Microsoft.Web`.
+* `service_endpoints` - (Optional, **Deprecated**) The list of Service endpoints to associate with the subnet. Possible values include: `Microsoft.AzureActiveDirectory`, `Microsoft.AzureCosmosDB`, `Microsoft.ContainerRegistry`, `Microsoft.EventHub`, `Microsoft.KeyVault`, `Microsoft.ServiceBus`, `Microsoft.Sql`, `Microsoft.Storage`, `Microsoft.Storage.Global` and `Microsoft.Web`. This property has been superseded by the `service_endpoint` block and will be removed in a future version of the provider.
+
+* `service_endpoint` - (Optional) One or more `service_endpoint` blocks as defined below.
 
 * `service_endpoint_policy_ids` - (Optional) The list of IDs of Service Endpoint Policies to associate with the subnet.
+
+---
+
+A `service_endpoint` block supports the following:
+
+* `service` - (Required) The name of the Service endpoint to associate with the subnet. Possible values include: `Microsoft.AzureActiveDirectory`, `Microsoft.AzureCosmosDB`, `Microsoft.ContainerRegistry`, `Microsoft.EventHub`, `Microsoft.KeyVault`, `Microsoft.ServiceBus`, `Microsoft.Sql`, `Microsoft.Storage`, `Microsoft.Storage.Global` and `Microsoft.Web`.
+
+* `network_identifier` - (Optional) The ARM resource ID of the network identifier to associate with the service endpoint.
 
 ---
 

--- a/website/docs/r/virtual_network.html.markdown
+++ b/website/docs/r/virtual_network.html.markdown
@@ -155,7 +155,7 @@ The `subnet` block supports:
 
 -> **Note:** If you declare the subnet inline inside `azurerm_virtual_network`, set `route_table_id` in that `subnet` block — do not also create an `azurerm_subnet_route_table_association` for the same subnet. The association resource is for when you manage the subnet as a separate `azurerm_subnet` resource.
 
-* `service_endpoint` - (Optional) A `service_endpoint` as defined below.
+* `service_endpoint` - (Optional) A `service_endpoint` block as defined below.
 
 * `service_endpoint_policy_ids` - (Optional) The list of IDs of Service Endpoint Policies to associate with the subnet.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This PR adds a new `service_endpoint` block to the following resources/data sources, supporting the `network_identifier` property for service endpoints. This deprecates the `service_endpoints` property as `service_endpoints` is a `TypeSet` and `service_endpoint` needs to be a `TypeList` to accomodate for the new `network_identifier` field.



## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<pre>
=== RUN   TestAccSubnet_serviceEndpoints
=== PAUSE TestAccSubnet_serviceEndpoints
=== RUN   TestAccSubnet_serviceEndpointBlock
=== PAUSE TestAccSubnet_serviceEndpointBlock
=== RUN   TestAccSubnet_serviceEndpointWithNetworkIdentifier
=== PAUSE TestAccSubnet_serviceEndpointWithNetworkIdentifier
=== RUN   TestAccSubnet_serviceEndpointPolicy
=== PAUSE TestAccSubnet_serviceEndpointPolicy
=== CONT  TestAccSubnet_serviceEndpoints
=== CONT  TestAccSubnet_serviceEndpointWithNetworkIdentifier
=== CONT  TestAccSubnet_serviceEndpointPolicy
=== CONT  TestAccSubnet_serviceEndpointBlock
--- PASS: TestAccSubnet_serviceEndpointWithNetworkIdentifier (153.09s)
--- PASS: TestAccSubnet_serviceEndpointBlock (183.47s)
--- PASS: TestAccSubnet_serviceEndpointPolicy (221.34s)
--- PASS: TestAccSubnet_serviceEndpoints (309.79s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/network       309.830s
</pre>

<pre>
=== RUN   TestAccVirtualNetwork_serviceEndpointBlock
=== PAUSE TestAccVirtualNetwork_serviceEndpointBlock
=== RUN   TestAccVirtualNetwork_serviceEndpointWithNetworkIdentifier
=== PAUSE TestAccVirtualNetwork_serviceEndpointWithNetworkIdentifier
=== CONT  TestAccVirtualNetwork_serviceEndpointBlock
=== CONT  TestAccVirtualNetwork_serviceEndpointWithNetworkIdentifier
--- PASS: TestAccVirtualNetwork_serviceEndpointWithNetworkIdentifier (131.85s)
--- PASS: TestAccVirtualNetwork_serviceEndpointBlock (155.32s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/network       155.346s
</pre>

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

`azurerm_virtual_network` & `azurerm_subnet` - Add `network_identifier` to `service_endpoint` field


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Resolves Task 37715801

