### PR TITLE
azurerm_management_lock - suppress case-only diffs on the scope property

### DIFF
--- a/internal/services/resource/management_lock_resource.go
+++ b/internal/services/resource/management_lock_resource.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/resource/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
@@ -48,6 +49,10 @@ func resourceManagementLock() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeString,
 				Required: true,
 				ForceNew: true,
+				// The Azure Resource Manager API is case-insensitive but does not return resource IDs
+				// with consistent casing, which would otherwise cause a spurious ForceNew replacement
+				// of the lock whenever the casing of the scope drifts (e.g. `resourceGroups` vs `resourcegroups`).
+				DiffSuppressFunc: suppress.CaseDifference,
 			},
 
 			"lock_level": {

--- a/internal/services/resource/management_lock_resource_test.go
+++ b/internal/services/resource/management_lock_resource_test.go
@@ -49,6 +49,27 @@ func TestAccManagementLock_requiresImport(t *testing.T) {
 	})
 }
 
+func TestAccManagementLock_scopeCaseInsensitive(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_management_lock", "test")
+	r := ManagementLockResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.resourceGroupReadOnlyBasic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			// the Azure Resource Manager API returns resource IDs with inconsistent casing - changing only
+			// the casing of the `scope` must not produce a diff (which would otherwise force a replacement).
+			Config:   r.scopeCaseInsensitive(data),
+			PlanOnly: true,
+		},
+	})
+}
+
 func TestAccManagementLock_resourceGroupReadOnlyComplete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_management_lock", "test")
 	r := ManagementLockResource{}
@@ -192,6 +213,25 @@ resource "azurerm_resource_group" "test" {
 resource "azurerm_management_lock" "test" {
   name       = "acctestlock-%d"
   scope      = azurerm_resource_group.test.id
+  lock_level = "ReadOnly"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (ManagementLockResource) scopeCaseInsensitive(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_management_lock" "test" {
+  name       = "acctestlock-%d"
+  scope      = upper(azurerm_resource_group.test.id)
   lock_level = "ReadOnly"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

The Azure Resource Manager API is case-insensitive but does not return resource IDs with consistent casing. Because scope is ForceNew, a casing-only change (e.g. My-ResourceGroup vs my-resourcegroup) previously triggered an unnecessary destroy/recreate of the lock.

Add DiffSuppressFunc: suppress.CaseDifference to scope so case-only differences are ignored, and add an acceptance test asserting an empty plan when the scope casing changes.


## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
