### PR TITLE
r/azurerm_key_vault_managed_hardware_security_module_key: allow key_size when key_type is oct-HSM (#32686)

### DIFF
--- a/internal/services/managedhsm/key_vault_managed_hardware_security_module_key_resource.go
+++ b/internal/services/managedhsm/key_vault_managed_hardware_security_module_key_resource.go
@@ -235,8 +235,8 @@ func (r KeyVaultMHSMKeyResource) Create() sdk.ResourceFunc {
 			}
 
 			if config.KeySize > 0 {
-				if config.KeyType != string(keyvault.JSONWebKeyTypeRSAHSM) {
-					return fmt.Errorf("`key_type` must be `RSA-HSM` when `key_size` is set")
+				if config.KeyType != string(keyvault.JSONWebKeyTypeRSAHSM) && config.KeyType != string(keyvault.JSONWebKeyTypeOctHSM) {
+					return fmt.Errorf("`key_type` must be `RSA-HSM` or `oct-HSM` when `key_size` is set")
 				}
 				parameters.KeySize = pointer.To(int32(config.KeySize))
 			}


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or "me too" comments, as they generate extra noise for pull request followers and do not help prioritize the request

### Description
Fixes #32686 where creating an `oct-HSM` key with `key_size` set (e.g., 256 bits for AES symmetric encryption keys on Azure Managed HSM) failed schema validation with:
`key_type` must be `RSA-HSM` when `key_size` is set.

This PR updates the resource validation in `key_vault_managed_hardware_security_module_key_resource.go` to accept both `RSA-HSM` and `oct-HSM` when `key_size` is populated, matching the existing documentation and Azure Managed HSM REST API specs.
