### PR TITLE
azurerm_mssql_server_transparent_data_encryption - support versionless key_vault_key_id

### DIFF
--- a/.changelog/32713.txt
+++ b/.changelog/32713.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+`azurerm_mssql_server_transparent_data_encryption` - support versionless `key_vault_key_id` when `auto_rotation_enabled` is `true`
+```

--- a/internal/services/mssql/mssql_server_transparent_data_encryption_resource.go
+++ b/internal/services/mssql/mssql_server_transparent_data_encryption_resource.go
@@ -4,6 +4,7 @@
 package mssql
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strings"
@@ -59,9 +60,10 @@ func resourceMsSqlTransparentDataEncryption() *pluginsdk.Resource {
 			},
 
 			"key_vault_key_id": {
-				Type:         pluginsdk.TypeString,
-				Optional:     true,
-				ValidateFunc: keyvault.ValidateNestedItemID(keyvault.VersionTypeVersioned, keyvault.NestedItemTypeKey),
+				Type:             pluginsdk.TypeString,
+				Optional:         true,
+				DiffSuppressFunc: diffSuppressKeyVaultVersionedKey,
+				ValidateFunc:     keyvault.ValidateNestedItemID(keyvault.VersionTypeAny, keyvault.NestedItemTypeKey),
 			},
 
 			"auto_rotation_enabled": {
@@ -77,6 +79,10 @@ func resourceMsSqlTransparentDataEncryption() *pluginsdk.Resource {
 			Type:     pluginsdk.TypeString,
 			Optional: true,
 			DiffSuppressFunc: func(_, oldValue, newValue string, d *schema.ResourceData) bool {
+				if diffSuppressKeyVaultVersionedKey("", oldValue, newValue, d) {
+					return true
+				}
+
 				if newValue == "" {
 					// If using `managed_hsm_key_id`, `key_vault_key_id` will also be set
 					// ignore diff if the 2 are equal.
@@ -88,7 +94,7 @@ func resourceMsSqlTransparentDataEncryption() *pluginsdk.Resource {
 
 				return false
 			},
-			ValidateFunc:  keyvault.ValidateNestedItemID(keyvault.VersionTypeVersioned, keyvault.NestedItemTypeKey),
+			ValidateFunc:  keyvault.ValidateNestedItemID(keyvault.VersionTypeAny, keyvault.NestedItemTypeKey),
 			ConflictsWith: []string{"managed_hsm_key_id"},
 		}
 
@@ -96,6 +102,10 @@ func resourceMsSqlTransparentDataEncryption() *pluginsdk.Resource {
 			Type:     pluginsdk.TypeString,
 			Optional: true,
 			DiffSuppressFunc: func(_, oldValue, newValue string, d *schema.ResourceData) bool {
+				if diffSuppressKeyVaultVersionedKey("", oldValue, newValue, d) {
+					return true
+				}
+
 				if newValue == "" {
 					// If using `key_vault_key_id` with MHSM key, `managed_hsm_key_id` will also be set
 					// ignore diff if the 2 are equal.
@@ -107,7 +117,7 @@ func resourceMsSqlTransparentDataEncryption() *pluginsdk.Resource {
 
 				return false
 			},
-			ValidateFunc:  keyvault.ValidateNestedItemID(keyvault.VersionTypeVersioned, keyvault.NestedItemTypeKey),
+			ValidateFunc:  keyvault.ValidateNestedItemID(keyvault.VersionTypeAny, keyvault.NestedItemTypeKey),
 			ConflictsWith: []string{"key_vault_key_id"},
 			Deprecated:    "`managed_hsm_key_id` has been deprecated in favour of `key_vault_key_id` and will be removed in v5.0 of the AzureRM provider",
 		}
@@ -147,20 +157,28 @@ func resourceMsSqlTransparentDataEncryptionCreateUpdate(d *pluginsdk.ResourceDat
 
 	var key *keyvault.NestedItemID
 	if v, ok := d.GetOk("key_vault_key_id"); ok {
-		keyId, err := keyvault.ParseNestedItemID(v.(string), keyvault.VersionTypeVersioned, keyvault.NestedItemTypeKey)
+		key, err = keyvault.ParseNestedItemID(v.(string), keyvault.VersionTypeAny, keyvault.NestedItemTypeKey)
 		if err != nil {
 			return err
 		}
-		key = keyId
+
+		key, err = resourceMsSqlTransparentDataEncryptionVersionedKey(ctx, key, "key_vault_key_id", d.Get("auto_rotation_enabled").(bool), meta)
+		if err != nil {
+			return err
+		}
 	}
 
 	if !features.FivePointOh() {
 		if !pluginsdk.IsExplicitlyNullInConfig(d, "managed_hsm_key_id") {
-			keyId, err := keyvault.ParseNestedItemID(d.Get("managed_hsm_key_id").(string), keyvault.VersionTypeVersioned, keyvault.NestedItemTypeKey)
+			key, err = keyvault.ParseNestedItemID(d.Get("managed_hsm_key_id").(string), keyvault.VersionTypeAny, keyvault.NestedItemTypeKey)
 			if err != nil {
 				return err
 			}
-			key = keyId
+
+			key, err = resourceMsSqlTransparentDataEncryptionVersionedKey(ctx, key, "managed_hsm_key_id", d.Get("auto_rotation_enabled").(bool), meta)
+			if err != nil {
+				return err
+			}
 		}
 	}
 
@@ -298,4 +316,70 @@ func resourceMsSqlTransparentDataEncryptionKeyVaultName(keyVaultURL string) (str
 	}
 
 	return strings.Split(parsedURL.Host, ".")[0], nil
+}
+
+// If versionless KV key is used in config/state, suppress the diff with versioned key.
+// This is needed because backend API will return back a versioned key if it's given versionless one
+func diffSuppressKeyVaultVersionedKey(_, oldValue, newValue string, d *schema.ResourceData) bool {
+	if d == nil || !d.Get("auto_rotation_enabled").(bool) {
+		return false
+	}
+
+	newId, err := keyvault.ParseNestedItemID(newValue, keyvault.VersionTypeAny, keyvault.NestedItemTypeKey)
+	if err != nil {
+		return false
+	}
+
+	if newId.Version != "" {
+		return false
+	}
+
+	oldId, err := keyvault.ParseNestedItemID(oldValue, keyvault.VersionTypeAny, keyvault.NestedItemTypeKey)
+	if err != nil {
+		return false
+	}
+
+	return strings.EqualFold(oldId.KeyVaultBaseURL, newId.KeyVaultBaseURL) && strings.EqualFold(oldId.Name, newId.Name)
+}
+
+func resourceMsSqlTransparentDataEncryptionVersionedKey(ctx context.Context, id *keyvault.NestedItemID, fieldName string, autoRotationEnabled bool, meta interface{}) (*keyvault.NestedItemID, error) {
+	if id.Version != "" {
+		return id, nil
+	}
+
+	if !autoRotationEnabled {
+		return nil, fmt.Errorf("`%s` must be a versioned Key Vault Key ID when `auto_rotation_enabled` is false", fieldName)
+	}
+
+	var keyUrl string
+	if id.IsManagedHSM() {
+		resp, err := meta.(*clients.Client).ManagedHSMs.DataPlaneKeysClient.GetKey(ctx, id.KeyVaultBaseURL, id.Name, "")
+		if err != nil {
+			return nil, err
+		}
+
+		if resp.Key != nil {
+			keyUrl = pointer.From(resp.Key.Kid)
+		}
+	} else {
+		resp, err := meta.(*clients.Client).KeyVault.ManagementClient.GetKey(ctx, id.KeyVaultBaseURL, id.Name, "")
+		if err != nil {
+			return nil, err
+		}
+
+		if resp.Key != nil {
+			keyUrl = pointer.From(resp.Key.Kid)
+		}
+	}
+
+	if keyUrl == "" {
+		return nil, fmt.Errorf("retrieving latest version for Key Vault Key %q at %q: empty key ID returned", id.Name, id.KeyVaultBaseURL)
+	}
+
+	versionedId, err := keyvault.ParseNestedItemID(keyUrl, keyvault.VersionTypeVersioned, keyvault.NestedItemTypeKey)
+	if err != nil {
+		return nil, err
+	}
+
+	return versionedId, nil
 }

--- a/internal/services/mssql/mssql_server_transparent_data_encryption_resource.go
+++ b/internal/services/mssql/mssql_server_transparent_data_encryption_resource.go
@@ -4,6 +4,7 @@
 package mssql
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strings"
@@ -15,6 +16,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/keyvault"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-08-01-preview/encryptionprotectors"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-08-01-preview/serverkeys"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/mssql/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/mssql/parse"
@@ -57,9 +59,10 @@ func resourceMsSqlTransparentDataEncryption() *pluginsdk.Resource {
 			},
 
 			"key_vault_key_id": {
-				Type:         pluginsdk.TypeString,
-				Optional:     true,
-				ValidateFunc: keyvault.ValidateNestedItemID(keyvault.VersionTypeVersioned, keyvault.NestedItemTypeKey),
+				Type:             pluginsdk.TypeString,
+				Optional:         true,
+				DiffSuppressFunc: diffSuppressKeyVaultVersionedKey,
+				ValidateFunc:     keyvault.ValidateNestedItemID(keyvault.VersionTypeAny, keyvault.NestedItemTypeKey),
 			},
 
 			"auto_rotation_enabled": {
@@ -102,10 +105,17 @@ func resourceMsSqlTransparentDataEncryptionCreateUpdate(d *pluginsdk.ResourceDat
 
 	var key *keyvault.NestedItemID
 	if v, ok := d.GetOk("key_vault_key_id"); ok {
-		keyId, err := keyvault.ParseNestedItemID(v.(string), keyvault.VersionTypeVersioned, keyvault.NestedItemTypeKey)
+		keyId, err := keyvault.ParseNestedItemID(v.(string), keyvault.VersionTypeAny, keyvault.NestedItemTypeKey)
 		if err != nil {
 			return err
 		}
+
+		// With `auto_rotation_enabled` the configured ID may be versionless, in which case
+		// the current version needs resolving before the Server Key can be created.
+		if keyId, err = resourceMsSqlTransparentDataEncryptionVersionedKey(ctx, keyId, "key_vault_key_id", d.Get("auto_rotation_enabled").(bool), meta); err != nil {
+			return err
+		}
+
 		key = keyId
 	}
 
@@ -233,4 +243,70 @@ func resourceMsSqlTransparentDataEncryptionKeyVaultName(keyVaultURL string) (str
 	}
 
 	return strings.Split(parsedURL.Host, ".")[0], nil
+}
+
+// If versionless KV key is used in config/state, suppress the diff with versioned key.
+// This is needed because backend API will return back a versioned key if it's given versionless one
+func diffSuppressKeyVaultVersionedKey(_, oldValue, newValue string, d *schema.ResourceData) bool {
+	if d == nil || !d.Get("auto_rotation_enabled").(bool) {
+		return false
+	}
+
+	newId, err := keyvault.ParseNestedItemID(newValue, keyvault.VersionTypeAny, keyvault.NestedItemTypeKey)
+	if err != nil {
+		return false
+	}
+
+	if newId.Version != "" {
+		return false
+	}
+
+	oldId, err := keyvault.ParseNestedItemID(oldValue, keyvault.VersionTypeAny, keyvault.NestedItemTypeKey)
+	if err != nil {
+		return false
+	}
+
+	return strings.EqualFold(oldId.KeyVaultBaseURL, newId.KeyVaultBaseURL) && strings.EqualFold(oldId.Name, newId.Name)
+}
+
+func resourceMsSqlTransparentDataEncryptionVersionedKey(ctx context.Context, id *keyvault.NestedItemID, fieldName string, autoRotationEnabled bool, meta interface{}) (*keyvault.NestedItemID, error) {
+	if id.Version != "" {
+		return id, nil
+	}
+
+	if !autoRotationEnabled {
+		return nil, fmt.Errorf("`%s` must be a versioned Key Vault Key ID when `auto_rotation_enabled` is false", fieldName)
+	}
+
+	var keyUrl string
+	if id.IsManagedHSM() {
+		resp, err := meta.(*clients.Client).ManagedHSMs.DataPlaneKeysClient.GetKey(ctx, id.KeyVaultBaseURL, id.Name, "")
+		if err != nil {
+			return nil, err
+		}
+
+		if resp.Key != nil {
+			keyUrl = pointer.From(resp.Key.Kid)
+		}
+	} else {
+		resp, err := meta.(*clients.Client).KeyVault.ManagementClient.GetKey(ctx, id.KeyVaultBaseURL, id.Name, "")
+		if err != nil {
+			return nil, err
+		}
+
+		if resp.Key != nil {
+			keyUrl = pointer.From(resp.Key.Kid)
+		}
+	}
+
+	if keyUrl == "" {
+		return nil, fmt.Errorf("retrieving latest version for Key Vault Key %q at %q: empty key ID returned", id.Name, id.KeyVaultBaseURL)
+	}
+
+	versionedId, err := keyvault.ParseNestedItemID(keyUrl, keyvault.VersionTypeVersioned, keyvault.NestedItemTypeKey)
+	if err != nil {
+		return nil, err
+	}
+
+	return versionedId, nil
 }

--- a/internal/services/mssql/mssql_server_transparent_data_encryption_resource_test.go
+++ b/internal/services/mssql/mssql_server_transparent_data_encryption_resource_test.go
@@ -85,6 +85,22 @@ func TestAccMsSqlServerTransparentDataEncryption_autoRotate(t *testing.T) {
 	})
 }
 
+func TestAccMsSqlServerTransparentDataEncryption_autoRotateVersionless(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_mssql_server_transparent_data_encryption", "test")
+	r := MsSqlServerTransparentDataEncryptionResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.autoRotateVersionless(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("key_vault_key_id").Exists(),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccMsSqlServerTransparentDataEncryption_systemManaged(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_mssql_server_transparent_data_encryption", "test")
 	r := MsSqlServerTransparentDataEncryptionResource{}
@@ -268,6 +284,18 @@ func (r MsSqlServerTransparentDataEncryptionResource) autoRotate(data acceptance
 resource "azurerm_mssql_server_transparent_data_encryption" "test" {
   server_id             = azurerm_mssql_server.test.id
   key_vault_key_id      = azurerm_key_vault_key.test.id
+  auto_rotation_enabled = true
+}
+`, r.baseKeyVault(data))
+}
+
+func (r MsSqlServerTransparentDataEncryptionResource) autoRotateVersionless(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_mssql_server_transparent_data_encryption" "test" {
+  server_id             = azurerm_mssql_server.test.id
+  key_vault_key_id      = azurerm_key_vault_key.test.versionless_id
   auto_rotation_enabled = true
 }
 `, r.baseKeyVault(data))

--- a/internal/services/mssql/mssql_server_transparent_data_encryption_resource_test.go
+++ b/internal/services/mssql/mssql_server_transparent_data_encryption_resource_test.go
@@ -84,6 +84,22 @@ func TestAccMsSqlServerTransparentDataEncryption_autoRotate(t *testing.T) {
 	})
 }
 
+func TestAccMsSqlServerTransparentDataEncryption_autoRotateVersionless(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_mssql_server_transparent_data_encryption", "test")
+	r := MsSqlServerTransparentDataEncryptionResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.autoRotateVersionless(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("key_vault_key_id").Exists(),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccMsSqlServerTransparentDataEncryption_systemManaged(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_mssql_server_transparent_data_encryption", "test")
 	r := MsSqlServerTransparentDataEncryptionResource{}
@@ -257,6 +273,18 @@ func (r MsSqlServerTransparentDataEncryptionResource) autoRotate(data acceptance
 resource "azurerm_mssql_server_transparent_data_encryption" "test" {
   server_id             = azurerm_mssql_server.test.id
   key_vault_key_id      = azurerm_key_vault_key.test.id
+  auto_rotation_enabled = true
+}
+`, r.baseKeyVault(data))
+}
+
+func (r MsSqlServerTransparentDataEncryptionResource) autoRotateVersionless(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_mssql_server_transparent_data_encryption" "test" {
+  server_id             = azurerm_mssql_server.test.id
+  key_vault_key_id      = azurerm_key_vault_key.test.versionless_id
   auto_rotation_enabled = true
 }
 `, r.baseKeyVault(data))

--- a/internal/services/mssql/mssql_server_transparent_data_encryption_resource_unit_test.go
+++ b/internal/services/mssql/mssql_server_transparent_data_encryption_resource_unit_test.go
@@ -1,0 +1,91 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package mssql
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestDiffSuppressKeyVaultVersionedKey(t *testing.T) {
+	versionlessKey := "https://example.vault.azure.net/keys/test-key"
+	versionedKey := versionlessKey + "/00000000000000000000000000000001"
+	otherVersionedKey := "https://example.vault.azure.net/keys/other-key/00000000000000000000000000000001"
+
+	testCases := []struct {
+		name                string
+		oldValue            string
+		newValue            string
+		autoRotationEnabled bool
+		expected            bool
+	}{
+		{
+			name:                "versionless key with auto rotation",
+			oldValue:            versionedKey,
+			newValue:            versionlessKey,
+			autoRotationEnabled: true,
+			expected:            true,
+		},
+		{
+			name:                "versionless key without auto rotation",
+			oldValue:            versionedKey,
+			newValue:            versionlessKey,
+			autoRotationEnabled: false,
+			expected:            false,
+		},
+		{
+			name:                "versioned key with auto rotation",
+			oldValue:            versionedKey,
+			newValue:            versionedKey + "2",
+			autoRotationEnabled: true,
+			expected:            false,
+		},
+		{
+			name:                "different versionless key with auto rotation",
+			oldValue:            otherVersionedKey,
+			newValue:            versionlessKey,
+			autoRotationEnabled: true,
+			expected:            false,
+		},
+		{
+			name:                "invalid configured key",
+			oldValue:            versionedKey,
+			newValue:            "invalid",
+			autoRotationEnabled: true,
+			expected:            false,
+		},
+		{
+			name:                "invalid state key",
+			oldValue:            "invalid",
+			newValue:            versionlessKey,
+			autoRotationEnabled: true,
+			expected:            false,
+		},
+	}
+
+	resourceSchema := map[string]*schema.Schema{
+		"auto_rotation_enabled": {
+			Type:     schema.TypeBool,
+			Optional: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			data := schema.TestResourceDataRaw(t, resourceSchema, map[string]interface{}{
+				"auto_rotation_enabled": testCase.autoRotationEnabled,
+			})
+
+			actual := diffSuppressKeyVaultVersionedKey("", testCase.oldValue, testCase.newValue, data)
+			if actual != testCase.expected {
+				t.Fatalf("expected diff suppression to be %t, got %t", testCase.expected, actual)
+			}
+		})
+	}
+
+	if diffSuppressKeyVaultVersionedKey("", versionedKey, versionlessKey, nil) {
+		t.Fatal("expected diff suppression to be false without resource data")
+	}
+}

--- a/website/docs/r/mssql_server_transparent_data_encryption.html.markdown
+++ b/website/docs/r/mssql_server_transparent_data_encryption.html.markdown
@@ -153,6 +153,8 @@ The following arguments are supported:
 
 ~> **Note:** In order to use customer managed keys, the identity of the MSSQL server must have the following permissions on the key vault: 'get', 'wrapKey' and 'unwrapKey'
 
+~> **Note:** When `auto_rotation_enabled` is `true`, `key_vault_key_id` can be either a versioned or versionless Key Vault Key ID. When using a versionless `key_vault_key_id`, the principal running Terraform must have permission to read the latest key version from Key Vault. When `auto_rotation_enabled` is `false`, `key_vault_key_id` must be a versioned Key Vault Key ID.
+
 ~> **Note:** If `server_id` denotes a secondary server deployed for disaster recovery purposes, then the `key_vault_key_id` should be the same key used for the primary server's transparent data encryption. Both primary and secondary servers should be encrypted with same key material.
 
 * `auto_rotation_enabled` - (Optional) When enabled, the server will continuously check the key vault for any new versions of the key being used as the TDE protector. If a new version of the key is detected, the TDE protector on the server will be automatically rotated to the latest key version within 60 minutes.

--- a/website/docs/r/mssql_server_transparent_data_encryption.html.markdown
+++ b/website/docs/r/mssql_server_transparent_data_encryption.html.markdown
@@ -154,6 +154,8 @@ The following arguments are supported:
 
 ~> **Note:** In order to use customer managed keys, the identity of the MSSQL server must have the following permissions on the key vault: 'get', 'wrapKey' and 'unwrapKey'
 
+~> **Note:** When `auto_rotation_enabled` is `true`, `key_vault_key_id` can be either a versioned or versionless Key Vault Key ID. When using a versionless `key_vault_key_id`, the principal running Terraform must have permission to read the latest key version from Key Vault. When `auto_rotation_enabled` is `false`, `key_vault_key_id` must be a versioned Key Vault Key ID.
+
 ~> **Note:** If `server_id` denotes a secondary server deployed for disaster recovery purposes, then the `key_vault_key_id` should be the same key used for the primary server's transparent data encryption. Both primary and secondary servers should be encrypted with same key material.
 
 * `auto_rotation_enabled` - (Optional) When enabled, the server will continuously check the key vault for any new versions of the key being used as the TDE protector. If a new version of the key is detected, the TDE protector on the server will be automatically rotated to the latest key version within 60 minutes.


### PR DESCRIPTION


## Community Note

* Please vote on this PR by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave &#34;+1&#34; or &#34;me too&#34; comments, they generate extra noise for PR followers and do not help prioritize for review

## Description

Adds versionless `key_vault_key_id` support to `azurerm_mssql_server_transparent_data_encryption`, mirroring the fix already merged for the Managed Instance equivalent in #32399.

Today the resource only accepts a **versioned** Key Vault key ID. With `auto_rotation_enabled = true`, Azure SQL rotates the TDE protector to newer key versions automatically; the Read then writes back the current versioned URI, producing perpetual drift against the pinned version in config (and re-applying the previously pinned version can fail server-side).

This change ports the pattern from #32399 into `internal/services/mssql/`:

* `key_vault_key_id`'s `ValidateFunc` changed from `VersionTypeVersioned` to `VersionTypeAny`.
* A `diffSuppressKeyVaultVersionedKey` `DiffSuppressFunc` that suppresses the version diff **only** when the configured value is versionless **and** `auto_rotation_enabled = true`.
* A `resourceMsSqlTransparentDataEncryptionVersionedKey` resolver that, at apply time, resolves a versionless ID to the current versioned key; it returns an error when a versionless ID is supplied with `auto_rotation_enabled = false`.
* Docs note + acceptance test (`autoRotateVersionless`) using `azurerm_key_vault_key.test.versionless_id`.
* Unit test coverage for `diffSuppressKeyVaultVersionedKey` (per review feedback).

Fixes #32711.

> **Note:** this branch has been rebased onto current `main`. #32399 was authored while `managed_hsm_key_id` and the `features.FivePointOh()` gating still existed in this resource; both were since removed by #33020, so the equivalent changes to the v5.0-gated schema entries are no longer applicable here and the diff now only touches the single ungated `key_vault_key_id`.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/README.md).
- [x] I have checked to ensure there aren&#39;t other open [Pull Requests](https://github.com/hashicorp/terraform-provider-azurerm/pulls) for the same update/change.
- [x] (For changes that include a `CHANGELOG.md` entry) I have used a **changelog entry** with a link to my PR.

## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I&#39;d like you to include them (This may be covered by the linked issue).
- [x] I have written new tests for my resource or datasource changes &amp; updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. `go build`, `go vet`, the `diffSuppressKeyVaultVersionedKey` unit test, and `make lint` (via `scripts/golangci-with-modules`, including the `azproviderlint`/`tfproviderlint` plugins) all pass for the `mssql` package. Acceptance tests require live Azure credentials.

## Testing

```
func TestDiffSuppressKeyVaultVersionedKey(t *testing.T)
func TestAccMsSqlServerTransparentDataEncryption_autoRotateVersionless(t *testing.T)
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/maintainer-changelog.md).

* `azurerm_mssql_server_transparent_data_encryption` - support versionless `key_vault_key_id` when `auto_rotation_enabled` is `true` [GH-32713]

## References

* Mirrors #32399 (Managed Instance), which closed #32382.
* Fixes #32711.
