### PR TITLE
`azurerm_kubernetes_cluster` - avoid unsupported bootstrap profile migration test

### DIFF
--- a/internal/services/containers/kubernetes_cluster_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_resource_test.go
@@ -280,21 +280,7 @@ func TestAccKubernetesCluster_bootstrapProfile(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.networkIsolatedBootstrapProfileArtifactSourceDirect(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
 			Config: r.networkIsolatedBootstrapProfileArtifactSourceCache(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.networkIsolatedBootstrapProfileRemoved(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -1319,7 +1305,7 @@ resource "azurerm_kubernetes_cluster" "test" {
   default_node_pool {
     name       = "default"
     node_count = 1
-    vm_size    = "Standard_DS2_v2"
+    vm_size    = "Standard_D2s_v3"
     upgrade_settings {
       max_surge = "10%%"
     }
@@ -1352,102 +1338,6 @@ resource "azurerm_kubernetes_cluster" "test" {
   bootstrap_profile {
     artifact_source       = "Cache"
     container_registry_id = azurerm_container_registry.registry.id
-  }
-}`, r.networkIsolatedBootstrapProfileTemplate(data), data.RandomInteger)
-}
-
-func (r KubernetesClusterResource) networkIsolatedBootstrapProfileArtifactSourceDirect(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-%[1]s
-
-resource "azurerm_kubernetes_cluster" "test" {
-  name                = "acctestaks%[2]d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  dns_prefix          = "acctestaks%[2]d"
-
-  private_cluster_enabled = true
-
-  default_node_pool {
-    name       = "default"
-    node_count = 1
-    vm_size    = "Standard_DS2_v2"
-    upgrade_settings {
-      max_surge = "10%%"
-    }
-    vnet_subnet_id = azurerm_subnet.vnet-nodepool.id
-  }
-
-  node_provisioning_profile {
-    mode               = "Manual"
-    default_node_pools = "Auto"
-  }
-
-  network_profile {
-    network_plugin_mode = "overlay"
-    network_plugin      = "azure"
-    load_balancer_sku   = "standard"
-  }
-
-  identity {
-    type         = "UserAssigned"
-    identity_ids = [azurerm_user_assigned_identity.aks.id]
-  }
-
-  kubelet_identity {
-    user_assigned_identity_id = azurerm_user_assigned_identity.aks_kubelet.id
-    client_id                 = azurerm_user_assigned_identity.aks_kubelet.client_id
-    object_id                 = azurerm_user_assigned_identity.aks_kubelet.principal_id
-  }
-
-  bootstrap_profile {
-    artifact_source = "Direct"
-  }
-}`, r.networkIsolatedBootstrapProfileTemplate(data), data.RandomInteger)
-}
-
-func (r KubernetesClusterResource) networkIsolatedBootstrapProfileRemoved(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-%[1]s
-
-resource "azurerm_kubernetes_cluster" "test" {
-  name                = "acctestaks%[2]d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  dns_prefix          = "acctestaks%[2]d"
-
-  private_cluster_enabled = true
-
-  default_node_pool {
-    name       = "default"
-    node_count = 1
-    vm_size    = "Standard_DS2_v2"
-    upgrade_settings {
-      max_surge = "10%%"
-    }
-    vnet_subnet_id = azurerm_subnet.vnet-nodepool.id
-  }
-
-  node_provisioning_profile {
-    mode               = "Manual"
-    default_node_pools = "Auto"
-  }
-
-  network_profile {
-    network_plugin_mode = "overlay"
-    network_plugin      = "azure"
-    load_balancer_sku   = "standard"
-  }
-
-  identity {
-    type         = "UserAssigned"
-    identity_ids = [azurerm_user_assigned_identity.aks.id]
-  }
-
-  kubelet_identity {
-    user_assigned_identity_id = azurerm_user_assigned_identity.aks_kubelet.id
-    client_id                 = azurerm_user_assigned_identity.aks_kubelet.client_id
-    object_id                 = azurerm_user_assigned_identity.aks_kubelet.principal_id
   }
 }`, r.networkIsolatedBootstrapProfileTemplate(data), data.RandomInteger)
 }


### PR DESCRIPTION
## Description

TeamCity build 683453 showed AKS rejecting the test update from `Direct` bootstrap artifacts with load balancer outbound to `Cache` artifacts with outbound `none`. AKS now requires the artifact source to be updated to `Cache` and nodes reimaged before changing outbound type to `none` or `block`. This keeps the acceptance coverage on the valid `Cache` create/import path and removes the unsupported migration sequence.

The active bootstrap profile test helper now uses `Standard_D2s_v3` because `Standard_DS2_v2` is not available for this subscription in `eastus`.

## Testing

- Rechecked [TeamCity 683453](https://hashicorp.teamcity.com/build/683453): the combined update failed with `InvalidNetworkIsolatedClusterConfiguration`. Azure requires switching to `Cache` and reimaging the nodes before changing outbound type to `none` or `block`.
- The exact current-merge containers package compiled locally. Acceptance was disabled, so the local skip is not an Azure pass.
- [TeamCity 743442](https://hashicorp.teamcity.com/build/743442) finished successfully: **1 passed, 0 failed, 0 ignored**. It verified the retained `Cache` create/import case at the pinned current PR merge. The actual revision, selected test, acceptance-enabled settings and disabled GitHub posting were read back after completion.

This PR removes the invalid combined migration sequence, not support for every network-isolation migration. It does not claim coverage of the ordered update/reimage workflow.
