### PR TITLE
`azurerm_mssql_server` - allow uppercase characters in server name validation

### DIFF
--- a/internal/services/mssql/helper/mssql_test.go
+++ b/internal/services/mssql/helper/mssql_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/mssql/validate"
 )
 
-// Your server name can contain only lowercase letters, numbers, and '-', but can't start or end with '-' or have more than 63 characters.
+// Your server name can contain only letters, numbers, and '-', but can't start or end with '-' or have more than 63 characters.
 func TestValidateMsSqlServerName(t *testing.T) {
 	cases := []struct {
 		Value  string
@@ -25,7 +25,7 @@ func TestValidateMsSqlServerName(t *testing.T) {
 		},
 		{
 			Value:  "K",
-			Errors: true,
+			Errors: false,
 		},
 		{
 			Value:  "k-",
@@ -37,7 +37,7 @@ func TestValidateMsSqlServerName(t *testing.T) {
 		},
 		{
 			Value:  "K-T",
-			Errors: true,
+			Errors: false,
 		},
 		{
 			Value:  "validname",

--- a/internal/services/mssql/validate/mssql.go
+++ b/internal/services/mssql/validate/mssql.go
@@ -9,10 +9,10 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
 )
 
-// Your server name can contain only lowercase letters, numbers, and '-', but can't start or end with '-' or have more than 63 characters.
+// Your server name can contain only letters, numbers, and '-', but can't start or end with '-' or have more than 63 characters.
 func ValidateMsSqlServerName(i interface{}, k string) (_ []string, errors []error) {
-	if m, regexErrs := validate.RegExHelper(i, k, `^[0-9a-z]([-0-9a-z]{0,61}[0-9a-z])?$`); !m {
-		return nil, append(regexErrs, fmt.Errorf("%q can contain only lowercase letters, numbers, and '-', but can't start or end with '-' or have more than 63 characters", k))
+	if m, regexErrs := validate.RegExHelper(i, k, `^[0-9A-Za-z]([-0-9A-Za-z]{0,61}[0-9A-Za-z])?$`); !m {
+		return nil, append(regexErrs, fmt.Errorf("%q can contain only letters, numbers, and '-', but can't start or end with '-' or have more than 63 characters", k))
 	}
 
 	return nil, nil

--- a/internal/services/mssqlmanagedinstance/mssql_managed_instance_data_source.go
+++ b/internal/services/mssqlmanagedinstance/mssql_managed_instance_data_source.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-08-01-preview/managedinstances"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/mssql/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/mssqlmanagedinstance/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
@@ -62,7 +62,7 @@ func (d MsSqlManagedInstanceDataSource) Arguments() map[string]*pluginsdk.Schema
 		"name": {
 			Type:         schema.TypeString,
 			Required:     true,
-			ValidateFunc: validate.ValidateMsSqlServerName,
+			ValidateFunc: validate.ValidateMsSqlManagedInstanceServerName,
 		},
 
 		"resource_group_name": commonschema.ResourceGroupNameForDataSource(),

--- a/internal/services/mssqlmanagedinstance/mssql_managed_instance_security_alert_policy_resource.go
+++ b/internal/services/mssqlmanagedinstance/mssql_managed_instance_security_alert_policy_resource.go
@@ -14,8 +14,8 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-08-01-preview/managedserversecurityalertpolicies"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/mssql/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/mssqlmanagedinstance/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/mssqlmanagedinstance/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
@@ -47,7 +47,7 @@ func resourceMsSqlManagedInstanceSecurityAlertPolicy() *pluginsdk.Resource {
 				Type:         pluginsdk.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validate.ValidateMsSqlServerName,
+				ValidateFunc: validate.ValidateMsSqlManagedInstanceServerName,
 			},
 
 			"disabled_alerts": {


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->
This PR: 
1. Change `azurerm_mssql_managed_instance_security_alert_policy` and data source `azurerm_mssql_managed_instance` to use the managed instance SQL validation function, so the No.2 validation change can be scoped only to `azurerm_mssql_server`.
2. Aligns SQL server name validation with the ARM API by allowing uppercase characters. The ARM API allows uppercase letters in SQL server names, while Terraform previously allowed only lowercase. This causes issues when users import existing SQL server resources and migrate them to Terraform.

For example, an `azurerm_private_endpoint` may already exist, and Azure can return mixed-case values for `private_connection_resource_id`. Because of the previous naming restriction, the Terraform configuration had to use lowercase, which created drift in terraform plan and could trigger recreation of `azurerm_private_endpoint`. An example config would be like below.

```
import {
    to = azurerm_mssql_server.example
    id = "..../SERVER_name"
}
resource "azurerm_mssql_server" "example" {
  name = "server_name"
  .....
}

import {
    to = azurerm_private_endpoint.example
    id = "..."
}

resource "azurerm_private_endpoint" "example" {
  ....
  private_service_connection {
    name                                 = "example-endpoint"
    is_manual_connection                 = false
    subresource_names                    = ["sqlServer"]
    private_connection_resource_id = azurerm_mssql_server.example.id
  }

}

```

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

Failed tests not related to the changes. 

<img width="893" height="574" alt="image" src="https://github.com/user-attachments/assets/6257cbe3-4775-4a90-a09f-a0d2ff2c088a" />

With 5.0 flag: 
<img width="817" height="832" alt="image" src="https://github.com/user-attachments/assets/a3ba0fa0-c7ca-41ad-8cff-6f4189f8b438" />

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

Change the regex. 

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
