### PR TITLE
`azurerm_kubernetes_cluster` - skip retired HTTP application routing acceptance tests

### DIFF
--- a/internal/services/containers/kubernetes_cluster_addons_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_addons_resource_test.go
@@ -135,6 +135,8 @@ func TestAccKubernetesCluster_addonProfileOMSToggle(t *testing.T) {
 }
 
 func TestAccKubernetesCluster_addonProfileRoutingToggle(t *testing.T) {
+	t.Skip("HTTP Application Routing can no longer be enabled on new AKS clusters")
+
 	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
 	r := KubernetesClusterResource{}
 

--- a/internal/services/containers/kubernetes_cluster_data_source_test.go
+++ b/internal/services/containers/kubernetes_cluster_data_source_test.go
@@ -348,6 +348,8 @@ func TestAccDataSourceKubernetesCluster_addOnProfileAzurePolicy(t *testing.T) {
 }
 
 func TestAccDataSourceKubernetesCluster_addOnProfileRouting(t *testing.T) {
+	t.Skip("HTTP Application Routing can no longer be enabled on new AKS clusters")
+
 	data := acceptance.BuildTestData(t, "data.azurerm_kubernetes_cluster", "test")
 	r := KubernetesClusterDataSource{}
 


### PR DESCRIPTION
## Description

TeamCity build 683453 showed AKS rejecting new clusters with the legacy HTTP Application Routing add-on. Since that add-on can no longer be enabled on new clusters, these legacy acceptance tests now skip instead of attempting an unsupported create path.

## Testing

- Rechecked both failures in [TeamCity 683453](https://hashicorp.teamcity.com/build/683453). Azure returned HTTP 400 stating that HTTP Application Routing can no longer be enabled on new clusters and directing users to Application Routing instead.
- The [official documentation](https://learn.microsoft.com/azure/aks/http-application-routing) marks this legacy add-on retired.
- Compiled the containers package at the current PR merge and ran the two affected test selectors locally. Both intentionally skipped with the retirement message before any Azure precheck or resource operation.

These are verified skips, not two passing Azure lifecycle tests. The change only prevents attempts to create the retired add-on; provider behaviour and the replacement Application Routing tests are unchanged. No additional deployment was triggered merely to exercise unconditional skips.
