### PR TITLE
Confidential ledger - fix `TestAccConfidentialLedger*`

### DIFF
--- a/.teamcity/components/settings.kt
+++ b/.teamcity/components/settings.kt
@@ -74,7 +74,7 @@ var serviceTestConfigurationOverrides = mapOf(
         "cosmos" to testConfiguration(locationOverride = LocationConfiguration("westus", "northeurope", "eastus2", true)),
 
         // Confidential Ledger
-        "confidentialledger" to testConfiguration(locationOverride = LocationConfiguration("eastus","southcentralus","westeurope", false)),
+        "confidentialledger" to testConfiguration(locationOverride = LocationConfiguration("eastus","southeastasia","westeurope", false)),
 
         // Container App Managed Environments are limited to 20 per location, using 10 as they can take some time to clear
         // Enable rotation test to mitigate resource burden in a single region

--- a/.teamcity/components/settings.kt
+++ b/.teamcity/components/settings.kt
@@ -74,7 +74,7 @@ var serviceTestConfigurationOverrides = mapOf(
         "cosmos" to testConfiguration(locationOverride = LocationConfiguration("westus", "northeurope", "eastus2", true)),
 
         // Confidential Ledger
-        "confidentialledger" to testConfiguration(locationOverride = LocationConfiguration("eastus","westus2","westeurope", false)),
+        "confidentialledger" to testConfiguration(locationOverride = LocationConfiguration("eastus","southeastasia","westeurope", false)),
 
         // Container App Managed Environments are limited to 20 per location, using 10 as they can take some time to clear
         // Enable rotation test to mitigate resource burden in a single region

--- a/.teamcity/components/settings.kt
+++ b/.teamcity/components/settings.kt
@@ -74,7 +74,7 @@ var serviceTestConfigurationOverrides = mapOf(
         "cosmos" to testConfiguration(locationOverride = LocationConfiguration("westus", "northeurope", "eastus2", true)),
 
         // Confidential Ledger
-        "confidentialledger" to testConfiguration(locationOverride = LocationConfiguration("eastus","southeastasia","westeurope", false)),
+        "confidentialledger" to testConfiguration(locationOverride = LocationConfiguration("eastus","westus2","westeurope", false)),
 
         // Container App Managed Environments are limited to 20 per location, using 10 as they can take some time to clear
         // Enable rotation test to mitigate resource burden in a single region

--- a/.teamcity/components/settings.kt
+++ b/.teamcity/components/settings.kt
@@ -74,7 +74,7 @@ var serviceTestConfigurationOverrides = mapOf(
         "cosmos" to testConfiguration(locationOverride = LocationConfiguration("westus", "northeurope", "eastus2", true)),
 
         // Confidential Ledger
-        "confidentialledger" to testConfiguration(locationOverride = LocationConfiguration("eastus","southeastasia","westeurope", false)),
+        "confidentialledger" to testConfiguration(parallelism = 1, locationOverride = LocationConfiguration("eastus","southeastasia","westeurope", false)),
 
         // Container App Managed Environments are limited to 20 per location, using 10 as they can take some time to clear
         // Enable rotation test to mitigate resource burden in a single region

--- a/internal/services/confidentialledger/confidential_ledger_resource_test.go
+++ b/internal/services/confidentialledger/confidential_ledger_resource_test.go
@@ -21,7 +21,7 @@ type ConfidentialLedgerResource struct{}
 func TestAccConfidentialLedgerSequential(t *testing.T) {
 	acceptance.RunTestsInSequence(t, map[string]map[string]func(t *testing.T){
 		"confidentialLedger": {
-			"public":         TestAccConfidentialLedger_public,
+			"public":         testAccConfidentialLedger_public,
 			"private":        testAccConfidentialLedger_private,
 			"requiresImport": testAccConfidentialLedger_requiresImport,
 			"certBased":      testAccConfidentialLedger_certBased,
@@ -29,7 +29,7 @@ func TestAccConfidentialLedgerSequential(t *testing.T) {
 	})
 }
 
-func TestAccConfidentialLedger_public(t *testing.T) {
+func testAccConfidentialLedger_public(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_confidential_ledger", "test")
 	r := ConfidentialLedgerResource{}
 

--- a/internal/services/confidentialledger/confidential_ledger_resource_test.go
+++ b/internal/services/confidentialledger/confidential_ledger_resource_test.go
@@ -21,7 +21,7 @@ type ConfidentialLedgerResource struct{}
 func TestAccConfidentialLedgerSequential(t *testing.T) {
 	acceptance.RunTestsInSequence(t, map[string]map[string]func(t *testing.T){
 		"confidentialLedger": {
-			"public":         testAccConfidentialLedger_public,
+			"public":         TestAccConfidentialLedger_public,
 			"private":        testAccConfidentialLedger_private,
 			"requiresImport": testAccConfidentialLedger_requiresImport,
 			"certBased":      testAccConfidentialLedger_certBased,
@@ -29,7 +29,7 @@ func TestAccConfidentialLedgerSequential(t *testing.T) {
 	})
 }
 
-func testAccConfidentialLedger_public(t *testing.T) {
+func TestAccConfidentialLedger_public(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_confidential_ledger", "test")
 	r := ConfidentialLedgerResource{}
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

`TestAccConfidentialLedgerDataSource_basic` and `TestAccConfidentialLedgerSequential` fail due to limitation of TeamCity quota in current test location as shown in the error log below. The test location is changed and parallelism is reduced in this PR.

```
    testcase.go:203: Step 1/1 error: Error running apply: exit status 1
        Error: creating /subscriptions/*******/resourceGroups/REDACTED/providers/Microsoft.ConfidentialLedger/ledgers/REDACTED: performing LedgerCreate: unexpected status 400 (400 Bad Request) with error: Failed: Multiple QuotasEntity entities were found for a subscription in storage.
          with azurerm_confidential_ledger.test,
          on terraform_plugin_test.tf line 61, in resource "azurerm_confidential_ledger" "test":
          61: resource "azurerm_confidential_ledger" "test" {
```


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] ~I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.~
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] ~I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).~
- [ ] ~I have written new tests for my resource or datasource changes & updated any relevant documentation.~
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] ~(For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.~


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

Version 4.x
https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_CONFIDENTIALLEDGER/696939?buildTab=overview
<img width="1463" height="352" alt="image" src="https://github.com/user-attachments/assets/398b364f-2594-496e-8639-5bee29d2d9d3" />

Version 5.0
https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_CONFIDENTIALLEDGER/697142?buildTab=overview
<img width="1467" height="349" alt="image" src="https://github.com/user-attachments/assets/afab9a12-8d48-46b3-8bbc-74a024be4135" />


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_confidential_ledger` - fix `TestAccConfidentialLedgerDataSource_basic` and `TestAccConfidentialLedgerSequential`


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
