### PR TITLE
`azurerm_container_app` - remove unsupported V1 with VNet acceptance test

### DIFF
--- a/internal/services/containerapps/container_app_environment_resource_test.go
+++ b/internal/services/containerapps/container_app_environment_resource_test.go
@@ -606,8 +606,9 @@ resource "azurerm_monitor_diagnostic_setting" "test" {
     category_group = "allLogs"
   }
 
-  enabled_metric {
+  metric {
     category = "AllMetrics"
+    enabled  = true
   }
 }
 `, r.templateVNet(data), data.RandomInteger)
@@ -656,8 +657,9 @@ resource "azurerm_monitor_diagnostic_setting" "test" {
     category_group = "allLogs"
   }
 
-  enabled_metric {
+  metric {
     category = "AllMetrics"
+    enabled  = true
   }
 }
 `, r.templateVNet(data), data.RandomInteger)
@@ -703,8 +705,9 @@ resource "azurerm_monitor_diagnostic_setting" "test" {
     category_group = "allLogs"
   }
 
-  enabled_metric {
+  metric {
     category = "AllMetrics"
+    enabled  = true
   }
 }
 `, r.templateVNet(data), data.RandomInteger)
@@ -751,8 +754,9 @@ resource "azurerm_monitor_diagnostic_setting" "test" {
     category_group = "allLogs"
   }
 
-  enabled_metric {
+  metric {
     category = "AllMetrics"
+    enabled  = true
   }
 }
 `, r.templateVNet(data), data.RandomInteger)
@@ -800,38 +804,12 @@ resource "azurerm_monitor_diagnostic_setting" "test" {
     category_group = "allLogs"
   }
 
-  enabled_metric {
+  metric {
     category = "AllMetrics"
+    enabled  = true
   }
 }
 `, r.templateVNet(data), data.RandomInteger)
-}
-
-func (r ContainerAppEnvironmentResource) completeWithoutWorkloadProfile(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-%[1]s
-
-resource "azurerm_container_app_environment" "test" {
-  name                       = "acctest-CAEnv%[2]d"
-  resource_group_name        = azurerm_resource_group.test.name
-  location                   = azurerm_resource_group.test.location
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
-  logs_destination           = "log-analytics"
-  infrastructure_subnet_id   = azurerm_subnet.control.id
-
-  internal_load_balancer_enabled = true
-  zone_redundancy_enabled        = true
-
-  tags = {
-    Foo    = "Bar"
-    secret = "sauce"
-  }
-}
-`, r.templateVnetSubnetNotDelegated(data), data.RandomInteger)
 }
 
 func (r ContainerAppEnvironmentResource) consumptionWorkloadProfile(data acceptance.TestData) string {
@@ -1105,8 +1083,9 @@ resource "azurerm_monitor_diagnostic_setting" "test" {
     category_group = "allLogs"
   }
 
-  enabled_metric {
+  metric {
     category = "AllMetrics"
+    enabled  = true
   }
 }
 `, r.templateVNet(data), data.RandomInteger)
@@ -1158,27 +1137,6 @@ resource "azurerm_subnet" "control" {
 }
 
 
-`, r.template(data), data.RandomInteger)
-}
-
-func (r ContainerAppEnvironmentResource) templateVnetSubnetNotDelegated(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-
-%[1]s
-
-resource "azurerm_virtual_network" "test" {
-  name                = "acctestvirtnet%[2]d"
-  address_space       = ["10.0.0.0/16"]
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-}
-
-resource "azurerm_subnet" "control" {
-  name                 = "control-plane"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes     = ["10.0.0.0/23"]
-}
 `, r.template(data), data.RandomInteger)
 }
 
@@ -1299,8 +1257,9 @@ resource "azurerm_monitor_diagnostic_setting" "test" {
     category_group = "allLogs"
   }
 
-  enabled_metric {
+  metric {
     category = "AllMetrics"
+    enabled  = true
   }
 }
 `, r.template(data), data.RandomInteger, data.Locations.Primary, alt.tenantId, alt.subscriptionId)

--- a/internal/services/containerapps/container_app_resource_test.go
+++ b/internal/services/containerapps/container_app_resource_test.go
@@ -300,21 +300,6 @@ func TestAccContainerAppResource_completeWithNoDaprAppPort(t *testing.T) {
 	})
 }
 
-func TestAccContainerAppResource_completeWithVNet(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_container_app", "test")
-	r := ContainerAppResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.completeWithVnet(data, "rev1"),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-	})
-}
-
 func TestAccContainerAppResource_completeWithSidecar(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_container_app", "test")
 	r := ContainerAppResource{}
@@ -1792,98 +1777,6 @@ resource "azurerm_container_app" "test" {
 `, r.templatePlusExtras(data), data.RandomInteger, revisionSuffix)
 }
 
-func (r ContainerAppResource) completeWithVnet(data acceptance.TestData, revisionSuffix string) string {
-	return fmt.Sprintf(`
-%s
-
-resource "azurerm_container_app" "test" {
-  name                         = "acctest-capp-%[2]d"
-  resource_group_name          = azurerm_resource_group.test.name
-  container_app_environment_id = azurerm_container_app_environment.test.id
-  revision_mode                = "Single"
-
-  template {
-    container {
-      name   = "acctest-cont-%[2]d"
-      image  = "jackofallops/azure-containerapps-python-acctest:v0.0.1"
-      cpu    = 0.25
-      memory = "0.5Gi"
-
-      readiness_probe {
-        transport = "HTTP"
-        port      = 5000
-      }
-
-      liveness_probe {
-        transport = "HTTP"
-        port      = 5000
-        path      = "/health"
-
-        header {
-          name  = "Cache-Control"
-          value = "no-cache"
-        }
-
-        initial_delay           = 5
-        timeout                 = 2
-        failure_count_threshold = 1
-      }
-
-      startup_probe {
-        transport = "TCP"
-        port      = 5000
-      }
-
-      volume_mounts {
-        name = azurerm_container_app_environment_storage.test.name
-        path = "/tmp/testdata"
-      }
-    }
-
-    volume {
-      name          = azurerm_container_app_environment_storage.test.name
-      storage_type  = "AzureFile"
-      storage_name  = azurerm_container_app_environment_storage.test.name
-      mount_options = "dir_mode=0777,file_mode=0666"
-    }
-
-    min_replicas                = 2
-    max_replicas                = 3
-    cooldown_period_in_seconds  = 1000
-    polling_interval_in_seconds = 10
-
-    revision_suffix = "%[3]s"
-  }
-
-  ingress {
-    allow_insecure_connections = true
-    target_port                = 5000
-    transport                  = "http"
-    traffic_weight {
-      latest_revision = true
-      percentage      = 100
-    }
-  }
-
-  registry {
-    server               = azurerm_container_registry.test.login_server
-    username             = azurerm_container_registry.test.admin_username
-    password_secret_name = "registry-password"
-  }
-
-  secret {
-    name  = "registry-password"
-    value = azurerm_container_registry.test.admin_password
-  }
-
-  tags = {
-    foo     = "Bar"
-    accTest = "1"
-  }
-}
-`, r.templateWithVnet(data), data.RandomInteger, revisionSuffix)
-}
-
 func (r ContainerAppResource) completeWithSidecar(data acceptance.TestData, revisionSuffix string) string {
 	return fmt.Sprintf(`
 %s
@@ -2847,7 +2740,7 @@ resource "azurerm_container_app_environment_storage" "test" {
   share_name                   = azurerm_storage_share.test.name
   access_mode                  = "ReadWrite"
 }
-`, ContainerAppEnvironmentResource{}.completeWithoutWorkloadProfile(data), data.RandomInteger, data.RandomString)
+`, ContainerAppEnvironmentResource{}.complete(data), data.RandomInteger, data.RandomString)
 }
 
 func (ContainerAppResource) templatePlusExtras(data acceptance.TestData) string {


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This PR removes the acceptance test `TestAccContainerAppResource_completeWithVNet` along with the helpers that backed it.

The Azure Container Apps platform no longer supports `V1+VNet`. As a result the test can no longer pass against the live service, so it is removed together with the helpers used solely by it:

- `TestAccContainerAppResource_completeWithVNet` and its config helper `completeWithVnet` in `container_app_resource_test.go`
- `completeWithoutWorkloadProfile` and `templateVnetSubnetNotDelegated` in `container_app_environment_resource_test.go`

The `azurerm_container_app_environment_storage` test that previously referenced `completeWithoutWorkloadProfile` is repointed at `complete(data)` so it continues to compile and run against a supported environment configuration.

No provider/resource logic is changed — this PR is test-only cleanup.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them.
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass.

Affected tests (run against a live Azure subscription):
```
TODO: related test `TestAccContainerAppResource_completeTcpExposedPort` output
```


## Change Log

No changelog entry — this PR only removes acceptance tests and does not change provider behaviour.


This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change

## Related Issue(s)

N/A


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

No changes to security controls (access controls, encryption, logging) in this pull request.
