### PR TITLE
Auto-delete $Default rule in `azurerm_servicebus_subscription`

### DIFF
--- a/internal/features/defaults.go
+++ b/internal/features/defaults.go
@@ -92,5 +92,8 @@ func Default() UserFeatures {
 		DatabricksWorkspace: DatabricksWorkspaceFeatures{
 			ForceDelete: false,
 		},
+		ServiceBus: ServiceBusFeatures{
+			AutoDeleteSubscriptionDefaultRule: false,
+		},
 	}
 }

--- a/internal/features/user_flags.go
+++ b/internal/features/user_flags.go
@@ -27,6 +27,7 @@ type UserFeatures struct {
 	TemplateDeployment       TemplateDeploymentFeatures
 	VirtualMachine           VirtualMachineFeatures
 	VirtualMachineScaleSet   VirtualMachineScaleSetFeatures
+	ServiceBus               ServiceBusFeatures
 }
 
 type CognitiveAccountFeatures struct {
@@ -131,4 +132,8 @@ type NetAppFeatures struct {
 
 type DatabricksWorkspaceFeatures struct {
 	ForceDelete bool
+}
+
+type ServiceBusFeatures struct {
+	AutoDeleteSubscriptionDefaultRule bool
 }

--- a/internal/provider/features.go
+++ b/internal/provider/features.go
@@ -478,6 +478,22 @@ func schemaFeatures(supportLegacyTestSuite bool) *pluginsdk.Schema {
 				},
 			},
 		},
+
+		"servicebus": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"auto_delete_subscription_default_rule": {
+						Description: "When enabled, the $Default rule is automatically deleted after creating a Service Bus subscription, preventing unfiltered message delivery.",
+						Type:        pluginsdk.TypeBool,
+						Optional:    true,
+						Default:     false,
+					},
+				},
+			},
+		},
 	}
 
 	if !features.FivePointOh() {
@@ -804,6 +820,16 @@ func expandFeatures(input []interface{}) features.UserFeatures {
 				if vStr, ok := v.(string); ok && vStr != "" {
 					featuresMap.EnhancedValidation.LocationFallback = pointer.To(vStr)
 				}
+			}
+		}
+	}
+
+	if raw, ok := val["servicebus"]; ok {
+		items := raw.([]interface{})
+		if len(items) > 0 {
+			servicebusRaw := items[0].(map[string]interface{})
+			if v, ok := servicebusRaw["auto_delete_subscription_default_rule"]; ok {
+				featuresMap.ServiceBus.AutoDeleteSubscriptionDefaultRule = v.(bool)
 			}
 		}
 	}

--- a/internal/provider/framework/config.go
+++ b/internal/provider/framework/config.go
@@ -530,6 +530,22 @@ func (p *ProviderConfig) Load(ctx context.Context, data *ProviderModel, tfVersio
 			f.DatabricksWorkspace.ForceDelete = false
 		}
 
+		if !features.ServiceBus.IsNull() && !features.ServiceBus.IsUnknown() {
+			var feature []ServiceBus
+			d := features.ServiceBus.ElementsAs(ctx, &feature, true)
+			diags.Append(d...)
+			if diags.HasError() {
+				return
+			}
+
+			f.ServiceBus.AutoDeleteSubscriptionDefaultRule = false
+			if !feature[0].AutoDeleteSubscriptionDefaultRule.IsNull() && !feature[0].AutoDeleteSubscriptionDefaultRule.IsUnknown() {
+				f.ServiceBus.AutoDeleteSubscriptionDefaultRule = feature[0].AutoDeleteSubscriptionDefaultRule.ValueBool()
+			}
+		} else {
+			f.ServiceBus.AutoDeleteSubscriptionDefaultRule = false
+		}
+
 		f.EnhancedValidation.Locations = providerfeatures.EnhancedValidationLocationsEnabled()
 		f.EnhancedValidation.ResourceProviders = providerfeatures.EnhancedValidationResourceProvidersEnabled()
 		f.EnhancedValidation.PreflightEnabled = providerfeatures.EnhancedValidationPreflightEnabled()

--- a/internal/provider/framework/config_test.go
+++ b/internal/provider/framework/config_test.go
@@ -227,6 +227,10 @@ func TestProviderConfig_LoadDefault(t *testing.T) {
 	if features.EnhancedValidation.PreflightEnabled {
 		t.Errorf("expected enhanced_validation.preflight_enabled to be false")
 	}
+
+	if features.ServiceBus.AutoDeleteSubscriptionDefaultRule {
+		t.Errorf("expected servicebus.AutoDeleteSubscriptionDefaultRule to be false")
+	}
 }
 
 // TODO - helper functions to make setting up test date more easily so we can add more configuration coverage
@@ -354,6 +358,11 @@ func defaultFeaturesList() types.List {
 	})
 	enhancedValidationList, _ := basetypes.NewListValue(types.ObjectType{}.WithAttributeTypes(EnhancedValidationModelAttributes), []attr.Value{enhancedValidation})
 
+	servicebus, _ := basetypes.NewObjectValueFrom(context.Background(), ServiceBusAttributes, map[string]attr.Value{
+		"auto_delete_subscription_default_rule": basetypes.NewBoolNull(),
+	})
+	servicebusList, _ := basetypes.NewListValue(types.ObjectType{}.WithAttributeTypes(ServiceBusAttributes), []attr.Value{servicebus})
+
 	fData, d := basetypes.NewObjectValue(FeaturesAttributes, map[string]attr.Value{
 		"persist_id_on_create_before_polling_for_completion":                   basetypes.NewBoolNull(),
 		"skip_import_check_on_create_and_allow_overwriting_existing_resources": basetypes.NewBoolNull(),
@@ -378,6 +387,7 @@ func defaultFeaturesList() types.List {
 		"recovery_services_vaults":   recoveryServicesVaultsList,
 		"netapp":                     netappList,
 		"databricks_workspace":       databricksWorkspaceList,
+		"servicebus":                 servicebusList,
 	})
 
 	fmt.Printf("%+v", d)

--- a/internal/provider/framework/model.go
+++ b/internal/provider/framework/model.go
@@ -69,6 +69,7 @@ type Features struct {
 	TemplateDeployment       types.List `tfsdk:"template_deployment"`
 	VirtualMachine           types.List `tfsdk:"virtual_machine"`
 	VirtualMachineScaleSet   types.List `tfsdk:"virtual_machine_scale_set"`
+	ServiceBus               types.List `tfsdk:"servicebus"`
 }
 
 // FeaturesAttributes and the other block attribute vars are required for unit testing on the Load func
@@ -97,6 +98,7 @@ var FeaturesAttributes = map[string]attr.Type{
 	"template_deployment":        types.ListType{}.WithElementType(types.ObjectType{}.WithAttributeTypes(TemplateDeploymentAttributes)),
 	"virtual_machine":            types.ListType{}.WithElementType(types.ObjectType{}.WithAttributeTypes(VirtualMachineAttributes)),
 	"virtual_machine_scale_set":  types.ListType{}.WithElementType(types.ObjectType{}.WithAttributeTypes(VirtualMachineScaleSetAttributes)),
+	"servicebus":                 types.ListType{}.WithElementType(types.ObjectType{}.WithAttributeTypes(ServiceBusAttributes)),
 }
 
 type APIManagement struct {
@@ -293,6 +295,14 @@ type DatabricksWorkspace struct {
 
 var DatabricksWorkspaceAttributes = map[string]attr.Type{
 	"force_delete": types.BoolType,
+}
+
+type ServiceBus struct {
+	AutoDeleteSubscriptionDefaultRule types.Bool `tfsdk:"auto_delete_subscription_default_rule"`
+}
+
+var ServiceBusAttributes = map[string]attr.Type{
+	"auto_delete_subscription_default_rule": types.BoolType,
 }
 
 type EnhancedValidationModel struct {

--- a/internal/provider/framework/provider.go
+++ b/internal/provider/framework/provider.go
@@ -304,6 +304,16 @@ func (p *azureRmFrameworkProvider) Schema(_ context.Context, _ provider.SchemaRe
 								},
 							},
 						},
+						"servicebus": schema.ListNestedBlock{
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"auto_delete_subscription_default_rule": schema.BoolAttribute{
+										Optional:    true,
+										Description: "When enabled, the $Default rule is automatically deleted after creating a Service Bus subscription, preventing unfiltered message delivery.",
+									},
+								},
+							},
+						},
 						"enhanced_validation": schema.ListNestedBlock{
 							Validators: []validator.List{
 								listvalidator.SizeAtMost(1),

--- a/internal/services/servicebus/servicebus_subscription_resource.go
+++ b/internal/services/servicebus/servicebus_subscription_resource.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2024-01-01/rules"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2024-01-01/subscriptions"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2024-01-01/topics"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
@@ -260,6 +261,17 @@ func resourceServiceBusSubscriptionCreateUpdate(d *pluginsdk.ResourceData, meta 
 
 	if d.IsNewResource() {
 		d.SetId(id.ID())
+	}
+
+	if d.IsNewResource() && meta.(*clients.Client).Features.ServiceBus.AutoDeleteSubscriptionDefaultRule {
+		rulesClient := meta.(*clients.Client).ServiceBus.SubscriptionRulesClient
+		defaultRuleId := rules.NewRuleID(id.SubscriptionId, id.ResourceGroupName, id.NamespaceName, id.TopicName, id.SubscriptionName, "$Default")
+
+		if resp, err := rulesClient.Delete(ctx, defaultRuleId); err != nil {
+			if !response.WasNotFound(resp.HttpResponse) {
+				return fmt.Errorf("deleting default rule for %s: %+v", id, err)
+			}
+		}
 	}
 
 	return resourceServiceBusSubscriptionRead(d, meta)

--- a/internal/services/servicebus/servicebus_subscription_resource_test.go
+++ b/internal/services/servicebus/servicebus_subscription_resource_test.go
@@ -7,8 +7,10 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2024-01-01/rules"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2024-01-01/subscriptions"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
@@ -388,6 +390,156 @@ func (ServiceBusSubscriptionResource) status(data acceptance.TestData, status st
 func (ServiceBusSubscriptionResource) updateDeadLetteringOnFilterEvaluationExceptions(data acceptance.TestData) string {
 	return fmt.Sprintf(testAccServiceBusSubscription_tfTemplate, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger,
 		"dead_lettering_on_filter_evaluation_error = false\n")
+}
+
+func TestAccServiceBusSubscription_defaultRuleFeatureFlagEnabled(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_servicebus_subscription", "test")
+	r := ServiceBusSubscriptionResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.defaultRuleFeatureFlagEnabled(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				data.CheckWithClient(r.defaultRuleAbsent),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccServiceBusSubscription_defaultRuleFeatureFlagDisabled(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_servicebus_subscription", "test")
+	r := ServiceBusSubscriptionResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.defaultRuleFeatureFlagDisabled(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				data.CheckWithClient(r.defaultRuleExists),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (r ServiceBusSubscriptionResource) defaultRuleAbsent(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) error {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+
+	id, err := subscriptions.ParseSubscriptions2ID(state.ID)
+	if err != nil {
+		return err
+	}
+
+	rulesId := rules.NewSubscriptions2ID(id.SubscriptionId, id.ResourceGroupName, id.NamespaceName, id.TopicName, id.SubscriptionName)
+	resp, err := client.ServiceBus.SubscriptionRulesClient.ListBySubscriptions(ctx, rulesId, rules.DefaultListBySubscriptionsOperationOptions())
+	if err != nil {
+		return fmt.Errorf("listing rules for %s: %+v", id, err)
+	}
+
+	if resp.Model != nil {
+		for _, rule := range *resp.Model {
+			if rule.Name != nil && *rule.Name == "$Default" {
+				return fmt.Errorf("expected $Default rule to be absent for %s, but it still exists", id)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (r ServiceBusSubscriptionResource) defaultRuleExists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) error {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+
+	id, err := subscriptions.ParseSubscriptions2ID(state.ID)
+	if err != nil {
+		return err
+	}
+
+	rulesId := rules.NewSubscriptions2ID(id.SubscriptionId, id.ResourceGroupName, id.NamespaceName, id.TopicName, id.SubscriptionName)
+	resp, err := client.ServiceBus.SubscriptionRulesClient.ListBySubscriptions(ctx, rulesId, rules.DefaultListBySubscriptionsOperationOptions())
+	if err != nil {
+		return fmt.Errorf("listing rules for %s: %+v", id, err)
+	}
+
+	if resp.Model != nil {
+		for _, rule := range *resp.Model {
+			if rule.Name != nil && *rule.Name == "$Default" {
+				return nil
+			}
+		}
+	}
+
+	return fmt.Errorf("expected $Default rule to exist for %s, but it was not found", id)
+}
+
+func (ServiceBusSubscriptionResource) defaultRuleFeatureFlagEnabled(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    servicebus {
+      auto_delete_subscription_default_rule = true
+    }
+  }
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_servicebus_namespace" "test" {
+  name                = "acctestservicebusnamespace-%[1]d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  sku                 = "Standard"
+}
+
+resource "azurerm_servicebus_topic" "test" {
+  name         = "acctestservicebustopic-%[1]d"
+  namespace_id = azurerm_servicebus_namespace.test.id
+}
+
+resource "azurerm_servicebus_subscription" "test" {
+  name               = "_acctestservicebussubscription-%[1]d_"
+  topic_id           = azurerm_servicebus_topic.test.id
+  max_delivery_count = 10
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (ServiceBusSubscriptionResource) defaultRuleFeatureFlagDisabled(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_servicebus_namespace" "test" {
+  name                = "acctestservicebusnamespace-%[1]d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  sku                 = "Standard"
+}
+
+resource "azurerm_servicebus_topic" "test" {
+  name         = "acctestservicebustopic-%[1]d"
+  namespace_id = azurerm_servicebus_namespace.test.id
+}
+
+resource "azurerm_servicebus_subscription" "test" {
+  name               = "_acctestservicebussubscription-%[1]d_"
+  topic_id           = azurerm_servicebus_topic.test.id
+  max_delivery_count = 10
+}
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func (ServiceBusSubscriptionResource) clientScopedSubscriptionEnabled(data acceptance.TestData) string {

--- a/website/docs/guides/features-block.html.markdown
+++ b/website/docs/guides/features-block.html.markdown
@@ -59,6 +59,10 @@ provider "azurerm" {
       preflight_location_fallback = "westeurope"
     }
 
+    servicebus {
+      auto_delete_subscription_default_rule = false
+    }
+
     key_vault {
       purge_soft_delete_on_destroy    = true
       recover_soft_deleted_key_vaults = true
@@ -151,6 +155,8 @@ The `features` block supports the following:
 
 * `enhanced_validation` - (Optional) An `enhanced_validation` block as defined below.
 
+* `servicebus` - (Optional) A `servicebus` block as defined below.
+
 * `key_vault` - (Optional) A `key_vault` block as defined below.
 
 * `log_analytics_workspace` - (Optional) A `log_analytics_workspace` block as defined below.
@@ -226,6 +232,12 @@ The `enhanced_validation` block supports the following:
 * `preflight_location_fallback` - (Optional) The Azure location to use as a fallback when Preflight Validation is enabled and a resource does not specify a location. This is typically used for resources that derive their location from a dependency that has not yet been created. This can also be sourced from the `ARM_PROVIDER_ENHANCED_VALIDATION_LOCATION_FALLBACK` Environment Variable.
 
 * `resource_providers` - (Optional) Should the AzureRM Provider validate Resource Provider arguments against the list of supported Resource Providers? When enabled, invalid resource providers are caught at `terraform plan` time; when disabled, they are caught at `terraform apply` time when Azure rejects the request. This can also be sourced from the `ARM_PROVIDER_ENHANCED_VALIDATION_RESOURCE_PROVIDERS` Environment Variable. Defaults to `true` in version 4.x and `false` in version 5.0+.
+
+---
+
+The `servicebus` block supports the following:
+
+* `auto_delete_subscription_default_rule` - (Optional) Should the `$Default` rule be automatically deleted after creating an `azurerm_servicebus_subscription`? This prevents unfiltered messages from being delivered during the window between subscription creation and custom rule application. Defaults to `false`.
 
 ---
 


### PR DESCRIPTION
Add a new provider features flag:

```
  features {
    servicebus {
      auto_delete_subscription_default_rule = true
    }
  }
```

When enabled, the `$Default` rule is deleted immediately after a Service Bus subscription is created, preventing unfiltered message delivery before custom rules are applied.

<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_servicebus_subscription` - [GH-20718]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #20718


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
