### PR TITLE
`azurerm_logic_app_standard` - add storage_account_connection_string attribute

### DIFF
--- a/internal/services/logic/logic_app_standard_data_source.go
+++ b/internal/services/logic/logic_app_standard_data_source.go
@@ -136,6 +136,12 @@ func dataSourceLogicAppStandard() *pluginsdk.Resource {
 				Sensitive: true,
 			},
 
+			"storage_key_vault_secret_id": {
+				Type:        pluginsdk.TypeString,
+				Computed:    true,
+				Description: "The Key Vault Secret ID, optionally including version, that contains the connection string to the backend storage account for the Logic App.",
+			},
+
 			"storage_account_share_name": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
@@ -270,21 +276,12 @@ func dataSourceLogicAppStandardRead(d *pluginsdk.ResourceData, meta interface{})
 
 		connectionString := appSettings["AzureWebJobsStorage"]
 
-		// This teases out the necessary attributes from the storage connection string
-		connectionStringParts := strings.Split(connectionString, ";")
-		for _, part := range connectionStringParts {
-			if strings.HasPrefix(part, "AccountName") {
-				accountNameParts := strings.Split(part, "AccountName=")
-				if len(accountNameParts) > 1 {
-					d.Set("storage_account_name", accountNameParts[1])
-				}
-			}
-			if strings.HasPrefix(part, "AccountKey") {
-				accountKeyParts := strings.Split(part, "AccountKey=")
-				if len(accountKeyParts) > 1 {
-					d.Set("storage_account_access_key", accountKeyParts[1])
-				}
-			}
+		if strings.HasPrefix(connectionString, "@Microsoft.KeyVault") {
+			d.Set("storage_key_vault_secret_id", strings.TrimPrefix(strings.TrimSuffix(connectionString, ")"), "@Microsoft.KeyVault(SecretUri="))
+		} else {
+			name, key := helpers.ParseWebJobsStorageString(connectionString)
+			d.Set("storage_account_name", name)
+			d.Set("storage_account_access_key", key)
 		}
 
 		d.Set("version", appSettings["FUNCTIONS_EXTENSION_VERSION"])

--- a/internal/services/logic/logic_app_standard_data_source_test.go
+++ b/internal/services/logic/logic_app_standard_data_source_test.go
@@ -43,3 +43,28 @@ data "azurerm_logic_app_standard" "test" {
 }
 `, LogicAppStandardResource{}.basic(data))
 }
+
+func TestAccLogicAppStandardDataSource_storageKeyVaultSecret(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_logic_app_standard", "test")
+	r := LogicAppStandardDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.storageKeyVaultSecret(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("storage_key_vault_secret_id").Exists(),
+			),
+		},
+	})
+}
+
+func (r LogicAppStandardDataSource) storageKeyVaultSecret(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_logic_app_standard" "test" {
+  name                = azurerm_logic_app_standard.test.name
+  resource_group_name = azurerm_logic_app_standard.test.resource_group_name
+}
+`, LogicAppStandardResource{}.storageKeyVaultSecret(data))
+}

--- a/internal/services/logic/logic_app_standard_resource.go
+++ b/internal/services/logic/logic_app_standard_resource.go
@@ -33,32 +33,32 @@ import (
 type LogicAppResource struct{}
 
 type LogicAppResourceModel struct {
-	Name                        string                                     `tfschema:"name"`
-	ResourceGroupName           string                                     `tfschema:"resource_group_name"`
-	Location                    string                                     `tfschema:"location"`
-	AppServicePlanId            string                                     `tfschema:"app_service_plan_id"`
-	AppSettings                 map[string]string                          `tfschema:"app_settings"`
-	UseExtensionBundle          bool                                       `tfschema:"use_extension_bundle"`
-	BundleVersion               string                                     `tfschema:"bundle_version"`
-	ClientAffinityEnabled       bool                                       `tfschema:"client_affinity_enabled"`
-	ClientCertificateMode       string                                     `tfschema:"client_certificate_mode"`
-	Enabled                     bool                                       `tfschema:"enabled"`
-	FtpPublishBasicAuthEnabled  bool                                       `tfschema:"ftp_publish_basic_authentication_enabled"`
-	HTTPSOnly                   bool                                       `tfschema:"https_only"`
-	Identity                    []identity.ModelSystemAssignedUserAssigned `tfschema:"identity"`
-	KeyvaultReferenceIdentityId string                                     `tfschema:"key_vault_reference_identity_id"`
-	SCMPublishBasicAuthEnabled  bool                                       `tfschema:"scm_publish_basic_authentication_enabled"`
-	SiteConfig                  []helpers.LogicAppSiteConfig               `tfschema:"site_config"`
-	ConnectionStrings           []helpers.ConnectionString                 `tfschema:"connection_string"`
+	Name                           string                                     `tfschema:"name"`
+	ResourceGroupName              string                                     `tfschema:"resource_group_name"`
+	Location                       string                                     `tfschema:"location"`
+	AppServicePlanId               string                                     `tfschema:"app_service_plan_id"`
+	AppSettings                    map[string]string                          `tfschema:"app_settings"`
+	UseExtensionBundle             bool                                       `tfschema:"use_extension_bundle"`
+	BundleVersion                  string                                     `tfschema:"bundle_version"`
+	ClientAffinityEnabled          bool                                       `tfschema:"client_affinity_enabled"`
+	ClientCertificateMode          string                                     `tfschema:"client_certificate_mode"`
+	Enabled                        bool                                       `tfschema:"enabled"`
+	FtpPublishBasicAuthEnabled     bool                                       `tfschema:"ftp_publish_basic_authentication_enabled"`
+	HTTPSOnly                      bool                                       `tfschema:"https_only"`
+	Identity                       []identity.ModelSystemAssignedUserAssigned `tfschema:"identity"`
+	KeyvaultReferenceIdentityId    string                                     `tfschema:"key_vault_reference_identity_id"`
+	SCMPublishBasicAuthEnabled     bool                                       `tfschema:"scm_publish_basic_authentication_enabled"`
+	SiteConfig                     []helpers.LogicAppSiteConfig               `tfschema:"site_config"`
+	ConnectionStrings              []helpers.ConnectionString                 `tfschema:"connection_string"`
 	StorageAccountName             string                                     `tfschema:"storage_account_name"`
 	StorageAccountAccessKey        string                                     `tfschema:"storage_account_access_key"`
 	StorageAccountConnectionString string                                     `tfschema:"storage_account_connection_string"`
-	PublicNetworkAccess         string                                     `tfschema:"public_network_access"`
-	StorageAccountShareName     string                                     `tfschema:"storage_account_share_name"`
-	Version                     string                                     `tfschema:"version"`
-	VNETContentShareEnabled     bool                                       `tfschema:"vnet_content_share_enabled"`
-	VirtualNetworkSubnetId      string                                     `tfschema:"virtual_network_subnet_id"`
-	Tags                        map[string]string                          `tfschema:"tags"`
+	PublicNetworkAccess            string                                     `tfschema:"public_network_access"`
+	StorageAccountShareName        string                                     `tfschema:"storage_account_share_name"`
+	Version                        string                                     `tfschema:"version"`
+	VNETContentShareEnabled        bool                                       `tfschema:"vnet_content_share_enabled"`
+	VirtualNetworkSubnetId         string                                     `tfschema:"virtual_network_subnet_id"`
+	Tags                           map[string]string                          `tfschema:"tags"`
 
 	CustomDomainVerificationId  string                           `tfschema:"custom_domain_verification_id"`
 	DefaultHostname             string                           `tfschema:"default_hostname"`
@@ -72,7 +72,7 @@ var (
 	logicAppStdKind   = "functionapp,workflowapp"
 	logicAppLinuxKind = "functionapp,linux,container,workflowapp"
 
-	storageConnectionStringFmt = "DefaultEndpointsProtocol=https;AccountName=%s;AccountKey=%s;EndpointSuffix=%s"
+	storageConnectionStringFmt           = "DefaultEndpointsProtocol=https;AccountName=%s;AccountKey=%s;EndpointSuffix=%s"
 	storageAppSettingName                = "AzureWebJobsStorage"
 	contentShareAppSettingName           = "WEBSITE_CONTENTSHARE"
 	contentFileConnStringAppSettingName  = "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING"
@@ -205,6 +205,9 @@ func (r LogicAppResource) Arguments() map[string]*pluginsdk.Schema {
 			Type:         pluginsdk.TypeString,
 			Optional:     true,
 			ValidateFunc: storageValidate.StorageAccountName,
+			RequiredWith: []string{
+				"storage_account_access_key",
+			},
 			ExactlyOneOf: []string{
 				"storage_account_name",
 				"storage_account_connection_string",
@@ -671,7 +674,14 @@ func (r LogicAppResource) Read() sdk.ResourceFunc {
 
 				connectionString := appSettings[storageAppSettingName]
 
-				if strings.Contains(connectionString, "AccountName=") && strings.Contains(connectionString, "AccountKey=") {
+				// Determine how to populate state based on which attribute the user configured.
+				// If storage_account_connection_string is in the current state/config, store the
+				// raw value there regardless of its content (it could be a KV reference or even
+				// a standard connection string). Otherwise, parse into name/key fields.
+				switch {
+				case metadata.ResourceData.Get("storage_account_connection_string").(string) != "":
+					state.StorageAccountConnectionString = connectionString
+				case strings.Contains(connectionString, "AccountName=") && strings.Contains(connectionString, "AccountKey="):
 					for _, part := range strings.Split(connectionString, ";") {
 						if strings.HasPrefix(part, "AccountName") {
 							accountNameParts := strings.Split(part, "AccountName=")
@@ -686,7 +696,7 @@ func (r LogicAppResource) Read() sdk.ResourceFunc {
 							}
 						}
 					}
-				} else {
+				default:
 					state.StorageAccountConnectionString = connectionString
 				}
 
@@ -1354,6 +1364,13 @@ func mergeAppSettings(existing []webapps.NameValuePair, old, new map[string]inte
 		if connString != "" {
 			eMap[storageAppSettingName] = connString
 			eMap[contentFileConnStringAppSettingName] = connString
+		} else if metadata.ResourceData.HasChanges("storage_account_name", "storage_account_access_key") {
+			accountName := metadata.ResourceData.Get("storage_account_name").(string)
+			accountAccessKey := metadata.ResourceData.Get("storage_account_access_key").(string)
+			suffix, _ := metadata.Client.Account.Environment.Storage.DomainSuffix()
+
+			eMap[storageAppSettingName] = fmt.Sprintf(storageConnectionStringFmt, accountName, accountAccessKey, *suffix)
+			eMap[contentFileConnStringAppSettingName] = fmt.Sprintf(storageConnectionStringFmt, accountName, accountAccessKey, *suffix)
 		}
 	} else if metadata.ResourceData.HasChanges("storage_account_name", "storage_account_access_key") {
 		accountName := metadata.ResourceData.Get("storage_account_name").(string)

--- a/internal/services/logic/logic_app_standard_resource.go
+++ b/internal/services/logic/logic_app_standard_resource.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/keyvault"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/web/2023-01-01/resourceproviders"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/web/2023-12-01/webapps"
@@ -52,6 +53,7 @@ type LogicAppResourceModel struct {
 	ConnectionStrings           []helpers.ConnectionString                 `tfschema:"connection_string"`
 	StorageAccountName          string                                     `tfschema:"storage_account_name"`
 	StorageAccountAccessKey     string                                     `tfschema:"storage_account_access_key"`
+	StorageKeyVaultSecretID     string                                     `tfschema:"storage_key_vault_secret_id"`
 	PublicNetworkAccess         string                                     `tfschema:"public_network_access"`
 	StorageAccountShareName     string                                     `tfschema:"storage_account_share_name"`
 	Version                     string                                     `tfschema:"version"`
@@ -72,6 +74,7 @@ var (
 	logicAppLinuxKind = "functionapp,linux,container,workflowapp"
 
 	storageConnectionStringFmt           = "DefaultEndpointsProtocol=https;AccountName=%s;AccountKey=%s;EndpointSuffix=%s"
+	storageKeyVaultReferenceFmt          = "@Microsoft.KeyVault(SecretUri=%s)"
 	storageAppSettingName                = "AzureWebJobsStorage"
 	contentShareAppSettingName           = "WEBSITE_CONTENTSHARE"
 	contentFileConnStringAppSettingName  = "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING"
@@ -202,16 +205,33 @@ func (r LogicAppResource) Arguments() map[string]*pluginsdk.Schema {
 
 		"storage_account_name": {
 			Type:         pluginsdk.TypeString,
-			Required:     true,
-			ForceNew:     true,
+			Optional:     true,
 			ValidateFunc: storageValidate.StorageAccountName,
+			ExactlyOneOf: []string{
+				"storage_account_name",
+				"storage_key_vault_secret_id",
+			},
 		},
 
 		"storage_account_access_key": {
 			Type:         pluginsdk.TypeString,
-			Required:     true,
+			Optional:     true,
 			Sensitive:    true,
 			ValidateFunc: validation.NoZeroValues,
+			ConflictsWith: []string{
+				"storage_key_vault_secret_id",
+			},
+		},
+
+		"storage_key_vault_secret_id": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			Sensitive:    true,
+			ValidateFunc: keyvault.ValidateNestedItemID(keyvault.VersionTypeAny, keyvault.NestedItemTypeSecret),
+			ExactlyOneOf: []string{
+				"storage_account_name",
+				"storage_key_vault_secret_id",
+			},
 		},
 
 		// Once this property is set, it can not be removed while identity is UserAssigned.

--- a/internal/services/logic/logic_app_standard_resource.go
+++ b/internal/services/logic/logic_app_standard_resource.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
-	"github.com/hashicorp/go-azure-helpers/resourcemanager/keyvault"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/web/2023-01-01/resourceproviders"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/web/2023-12-01/webapps"
@@ -51,9 +50,9 @@ type LogicAppResourceModel struct {
 	SCMPublishBasicAuthEnabled  bool                                       `tfschema:"scm_publish_basic_authentication_enabled"`
 	SiteConfig                  []helpers.LogicAppSiteConfig               `tfschema:"site_config"`
 	ConnectionStrings           []helpers.ConnectionString                 `tfschema:"connection_string"`
-	StorageAccountName          string                                     `tfschema:"storage_account_name"`
-	StorageAccountAccessKey     string                                     `tfschema:"storage_account_access_key"`
-	StorageKeyVaultSecretID     string                                     `tfschema:"storage_key_vault_secret_id"`
+	StorageAccountName             string                                     `tfschema:"storage_account_name"`
+	StorageAccountAccessKey        string                                     `tfschema:"storage_account_access_key"`
+	StorageAccountConnectionString string                                     `tfschema:"storage_account_connection_string"`
 	PublicNetworkAccess         string                                     `tfschema:"public_network_access"`
 	StorageAccountShareName     string                                     `tfschema:"storage_account_share_name"`
 	Version                     string                                     `tfschema:"version"`
@@ -73,8 +72,7 @@ var (
 	logicAppStdKind   = "functionapp,workflowapp"
 	logicAppLinuxKind = "functionapp,linux,container,workflowapp"
 
-	storageConnectionStringFmt           = "DefaultEndpointsProtocol=https;AccountName=%s;AccountKey=%s;EndpointSuffix=%s"
-	storageKeyVaultReferenceFmt          = "@Microsoft.KeyVault(SecretUri=%s)"
+	storageConnectionStringFmt = "DefaultEndpointsProtocol=https;AccountName=%s;AccountKey=%s;EndpointSuffix=%s"
 	storageAppSettingName                = "AzureWebJobsStorage"
 	contentShareAppSettingName           = "WEBSITE_CONTENTSHARE"
 	contentFileConnStringAppSettingName  = "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING"
@@ -209,7 +207,7 @@ func (r LogicAppResource) Arguments() map[string]*pluginsdk.Schema {
 			ValidateFunc: storageValidate.StorageAccountName,
 			ExactlyOneOf: []string{
 				"storage_account_name",
-				"storage_key_vault_secret_id",
+				"storage_account_connection_string",
 			},
 		},
 
@@ -218,19 +216,21 @@ func (r LogicAppResource) Arguments() map[string]*pluginsdk.Schema {
 			Optional:     true,
 			Sensitive:    true,
 			ValidateFunc: validation.NoZeroValues,
+			RequiredWith: []string{
+				"storage_account_name",
+			},
 			ConflictsWith: []string{
-				"storage_key_vault_secret_id",
+				"storage_account_connection_string",
 			},
 		},
 
-		"storage_key_vault_secret_id": {
-			Type:         pluginsdk.TypeString,
-			Optional:     true,
-			Sensitive:    true,
-			ValidateFunc: keyvault.ValidateNestedItemID(keyvault.VersionTypeAny, keyvault.NestedItemTypeSecret),
+		"storage_account_connection_string": {
+			Type:      pluginsdk.TypeString,
+			Optional:  true,
+			Sensitive: true,
 			ExactlyOneOf: []string{
 				"storage_account_name",
-				"storage_key_vault_secret_id",
+				"storage_account_connection_string",
 			},
 		},
 
@@ -671,11 +671,7 @@ func (r LogicAppResource) Read() sdk.ResourceFunc {
 
 				connectionString := appSettings[storageAppSettingName]
 
-				if strings.HasPrefix(connectionString, "@Microsoft.KeyVault") {
-					trimmed := strings.TrimPrefix(connectionString, "@Microsoft.KeyVault(SecretUri=")
-					trimmed = strings.TrimSuffix(trimmed, ")")
-					state.StorageKeyVaultSecretID = trimmed
-				} else {
+				if strings.Contains(connectionString, "AccountName=") && strings.Contains(connectionString, "AccountKey=") {
 					for _, part := range strings.Split(connectionString, ";") {
 						if strings.HasPrefix(part, "AccountName") {
 							accountNameParts := strings.Split(part, "AccountName=")
@@ -690,6 +686,8 @@ func (r LogicAppResource) Read() sdk.ResourceFunc {
 							}
 						}
 					}
+				} else {
+					state.StorageAccountConnectionString = connectionString
 				}
 
 				if v, ok := appSettings[functionVersionAppSettingName]; ok {
@@ -981,8 +979,8 @@ func getBasicLogicAppSettings(d LogicAppResourceModel, endpointSuffix string) ([
 	appKindPropValue := "workflowApp"
 
 	var storageConnection string
-	if d.StorageKeyVaultSecretID != "" {
-		storageConnection = fmt.Sprintf(storageKeyVaultReferenceFmt, d.StorageKeyVaultSecretID)
+	if d.StorageAccountConnectionString != "" {
+		storageConnection = d.StorageAccountConnectionString
 	} else {
 		storageConnection = fmt.Sprintf(
 			"DefaultEndpointsProtocol=https;AccountName=%s;AccountKey=%s;EndpointSuffix=%s",
@@ -1351,12 +1349,11 @@ func mergeAppSettings(existing []webapps.NameValuePair, old, new map[string]inte
 	oMap := f(old)
 	cMap := f(new)
 
-	if metadata.ResourceData.HasChange("storage_key_vault_secret_id") {
-		kvSecretID := metadata.ResourceData.Get("storage_key_vault_secret_id").(string)
-		if kvSecretID != "" {
-			kvRef := fmt.Sprintf(storageKeyVaultReferenceFmt, kvSecretID)
-			eMap[storageAppSettingName] = kvRef
-			eMap[contentFileConnStringAppSettingName] = kvRef
+	if metadata.ResourceData.HasChange("storage_account_connection_string") {
+		connString := metadata.ResourceData.Get("storage_account_connection_string").(string)
+		if connString != "" {
+			eMap[storageAppSettingName] = connString
+			eMap[contentFileConnStringAppSettingName] = connString
 		}
 	} else if metadata.ResourceData.HasChanges("storage_account_name", "storage_account_access_key") {
 		accountName := metadata.ResourceData.Get("storage_account_name").(string)

--- a/internal/services/logic/logic_app_standard_resource.go
+++ b/internal/services/logic/logic_app_standard_resource.go
@@ -671,17 +671,23 @@ func (r LogicAppResource) Read() sdk.ResourceFunc {
 
 				connectionString := appSettings[storageAppSettingName]
 
-				for _, part := range strings.Split(connectionString, ";") {
-					if strings.HasPrefix(part, "AccountName") {
-						accountNameParts := strings.Split(part, "AccountName=")
-						if len(accountNameParts) > 1 {
-							state.StorageAccountName = accountNameParts[1]
+				if strings.HasPrefix(connectionString, "@Microsoft.KeyVault") {
+					trimmed := strings.TrimPrefix(connectionString, "@Microsoft.KeyVault(SecretUri=")
+					trimmed = strings.TrimSuffix(trimmed, ")")
+					state.StorageKeyVaultSecretID = trimmed
+				} else {
+					for _, part := range strings.Split(connectionString, ";") {
+						if strings.HasPrefix(part, "AccountName") {
+							accountNameParts := strings.Split(part, "AccountName=")
+							if len(accountNameParts) > 1 {
+								state.StorageAccountName = accountNameParts[1]
+							}
 						}
-					}
-					if strings.HasPrefix(part, "AccountKey") {
-						accountKeyParts := strings.Split(part, "AccountKey=")
-						if len(accountKeyParts) > 1 {
-							state.StorageAccountAccessKey = accountKeyParts[1]
+						if strings.HasPrefix(part, "AccountKey") {
+							accountKeyParts := strings.Split(part, "AccountKey=")
+							if len(accountKeyParts) > 1 {
+								state.StorageAccountAccessKey = accountKeyParts[1]
+							}
 						}
 					}
 				}
@@ -974,14 +980,18 @@ func getBasicLogicAppSettings(d LogicAppResourceModel, endpointSuffix string) ([
 	appKindPropName := "APP_KIND"
 	appKindPropValue := "workflowApp"
 
-	storageAccount := d.StorageAccountName
-	accountKey := d.StorageAccountAccessKey
-	storageConnection := fmt.Sprintf(
-		"DefaultEndpointsProtocol=https;AccountName=%s;AccountKey=%s;EndpointSuffix=%s",
-		storageAccount,
-		accountKey,
-		endpointSuffix,
-	)
+	var storageConnection string
+	if d.StorageKeyVaultSecretID != "" {
+		storageConnection = fmt.Sprintf(storageKeyVaultReferenceFmt, d.StorageKeyVaultSecretID)
+	} else {
+		storageConnection = fmt.Sprintf(
+			"DefaultEndpointsProtocol=https;AccountName=%s;AccountKey=%s;EndpointSuffix=%s",
+			d.StorageAccountName,
+			d.StorageAccountAccessKey,
+			endpointSuffix,
+		)
+	}
+
 	functionVersion := d.Version
 
 	contentShare := strings.ToLower(d.Name) + "-content"
@@ -1341,7 +1351,14 @@ func mergeAppSettings(existing []webapps.NameValuePair, old, new map[string]inte
 	oMap := f(old)
 	cMap := f(new)
 
-	if metadata.ResourceData.HasChanges("storage_account_name", "storage_account_access_key") {
+	if metadata.ResourceData.HasChange("storage_key_vault_secret_id") {
+		kvSecretID := metadata.ResourceData.Get("storage_key_vault_secret_id").(string)
+		if kvSecretID != "" {
+			kvRef := fmt.Sprintf(storageKeyVaultReferenceFmt, kvSecretID)
+			eMap[storageAppSettingName] = kvRef
+			eMap[contentFileConnStringAppSettingName] = kvRef
+		}
+	} else if metadata.ResourceData.HasChanges("storage_account_name", "storage_account_access_key") {
 		accountName := metadata.ResourceData.Get("storage_account_name").(string)
 		accountAccessKey := metadata.ResourceData.Get("storage_account_access_key").(string)
 		suffix, _ := metadata.Client.Account.Environment.Storage.DomainSuffix()

--- a/internal/services/logic/logic_app_standard_resource.go
+++ b/internal/services/logic/logic_app_standard_resource.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/keyvault"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/web/2023-01-01/resourceproviders"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/web/2023-12-01/webapps"
@@ -33,32 +34,32 @@ import (
 type LogicAppResource struct{}
 
 type LogicAppResourceModel struct {
-	Name                           string                                     `tfschema:"name"`
-	ResourceGroupName              string                                     `tfschema:"resource_group_name"`
-	Location                       string                                     `tfschema:"location"`
-	AppServicePlanId               string                                     `tfschema:"app_service_plan_id"`
-	AppSettings                    map[string]string                          `tfschema:"app_settings"`
-	UseExtensionBundle             bool                                       `tfschema:"use_extension_bundle"`
-	BundleVersion                  string                                     `tfschema:"bundle_version"`
-	ClientAffinityEnabled          bool                                       `tfschema:"client_affinity_enabled"`
-	ClientCertificateMode          string                                     `tfschema:"client_certificate_mode"`
-	Enabled                        bool                                       `tfschema:"enabled"`
-	FtpPublishBasicAuthEnabled     bool                                       `tfschema:"ftp_publish_basic_authentication_enabled"`
-	HTTPSOnly                      bool                                       `tfschema:"https_only"`
-	Identity                       []identity.ModelSystemAssignedUserAssigned `tfschema:"identity"`
-	KeyvaultReferenceIdentityId    string                                     `tfschema:"key_vault_reference_identity_id"`
-	SCMPublishBasicAuthEnabled     bool                                       `tfschema:"scm_publish_basic_authentication_enabled"`
-	SiteConfig                     []helpers.LogicAppSiteConfig               `tfschema:"site_config"`
-	ConnectionStrings              []helpers.ConnectionString                 `tfschema:"connection_string"`
-	StorageAccountName             string                                     `tfschema:"storage_account_name"`
-	StorageAccountAccessKey        string                                     `tfschema:"storage_account_access_key"`
-	StorageAccountConnectionString string                                     `tfschema:"storage_account_connection_string"`
-	PublicNetworkAccess            string                                     `tfschema:"public_network_access"`
-	StorageAccountShareName        string                                     `tfschema:"storage_account_share_name"`
-	Version                        string                                     `tfschema:"version"`
-	VNETContentShareEnabled        bool                                       `tfschema:"vnet_content_share_enabled"`
-	VirtualNetworkSubnetId         string                                     `tfschema:"virtual_network_subnet_id"`
-	Tags                           map[string]string                          `tfschema:"tags"`
+	Name                        string                                     `tfschema:"name"`
+	ResourceGroupName           string                                     `tfschema:"resource_group_name"`
+	Location                    string                                     `tfschema:"location"`
+	AppServicePlanId            string                                     `tfschema:"app_service_plan_id"`
+	AppSettings                 map[string]string                          `tfschema:"app_settings"`
+	UseExtensionBundle          bool                                       `tfschema:"use_extension_bundle"`
+	BundleVersion               string                                     `tfschema:"bundle_version"`
+	ClientAffinityEnabled       bool                                       `tfschema:"client_affinity_enabled"`
+	ClientCertificateMode       string                                     `tfschema:"client_certificate_mode"`
+	Enabled                     bool                                       `tfschema:"enabled"`
+	FtpPublishBasicAuthEnabled  bool                                       `tfschema:"ftp_publish_basic_authentication_enabled"`
+	HTTPSOnly                   bool                                       `tfschema:"https_only"`
+	Identity                    []identity.ModelSystemAssignedUserAssigned `tfschema:"identity"`
+	KeyvaultReferenceIdentityId string                                     `tfschema:"key_vault_reference_identity_id"`
+	SCMPublishBasicAuthEnabled  bool                                       `tfschema:"scm_publish_basic_authentication_enabled"`
+	SiteConfig                  []helpers.LogicAppSiteConfig               `tfschema:"site_config"`
+	ConnectionStrings           []helpers.ConnectionString                 `tfschema:"connection_string"`
+	StorageAccountName          string                                     `tfschema:"storage_account_name"`
+	StorageAccountAccessKey     string                                     `tfschema:"storage_account_access_key"`
+	StorageKeyVaultSecretID     string                                     `tfschema:"storage_key_vault_secret_id"`
+	PublicNetworkAccess         string                                     `tfschema:"public_network_access"`
+	StorageAccountShareName     string                                     `tfschema:"storage_account_share_name"`
+	Version                     string                                     `tfschema:"version"`
+	VNETContentShareEnabled     bool                                       `tfschema:"vnet_content_share_enabled"`
+	VirtualNetworkSubnetId      string                                     `tfschema:"virtual_network_subnet_id"`
+	Tags                        map[string]string                          `tfschema:"tags"`
 
 	CustomDomainVerificationId  string                           `tfschema:"custom_domain_verification_id"`
 	DefaultHostname             string                           `tfschema:"default_hostname"`
@@ -72,7 +73,6 @@ var (
 	logicAppStdKind   = "functionapp,workflowapp"
 	logicAppLinuxKind = "functionapp,linux,container,workflowapp"
 
-	storageConnectionStringFmt           = "DefaultEndpointsProtocol=https;AccountName=%s;AccountKey=%s;EndpointSuffix=%s"
 	storageAppSettingName                = "AzureWebJobsStorage"
 	contentShareAppSettingName           = "WEBSITE_CONTENTSHARE"
 	contentFileConnStringAppSettingName  = "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING"
@@ -210,7 +210,7 @@ func (r LogicAppResource) Arguments() map[string]*pluginsdk.Schema {
 			},
 			ExactlyOneOf: []string{
 				"storage_account_name",
-				"storage_account_connection_string",
+				"storage_key_vault_secret_id",
 			},
 		},
 
@@ -223,17 +223,17 @@ func (r LogicAppResource) Arguments() map[string]*pluginsdk.Schema {
 				"storage_account_name",
 			},
 			ConflictsWith: []string{
-				"storage_account_connection_string",
+				"storage_key_vault_secret_id",
 			},
 		},
 
-		"storage_account_connection_string": {
-			Type:      pluginsdk.TypeString,
-			Optional:  true,
-			Sensitive: true,
+		"storage_key_vault_secret_id": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: keyvault.ValidateNestedItemID(keyvault.VersionTypeAny, keyvault.NestedItemTypeSecret),
 			ExactlyOneOf: []string{
 				"storage_account_name",
-				"storage_account_connection_string",
+				"storage_key_vault_secret_id",
 			},
 		},
 
@@ -674,30 +674,10 @@ func (r LogicAppResource) Read() sdk.ResourceFunc {
 
 				connectionString := appSettings[storageAppSettingName]
 
-				// Determine how to populate state based on which attribute the user configured.
-				// If storage_account_connection_string is in the current state/config, store the
-				// raw value there regardless of its content (it could be a KV reference or even
-				// a standard connection string). Otherwise, parse into name/key fields.
-				switch {
-				case metadata.ResourceData.Get("storage_account_connection_string").(string) != "":
-					state.StorageAccountConnectionString = connectionString
-				case strings.Contains(connectionString, "AccountName=") && strings.Contains(connectionString, "AccountKey="):
-					for _, part := range strings.Split(connectionString, ";") {
-						if strings.HasPrefix(part, "AccountName") {
-							accountNameParts := strings.Split(part, "AccountName=")
-							if len(accountNameParts) > 1 {
-								state.StorageAccountName = accountNameParts[1]
-							}
-						}
-						if strings.HasPrefix(part, "AccountKey") {
-							accountKeyParts := strings.Split(part, "AccountKey=")
-							if len(accountKeyParts) > 1 {
-								state.StorageAccountAccessKey = accountKeyParts[1]
-							}
-						}
-					}
-				default:
-					state.StorageAccountConnectionString = connectionString
+				if strings.HasPrefix(connectionString, "@Microsoft.KeyVault") {
+					state.StorageKeyVaultSecretID = strings.TrimPrefix(strings.TrimSuffix(connectionString, ")"), "@Microsoft.KeyVault(SecretUri=")
+				} else {
+					state.StorageAccountName, state.StorageAccountAccessKey = helpers.ParseWebJobsStorageString(connectionString)
 				}
 
 				if v, ok := appSettings[functionVersionAppSettingName]; ok {
@@ -849,7 +829,7 @@ func (r LogicAppResource) Update() sdk.ResourceFunc {
 			}
 			existingSiteConfig.AppSettings = pointer.To(currentAppSettings)
 
-			if metadata.ResourceData.HasChanges("site_config", "app_settings", "version", "storage_account_name", "storage_account_access_key") {
+			if metadata.ResourceData.HasChanges("site_config", "app_settings", "version", "storage_account_name", "storage_account_access_key", "storage_key_vault_secret_id") {
 				existingSiteConfig, err = expandLogicAppStandardSiteConfigForUpdate(data.SiteConfig, metadata, existingSiteConfig)
 				if err != nil {
 					return fmt.Errorf("expanding site_config update for %s: %v", *id, err)
@@ -989,15 +969,10 @@ func getBasicLogicAppSettings(d LogicAppResourceModel, endpointSuffix string) ([
 	appKindPropValue := "workflowApp"
 
 	var storageConnection string
-	if d.StorageAccountConnectionString != "" {
-		storageConnection = d.StorageAccountConnectionString
+	if d.StorageKeyVaultSecretID != "" {
+		storageConnection = fmt.Sprintf(helpers.StorageStringFmtKV, d.StorageKeyVaultSecretID)
 	} else {
-		storageConnection = fmt.Sprintf(
-			"DefaultEndpointsProtocol=https;AccountName=%s;AccountKey=%s;EndpointSuffix=%s",
-			d.StorageAccountName,
-			d.StorageAccountAccessKey,
-			endpointSuffix,
-		)
+		storageConnection = fmt.Sprintf(helpers.StorageStringFmt, d.StorageAccountName, d.StorageAccountAccessKey, endpointSuffix)
 	}
 
 	functionVersion := d.Version
@@ -1308,7 +1283,7 @@ func expandLogicAppStandardSiteConfigForUpdate(d []helpers.LogicAppSiteConfig, m
 		siteConfig.PublicNetworkAccess = pointer.To(reconcilePNA(metadata))
 	}
 
-	if metadata.ResourceData.HasChanges("app_settings", "storage_account_name", "storage_account_share_name", "storage_account_access_key", "version") {
+	if metadata.ResourceData.HasChanges("app_settings", "storage_account_name", "storage_account_share_name", "storage_account_access_key", "version", "storage_key_vault_secret_id") {
 		o, n := metadata.ResourceData.GetChange("app_settings")
 
 		appSettings := make([]webapps.NameValuePair, 0)
@@ -1359,26 +1334,18 @@ func mergeAppSettings(existing []webapps.NameValuePair, old, new map[string]inte
 	oMap := f(old)
 	cMap := f(new)
 
-	if metadata.ResourceData.HasChange("storage_account_connection_string") {
-		connString := metadata.ResourceData.Get("storage_account_connection_string").(string)
-		if connString != "" {
-			eMap[storageAppSettingName] = connString
-			eMap[contentFileConnStringAppSettingName] = connString
-		} else if metadata.ResourceData.HasChanges("storage_account_name", "storage_account_access_key") {
-			accountName := metadata.ResourceData.Get("storage_account_name").(string)
-			accountAccessKey := metadata.ResourceData.Get("storage_account_access_key").(string)
-			suffix, _ := metadata.Client.Account.Environment.Storage.DomainSuffix()
-
-			eMap[storageAppSettingName] = fmt.Sprintf(storageConnectionStringFmt, accountName, accountAccessKey, *suffix)
-			eMap[contentFileConnStringAppSettingName] = fmt.Sprintf(storageConnectionStringFmt, accountName, accountAccessKey, *suffix)
-		}
+	if metadata.ResourceData.HasChange("storage_key_vault_secret_id") && metadata.ResourceData.Get("storage_key_vault_secret_id").(string) != "" {
+		kvRef := fmt.Sprintf(helpers.StorageStringFmtKV, metadata.ResourceData.Get("storage_key_vault_secret_id").(string))
+		eMap[storageAppSettingName] = kvRef
+		eMap[contentFileConnStringAppSettingName] = kvRef
 	} else if metadata.ResourceData.HasChanges("storage_account_name", "storage_account_access_key") {
 		accountName := metadata.ResourceData.Get("storage_account_name").(string)
 		accountAccessKey := metadata.ResourceData.Get("storage_account_access_key").(string)
 		suffix, _ := metadata.Client.Account.Environment.Storage.DomainSuffix()
 
-		eMap[storageAppSettingName] = fmt.Sprintf(storageConnectionStringFmt, accountName, accountAccessKey, *suffix)
-		eMap[contentFileConnStringAppSettingName] = fmt.Sprintf(storageConnectionStringFmt, accountName, accountAccessKey, *suffix)
+		conn := fmt.Sprintf(helpers.StorageStringFmt, accountName, accountAccessKey, *suffix)
+		eMap[storageAppSettingName] = conn
+		eMap[contentFileConnStringAppSettingName] = conn
 	}
 
 	if metadata.ResourceData.HasChange("storage_account_share_name") {

--- a/internal/services/logic/logic_app_standard_resource_test.go
+++ b/internal/services/logic/logic_app_standard_resource_test.go
@@ -2648,29 +2648,29 @@ resource "azurerm_logic_app_standard" "test" {
 `, r.template(data), data.RandomInteger)
 }
 
-func TestAccLogicAppStandard_storageKeyVaultSecret(t *testing.T) {
+func TestAccLogicAppStandard_storageAccountConnectionString(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_logic_app_standard", "test")
 	r := LogicAppStandardResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.storageKeyVaultSecret(data),
+			Config: r.storageAccountConnectionString(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("storage_key_vault_secret_id").IsNotEmpty(),
+				check.That(data.ResourceName).Key("storage_account_connection_string").IsNotEmpty(),
 			),
 		},
 		data.ImportStep(),
 	})
 }
 
-func TestAccLogicAppStandard_storageKeyVaultSecretUpdate(t *testing.T) {
+func TestAccLogicAppStandard_storageAccountConnectionStringUpdate(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_logic_app_standard", "test")
 	r := LogicAppStandardResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.storageKeyVaultSecretNameKey(data),
+			Config: r.storageAccountConnectionStringNameKey(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("storage_account_name").IsNotEmpty(),
@@ -2678,15 +2678,15 @@ func TestAccLogicAppStandard_storageKeyVaultSecretUpdate(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			Config: r.storageKeyVaultSecret(data),
+			Config: r.storageAccountConnectionString(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("storage_key_vault_secret_id").IsNotEmpty(),
+				check.That(data.ResourceName).Key("storage_account_connection_string").IsNotEmpty(),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config: r.storageKeyVaultSecretNameKey(data),
+			Config: r.storageAccountConnectionStringNameKey(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("storage_account_name").IsNotEmpty(),
@@ -2696,7 +2696,7 @@ func TestAccLogicAppStandard_storageKeyVaultSecretUpdate(t *testing.T) {
 	})
 }
 
-func (r LogicAppStandardResource) storageKeyVaultSecretNameKey(data acceptance.TestData) string {
+func (r LogicAppStandardResource) storageAccountConnectionStringNameKey(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {
@@ -2791,7 +2791,7 @@ resource "azurerm_logic_app_standard" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }
 
-func (r LogicAppStandardResource) storageKeyVaultSecret(data acceptance.TestData) string {
+func (r LogicAppStandardResource) storageAccountConnectionString(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {
@@ -2880,7 +2880,7 @@ resource "azurerm_logic_app_standard" "test" {
   location                   = azurerm_resource_group.test.location
   resource_group_name        = azurerm_resource_group.test.name
   app_service_plan_id        = azurerm_service_plan.test.id
-  storage_key_vault_secret_id = azurerm_key_vault_secret.test.versionless_id
+  storage_account_connection_string = "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault_secret.test.versionless_id})"
 
   key_vault_reference_identity_id = azurerm_user_assigned_identity.test.id
 

--- a/internal/services/logic/logic_app_standard_resource_test.go
+++ b/internal/services/logic/logic_app_standard_resource_test.go
@@ -1171,6 +1171,54 @@ func TestAccLogicAppStandard_keyVaultReferenceIdentity(t *testing.T) {
 	})
 }
 
+func TestAccLogicAppStandard_storageAccountConnectionString(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_logic_app_standard", "test")
+	r := LogicAppStandardResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.storageAccountConnectionString(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("storage_account_connection_string").IsNotEmpty(),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccLogicAppStandard_storageAccountConnectionStringUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_logic_app_standard", "test")
+	r := LogicAppStandardResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.storageAccountConnectionStringNameKey(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("storage_account_name").IsNotEmpty(),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.storageAccountConnectionString(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("storage_account_connection_string").IsNotEmpty(),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.storageAccountConnectionStringNameKey(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("storage_account_name").IsNotEmpty(),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (r LogicAppStandardResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := commonids.ParseLogicAppId(state.ID)
 	if err != nil {
@@ -2648,54 +2696,6 @@ resource "azurerm_logic_app_standard" "test" {
 `, r.template(data), data.RandomInteger)
 }
 
-func TestAccLogicAppStandard_storageAccountConnectionString(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_logic_app_standard", "test")
-	r := LogicAppStandardResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.storageAccountConnectionString(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("storage_account_connection_string").IsNotEmpty(),
-			),
-		},
-		data.ImportStep(),
-	})
-}
-
-func TestAccLogicAppStandard_storageAccountConnectionStringUpdate(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_logic_app_standard", "test")
-	r := LogicAppStandardResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.storageAccountConnectionStringNameKey(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("storage_account_name").IsNotEmpty(),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.storageAccountConnectionString(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("storage_account_connection_string").IsNotEmpty(),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.storageAccountConnectionStringNameKey(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("storage_account_name").IsNotEmpty(),
-			),
-		},
-		data.ImportStep(),
-	})
-}
-
 func (r LogicAppStandardResource) storageAccountConnectionStringNameKey(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -2876,10 +2876,10 @@ resource "azurerm_key_vault_secret" "test" {
 }
 
 resource "azurerm_logic_app_standard" "test" {
-  name                       = "acctest-%[1]d-func"
-  location                   = azurerm_resource_group.test.location
-  resource_group_name        = azurerm_resource_group.test.name
-  app_service_plan_id        = azurerm_service_plan.test.id
+  name                              = "acctest-%[1]d-func"
+  location                          = azurerm_resource_group.test.location
+  resource_group_name               = azurerm_resource_group.test.name
+  app_service_plan_id               = azurerm_service_plan.test.id
   storage_account_connection_string = "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault_secret.test.versionless_id})"
 
   key_vault_reference_identity_id = azurerm_user_assigned_identity.test.id

--- a/internal/services/logic/logic_app_standard_resource_test.go
+++ b/internal/services/logic/logic_app_standard_resource_test.go
@@ -2647,3 +2647,144 @@ resource "azurerm_logic_app_standard" "test" {
 }
 `, r.template(data), data.RandomInteger)
 }
+
+func TestAccLogicAppStandard_storageKeyVaultSecret(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_logic_app_standard", "test")
+	r := LogicAppStandardResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.storageKeyVaultSecret(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("storage_key_vault_secret_id").IsNotEmpty(),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccLogicAppStandard_storageKeyVaultSecretUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_logic_app_standard", "test")
+	r := LogicAppStandardResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("storage_account_name").IsNotEmpty(),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.storageKeyVaultSecret(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("storage_key_vault_secret_id").IsNotEmpty(),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (r LogicAppStandardResource) storageKeyVaultSecret(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy    = true
+      recover_soft_deleted_key_vaults = true
+    }
+  }
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctestsa%[3]s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_service_plan" "test" {
+  name                = "acctestASP-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  os_type  = "Windows"
+  sku_name = "WS1"
+}
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acctest-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_key_vault" "test" {
+  name                       = "acctestkv-%[3]s"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "standard"
+  soft_delete_retention_days = 7
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+
+    key_permissions = [
+      "Get",
+    ]
+
+    secret_permissions = [
+      "Get",
+      "Delete",
+      "List",
+      "Purge",
+      "Recover",
+      "Set",
+    ]
+  }
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = azurerm_user_assigned_identity.test.principal_id
+
+    secret_permissions = [
+      "Get",
+      "List",
+    ]
+  }
+}
+
+resource "azurerm_key_vault_secret" "test" {
+  name         = "secret-%[3]s"
+  value        = "DefaultEndpointsProtocol=https;AccountName=${azurerm_storage_account.test.name};AccountKey=${azurerm_storage_account.test.primary_access_key};EndpointSuffix=core.windows.net"
+  key_vault_id = azurerm_key_vault.test.id
+}
+
+resource "azurerm_logic_app_standard" "test" {
+  name                       = "acctest-%[1]d-func"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  app_service_plan_id        = azurerm_service_plan.test.id
+  storage_key_vault_secret_id = azurerm_key_vault_secret.test.versionless_id
+
+  key_vault_reference_identity_id = azurerm_user_assigned_identity.test.id
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.test.id]
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}

--- a/internal/services/logic/logic_app_standard_resource_test.go
+++ b/internal/services/logic/logic_app_standard_resource_test.go
@@ -2670,7 +2670,7 @@ func TestAccLogicAppStandard_storageKeyVaultSecretUpdate(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.basic(data),
+			Config: r.storageKeyVaultSecretNameKey(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("storage_account_name").IsNotEmpty(),
@@ -2685,7 +2685,110 @@ func TestAccLogicAppStandard_storageKeyVaultSecretUpdate(t *testing.T) {
 			),
 		},
 		data.ImportStep(),
+		{
+			Config: r.storageKeyVaultSecretNameKey(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("storage_account_name").IsNotEmpty(),
+			),
+		},
+		data.ImportStep(),
 	})
+}
+
+func (r LogicAppStandardResource) storageKeyVaultSecretNameKey(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy    = true
+      recover_soft_deleted_key_vaults = true
+    }
+  }
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctestsa%[3]s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_service_plan" "test" {
+  name                = "acctestASP-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  os_type  = "Windows"
+  sku_name = "WS1"
+}
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acctest-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_key_vault" "test" {
+  name                       = "acctestkv-%[3]s"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "standard"
+  soft_delete_retention_days = 7
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+
+    key_permissions = [
+      "Get",
+    ]
+
+    secret_permissions = [
+      "Get",
+      "Delete",
+      "List",
+      "Purge",
+      "Recover",
+      "Set",
+    ]
+  }
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = azurerm_user_assigned_identity.test.principal_id
+
+    secret_permissions = [
+      "Get",
+      "List",
+    ]
+  }
+}
+
+resource "azurerm_key_vault_secret" "test" {
+  name         = "secret-%[3]s"
+  value        = "DefaultEndpointsProtocol=https;AccountName=${azurerm_storage_account.test.name};AccountKey=${azurerm_storage_account.test.primary_access_key};EndpointSuffix=core.windows.net"
+  key_vault_id = azurerm_key_vault.test.id
+}
+
+resource "azurerm_logic_app_standard" "test" {
+  name                       = "acctest-%[1]d-func"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  app_service_plan_id        = azurerm_service_plan.test.id
+  storage_account_name       = azurerm_storage_account.test.name
+  storage_account_access_key = azurerm_storage_account.test.primary_access_key
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }
 
 func (r LogicAppStandardResource) storageKeyVaultSecret(data acceptance.TestData) string {

--- a/internal/services/logic/logic_app_standard_resource_test.go
+++ b/internal/services/logic/logic_app_standard_resource_test.go
@@ -1171,29 +1171,29 @@ func TestAccLogicAppStandard_keyVaultReferenceIdentity(t *testing.T) {
 	})
 }
 
-func TestAccLogicAppStandard_storageAccountConnectionString(t *testing.T) {
+func TestAccLogicAppStandard_storageKeyVaultSecret(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_logic_app_standard", "test")
 	r := LogicAppStandardResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.storageAccountConnectionString(data),
+			Config: r.storageKeyVaultSecret(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("storage_account_connection_string").IsNotEmpty(),
+				check.That(data.ResourceName).Key("storage_key_vault_secret_id").IsNotEmpty(),
 			),
 		},
 		data.ImportStep(),
 	})
 }
 
-func TestAccLogicAppStandard_storageAccountConnectionStringUpdate(t *testing.T) {
+func TestAccLogicAppStandard_storageKeyVaultSecretUpdate(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_logic_app_standard", "test")
 	r := LogicAppStandardResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.storageAccountConnectionStringNameKey(data),
+			Config: r.storageKeyVaultSecretNameKey(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("storage_account_name").IsNotEmpty(),
@@ -1201,15 +1201,25 @@ func TestAccLogicAppStandard_storageAccountConnectionStringUpdate(t *testing.T) 
 		},
 		data.ImportStep(),
 		{
-			Config: r.storageAccountConnectionString(data),
+			Config: r.storageKeyVaultSecret(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("storage_account_connection_string").IsNotEmpty(),
+				check.That(data.ResourceName).Key("storage_key_vault_secret_id").IsNotEmpty(),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config: r.storageAccountConnectionStringNameKey(data),
+			// Change only storage_key_vault_secret_id (name/key stay empty) to ensure the
+			// AzureWebJobsStorage app setting is updated in-place on a secret-only change.
+			Config: r.storageKeyVaultSecretSecond(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("storage_key_vault_secret_id").IsNotEmpty(),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.storageKeyVaultSecretNameKey(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("storage_account_name").IsNotEmpty(),
@@ -2696,7 +2706,7 @@ resource "azurerm_logic_app_standard" "test" {
 `, r.template(data), data.RandomInteger)
 }
 
-func (r LogicAppStandardResource) storageAccountConnectionStringNameKey(data acceptance.TestData) string {
+func (r LogicAppStandardResource) storageKeyVaultSecretNameKey(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {
@@ -2791,7 +2801,7 @@ resource "azurerm_logic_app_standard" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }
 
-func (r LogicAppStandardResource) storageAccountConnectionString(data acceptance.TestData) string {
+func (r LogicAppStandardResource) storageKeyVaultSecretTemplate(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {
@@ -2875,12 +2885,24 @@ resource "azurerm_key_vault_secret" "test" {
   key_vault_id = azurerm_key_vault.test.id
 }
 
+resource "azurerm_key_vault_secret" "test2" {
+  name         = "secret2-%[3]s"
+  value        = "DefaultEndpointsProtocol=https;AccountName=${azurerm_storage_account.test.name};AccountKey=${azurerm_storage_account.test.primary_access_key};EndpointSuffix=core.windows.net"
+  key_vault_id = azurerm_key_vault.test.id
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}
+
+func (r LogicAppStandardResource) storageKeyVaultSecret(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
 resource "azurerm_logic_app_standard" "test" {
-  name                              = "acctest-%[1]d-func"
-  location                          = azurerm_resource_group.test.location
-  resource_group_name               = azurerm_resource_group.test.name
-  app_service_plan_id               = azurerm_service_plan.test.id
-  storage_account_connection_string = "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault_secret.test.versionless_id})"
+  name                        = "acctest-%[2]d-func"
+  location                    = azurerm_resource_group.test.location
+  resource_group_name         = azurerm_resource_group.test.name
+  app_service_plan_id         = azurerm_service_plan.test.id
+  storage_key_vault_secret_id = azurerm_key_vault_secret.test.versionless_id
 
   key_vault_reference_identity_id = azurerm_user_assigned_identity.test.id
 
@@ -2889,5 +2911,26 @@ resource "azurerm_logic_app_standard" "test" {
     identity_ids = [azurerm_user_assigned_identity.test.id]
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+`, r.storageKeyVaultSecretTemplate(data), data.RandomInteger)
+}
+
+func (r LogicAppStandardResource) storageKeyVaultSecretSecond(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_logic_app_standard" "test" {
+  name                        = "acctest-%[2]d-func"
+  location                    = azurerm_resource_group.test.location
+  resource_group_name         = azurerm_resource_group.test.name
+  app_service_plan_id         = azurerm_service_plan.test.id
+  storage_key_vault_secret_id = azurerm_key_vault_secret.test2.versionless_id
+
+  key_vault_reference_identity_id = azurerm_user_assigned_identity.test.id
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.test.id]
+  }
+}
+`, r.storageKeyVaultSecretTemplate(data), data.RandomInteger)
 }

--- a/website/docs/d/logic_app_standard.html.markdown
+++ b/website/docs/d/logic_app_standard.html.markdown
@@ -83,6 +83,8 @@ The following attributes are exported:
 
 * `storage_account_access_key` - The access key which will be used to access the backend storage account for the Logic App.
 
+* `storage_key_vault_secret_id` - The Key Vault Secret ID, optionally including version, that contains the connection string to the backend storage account for the Logic App.
+
 * `storage_account_share_name` - The name of the share used by the logic app.
 
 * `tags` - A mapping of tags assigned to the resource.

--- a/website/docs/r/logic_app_standard.html.markdown
+++ b/website/docs/r/logic_app_standard.html.markdown
@@ -108,15 +108,19 @@ The following arguments are supported:
 
 * `app_service_plan_id` - (Required) The ID of the App Service Plan within which to create this Logic App.
 
-* `storage_account_name` - (Required) The backend storage account name which will be used by this Logic App (e.g. for Stateful workflows data). Changing this forces a new resource to be created.
+* `storage_account_name` - (Optional) The backend storage account name which will be used by this Logic App (e.g. for Stateful workflows data). Exactly one of `storage_account_name` or `storage_key_vault_secret_id` must be specified.
 
-* `storage_account_access_key` - (Required) The access key which will be used to access the backend storage account for the Logic App.
+* `storage_account_access_key` - (Optional) The access key which will be used to access the backend storage account for the Logic App. Required when `storage_account_name` is specified. Conflicts with `storage_key_vault_secret_id`.
+
+* `storage_key_vault_secret_id` - (Optional) The Key Vault Secret ID, including version, that contains the Connection String to connect to the storage account for this Logic App. Exactly one of `storage_account_name` or `storage_key_vault_secret_id` must be specified.
+
+~> **Note:** When using `storage_key_vault_secret_id`, a `key_vault_reference_identity_id` must be set and the corresponding identity must have `Get` and `List` secret permissions on the Key Vault.
 
 ---
 
 * `app_settings` - (Optional) A map of key-value pairs for [App Settings](https://docs.microsoft.com/azure/azure-functions/functions-app-settings) and custom values.
 
-~> **Note:** There are a number of application settings that will be managed for you by this resource type and *shouldn't* be configured separately as part of the app_settings you specify.  `AzureWebJobsStorage` is filled based on `storage_account_name` and `storage_account_access_key`. `WEBSITE_CONTENTSHARE` is detailed below. `FUNCTIONS_EXTENSION_VERSION` is filled based on `version`. `APP_KIND` is set to workflowApp and `AzureFunctionsJobHost__extensionBundle__id` and `AzureFunctionsJobHost__extensionBundle__version` are set as detailed below.
+~> **Note:** There are a number of application settings that will be managed for you by this resource type and *shouldn't* be configured separately as part of the app_settings you specify.  `AzureWebJobsStorage` is filled based on `storage_account_name` and `storage_account_access_key`, or from `storage_key_vault_secret_id` when using a Key Vault reference. `WEBSITE_CONTENTSHARE` is detailed below. `FUNCTIONS_EXTENSION_VERSION` is filled based on `version`. `APP_KIND` is set to workflowApp and `AzureFunctionsJobHost__extensionBundle__id` and `AzureFunctionsJobHost__extensionBundle__version` are set as detailed below.
 
 * `use_extension_bundle` - (Optional) Should the logic app use the bundled extension package? If true, then application settings for `AzureFunctionsJobHost__extensionBundle__id` and `AzureFunctionsJobHost__extensionBundle__version` will be created. Defaults to `true`.
 

--- a/website/docs/r/logic_app_standard.html.markdown
+++ b/website/docs/r/logic_app_standard.html.markdown
@@ -108,19 +108,19 @@ The following arguments are supported:
 
 * `app_service_plan_id` - (Required) The ID of the App Service Plan within which to create this Logic App.
 
-* `storage_account_name` - (Optional) The backend storage account name which will be used by this Logic App (e.g. for Stateful workflows data). Exactly one of `storage_account_name` or `storage_key_vault_secret_id` must be specified.
+* `storage_account_name` - (Optional) The backend storage account name which will be used by this Logic App (e.g. for Stateful workflows data). Exactly one of `storage_account_name` or `storage_account_connection_string` must be specified.
 
-* `storage_account_access_key` - (Optional) The access key which will be used to access the backend storage account for the Logic App. Required when `storage_account_name` is specified. Conflicts with `storage_key_vault_secret_id`.
+* `storage_account_access_key` - (Optional) The access key which will be used to access the backend storage account for the Logic App. Required when `storage_account_name` is specified. Conflicts with `storage_account_connection_string`.
 
-* `storage_key_vault_secret_id` - (Optional) The Key Vault Secret ID, including version, that contains the Connection String to connect to the storage account for this Logic App. Exactly one of `storage_account_name` or `storage_key_vault_secret_id` must be specified.
+* `storage_account_connection_string` - (Optional) The connection string for the backend storage account which will be used by this Logic App (e.g. for Stateful workflows data). This can be a plain connection string or a Key Vault reference (e.g. `@Microsoft.KeyVault(SecretUri=https://myvault.vault.azure.net/secrets/mysecret)`). Exactly one of `storage_account_name` or `storage_account_connection_string` must be specified.
 
-~> **Note:** When using `storage_key_vault_secret_id`, a `key_vault_reference_identity_id` must be set and the corresponding identity must have `Get` and `List` secret permissions on the Key Vault.
+~> **Note:** When using a Key Vault reference in `storage_account_connection_string`, a `key_vault_reference_identity_id` must be set and the corresponding identity must have `Get` and `List` secret permissions on the Key Vault.
 
 ---
 
 * `app_settings` - (Optional) A map of key-value pairs for [App Settings](https://docs.microsoft.com/azure/azure-functions/functions-app-settings) and custom values.
 
-~> **Note:** There are a number of application settings that will be managed for you by this resource type and *shouldn't* be configured separately as part of the app_settings you specify.  `AzureWebJobsStorage` is filled based on `storage_account_name` and `storage_account_access_key`, or from `storage_key_vault_secret_id` when using a Key Vault reference. `WEBSITE_CONTENTSHARE` is detailed below. `FUNCTIONS_EXTENSION_VERSION` is filled based on `version`. `APP_KIND` is set to workflowApp and `AzureFunctionsJobHost__extensionBundle__id` and `AzureFunctionsJobHost__extensionBundle__version` are set as detailed below.
+~> **Note:** There are a number of application settings that will be managed for you by this resource type and *shouldn't* be configured separately as part of the app_settings you specify.  `AzureWebJobsStorage` is filled based on `storage_account_name` and `storage_account_access_key`, or from `storage_account_connection_string` when specified directly. `WEBSITE_CONTENTSHARE` is detailed below. `FUNCTIONS_EXTENSION_VERSION` is filled based on `version`. `APP_KIND` is set to workflowApp and `AzureFunctionsJobHost__extensionBundle__id` and `AzureFunctionsJobHost__extensionBundle__version` are set as detailed below.
 
 * `use_extension_bundle` - (Optional) Should the logic app use the bundled extension package? If true, then application settings for `AzureFunctionsJobHost__extensionBundle__id` and `AzureFunctionsJobHost__extensionBundle__version` will be created. Defaults to `true`.
 

--- a/website/docs/r/logic_app_standard.html.markdown
+++ b/website/docs/r/logic_app_standard.html.markdown
@@ -108,19 +108,21 @@ The following arguments are supported:
 
 * `app_service_plan_id` - (Required) The ID of the App Service Plan within which to create this Logic App.
 
-* `storage_account_name` - (Optional) The backend storage account name which will be used by this Logic App (e.g. for Stateful workflows data). Exactly one of `storage_account_name` or `storage_account_connection_string` must be specified.
+* `storage_account_name` - (Optional) The backend storage account name which will be used by this Logic App (e.g. for Stateful workflows data). Exactly one of `storage_account_name` or `storage_key_vault_secret_id` must be specified.
 
-* `storage_account_access_key` - (Optional) The access key which will be used to access the backend storage account for the Logic App. Required when `storage_account_name` is specified. Conflicts with `storage_account_connection_string`.
+* `storage_account_access_key` - (Optional) The access key which will be used to access the backend storage account for the Logic App. Required when `storage_account_name` is specified. Conflicts with `storage_key_vault_secret_id`.
 
-* `storage_account_connection_string` - (Optional) The connection string for the backend storage account which will be used by this Logic App (e.g. for Stateful workflows data). This can be a plain connection string or a Key Vault reference (e.g. `@Microsoft.KeyVault(SecretUri=https://myvault.vault.azure.net/secrets/mysecret)`). Exactly one of `storage_account_name` or `storage_account_connection_string` must be specified.
+* `storage_key_vault_secret_id` - (Optional) The Key Vault Secret ID, optionally including version, that contains the connection string to the backend storage account for the Logic App. Exactly one of `storage_account_name` or `storage_key_vault_secret_id` must be specified.
 
-~> **Note:** When using a Key Vault reference in `storage_account_connection_string`, a `key_vault_reference_identity_id` must be set and the corresponding identity must have `Get` and `List` secret permissions on the Key Vault.
+~> **Note:** When using `storage_key_vault_secret_id`, a `key_vault_reference_identity_id` must be set and the corresponding identity must have `Get` and `List` secret permissions on the Key Vault.
+
+~> **Note:** `storage_key_vault_secret_id` used without a version will use the latest version of the secret, however, the service can take up to 24h to pick up a rotation of the latest version. See the [official docs](https://docs.microsoft.com/azure/app-service/app-service-key-vault-references#rotation) for more information.
 
 ---
 
 * `app_settings` - (Optional) A map of key-value pairs for [App Settings](https://docs.microsoft.com/azure/azure-functions/functions-app-settings) and custom values.
 
-~> **Note:** There are a number of application settings that will be managed for you by this resource type and *shouldn't* be configured separately as part of the app_settings you specify.  `AzureWebJobsStorage` is filled based on `storage_account_name` and `storage_account_access_key`, or from `storage_account_connection_string` when specified directly. `WEBSITE_CONTENTSHARE` is detailed below. `FUNCTIONS_EXTENSION_VERSION` is filled based on `version`. `APP_KIND` is set to workflowApp and `AzureFunctionsJobHost__extensionBundle__id` and `AzureFunctionsJobHost__extensionBundle__version` are set as detailed below.
+~> **Note:** There are a number of application settings that will be managed for you by this resource type and *shouldn't* be configured separately as part of the app_settings you specify.  `AzureWebJobsStorage` is filled based on `storage_account_name` and `storage_account_access_key`, or from `storage_key_vault_secret_id` when using a Key Vault reference. `WEBSITE_CONTENTSHARE` is detailed below. `FUNCTIONS_EXTENSION_VERSION` is filled based on `version`. `APP_KIND` is set to workflowApp and `AzureFunctionsJobHost__extensionBundle__id` and `AzureFunctionsJobHost__extensionBundle__version` are set as detailed below.
 
 * `use_extension_bundle` - (Optional) Should the logic app use the bundled extension package? If true, then application settings for `AzureFunctionsJobHost__extensionBundle__id` and `AzureFunctionsJobHost__extensionBundle__version` will be created. Defaults to `true`.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->
Closes #30750

This PR adds a `storage_account_connection_string` attribute to the `azurerm_logic_app_standard` resource, allowing users to specify a raw connection string value (including Key Vault references) for AzureWebJobsStorage instead of the existing `storage_account_name` + `storage_account_access_key` pair.

- Added `storage_account_connection_string` (Optional, Sensitive) - accepts any valid AzureWebJobsStorage value (Key Vault reference, raw connection string, etc.)
- Changed `storage_account_name` and `storage_account_access_key` from Required to Optional with `ExactlyOneOf` / `RequiredWith` / `ConflictsWith` constraints
- Removed `ForceNew` from `storage_account_name` to allow in-place transitions between storage modes
- Updated Read logic to use current state to determine which attribute to populate (prevents perpetual diff)
- Updated `mergeAppSettings` to handle bidirectional transitions (name/key → connection string and back)

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_LOGIC/700888?buildTab=tests

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_logic_app_standard` - support for the `storage_account_connection_string` property [GH-30750]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #30684 
Fixes #30750


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
