### PR TITLE
`azurerm_storage_account` - support for the `smb_oauth_enabled` property

### DIFF
--- a/internal/services/storage/storage_account_data_source.go
+++ b/internal/services/storage/storage_account_data_source.go
@@ -532,6 +532,11 @@ func dataSourceStorageAccount() *pluginsdk.Resource {
 				},
 			},
 
+			"smb_oauth_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Computed: true,
+			},
+
 			"dns_endpoint_type": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
@@ -651,6 +656,11 @@ func dataSourceStorageAccountRead(d *pluginsdk.ResourceData, meta interface{}) e
 			if err := d.Set("azure_files_authentication", flattenAccountAzureFilesAuthentication(props.AzureFilesIdentityBasedAuthentication)); err != nil {
 				return fmt.Errorf("setting `azure_files_authentication`: %+v", err)
 			}
+			smbOAuthEnabled := false
+			if afa := props.AzureFilesIdentityBasedAuthentication; afa != nil && afa.SmbOAuthSettings != nil {
+				smbOAuthEnabled = pointer.From(afa.SmbOAuthSettings.IsSmbOAuthEnabled)
+			}
+			d.Set("smb_oauth_enabled", smbOAuthEnabled)
 		}
 	}
 

--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -228,6 +228,12 @@ func resourceStorageAccount() *pluginsdk.Resource {
 				},
 			},
 
+			"smb_oauth_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
 			"cross_tenant_replication_enabled": {
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
@@ -1458,8 +1464,10 @@ func resourceStorageAccountCreate(d *pluginsdk.ResourceData, meta interface{}) e
 	if v := d.Get("allowed_copy_scope").(string); v != "" {
 		payload.Properties.AllowedCopyScope = pointer.To(storageaccounts.AllowedCopyScope(v))
 	}
-	if v, ok := d.GetOk("azure_files_authentication"); ok {
-		expandAADFilesAuthentication, err := expandAccountAzureFilesAuthentication(v.([]interface{}))
+	azureFilesAuthenticationRaw := d.Get("azure_files_authentication").([]interface{})
+	smbOAuthEnabled := d.Get("smb_oauth_enabled").(bool)
+	if len(azureFilesAuthenticationRaw) > 0 || smbOAuthEnabled {
+		expandAADFilesAuthentication, err := expandAccountAzureFilesAuthentication(azureFilesAuthenticationRaw, smbOAuthEnabled)
 		if err != nil {
 			return fmt.Errorf("parsing `azure_files_authentication`: %v", err)
 		}
@@ -1928,7 +1936,7 @@ func resourceStorageAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 	}
 
 	// azure_files_authentication must be the last to be updated, cause it'll occupy the storage account for several minutes after receiving the response 200 OK. Issue: https://github.com/Azure/azure-rest-api-specs/issues/11272
-	if d.HasChange("azure_files_authentication") {
+	if d.HasChange("azure_files_authentication") || d.HasChange("smb_oauth_enabled") {
 		// due to service issue: https://github.com/Azure/azure-rest-api-specs/issues/12473, we need to update to None before changing its DirectoryServiceOptions
 		old, new := d.GetChange("azure_files_authentication.0.directory_type")
 		if old != new && new != string(storageaccounts.DirectoryServiceOptionsNone) {
@@ -1945,7 +1953,7 @@ func resourceStorageAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 			}
 		}
 
-		expandAADFilesAuthentication, err := expandAccountAzureFilesAuthentication(d.Get("azure_files_authentication").([]interface{}))
+		expandAADFilesAuthentication, err := expandAccountAzureFilesAuthentication(d.Get("azure_files_authentication").([]interface{}), d.Get("smb_oauth_enabled").(bool))
 		if err != nil {
 			return fmt.Errorf("expanding `azure_files_authentication`: %+v", err)
 		}
@@ -2194,6 +2202,11 @@ func resourceStorageAccountFlatten(ctx context.Context, d *pluginsdk.ResourceDat
 		if err := d.Set("azure_files_authentication", flattenAccountAzureFilesAuthentication(props.AzureFilesIdentityBasedAuthentication)); err != nil {
 			return fmt.Errorf("setting `azure_files_authentication`: %+v", err)
 		}
+		smbOAuthEnabled := false
+		if afa := props.AzureFilesIdentityBasedAuthentication; afa != nil && afa.SmbOAuthSettings != nil {
+			smbOAuthEnabled = pointer.From(afa.SmbOAuthSettings.IsSmbOAuthEnabled)
+		}
+		d.Set("smb_oauth_enabled", smbOAuthEnabled)
 		d.Set("cross_tenant_replication_enabled", pointer.From(props.AllowCrossTenantReplication))
 		d.Set("https_traffic_only_enabled", pointer.From(props.SupportsHTTPSTrafficOnly))
 		d.Set("is_hns_enabled", pointer.From(props.IsHnsEnabled))
@@ -2722,16 +2735,22 @@ func flattenAccountActiveDirectoryProperties(input *storageaccounts.ActiveDirect
 	return output
 }
 
-func expandAccountAzureFilesAuthentication(input []interface{}) (*storageaccounts.AzureFilesIdentityBasedAuthentication, error) {
+func expandAccountAzureFilesAuthentication(input []interface{}, smbOAuthEnabled bool) (*storageaccounts.AzureFilesIdentityBasedAuthentication, error) {
+	smbOAuthSettings := &storageaccounts.SmbOAuthSettings{
+		IsSmbOAuthEnabled: pointer.To(smbOAuthEnabled),
+	}
+
 	if len(input) == 0 {
 		return &storageaccounts.AzureFilesIdentityBasedAuthentication{
 			DirectoryServiceOptions: storageaccounts.DirectoryServiceOptionsNone,
+			SmbOAuthSettings:        smbOAuthSettings,
 		}, nil
 	}
 
 	v := input[0].(map[string]interface{})
 	output := storageaccounts.AzureFilesIdentityBasedAuthentication{
 		DirectoryServiceOptions: storageaccounts.DirectoryServiceOptions(v["directory_type"].(string)),
+		SmbOAuthSettings:        smbOAuthSettings,
 	}
 	if output.DirectoryServiceOptions == storageaccounts.DirectoryServiceOptionsAD ||
 		output.DirectoryServiceOptions == storageaccounts.DirectoryServiceOptionsAADDS ||

--- a/internal/services/storage/storage_account_resource_test.go
+++ b/internal/services/storage/storage_account_resource_test.go
@@ -1009,6 +1009,38 @@ func TestAccStorageAccount_azureFilesAuthentication(t *testing.T) {
 	})
 }
 
+func TestAccStorageAccount_smbOAuth(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_account", "test")
+	r := StorageAccountResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.smbOAuth(data, false),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("smb_oauth_enabled").HasValue("false"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.smbOAuth(data, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("smb_oauth_enabled").HasValue("true"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.smbOAuth(data, false),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("smb_oauth_enabled").HasValue("false"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccStorageAccount_routing(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_account", "test")
 	r := StorageAccountResource{}
@@ -2072,6 +2104,30 @@ resource "azurerm_storage_account" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}
+
+func (r StorageAccountResource) smbOAuth(data acceptance.TestData, enabled bool) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-storage-%d"
+  location = "%s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                = "unlikely23exst2acct%s"
+  resource_group_name = azurerm_resource_group.test.name
+
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  smb_oauth_enabled = %t
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, enabled)
 }
 
 func (r StorageAccountResource) publicNetworkAccess(data acceptance.TestData, enabled bool) string {

--- a/website/docs/d/storage_account.html.markdown
+++ b/website/docs/d/storage_account.html.markdown
@@ -216,6 +216,8 @@ output "storage_account_tier" {
 
 * `azure_files_authentication` - A `azure_files_authentication` block as documented below.
 
+* `smb_oauth_enabled` - Whether managed identities can access SMB Azure file shares using OAuth.
+
 ---
 
 * `custom_domain` supports the following:

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -164,6 +164,8 @@ The following arguments are supported:
 
 * `azure_files_authentication` - (Optional) A `azure_files_authentication` block as defined below.
 
+* `smb_oauth_enabled` - (Optional) Whether managed identities can access SMB Azure file shares using OAuth. Defaults to `false`.
+
 * `routing` - (Optional) A `routing` block as defined below.
 
 * `queue_encryption_key_type` - (Optional) The encryption type of the queue service. Possible values are `Service` and `Account`. Changing this forces a new resource to be created. Default value is `Service`.


### PR DESCRIPTION
## Community Note

* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

Adds a top-level `smb_oauth_enabled` toggle to `azurerm_storage_account` that maps to `properties.azureFilesIdentityBasedAuthentication.smbOAuthSettings.isSmbOAuthEnabled` (storage RP `2025-08-01`, already vendored). Enabling it lets managed identities access Azure file shares over SMB using OAuth, recently made generally available (Azure portal: "Managed Identity for SMB"; CLI: `az storage account ... --enable-smb-oauth true`).

SMB OAuth is independent of the directory service: it can be enabled with `directoryServiceOptions=None` and requires no Active Directory or Entra DS configuration. The existing `azure_files_authentication` block makes `directory_type` required, so putting the toggle there would force users to configure a directory service they don't need. It is therefore exposed as a top-level boolean, matching the Azure CLI/PowerShell/portal surface and the existing pattern of other top-level storage account toggles such as `shared_access_key_enabled` and `cross_tenant_replication_enabled`.

`azure_files_authentication` and `smb_oauth_enabled` both write into the same `azureFilesIdentityBasedAuthentication` object, which is sent in the resource's trailing `Update` call (it holds the account for several minutes). They are expanded together so neither overwrites the other. The data source exposes the value as a computed attribute.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues.
- [x] I have updated/added Documentation as required.
- [x] I have used a meaningful PR title.

## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them.
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally.

`go build`, `go vet`, the `storage` unit tests, `golangci-lint`, and `document-lint` all pass locally. The acceptance test below requires an Azure subscription and has not been run in my environment.

## Testing

`TestAccStorageAccount_smbOAuth` creates a Standard LRS account with the toggle off, enables it, then disables it, asserting the round-trip through `ImportStep` at each step. The config has no directory-service prerequisites.

```
make acctests SERVICE='storage' TESTARGS='-run=TestAccStorageAccount_smbOAuth'
```

## Change Log

* `azurerm_storage_account` - support for the `smb_oauth_enabled` property [GH-00000]

This is a (please select all that apply):

- [x] Enhancement

## Related Issue(s)

Fixes #31756

## AI Assistance Disclosure

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

AI (Claude Code) was used to research the Azure feature and SDK, draft the implementation, tests, and documentation, and write this description. I reviewed all changes.

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

This adds an opt-in toggle (`smb_oauth_enabled`, default `false`) for managed-identity (OAuth) access to Azure file shares over SMB. It changes no defaults.
