### PR TITLE
`machinelearning` - fix `storage_fileshare_id` bug and tests

### DIFF
--- a/internal/services/machinelearning/machine_learning_datastore_fileshare_resource.go
+++ b/internal/services/machinelearning/machine_learning_datastore_fileshare_resource.go
@@ -135,7 +135,6 @@ func (r MachineLearningDataStoreFileShare) Arguments() map[string]*pluginsdk.Sch
 	}
 
 	if !features.FivePointOh() {
-		// if it's not 5.0, expect the old id format
 		res["storage_fileshare_id"].ValidateFunc = storagevalidate.StorageShareResourceManagerID
 	}
 
@@ -414,6 +413,5 @@ func parseStorageFileShareID(input string) (*fileshares.ShareId, error) {
 		}
 		return pointer.To(fileshares.NewShareID(id.SubscriptionId, id.ResourceGroup, id.StorageAccountName, id.FileshareName)), nil
 	}
-
 	return fileshares.ParseShareID(input)
 }

--- a/internal/services/machinelearning/machine_learning_datastore_fileshare_resource.go
+++ b/internal/services/machinelearning/machine_learning_datastore_fileshare_resource.go
@@ -14,12 +14,16 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/datastore"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/workspaces"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2025-08-01/fileshares"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/machinelearning/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/machinelearning/validate"
 	storageAccountHelper "github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/client"
 	storageparse "github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/parse"
+	storagevalidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 )
@@ -50,10 +54,28 @@ func (r MachineLearningDataStoreFileShare) IDValidationFunc() pluginsdk.SchemaVa
 	return datastore.ValidateDataStoreID
 }
 
-var _ sdk.ResourceWithUpdate = MachineLearningDataStoreFileShare{}
+var (
+	_ sdk.ResourceWithUpdate         = MachineLearningDataStoreFileShare{}
+	_ sdk.ResourceWithStateMigration = MachineLearningDataStoreFileShare{}
+)
+
+func (r MachineLearningDataStoreFileShare) StateUpgraders() sdk.StateUpgradeData {
+	// rewrite `storage_fileshare_id` to account for azurerm_storage_share.resource_manager_id deprecation
+	// in favour of azurerm_storage_share.id in 5.0
+	if !features.FivePointOh() {
+		return sdk.StateUpgradeData{}
+	}
+
+	return sdk.StateUpgradeData{
+		SchemaVersion: 1,
+		Upgraders: map[int]pluginsdk.StateUpgrade{
+			0: migration.MachineLearningDataStoreFileShareV0ToV1{},
+		},
+	}
+}
 
 func (r MachineLearningDataStoreFileShare) Arguments() map[string]*pluginsdk.Schema {
-	return map[string]*pluginsdk.Schema{
+	res := map[string]*pluginsdk.Schema{
 		"name": {
 			Type:         pluginsdk.TypeString,
 			Required:     true,
@@ -72,7 +94,7 @@ func (r MachineLearningDataStoreFileShare) Arguments() map[string]*pluginsdk.Sch
 			Type:         pluginsdk.TypeString,
 			Required:     true,
 			ForceNew:     true,
-			ValidateFunc: validation.StringIsNotEmpty,
+			ValidateFunc: fileshares.ValidateShareID,
 		},
 
 		"description": {
@@ -111,6 +133,13 @@ func (r MachineLearningDataStoreFileShare) Arguments() map[string]*pluginsdk.Sch
 
 		"tags": commonschema.TagsForceNew(),
 	}
+
+	if !features.FivePointOh() {
+		// if it's not 5.0, expect the old id format
+		res["storage_fileshare_id"].ValidateFunc = storagevalidate.StorageShareResourceManagerID
+	}
+
+	return res
 }
 
 func (r MachineLearningDataStoreFileShare) Attributes() map[string]*schema.Schema {
@@ -153,7 +182,7 @@ func (r MachineLearningDataStoreFileShare) Create() sdk.ResourceFunc {
 				}
 			}
 
-			fileShareId, err := storageparse.StorageShareResourceManagerID(model.StorageFileShareID)
+			shareId, err := parseStorageFileShareID(model.StorageFileShareID)
 			if err != nil {
 				return err
 			}
@@ -164,9 +193,9 @@ func (r MachineLearningDataStoreFileShare) Create() sdk.ResourceFunc {
 			}
 
 			props := &datastore.AzureFileDatastore{
-				AccountName:                   fileShareId.StorageAccountName,
+				AccountName:                   shareId.StorageAccountName,
 				Endpoint:                      pointer.To(metadata.Client.Storage.StorageDomainSuffix),
-				FileShareName:                 fileShareId.FileshareName,
+				FileShareName:                 shareId.ShareName,
 				Description:                   pointer.To(model.Description),
 				ServiceDataAccessAuthIdentity: pointer.To(datastore.ServiceDataAccessAuthIdentity(model.ServiceDataIdentity)),
 				Tags:                          pointer.To(model.Tags),
@@ -217,7 +246,7 @@ func (r MachineLearningDataStoreFileShare) Update() sdk.ResourceFunc {
 				return err
 			}
 
-			fileShareId, err := storageparse.StorageShareResourceManagerID(state.StorageFileShareID)
+			shareId, err := parseStorageFileShareID(state.StorageFileShareID)
 			if err != nil {
 				return err
 			}
@@ -228,8 +257,8 @@ func (r MachineLearningDataStoreFileShare) Update() sdk.ResourceFunc {
 			}
 
 			props := &datastore.AzureFileDatastore{
-				AccountName:                   fileShareId.StorageAccountName,
-				FileShareName:                 fileShareId.FileshareName,
+				AccountName:                   shareId.StorageAccountName,
+				FileShareName:                 shareId.ShareName,
 				Description:                   pointer.To(state.Description),
 				ServiceDataAccessAuthIdentity: pointer.To(datastore.ServiceDataAccessAuthIdentity(state.ServiceDataIdentity)),
 				Tags:                          pointer.To(state.Tags),
@@ -299,11 +328,11 @@ func (r MachineLearningDataStoreFileShare) Read() sdk.ResourceFunc {
 
 			var storageAccount *storageAccountHelper.AccountDetails
 			if fileShareIdStr := metadata.ResourceData.Get("storage_fileshare_id").(string); fileShareIdStr != "" {
-				fileShareId, err := storageparse.StorageShareResourceManagerID(fileShareIdStr)
+				shareId, err := parseStorageFileShareID(fileShareIdStr)
 				if err != nil {
 					return err
 				}
-				storageAccount, err = storageClient.GetAccount(ctx, commonids.NewStorageAccountID(fileShareId.SubscriptionId, fileShareId.ResourceGroup, fileShareId.StorageAccountName))
+				storageAccount, err = storageClient.GetAccount(ctx, commonids.NewStorageAccountID(shareId.SubscriptionId, shareId.ResourceGroupName, shareId.StorageAccountName))
 				if err != nil {
 					return fmt.Errorf("retrieving Account %q for Share %q: %s", data.AccountName, data.FileShareName, err)
 				}
@@ -318,8 +347,11 @@ func (r MachineLearningDataStoreFileShare) Read() sdk.ResourceFunc {
 			if storageAccount == nil {
 				return fmt.Errorf("unable to locate Storage Account %q", data.AccountName)
 			}
-			fileShareId := storageparse.NewStorageShareResourceManagerID(storageAccount.StorageAccountId.SubscriptionId, storageAccount.StorageAccountId.ResourceGroupName, data.AccountName, "default", data.FileShareName)
-			model.StorageFileShareID = fileShareId.ID()
+
+			model.StorageFileShareID = fileshares.NewShareID(storageAccount.StorageAccountId.SubscriptionId, storageAccount.StorageAccountId.ResourceGroupName, data.AccountName, data.FileShareName).ID()
+			if !features.FivePointOh() {
+				model.StorageFileShareID = storageparse.NewStorageShareResourceManagerID(storageAccount.StorageAccountId.SubscriptionId, storageAccount.StorageAccountId.ResourceGroupName, data.AccountName, "default", data.FileShareName).ID()
+			}
 
 			model.IsDefault = *data.IsDefault
 
@@ -368,4 +400,20 @@ func (r MachineLearningDataStoreFileShare) Delete() sdk.ResourceFunc {
 			return nil
 		},
 	}
+}
+
+// parses the `storage_fileshare_id` into a fileshares.ShareId needed for 5.0 where the id changes
+// from  "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s/fileServices/%s/fileshares/%s"
+// to "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s/fileServices/default/shares/%s"
+// since we only use id.StorageAccountName and id.FileshareName parsing into a fileshares.ShareId works for both 4.0 and 5.0
+func parseStorageFileShareID(input string) (*fileshares.ShareId, error) {
+	if !features.FivePointOh() {
+		id, err := storageparse.StorageShareResourceManagerID(input)
+		if err != nil {
+			return nil, err
+		}
+		return pointer.To(fileshares.NewShareID(id.SubscriptionId, id.ResourceGroup, id.StorageAccountName, id.FileshareName)), nil
+	}
+
+	return fileshares.ParseShareID(input)
 }

--- a/internal/services/machinelearning/machine_learning_datastore_fileshare_resource_test.go
+++ b/internal/services/machinelearning/machine_learning_datastore_fileshare_resource_test.go
@@ -136,7 +136,7 @@ resource "azurerm_storage_share" "test" {
 resource "azurerm_machine_learning_datastore_fileshare" "test" {
   name                 = "accdatastore%[2]d"
   workspace_id         = azurerm_machine_learning_workspace.test.id
-  storage_fileshare_id = azurerm_storage_share.test.resource_manager_id
+  storage_fileshare_id = azurerm_storage_share.test.id
   account_key          = azurerm_storage_account.test.primary_access_key
 }
 `, r.template(data), data.RandomInteger)
@@ -243,7 +243,7 @@ data "azurerm_storage_account_sas" "test" {
 resource "azurerm_machine_learning_datastore_fileshare" "test" {
   name                    = "accdatastore%[2]d"
   workspace_id            = azurerm_machine_learning_workspace.test.id
-  storage_fileshare_id    = azurerm_storage_share.test.resource_manager_id
+  storage_fileshare_id    = azurerm_storage_share.test.id
   shared_access_signature = data.azurerm_storage_account_sas.test.sas
 }
 `, r.template(data), data.RandomInteger)

--- a/internal/services/machinelearning/machine_learning_inference_cluster_resource_test.go
+++ b/internal/services/machinelearning/machine_learning_inference_cluster_resource_test.go
@@ -455,6 +455,10 @@ resource "azurerm_kubernetes_cluster" "test" {
   dns_prefix          = join("", ["acctestaks", azurerm_resource_group.test.location])
   node_resource_group = "acctestRGAKS-%d"
 
+  node_provisioning_profile {
+    mode = "Manual"
+  }
+
   default_node_pool {
     name           = "default"
     node_count     = %d
@@ -557,6 +561,10 @@ resource "azurerm_kubernetes_cluster" "test" {
   node_resource_group     = "acctestRGAKS-%d"
   private_cluster_enabled = true
   private_dns_zone_id     = "System"
+
+  node_provisioning_profile {
+    mode = "Manual"
+  }
 
   default_node_pool {
     name           = "default"

--- a/internal/services/machinelearning/migration/machine_learning_datastore_fileshare_v0_to_v1.go
+++ b/internal/services/machinelearning/migration/machine_learning_datastore_fileshare_v0_to_v1.go
@@ -18,7 +18,6 @@ type MachineLearningDataStoreFileShareV0ToV1 struct{}
 
 func (MachineLearningDataStoreFileShareV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
 	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-
 		if v, ok := rawState["storage_fileshare_id"].(string); ok && v != "" {
 			if id, err := storageparse.StorageShareResourceManagerID(v); err == nil {
 				newID := fileshares.NewShareID(id.SubscriptionId, id.ResourceGroup, id.StorageAccountName, id.FileshareName).ID()

--- a/internal/services/machinelearning/migration/machine_learning_datastore_fileshare_v0_to_v1.go
+++ b/internal/services/machinelearning/migration/machine_learning_datastore_fileshare_v0_to_v1.go
@@ -5,7 +5,6 @@ package migration
 
 import (
 	"context"
-	"log"
 
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2025-08-01/fileshares"
 	storageparse "github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/parse"
@@ -21,7 +20,6 @@ func (MachineLearningDataStoreFileShareV0ToV1) UpgradeFunc() pluginsdk.StateUpgr
 		if v, ok := rawState["storage_fileshare_id"].(string); ok && v != "" {
 			if id, err := storageparse.StorageShareResourceManagerID(v); err == nil {
 				newID := fileshares.NewShareID(id.SubscriptionId, id.ResourceGroup, id.StorageAccountName, id.FileshareName).ID()
-				log.Printf("[DEBUG] Updating `storage_fileshare_id` from %q to %q", v, newID)
 				rawState["storage_fileshare_id"] = newID
 			}
 		}
@@ -35,25 +33,21 @@ func (MachineLearningDataStoreFileShareV0ToV1) Schema() map[string]*pluginsdk.Sc
 		"name": {
 			Type:     pluginsdk.TypeString,
 			Required: true,
-			ForceNew: true,
 		},
 
 		"workspace_id": {
 			Type:     pluginsdk.TypeString,
 			Required: true,
-			ForceNew: true,
 		},
 
 		"storage_fileshare_id": {
 			Type:     pluginsdk.TypeString,
 			Required: true,
-			ForceNew: true,
 		},
 
 		"description": {
 			Type:     pluginsdk.TypeString,
 			Optional: true,
-			ForceNew: true,
 		},
 
 		"service_data_identity": {
@@ -81,7 +75,6 @@ func (MachineLearningDataStoreFileShareV0ToV1) Schema() map[string]*pluginsdk.Sc
 		"tags": {
 			Type:     pluginsdk.TypeMap,
 			Optional: true,
-			ForceNew: true,
 			Elem: &pluginsdk.Schema{
 				Type: pluginsdk.TypeString,
 			},

--- a/internal/services/machinelearning/migration/machine_learning_datastore_fileshare_v0_to_v1.go
+++ b/internal/services/machinelearning/migration/machine_learning_datastore_fileshare_v0_to_v1.go
@@ -1,0 +1,91 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package migration
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2025-08-01/fileshares"
+	storageparse "github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+var _ pluginsdk.StateUpgrade = MachineLearningDataStoreFileShareV0ToV1{}
+
+type MachineLearningDataStoreFileShareV0ToV1 struct{}
+
+func (MachineLearningDataStoreFileShareV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+
+		if v, ok := rawState["storage_fileshare_id"].(string); ok && v != "" {
+			if id, err := storageparse.StorageShareResourceManagerID(v); err == nil {
+				newID := fileshares.NewShareID(id.SubscriptionId, id.ResourceGroup, id.StorageAccountName, id.FileshareName).ID()
+				log.Printf("[DEBUG] Updating `storage_fileshare_id` from %q to %q", v, newID)
+				rawState["storage_fileshare_id"] = newID
+			}
+		}
+
+		return rawState, nil
+	}
+}
+
+func (MachineLearningDataStoreFileShareV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"workspace_id": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"storage_fileshare_id": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"description": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			ForceNew: true,
+		},
+
+		"service_data_identity": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+		},
+
+		"account_key": {
+			Type:      pluginsdk.TypeString,
+			Optional:  true,
+			Sensitive: true,
+		},
+
+		"shared_access_signature": {
+			Type:      pluginsdk.TypeString,
+			Optional:  true,
+			Sensitive: true,
+		},
+
+		"is_default": {
+			Type:     pluginsdk.TypeBool,
+			Computed: true,
+		},
+
+		"tags": {
+			Type:     pluginsdk.TypeMap,
+			Optional: true,
+			ForceNew: true,
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+			},
+		},
+	}
+}


### PR DESCRIPTION
In 5.0 `azurerm_storage_share.resource_manager_id` is deprecated in favour of `azurerm_storage_share.id`. This changes it from `/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s/fileServices/%s/fileshares/%s` to `subscriptions/%s/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s/fileServices/default/shares/%s`.  `azurerm_machine_learning_datastore_fileshare` accepts a `storage_fileshare_id` so this needs updating to work with 5.0