### PR TITLE
`azurerm_kubernetes_cluster` / `azurerm_kubernetes_cluster_node_pool` - suppress perpetual diff for Kubernetes minor version aliases

### DIFF
--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -323,10 +323,11 @@ func resourceKubernetesClusterNodePoolSchema() map[string]*pluginsdk.Schema {
 		},
 
 		"orchestrator_version": {
-			Type:         pluginsdk.TypeString,
-			Optional:     true,
-			Computed:     true,
-			ValidateFunc: validation.StringIsNotEmpty,
+			Type:             pluginsdk.TypeString,
+			Optional:         true,
+			Computed:         true,
+			ValidateFunc:     validation.StringIsNotEmpty,
+			DiffSuppressFunc: suppressKubernetesVersionDiff,
 		},
 
 		"os_disk_size_gb": {

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -278,10 +278,11 @@ func resourceKubernetesClusterNodePoolSchema() map[string]*pluginsdk.Schema {
 		},
 
 		"orchestrator_version": {
-			Type:         pluginsdk.TypeString,
-			Optional:     true,
-			Computed:     true,
-			ValidateFunc: validation.StringIsNotEmpty,
+			Type:             pluginsdk.TypeString,
+			Optional:         true,
+			Computed:         true,
+			ValidateFunc:     validation.StringIsNotEmpty,
+			DiffSuppressFunc: suppressKubernetesVersionDiff,
 		},
 
 		"os_disk_size_gb": {

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -1658,6 +1658,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
   vm_size               = "Standard_DS2_v2"
   node_count            = 1
+  upgrade_settings {
+    max_surge = "10%%"
+  }
 
   kubelet_config {
     cpu_manager_policy    = "static"

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -725,10 +725,11 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 			},
 
 			"kubernetes_version": {
-				Type:         pluginsdk.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validation.StringIsNotEmpty,
+				Type:             pluginsdk.TypeString,
+				Optional:         true,
+				Computed:         true,
+				ValidateFunc:     validation.StringIsNotEmpty,
+				DiffSuppressFunc: suppressKubernetesVersionDiff,
 			},
 
 			"linux_profile": {

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -743,10 +743,11 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 			},
 
 			"kubernetes_version": {
-				Type:         pluginsdk.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validation.StringIsNotEmpty,
+				Type:             pluginsdk.TypeString,
+				Optional:         true,
+				Computed:         true,
+				ValidateFunc:     validation.StringIsNotEmpty,
+				DiffSuppressFunc: suppressKubernetesVersionDiff,
 			},
 
 			"linux_profile": {

--- a/internal/services/containers/kubernetes_nodepool.go
+++ b/internal/services/containers/kubernetes_nodepool.go
@@ -209,10 +209,11 @@ func SchemaDefaultNodePool() *pluginsdk.Schema {
 						ValidateFunc: commonids.ValidateSubnetID,
 					},
 					"orchestrator_version": {
-						Type:         pluginsdk.TypeString,
-						Optional:     true,
-						Computed:     true,
-						ValidateFunc: validation.StringIsNotEmpty,
+						Type:             pluginsdk.TypeString,
+						Optional:         true,
+						Computed:         true,
+						ValidateFunc:     validation.StringIsNotEmpty,
+						DiffSuppressFunc: suppressKubernetesVersionDiff,
 					},
 					"pod_subnet_id": {
 						Type:         pluginsdk.TypeString,

--- a/internal/services/containers/kubernetes_nodepool.go
+++ b/internal/services/containers/kubernetes_nodepool.go
@@ -208,10 +208,11 @@ func SchemaDefaultNodePool() *pluginsdk.Schema {
 						ValidateFunc: commonids.ValidateSubnetID,
 					},
 					"orchestrator_version": {
-						Type:         pluginsdk.TypeString,
-						Optional:     true,
-						Computed:     true,
-						ValidateFunc: validation.StringIsNotEmpty,
+						Type:             pluginsdk.TypeString,
+						Optional:         true,
+						Computed:         true,
+						ValidateFunc:     validation.StringIsNotEmpty,
+						DiffSuppressFunc: suppressKubernetesVersionDiff,
 					},
 					"pod_subnet_id": {
 						Type:         pluginsdk.TypeString,

--- a/internal/services/containers/kubernetes_version_diff.go
+++ b/internal/services/containers/kubernetes_version_diff.go
@@ -1,0 +1,33 @@
+package containers
+
+import (
+	"strings"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+// suppressKubernetesVersionDiff suppresses the noisy no-op diff produced when an AKS
+// automatic patch upgrade rewrites a configured minor version alias (e.g. "1.27") to the
+// full patch version (e.g. "1.27.14"). When the configured value is a "major.minor" alias
+// whose major and minor match the running patch version, the two are semantically equal
+// (the alias resolves to the latest GA patch of that minor version, which is what is
+// already running) so the diff is suppressed.
+//
+// It deliberately does not suppress when the configured value is a full patch version, so
+// pinning an exact patch (e.g. "1.27.15" while running "1.27.14") still surfaces a real
+// change.
+func suppressKubernetesVersionDiff(_, old, new string, _ *pluginsdk.ResourceData) bool {
+	// new = configured value, old = value currently in state.
+	// Only a two-part "major.minor" configured value is treated as a minor version alias.
+	configParts := strings.Split(new, ".")
+	if len(configParts) != 2 {
+		return false
+	}
+
+	stateParts := strings.Split(old, ".")
+	if len(stateParts) < 2 {
+		return false
+	}
+
+	return configParts[0] == stateParts[0] && configParts[1] == stateParts[1]
+}

--- a/internal/services/containers/kubernetes_version_diff.go
+++ b/internal/services/containers/kubernetes_version_diff.go
@@ -1,3 +1,6 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
 package containers
 
 import (

--- a/internal/services/containers/kubernetes_version_diff_test.go
+++ b/internal/services/containers/kubernetes_version_diff_test.go
@@ -1,0 +1,82 @@
+package containers
+
+import "testing"
+
+func TestSuppressKubernetesVersionDiff(t *testing.T) {
+	testCases := []struct {
+		name     string
+		old      string // value currently in state
+		new      string // configured value
+		expected bool   // true == diff suppressed
+	}{
+		{
+			name:     "minor alias matches running patch version is suppressed",
+			old:      "1.27.14",
+			new:      "1.27",
+			expected: true,
+		},
+		{
+			name:     "minor alias with different minor is a real change",
+			old:      "1.27.14",
+			new:      "1.28",
+			expected: false,
+		},
+		{
+			name:     "minor alias with different major is a real change",
+			old:      "1.27.14",
+			new:      "2.27",
+			expected: false,
+		},
+		{
+			name:     "exact patch pin differing from running patch is a real change",
+			old:      "1.27.14",
+			new:      "1.27.15",
+			expected: false,
+		},
+		{
+			name:     "exact patch pin matching running patch is not suppressed by this func",
+			old:      "1.27.14",
+			new:      "1.27.14",
+			expected: false,
+		},
+		{
+			name:     "empty state (create) is not suppressed",
+			old:      "",
+			new:      "1.27",
+			expected: false,
+		},
+		{
+			name:     "empty config is not suppressed",
+			old:      "1.27.14",
+			new:      "",
+			expected: false,
+		},
+		{
+			name:     "alias matching an alias state with same minor is suppressed",
+			old:      "1.27",
+			new:      "1.27",
+			expected: true,
+		},
+		{
+			name:     "alias matching an alias state with different minor is a real change",
+			old:      "1.27",
+			new:      "1.28",
+			expected: false,
+		},
+		{
+			name:     "double-digit minor alias matches running patch version is suppressed",
+			old:      "1.34.3",
+			new:      "1.34",
+			expected: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := suppressKubernetesVersionDiff("", tc.old, tc.new, nil)
+			if actual != tc.expected {
+				t.Fatalf("suppressKubernetesVersionDiff(old=%q, new=%q) = %t, expected %t", tc.old, tc.new, actual, tc.expected)
+			}
+		})
+	}
+}

--- a/internal/services/containers/kubernetes_version_diff_test.go
+++ b/internal/services/containers/kubernetes_version_diff_test.go
@@ -67,6 +67,12 @@ func TestSuppressKubernetesVersionDiff(t *testing.T) {
 			expected: false,
 		},
 		{
+			name:     "exact patch pin against an alias state is a real change",
+			old:      "1.27",
+			new:      "1.27.14",
+			expected: false,
+		},
+		{
 			name:     "double-digit minor alias matches running patch version is suppressed",
 			old:      "1.34.3",
 			new:      "1.34",

--- a/internal/services/containers/kubernetes_version_diff_test.go
+++ b/internal/services/containers/kubernetes_version_diff_test.go
@@ -1,3 +1,6 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
 package containers
 
 import "testing"


### PR DESCRIPTION
## Community Note

* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

Fixes #26946.

When `kubernetes_version` (on `azurerm_kubernetes_cluster`) or `orchestrator_version` (on the cluster's `default_node_pool` and on `azurerm_kubernetes_cluster_node_pool`) is configured with a **minor version alias** such as `1.27`, and AKS performs an automatic patch upgrade (e.g. `automatic_channel_upgrade = "patch"`), Azure rewrites the stored version field from the alias `1.27` to the full patch version `1.27.14`.

The provider reads that value back into state, so every subsequent plan shows a perpetual no-op diff:

```
~ kubernetes_version           = "1.27.14" -> "1.27"
~ orchestrator_version         = "1.27.14" -> "1.27"
```

Applying does nothing meaningful against Azure (the alias `1.27` already resolves to the running `1.27.14`) but takes several minutes and is noisy.

This PR adds a `DiffSuppressFunc` (`suppressKubernetesVersionDiff`) that treats a configured `major.minor` alias as equal to a running `major.minor.patch` version that shares the same major and minor. It is applied to:

* `azurerm_kubernetes_cluster` → `kubernetes_version`
* `azurerm_kubernetes_cluster` → `default_node_pool.orchestrator_version`
* `azurerm_kubernetes_cluster_node_pool` → `orchestrator_version`

The suppression is deliberately narrow:

| config value | state value | result |
|---|---|---|
| `1.27` | `1.27.14` | suppressed (the bug) |
| `1.28` | `1.27.14` | real change (minor upgrade) |
| `1.27.15` | `1.27.14` | real change (exact patch pin) |
| `1.27` | `""` (create) | not suppressed |

A full patch version configured by the user (e.g. `1.27.15`) is left untouched, so exact-patch pins and genuine minor upgrades still surface a real change. Only plan output is affected — the value stored in state continues to reflect the true running patch version.

## PR Checklist

- [x] I have followed the guidelines in our Contributing Documentation.
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate closing keywords below.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.

No documentation change is included: the existing docs already state that minor version aliases are supported, and this change only removes a spurious diff that users would not expect in the first place.

## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them.
- [x] I have written new tests for my changes.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.

## Testing

A unit test (`TestSuppressKubernetesVersionDiff`) covers the full behavior matrix deterministically:

```
$ go test ./internal/services/containers/ -run TestSuppressKubernetesVersionDiff -v
=== RUN   TestSuppressKubernetesVersionDiff
... (11 sub-cases) ...
--- PASS: TestSuppressKubernetesVersionDiff (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/containers
```

The original bug only manifests after a real Azure-driven automatic patch upgrade, which cannot be forced on demand within an acceptance test, so the logic is covered by the unit test above. The existing version-alias acceptance test (`TestAccKubernetesCluster_upgradeControlPlaneAndAllPoolsTogetherVersionAlias`) is unaffected, since the `DiffSuppressFunc` changes plan output only and does not alter what is stored in state.

## Change Log

* `azurerm_kubernetes_cluster` - no longer shows a perpetual diff on `kubernetes_version` / `orchestrator_version` after an automatic patch upgrade when a minor version alias is used [GH-00000]
* `azurerm_kubernetes_cluster_node_pool` - no longer shows a perpetual diff on `orchestrator_version` after an automatic patch upgrade when a minor version alias is used [GH-00000]

This is a (please select all that apply):

- [x] Bug Fix
