### PR TITLE
`azurerm_role_assignment` - Support update for `description`, `condition` and `condition_version`

### DIFF
--- a/internal/services/authorization/role_assignment_resource.go
+++ b/internal/services/authorization/role_assignment_resource.go
@@ -37,6 +37,7 @@ func resourceArmRoleAssignment() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
 		Create: resourceArmRoleAssignmentCreate,
 		Read:   resourceArmRoleAssignmentRead,
+		Update: resourceArmRoleAssignmentUpdate,
 		Delete: resourceArmRoleAssignmentDelete,
 
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
@@ -47,6 +48,7 @@ func resourceArmRoleAssignment() *pluginsdk.Resource {
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
+			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 
@@ -132,21 +134,18 @@ func resourceArmRoleAssignment() *pluginsdk.Resource {
 			"description": {
 				Type:         pluginsdk.TypeString,
 				Optional:     true,
-				ForceNew:     true,
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
 
 			"condition": {
 				Type:         pluginsdk.TypeString,
 				Optional:     true,
-				ForceNew:     true,
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
 
 			"condition_version": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
-				ForceNew: true,
 				Computed: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					"1.0",
@@ -274,6 +273,63 @@ func resourceArmRoleAssignmentCreate(d *pluginsdk.ResourceData, meta interface{}
 	}
 
 	d.SetId(id.ID())
+
+	return resourceArmRoleAssignmentRead(d, meta)
+}
+
+func resourceArmRoleAssignmentUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Authorization.ScopedRoleAssignmentsClient
+	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.ScopedRoleAssignmentID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	options := roleassignments.DefaultGetOperationOptions()
+	if id.TenantId != "" {
+		options.TenantId = pointer.To(id.TenantId)
+	}
+
+	existing, err := client.Get(ctx, id.ScopedId, options)
+	if err != nil {
+		return fmt.Errorf("retrieving %s: %+v", *id, err)
+	}
+	if existing.Model == nil || existing.Model.Properties == nil {
+		return fmt.Errorf("retrieving %s: `model.properties` was nil", *id)
+	}
+
+	props := *existing.Model.Properties
+
+	if d.HasChange("description") {
+		props.Description = pointer.ToOrNil(d.Get("description").(string))
+	}
+
+	// Order matters here that "condition_version" shall be handled prior to "condition".
+	if d.HasChange("condition_version") {
+		props.ConditionVersion = pointer.ToOrNil(d.Get("condition_version").(string))
+	}
+	if d.HasChange("condition") {
+		props.Condition = pointer.ToOrNil(d.Get("condition").(string))
+
+		// Implicitly setting the condition_version in case it is not specified in config (as how Create() has been implemented).
+		if d.GetRawConfig().AsValueMap()["condition_version"].IsNull() {
+			if props.Condition == nil {
+				props.ConditionVersion = nil
+			} else {
+				props.ConditionVersion = new("2.0")
+			}
+		}
+	}
+
+	params := roleassignments.RoleAssignmentCreateParameters{
+		Properties: props,
+	}
+
+	if _, err := client.Create(ctx, id.ScopedId, params); err != nil {
+		return fmt.Errorf("updating %s: %+v", *id, err)
+	}
 
 	return resourceArmRoleAssignmentRead(d, meta)
 }

--- a/internal/services/authorization/role_assignment_resource.go
+++ b/internal/services/authorization/role_assignment_resource.go
@@ -303,25 +303,22 @@ func resourceArmRoleAssignmentUpdate(d *pluginsdk.ResourceData, meta interface{}
 	props := *existing.Model.Properties
 
 	if d.HasChange("description") {
-		if v := d.Get("description").(string); v == "" {
-			props.Description = nil
-		} else {
+		props.Description = nil
+		if v := d.Get("description").(string); v != "" {
 			props.Description = &v
 		}
 	}
 
 	// Order matters here that "condition_version" shall be handled prior to "condition".
 	if d.HasChange("condition_version") {
-		if v := d.Get("condition_version").(string); v == "" {
-			props.ConditionVersion = nil
-		} else {
+		props.ConditionVersion = nil
+		if v := d.Get("condition_version").(string); v != "" {
 			props.ConditionVersion = &v
 		}
 	}
 	if d.HasChange("condition") {
-		if v := d.Get("condition").(string); v == "" {
-			props.Condition = nil
-		} else {
+		props.Condition = nil
+		if v := d.Get("condition").(string); v != "" {
 			props.Condition = &v
 		}
 

--- a/internal/services/authorization/role_assignment_resource.go
+++ b/internal/services/authorization/role_assignment_resource.go
@@ -303,15 +303,27 @@ func resourceArmRoleAssignmentUpdate(d *pluginsdk.ResourceData, meta interface{}
 	props := *existing.Model.Properties
 
 	if d.HasChange("description") {
-		props.Description = pointer.ToOrNil(d.Get("description").(string))
+		if v := d.Get("description").(string); v == "" {
+			props.Description = nil
+		} else {
+			props.Description = &v
+		}
 	}
 
 	// Order matters here that "condition_version" shall be handled prior to "condition".
 	if d.HasChange("condition_version") {
-		props.ConditionVersion = pointer.ToOrNil(d.Get("condition_version").(string))
+		if v := d.Get("condition_version").(string); v == "" {
+			props.ConditionVersion = nil
+		} else {
+			props.ConditionVersion = &v
+		}
 	}
 	if d.HasChange("condition") {
-		props.Condition = pointer.ToOrNil(d.Get("condition").(string))
+		if v := d.Get("condition").(string); v == "" {
+			props.Condition = nil
+		} else {
+			props.Condition = &v
+		}
 
 		// Implicitly setting the condition_version in case it is not specified in config (as how Create() has been implemented).
 		if d.GetRawConfig().AsValueMap()["condition_version"].IsNull() {

--- a/internal/services/authorization/role_assignment_resource.go
+++ b/internal/services/authorization/role_assignment_resource.go
@@ -327,7 +327,7 @@ func resourceArmRoleAssignmentUpdate(d *pluginsdk.ResourceData, meta interface{}
 			if props.Condition == nil {
 				props.ConditionVersion = nil
 			} else {
-				props.ConditionVersion = new("2.0")
+				props.ConditionVersion = pointer.To("2.0")
 			}
 		}
 	}

--- a/internal/services/authorization/role_assignment_resource_test.go
+++ b/internal/services/authorization/role_assignment_resource_test.go
@@ -215,7 +215,7 @@ func TestAccRoleAssignment_condition(t *testing.T) {
 	})
 }
 
-func TestAccRoleAssignment_implicitCondition(t *testing.T) {
+func TestAccRoleAssignment_conditionUpdate(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_role_assignment", "test")
 	id := uuid.New().String()
 
@@ -223,7 +223,35 @@ func TestAccRoleAssignment_implicitCondition(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.implicitConditionVersion(id),
+			Config: r.noConditionNoDescription(id),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("skip_service_principal_aad_check"),
+		{
+			Config: r.condition(id),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("skip_service_principal_aad_check"),
+		{
+			Config: r.noConditionNoDescription(id),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("skip_service_principal_aad_check"),
+		{
+			Config: r.conditionImplicitVersion(id),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("skip_service_principal_aad_check"),
+		{
+			Config: r.noConditionNoDescription(id),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -620,7 +648,7 @@ resource "azurerm_role_assignment" "test" {
 `, groupId)
 }
 
-func (RoleAssignmentResource) implicitConditionVersion(groupId string) string {
+func (RoleAssignmentResource) conditionImplicitVersion(groupId string) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -633,13 +661,33 @@ data "azurerm_client_config" "test" {
 }
 
 resource "azurerm_role_assignment" "test" {
-
   name                 = "%s"
   scope                = data.azurerm_subscription.primary.id
   role_definition_name = "Monitoring Reader"
   principal_id         = data.azurerm_client_config.test.object_id
   description          = "Monitoring Reader except "
   condition            = "@Resource[Microsoft.Storage/storageAccounts/blobServices/containers:name] StringEqualsIgnoreCase 'foo_storage_container'"
+}
+`, groupId)
+}
+
+func (RoleAssignmentResource) noConditionNoDescription(groupId string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_subscription" "primary" {
+}
+
+data "azurerm_client_config" "test" {
+}
+
+resource "azurerm_role_assignment" "test" {
+  name                 = "%s"
+  scope                = data.azurerm_subscription.primary.id
+  role_definition_name = "Monitoring Reader"
+  principal_id         = data.azurerm_client_config.test.object_id
 }
 `, groupId)
 }

--- a/vendor/github.com/hashicorp/go-azure-helpers/lang/pointer/generic.go
+++ b/vendor/github.com/hashicorp/go-azure-helpers/lang/pointer/generic.go
@@ -32,6 +32,15 @@ func To[T any](input T) *T {
 	return &input
 }
 
+// ToOrNil is similar to To, but will return nil on zero value.
+func ToOrNil[T comparable](input T) *T {
+	var zero T
+	if zero == input {
+		return nil
+	}
+	return &input
+}
+
 // ToEnum is a helper function to cast strings as an Enum type where API objects expect a pointer to the Enum value
 // example code simplification:
 // APIModel.SomeValue = pointer.To(someservice.SomeEnumType(model.SomeVariable))

--- a/vendor/github.com/hashicorp/go-azure-helpers/lang/pointer/generic.go
+++ b/vendor/github.com/hashicorp/go-azure-helpers/lang/pointer/generic.go
@@ -32,15 +32,6 @@ func To[T any](input T) *T {
 	return &input
 }
 
-// ToOrNil is similar to To, but will return nil on zero value.
-func ToOrNil[T comparable](input T) *T {
-	var zero T
-	if zero == input {
-		return nil
-	}
-	return &input
-}
-
 // ToEnum is a helper function to cast strings as an Enum type where API objects expect a pointer to the Enum value
 // example code simplification:
 // APIModel.SomeValue = pointer.To(someservice.SomeEnumType(model.SomeVariable))

--- a/website/docs/r/role_assignment.html.markdown
+++ b/website/docs/r/role_assignment.html.markdown
@@ -191,9 +191,9 @@ The following arguments are supported:
 
 * `principal_type` - (Optional) The type of the `principal_id`. Possible values are `User`, `Group` and `ServicePrincipal`. Changing this forces a new resource to be created. It is necessary to explicitly set this attribute when creating role assignments if the principal creating the assignment is constrained by ABAC rules that filters on the PrincipalType attribute.
 
-* `condition` - (Optional) The condition that limits the resources that the role can be assigned to. Changing this forces a new resource to be created.
+* `condition` - (Optional) The condition that limits the resources that the role can be assigned to.
 
-* `condition_version` - (Optional) The version of the condition. Possible values are `1.0` or `2.0`. Changing this forces a new resource to be created.
+* `condition_version` - (Optional) The version of the condition. Possible values are `1.0` or `2.0`.
 
 ~> **Note:** `condition` is required when `condition_version` is set.
 
@@ -201,7 +201,7 @@ The following arguments are supported:
 
 ~> **Note:** This field is only used in cross tenant scenarios.
 
-* `description` - (Optional) The description for this Role Assignment. Changing this forces a new resource to be created.
+* `description` - (Optional) The description for this Role Assignment.
 
 * `skip_service_principal_aad_check` - (Optional) If the `principal_id` is a newly provisioned `Service Principal` set this value to `true` to skip the `Azure Active Directory` check which may fail due to replication lag. This argument is only valid if the `principal_id` is a `Service Principal` identity. Defaults to `false`.
 
@@ -219,6 +219,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 * `create` - (Defaults to 30 minutes) Used when creating the Role Assignment.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Role Assignment.
+* `update` - (Defaults to 30 minutes) Used when updating the Role Assignment.
 * `delete` - (Defaults to 30 minutes) Used when deleting the Role Assignment.
 
 ## Import


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Adding the `Update()` for `azurerm_role_assignment` to be able to update `description`, `condition` and `condition_version`.

The test case covers all of these except the `condition_version` for v1 <-> v2 as I can't find a v1 sample for the `condition` (while the absence vs v2 is covered).

In the description of #27189, it says:

> conditionVersion: A condition version number. Defaults to 2.0 and is the only publicly supported version.

Note that there is some special handling of the `condition_version` in the `Update()`, which is a accomodate to the implicit behavior of the `condition_version` in `Create()` (added in https://github.com/hashicorp/terraform-provider-azurerm/pull/27189).


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

```shell
terraform-provider-azurerm role_assignment_update*​ ≡20s
❯ TF_ACC=1 go test -v -timeout=20h -run=TestAccRoleAssignment_conditionUpdate ./internal/services/authorization
=== RUN   TestAccRoleAssignment_conditionUpdate
=== PAUSE TestAccRoleAssignment_conditionUpdate
=== CONT  TestAccRoleAssignment_conditionUpdate
--- PASS: TestAccRoleAssignment_conditionUpdate (141.92s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/authorization	141.940s
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
