### PR TITLE
`hsm` - fix test template

### DIFF
--- a/internal/services/hsm/dedicated_hardware_security_module_resource_test.go
+++ b/internal/services/hsm/dedicated_hardware_security_module_resource_test.go
@@ -125,19 +125,19 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-hsm-%d"
-  location = "%s"
+  name     = "acctestRG-hsm-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_virtual_network" "test" {
-  name                = "acctest-vnet-%d"
+  name                = "acctest-vnet-%[1]d"
   address_space       = ["10.2.0.0/16"]
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
 }
 
 resource "azurerm_subnet" "test2" {
-  name                 = "acctest-hsmsubnet-%d"
+  name                 = "acctest-hsmsubnet-%[1]d"
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.2.1.0/24"]
@@ -163,16 +163,8 @@ resource "azurerm_subnet" "test3" {
   address_prefixes     = ["10.2.255.0/26"]
 }
 
-resource "azurerm_public_ip" "test" {
-  name                = "acctest-pip-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  sku                 = "Standard"
-  allocation_method   = "Static"
-}
-
 resource "azurerm_virtual_network_gateway" "test" {
-  name                = "acctest-vnetgateway-%d"
+  name                = "acctest-vnetgateway-%[1]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
 
@@ -181,16 +173,14 @@ resource "azurerm_virtual_network_gateway" "test" {
   sku      = "Standard"
 
   ip_configuration {
-    public_ip_address_id          = azurerm_public_ip.test.id
     private_ip_address_allocation = "Dynamic"
     subnet_id                     = azurerm_subnet.test3.id
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary)
 }
 
-func (DedicatedHardwareSecurityModuleResource) basic(data acceptance.TestData) string {
-	template := DedicatedHardwareSecurityModuleResource{}.template(data)
+func (r DedicatedHardwareSecurityModuleResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -209,11 +199,10 @@ resource "azurerm_dedicated_hardware_security_module" "test" {
 
   depends_on = [azurerm_virtual_network_gateway.test]
 }
-`, template, data.RandomString)
+`, r.template(data), data.RandomString)
 }
 
-func (DedicatedHardwareSecurityModuleResource) managementNetworkProfile(data acceptance.TestData) string {
-	template := DedicatedHardwareSecurityModuleResource{}.template(data)
+func (r DedicatedHardwareSecurityModuleResource) managementNetworkProfile(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -237,11 +226,10 @@ resource "azurerm_dedicated_hardware_security_module" "test" {
 
   depends_on = [azurerm_virtual_network_gateway.test]
 }
-`, template, data.RandomString)
+`, r.template(data), data.RandomString)
 }
 
-func (DedicatedHardwareSecurityModuleResource) complete(data acceptance.TestData) string {
-	template := DedicatedHardwareSecurityModuleResource{}.template(data)
+func (r DedicatedHardwareSecurityModuleResource) complete(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -269,5 +257,5 @@ resource "azurerm_dedicated_hardware_security_module" "test" {
 
   depends_on = [azurerm_virtual_network_gateway.test]
 }
-`, template, data.RandomString)
+`, r.template(data), data.RandomString)
 }

--- a/internal/services/hsm/dedicated_hardware_security_module_resource_test.go
+++ b/internal/services/hsm/dedicated_hardware_security_module_resource_test.go
@@ -210,7 +210,7 @@ resource "azurerm_dedicated_hardware_security_module" "test" {
   name                = "acctest-hsm-%s"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-  sku_name            = "payShield10K_LMK1_CPS60"
+  sku_name            = "SafeNet Luna Network HSM A790"
 
   network_profile {
     network_interface_private_ip_addresses = ["10.2.1.8"]
@@ -237,7 +237,7 @@ resource "azurerm_dedicated_hardware_security_module" "test" {
   name                = "acctest-hsm-%s"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-  sku_name            = "payShield10K_LMK1_CPS60"
+  sku_name            = "SafeNet Luna Network HSM A790"
 
   network_profile {
     network_interface_private_ip_addresses = ["10.2.1.8"]


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

All HSM tests were failing due to an incorrectly configured `azurerm_virtual_network_gateway` resource


## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change





## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
