### PR TITLE
New (Data Source|Resource) - `azurerm_cdn_frontdoor_batch_rule_set`

### DIFF
--- a/internal/services/cdn/cdn_frontdoor_batch_rule_set_data_source.go
+++ b/internal/services/cdn/cdn_frontdoor_batch_rule_set_data_source.go
@@ -1,0 +1,363 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package cdn
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/profiles"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rulesets"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cdn/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+var _ sdk.DataSource = CdnFrontDoorBatchRuleSetDataSource{}
+
+type CdnFrontDoorBatchRuleSetDataSource struct{}
+
+type CdnFrontDoorBatchRuleSetDataSourceModel struct {
+	Name                  string                              `tfschema:"name"`
+	ProfileName           string                              `tfschema:"profile_name"`
+	ResourceGroupName     string                              `tfschema:"resource_group_name"`
+	CdnFrontDoorProfileID string                              `tfschema:"cdn_frontdoor_profile_id"`
+	Rules                 []CdnFrontDoorBatchRuleSetRuleModel `tfschema:"rules"`
+}
+
+func (CdnFrontDoorBatchRuleSetDataSource) ResourceType() string {
+	return "azurerm_cdn_frontdoor_batch_rule_set"
+}
+
+func (CdnFrontDoorBatchRuleSetDataSource) ModelObject() interface{} {
+	return &CdnFrontDoorBatchRuleSetDataSourceModel{}
+}
+
+func (CdnFrontDoorBatchRuleSetDataSource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: validate.FrontDoorRuleSetName,
+		},
+		"profile_name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: validate.FrontDoorName,
+		},
+		"resource_group_name": commonschema.ResourceGroupNameForDataSource(),
+	}
+}
+
+func (CdnFrontDoorBatchRuleSetDataSource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"cdn_frontdoor_profile_id": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+		"rules": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"name": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+					"behaviour_on_match": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+					"order": {
+						Type:     pluginsdk.TypeInt,
+						Computed: true,
+					},
+					"actions": {
+						Type:     pluginsdk.TypeList,
+						Computed: true,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"url_redirect": {
+									Type:     pluginsdk.TypeList,
+									Computed: true,
+									Elem: &pluginsdk.Resource{Schema: map[string]*pluginsdk.Schema{
+										"redirect_type": {
+											Type:     pluginsdk.TypeString,
+											Computed: true,
+										},
+										"redirect_protocol": {
+											Type:     pluginsdk.TypeString,
+											Computed: true,
+										},
+										"destination_path": {
+											Type:     pluginsdk.TypeString,
+											Computed: true,
+										},
+										"destination_host_name": {
+											Type:     pluginsdk.TypeString,
+											Computed: true,
+										},
+										"destination_fragment": {
+											Type:     pluginsdk.TypeString,
+											Computed: true,
+										},
+										"query_string": {
+											Type:     pluginsdk.TypeString,
+											Computed: true,
+										},
+									}},
+								},
+								"url_rewrite": {
+									Type:     pluginsdk.TypeList,
+									Computed: true,
+									Elem: &pluginsdk.Resource{Schema: map[string]*pluginsdk.Schema{
+										"source_pattern": {
+											Type:     pluginsdk.TypeString,
+											Computed: true,
+										},
+										"destination_path": {
+											Type:     pluginsdk.TypeString,
+											Computed: true,
+										},
+										"preserve_unmatched_path_enabled": {
+											Type:     pluginsdk.TypeBool,
+											Computed: true,
+										},
+									}},
+								},
+								"modify_request_header":  cdnFrontDoorBatchRuleSetRuleHeaderActionComputedSchema(),
+								"modify_response_header": cdnFrontDoorBatchRuleSetRuleHeaderActionComputedSchema(),
+								"route_configuration_override": {
+									Type:     pluginsdk.TypeList,
+									Computed: true,
+									Elem: &pluginsdk.Resource{Schema: map[string]*pluginsdk.Schema{
+										"origin_group": {
+											Type:     pluginsdk.TypeList,
+											Computed: true,
+											Elem: &pluginsdk.Resource{Schema: map[string]*pluginsdk.Schema{
+												"cdn_frontdoor_origin_group_id": {
+													Type:     pluginsdk.TypeString,
+													Computed: true,
+												},
+												"forwarding_protocol": {
+													Type:     pluginsdk.TypeString,
+													Computed: true,
+												},
+											}},
+										},
+										"caching": {
+											Type:     pluginsdk.TypeList,
+											Computed: true,
+											Elem: &pluginsdk.Resource{Schema: map[string]*pluginsdk.Schema{
+												"behaviour": {
+													Type:     pluginsdk.TypeString,
+													Computed: true,
+												},
+												"duration": {
+													Type:     pluginsdk.TypeString,
+													Computed: true,
+												},
+												"compression_enabled": {
+													Type:     pluginsdk.TypeBool,
+													Computed: true,
+												},
+												"query_string_behaviour": {
+													Type:     pluginsdk.TypeString,
+													Computed: true,
+												},
+												"query_string_parameters": cdnFrontDoorBatchRuleSetConditionStringListSchema(),
+											}},
+										},
+									}},
+								},
+							},
+						},
+					},
+					"conditions": {
+						Type:     pluginsdk.TypeList,
+						Computed: true,
+						Elem: &pluginsdk.Resource{Schema: map[string]*pluginsdk.Schema{
+							"remote_address":         cdnFrontDoorBatchRuleSetConditionBaseListValuesComputedSchema(),
+							"request_method":         cdnFrontDoorBatchRuleSetConditionBaseSetValuesComputedSchema(),
+							"query_string":           cdnFrontDoorBatchRuleSetConditionWithTransformsComputedSchema(),
+							"post_argument":          cdnFrontDoorBatchRuleSetConditionWithNameAndTransformsComputedSchema(),
+							"request_url":            cdnFrontDoorBatchRuleSetConditionWithTransformsComputedSchema(),
+							"request_header":         cdnFrontDoorBatchRuleSetConditionWithNameAndTransformsComputedSchema(),
+							"request_body":           cdnFrontDoorBatchRuleSetConditionWithTransformsComputedSchema(),
+							"request_scheme":         cdnFrontDoorBatchRuleSetConditionBaseListValuesComputedSchema(),
+							"request_path":           cdnFrontDoorBatchRuleSetConditionWithTransformsComputedSchema(),
+							"request_file_extension": cdnFrontDoorBatchRuleSetConditionWithTransformsComputedSchema(),
+							"request_filename":       cdnFrontDoorBatchRuleSetConditionWithTransformsComputedSchema(),
+							"http_version":           cdnFrontDoorBatchRuleSetConditionBaseSetValuesComputedSchema(),
+							"request_cookies":        cdnFrontDoorBatchRuleSetConditionWithNameAndTransformsComputedSchema(),
+							"device_type":            cdnFrontDoorBatchRuleSetConditionBaseListValuesComputedSchema(),
+							"socket_address":         cdnFrontDoorBatchRuleSetConditionBaseListValuesComputedSchema(),
+							"client_port":            cdnFrontDoorBatchRuleSetConditionBaseListValuesComputedSchema(),
+							"server_port":            cdnFrontDoorBatchRuleSetConditionBaseSetValuesComputedSchema(),
+							"host_name":              cdnFrontDoorBatchRuleSetConditionWithTransformsComputedSchema(),
+							"ssl_protocol":           cdnFrontDoorBatchRuleSetConditionBaseSetValuesComputedSchema(),
+						}},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (CdnFrontDoorBatchRuleSetDataSource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Cdn.FrontDoorRuleSetsClient
+
+			var state CdnFrontDoorBatchRuleSetDataSourceModel
+			if err := metadata.Decode(&state); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			id := rulesets.NewRuleSetID(metadata.Client.Account.SubscriptionId, state.ResourceGroupName, state.ProfileName, state.Name)
+
+			resp, err := client.Get(ctx, id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return fmt.Errorf("%s was not found", id)
+				}
+
+				return fmt.Errorf("retrieving %s: %+v", id, err)
+			}
+
+			if resp.Model != nil && resp.Model.Properties != nil && !pointer.From(resp.Model.Properties.BatchMode) {
+				return fmt.Errorf("%s was not provisioned using batch mode, and cannot be read by this data source, use `azurerm_cdn_frontdoor_rule_set` instead", id)
+			}
+
+			metadata.SetID(&id)
+
+			state.Name = id.RuleSetName
+			state.ProfileName = id.ProfileName
+			state.ResourceGroupName = id.ResourceGroupName
+			state.CdnFrontDoorProfileID = profiles.NewProfileID(id.SubscriptionId, id.ResourceGroupName, id.ProfileName).ID()
+
+			if model := resp.Model; model != nil {
+				if props := model.Properties; props != nil {
+					rulesState, err := flattenCdnFrontDoorBatchRuleSetRules(props.Rules)
+					if err != nil {
+						return fmt.Errorf("flattening `rules`: %+v", err)
+					}
+					state.Rules = rulesState
+				}
+			}
+
+			return metadata.Encode(&state)
+		},
+	}
+}
+
+// Reusable schema helpers
+
+func cdnFrontDoorBatchRuleSetRuleHeaderActionComputedSchema() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Computed: true,
+		Elem: &pluginsdk.Resource{Schema: map[string]*pluginsdk.Schema{
+			"operator": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+			"header_name": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+			"header_value": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+		}},
+	}
+}
+
+func cdnFrontDoorBatchRuleSetConditionBaseListValuesComputedSchema() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Computed: true,
+		Elem: &pluginsdk.Resource{Schema: map[string]*pluginsdk.Schema{
+			"operator": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+			"values": cdnFrontDoorBatchRuleSetConditionStringListSchema(),
+		}},
+	}
+}
+
+func cdnFrontDoorBatchRuleSetConditionBaseSetValuesComputedSchema() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Computed: true,
+		Elem: &pluginsdk.Resource{Schema: map[string]*pluginsdk.Schema{
+			"operator": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+			"values": cdnFrontDoorBatchRuleSetConditionStringSetSchema(),
+		}},
+	}
+}
+
+func cdnFrontDoorBatchRuleSetConditionWithTransformsComputedSchema() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Computed: true,
+		Elem: &pluginsdk.Resource{Schema: map[string]*pluginsdk.Schema{
+			"operator": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+			"values":     cdnFrontDoorBatchRuleSetConditionStringListSchema(),
+			"transforms": cdnFrontDoorBatchRuleSetConditionStringSetSchema(),
+		}},
+	}
+}
+
+func cdnFrontDoorBatchRuleSetConditionWithNameAndTransformsComputedSchema() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Computed: true,
+		Elem: &pluginsdk.Resource{Schema: map[string]*pluginsdk.Schema{
+			"name": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+			"operator": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+			"values":     cdnFrontDoorBatchRuleSetConditionStringListSchema(),
+			"transforms": cdnFrontDoorBatchRuleSetConditionStringSetSchema(),
+		}},
+	}
+}
+
+func cdnFrontDoorBatchRuleSetConditionStringListSchema() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Computed: true,
+		Elem: &pluginsdk.Schema{
+			Type: pluginsdk.TypeString,
+		},
+	}
+}
+
+func cdnFrontDoorBatchRuleSetConditionStringSetSchema() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeSet,
+		Computed: true,
+		Elem: &pluginsdk.Schema{
+			Type: pluginsdk.TypeString,
+		},
+	}
+}

--- a/internal/services/cdn/cdn_frontdoor_batch_rule_set_data_source_test.go
+++ b/internal/services/cdn/cdn_frontdoor_batch_rule_set_data_source_test.go
@@ -1,0 +1,68 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package cdn_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+)
+
+type CdnFrontDoorBatchRuleSetDataSource struct{}
+
+func TestAccCdnFrontDoorBatchRuleSetDataSource_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_cdn_frontdoor_batch_rule_set", "test")
+	d := CdnFrontDoorBatchRuleSetDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: d.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("cdn_frontdoor_profile_id").MatchesOtherKey(check.That("azurerm_cdn_frontdoor_profile.test").Key("id")),
+				check.That(data.ResourceName).Key("rules.#").HasValue("2"),
+				check.That(data.ResourceName).Key("rules.0.order").HasValue("1"),
+				check.That(data.ResourceName).Key("rules.1.order").HasValue("2"),
+			),
+		},
+	})
+}
+
+func TestAccCdnFrontDoorBatchRuleSetDataSource_nonBatchRuleSet(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_cdn_frontdoor_batch_rule_set", "test")
+	d := CdnFrontDoorBatchRuleSetDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config:      d.nonBatchRuleSet(data),
+			ExpectError: regexp.MustCompile("was not provisioned using batch mode, and cannot be read by this data source"),
+		},
+	})
+}
+
+func (CdnFrontDoorBatchRuleSetDataSource) complete(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_cdn_frontdoor_batch_rule_set" "test" {
+  name                = azurerm_cdn_frontdoor_batch_rule_set.test.name
+  profile_name        = azurerm_cdn_frontdoor_profile.test.name
+  resource_group_name = azurerm_cdn_frontdoor_profile.test.resource_group_name
+}
+`, CdnFrontdoorBatchRuleSetResource{}.complete(data))
+}
+
+func (CdnFrontDoorBatchRuleSetDataSource) nonBatchRuleSet(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_cdn_frontdoor_batch_rule_set" "test" {
+  name                = azurerm_cdn_frontdoor_rule_set.test.name
+  profile_name        = azurerm_cdn_frontdoor_profile.test.name
+  resource_group_name = azurerm_cdn_frontdoor_profile.test.resource_group_name
+}
+`, CdnFrontDoorRuleSetResource{}.basic(data, true))
+}

--- a/internal/services/cdn/cdn_frontdoor_batch_rule_set_definition.go
+++ b/internal/services/cdn/cdn_frontdoor_batch_rule_set_definition.go
@@ -1,0 +1,1243 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package cdn
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigins"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rulesets"
+	helperValidate "github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cdn/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+const cdnFrontDoorBatchRuleConditionOperatorNegatedPrefix = "Not"
+
+type CdnFrontDoorBatchRuleSetModel struct {
+	Name                  string                              `tfschema:"name"`
+	CdnFrontdoorProfileID string                              `tfschema:"cdn_frontdoor_profile_id"`
+	Rule                  []CdnFrontDoorBatchRuleSetRuleModel `tfschema:"rule"`
+	ID                    string                              `tfschema:"id"`
+}
+
+type CdnFrontDoorBatchRuleSetRuleModel struct {
+	Name             string                                    `tfschema:"name"`
+	BehaviourOnMatch string                                    `tfschema:"behaviour_on_match"`
+	Order            int64                                     `tfschema:"order"`
+	Actions          []CdnFrontDoorBatchRuleSetActionsModel    `tfschema:"actions"`
+	Conditions       []CdnFrontDoorBatchRuleSetConditionsModel `tfschema:"conditions"`
+}
+
+type CdnFrontDoorBatchRuleSetActionsModel struct {
+	URLRedirect                []CdnFrontDoorBatchRuleSetURLRedirectActionModel                `tfschema:"url_redirect"`
+	URLRewrite                 []CdnFrontDoorBatchRuleSetURLRewriteActionModel                 `tfschema:"url_rewrite"`
+	ModifyRequestHeader        []CdnFrontDoorBatchRuleSetHeaderActionModel                     `tfschema:"modify_request_header"`
+	ModifyResponseHeader       []CdnFrontDoorBatchRuleSetHeaderActionModel                     `tfschema:"modify_response_header"`
+	RouteConfigurationOverride []CdnFrontDoorBatchRuleSetRouteConfigurationOverrideActionModel `tfschema:"route_configuration_override"`
+}
+
+type CdnFrontDoorBatchRuleSetURLRedirectActionModel struct {
+	RedirectType        string `tfschema:"redirect_type"`
+	RedirectProtocol    string `tfschema:"redirect_protocol"`
+	DestinationPath     string `tfschema:"destination_path"`
+	DestinationHostName string `tfschema:"destination_host_name"`
+	QueryString         string `tfschema:"query_string"`
+	DestinationFragment string `tfschema:"destination_fragment"`
+}
+
+type CdnFrontDoorBatchRuleSetURLRewriteActionModel struct {
+	SourcePattern                string `tfschema:"source_pattern"`
+	DestinationPath              string `tfschema:"destination_path"`
+	PreserveUnmatchedPathEnabled bool   `tfschema:"preserve_unmatched_path_enabled"`
+}
+
+type CdnFrontDoorBatchRuleSetHeaderActionModel struct {
+	Operator    string `tfschema:"operator"`
+	HeaderName  string `tfschema:"header_name"`
+	HeaderValue string `tfschema:"header_value"`
+}
+
+type CdnFrontDoorBatchRuleSetRouteConfigurationOverrideActionModel struct {
+	OriginGroup []CdnFrontDoorBatchRuleSetRouteConfigurationOverrideOriginGroupModel `tfschema:"origin_group"`
+	Caching     []CdnFrontDoorBatchRuleSetRouteConfigurationOverrideCachingModel     `tfschema:"caching"`
+}
+
+type CdnFrontDoorBatchRuleSetRouteConfigurationOverrideOriginGroupModel struct {
+	CdnFrontdoorOriginGroupID string `tfschema:"cdn_frontdoor_origin_group_id"`
+	ForwardingProtocol        string `tfschema:"forwarding_protocol"`
+}
+
+type CdnFrontDoorBatchRuleSetRouteConfigurationOverrideCachingModel struct {
+	Behaviour             string   `tfschema:"behaviour"`
+	Duration              string   `tfschema:"duration"`
+	CompressionEnabled    bool     `tfschema:"compression_enabled"`
+	QueryStringBehaviour  string   `tfschema:"query_string_behaviour"`
+	QueryStringParameters []string `tfschema:"query_string_parameters"`
+}
+
+type CdnFrontDoorBatchRuleSetConditionsModel struct {
+	RemoteAddress        []CdnFrontDoorBatchRuleSetConditionBaseModel                  `tfschema:"remote_address"`
+	RequestMethod        []CdnFrontDoorBatchRuleSetConditionBaseModel                  `tfschema:"request_method"`
+	QueryString          []CdnFrontDoorBatchRuleSetConditionWithTransformsModel        `tfschema:"query_string"`
+	PostArgs             []CdnFrontDoorBatchRuleSetConditionWithNameAndTransformsModel `tfschema:"post_argument"`
+	RequestURL           []CdnFrontDoorBatchRuleSetConditionWithTransformsModel        `tfschema:"request_url"`
+	RequestHeader        []CdnFrontDoorBatchRuleSetConditionWithNameAndTransformsModel `tfschema:"request_header"`
+	RequestBody          []CdnFrontDoorBatchRuleSetConditionWithTransformsModel        `tfschema:"request_body"`
+	RequestScheme        []CdnFrontDoorBatchRuleSetConditionBaseModel                  `tfschema:"request_scheme"`
+	RequestPath          []CdnFrontDoorBatchRuleSetConditionWithTransformsModel        `tfschema:"request_path"`
+	RequestFileExtension []CdnFrontDoorBatchRuleSetConditionWithTransformsModel        `tfschema:"request_file_extension"`
+	RequestFilename      []CdnFrontDoorBatchRuleSetConditionWithTransformsModel        `tfschema:"request_filename"`
+	HTTPVersion          []CdnFrontDoorBatchRuleSetConditionBaseModel                  `tfschema:"http_version"`
+	RequestCookies       []CdnFrontDoorBatchRuleSetConditionWithNameAndTransformsModel `tfschema:"request_cookies"`
+	DeviceType           []CdnFrontDoorBatchRuleSetConditionBaseModel                  `tfschema:"device_type"`
+	SocketAddress        []CdnFrontDoorBatchRuleSetConditionBaseModel                  `tfschema:"socket_address"`
+	ClientPort           []CdnFrontDoorBatchRuleSetConditionBaseModel                  `tfschema:"client_port"`
+	ServerPort           []CdnFrontDoorBatchRuleSetConditionBaseModel                  `tfschema:"server_port"`
+	HostName             []CdnFrontDoorBatchRuleSetConditionWithTransformsModel        `tfschema:"host_name"`
+	SSLProtocol          []CdnFrontDoorBatchRuleSetConditionBaseModel                  `tfschema:"ssl_protocol"`
+}
+
+type CdnFrontDoorBatchRuleSetConditionBaseModel struct {
+	Operator string   `tfschema:"operator"`
+	Values   []string `tfschema:"values"`
+}
+
+type CdnFrontDoorBatchRuleSetConditionWithTransformsModel struct {
+	Operator   string   `tfschema:"operator"`
+	Values     []string `tfschema:"values"`
+	Transforms []string `tfschema:"transforms"`
+}
+
+type CdnFrontDoorBatchRuleSetConditionWithNameAndTransformsModel struct {
+	Name       string   `tfschema:"name"`
+	Operator   string   `tfschema:"operator"`
+	Values     []string `tfschema:"values"`
+	Transforms []string `tfschema:"transforms"`
+}
+
+func cdnFrontDoorBatchRuleSetActionModifyHeaderSchema() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"operator": {
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringInSlice(rulesets.PossibleValuesForHeaderAction(), false),
+				},
+				"header_name": {
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+				"header_value": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+			},
+		},
+	}
+}
+
+func cdnFrontDoorBatchRuleSetConditionValuesSchema() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		MaxItems: 25,
+		Elem: &pluginsdk.Schema{
+			Type:         pluginsdk.TypeString,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+	}
+}
+
+func cdnFrontDoorBatchRuleSetConditionTransformsSchema() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeSet,
+		Optional: true,
+		MaxItems: 4,
+		Elem: &pluginsdk.Schema{
+			Type:         pluginsdk.TypeString,
+			ValidateFunc: validation.StringInSlice(rulesets.PossibleValuesForTransform(), false),
+		},
+	}
+}
+
+func cdnFrontDoorBatchRuleSetConditionSelectorSchema() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:         pluginsdk.TypeString,
+		Required:     true,
+		ValidateFunc: validation.StringIsNotEmpty,
+	}
+}
+
+func cdnFrontDoorBatchRuleSetConditionOperatorPossibleValues(values []string) []string {
+	result := make([]string, 0, len(values)*2)
+	for _, value := range values {
+		// For each SDK constant, we'll add a negated version in favour of exposing another property
+		// this matches portal more closely, and avoids exposing a number of `operator` fields with only a single allowed value.
+		result = append(result, value, cdnFrontDoorBatchRuleConditionOperatorNegatedPrefix+value)
+	}
+	return result
+}
+
+func expandCdnFrontDoorBatchRuleSetPayload(model CdnFrontDoorBatchRuleSetModel) (rulesets.RuleSet, error) {
+	expandedRules, err := expandCdnFrontDoorBatchRuleSetRules(model.Rule)
+	if err != nil {
+		return rulesets.RuleSet{}, err
+	}
+
+	return rulesets.RuleSet{
+		Properties: &rulesets.RuleSetProperties{
+			BatchMode: pointer.To(true),
+			Rules:     pointer.To(expandedRules),
+		},
+	}, nil
+}
+
+func expandCdnFrontDoorBatchRuleSetRules(input []CdnFrontDoorBatchRuleSetRuleModel) ([]rulesets.BatchRuleProperties, error) {
+	results := make([]rulesets.BatchRuleProperties, 0, len(input))
+	for _, item := range input {
+		actions, err := expandCdnFrontDoorBatchRuleSetActions(item.Actions)
+		if err != nil {
+			return nil, err
+		}
+
+		conditions, err := expandCdnFrontDoorBatchRuleSetConditions(item.Conditions)
+		if err != nil {
+			return nil, err
+		}
+
+		results = append(results, rulesets.BatchRuleProperties{
+			Actions:                 pointer.To(actions),
+			Conditions:              pointer.To(conditions),
+			MatchProcessingBehavior: pointer.ToEnum[rulesets.MatchProcessingBehavior](item.BehaviourOnMatch),
+			Order:                   pointer.To(item.Order),
+			RuleName:                item.Name,
+		})
+	}
+
+	return results, nil
+}
+
+func flattenCdnFrontDoorBatchRuleSetRules(input *[]rulesets.BatchRuleProperties) ([]CdnFrontDoorBatchRuleSetRuleModel, error) {
+	results := make([]CdnFrontDoorBatchRuleSetRuleModel, 0)
+	if input == nil || len(*input) == 0 {
+		return results, nil
+	}
+
+	for _, item := range *input {
+		ruleState, err := flattenCdnFrontDoorBatchRuleSetRule(item)
+		if err != nil {
+			return results, err
+		}
+		results = append(results, ruleState)
+	}
+
+	sort.SliceStable(results, func(i, j int) bool {
+		return results[i].Order < results[j].Order
+	})
+
+	return results, nil
+}
+
+func flattenCdnFrontDoorBatchRuleSetRule(input rulesets.BatchRuleProperties) (CdnFrontDoorBatchRuleSetRuleModel, error) {
+	state := CdnFrontDoorBatchRuleSetRuleModel{
+		BehaviourOnMatch: pointer.FromEnum(input.MatchProcessingBehavior),
+		Name:             input.RuleName,
+		Order:            pointer.From(input.Order),
+	}
+
+	actions, err := flattenCdnFrontDoorBatchRuleSetActions(input.Actions)
+	if err != nil {
+		return CdnFrontDoorBatchRuleSetRuleModel{}, fmt.Errorf("flattening `actions`: %+v", err)
+	}
+	state.Actions = actions
+
+	conditions, err := flattenCdnFrontDoorBatchRuleSetConditions(input.Conditions)
+	if err != nil {
+		return CdnFrontDoorBatchRuleSetRuleModel{}, fmt.Errorf("flattening `conditions`: %+v", err)
+	}
+	state.Conditions = conditions
+
+	return state, nil
+}
+
+func expandCdnFrontDoorBatchRuleSetActions(input []CdnFrontDoorBatchRuleSetActionsModel) ([]rulesets.DeliveryRuleAction, error) {
+	results := make([]rulesets.DeliveryRuleAction, 0)
+	if len(input) == 0 {
+		return results, nil
+	}
+
+	actions := input[0]
+	if err := validateCdnFrontDoorBatchRuleActionCounts(countCdnFrontDoorBatchRuleActions(input)); err != nil {
+		return nil, err
+	}
+
+	for _, item := range actions.URLRedirect {
+		results = append(results, rulesets.URLRedirectAction{
+			Name: rulesets.DeliveryRuleActionNameURLRedirect,
+			Parameters: rulesets.URLRedirectActionParameters{
+				TypeName:            rulesets.DeliveryRuleActionParametersTypeDeliveryRuleURLRedirectActionParameters,
+				RedirectType:        rulesets.RedirectType(item.RedirectType),
+				DestinationProtocol: pointer.ToEnum[rulesets.DestinationProtocol](item.RedirectProtocol),
+				CustomPath:          pointer.To(item.DestinationPath),
+				CustomHostname:      pointer.To(item.DestinationHostName),
+				CustomQueryString:   pointer.To(item.QueryString),
+				CustomFragment:      pointer.To(item.DestinationFragment),
+			},
+		})
+	}
+
+	for _, item := range actions.URLRewrite {
+		results = append(results, rulesets.URLRewriteAction{
+			Name: rulesets.DeliveryRuleActionNameURLRewrite,
+			Parameters: rulesets.URLRewriteActionParameters{
+				TypeName:              rulesets.DeliveryRuleActionParametersTypeDeliveryRuleURLRewriteActionParameters,
+				SourcePattern:         item.SourcePattern,
+				Destination:           item.DestinationPath,
+				PreserveUnmatchedPath: pointer.To(item.PreserveUnmatchedPathEnabled),
+			},
+		})
+	}
+
+	for _, item := range actions.ModifyRequestHeader {
+		if err := validateCdnFrontDoorBatchRuleModifyHeaderAction("modify_request_header", item.Operator, item.HeaderValue); err != nil {
+			return nil, err
+		}
+		results = append(results, rulesets.DeliveryRuleRequestHeaderAction{
+			Name: rulesets.DeliveryRuleActionNameModifyRequestHeader,
+			Parameters: rulesets.HeaderActionParameters{
+				TypeName:     rulesets.DeliveryRuleActionParametersTypeDeliveryRuleHeaderActionParameters,
+				HeaderAction: rulesets.HeaderAction(item.Operator),
+				HeaderName:   item.HeaderName,
+				Value:        pointer.To(item.HeaderValue),
+			},
+		})
+	}
+
+	for _, item := range actions.ModifyResponseHeader {
+		if err := validateCdnFrontDoorBatchRuleModifyHeaderAction("modify_response_header", item.Operator, item.HeaderValue); err != nil {
+			return nil, err
+		}
+		results = append(results, rulesets.DeliveryRuleResponseHeaderAction{
+			Name: rulesets.DeliveryRuleActionNameModifyResponseHeader,
+			Parameters: rulesets.HeaderActionParameters{
+				TypeName:     rulesets.DeliveryRuleActionParametersTypeDeliveryRuleHeaderActionParameters,
+				HeaderAction: rulesets.HeaderAction(item.Operator),
+				HeaderName:   item.HeaderName,
+				Value:        pointer.To(item.HeaderValue),
+			},
+		})
+	}
+
+	for _, item := range actions.RouteConfigurationOverride {
+		expandedCache, err := expandCdnFrontDoorBatchRuleSetRouteConfigurationOverrideCaching(item.Caching)
+		if err != nil {
+			return nil, fmt.Errorf("expanding `route_configuration_override.0.caching`: %+v", err)
+		}
+
+		results = append(results, rulesets.DeliveryRuleRouteConfigurationOverrideAction{
+			Name: rulesets.DeliveryRuleActionNameRouteConfigurationOverride,
+			Parameters: rulesets.RouteConfigurationOverrideActionParameters{
+				TypeName:            rulesets.DeliveryRuleActionParametersTypeDeliveryRuleRouteConfigurationOverrideActionParameters,
+				CacheConfiguration:  expandedCache,
+				OriginGroupOverride: expandCdnFrontDoorBatchRuleSetRouteConfigurationOverrideOriginGroup(item.OriginGroup),
+			},
+		})
+	}
+
+	return results, nil
+}
+
+func flattenCdnFrontDoorBatchRuleSetActions(input *[]rulesets.DeliveryRuleAction) ([]CdnFrontDoorBatchRuleSetActionsModel, error) {
+	if input == nil {
+		return []CdnFrontDoorBatchRuleSetActionsModel{}, nil
+	}
+
+	results := make([]CdnFrontDoorBatchRuleSetActionsModel, 0, len(*input))
+	actions := CdnFrontDoorBatchRuleSetActionsModel{}
+
+	for _, action := range *input {
+		switch a := action.(type) {
+		case rulesets.URLRedirectAction:
+			actions.URLRedirect = append(actions.URLRedirect, CdnFrontDoorBatchRuleSetURLRedirectActionModel{
+				RedirectType:        string(a.Parameters.RedirectType),
+				RedirectProtocol:    pointer.FromEnum(a.Parameters.DestinationProtocol),
+				DestinationPath:     pointer.From(a.Parameters.CustomPath),
+				DestinationHostName: pointer.From(a.Parameters.CustomHostname),
+				QueryString:         pointer.From(a.Parameters.CustomQueryString),
+				DestinationFragment: pointer.From(a.Parameters.CustomFragment),
+			})
+		case rulesets.URLRewriteAction:
+			actions.URLRewrite = append(actions.URLRewrite, CdnFrontDoorBatchRuleSetURLRewriteActionModel{
+				SourcePattern:                a.Parameters.SourcePattern,
+				DestinationPath:              a.Parameters.Destination,
+				PreserveUnmatchedPathEnabled: pointer.From(a.Parameters.PreserveUnmatchedPath),
+			})
+		case rulesets.DeliveryRuleRequestHeaderAction:
+			actions.ModifyRequestHeader = append(actions.ModifyRequestHeader, CdnFrontDoorBatchRuleSetHeaderActionModel{
+				Operator:    string(a.Parameters.HeaderAction),
+				HeaderName:  a.Parameters.HeaderName,
+				HeaderValue: pointer.From(a.Parameters.Value),
+			})
+		case rulesets.DeliveryRuleResponseHeaderAction:
+			actions.ModifyResponseHeader = append(actions.ModifyResponseHeader, CdnFrontDoorBatchRuleSetHeaderActionModel{
+				Operator:    string(a.Parameters.HeaderAction),
+				HeaderName:  a.Parameters.HeaderName,
+				HeaderValue: pointer.From(a.Parameters.Value),
+			})
+		case rulesets.DeliveryRuleRouteConfigurationOverrideAction:
+			flattened, err := flattenCdnFrontDoorBatchRuleSetRouteConfigurationOverrideAction(a.Parameters)
+			if err != nil {
+				return results, err
+			}
+			actions.RouteConfigurationOverride = append(actions.RouteConfigurationOverride, flattened)
+		default:
+			return results, fmt.Errorf("unsupported action (`%s`) encountered", a.DeliveryRuleAction().Name)
+		}
+	}
+
+	return append(results, actions), nil
+}
+
+func flattenCdnFrontDoorBatchRuleSetRouteConfigurationOverrideAction(input rulesets.RouteConfigurationOverrideActionParameters) (CdnFrontDoorBatchRuleSetRouteConfigurationOverrideActionModel, error) {
+	result := CdnFrontDoorBatchRuleSetRouteConfigurationOverrideActionModel{
+		Caching: flattenCdnFrontDoorBatchRuleSetRouteConfigurationOverrideCaching(input.CacheConfiguration),
+	}
+
+	originGroup, err := flattenCdnFrontDoorBatchRuleSetRouteConfigurationOverrideOriginGroup(input.OriginGroupOverride)
+	if err != nil {
+		return result, err
+	}
+	result.OriginGroup = originGroup
+
+	return result, nil
+}
+
+func expandCdnFrontDoorBatchRuleSetRouteConfigurationOverrideCaching(input []CdnFrontDoorBatchRuleSetRouteConfigurationOverrideCachingModel) (*rulesets.CacheConfiguration, error) {
+	if len(input) == 0 {
+		return nil, nil
+	}
+
+	v := input[0]
+	if v.Behaviour == RuleCacheBehaviorDisabled {
+		if v.Duration != "" {
+			return nil, fmt.Errorf("when `route_configuration_override.caching.behaviour` is set to `Disabled`, you cannot define `route_configuration_override.caching.duration`, got `%s`", v.Duration)
+		}
+
+		if len(v.QueryStringParameters) != 0 {
+			return nil, fmt.Errorf("when `route_configuration_override.caching.behaviour` is set to `Disabled`, you cannot define any `route_configuration_override.caching.query_string_parameters`, got `%d` parameters", len(v.QueryStringParameters))
+		}
+
+		if v.QueryStringBehaviour != "" {
+			return nil, fmt.Errorf("when `route_configuration_override.caching.behaviour` is set to `Disabled`, you cannot define `route_configuration_override.caching.query_string_behaviour`, got `%s`", v.QueryStringBehaviour)
+		}
+
+		if v.CompressionEnabled {
+			return nil, fmt.Errorf("when `route_configuration_override.caching.behaviour` is set to `Disabled`, you cannot define `route_configuration_override.caching.compression_enabled`, got `%t`", v.CompressionEnabled)
+		}
+
+		return nil, nil
+	}
+
+	if v.QueryStringBehaviour == "" {
+		return nil, fmt.Errorf("when `route_configuration_override.caching.behaviour` is set to `%s`, you must also define `route_configuration_override.caching.query_string_behaviour`", v.Behaviour)
+	}
+
+	// `HonorOrigin` must not carry an explicit cache duration.
+	if v.Behaviour == string(rulesets.RuleCacheBehaviorHonorOrigin) {
+		if v.Duration != "" {
+			return nil, fmt.Errorf("when `route_configuration_override.caching.behaviour` is set to `%s`, you cannot define `route_configuration_override.caching.duration`, got `%s`", rulesets.RuleCacheBehaviorHonorOrigin, v.Duration)
+		}
+	} else if v.Duration == "" {
+		return nil, fmt.Errorf("when `route_configuration_override.caching.behaviour` is set to `%s`, you must also define `route_configuration_override.caching.duration`", v.Behaviour)
+	}
+
+	switch rulesets.RuleQueryStringCachingBehavior(v.QueryStringBehaviour) {
+	case rulesets.RuleQueryStringCachingBehaviorIncludeSpecifiedQueryStrings, rulesets.RuleQueryStringCachingBehaviorIgnoreSpecifiedQueryStrings:
+		if len(v.QueryStringParameters) == 0 {
+			return nil, fmt.Errorf("when `route_configuration_override.caching.query_string_behaviour` is set to `%s`, you must also define one or more `route_configuration_override.caching.query_string_parameters`", v.QueryStringBehaviour)
+		}
+	case rulesets.RuleQueryStringCachingBehaviorUseQueryString, rulesets.RuleQueryStringCachingBehaviorIgnoreQueryString:
+		if len(v.QueryStringParameters) > 0 {
+			return nil, fmt.Errorf("when `route_configuration_override.caching.query_string_behaviour` is set to `%s`, you cannot define `route_configuration_override.caching.query_string_parameters`", v.QueryStringBehaviour)
+		}
+	}
+
+	compressionEnabled := rulesets.RuleIsCompressionEnabledDisabled
+	if v.CompressionEnabled {
+		compressionEnabled = rulesets.RuleIsCompressionEnabledEnabled
+	}
+
+	queryParameters := (*string)(nil)
+	if len(v.QueryStringParameters) > 0 {
+		queryParameters = pointer.To(strings.Join(v.QueryStringParameters, ","))
+	}
+
+	return &rulesets.CacheConfiguration{
+		CacheBehavior:              pointer.ToEnum[rulesets.RuleCacheBehavior](v.Behaviour),
+		CacheDuration:              pointer.ToOrNil(v.Duration),
+		IsCompressionEnabled:       pointer.To(compressionEnabled),
+		QueryParameters:            queryParameters,
+		QueryStringCachingBehavior: pointer.ToOrNil(rulesets.RuleQueryStringCachingBehavior(v.QueryStringBehaviour)),
+	}, nil
+}
+
+func flattenCdnFrontDoorBatchRuleSetRouteConfigurationOverrideCaching(input *rulesets.CacheConfiguration) []CdnFrontDoorBatchRuleSetRouteConfigurationOverrideCachingModel {
+	result := make([]CdnFrontDoorBatchRuleSetRouteConfigurationOverrideCachingModel, 0)
+	if input == nil {
+		// The API treats omission as disabled, so we'll need to set `Disabled` back into state if it's nil
+		return append(result, CdnFrontDoorBatchRuleSetRouteConfigurationOverrideCachingModel{
+			Behaviour: string(rulesets.RuleIsCompressionEnabledDisabled),
+		})
+	}
+
+	v := CdnFrontDoorBatchRuleSetRouteConfigurationOverrideCachingModel{
+		Behaviour:            pointer.FromEnum(input.CacheBehavior),
+		Duration:             pointer.FromEnum(input.CacheDuration),
+		CompressionEnabled:   pointer.From(input.IsCompressionEnabled) == rulesets.RuleIsCompressionEnabledEnabled,
+		QueryStringBehaviour: pointer.FromEnum(input.QueryStringCachingBehavior),
+	}
+
+	if input.QueryParameters != nil {
+		v.QueryStringParameters = strings.Split(*input.QueryParameters, ",")
+	}
+
+	return append(result, v)
+}
+
+func expandCdnFrontDoorBatchRuleSetRouteConfigurationOverrideOriginGroup(input []CdnFrontDoorBatchRuleSetRouteConfigurationOverrideOriginGroupModel) *rulesets.OriginGroupOverride {
+	if len(input) == 0 {
+		return nil
+	}
+
+	v := input[0]
+	return &rulesets.OriginGroupOverride{
+		ForwardingProtocol: pointer.ToEnum[rulesets.ForwardingProtocol](v.ForwardingProtocol),
+		OriginGroup: &rulesets.ResourceReference{
+			Id: pointer.To(v.CdnFrontdoorOriginGroupID),
+		},
+	}
+}
+
+func flattenCdnFrontDoorBatchRuleSetRouteConfigurationOverrideOriginGroup(input *rulesets.OriginGroupOverride) ([]CdnFrontDoorBatchRuleSetRouteConfigurationOverrideOriginGroupModel, error) {
+	result := make([]CdnFrontDoorBatchRuleSetRouteConfigurationOverrideOriginGroupModel, 0)
+	if input == nil {
+		return result, nil
+	}
+
+	v := CdnFrontDoorBatchRuleSetRouteConfigurationOverrideOriginGroupModel{
+		ForwardingProtocol: pointer.FromEnum(input.ForwardingProtocol),
+	}
+
+	if input.OriginGroup != nil && input.OriginGroup.Id != nil {
+		originGroupID, err := afdorigins.ParseOriginGroupID(*input.OriginGroup.Id)
+		if err != nil {
+			return result, err
+		}
+		v.CdnFrontdoorOriginGroupID = originGroupID.ID()
+	}
+
+	return append(result, v), nil
+}
+
+func expandCdnFrontDoorBatchRuleSetConditions(input []CdnFrontDoorBatchRuleSetConditionsModel) ([]rulesets.DeliveryRuleCondition, error) {
+	results := make([]rulesets.DeliveryRuleCondition, 0)
+	if len(input) == 0 {
+		return results, nil
+	}
+
+	conditions := input[0]
+
+	expanded, err := expandCdnFrontDoorBatchRuleSetConditionBaseModel(conditions.RemoteAddress, "remote_address", expandCdnFrontDoorBatchRuleSetRemoteAddressCondition)
+	if err != nil {
+		return nil, err
+	}
+	results = append(results, expanded...)
+
+	expanded, err = expandCdnFrontDoorBatchRuleSetConditionWithTransformsModel(conditions.QueryString, "query_string", expandCdnFrontDoorBatchRuleSetQueryStringCondition)
+	if err != nil {
+		return nil, err
+	}
+	results = append(results, expanded...)
+
+	expanded, err = expandCdnFrontDoorBatchRuleSetConditionWithTransformsModel(conditions.RequestURL, "request_url", expandCdnFrontDoorBatchRuleSetRequestURLCondition)
+	if err != nil {
+		return nil, err
+	}
+	results = append(results, expanded...)
+
+	expanded, err = expandCdnFrontDoorBatchRuleSetConditionWithTransformsModel(conditions.RequestBody, "request_body", expandCdnFrontDoorBatchRuleSetRequestBodyCondition)
+	if err != nil {
+		return nil, err
+	}
+	results = append(results, expanded...)
+
+	expanded, err = expandCdnFrontDoorBatchRuleSetConditionWithTransformsModel(conditions.RequestPath, "request_path", expandCdnFrontDoorBatchRuleSetRequestPathCondition)
+	if err != nil {
+		return nil, err
+	}
+	results = append(results, expanded...)
+
+	expanded, err = expandCdnFrontDoorBatchRuleSetConditionWithTransformsModel(conditions.RequestFileExtension, "request_file_extension", expandCdnFrontDoorBatchRuleSetRequestFileExtensionCondition)
+	if err != nil {
+		return nil, err
+	}
+	results = append(results, expanded...)
+
+	expanded, err = expandCdnFrontDoorBatchRuleSetConditionWithTransformsModel(conditions.RequestFilename, "request_filename", expandCdnFrontDoorBatchRuleSetRequestFilenameCondition)
+	if err != nil {
+		return nil, err
+	}
+	results = append(results, expanded...)
+
+	expanded, err = expandCdnFrontDoorBatchRuleSetConditionBaseModel(conditions.SocketAddress, "socket_address", expandCdnFrontDoorBatchRuleSetSocketAddressCondition)
+	if err != nil {
+		return nil, err
+	}
+	results = append(results, expanded...)
+
+	expanded, err = expandCdnFrontDoorBatchRuleSetConditionBaseModel(conditions.ClientPort, "client_port", expandCdnFrontDoorBatchRuleSetClientPortCondition)
+	if err != nil {
+		return nil, err
+	}
+	results = append(results, expanded...)
+
+	expanded, err = expandCdnFrontDoorBatchRuleSetConditionBaseModel(conditions.ServerPort, "server_port", expandCdnFrontDoorBatchRuleSetServerPortCondition)
+	if err != nil {
+		return nil, err
+	}
+	results = append(results, expanded...)
+
+	expanded, err = expandCdnFrontDoorBatchRuleSetConditionWithTransformsModel(conditions.HostName, "host_name", expandCdnFrontDoorBatchRuleSetHostNameCondition)
+	if err != nil {
+		return nil, err
+	}
+	results = append(results, expanded...)
+
+	expanded, err = expandCdnFrontDoorBatchRuleSetConditionBaseModel(conditions.RequestMethod, "request_method", expandCdnFrontDoorBatchRuleSetRequestMethodCondition)
+	if err != nil {
+		return nil, err
+	}
+	results = append(results, expanded...)
+
+	expanded, err = expandCdnFrontDoorBatchRuleSetConditionWithNameAndTransformsModel(conditions.PostArgs, "post_argument", expandCdnFrontDoorBatchRuleSetPostArgsCondition)
+	if err != nil {
+		return nil, err
+	}
+	results = append(results, expanded...)
+
+	expanded, err = expandCdnFrontDoorBatchRuleSetConditionWithNameAndTransformsModel(conditions.RequestHeader, "request_header", expandCdnFrontDoorBatchRuleSetRequestHeaderCondition)
+	if err != nil {
+		return nil, err
+	}
+	results = append(results, expanded...)
+
+	expanded, err = expandCdnFrontDoorBatchRuleSetConditionBaseModel(conditions.RequestScheme, "request_scheme", expandCdnFrontDoorBatchRuleSetRequestSchemeCondition)
+	if err != nil {
+		return nil, err
+	}
+	results = append(results, expanded...)
+
+	expanded, err = expandCdnFrontDoorBatchRuleSetConditionBaseModel(conditions.HTTPVersion, "http_version", expandCdnFrontDoorBatchRuleSetHTTPVersionCondition)
+	if err != nil {
+		return nil, err
+	}
+	results = append(results, expanded...)
+
+	expanded, err = expandCdnFrontDoorBatchRuleSetConditionWithNameAndTransformsModel(conditions.RequestCookies, "request_cookies", expandCdnFrontDoorBatchRuleSetCookiesCondition)
+	if err != nil {
+		return nil, err
+	}
+	results = append(results, expanded...)
+
+	expanded, err = expandCdnFrontDoorBatchRuleSetConditionBaseModel(conditions.DeviceType, "device_type", expandCdnFrontDoorBatchRuleSetDeviceTypeCondition)
+	if err != nil {
+		return nil, err
+	}
+	results = append(results, expanded...)
+
+	expanded, err = expandCdnFrontDoorBatchRuleSetConditionBaseModel(conditions.SSLProtocol, "ssl_protocol", expandCdnFrontDoorBatchRuleSetSSLProtocolCondition)
+	if err != nil {
+		return nil, err
+	}
+	results = append(results, expanded...)
+
+	if len(results) > 10 {
+		return nil, fmt.Errorf("the `conditions` block may only contain up to 10 match conditions, got %d", len(results))
+	}
+
+	return results, nil
+}
+
+func flattenCdnFrontDoorBatchRuleSetConditions(input *[]rulesets.DeliveryRuleCondition) ([]CdnFrontDoorBatchRuleSetConditionsModel, error) {
+	if input == nil || len(*input) == 0 {
+		return []CdnFrontDoorBatchRuleSetConditionsModel{}, nil
+	}
+
+	conditions := CdnFrontDoorBatchRuleSetConditionsModel{}
+	for _, condition := range *input {
+		switch c := condition.(type) {
+		case rulesets.DeliveryRuleRemoteAddressCondition:
+			conditions.RemoteAddress = append(conditions.RemoteAddress, flattenCdnFrontDoorBatchRuleSetConditionBaseModel(string(c.Parameters.Operator), pointer.From(c.Parameters.MatchValues), c.Parameters.NegateCondition))
+		case rulesets.DeliveryRuleRequestMethodCondition:
+			conditions.RequestMethod = append(conditions.RequestMethod, flattenCdnFrontDoorBatchRuleSetConditionBaseModel(string(c.Parameters.Operator), pointer.FromEnumSlice(c.Parameters.MatchValues), c.Parameters.NegateCondition))
+		case rulesets.DeliveryRuleQueryStringCondition:
+			conditions.QueryString = append(conditions.QueryString, flattenCdnFrontDoorBatchRuleSetConditionWithTransformsModel(string(c.Parameters.Operator), pointer.From(c.Parameters.MatchValues), pointer.FromEnumSlice(c.Parameters.Transforms), c.Parameters.NegateCondition))
+		case rulesets.DeliveryRulePostArgsCondition:
+			conditions.PostArgs = append(conditions.PostArgs, flattenCdnFrontDoorBatchRuleSetConditionWithNameAndTransformsModel(string(c.Parameters.Operator), c.Parameters.Selector, pointer.From(c.Parameters.MatchValues), pointer.FromEnumSlice(c.Parameters.Transforms), c.Parameters.NegateCondition))
+		case rulesets.DeliveryRuleRequestUriCondition:
+			conditions.RequestURL = append(conditions.RequestURL, flattenCdnFrontDoorBatchRuleSetConditionWithTransformsModel(string(c.Parameters.Operator), pointer.From(c.Parameters.MatchValues), pointer.FromEnumSlice(c.Parameters.Transforms), c.Parameters.NegateCondition))
+		case rulesets.DeliveryRuleRequestHeaderCondition:
+			conditions.RequestHeader = append(conditions.RequestHeader, flattenCdnFrontDoorBatchRuleSetConditionWithNameAndTransformsModel(string(c.Parameters.Operator), c.Parameters.Selector, pointer.From(c.Parameters.MatchValues), pointer.FromEnumSlice(c.Parameters.Transforms), c.Parameters.NegateCondition))
+		case rulesets.DeliveryRuleRequestBodyCondition:
+			conditions.RequestBody = append(conditions.RequestBody, flattenCdnFrontDoorBatchRuleSetConditionWithTransformsModel(string(c.Parameters.Operator), pointer.From(c.Parameters.MatchValues), pointer.FromEnumSlice(c.Parameters.Transforms), c.Parameters.NegateCondition))
+		case rulesets.DeliveryRuleRequestSchemeCondition:
+			conditions.RequestScheme = append(conditions.RequestScheme, flattenCdnFrontDoorBatchRuleSetConditionBaseModel(string(c.Parameters.Operator), pointer.FromEnumSlice(c.Parameters.MatchValues), c.Parameters.NegateCondition))
+		case rulesets.DeliveryRuleURLPathCondition:
+			conditions.RequestPath = append(conditions.RequestPath, flattenCdnFrontDoorBatchRuleSetConditionWithTransformsModel(string(c.Parameters.Operator), pointer.From(c.Parameters.MatchValues), pointer.FromEnumSlice(c.Parameters.Transforms), c.Parameters.NegateCondition))
+		case rulesets.DeliveryRuleURLFileExtensionCondition:
+			conditions.RequestFileExtension = append(conditions.RequestFileExtension, flattenCdnFrontDoorBatchRuleSetConditionWithTransformsModel(string(c.Parameters.Operator), pointer.From(c.Parameters.MatchValues), pointer.FromEnumSlice(c.Parameters.Transforms), c.Parameters.NegateCondition))
+		case rulesets.DeliveryRuleURLFileNameCondition:
+			conditions.RequestFilename = append(conditions.RequestFilename, flattenCdnFrontDoorBatchRuleSetConditionWithTransformsModel(string(c.Parameters.Operator), pointer.From(c.Parameters.MatchValues), pointer.FromEnumSlice(c.Parameters.Transforms), c.Parameters.NegateCondition))
+		case rulesets.DeliveryRuleHTTPVersionCondition:
+			conditions.HTTPVersion = append(conditions.HTTPVersion, flattenCdnFrontDoorBatchRuleSetConditionBaseModel(string(c.Parameters.Operator), pointer.FromEnumSlice(c.Parameters.MatchValues), c.Parameters.NegateCondition))
+		case rulesets.DeliveryRuleCookiesCondition:
+			conditions.RequestCookies = append(conditions.RequestCookies, flattenCdnFrontDoorBatchRuleSetConditionWithNameAndTransformsModel(string(c.Parameters.Operator), c.Parameters.Selector, pointer.From(c.Parameters.MatchValues), pointer.FromEnumSlice(c.Parameters.Transforms), c.Parameters.NegateCondition))
+		case rulesets.DeliveryRuleIsDeviceCondition:
+			conditions.DeviceType = append(conditions.DeviceType, flattenCdnFrontDoorBatchRuleSetConditionBaseModel(string(c.Parameters.Operator), pointer.FromEnumSlice(c.Parameters.MatchValues), c.Parameters.NegateCondition))
+		case rulesets.DeliveryRuleSocketAddrCondition:
+			conditions.SocketAddress = append(conditions.SocketAddress, flattenCdnFrontDoorBatchRuleSetConditionBaseModel(string(c.Parameters.Operator), pointer.From(c.Parameters.MatchValues), c.Parameters.NegateCondition))
+		case rulesets.DeliveryRuleClientPortCondition:
+			conditions.ClientPort = append(conditions.ClientPort, flattenCdnFrontDoorBatchRuleSetConditionBaseModel(string(c.Parameters.Operator), pointer.From(c.Parameters.MatchValues), c.Parameters.NegateCondition))
+		case rulesets.DeliveryRuleServerPortCondition:
+			conditions.ServerPort = append(conditions.ServerPort, flattenCdnFrontDoorBatchRuleSetConditionBaseModel(string(c.Parameters.Operator), pointer.From(c.Parameters.MatchValues), c.Parameters.NegateCondition))
+		case rulesets.DeliveryRuleHostNameCondition:
+			conditions.HostName = append(conditions.HostName, flattenCdnFrontDoorBatchRuleSetConditionWithTransformsModel(string(c.Parameters.Operator), pointer.From(c.Parameters.MatchValues), pointer.FromEnumSlice(c.Parameters.Transforms), c.Parameters.NegateCondition))
+		case rulesets.DeliveryRuleSslProtocolCondition:
+			conditions.SSLProtocol = append(conditions.SSLProtocol, flattenCdnFrontDoorBatchRuleSetConditionBaseModel(string(c.Parameters.Operator), pointer.FromEnumSlice(c.Parameters.MatchValues), c.Parameters.NegateCondition))
+		default:
+			return []CdnFrontDoorBatchRuleSetConditionsModel{}, fmt.Errorf("unsupported condition (`%s`) encountered", condition.DeliveryRuleCondition().Name)
+		}
+	}
+
+	return []CdnFrontDoorBatchRuleSetConditionsModel{conditions}, nil
+}
+
+func expandCdnFrontDoorBatchRuleSetClientPortCondition(input CdnFrontDoorBatchRuleSetConditionBaseModel) (rulesets.DeliveryRuleCondition, error) {
+	operator, negated := expandCdnFrontDoorBatchRuleSetConditionOperator(input.Operator)
+	if err := validateCdnFrontDoorBatchRuleConditionValues("client_port", operator, input.Values); err != nil {
+		return nil, err
+	}
+
+	return rulesets.DeliveryRuleClientPortCondition{
+		Name: rulesets.MatchVariableClientPort,
+		Parameters: rulesets.ClientPortMatchConditionParameters{
+			TypeName:        rulesets.DeliveryRuleConditionParametersTypeDeliveryRuleClientPortConditionParameters,
+			Operator:        rulesets.ClientPortOperator(operator),
+			NegateCondition: pointer.To(negated),
+			MatchValues:     pointer.To(input.Values),
+		},
+	}, nil
+}
+
+func expandCdnFrontDoorBatchRuleSetCookiesCondition(input CdnFrontDoorBatchRuleSetConditionWithNameAndTransformsModel) (rulesets.DeliveryRuleCondition, error) {
+	operator, negated := expandCdnFrontDoorBatchRuleSetConditionOperator(input.Operator)
+	if err := validateCdnFrontDoorBatchRuleConditionValues("request_cookies", operator, input.Values); err != nil {
+		return nil, err
+	}
+
+	return rulesets.DeliveryRuleCookiesCondition{
+		Name: rulesets.MatchVariableCookies,
+		Parameters: rulesets.CookiesMatchConditionParameters{
+			TypeName:        rulesets.DeliveryRuleConditionParametersTypeDeliveryRuleCookiesConditionParameters,
+			Selector:        pointer.To(input.Name),
+			Operator:        rulesets.CookiesOperator(operator),
+			NegateCondition: pointer.To(negated),
+			MatchValues:     pointer.To(input.Values),
+			Transforms:      pointer.ToEnumSlice[rulesets.Transform](input.Transforms),
+		},
+	}, nil
+}
+
+func expandCdnFrontDoorBatchRuleSetHostNameCondition(input CdnFrontDoorBatchRuleSetConditionWithTransformsModel) (rulesets.DeliveryRuleCondition, error) {
+	operator, negated := expandCdnFrontDoorBatchRuleSetConditionOperator(input.Operator)
+	if err := validateCdnFrontDoorBatchRuleConditionValues("host_name", operator, input.Values); err != nil {
+		return nil, err
+	}
+
+	return rulesets.DeliveryRuleHostNameCondition{
+		Name: rulesets.MatchVariableHostName,
+		Parameters: rulesets.HostNameMatchConditionParameters{
+			TypeName:        rulesets.DeliveryRuleConditionParametersTypeDeliveryRuleHostNameConditionParameters,
+			Operator:        rulesets.HostNameOperator(operator),
+			NegateCondition: pointer.To(negated),
+			MatchValues:     pointer.To(input.Values),
+			Transforms:      pointer.ToEnumSlice[rulesets.Transform](input.Transforms),
+		},
+	}, nil
+}
+
+func expandCdnFrontDoorBatchRuleSetHTTPVersionCondition(input CdnFrontDoorBatchRuleSetConditionBaseModel) (rulesets.DeliveryRuleCondition, error) {
+	operator, negated := expandCdnFrontDoorBatchRuleSetConditionOperator(input.Operator)
+
+	return rulesets.DeliveryRuleHTTPVersionCondition{
+		Name: rulesets.MatchVariableHTTPVersion,
+		Parameters: rulesets.HTTPVersionMatchConditionParameters{
+			TypeName:        rulesets.DeliveryRuleConditionParametersTypeDeliveryRuleHTTPVersionConditionParameters,
+			Operator:        rulesets.HTTPVersionOperator(operator),
+			NegateCondition: pointer.To(negated),
+			MatchValues:     pointer.To(input.Values),
+		},
+	}, nil
+}
+
+func expandCdnFrontDoorBatchRuleSetDeviceTypeCondition(input CdnFrontDoorBatchRuleSetConditionBaseModel) (rulesets.DeliveryRuleCondition, error) {
+	operator, negated := expandCdnFrontDoorBatchRuleSetConditionOperator(input.Operator)
+
+	return rulesets.DeliveryRuleIsDeviceCondition{
+		Name: rulesets.MatchVariableIsDevice,
+		Parameters: rulesets.IsDeviceMatchConditionParameters{
+			TypeName:        rulesets.DeliveryRuleConditionParametersTypeDeliveryRuleIsDeviceConditionParameters,
+			Operator:        rulesets.IsDeviceOperator(operator),
+			NegateCondition: pointer.To(negated),
+			MatchValues:     pointer.ToEnumSlice[rulesets.IsDeviceMatchValue](input.Values),
+		},
+	}, nil
+}
+
+func expandCdnFrontDoorBatchRuleSetPostArgsCondition(input CdnFrontDoorBatchRuleSetConditionWithNameAndTransformsModel) (rulesets.DeliveryRuleCondition, error) {
+	operator, negated := expandCdnFrontDoorBatchRuleSetConditionOperator(input.Operator)
+	if err := validateCdnFrontDoorBatchRuleConditionValues("post_argument", operator, input.Values); err != nil {
+		return nil, err
+	}
+
+	return rulesets.DeliveryRulePostArgsCondition{
+		Name: rulesets.MatchVariablePostArgs,
+		Parameters: rulesets.PostArgsMatchConditionParameters{
+			TypeName:        rulesets.DeliveryRuleConditionParametersTypeDeliveryRulePostArgsConditionParameters,
+			Selector:        pointer.To(input.Name),
+			Operator:        rulesets.PostArgsOperator(operator),
+			NegateCondition: pointer.To(negated),
+			MatchValues:     pointer.To(input.Values),
+			Transforms:      pointer.ToEnumSlice[rulesets.Transform](input.Transforms),
+		},
+	}, nil
+}
+
+func expandCdnFrontDoorBatchRuleSetQueryStringCondition(input CdnFrontDoorBatchRuleSetConditionWithTransformsModel) (rulesets.DeliveryRuleCondition, error) {
+	operator, negated := expandCdnFrontDoorBatchRuleSetConditionOperator(input.Operator)
+	if err := validateCdnFrontDoorBatchRuleConditionValues("query_string", operator, input.Values); err != nil {
+		return nil, err
+	}
+
+	return rulesets.DeliveryRuleQueryStringCondition{
+		Name: rulesets.MatchVariableQueryString,
+		Parameters: rulesets.QueryStringMatchConditionParameters{
+			TypeName:        rulesets.DeliveryRuleConditionParametersTypeDeliveryRuleQueryStringConditionParameters,
+			Operator:        rulesets.QueryStringOperator(operator),
+			NegateCondition: pointer.To(negated),
+			MatchValues:     pointer.To(input.Values),
+			Transforms:      pointer.ToEnumSlice[rulesets.Transform](input.Transforms),
+		},
+	}, nil
+}
+
+func expandCdnFrontDoorBatchRuleSetRemoteAddressCondition(input CdnFrontDoorBatchRuleSetConditionBaseModel) (rulesets.DeliveryRuleCondition, error) {
+	operator, negated := expandCdnFrontDoorBatchRuleSetConditionOperator(input.Operator)
+
+	switch rulesets.RemoteAddressOperator(operator) {
+	case rulesets.RemoteAddressOperatorGeoMatch:
+		for _, v := range input.Values {
+			if ok, _ := helperValidate.RegExHelper(v, "values", `^[A-Z]{2}$`); !ok {
+				return nil, fmt.Errorf("when `conditions.remote_address.operator` is `%s` the values in `conditions.remote_address.values` must be valid country codes consisting of 2 uppercase characters, got `%s`", input.Operator, v)
+			}
+		}
+	case rulesets.RemoteAddressOperatorIPMatch:
+		values := make([]interface{}, 0, len(input.Values))
+		for _, matchValue := range input.Values {
+			values = append(values, matchValue)
+			if _, errs := validate.FrontDoorRuleCidrIsValid(matchValue, "values"); len(errs) > 0 {
+				return nil, fmt.Errorf("when `conditions.remote_address.operator` is `%s` the values in `conditions.remote_address.values` must be valid IPv4 or IPv6 CIDRs, got `%s`", input.Operator, matchValue)
+			}
+		}
+
+		if _, errs := validate.FrontDoorRuleCidrOverlap(values, "values"); len(errs) > 0 {
+			return nil, fmt.Errorf("`remote_address` is invalid: %+v", errs[0])
+		}
+	}
+
+	return rulesets.DeliveryRuleRemoteAddressCondition{
+		Name: rulesets.MatchVariableRemoteAddress,
+		Parameters: rulesets.RemoteAddressMatchConditionParameters{
+			TypeName:        rulesets.DeliveryRuleConditionParametersTypeDeliveryRuleRemoteAddressConditionParameters,
+			Operator:        rulesets.RemoteAddressOperator(operator),
+			NegateCondition: pointer.To(negated),
+			MatchValues:     pointer.To(input.Values),
+		},
+	}, nil
+}
+
+func expandCdnFrontDoorBatchRuleSetRequestBodyCondition(input CdnFrontDoorBatchRuleSetConditionWithTransformsModel) (rulesets.DeliveryRuleCondition, error) {
+	operator, negated := expandCdnFrontDoorBatchRuleSetConditionOperator(input.Operator)
+	if err := validateCdnFrontDoorBatchRuleConditionValues("request_body", operator, input.Values); err != nil {
+		return nil, err
+	}
+
+	return rulesets.DeliveryRuleRequestBodyCondition{
+		Name: rulesets.MatchVariableRequestBody,
+		Parameters: rulesets.RequestBodyMatchConditionParameters{
+			TypeName:        rulesets.DeliveryRuleConditionParametersTypeDeliveryRuleRequestBodyConditionParameters,
+			Operator:        rulesets.RequestBodyOperator(operator),
+			NegateCondition: pointer.To(negated),
+			MatchValues:     pointer.To(input.Values),
+			Transforms:      pointer.ToEnumSlice[rulesets.Transform](input.Transforms),
+		},
+	}, nil
+}
+
+func expandCdnFrontDoorBatchRuleSetRequestHeaderCondition(input CdnFrontDoorBatchRuleSetConditionWithNameAndTransformsModel) (rulesets.DeliveryRuleCondition, error) {
+	operator, negated := expandCdnFrontDoorBatchRuleSetConditionOperator(input.Operator)
+	if err := validateCdnFrontDoorBatchRuleConditionValues("request_header", operator, input.Values); err != nil {
+		return nil, err
+	}
+
+	return rulesets.DeliveryRuleRequestHeaderCondition{
+		Name: rulesets.MatchVariableRequestHeader,
+		Parameters: rulesets.RequestHeaderMatchConditionParameters{
+			TypeName:        rulesets.DeliveryRuleConditionParametersTypeDeliveryRuleRequestHeaderConditionParameters,
+			Selector:        pointer.To(input.Name),
+			Operator:        rulesets.RequestHeaderOperator(operator),
+			NegateCondition: pointer.To(negated),
+			MatchValues:     pointer.To(input.Values),
+			Transforms:      pointer.ToEnumSlice[rulesets.Transform](input.Transforms),
+		},
+	}, nil
+}
+
+func expandCdnFrontDoorBatchRuleSetRequestMethodCondition(input CdnFrontDoorBatchRuleSetConditionBaseModel) (rulesets.DeliveryRuleCondition, error) {
+	operator, negated := expandCdnFrontDoorBatchRuleSetConditionOperator(input.Operator)
+
+	return rulesets.DeliveryRuleRequestMethodCondition{
+		Name: rulesets.MatchVariableRequestMethod,
+		Parameters: rulesets.RequestMethodMatchConditionParameters{
+			TypeName:        rulesets.DeliveryRuleConditionParametersTypeDeliveryRuleRequestMethodConditionParameters,
+			Operator:        rulesets.RequestMethodOperator(operator),
+			NegateCondition: pointer.To(negated),
+			MatchValues:     pointer.ToEnumSlice[rulesets.RequestMethodMatchValue](input.Values),
+		},
+	}, nil
+}
+
+func expandCdnFrontDoorBatchRuleSetRequestSchemeCondition(input CdnFrontDoorBatchRuleSetConditionBaseModel) (rulesets.DeliveryRuleCondition, error) {
+	operator, negated := expandCdnFrontDoorBatchRuleSetConditionOperator(input.Operator)
+
+	return rulesets.DeliveryRuleRequestSchemeCondition{
+		Name: rulesets.MatchVariableRequestScheme,
+		Parameters: rulesets.RequestSchemeMatchConditionParameters{
+			TypeName:        rulesets.DeliveryRuleConditionParametersTypeDeliveryRuleRequestSchemeConditionParameters,
+			Operator:        rulesets.RequestSchemeMatchConditionParametersOperator(operator),
+			NegateCondition: pointer.To(negated),
+			MatchValues:     pointer.ToEnumSlice[rulesets.RequestSchemeMatchValue](input.Values),
+		},
+	}, nil
+}
+
+func expandCdnFrontDoorBatchRuleSetRequestURLCondition(input CdnFrontDoorBatchRuleSetConditionWithTransformsModel) (rulesets.DeliveryRuleCondition, error) {
+	operator, negated := expandCdnFrontDoorBatchRuleSetConditionOperator(input.Operator)
+	if err := validateCdnFrontDoorBatchRuleConditionValues("request_url", operator, input.Values); err != nil {
+		return nil, err
+	}
+
+	return rulesets.DeliveryRuleRequestUriCondition{
+		Name: rulesets.MatchVariableRequestUri,
+		Parameters: rulesets.RequestUriMatchConditionParameters{
+			TypeName:        rulesets.DeliveryRuleConditionParametersTypeDeliveryRuleRequestUriConditionParameters,
+			Operator:        rulesets.RequestUriOperator(operator),
+			NegateCondition: pointer.To(negated),
+			MatchValues:     pointer.To(input.Values),
+			Transforms:      pointer.ToEnumSlice[rulesets.Transform](input.Transforms),
+		},
+	}, nil
+}
+
+func expandCdnFrontDoorBatchRuleSetServerPortCondition(input CdnFrontDoorBatchRuleSetConditionBaseModel) (rulesets.DeliveryRuleCondition, error) {
+	operator, negated := expandCdnFrontDoorBatchRuleSetConditionOperator(input.Operator)
+	if err := validateCdnFrontDoorBatchRuleConditionValues("server_port", operator, input.Values); err != nil {
+		return nil, err
+	}
+
+	return rulesets.DeliveryRuleServerPortCondition{
+		Name: rulesets.MatchVariableServerPort,
+		Parameters: rulesets.ServerPortMatchConditionParameters{
+			TypeName:        rulesets.DeliveryRuleConditionParametersTypeDeliveryRuleServerPortConditionParameters,
+			Operator:        rulesets.ServerPortOperator(operator),
+			NegateCondition: pointer.To(negated),
+			MatchValues:     pointer.To(input.Values),
+		},
+	}, nil
+}
+
+func expandCdnFrontDoorBatchRuleSetSocketAddressCondition(input CdnFrontDoorBatchRuleSetConditionBaseModel) (rulesets.DeliveryRuleCondition, error) {
+	operator, negated := expandCdnFrontDoorBatchRuleSetConditionOperator(input.Operator)
+
+	return rulesets.DeliveryRuleSocketAddrCondition{
+		Name: rulesets.MatchVariableSocketAddr,
+		Parameters: rulesets.SocketAddrMatchConditionParameters{
+			TypeName:        rulesets.DeliveryRuleConditionParametersTypeDeliveryRuleSocketAddrConditionParameters,
+			Operator:        rulesets.SocketAddrOperator(operator),
+			NegateCondition: pointer.To(negated),
+			MatchValues:     pointer.To(input.Values),
+		},
+	}, nil
+}
+
+func expandCdnFrontDoorBatchRuleSetSSLProtocolCondition(input CdnFrontDoorBatchRuleSetConditionBaseModel) (rulesets.DeliveryRuleCondition, error) {
+	operator, negated := expandCdnFrontDoorBatchRuleSetConditionOperator(input.Operator)
+
+	return rulesets.DeliveryRuleSslProtocolCondition{
+		Name: rulesets.MatchVariableSslProtocol,
+		Parameters: rulesets.SslProtocolMatchConditionParameters{
+			TypeName:        rulesets.DeliveryRuleConditionParametersTypeDeliveryRuleSslProtocolConditionParameters,
+			Operator:        rulesets.SslProtocolOperator(operator),
+			NegateCondition: pointer.To(negated),
+			MatchValues:     pointer.ToEnumSlice[rulesets.SslProtocol](input.Values),
+		},
+	}, nil
+}
+
+func expandCdnFrontDoorBatchRuleSetRequestFileExtensionCondition(input CdnFrontDoorBatchRuleSetConditionWithTransformsModel) (rulesets.DeliveryRuleCondition, error) {
+	operator, negated := expandCdnFrontDoorBatchRuleSetConditionOperator(input.Operator)
+	if err := validateCdnFrontDoorBatchRuleConditionValues("request_file_extension", operator, input.Values); err != nil {
+		return nil, err
+	}
+
+	return rulesets.DeliveryRuleURLFileExtensionCondition{
+		Name: rulesets.MatchVariableURLFileExtension,
+		Parameters: rulesets.URLFileExtensionMatchConditionParameters{
+			TypeName:        rulesets.DeliveryRuleConditionParametersTypeDeliveryRuleURLFileExtensionMatchConditionParameters,
+			Operator:        rulesets.URLFileExtensionOperator(operator),
+			NegateCondition: pointer.To(negated),
+			MatchValues:     pointer.To(input.Values),
+			Transforms:      pointer.ToEnumSlice[rulesets.Transform](input.Transforms),
+		},
+	}, nil
+}
+
+func expandCdnFrontDoorBatchRuleSetRequestFilenameCondition(input CdnFrontDoorBatchRuleSetConditionWithTransformsModel) (rulesets.DeliveryRuleCondition, error) {
+	operator, negated := expandCdnFrontDoorBatchRuleSetConditionOperator(input.Operator)
+	if err := validateCdnFrontDoorBatchRuleConditionValues("request_filename", operator, input.Values); err != nil {
+		return nil, err
+	}
+
+	return rulesets.DeliveryRuleURLFileNameCondition{
+		Name: rulesets.MatchVariableURLFileName,
+		Parameters: rulesets.URLFileNameMatchConditionParameters{
+			TypeName:        rulesets.DeliveryRuleConditionParametersTypeDeliveryRuleURLFilenameConditionParameters,
+			Operator:        rulesets.URLFileNameOperator(operator),
+			NegateCondition: pointer.To(negated),
+			MatchValues:     pointer.To(input.Values),
+			Transforms:      pointer.ToEnumSlice[rulesets.Transform](input.Transforms),
+		},
+	}, nil
+}
+
+func expandCdnFrontDoorBatchRuleSetRequestPathCondition(input CdnFrontDoorBatchRuleSetConditionWithTransformsModel) (rulesets.DeliveryRuleCondition, error) {
+	operator, negated := expandCdnFrontDoorBatchRuleSetConditionOperator(input.Operator)
+	if err := validateCdnFrontDoorBatchRuleConditionValues("request_path", operator, input.Values); err != nil {
+		return nil, err
+	}
+
+	return rulesets.DeliveryRuleURLPathCondition{
+		Name: rulesets.MatchVariableURLPath,
+		Parameters: rulesets.URLPathMatchConditionParameters{
+			TypeName:        rulesets.DeliveryRuleConditionParametersTypeDeliveryRuleURLPathMatchConditionParameters,
+			Operator:        rulesets.URLPathOperator(operator),
+			NegateCondition: pointer.To(negated),
+			MatchValues:     pointer.To(input.Values),
+			Transforms:      pointer.ToEnumSlice[rulesets.Transform](input.Transforms),
+		},
+	}, nil
+}
+
+func expandCdnFrontDoorBatchRuleSetConditionOperator(input string) (string, bool) {
+	negated := false
+	if strings.HasPrefix(input, cdnFrontDoorBatchRuleConditionOperatorNegatedPrefix) {
+		negated = true
+		input = strings.TrimPrefix(input, cdnFrontDoorBatchRuleConditionOperatorNegatedPrefix)
+	}
+	return input, negated
+}
+
+func flattenCdnFrontDoorBatchRuleSetConditionOperator(input string, negated bool) string {
+	result := input
+	if negated {
+		result = cdnFrontDoorBatchRuleConditionOperatorNegatedPrefix + result
+	}
+	return result
+}
+
+func expandCdnFrontDoorBatchRuleSetConditionBaseModel(input []CdnFrontDoorBatchRuleSetConditionBaseModel, key string, expand func(CdnFrontDoorBatchRuleSetConditionBaseModel) (rulesets.DeliveryRuleCondition, error)) ([]rulesets.DeliveryRuleCondition, error) {
+	result := make([]rulesets.DeliveryRuleCondition, 0, len(input))
+	for _, c := range input {
+		expandedCondition, err := expand(c)
+		if err != nil {
+			return nil, fmt.Errorf("expanding `%s`: %+v", key, err)
+		}
+		result = append(result, expandedCondition)
+	}
+	return result, nil
+}
+
+func flattenCdnFrontDoorBatchRuleSetConditionBaseModel(operator string, values []string, negated *bool) CdnFrontDoorBatchRuleSetConditionBaseModel {
+	return CdnFrontDoorBatchRuleSetConditionBaseModel{
+		Operator: flattenCdnFrontDoorBatchRuleSetConditionOperator(operator, pointer.From(negated)),
+		Values:   values,
+	}
+}
+
+func expandCdnFrontDoorBatchRuleSetConditionWithNameAndTransformsModel(input []CdnFrontDoorBatchRuleSetConditionWithNameAndTransformsModel, key string, expand func(CdnFrontDoorBatchRuleSetConditionWithNameAndTransformsModel) (rulesets.DeliveryRuleCondition, error)) ([]rulesets.DeliveryRuleCondition, error) {
+	result := make([]rulesets.DeliveryRuleCondition, 0, len(input))
+	for _, c := range input {
+		expandedCondition, err := expand(c)
+		if err != nil {
+			return nil, fmt.Errorf("expanding `%s`: %+v", key, err)
+		}
+		result = append(result, expandedCondition)
+	}
+	return result, nil
+}
+
+func flattenCdnFrontDoorBatchRuleSetConditionWithNameAndTransformsModel(operator string, name *string, values, transforms []string, negated *bool) CdnFrontDoorBatchRuleSetConditionWithNameAndTransformsModel {
+	return CdnFrontDoorBatchRuleSetConditionWithNameAndTransformsModel{
+		Name:       pointer.From(name),
+		Operator:   flattenCdnFrontDoorBatchRuleSetConditionOperator(operator, pointer.From(negated)),
+		Values:     values,
+		Transforms: transforms,
+	}
+}
+
+func expandCdnFrontDoorBatchRuleSetConditionWithTransformsModel(input []CdnFrontDoorBatchRuleSetConditionWithTransformsModel, key string, expand func(CdnFrontDoorBatchRuleSetConditionWithTransformsModel) (rulesets.DeliveryRuleCondition, error)) ([]rulesets.DeliveryRuleCondition, error) {
+	result := make([]rulesets.DeliveryRuleCondition, 0, len(input))
+	for _, c := range input {
+		expandedCondition, err := expand(c)
+		if err != nil {
+			return nil, fmt.Errorf("expanding `%s`: %+v", key, err)
+		}
+		result = append(result, expandedCondition)
+	}
+	return result, nil
+}
+
+func flattenCdnFrontDoorBatchRuleSetConditionWithTransformsModel(operator string, values, transforms []string, negated *bool) CdnFrontDoorBatchRuleSetConditionWithTransformsModel {
+	return CdnFrontDoorBatchRuleSetConditionWithTransformsModel{
+		Operator:   flattenCdnFrontDoorBatchRuleSetConditionOperator(operator, pointer.From(negated)),
+		Values:     values,
+		Transforms: transforms,
+	}
+}
+
+func validateCdnFrontDoorBatchRules(input []CdnFrontDoorBatchRuleSetRuleModel) error {
+	names := make(map[string]struct{}, len(input))
+	orders := make(map[int64]struct{}, len(input))
+	lastOrder := int64(math.MinInt64)
+
+	for _, item := range input {
+		if _, exists := names[item.Name]; exists {
+			return fmt.Errorf("the `rule` blocks must have unique `name` values, got duplicate `%s`", item.Name)
+		}
+		names[item.Name] = struct{}{}
+
+		if _, exists := orders[item.Order]; exists {
+			return fmt.Errorf("the `rule` blocks must have unique `order` values, got duplicate `%d`", item.Order)
+		}
+		orders[item.Order] = struct{}{}
+
+		if item.Order < lastOrder {
+			return fmt.Errorf("the `rule` blocks must be declared in ascending `order`, got `%d` before `%d`", lastOrder, item.Order)
+		}
+
+		if err := validateCdnFrontDoorBatchRuleActionCounts(countCdnFrontDoorBatchRuleActions(item.Actions)); err != nil {
+			return err
+		}
+
+		lastOrder = item.Order
+	}
+
+	return nil
+}
+
+func validateCdnFrontDoorBatchRuleConditionValues(configName, operator string, matchValues []string) error {
+	if operator == "" {
+		return fmt.Errorf("`%s` is invalid: no `operator` value has been set, got `%s`", configName, operator)
+	}
+
+	// There are multiple condition-specific `Any` operators in the API surface, but they all
+	// resolve to the same literal value.
+	if operator == "Any" && len(matchValues) > 0 {
+		return fmt.Errorf("when `conditions.%[1]s.operator` is set to `Any`, `conditions.%[1]s.values` cannot be defined", configName)
+	}
+
+	if operator != "Any" && len(matchValues) == 0 {
+		return fmt.Errorf("when `conditions.%[1]s.operator` is set to `%[2]s`, `conditions.%[1]s.values` must set one or more values", configName, operator)
+	}
+
+	return nil
+}
+
+func validateCdnFrontDoorBatchRuleActionCounts(urlRewriteCount, urlRedirectCount, routeConfigurationOverrideCount, totalCount int) error {
+	if totalCount == 0 {
+		return errors.New("the `actions` block must define at least one action")
+	}
+
+	if urlRedirectCount > 0 && urlRewriteCount > 0 {
+		return errors.New("the `url_redirect` and the `url_rewrite` are both present in the `actions` block which is invalid")
+	}
+
+	if urlRedirectCount > 0 && routeConfigurationOverrideCount > 0 {
+		return errors.New("the `url_redirect` and the `route_configuration_override` are both present in the `actions` block which is invalid")
+	}
+
+	if totalCount > 5 {
+		return fmt.Errorf("the `actions` block may only contain up to 5 actions, got %d", totalCount)
+	}
+
+	return nil
+}
+
+func validateCdnFrontDoorBatchRuleModifyHeaderAction(blockName, headerAction, value string) error {
+	if value == "" {
+		if headerAction == string(rulesets.HeaderActionOverwrite) || headerAction == string(rulesets.HeaderActionAppend) {
+			return fmt.Errorf("the `%s` block is not valid, `header_value` cannot be empty if the `operator` is set to `Append` or `Overwrite`", blockName)
+		}
+	} else if headerAction == string(rulesets.HeaderActionDelete) {
+		return fmt.Errorf("the `%s` block is not valid, `header_value` must be empty if the `operator` is set to `Delete`", blockName)
+	}
+
+	return nil
+}
+
+func countCdnFrontDoorBatchRuleActions(input []CdnFrontDoorBatchRuleSetActionsModel) (urlRewrite, urlRedirect, routeConfigurationOverride, total int) {
+	if len(input) == 0 {
+		return
+	}
+
+	actions := input[0]
+	urlRewrite = len(actions.URLRewrite)
+	urlRedirect = len(actions.URLRedirect)
+	routeConfigurationOverride = len(actions.RouteConfigurationOverride)
+	total = urlRewrite + urlRedirect + routeConfigurationOverride + len(actions.ModifyRequestHeader) + len(actions.ModifyResponseHeader)
+
+	return
+}

--- a/internal/services/cdn/cdn_frontdoor_batch_rule_set_definition.go
+++ b/internal/services/cdn/cdn_frontdoor_batch_rule_set_definition.go
@@ -1202,11 +1202,11 @@ func validateCdnFrontDoorBatchRuleActionCounts(urlRewriteCount, urlRedirectCount
 	}
 
 	if urlRedirectCount > 0 && urlRewriteCount > 0 {
-		return errors.New("the `url_redirect` and the `url_rewrite` are both present in the `actions` block which is invalid")
+		return errors.New("cannot specify both `url_redirect` and the `url_rewrite` in the `actions` block")
 	}
 
 	if urlRedirectCount > 0 && routeConfigurationOverrideCount > 0 {
-		return errors.New("the `url_redirect` and the `route_configuration_override` are both present in the `actions` block which is invalid")
+		return errors.New("cannot specify both `url_redirect` and the `route_configuration_override` in the `actions` block")
 	}
 
 	if totalCount > 5 {

--- a/internal/services/cdn/cdn_frontdoor_batch_rule_set_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_batch_rule_set_resource.go
@@ -1,0 +1,932 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package cdn
+
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name cdn_frontdoor_batch_rule_set -properties "name" -compare-values "subscription_id:cdn_frontdoor_profile_id,resource_group_name:cdn_frontdoor_profile_id,profile_name:cdn_frontdoor_profile_id" -test-name "basicAttachedRoute"
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigingroups"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/profiles"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rulesets"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cdn/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+var (
+	_ sdk.ResourceWithCustomImporter = CdnFrontDoorBatchRuleSetResource{}
+	_ sdk.ResourceWithCustomizeDiff  = CdnFrontDoorBatchRuleSetResource{}
+	_ sdk.ResourceWithIdentity       = CdnFrontDoorBatchRuleSetResource{}
+	_ sdk.ResourceWithUpdate         = CdnFrontDoorBatchRuleSetResource{}
+)
+
+type CdnFrontDoorBatchRuleSetResource struct{}
+
+func (r CdnFrontDoorBatchRuleSetResource) CustomImporter() sdk.ResourceRunFunc {
+	return func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+		client := metadata.Client.Cdn.FrontDoorRuleSetsClient
+
+		id, err := rulesets.ParseRuleSetID(metadata.ResourceData.Id())
+		if err != nil {
+			return err
+		}
+
+		resp, err := client.Get(ctx, *id)
+		if err != nil {
+			return fmt.Errorf("retrieving %s: %+v", id, err)
+		}
+
+		if resp.Model == nil {
+			return fmt.Errorf("retrieving %s: `model` was nil`", id)
+		}
+
+		if resp.Model.Properties == nil {
+			return fmt.Errorf("retrieving %s: `properties` was nil`", id)
+		}
+
+		if !pointer.From(resp.Model.Properties.BatchMode) {
+			return fmt.Errorf("%s was not provisioned using batch mode and cannot be managed by this resource, use `azurerm_cdn_frontdoor_rule_set` instead", id)
+		}
+
+		return nil
+	}
+}
+
+func (CdnFrontDoorBatchRuleSetResource) Identity() resourceids.ResourceId {
+	return &rulesets.RuleSetId{}
+}
+
+func (CdnFrontDoorBatchRuleSetResource) ResourceType() string {
+	return "azurerm_cdn_frontdoor_batch_rule_set"
+}
+
+func (CdnFrontDoorBatchRuleSetResource) ModelObject() interface{} {
+	return &CdnFrontDoorBatchRuleSetModel{}
+}
+
+func (CdnFrontDoorBatchRuleSetResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return rulesets.ValidateRuleSetID
+}
+
+func (CdnFrontDoorBatchRuleSetResource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validate.FrontDoorRuleSetName,
+		},
+		"cdn_frontdoor_profile_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: profiles.ValidateProfileID,
+		},
+		"rule": {
+			Type:     pluginsdk.TypeList,
+			Required: true,
+			MinItems: 1,
+			MaxItems: 100,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"name": {
+						Type:         pluginsdk.TypeString,
+						Required:     true,
+						ValidateFunc: validate.CdnFrontDoorRuleName,
+					},
+					"behaviour_on_match": {
+						Type:         pluginsdk.TypeString,
+						Optional:     true,
+						Default:      string(rulesets.MatchProcessingBehaviorContinue),
+						ValidateFunc: validation.StringInSlice(rulesets.PossibleValuesForMatchProcessingBehavior(), false),
+					},
+					"order": {
+						Type:         pluginsdk.TypeInt,
+						Required:     true,
+						ValidateFunc: validation.IntAtLeast(0),
+					},
+					"actions": {
+						Type:     pluginsdk.TypeList,
+						Required: true,
+						MaxItems: 1,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"url_redirect": {
+									Type:     pluginsdk.TypeList,
+									Optional: true,
+									MaxItems: 1,
+									Elem: &pluginsdk.Resource{
+										Schema: map[string]*pluginsdk.Schema{
+											"redirect_type": {
+												Type:         pluginsdk.TypeString,
+												Required:     true,
+												ValidateFunc: validation.StringInSlice(rulesets.PossibleValuesForRedirectType(), false),
+											},
+											"redirect_protocol": {
+												Type:         pluginsdk.TypeString,
+												Optional:     true,
+												Default:      string(rulesets.DestinationProtocolMatchRequest),
+												ValidateFunc: validation.StringInSlice(rulesets.PossibleValuesForDestinationProtocol(), false),
+											},
+											"destination_path": {
+												Type:         pluginsdk.TypeString,
+												Optional:     true,
+												ValidateFunc: validation.StringStartsWithOneOf("/"),
+											},
+											"destination_host_name": {
+												Type:         pluginsdk.TypeString,
+												Optional:     true,
+												ValidateFunc: validation.StringLenBetween(1, 2048),
+											},
+											"destination_fragment": {
+												Type:     pluginsdk.TypeString,
+												Optional: true,
+												ValidateFunc: validation.All(
+													validation.StringLenBetween(1, 1024),
+													validation.StringDoesNotStartWithOneOf("#"),
+												),
+											},
+											"query_string": {
+												Type:         pluginsdk.TypeString,
+												Optional:     true,
+												ValidateFunc: validate.CdnFrontDoorUrlRedirectActionQueryString,
+											},
+										},
+									},
+								},
+								"url_rewrite": {
+									Type:     pluginsdk.TypeList,
+									Optional: true,
+									MaxItems: 1,
+									Elem: &pluginsdk.Resource{
+										Schema: map[string]*pluginsdk.Schema{
+											"source_pattern": {
+												Type:         pluginsdk.TypeString,
+												Required:     true,
+												ValidateFunc: validation.StringStartsWithOneOf("/"),
+											},
+											"destination_path": {
+												Type:         pluginsdk.TypeString,
+												Required:     true,
+												ValidateFunc: validation.StringStartsWithOneOf("/"),
+											},
+											"preserve_unmatched_path_enabled": {
+												Type:     pluginsdk.TypeBool,
+												Optional: true,
+												Default:  false,
+											},
+										},
+									},
+								},
+								"modify_request_header":  cdnFrontDoorBatchRuleSetActionModifyHeaderSchema(),
+								"modify_response_header": cdnFrontDoorBatchRuleSetActionModifyHeaderSchema(),
+								"route_configuration_override": {
+									Type:     pluginsdk.TypeList,
+									Optional: true,
+									MaxItems: 1,
+									Elem: &pluginsdk.Resource{Schema: map[string]*pluginsdk.Schema{
+										"origin_group": {
+											Type:     pluginsdk.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											Elem: &pluginsdk.Resource{
+												Schema: map[string]*pluginsdk.Schema{
+													"cdn_frontdoor_origin_group_id": {
+														Type:         pluginsdk.TypeString,
+														Required:     true,
+														ValidateFunc: afdorigingroups.ValidateOriginGroupID,
+													},
+													"forwarding_protocol": {
+														Type:         pluginsdk.TypeString,
+														Required:     true,
+														ValidateFunc: validation.StringInSlice(rulesets.PossibleValuesForForwardingProtocol(), false),
+													},
+												},
+											},
+										},
+
+										"caching": {
+											Type:     pluginsdk.TypeList,
+											Required: true,
+											MaxItems: 1,
+											Elem: &pluginsdk.Resource{
+												Schema: map[string]*pluginsdk.Schema{
+													"behaviour": {
+														Type:         pluginsdk.TypeString,
+														Required:     true,
+														ValidateFunc: validation.StringInSlice(PossibleValuesForRuleCacheBehavior(), false),
+													},
+													"duration": {
+														Type:         pluginsdk.TypeString,
+														Optional:     true,
+														ValidateFunc: validate.CdnFrontDoorCacheDuration,
+													},
+													"compression_enabled": {
+														Type:     pluginsdk.TypeBool,
+														Optional: true,
+														Default:  false,
+													},
+													"query_string_behaviour": {
+														Type:         pluginsdk.TypeString,
+														Optional:     true,
+														ValidateFunc: validation.StringInSlice(rulesets.PossibleValuesForRuleQueryStringCachingBehavior(), false),
+													},
+													"query_string_parameters": {
+														Type:     pluginsdk.TypeList,
+														Optional: true,
+														MaxItems: 100,
+														Elem: &pluginsdk.Schema{
+															Type: pluginsdk.TypeString,
+														},
+													},
+												},
+											},
+										},
+									}},
+								},
+							},
+						},
+					},
+
+					"conditions": {
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						MaxItems: 1,
+						Elem: &pluginsdk.Resource{Schema: map[string]*pluginsdk.Schema{
+							"remote_address": {
+								Type:     pluginsdk.TypeList,
+								Optional: true,
+								Elem: &pluginsdk.Resource{
+									Schema: map[string]*pluginsdk.Schema{
+										"operator": {
+											Type:         pluginsdk.TypeString,
+											Required:     true,
+											ValidateFunc: validation.StringInSlice(cdnFrontDoorBatchRuleSetConditionOperatorPossibleValues([]string{string(rulesets.RemoteAddressOperatorGeoMatch), string(rulesets.RemoteAddressOperatorIPMatch)}), false),
+										},
+										"values": {
+											Type:     pluginsdk.TypeList,
+											Required: true,
+											MinItems: 1,
+											MaxItems: 25,
+											Elem: &pluginsdk.Schema{
+												Type:         pluginsdk.TypeString,
+												ValidateFunc: validation.StringIsNotEmpty,
+											},
+										},
+									},
+								},
+							},
+							"request_method": {
+								Type:     pluginsdk.TypeList,
+								Optional: true,
+								Elem: &pluginsdk.Resource{
+									Schema: map[string]*pluginsdk.Schema{
+										"operator": {
+											Type:         pluginsdk.TypeString,
+											Required:     true,
+											ValidateFunc: validation.StringInSlice(cdnFrontDoorBatchRuleSetConditionOperatorPossibleValues(rulesets.PossibleValuesForRequestMethodOperator()), false),
+										},
+										"values": {
+											Type:     pluginsdk.TypeSet,
+											Required: true,
+											MinItems: 1,
+											MaxItems: 7,
+											Elem: &pluginsdk.Schema{
+												Type:         pluginsdk.TypeString,
+												ValidateFunc: validation.StringInSlice(rulesets.PossibleValuesForRequestMethodMatchValue(), false),
+											},
+										},
+									},
+								},
+							},
+							"query_string": {
+								Type:     pluginsdk.TypeList,
+								Optional: true,
+								Elem: &pluginsdk.Resource{
+									Schema: map[string]*pluginsdk.Schema{
+										"operator": {
+											Type:         pluginsdk.TypeString,
+											Required:     true,
+											ValidateFunc: validation.StringInSlice(cdnFrontDoorBatchRuleSetConditionOperatorPossibleValues(rulesets.PossibleValuesForQueryStringOperator()), false),
+										},
+										"values":     cdnFrontDoorBatchRuleSetConditionValuesSchema(),
+										"transforms": cdnFrontDoorBatchRuleSetConditionTransformsSchema(),
+									},
+								},
+							},
+							"post_argument": {
+								Type:     pluginsdk.TypeList,
+								Optional: true,
+								Elem: &pluginsdk.Resource{
+									Schema: map[string]*pluginsdk.Schema{
+										"name": cdnFrontDoorBatchRuleSetConditionSelectorSchema(),
+										"operator": {
+											Type:         pluginsdk.TypeString,
+											Required:     true,
+											ValidateFunc: validation.StringInSlice(cdnFrontDoorBatchRuleSetConditionOperatorPossibleValues(rulesets.PossibleValuesForPostArgsOperator()), false),
+										},
+										"values":     cdnFrontDoorBatchRuleSetConditionValuesSchema(),
+										"transforms": cdnFrontDoorBatchRuleSetConditionTransformsSchema(),
+									},
+								},
+							},
+							"request_url": {
+								Type:     pluginsdk.TypeList,
+								Optional: true,
+								Elem: &pluginsdk.Resource{
+									Schema: map[string]*pluginsdk.Schema{
+										"operator": {
+											Type:         pluginsdk.TypeString,
+											Required:     true,
+											ValidateFunc: validation.StringInSlice(cdnFrontDoorBatchRuleSetConditionOperatorPossibleValues(rulesets.PossibleValuesForRequestUriOperator()), false),
+										},
+										"values":     cdnFrontDoorBatchRuleSetConditionValuesSchema(),
+										"transforms": cdnFrontDoorBatchRuleSetConditionTransformsSchema(),
+									},
+								},
+							},
+							"request_header": {
+								Type:     pluginsdk.TypeList,
+								Optional: true,
+								Elem: &pluginsdk.Resource{
+									Schema: map[string]*pluginsdk.Schema{
+										"name": cdnFrontDoorBatchRuleSetConditionSelectorSchema(),
+										"operator": {
+											Type:         pluginsdk.TypeString,
+											Required:     true,
+											ValidateFunc: validation.StringInSlice(cdnFrontDoorBatchRuleSetConditionOperatorPossibleValues(rulesets.PossibleValuesForRequestHeaderOperator()), false),
+										},
+										"values":     cdnFrontDoorBatchRuleSetConditionValuesSchema(),
+										"transforms": cdnFrontDoorBatchRuleSetConditionTransformsSchema(),
+									},
+								},
+							},
+							"request_body": {
+								Type:     pluginsdk.TypeList,
+								Optional: true,
+								Elem: &pluginsdk.Resource{
+									Schema: map[string]*pluginsdk.Schema{
+										"operator": {
+											Type:         pluginsdk.TypeString,
+											Required:     true,
+											ValidateFunc: validation.StringInSlice(cdnFrontDoorBatchRuleSetConditionOperatorPossibleValues(rulesets.PossibleValuesForRequestBodyOperator()), false),
+										},
+										"values":     cdnFrontDoorBatchRuleSetConditionValuesSchema(),
+										"transforms": cdnFrontDoorBatchRuleSetConditionTransformsSchema(),
+									},
+								},
+							},
+							"request_scheme": {
+								Type:     pluginsdk.TypeList,
+								Optional: true,
+								Elem: &pluginsdk.Resource{
+									Schema: map[string]*pluginsdk.Schema{
+										"operator": {
+											Type:         pluginsdk.TypeString,
+											Required:     true,
+											ValidateFunc: validation.StringInSlice(cdnFrontDoorBatchRuleSetConditionOperatorPossibleValues(rulesets.PossibleValuesForRequestSchemeMatchConditionParametersOperator()), false),
+										},
+										"values": {
+											Type:     pluginsdk.TypeList,
+											Required: true,
+											MinItems: 1,
+											// This uses a List instead of a String to stay consistent with the other conditions, even though only 1 item can be defined
+											MaxItems: 1,
+											Elem: &pluginsdk.Schema{
+												Type:         pluginsdk.TypeString,
+												ValidateFunc: validation.StringInSlice(rulesets.PossibleValuesForRequestSchemeMatchValue(), false),
+											},
+										},
+									},
+								},
+							},
+							"request_path": {
+								Type:     pluginsdk.TypeList,
+								Optional: true,
+								Elem: &pluginsdk.Resource{
+									Schema: map[string]*pluginsdk.Schema{
+										"operator": {
+											Type:         pluginsdk.TypeString,
+											Required:     true,
+											ValidateFunc: validation.StringInSlice(cdnFrontDoorBatchRuleSetConditionOperatorPossibleValues(rulesets.PossibleValuesForURLPathOperator()), false),
+										},
+										"values": {
+											Type:     pluginsdk.TypeList,
+											Optional: true,
+											MaxItems: 25,
+											Elem: &pluginsdk.Schema{
+												Type: pluginsdk.TypeString,
+												ValidateFunc: validation.All(
+													validation.StringIsNotEmpty,
+													validation.StringDoesNotStartWithOneOf("/"),
+												),
+											},
+										},
+										"transforms": cdnFrontDoorBatchRuleSetConditionTransformsSchema(),
+									},
+								},
+							},
+							"request_file_extension": {
+								Type:     pluginsdk.TypeList,
+								Optional: true,
+								Elem: &pluginsdk.Resource{
+									Schema: map[string]*pluginsdk.Schema{
+										"operator": {
+											Type:         pluginsdk.TypeString,
+											Required:     true,
+											ValidateFunc: validation.StringInSlice(cdnFrontDoorBatchRuleSetConditionOperatorPossibleValues(rulesets.PossibleValuesForURLFileExtensionOperator()), false),
+										},
+										"values": {
+											Type:     pluginsdk.TypeList,
+											Optional: true,
+											MaxItems: 25,
+											Elem: &pluginsdk.Schema{
+												Type: pluginsdk.TypeString,
+												ValidateFunc: validation.All(
+													validation.StringIsNotEmpty,
+													validation.StringDoesNotStartWithOneOf("."),
+												),
+											},
+										},
+										"transforms": cdnFrontDoorBatchRuleSetConditionTransformsSchema(),
+									},
+								},
+							},
+							"request_filename": {
+								Type:     pluginsdk.TypeList,
+								Optional: true,
+								Elem: &pluginsdk.Resource{
+									Schema: map[string]*pluginsdk.Schema{
+										"operator": {
+											Type:         pluginsdk.TypeString,
+											Required:     true,
+											ValidateFunc: validation.StringInSlice(cdnFrontDoorBatchRuleSetConditionOperatorPossibleValues(rulesets.PossibleValuesForURLFileNameOperator()), false),
+										},
+										"values":     cdnFrontDoorBatchRuleSetConditionValuesSchema(),
+										"transforms": cdnFrontDoorBatchRuleSetConditionTransformsSchema(),
+									},
+								},
+							},
+							"http_version": {
+								Type:     pluginsdk.TypeList,
+								Optional: true,
+								Elem: &pluginsdk.Resource{
+									Schema: map[string]*pluginsdk.Schema{
+										"operator": {
+											Type:         pluginsdk.TypeString,
+											Required:     true,
+											ValidateFunc: validation.StringInSlice(cdnFrontDoorBatchRuleSetConditionOperatorPossibleValues(rulesets.PossibleValuesForHTTPVersionOperator()), false),
+										},
+										"values": {
+											Type:     pluginsdk.TypeSet,
+											Required: true,
+											MinItems: 1,
+											MaxItems: 4,
+											Elem: &pluginsdk.Schema{
+												Type:         pluginsdk.TypeString,
+												ValidateFunc: validation.StringInSlice([]string{"2.0", "1.1", "1.0", "0.9"}, false),
+											},
+										},
+									},
+								},
+							},
+							"request_cookies": {
+								Type:     pluginsdk.TypeList,
+								Optional: true,
+								Elem: &pluginsdk.Resource{
+									Schema: map[string]*pluginsdk.Schema{
+										"name": cdnFrontDoorBatchRuleSetConditionSelectorSchema(),
+										"operator": {
+											Type:         pluginsdk.TypeString,
+											Required:     true,
+											ValidateFunc: validation.StringInSlice(cdnFrontDoorBatchRuleSetConditionOperatorPossibleValues(rulesets.PossibleValuesForCookiesOperator()), false),
+										},
+										"values":     cdnFrontDoorBatchRuleSetConditionValuesSchema(),
+										"transforms": cdnFrontDoorBatchRuleSetConditionTransformsSchema(),
+									},
+								},
+							},
+							"device_type": {
+								Type:     pluginsdk.TypeList,
+								Optional: true,
+								Elem: &pluginsdk.Resource{
+									Schema: map[string]*pluginsdk.Schema{
+										"operator": {
+											Type:         pluginsdk.TypeString,
+											Required:     true,
+											ValidateFunc: validation.StringInSlice(cdnFrontDoorBatchRuleSetConditionOperatorPossibleValues(rulesets.PossibleValuesForIsDeviceOperator()), false),
+										},
+										"values": {
+											Type:     pluginsdk.TypeList,
+											Required: true,
+											MinItems: 1,
+											// This uses a List instead of a String to stay consistent with the other conditions, even though only 1 item can be defined
+											MaxItems: 1,
+											Elem: &pluginsdk.Schema{
+												Type:         pluginsdk.TypeString,
+												ValidateFunc: validation.StringInSlice(rulesets.PossibleValuesForIsDeviceMatchValue(), false),
+											},
+										},
+									},
+								},
+							},
+							"socket_address": {
+								Type:     pluginsdk.TypeList,
+								Optional: true,
+								Elem: &pluginsdk.Resource{
+									Schema: map[string]*pluginsdk.Schema{
+										"operator": {
+											Type:         pluginsdk.TypeString,
+											Required:     true,
+											ValidateFunc: validation.StringInSlice(cdnFrontDoorBatchRuleSetConditionOperatorPossibleValues([]string{string(rulesets.SocketAddrOperatorIPMatch)}), false),
+										},
+										"values": {
+											Type:     pluginsdk.TypeList,
+											Required: true,
+											MinItems: 1,
+											MaxItems: 25,
+											Elem: &pluginsdk.Schema{
+												Type:         pluginsdk.TypeString,
+												ValidateFunc: validate.FrontDoorRuleCidrIsValid,
+											},
+										},
+									},
+								},
+							},
+							"client_port": {
+								Type:     pluginsdk.TypeList,
+								Optional: true,
+								Elem: &pluginsdk.Resource{
+									Schema: map[string]*pluginsdk.Schema{
+										"operator": {
+											Type:         pluginsdk.TypeString,
+											Required:     true,
+											ValidateFunc: validation.StringInSlice(cdnFrontDoorBatchRuleSetConditionOperatorPossibleValues(rulesets.PossibleValuesForClientPortOperator()), false),
+										},
+										"values": cdnFrontDoorBatchRuleSetConditionValuesSchema(),
+									},
+								},
+							},
+							"server_port": {
+								Type:     pluginsdk.TypeList,
+								Optional: true,
+								Elem: &pluginsdk.Resource{
+									Schema: map[string]*pluginsdk.Schema{
+										"operator": {
+											Type:         pluginsdk.TypeString,
+											Required:     true,
+											ValidateFunc: validation.StringInSlice(cdnFrontDoorBatchRuleSetConditionOperatorPossibleValues(rulesets.PossibleValuesForQueryStringOperator()), false),
+										},
+										"values": {
+											Type:     pluginsdk.TypeSet,
+											Optional: true,
+											MaxItems: 2,
+											Elem: &pluginsdk.Schema{
+												Type:         pluginsdk.TypeString,
+												ValidateFunc: validation.StringInSlice([]string{"80", "443"}, false),
+											},
+										},
+									},
+								},
+							},
+							"host_name": {
+								Type:     pluginsdk.TypeList,
+								Optional: true,
+								Elem: &pluginsdk.Resource{
+									Schema: map[string]*pluginsdk.Schema{
+										"operator": {
+											Type:         pluginsdk.TypeString,
+											Required:     true,
+											ValidateFunc: validation.StringInSlice(cdnFrontDoorBatchRuleSetConditionOperatorPossibleValues(rulesets.PossibleValuesForHostNameOperator()), false),
+										},
+										"values":     cdnFrontDoorBatchRuleSetConditionValuesSchema(),
+										"transforms": cdnFrontDoorBatchRuleSetConditionTransformsSchema(),
+									},
+								},
+							},
+							"ssl_protocol": {
+								Type:     pluginsdk.TypeList,
+								Optional: true,
+								Elem: &pluginsdk.Resource{
+									Schema: map[string]*pluginsdk.Schema{
+										"operator": {
+											Type:         pluginsdk.TypeString,
+											Required:     true,
+											ValidateFunc: validation.StringInSlice(cdnFrontDoorBatchRuleSetConditionOperatorPossibleValues(rulesets.PossibleValuesForSslProtocolOperator()), false),
+										},
+										"values": {
+											Type:     pluginsdk.TypeSet,
+											Required: true,
+											MinItems: 1,
+											MaxItems: 3,
+											Elem: &pluginsdk.Schema{
+												Type:         pluginsdk.TypeString,
+												ValidateFunc: validation.StringInSlice(rulesets.PossibleValuesForSslProtocol(), false),
+											},
+										},
+									},
+								},
+							},
+						}},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (CdnFrontDoorBatchRuleSetResource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"id": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+	}
+}
+
+func (r CdnFrontDoorBatchRuleSetResource) CustomizeDiff() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			var model CdnFrontDoorBatchRuleSetModel
+			if err := metadata.DecodeDiff(&model); err != nil {
+				return fmt.Errorf("decoding diff: %+v", err)
+			}
+
+			if err := validateCdnFrontDoorBatchRules(model.Rule); err != nil {
+				return err
+			}
+
+			if err := validateCdnFrontDoorBatchRuleDiffQuota(metadata.ResourceDiff); err != nil {
+				return err
+			}
+
+			return nil
+		},
+	}
+}
+
+func validateCdnFrontDoorBatchRuleDiffQuota(diff *pluginsdk.ResourceDiff) error {
+	hashFunc := pluginsdk.HashResource(CdnFrontDoorBatchRuleSetResource{}.Arguments()["rule"].Elem.(*pluginsdk.Resource))
+
+	oldRaw, newRaw := diff.GetChange("rule")
+	oldRules := cdnFrontDoorBatchRuleSetRules(oldRaw, hashFunc)
+	newRules := cdnFrontDoorBatchRuleSetRules(newRaw, hashFunc)
+
+	names := make(map[string]struct{}, len(oldRules)+len(newRules))
+	for name := range oldRules {
+		names[name] = struct{}{}
+	}
+	for name := range newRules {
+		names[name] = struct{}{}
+	}
+
+	changedRules, cacheOperations := 0, 0
+	for name := range names {
+		oldRule, oldExists := oldRules[name]
+		newRule, newExists := newRules[name]
+
+		if oldExists == newExists && oldRule.hash == newRule.hash {
+			continue
+		}
+
+		changedRules++
+		if oldRule.usesCache || newRule.usesCache {
+			cacheOperations++
+		}
+	}
+
+	// NOTE: Front Door Standard/Premium allows up to 100 rules per ruleset. For batch
+	// rulesets, internal service guidance states that a rule with a cache-enabled
+	// `route_configuration_override_action` consumes two effective rule slots during
+	// replacement. This means a batch update can fail even when the final desired
+	// ruleset is within the documented 100 rule limit, because the service evaluates the effective
+	// change set for the PATCH and returns a 400 Bad Request once that replacement crosses
+	// that quota. We validate `changedRules + cacheOperations` here so the plan
+	// fails with the same service-side constraint before sending the batch ruleset update.
+	if effectiveDiff := changedRules + cacheOperations; effectiveDiff > 100 {
+		return fmt.Errorf("the number of changed `rule` blocks exceeds the service-side quota: got changed `%d` rules, (`%d` of which include caching, which counts for 2 rule slots), total `%d` rule slots used, but the maximum allowed is `100`", changedRules, cacheOperations, effectiveDiff)
+	}
+
+	return nil
+}
+
+type cdnFrontDoorBatchRuleSetRule struct {
+	hash      int
+	usesCache bool
+}
+
+func cdnFrontDoorBatchRuleSetRules(input interface{}, hash pluginsdk.SchemaSetFunc) map[string]cdnFrontDoorBatchRuleSetRule {
+	results := make(map[string]cdnFrontDoorBatchRuleSetRule)
+	if input == nil {
+		return results
+	}
+
+	rulesList, ok := input.([]interface{})
+	if !ok {
+		return results
+	}
+
+	for _, rule := range rulesList {
+		r, ok := rule.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		results[r["name"].(string)] = cdnFrontDoorBatchRuleSetRule{
+			hash:      hash(r),
+			usesCache: cdnFrontDoorBatchRuleSetRuleUsesCache(r),
+		}
+	}
+
+	return results
+}
+
+func cdnFrontDoorBatchRuleSetRuleUsesCache(input map[string]interface{}) bool {
+	actionsRaw, ok := input["actions"].([]interface{})
+	if !ok || len(actionsRaw) == 0 || actionsRaw[0] == nil {
+		return false
+	}
+
+	actions, ok := actionsRaw[0].(map[string]interface{})
+	if !ok {
+		return false
+	}
+
+	routeOverrides, ok := actions["route_configuration_override"].([]interface{})
+	if !ok || len(routeOverrides) == 0 || routeOverrides[0] == nil {
+		return false
+	}
+
+	routeOverride, ok := routeOverrides[0].(map[string]interface{})
+	if !ok {
+		return false
+	}
+
+	cachingList, ok := routeOverride["caching"].([]interface{})
+	if !ok {
+		return false
+	}
+
+	caching, ok := cachingList[0].(map[string]interface{})
+	if !ok {
+		return false
+	}
+
+	cacheBehaviour, ok := caching["behaviour"].(string)
+	if !ok {
+		return false
+	}
+
+	return cacheBehaviour != RuleCacheBehaviorDisabled
+}
+
+func (r CdnFrontDoorBatchRuleSetResource) Create() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 4 * time.Hour,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Cdn.FrontDoorRuleSetsClient
+
+			var model CdnFrontDoorBatchRuleSetModel
+			if err := metadata.Decode(&model); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			profileId, err := profiles.ParseProfileID(model.CdnFrontdoorProfileID)
+			if err != nil {
+				return err
+			}
+
+			id := rulesets.NewRuleSetID(profileId.SubscriptionId, profileId.ResourceGroupName, profileId.ProfileName, model.Name)
+			if !metadata.Client.Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+				existing, err := client.Get(ctx, id)
+				if err != nil {
+					if !response.WasNotFound(existing.HttpResponse) {
+						return fmt.Errorf("retrieving %s: %+v", id, err)
+					}
+				}
+				if !response.WasNotFound(existing.HttpResponse) {
+					return metadata.ResourceRequiresImport(r.ResourceType(), id)
+				}
+			}
+
+			payload, err := expandCdnFrontDoorBatchRuleSetPayload(model)
+			if err != nil {
+				return err
+			}
+
+			if err := client.CreateCallbackThenPoll(ctx, id, payload, metadata.SetIDAndIdentityCallback(&id)); err != nil {
+				return fmt.Errorf("creating %s: %+v", id, err)
+			}
+
+			metadata.SetID(id)
+			return pluginsdk.SetResourceIdentityData(metadata.ResourceData, &id)
+		},
+	}
+}
+
+func (r CdnFrontDoorBatchRuleSetResource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Cdn.FrontDoorRuleSetsClient
+
+			id, err := rulesets.ParseRuleSetID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.Get(ctx, *id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return metadata.MarkAsGone(id)
+				}
+
+				return fmt.Errorf("retrieving %s: %+v", id, err)
+			}
+
+			return r.flatten(metadata, id, resp.Model)
+		},
+	}
+}
+
+func (r CdnFrontDoorBatchRuleSetResource) flatten(metadata sdk.ResourceMetaData, id *rulesets.RuleSetId, model *rulesets.RuleSet) error {
+	state := CdnFrontDoorBatchRuleSetModel{
+		ID:                    id.ID(),
+		Name:                  id.RuleSetName,
+		CdnFrontdoorProfileID: profiles.NewProfileID(id.SubscriptionId, id.ResourceGroupName, id.ProfileName).ID(),
+	}
+
+	if model != nil && model.Properties != nil {
+		rulesetsState, err := flattenCdnFrontDoorBatchRuleSetRules(model.Properties.Rules)
+		if err != nil {
+			return fmt.Errorf("flattening `rules`: %+v", err)
+		}
+		state.Rule = rulesetsState
+	}
+
+	if err := pluginsdk.SetResourceIdentityData(metadata.ResourceData, id); err != nil {
+		return err
+	}
+
+	return metadata.Encode(&state)
+}
+
+func (r CdnFrontDoorBatchRuleSetResource) Update() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 4 * time.Hour,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Cdn.FrontDoorRuleSetsClient
+
+			id, err := rulesets.ParseRuleSetID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			var model CdnFrontDoorBatchRuleSetModel
+			if err := metadata.Decode(&model); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			payload, err := expandCdnFrontDoorBatchRuleSetPayload(model)
+			if err != nil {
+				return err
+			}
+
+			if err := client.CreateThenPoll(ctx, *id, payload); err != nil {
+				return fmt.Errorf("updating %s: %+v", id, err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func (r CdnFrontDoorBatchRuleSetResource) Delete() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 6 * time.Hour,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Cdn.FrontDoorRuleSetsClient
+
+			id, err := rulesets.ParseRuleSetID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			if err := client.DeleteThenPoll(ctx, *id); err != nil {
+				return fmt.Errorf("deleting %s: %+v", id, err)
+			}
+
+			return nil
+		},
+	}
+}

--- a/internal/services/cdn/cdn_frontdoor_batch_rule_set_resource_identity_gen_test.go
+++ b/internal/services/cdn/cdn_frontdoor_batch_rule_set_resource_identity_gen_test.go
@@ -1,0 +1,40 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package cdn_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
+)
+
+func TestAccCdnFrontdoorBatchRuleSet_resourceIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_batch_rule_set", "test")
+	r := CdnFrontdoorBatchRuleSetResource{}
+
+	checkedFields := map[string]struct{}{
+		"name":                {},
+		"profile_name":        {},
+		"resource_group_name": {},
+		"subscription_id":     {},
+	}
+
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basicAttachedRoute(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				customstatecheck.ExpectAllIdentityFieldsAreChecked("azurerm_cdn_frontdoor_batch_rule_set.test", checkedFields),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_cdn_frontdoor_batch_rule_set.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_cdn_frontdoor_batch_rule_set.test", tfjsonpath.New("profile_name"), tfjsonpath.New("cdn_frontdoor_profile_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_cdn_frontdoor_batch_rule_set.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("cdn_frontdoor_profile_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_cdn_frontdoor_batch_rule_set.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("cdn_frontdoor_profile_id")),
+			},
+		},
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
+}

--- a/internal/services/cdn/cdn_frontdoor_batch_rule_set_resource_list.go
+++ b/internal/services/cdn/cdn_frontdoor_batch_rule_set_resource_list.go
@@ -1,0 +1,126 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package cdn
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-azure-helpers/framework/typehelpers"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/profiles"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rulesets"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type CdnFrontDoorBatchRuleSetListResource struct{}
+
+type CdnFrontDoorBatchRuleSetListModel struct {
+	CdnFrontDoorProfileID types.String `tfsdk:"cdn_frontdoor_profile_id"`
+}
+
+var _ sdk.FrameworkListWrappedResource = new(CdnFrontDoorBatchRuleSetListResource)
+
+func (CdnFrontDoorBatchRuleSetListResource) Metadata(_ context.Context, _ resource.MetadataRequest, response *resource.MetadataResponse) {
+	response.TypeName = CdnFrontDoorBatchRuleSetResource{}.ResourceType()
+}
+
+func (CdnFrontDoorBatchRuleSetListResource) ResourceFunc() *pluginsdk.Resource {
+	return sdk.WrappedResource(CdnFrontDoorBatchRuleSetResource{})
+}
+
+func (CdnFrontDoorBatchRuleSetListResource) ListResourceConfigSchema(_ context.Context, _ list.ListResourceSchemaRequest, response *list.ListResourceSchemaResponse) {
+	response.Schema = listschema.Schema{
+		Attributes: map[string]listschema.Attribute{
+			"cdn_frontdoor_profile_id": listschema.StringAttribute{
+				Required: true,
+				Validators: []validator.String{
+					typehelpers.WrappedStringValidator{
+						Func: rulesets.ValidateProfileID,
+					},
+				},
+			},
+		},
+	}
+}
+
+func (CdnFrontDoorBatchRuleSetListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream, metadata sdk.ResourceMetadata) {
+	client := metadata.Client.Cdn.FrontDoorRuleSetsClient
+
+	var data CdnFrontDoorBatchRuleSetListModel
+	diags := request.Config.Get(ctx, &data)
+	if diags.HasError() {
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+
+	profileID, err := profiles.ParseProfileID(data.CdnFrontDoorProfileID.ValueString())
+	if err != nil {
+		sdk.SetResponseErrorDiagnostic(stream, "parsing `cdn_frontdoor_profile_id`", err)
+		return
+	}
+
+	r := CdnFrontDoorBatchRuleSetResource{}
+
+	resp, err := client.ListByProfileComplete(ctx, rulesets.NewProfileID(profileID.SubscriptionId, profileID.ResourceGroupName, profileID.ProfileName))
+	if err != nil {
+		sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("retrieving `%s`", r.ResourceType()), err)
+		return
+	}
+
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		sdk.SetResponseErrorDiagnostic(stream, "internal-error", "context had no deadline")
+		return
+	}
+
+	stream.Results = func(push func(list.ListResult) bool) {
+		ctx, cancel := context.WithDeadline(context.Background(), deadline)
+		defer cancel()
+
+		for _, item := range resp.Items {
+			result := request.NewListResult(ctx)
+			result.DisplayName = pointer.From(item.Name)
+
+			ruleSetID, err := rulesets.ParseRuleSetIDInsensitively(pointer.From(item.Id))
+			if err != nil {
+				sdk.SetErrorDiagnosticAndPushListResult(result, push, "parsing Rule Set ID", err)
+				return
+			}
+
+			detailedResp, err := client.Get(ctx, *ruleSetID)
+			if err != nil {
+				sdk.SetErrorDiagnosticAndPushListResult(result, push, fmt.Sprintf("retrieving `%s`", r.ResourceType()), err)
+				return
+			}
+			if detailedResp.Model == nil || detailedResp.Model.Properties == nil || detailedResp.Model.Properties.BatchMode == nil || !*detailedResp.Model.Properties.BatchMode {
+				continue
+			}
+
+			rmd := sdk.NewResourceMetaData(metadata.Client, r)
+			rmd.ResourceData.SetId(ruleSetID.ID())
+
+			if err := r.flatten(rmd, ruleSetID, detailedResp.Model); err != nil {
+				sdk.SetErrorDiagnosticAndPushListResult(result, push, fmt.Sprintf("encoding `%s` resource data", r.ResourceType()), err)
+				return
+			}
+
+			sdk.EncodeListResult(ctx, rmd.ResourceData, &result)
+			if result.Diagnostics.HasError() {
+				push(result)
+				return
+			}
+
+			if !push(result) {
+				return
+			}
+		}
+	}
+}

--- a/internal/services/cdn/cdn_frontdoor_batch_rule_set_resource_list_test.go
+++ b/internal/services/cdn/cdn_frontdoor_batch_rule_set_resource_list_test.go
@@ -1,0 +1,62 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package cdn_test
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
+)
+
+func TestAccCdnFrontDoorBatchRuleSet_listByProfileID(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_batch_rule_set", "testlist1")
+	r := CdnFrontdoorBatchRuleSetResource{}
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []resource.TestStep{
+			{
+				Config: r.basicAttachedRoute(data),
+			},
+			{
+				Query:  true,
+				Config: r.basicQuery(),
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectLengthAtLeast("azurerm_cdn_frontdoor_batch_rule_set.list", 1),
+					querycheck.ExpectIdentity(
+						"azurerm_cdn_frontdoor_batch_rule_set.list",
+						map[string]knownvalue.Check{
+							"resource_group_name": knownvalue.StringRegexp(regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
+							"profile_name":        knownvalue.StringRegexp(regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
+							"name":                knownvalue.StringExact(fmt.Sprintf("accTestBatchRuleSet%d", data.RandomInteger)),
+							"subscription_id":     knownvalue.StringExact(data.Subscriptions.Primary),
+						},
+					),
+				},
+			},
+		},
+	})
+}
+
+func (r CdnFrontdoorBatchRuleSetResource) basicQuery() string {
+	return `
+list "azurerm_cdn_frontdoor_batch_rule_set" "list" {
+  provider = azurerm
+  config {
+    cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.test.id
+  }
+}`
+}

--- a/internal/services/cdn/cdn_frontdoor_batch_rule_set_resource_list_test.go
+++ b/internal/services/cdn/cdn_frontdoor_batch_rule_set_resource_list_test.go
@@ -41,7 +41,7 @@ func TestAccCdnFrontDoorBatchRuleSet_listByProfileID(t *testing.T) {
 						map[string]knownvalue.Check{
 							"resource_group_name": knownvalue.StringRegexp(regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
 							"profile_name":        knownvalue.StringRegexp(regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
-							"name":                knownvalue.StringExact(fmt.Sprintf("accTestBatchRuleSet%d", data.RandomInteger)),
+							"name":                knownvalue.StringExact(fmt.Sprintf("acctestBatchRuleSet%d", data.RandomInteger)),
 							"subscription_id":     knownvalue.StringExact(data.Subscriptions.Primary),
 						},
 					),

--- a/internal/services/cdn/cdn_frontdoor_batch_rule_set_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_batch_rule_set_resource_test.go
@@ -1,0 +1,2429 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package cdn_test
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rulesets"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type CdnFrontdoorBatchRuleSetResource struct{}
+
+func TestAccCdnFrontDoorBatchRuleSet_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_batch_rule_set", "test")
+	r := CdnFrontdoorBatchRuleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicAttachedRoute(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccCdnFrontDoorBatchRuleSet_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_batch_rule_set", "test")
+	r := CdnFrontdoorBatchRuleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicAttachedRoute(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func TestAccCdnFrontDoorBatchRuleSet_importNonBatchRuleSet(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_batch_rule_set", "test")
+	r := CdnFrontdoorBatchRuleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: CdnFrontDoorRuleSetResource{}.basic(data, false),
+		},
+		{
+			Config:      r.nonBatchRuleSetImport(data),
+			ExpectError: regexp.MustCompile("was not provisioned using batch mode and cannot be managed by this resource"),
+		},
+	})
+}
+
+func TestAccCdnFrontDoorBatchRuleSet_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_batch_rule_set", "test")
+	r := CdnFrontdoorBatchRuleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccCdnFrontDoorBatchRuleSet_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_batch_rule_set", "test")
+	r := CdnFrontdoorBatchRuleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicAttachedRoute(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.update(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basicAttachedRoute(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccCdnFrontDoorBatchRuleSet_disableCache_attachedRoute(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_batch_rule_set", "test")
+	r := CdnFrontdoorBatchRuleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicAttachedRoute(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.disableCacheAttachedRoute(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basicAttachedRoute(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.disableCacheAndNoOriginGroupWithTemplate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccCdnFrontDoorBatchRuleSet_disableCache_unattachedRoute(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_batch_rule_set", "test")
+	r := CdnFrontdoorBatchRuleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.disableCacheUnattachedRoute(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccCdnFrontDoorBatchRuleSet_cacheDurationZero_attachedRoute(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_batch_rule_set", "test")
+	r := CdnFrontdoorBatchRuleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.cacheDurationZeroAttachedRoute(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccCdnFrontDoorBatchRuleSet_cacheDurationZero_unattachedRoute(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_batch_rule_set", "test")
+	r := CdnFrontdoorBatchRuleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.cacheDurationZeroUnattachedRoute(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccCdnFrontDoorBatchRuleSet_originGroupIdOptional_attachedRoute(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_batch_rule_set", "test")
+	r := CdnFrontdoorBatchRuleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.originGroupIdOptionalAttachedRoute(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccCdnFrontDoorBatchRuleSet_originGroupIdOptional_unattachedRoute(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_batch_rule_set", "test")
+	r := CdnFrontdoorBatchRuleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.originGroupIdOptionalWithoutOrigin(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccCdnFrontDoorBatchRuleSet_originGroupIdOptionalUpdate_attachedRoute(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_batch_rule_set", "test")
+	r := CdnFrontdoorBatchRuleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.originGroupIdOptionalAttachedRoute(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basicAttachedRoute(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.originGroupIdOptionalAttachedRoute(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccCdnFrontDoorBatchRuleSet_originGroupIdOptionalUpdate_unattachedRoute(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_batch_rule_set", "test")
+	r := CdnFrontdoorBatchRuleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.originGroupIdOptionalWithoutOrigin(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basicUnattachedRoute(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basicUnattachedRouteWithoutOriginGroupOverride(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		{
+			Config: r.originGroupIdOptionalWithoutOrigin(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccCdnFrontDoorBatchRuleSet_honorOrigin_attachedRoute(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_batch_rule_set", "test")
+	r := CdnFrontdoorBatchRuleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.honorOriginAttachedRoute(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccCdnFrontDoorBatchRuleSet_honorOrigin_unattachedRoute(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_batch_rule_set", "test")
+	r := CdnFrontdoorBatchRuleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.honorOriginWithoutOrigin(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccCdnFrontDoorBatchRuleSet_collectionReorderUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_batch_rule_set", "test")
+	r := CdnFrontdoorBatchRuleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.insertAndReorder(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		{
+			Config: r.deleteAndReorder(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccCdnFrontDoorBatchRuleSet_routeConfigurationOverrideValidation(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_batch_rule_set", "test")
+	r := CdnFrontdoorBatchRuleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.invalidRouteConfigurationOverrideCaching(data, `
+        caching {
+          behaviour = "Disabled"
+          duration  = "23:59:59"
+        }`),
+			ExpectError: regexp.MustCompile("when `route_configuration_override.caching.behaviour` is set to `Disabled`, you cannot define `route_configuration_override.caching.duration`"),
+		},
+		{
+			Config: r.invalidRouteConfigurationOverrideCaching(data, `
+        caching {
+          behaviour               = "Disabled"
+          query_string_parameters = ["foo"]
+        }`),
+			ExpectError: regexp.MustCompile("when `route_configuration_override.caching.behaviour` is set to `Disabled`, you cannot define any `route_configuration_override.caching.query_string_parameters`"),
+		},
+		{
+			Config: r.invalidRouteConfigurationOverrideCaching(data, `
+        caching {
+          behaviour              = "Disabled"
+          query_string_behaviour = "UseQueryString"
+        }`),
+			ExpectError: regexp.MustCompile("when `route_configuration_override.caching.behaviour` is set to `Disabled`, you cannot define `route_configuration_override.caching.query_string_behaviour`"),
+		},
+		{
+			Config: r.invalidRouteConfigurationOverrideCaching(data, `
+        caching {
+          behaviour           = "Disabled"
+          compression_enabled = true
+        }`),
+			ExpectError: regexp.MustCompile("when `route_configuration_override.caching.behaviour` is set to `Disabled`, you cannot define `route_configuration_override.caching.compression_enabled`"),
+		},
+		{
+			Config: r.invalidRouteConfigurationOverrideCaching(data, `
+        caching {
+          behaviour = "OverrideIfOriginMissing"
+          duration  = "23:59:59"
+        }`),
+			ExpectError: regexp.MustCompile("when `route_configuration_override.caching.behaviour` is set to `OverrideIfOriginMissing`, you must also define `route_configuration_override.caching.query_string_behaviour`"),
+		},
+		{
+			Config: r.invalidRouteConfigurationOverrideCaching(data, `
+        caching {
+          behaviour              = "HonorOrigin"
+          query_string_behaviour = "UseQueryString"
+          duration               = "23:59:59"
+        }`),
+			ExpectError: regexp.MustCompile("when `route_configuration_override.caching.behaviour` is set to `HonorOrigin`, you cannot define `route_configuration_override.caching.duration`"),
+		},
+		{
+			Config: r.invalidRouteConfigurationOverrideCaching(data, `
+        caching {
+          behaviour              = "OverrideAlways"
+          query_string_behaviour = "UseQueryString"
+        }`),
+			ExpectError: regexp.MustCompile("when `route_configuration_override.caching.behaviour` is set to `OverrideAlways`, you must also define `route_configuration_override.caching.duration`"),
+		},
+		{
+			Config: r.invalidRouteConfigurationOverrideCaching(data, `
+        caching {
+          behaviour              = "OverrideAlways"
+          duration               = "23:59:59"
+          query_string_behaviour = "IncludeSpecifiedQueryStrings"
+        }`),
+			ExpectError: regexp.MustCompile("when `route_configuration_override.caching.query_string_behaviour` is set to `IncludeSpecifiedQueryStrings`, you must also define one or more `route_configuration_override.caching.query_string_parameters`"),
+		},
+		{
+			Config: r.invalidRouteConfigurationOverrideCaching(data, `
+        caching {
+          behaviour               = "OverrideAlways"
+          duration                = "23:59:59"
+          query_string_behaviour  = "UseQueryString"
+          query_string_parameters = ["foo"]
+        }`),
+			ExpectError: regexp.MustCompile("when `route_configuration_override.caching.query_string_behaviour` is set to `UseQueryString`, you cannot define `route_configuration_override.caching.query_string_parameters`"),
+		},
+	})
+}
+
+func TestAccCdnFrontDoorBatchRuleSet_urlFilenameConditionOperatorAny(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_batch_rule_set", "test")
+	r := CdnFrontdoorBatchRuleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.urlFilenameConditionOperator(data, "Any"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccCdnFrontDoorBatchRuleSet_conditionValidation(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_batch_rule_set", "test")
+	r := CdnFrontdoorBatchRuleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config:      r.urlFilenameConditionOperator(data, "Contains"),
+			ExpectError: regexp.MustCompile("when `conditions.request_filename.operator` is set to `Contains`, `conditions.request_filename.values` must set one or more values"),
+		},
+		{
+			Config:      r.conditionAnyOperatorWithValues(data),
+			ExpectError: regexp.MustCompile("when `conditions.request_path.operator` is set to `Any`, `conditions.request_path.values` cannot be defined"),
+		},
+		{
+			Config:      r.remoteAddressGeoMatchInvalid(data),
+			ExpectError: regexp.MustCompile(`remote_address.*valid country code`),
+		},
+	})
+}
+
+func TestAccCdnFrontDoorBatchRuleSet_rulesValidation(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_batch_rule_set", "test")
+	r := CdnFrontdoorBatchRuleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config:      r.duplicateRuleName(data),
+			ExpectError: regexp.MustCompile("the `rule` blocks must have unique `name` values, got duplicate"),
+		},
+		{
+			Config:      r.duplicateRuleOrder(data),
+			ExpectError: regexp.MustCompile("the `rule` blocks must have unique `order` values, got duplicate `1`"),
+		},
+		{
+			Config:      r.unsortedRules(data),
+			ExpectError: regexp.MustCompile("the `rule` blocks must be declared in ascending `order`, got `2` before `1`"),
+		},
+	})
+}
+
+func TestAccCdnFrontDoorBatchRuleSet_modifyHeaderActionValidation(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_batch_rule_set", "test")
+	r := CdnFrontdoorBatchRuleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config:      r.modifyHeaderActionMissingValue(data),
+			ExpectError: regexp.MustCompile("the `modify_request_header` block is not valid, `header_value` cannot be empty if the `operator` is set to `Append` or `Overwrite`"),
+		},
+		{
+			Config:      r.modifyHeaderActionUnexpectedValue(data),
+			ExpectError: regexp.MustCompile("the `modify_response_header` block is not valid, `header_value` must be empty if the `operator` is set to `Delete`"),
+		},
+	})
+}
+
+func TestAccCdnFrontDoorBatchRuleSet_actionCountValidation(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_batch_rule_set", "test")
+	r := CdnFrontdoorBatchRuleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config:      r.actionCountValidation(data, ``),
+			ExpectError: regexp.MustCompile("the `actions` block must define at least one action"),
+		},
+		{
+			Config: r.actionCountValidation(data, `
+      url_redirect {
+        redirect_type = "Found"
+      }
+
+      url_rewrite {
+        source_pattern   = "/"
+        destination_path = "/rewritten"
+      }`),
+			ExpectError: regexp.MustCompile("the `url_redirect` and the `url_rewrite` are both present in the `actions` block which is invalid"),
+		},
+		{
+			Config: r.actionCountValidation(data, `
+      url_redirect {
+        redirect_type = "Found"
+      }
+
+      route_configuration_override {
+        origin_group {
+          cdn_frontdoor_origin_group_id = azurerm_cdn_frontdoor_origin_group.test.id
+          forwarding_protocol           = "HttpsOnly"
+        }
+
+        caching {
+          behaviour = "Disabled"
+        }
+      }`),
+			ExpectError: regexp.MustCompile("the `url_redirect` and the `route_configuration_override` are both present in the `actions` block which is invalid"),
+		},
+		{
+			Config: r.actionCountValidation(data, `
+      modify_request_header {
+        operator     = "Overwrite"
+        header_name  = "X-1"
+        header_value = "1"
+      }
+
+      modify_request_header {
+        operator     = "Overwrite"
+        header_name  = "X-2"
+        header_value = "2"
+      }
+
+      modify_request_header {
+        operator     = "Overwrite"
+        header_name  = "X-3"
+        header_value = "3"
+      }
+
+      modify_response_header {
+        operator     = "Overwrite"
+        header_name  = "Y-1"
+        header_value = "1"
+      }
+
+      modify_response_header {
+        operator     = "Overwrite"
+        header_name  = "Y-2"
+        header_value = "2"
+      }
+
+      modify_response_header {
+        operator     = "Overwrite"
+        header_name  = "Y-3"
+        header_value = "3"
+      }`),
+			ExpectError: regexp.MustCompile("the `actions` block may only contain up to 5 actions"),
+		},
+	})
+}
+
+func TestAccCdnFrontDoorBatchRuleSet_gapInRuleOrder(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_batch_rule_set", "test")
+	r := CdnFrontdoorBatchRuleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.gapInRuleOrder(data, [2]int{0, 2}),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.gapInRuleOrder(data, [2]int{1, 2}),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccCdnFrontDoorBatchRuleSet_diffQuotaValidation(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_batch_rule_set", "test")
+	r := CdnFrontdoorBatchRuleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.allConditions(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config:      r.diffQuotaExceeded(data),
+			ExpectError: regexp.MustCompile("the number of `rule` blocks exceeds the service-side quota"),
+		},
+	})
+}
+
+func TestAccCdnFrontDoorBatchRuleSet_urlRedirect(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_batch_rule_set", "test")
+	r := CdnFrontdoorBatchRuleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.urlRedirect(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccCdnFrontDoorBatchRuleSet_allConditions(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_batch_rule_set", "test")
+	r := CdnFrontdoorBatchRuleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.allConditions(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccCdnFrontDoorBatchRuleSet_allConditionsUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_batch_rule_set", "test")
+	r := CdnFrontdoorBatchRuleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.allConditions(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.allConditionsUpdate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.allConditions(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccCdnFrontDoorBatchRuleSet_allActions(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_batch_rule_set", "test")
+	r := CdnFrontdoorBatchRuleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.allActions(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccCdnFrontDoorBatchRuleSet_allActionsUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_batch_rule_set", "test")
+	r := CdnFrontdoorBatchRuleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.allActions(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.allActionsUpdate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.allActions(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (r CdnFrontdoorBatchRuleSetResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := rulesets.ParseRuleSetID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	batchModeRuleSetClient := clients.Cdn.FrontDoorRuleSetsClient
+	resp, err := batchModeRuleSetClient.Get(ctx, *id)
+	if err != nil {
+		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	return pointer.To(resp.Model != nil), nil
+}
+
+func (r CdnFrontdoorBatchRuleSetResource) nonBatchRuleSetImport(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+import {
+  id = azurerm_cdn_frontdoor_rule_set.test.id
+  to = azurerm_cdn_frontdoor_batch_rule_set.test
+}
+
+resource "azurerm_cdn_frontdoor_batch_rule_set" "test" {
+  name                     = "acctestBatchRuleSet0706"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.test.id
+
+  rule {
+    name  = "acctestBatchRule%[2]d"
+    order = 0
+
+    actions {
+      url_rewrite {
+        source_pattern   = "/test"
+        destination_path = "/new"
+      }
+    }
+  }
+}
+`, CdnFrontDoorRuleSetResource{}.basic(data, false), data.RandomInteger)
+}
+
+func (r CdnFrontdoorBatchRuleSetResource) templateAttachedRoute(data acceptance.TestData) string {
+	return fmt.Sprintf(`%[1]s
+
+%[2]s`, r.templateUnattachedRoute(data), r.routeTemplate(data))
+}
+
+func (r CdnFrontdoorBatchRuleSetResource) templateUnattachedRoute(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-cdn-afdx-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_cdn_frontdoor_profile" "test" {
+  name                = "acctestProfile-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  sku_name            = "Standard_AzureFrontDoor"
+}
+
+resource "azurerm_cdn_frontdoor_origin_group" "test" {
+  name                     = "acctestOriginGroup-%[1]d"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.test.id
+
+  load_balancing {
+    additional_latency_in_milliseconds = 0
+    sample_size                        = 16
+    successful_samples_required        = 3
+  }
+}
+
+resource "azurerm_cdn_frontdoor_origin" "test" {
+  name                          = "acctestOrigin-%[1]d"
+  cdn_frontdoor_origin_group_id = azurerm_cdn_frontdoor_origin_group.test.id
+  enabled                       = true
+
+  certificate_name_check_enabled = false
+  host_name                      = "contoso.com"
+  http_port                      = 80
+  https_port                     = 443
+  origin_host_header             = "www.contoso.com"
+  priority                       = 1
+  weight                         = 1
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (r CdnFrontdoorBatchRuleSetResource) templateWithoutOrigin(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-cdn-afdx-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_cdn_frontdoor_profile" "test" {
+  name                = "acctestProfile-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  sku_name            = "Standard_AzureFrontDoor"
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (r CdnFrontdoorBatchRuleSetResource) routeTemplate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+
+resource "azurerm_cdn_frontdoor_endpoint" "test" {
+  name                     = "acctestEndpoint-%[1]d"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.test.id
+}
+
+resource "azurerm_cdn_frontdoor_route" "test" {
+  name                          = "acctestRoute-%[1]d"
+  cdn_frontdoor_endpoint_id     = azurerm_cdn_frontdoor_endpoint.test.id
+  cdn_frontdoor_origin_group_id = azurerm_cdn_frontdoor_origin_group.test.id
+  cdn_frontdoor_origin_ids      = [azurerm_cdn_frontdoor_origin.test.id]
+  cdn_frontdoor_rule_set_ids    = [azurerm_cdn_frontdoor_batch_rule_set.test.id]
+  patterns_to_match             = ["/*"]
+  supported_protocols           = ["Http", "Https"]
+}
+`, data.RandomInteger)
+}
+
+func (r CdnFrontdoorBatchRuleSetResource) basicAttachedRoute(data acceptance.TestData) string {
+	return r.basicWithTemplate(data, r.templateAttachedRoute(data))
+}
+
+func (r CdnFrontdoorBatchRuleSetResource) basicUnattachedRoute(data acceptance.TestData) string {
+	return r.basicWithTemplate(data, r.templateUnattachedRoute(data))
+}
+
+func (r CdnFrontdoorBatchRuleSetResource) basicUnattachedRouteWithoutOriginGroupOverride(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_cdn_frontdoor_batch_rule_set" "test" {
+  name                     = "acctestBatchRuleSet%[2]d"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.test.id
+
+  rule {
+    name  = "acctestBatchRule%[2]d"
+    order = 0
+
+    actions {
+      route_configuration_override {
+        caching {
+          query_string_behaviour  = "IncludeSpecifiedQueryStrings"
+          query_string_parameters = ["foo", "clientIp={client_ip}"]
+          compression_enabled     = true
+          behaviour               = "OverrideIfOriginMissing"
+          duration                = "365.23:59:59"
+        }
+      }
+    }
+  }
+}
+`, r.templateUnattachedRoute(data), data.RandomInteger)
+}
+
+func (r CdnFrontdoorBatchRuleSetResource) allActions(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_cdn_frontdoor_batch_rule_set" "test" {
+  depends_on = [azurerm_cdn_frontdoor_origin_group.test, azurerm_cdn_frontdoor_origin.test]
+
+  name                     = "acctestBatchRuleSet%[2]d"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.test.id
+
+  rule {
+    name  = "acctestBatchRule%[2]d"
+    order = 1
+
+    actions {
+      url_redirect {
+        redirect_type         = "Found"
+        redirect_protocol     = "Https"
+        destination_host_name = "contoso.com"
+        destination_path      = "/redirected"
+        destination_fragment  = "fragment"
+        query_string          = "a=b"
+      }
+
+      modify_request_header {
+        operator     = "Overwrite"
+        header_name  = "X-Request"
+        header_value = "request-value"
+      }
+
+      modify_response_header {
+        operator     = "Append"
+        header_name  = "X-Response"
+        header_value = "response-value"
+      }
+    }
+  }
+
+  rule {
+    name  = "acctestBatchRule2%[2]d"
+    order = 2
+
+    actions {
+      url_rewrite {
+        source_pattern                  = "/"
+        destination_path                = "/rewritten"
+        preserve_unmatched_path_enabled = true
+      }
+    }
+  }
+
+  rule {
+    name  = "acctestBatchRule3%[2]d"
+    order = 3
+
+    actions {
+      route_configuration_override {
+        origin_group {
+          cdn_frontdoor_origin_group_id = azurerm_cdn_frontdoor_origin_group.test.id
+          forwarding_protocol           = "HttpsOnly"
+        }
+        caching {
+          query_string_behaviour  = "IncludeSpecifiedQueryStrings"
+          query_string_parameters = ["foo", "clientIp={client_ip}"]
+          compression_enabled     = true
+          behaviour               = "OverrideIfOriginMissing"
+          duration                = "365.23:59:59"
+        }
+      }
+    }
+  }
+}
+`, r.templateUnattachedRoute(data), data.RandomInteger)
+}
+
+func (r CdnFrontdoorBatchRuleSetResource) allActionsUpdate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_cdn_frontdoor_batch_rule_set" "test" {
+  depends_on = [azurerm_cdn_frontdoor_origin_group.test, azurerm_cdn_frontdoor_origin.test]
+
+  name                     = "acctestBatchRuleSet%[2]d"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.test.id
+
+  rule {
+    name  = "acctestBatchRule%[2]d"
+    order = 10
+
+    actions {
+      url_redirect {
+        redirect_type         = "PermanentRedirect"
+        redirect_protocol     = "Http"
+        destination_host_name = "www.contoso.com"
+        destination_path      = "/moved"
+        query_string          = "c=d"
+      }
+
+      modify_request_header {
+        operator     = "Append"
+        header_name  = "X-RequestUpdate"
+        header_value = "request-value-update"
+      }
+
+      modify_response_header {
+        operator    = "Delete"
+        header_name = "X-Response"
+      }
+    }
+  }
+
+  rule {
+    name  = "acctestBatchRule2%[2]d"
+    order = 20
+
+    actions {
+      url_rewrite {
+        source_pattern                  = "/updated"
+        destination_path                = "/rewritten-update"
+        preserve_unmatched_path_enabled = false
+      }
+    }
+  }
+
+  rule {
+    name  = "acctestBatchRule3%[2]d"
+    order = 30
+
+    actions {
+      route_configuration_override {
+        origin_group {
+          cdn_frontdoor_origin_group_id = azurerm_cdn_frontdoor_origin_group.test.id
+          forwarding_protocol           = "MatchRequest"
+        }
+        caching {
+          query_string_behaviour = "IgnoreQueryString"
+          compression_enabled    = false
+          behaviour              = "HonorOrigin"
+        }
+      }
+    }
+  }
+}
+`, r.templateUnattachedRoute(data), data.RandomInteger)
+}
+
+func (r CdnFrontdoorBatchRuleSetResource) basicWithTemplate(data acceptance.TestData, template string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_cdn_frontdoor_batch_rule_set" "test" {
+  depends_on = [azurerm_cdn_frontdoor_origin_group.test, azurerm_cdn_frontdoor_origin.test]
+
+  name                     = "acctestBatchRuleSet%[2]d"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.test.id
+
+  rule {
+    name  = "acctestBatchRule%[2]d"
+    order = 0
+
+    actions {
+      route_configuration_override {
+        origin_group {
+          cdn_frontdoor_origin_group_id = azurerm_cdn_frontdoor_origin_group.test.id
+          forwarding_protocol           = "HttpsOnly"
+        }
+        caching {
+          query_string_behaviour  = "IncludeSpecifiedQueryStrings"
+          query_string_parameters = ["foo", "clientIp={client_ip}"]
+          compression_enabled     = true
+          behaviour               = "OverrideIfOriginMissing"
+          duration                = "365.23:59:59"
+        }
+      }
+    }
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func (r CdnFrontdoorBatchRuleSetResource) disableCacheAttachedRoute(data acceptance.TestData) string {
+	return r.disableCacheWithTemplate(data, r.templateAttachedRoute(data))
+}
+
+func (r CdnFrontdoorBatchRuleSetResource) disableCacheUnattachedRoute(data acceptance.TestData) string {
+	return r.disableCacheWithTemplate(data, r.templateUnattachedRoute(data))
+}
+
+func (r CdnFrontdoorBatchRuleSetResource) disableCacheWithTemplate(data acceptance.TestData, template string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_cdn_frontdoor_batch_rule_set" "test" {
+  depends_on = [azurerm_cdn_frontdoor_origin_group.test, azurerm_cdn_frontdoor_origin.test]
+
+  name                     = "acctestBatchRuleSet%[2]d"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.test.id
+
+  rule {
+    name  = "acctestBatchRule%[2]d"
+    order = 0
+
+    actions {
+      route_configuration_override {
+        origin_group {
+          cdn_frontdoor_origin_group_id = azurerm_cdn_frontdoor_origin_group.test.id
+          forwarding_protocol           = "HttpsOnly"
+        }
+        caching {
+          behaviour = "Disabled"
+        }
+      }
+    }
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func (r CdnFrontdoorBatchRuleSetResource) disableCacheAndNoOriginGroupWithTemplate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_cdn_frontdoor_batch_rule_set" "test" {
+  depends_on = [azurerm_cdn_frontdoor_origin_group.test, azurerm_cdn_frontdoor_origin.test]
+
+  name                     = "acctestBatchRuleSet%[2]d"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.test.id
+
+  rule {
+    name  = "acctestBatchRule%[2]d"
+    order = 0
+
+    actions {
+      route_configuration_override {
+        caching {
+          behaviour = "Disabled"
+        }
+      }
+    }
+  }
+}
+`, r.templateAttachedRoute(data), data.RandomInteger)
+}
+
+func (r CdnFrontdoorBatchRuleSetResource) cacheDurationZeroAttachedRoute(data acceptance.TestData) string {
+	return r.cacheDurationZeroWithTemplate(data, r.templateAttachedRoute(data))
+}
+
+func (r CdnFrontdoorBatchRuleSetResource) cacheDurationZeroUnattachedRoute(data acceptance.TestData) string {
+	return r.cacheDurationZeroWithoutOrigin(data)
+}
+
+func (r CdnFrontdoorBatchRuleSetResource) cacheDurationZeroWithoutOrigin(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_cdn_frontdoor_batch_rule_set" "test" {
+  name                     = "acctestBatchRuleSet%[2]d"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.test.id
+
+  rule {
+    name  = "acctestBatchRule%[2]d"
+    order = 0
+
+    actions {
+      route_configuration_override {
+        caching {
+          query_string_behaviour  = "IncludeSpecifiedQueryStrings"
+          query_string_parameters = ["foo", "clientIp={client_ip}"]
+          compression_enabled     = true
+          behaviour               = "OverrideIfOriginMissing"
+          duration                = "00:00:00"
+        }
+      }
+    }
+  }
+}
+`, r.templateWithoutOrigin(data), data.RandomInteger)
+}
+
+func (r CdnFrontdoorBatchRuleSetResource) cacheDurationZeroWithTemplate(data acceptance.TestData, template string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_cdn_frontdoor_batch_rule_set" "test" {
+  depends_on = [azurerm_cdn_frontdoor_origin_group.test, azurerm_cdn_frontdoor_origin.test]
+
+  name                     = "acctestBatchRuleSet%[2]d"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.test.id
+
+  rule {
+    name  = "acctestBatchRule%[2]d"
+    order = 0
+
+    actions {
+      route_configuration_override {
+        origin_group {
+          cdn_frontdoor_origin_group_id = azurerm_cdn_frontdoor_origin_group.test.id
+          forwarding_protocol           = "HttpsOnly"
+        }
+        caching {
+          query_string_behaviour  = "IncludeSpecifiedQueryStrings"
+          query_string_parameters = ["foo", "clientIp={client_ip}"]
+          compression_enabled     = true
+          behaviour               = "OverrideIfOriginMissing"
+          duration                = "00:00:00"
+        }
+      }
+    }
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func (r CdnFrontdoorBatchRuleSetResource) originGroupIdOptionalAttachedRoute(data acceptance.TestData) string {
+	return r.originGroupIdOptionalWithTemplate(data, r.templateAttachedRoute(data))
+}
+
+func (r CdnFrontdoorBatchRuleSetResource) originGroupIdOptionalWithoutOrigin(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_cdn_frontdoor_batch_rule_set" "test" {
+  name                     = "acctestBatchRuleSet%[2]d"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.test.id
+
+  rule {
+    name  = "acctestBatchRule%[2]d"
+    order = 0
+
+    actions {
+      route_configuration_override {
+        caching {
+          query_string_behaviour  = "IncludeSpecifiedQueryStrings"
+          query_string_parameters = ["foo", "clientIp={client_ip}"]
+          compression_enabled     = true
+          behaviour               = "OverrideIfOriginMissing"
+          duration                = "365.23:59:59"
+        }
+      }
+    }
+  }
+}
+`, r.templateWithoutOrigin(data), data.RandomInteger)
+}
+
+func (r CdnFrontdoorBatchRuleSetResource) originGroupIdOptionalWithTemplate(data acceptance.TestData, template string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_cdn_frontdoor_batch_rule_set" "test" {
+  depends_on = [azurerm_cdn_frontdoor_origin_group.test, azurerm_cdn_frontdoor_origin.test]
+
+  name                     = "acctestBatchRuleSet%[2]d"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.test.id
+
+  rule {
+    name  = "acctestBatchRule%[2]d"
+    order = 0
+
+    actions {
+      route_configuration_override {
+        caching {
+          query_string_behaviour  = "IncludeSpecifiedQueryStrings"
+          query_string_parameters = ["foo", "clientIp={client_ip}"]
+          compression_enabled     = true
+          behaviour               = "OverrideIfOriginMissing"
+          duration                = "365.23:59:59"
+        }
+      }
+    }
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func (r CdnFrontdoorBatchRuleSetResource) honorOriginAttachedRoute(data acceptance.TestData) string {
+	return r.honorOriginWithTemplate(data, r.templateAttachedRoute(data))
+}
+
+func (r CdnFrontdoorBatchRuleSetResource) honorOriginWithoutOrigin(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_cdn_frontdoor_batch_rule_set" "test" {
+  name                     = "acctestBatchRuleSet%[2]d"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.test.id
+
+  rule {
+    name  = "acctestBatchRule%[2]d"
+    order = 0
+
+    actions {
+      route_configuration_override {
+        caching {
+          behaviour              = "HonorOrigin"
+          compression_enabled    = true
+          query_string_behaviour = "IgnoreQueryString"
+        }
+      }
+    }
+
+    conditions {
+      request_path {
+        values   = ["data/"]
+        operator = "BeginsWith"
+      }
+
+      request_path {
+        values   = [".html", ".htm"]
+        operator = "EndsWith"
+      }
+    }
+  }
+}
+`, r.templateWithoutOrigin(data), data.RandomInteger)
+}
+
+func (r CdnFrontdoorBatchRuleSetResource) honorOriginWithTemplate(data acceptance.TestData, template string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_cdn_frontdoor_batch_rule_set" "test" {
+  depends_on = [azurerm_cdn_frontdoor_origin_group.test, azurerm_cdn_frontdoor_origin.test]
+
+  name                     = "acctestBatchRuleSet%[2]d"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.test.id
+
+  rule {
+    name  = "acctestBatchRule%[2]d"
+    order = 0
+
+    actions {
+      route_configuration_override {
+        caching {
+          behaviour              = "HonorOrigin"
+          compression_enabled    = true
+          query_string_behaviour = "IgnoreQueryString"
+        }
+      }
+    }
+
+    conditions {
+      request_path {
+        values   = ["data/"]
+        operator = "BeginsWith"
+      }
+
+      request_path {
+        values   = [".html", ".htm"]
+        operator = "EndsWith"
+      }
+    }
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func (r CdnFrontdoorBatchRuleSetResource) requiresImport(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_cdn_frontdoor_batch_rule_set" "import" {
+  depends_on = [azurerm_cdn_frontdoor_origin_group.test, azurerm_cdn_frontdoor_origin.test]
+
+  name                     = azurerm_cdn_frontdoor_batch_rule_set.test.name
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_batch_rule_set.test.cdn_frontdoor_profile_id
+
+  rule {
+    name  = azurerm_cdn_frontdoor_batch_rule_set.test.rule.0.name
+    order = azurerm_cdn_frontdoor_batch_rule_set.test.rule.0.order
+
+    actions {
+      route_configuration_override {
+        origin_group {
+          cdn_frontdoor_origin_group_id = azurerm_cdn_frontdoor_batch_rule_set.test.rule.0.actions.0.route_configuration_override.0.origin_group.0.cdn_frontdoor_origin_group_id
+          forwarding_protocol           = azurerm_cdn_frontdoor_batch_rule_set.test.rule.0.actions.0.route_configuration_override.0.origin_group.0.forwarding_protocol
+        }
+        caching {
+          query_string_behaviour  = azurerm_cdn_frontdoor_batch_rule_set.test.rule.0.actions.0.route_configuration_override.0.caching.0.query_string_behaviour
+          query_string_parameters = azurerm_cdn_frontdoor_batch_rule_set.test.rule.0.actions.0.route_configuration_override.0.caching.0.query_string_parameters
+          compression_enabled     = azurerm_cdn_frontdoor_batch_rule_set.test.rule.0.actions.0.route_configuration_override.0.caching.0.compression_enabled
+          behaviour               = azurerm_cdn_frontdoor_batch_rule_set.test.rule.0.actions.0.route_configuration_override.0.caching.0.behaviour
+          duration                = azurerm_cdn_frontdoor_batch_rule_set.test.rule.0.actions.0.route_configuration_override.0.caching.0.duration
+        }
+      }
+    }
+  }
+}
+`, r.basicAttachedRoute(data), data.RandomInteger)
+}
+
+func (r CdnFrontdoorBatchRuleSetResource) complete(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_cdn_frontdoor_batch_rule_set" "test" {
+  depends_on = [azurerm_cdn_frontdoor_origin_group.test, azurerm_cdn_frontdoor_origin.test]
+
+  name                     = "acctestBatchRuleSet%[2]d"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.test.id
+
+  rule {
+    name               = "acctestBatchRule%[2]d"
+    behaviour_on_match = "Continue"
+    order              = 1
+
+    actions {
+      route_configuration_override {
+        origin_group {
+          cdn_frontdoor_origin_group_id = azurerm_cdn_frontdoor_origin_group.test.id
+          forwarding_protocol           = "HttpsOnly"
+        }
+        caching {
+          query_string_behaviour  = "IncludeSpecifiedQueryStrings"
+          query_string_parameters = ["foo", "clientIp={client_ip}"]
+          compression_enabled     = true
+          behaviour               = "OverrideIfOriginMissing"
+          duration                = "365.23:59:59"
+        }
+      }
+
+      modify_response_header {
+        operator     = "Append"
+        header_name  = "Set-Cookie"
+        header_value = "sessionId=12345678"
+      }
+    }
+
+    conditions {
+      host_name {
+        operator   = "Equal"
+        values     = ["www.contoso.com", "images.contoso.com", "video.contoso.com"]
+        transforms = ["Lowercase", "Trim"]
+      }
+
+      device_type {
+        operator = "Equal"
+        values   = ["Mobile"]
+      }
+
+      request_method {
+        operator = "Equal"
+        values   = ["DELETE"]
+      }
+    }
+  }
+
+  rule {
+    name  = "acctestBatchRuleExtra%[3]d"
+    order = 2
+
+    actions {
+      modify_request_header {
+        operator     = "Overwrite"
+        header_name  = "X-Test"
+        header_value = "second-rule"
+      }
+    }
+  }
+}
+`, r.templateAttachedRoute(data), data.RandomInteger, data.RandomInteger)
+}
+
+func (r CdnFrontdoorBatchRuleSetResource) update(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_cdn_frontdoor_batch_rule_set" "test" {
+  depends_on = [azurerm_cdn_frontdoor_origin_group.test, azurerm_cdn_frontdoor_origin.test]
+
+  name                     = "acctestBatchRuleSet%[2]d"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.test.id
+
+  rule {
+    name               = "acctestBatchRuleExtra%[2]d"
+    behaviour_on_match = "Stop"
+    order              = 1
+
+    actions {
+      route_configuration_override {
+        origin_group {
+          cdn_frontdoor_origin_group_id = azurerm_cdn_frontdoor_origin_group.test.id
+          forwarding_protocol           = "HttpsOnly"
+        }
+        caching {
+          query_string_behaviour  = "IgnoreSpecifiedQueryStrings"
+          query_string_parameters = ["clientIp={client_ip}"]
+          compression_enabled     = false
+          behaviour               = "OverrideIfOriginMissing"
+          duration                = "23:59:59"
+        }
+      }
+    }
+
+    conditions {
+      host_name {
+        operator   = "Equal"
+        values     = ["www.contoso.com", "images.contoso.com", "video.contoso.com"]
+        transforms = ["Lowercase", "Trim"]
+      }
+
+      device_type {
+        operator = "Equal"
+        values   = ["Mobile"]
+      }
+
+      request_method {
+        operator = "Equal"
+        values   = ["DELETE"]
+      }
+    }
+  }
+}
+`, r.templateAttachedRoute(data), data.RandomInteger)
+}
+
+func (r CdnFrontdoorBatchRuleSetResource) insertAndReorder(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_cdn_frontdoor_batch_rule_set" "test" {
+  depends_on = [azurerm_cdn_frontdoor_origin_group.test, azurerm_cdn_frontdoor_origin.test]
+
+  name                     = "acctestBatchRuleSet%[2]d"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.test.id
+
+  rule {
+    name               = "acctestBatchRule%[2]d"
+    behaviour_on_match = "Continue"
+    order              = 1
+
+    actions {
+      route_configuration_override {
+        origin_group {
+          cdn_frontdoor_origin_group_id = azurerm_cdn_frontdoor_origin_group.test.id
+          forwarding_protocol           = "HttpsOnly"
+        }
+        caching {
+          query_string_behaviour  = "IncludeSpecifiedQueryStrings"
+          query_string_parameters = ["foo", "clientIp={client_ip}"]
+          compression_enabled     = true
+          behaviour               = "OverrideIfOriginMissing"
+          duration                = "365.23:59:59"
+        }
+      }
+    }
+  }
+
+  rule {
+    name               = "acctestBatchRuleInserted%[3]d"
+    behaviour_on_match = "Continue"
+    order              = 2
+
+    actions {
+      modify_request_header {
+        operator     = "Overwrite"
+        header_name  = "X-Test-Inserted"
+        header_value = "inserted-rule"
+      }
+    }
+  }
+
+  rule {
+    name  = "acctestBatchRuleExtra%[4]d"
+    order = 3
+
+    actions {
+      modify_request_header {
+        operator     = "Overwrite"
+        header_name  = "X-Test"
+        header_value = "second-rule"
+      }
+    }
+  }
+}
+`, r.templateAttachedRoute(data), data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func (r CdnFrontdoorBatchRuleSetResource) deleteAndReorder(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_cdn_frontdoor_batch_rule_set" "test" {
+  depends_on = [azurerm_cdn_frontdoor_origin_group.test, azurerm_cdn_frontdoor_origin.test]
+
+  name                     = "acctestBatchRuleSet%[2]d"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.test.id
+
+  rule {
+    name               = "acctestBatchRuleInserted%[2]d"
+    behaviour_on_match = "Stop"
+    order              = 1
+
+    actions {
+      route_configuration_override {
+        origin_group {
+          cdn_frontdoor_origin_group_id = azurerm_cdn_frontdoor_origin_group.test.id
+          forwarding_protocol           = "HttpsOnly"
+        }
+        caching {
+          query_string_behaviour  = "IgnoreSpecifiedQueryStrings"
+          query_string_parameters = ["clientIp={client_ip}"]
+          compression_enabled     = false
+          behaviour               = "OverrideIfOriginMissing"
+          duration                = "23:59:59"
+        }
+      }
+    }
+  }
+
+  rule {
+    name  = "acctestBatchRuleExtra%[3]d"
+    order = 2
+
+    actions {
+      modify_request_header {
+        operator     = "Overwrite"
+        header_name  = "X-Test"
+        header_value = "second-rule"
+      }
+    }
+  }
+}
+`, r.templateAttachedRoute(data), data.RandomInteger, data.RandomInteger)
+}
+
+func (r CdnFrontdoorBatchRuleSetResource) invalidRouteConfigurationOverrideCaching(data acceptance.TestData, cachingBlock string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_cdn_frontdoor_batch_rule_set" "test" {
+  depends_on = [azurerm_cdn_frontdoor_origin_group.test, azurerm_cdn_frontdoor_origin.test]
+
+  name                     = "acctestBatchRuleSet%[2]d"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.test.id
+
+  rule {
+    name  = "acctestBatchRule%[2]d"
+    order = 1
+
+    actions {
+      route_configuration_override {
+        origin_group {
+          cdn_frontdoor_origin_group_id = azurerm_cdn_frontdoor_origin_group.test.id
+          forwarding_protocol           = "HttpsOnly"
+        }
+%[3]s
+      }
+    }
+  }
+}
+`, r.templateAttachedRoute(data), data.RandomInteger, cachingBlock)
+}
+
+func (r CdnFrontdoorBatchRuleSetResource) urlFilenameConditionOperator(data acceptance.TestData, operator string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_cdn_frontdoor_batch_rule_set" "test" {
+  depends_on = [azurerm_cdn_frontdoor_origin_group.test, azurerm_cdn_frontdoor_origin.test]
+
+  name                     = "acctestBatchRuleSet%[2]d"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.test.id
+
+  rule {
+    name               = "acctestBatchRule%[2]d"
+    behaviour_on_match = "Stop"
+    order              = 1
+
+    actions {
+      url_rewrite {
+        source_pattern                  = "/"
+        destination_path                = "/index.html"
+        preserve_unmatched_path_enabled = false
+      }
+    }
+
+    conditions {
+      request_filename {
+        operator = "%[3]s"
+      }
+    }
+  }
+}
+`, r.templateAttachedRoute(data), data.RandomInteger, operator)
+}
+
+func (r CdnFrontdoorBatchRuleSetResource) conditionAnyOperatorWithValues(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_cdn_frontdoor_batch_rule_set" "test" {
+  depends_on = [azurerm_cdn_frontdoor_origin_group.test, azurerm_cdn_frontdoor_origin.test]
+
+  name                     = "acctestBatchRuleSet%[2]d"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.test.id
+
+  rule {
+    name               = "acctestBatchRule%[2]d"
+    behaviour_on_match = "Stop"
+    order              = 1
+
+    actions {
+      url_rewrite {
+        source_pattern                  = "/"
+        destination_path                = "/index.html"
+        preserve_unmatched_path_enabled = false
+      }
+    }
+
+    conditions {
+      request_path {
+        operator = "Any"
+        values   = ["foo", "bar"]
+      }
+    }
+  }
+}
+`, r.templateAttachedRoute(data), data.RandomInteger)
+}
+
+func (r CdnFrontdoorBatchRuleSetResource) remoteAddressGeoMatchInvalid(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_cdn_frontdoor_batch_rule_set" "test" {
+  depends_on = [azurerm_cdn_frontdoor_origin_group.test, azurerm_cdn_frontdoor_origin.test]
+
+  name                     = "acctestBatchRuleSet%[2]d"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.test.id
+
+  rule {
+    name  = "acctestBatchRule%[2]d"
+    order = 1
+
+    actions {
+      url_rewrite {
+        source_pattern                  = "/"
+        destination_path                = "/index.html"
+        preserve_unmatched_path_enabled = false
+      }
+    }
+
+    conditions {
+      remote_address {
+        operator = "GeoMatch"
+        values   = ["us"]
+      }
+    }
+  }
+}
+`, r.templateAttachedRoute(data), data.RandomInteger)
+}
+
+func (r CdnFrontdoorBatchRuleSetResource) duplicateRuleName(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_cdn_frontdoor_batch_rule_set" "test" {
+  depends_on = [azurerm_cdn_frontdoor_origin_group.test, azurerm_cdn_frontdoor_origin.test]
+
+  name                     = "acctestBatchRuleSet%[2]d"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.test.id
+
+  rule {
+    name  = "acctestBatchRule%[2]d"
+    order = 1
+
+    actions {
+      url_rewrite {
+        source_pattern                  = "/"
+        destination_path                = "/first.html"
+        preserve_unmatched_path_enabled = false
+      }
+    }
+  }
+
+  rule {
+    name  = "acctestBatchRule%[3]d"
+    order = 2
+
+    actions {
+      url_rewrite {
+        source_pattern                  = "/"
+        destination_path                = "/second.html"
+        preserve_unmatched_path_enabled = false
+      }
+    }
+  }
+}
+`, r.templateAttachedRoute(data), data.RandomInteger, data.RandomInteger)
+}
+
+func (r CdnFrontdoorBatchRuleSetResource) duplicateRuleOrder(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_cdn_frontdoor_batch_rule_set" "test" {
+  depends_on = [azurerm_cdn_frontdoor_origin_group.test, azurerm_cdn_frontdoor_origin.test]
+
+  name                     = "acctestBatchRuleSet%[2]d"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.test.id
+
+  rule {
+    name  = "acctestBatchRule%[2]d"
+    order = 1
+
+    actions {
+      url_rewrite {
+        source_pattern                  = "/"
+        destination_path                = "/first.html"
+        preserve_unmatched_path_enabled = false
+      }
+    }
+  }
+
+  rule {
+    name  = "acctestBatchRuleExtra%[3]d"
+    order = 1
+
+    actions {
+      url_rewrite {
+        source_pattern                  = "/"
+        destination_path                = "/second.html"
+        preserve_unmatched_path_enabled = false
+      }
+    }
+  }
+}
+`, r.templateAttachedRoute(data), data.RandomInteger, data.RandomInteger)
+}
+
+func (r CdnFrontdoorBatchRuleSetResource) unsortedRules(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_cdn_frontdoor_batch_rule_set" "test" {
+  depends_on = [azurerm_cdn_frontdoor_origin_group.test, azurerm_cdn_frontdoor_origin.test]
+
+  name                     = "acctestBatchRuleSet%[2]d"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.test.id
+
+  rule {
+    name  = "acctestBatchRule%[2]d"
+    order = 2
+
+    actions {
+      url_rewrite {
+        source_pattern                  = "/"
+        destination_path                = "/second.html"
+        preserve_unmatched_path_enabled = false
+      }
+    }
+  }
+
+  rule {
+    name  = "acctestBatchRulePrimary%[3]d"
+    order = 1
+
+    actions {
+      url_rewrite {
+        source_pattern                  = "/"
+        destination_path                = "/first.html"
+        preserve_unmatched_path_enabled = false
+      }
+    }
+  }
+}
+`, r.templateAttachedRoute(data), data.RandomInteger, data.RandomInteger)
+}
+
+func (r CdnFrontdoorBatchRuleSetResource) modifyHeaderActionMissingValue(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_cdn_frontdoor_batch_rule_set" "test" {
+  depends_on = [azurerm_cdn_frontdoor_origin_group.test, azurerm_cdn_frontdoor_origin.test]
+
+  name                     = "acctestBatchRuleSet%[2]d"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.test.id
+
+  rule {
+    name  = "acctestBatchRule%[2]d"
+    order = 1
+
+    actions {
+      modify_request_header {
+        operator    = "Overwrite"
+        header_name = "X-Test"
+      }
+    }
+  }
+}
+`, r.templateAttachedRoute(data), data.RandomInteger)
+}
+
+func (r CdnFrontdoorBatchRuleSetResource) modifyHeaderActionUnexpectedValue(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_cdn_frontdoor_batch_rule_set" "test" {
+  depends_on = [azurerm_cdn_frontdoor_origin_group.test, azurerm_cdn_frontdoor_origin.test]
+
+  name                     = "acctestBatchRuleSet%[2]d"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.test.id
+
+  rule {
+    name  = "acctestBatchRule%[2]d"
+    order = 1
+
+    actions {
+      modify_response_header {
+        operator     = "Delete"
+        header_name  = "X-Test"
+        header_value = "should-be-empty"
+      }
+    }
+  }
+}
+`, r.templateAttachedRoute(data), data.RandomInteger)
+}
+
+func (r CdnFrontdoorBatchRuleSetResource) actionCountValidation(data acceptance.TestData, actionsBlock string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_cdn_frontdoor_batch_rule_set" "test" {
+  depends_on = [azurerm_cdn_frontdoor_origin_group.test, azurerm_cdn_frontdoor_origin.test]
+
+  name                     = "acctestBatchRuleSet%[2]d"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.test.id
+
+  rule {
+    name  = "acctestBatchRule%[2]d"
+    order = 1
+
+    actions {
+      %[3]s
+    }
+  }
+}
+`, r.templateAttachedRoute(data), data.RandomInteger, actionsBlock)
+}
+
+func (r CdnFrontdoorBatchRuleSetResource) gapInRuleOrder(data acceptance.TestData, orders [2]int) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_cdn_frontdoor_batch_rule_set" "test" {
+  depends_on = [azurerm_cdn_frontdoor_origin_group.test, azurerm_cdn_frontdoor_origin.test]
+
+  name                     = "acctestBatchRuleSet%[2]d"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.test.id
+
+  rule {
+    name  = "acctestBatchRulePrimary%[2]d"
+    order = %[4]d
+
+    actions {
+      url_rewrite {
+        source_pattern                  = "/"
+        destination_path                = "/first.html"
+        preserve_unmatched_path_enabled = false
+      }
+    }
+  }
+
+  rule {
+    name  = "acctestBatchRuleGap%[3]d"
+    order = %[5]d
+
+    actions {
+      url_rewrite {
+        source_pattern                  = "/"
+        destination_path                = "/second.html"
+        preserve_unmatched_path_enabled = false
+      }
+    }
+  }
+}
+`, r.templateAttachedRoute(data), data.RandomInteger, data.RandomInteger, orders[0], orders[1])
+}
+
+func (r CdnFrontdoorBatchRuleSetResource) diffQuotaExceeded(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_cdn_frontdoor_batch_rule_set" "test" {
+  depends_on = [azurerm_cdn_frontdoor_origin_group.test, azurerm_cdn_frontdoor_origin.test]
+
+  name                     = "acctestBatchRuleSet%[2]d"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.test.id
+
+  dynamic "rule" {
+    for_each = range(51)
+
+    content {
+      name  = "acctestRule${rule.key}"
+      order = rule.key
+
+      actions {
+        route_configuration_override {
+          caching {
+            behaviour              = "OverrideIfOriginMissing"
+            duration               = "365.23:59:59"
+            query_string_behaviour = "UseQueryString"
+          }
+        }
+      }
+    }
+  }
+
+}
+`, r.templateAttachedRoute(data), data.RandomInteger)
+}
+
+func (r CdnFrontdoorBatchRuleSetResource) urlRedirect(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_cdn_frontdoor_batch_rule_set" "test" {
+  name                     = "acctestBatchRuleSet%[2]d"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.test.id
+
+  rule {
+    name  = "acctestBatchRule%[2]d"
+    order = 1
+
+    actions {
+      url_redirect {
+        redirect_type         = "Found"
+        redirect_protocol     = "Https"
+        destination_host_name = "contoso.com"
+        destination_path      = "/redirected"
+        query_string          = "a=b"
+      }
+    }
+  }
+}
+`, r.templateWithoutOrigin(data), data.RandomInteger)
+}
+
+func (r CdnFrontdoorBatchRuleSetResource) allConditions(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_cdn_frontdoor_batch_rule_set" "test" {
+  name                     = "acctestBatchRuleSet%[2]d"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.test.id
+
+  rule {
+    name  = "acctestBatchRule%[2]d"
+    order = 1
+
+    actions {
+      url_rewrite {
+        source_pattern                  = "/"
+        destination_path                = "/rewritten"
+        preserve_unmatched_path_enabled = true
+      }
+    }
+
+    conditions {
+      remote_address {
+        operator = "GeoMatch"
+        values   = ["US", "CA"]
+      }
+
+      request_scheme {
+        operator = "Equal"
+        values   = ["HTTP"]
+      }
+
+      socket_address {
+        operator = "IPMatch"
+        values   = ["10.0.0.0/24"]
+      }
+
+      query_string {
+        operator   = "Contains"
+        values     = ["a=b"]
+        transforms = ["Lowercase"]
+      }
+
+      post_argument {
+        name     = "arg"
+        operator = "Equal"
+        values   = ["value"]
+      }
+
+      request_url {
+        operator = "BeginsWith"
+        values   = ["https://contoso.com"]
+      }
+
+      request_header {
+        name     = "X-Test"
+        operator = "Equal"
+        values   = ["value"]
+      }
+
+      request_body {
+        operator = "Contains"
+        values   = ["body"]
+      }
+
+      request_file_extension {
+        operator = "Equal"
+        values   = ["html"]
+      }
+
+      http_version {
+        operator = "Equal"
+        values   = ["2.0"]
+      }
+    }
+  }
+
+  rule {
+    name  = "acctestBatchRuleExtra%[2]d"
+    order = 2
+
+    actions {
+      modify_request_header {
+        operator     = "Overwrite"
+        header_name  = "X-Test"
+        header_value = "value"
+      }
+    }
+
+    conditions {
+      request_cookies {
+        name     = "cookie"
+        operator = "Equal"
+        values   = ["value"]
+      }
+
+      client_port {
+        operator = "Equal"
+        values   = ["8080"]
+      }
+
+      server_port {
+        operator = "Equal"
+        values   = ["443"]
+      }
+
+      ssl_protocol {
+        operator = "Equal"
+        values   = ["TLSv1.2"]
+      }
+
+      device_type {
+        operator = "NotEqual"
+        values   = ["Mobile"]
+      }
+
+      host_name {
+        operator   = "NotEqual"
+        values     = ["www.contoso.com"]
+        transforms = ["Lowercase"]
+      }
+
+      request_path {
+        operator = "NotBeginsWith"
+        values   = ["data"]
+      }
+
+      request_method {
+        operator = "NotEqual"
+        values   = ["GET"]
+      }
+    }
+  }
+}
+`, r.templateWithoutOrigin(data), data.RandomInteger)
+}
+
+func (r CdnFrontdoorBatchRuleSetResource) allConditionsUpdate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_cdn_frontdoor_batch_rule_set" "test" {
+  name                     = "acctestBatchRuleSet%[2]d"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.test.id
+
+  rule {
+    name  = "acctestBatchRule%[2]d"
+    order = 10
+
+    actions {
+      url_rewrite {
+        source_pattern                  = "/"
+        destination_path                = "/rewritten"
+        preserve_unmatched_path_enabled = true
+      }
+    }
+
+    conditions {
+      remote_address {
+        operator = "NotIPMatch"
+        values   = ["10.0.0.0/24"]
+      }
+
+      request_scheme {
+        operator = "NotEqual"
+        values   = ["HTTPS"]
+      }
+
+      socket_address {
+        operator = "NotIPMatch"
+        values   = ["10.0.1.0/24"]
+      }
+
+      query_string {
+        operator = "Any"
+      }
+
+      post_argument {
+        name     = "arg"
+        operator = "NotEqual"
+        values   = ["foo", "bar"]
+      }
+
+      request_url {
+        operator = "EndsWith"
+        values   = [".ca"]
+      }
+
+      request_header {
+        name       = "X-TestUpdate"
+        operator   = "NotEqual"
+        values     = ["value", "value2"]
+        transforms = ["Lowercase", "RemoveNulls"]
+      }
+
+      request_body {
+        operator   = "NotBeginsWith"
+        values     = ["HELLO"]
+        transforms = ["Uppercase"]
+      }
+
+      request_file_extension {
+        operator = "NotEqual"
+        values   = ["php"]
+      }
+
+      http_version {
+        operator = "NotEqual"
+        values   = ["1.0"]
+      }
+    }
+  }
+
+  rule {
+    name  = "acctestBatchRuleExtra%[2]d"
+    order = 20
+
+    actions {
+      modify_request_header {
+        operator     = "Append"
+        header_name  = "X-TestUpdate"
+        header_value = "valueUpdate"
+      }
+    }
+
+    conditions {
+      request_cookies {
+        name       = "cookie"
+        operator   = "NotEqual"
+        values     = ["hello", "world"]
+        transforms = ["Lowercase"]
+      }
+
+      client_port {
+        operator = "NotEqual"
+        values   = ["8080", "8181"]
+      }
+
+      server_port {
+        operator = "NotEqual"
+        values   = ["80"]
+      }
+
+      ssl_protocol {
+        operator = "NotEqual"
+        values   = ["TLSv1"]
+      }
+
+      device_type {
+        operator = "Equal"
+        values   = ["Desktop"]
+      }
+
+      host_name {
+        operator   = "Equal"
+        values     = ["www.google.com"]
+        transforms = ["RemoveNulls"]
+      }
+
+      request_path {
+        operator   = "EndsWith"
+        values     = ["foo", "bar", "hello", "world"]
+        transforms = ["Lowercase", "UrlDecode", "RemoveNulls", "Trim"]
+      }
+
+      request_method {
+        operator = "Equal"
+        values   = ["DELETE", "GET", "HEAD", "OPTIONS", "POST", "PUT", "TRACE"]
+      }
+    }
+  }
+}
+`, r.templateWithoutOrigin(data), data.RandomInteger)
+}

--- a/internal/services/cdn/cdn_frontdoor_batch_rule_set_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_batch_rule_set_resource_test.go
@@ -696,6 +696,13 @@ func TestAccCdnFrontDoorBatchRuleSet_allActions(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
+			Config: r.basicUnattachedRouteWithoutOriginGroupOverride(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
 			Config: r.originGroupIdOptionalWithoutOrigin(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
@@ -726,6 +733,13 @@ func TestAccCdnFrontDoorBatchRuleSet_allActionsUpdate(t *testing.T) {
 		data.ImportStep(),
 		{
 			Config: r.allActions(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basicUnattachedRouteWithoutOriginGroupOverride(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),

--- a/internal/services/cdn/cdn_frontdoor_batch_rule_set_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_batch_rule_set_resource_test.go
@@ -619,7 +619,7 @@ func TestAccCdnFrontDoorBatchRuleSet_diffQuotaValidation(t *testing.T) {
 		data.ImportStep(),
 		{
 			Config:      r.diffQuotaExceeded(data),
-			ExpectError: regexp.MustCompile("the number of `rule` blocks exceeds the service-side quota"),
+			ExpectError: regexp.MustCompile("the number of changed `rule` blocks exceeds the service-side quota"),
 		},
 	})
 }
@@ -695,6 +695,13 @@ func TestAccCdnFrontDoorBatchRuleSet_allActions(t *testing.T) {
 			),
 		},
 		data.ImportStep(),
+		{
+			Config: r.originGroupIdOptionalWithoutOrigin(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
 	})
 }
 
@@ -719,6 +726,13 @@ func TestAccCdnFrontDoorBatchRuleSet_allActionsUpdate(t *testing.T) {
 		data.ImportStep(),
 		{
 			Config: r.allActions(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.originGroupIdOptionalWithoutOrigin(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),

--- a/internal/services/cdn/cdn_frontdoor_batch_rule_set_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_batch_rule_set_resource_test.go
@@ -135,7 +135,7 @@ func TestAccCdnFrontDoorBatchRuleSet_disableCache_attachedRoute(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			Config: r.disableCacheAndNoOriginGroupWithTemplate(data),
+			Config: r.disableCacheAndNoOriginGroup(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -1139,7 +1139,7 @@ resource "azurerm_cdn_frontdoor_batch_rule_set" "test" {
 `, template, data.RandomInteger)
 }
 
-func (r CdnFrontdoorBatchRuleSetResource) disableCacheAndNoOriginGroupWithTemplate(data acceptance.TestData) string {
+func (r CdnFrontdoorBatchRuleSetResource) disableCacheAndNoOriginGroup(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}

--- a/internal/services/cdn/cdn_frontdoor_batch_rule_set_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_batch_rule_set_resource_test.go
@@ -521,7 +521,7 @@ func TestAccCdnFrontDoorBatchRuleSet_actionCountValidation(t *testing.T) {
         source_pattern   = "/"
         destination_path = "/rewritten"
       }`),
-			ExpectError: regexp.MustCompile("the `url_redirect` and the `url_rewrite` are both present in the `actions` block which is invalid"),
+			ExpectError: regexp.MustCompile("cannot specify both `url_redirect` and the `url_rewrite` in the `actions` block"),
 		},
 		{
 			Config: r.actionCountValidation(data, `
@@ -539,7 +539,7 @@ func TestAccCdnFrontDoorBatchRuleSet_actionCountValidation(t *testing.T) {
           behaviour = "Disabled"
         }
       }`),
-			ExpectError: regexp.MustCompile("the `url_redirect` and the `route_configuration_override` are both present in the `actions` block which is invalid"),
+			ExpectError: regexp.MustCompile("cannot specify both `url_redirect` and the `route_configuration_override` in the `actions` block"),
 		},
 		{
 			Config: r.actionCountValidation(data, `

--- a/internal/services/cdn/cdn_frontdoor_helpers.go
+++ b/internal/services/cdn/cdn_frontdoor_helpers.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/cdn/mgmt/2021-06-01/cdn" // nolint: staticcheck
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules"
 	waf "github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
@@ -552,4 +553,16 @@ func expandCustomDomains(input []interface{}) ([]interface{}, error) {
 	}
 
 	return out, nil
+}
+
+const RuleCacheBehaviorDisabled = "Disabled"
+
+func PossibleValuesForRuleCacheBehavior() []string {
+	return []string{
+		string(rules.RuleCacheBehaviorHonorOrigin),
+		string(rules.RuleCacheBehaviorOverrideAlways),
+		string(rules.RuleCacheBehaviorOverrideIfOriginMissing),
+		// Exposed `Disabled` as a valid value for provider issue #19008.
+		RuleCacheBehaviorDisabled,
+	}
 }

--- a/internal/services/cdn/cdn_frontdoor_rule_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_rule_resource.go
@@ -4,6 +4,7 @@
 package cdn
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"time"
@@ -39,9 +40,33 @@ func resourceCdnFrontDoorRule() *pluginsdk.Resource {
 			Delete: pluginsdk.DefaultTimeout(6 * time.Hour),
 		},
 
-		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+		Importer: pluginsdk.ImporterValidatingResourceIdThen(func(id string) error {
 			_, err := rules.ParseRuleID(id)
 			return err
+		}, func(ctx context.Context, d *pluginsdk.ResourceData, meta any) ([]*pluginsdk.ResourceData, error) {
+			client := meta.(*clients.Client).Cdn.FrontDoorRuleSetsClient
+
+			id, _ := rules.ParseRuleID(d.Id())
+			ruleSetID := rulesets.NewRuleSetID(id.SubscriptionId, id.ResourceGroupName, id.ProfileName, id.RuleSetName)
+
+			resp, err := client.Get(ctx, ruleSetID)
+			if err != nil {
+				return nil, fmt.Errorf("retrieving %s: %+v", ruleSetID, err)
+			}
+
+			if resp.Model == nil {
+				return nil, fmt.Errorf("retrieving %s: `model` was nil`", id)
+			}
+
+			if resp.Model.Properties == nil {
+				return nil, fmt.Errorf("retrieving %s: `properties` was nil`", id)
+			}
+
+			if pointer.From(resp.Model.Properties.BatchMode) {
+				return nil, fmt.Errorf("the parent ruleset (%s) was provisioned using batch mode, and individual rules for this cannot be managed by this resource, use `azurerm_cdn_frontdoor_batch_rule_set` instead, or create a non-batch Rule Set with `azurerm_cdn_frontdoor_rule_set`", ruleSetID)
+			}
+
+			return []*pluginsdk.ResourceData{d}, nil
 		}),
 
 		Schema: map[string]*pluginsdk.Schema{
@@ -619,6 +644,7 @@ func resourceCdnFrontDoorRule() *pluginsdk.Resource {
 
 func resourceCdnFrontDoorRuleCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Cdn.FrontDoorRulesClient
+	ruleSetsClient := meta.(*clients.Client).Cdn.FrontDoorRuleSetsClient
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -628,6 +654,23 @@ func resourceCdnFrontDoorRuleCreate(d *pluginsdk.ResourceData, meta interface{})
 	}
 
 	id := rules.NewRuleID(ruleSetId.SubscriptionId, ruleSetId.ResourceGroupName, ruleSetId.ProfileName, ruleSetId.RuleSetName, d.Get("name").(string))
+
+	ruleSet, err := ruleSetsClient.Get(ctx, *ruleSetId)
+	if err != nil {
+		return fmt.Errorf("retrieving %s: %+v", ruleSetId, err)
+	}
+
+	if ruleSet.Model == nil {
+		return fmt.Errorf("retrieving %s: `model` was nil", ruleSetId)
+	}
+
+	if ruleSet.Model.Properties == nil {
+		return fmt.Errorf("retrieving %s: `properties` was nil", ruleSetId)
+	}
+
+	if pointer.From(ruleSet.Model.Properties.BatchMode) {
+		return fmt.Errorf("the parent ruleset (%s) was provisioned using batch mode, and individual rules for this cannot be managed by this resource, use `azurerm_cdn_frontdoor_batch_rule_set` instead, or create a non-batch Rule Set with `azurerm_cdn_frontdoor_rule_set`", ruleSetId)
+	}
 
 	if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
 		result, err := client.Get(ctx, id)

--- a/internal/services/cdn/cdn_frontdoor_rule_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_rule_resource_test.go
@@ -479,7 +479,7 @@ func TestAccCdnFrontDoorRule_importBatchRule(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: CdnFrontdoorBatchRuleSetResource{}.disableCacheAndNoOriginGroupWithTemplate(data),
+			Config: CdnFrontdoorBatchRuleSetResource{}.disableCacheAndNoOriginGroup(data),
 		},
 		{
 			Config:      r.batchRuleImport(data),

--- a/internal/services/cdn/cdn_frontdoor_rule_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_rule_resource_test.go
@@ -473,6 +473,21 @@ func TestAccCdnFrontDoorRule_requiresImport(t *testing.T) {
 	})
 }
 
+func TestAccCdnFrontDoorRule_importBatchRule(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_rule", "test")
+	r := CdnFrontDoorRuleResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: CdnFrontdoorBatchRuleSetResource{}.disableCacheAndNoOriginGroupWithTemplate(data),
+		},
+		{
+			Config:      r.batchRuleImport(data),
+			ExpectError: regexp.MustCompile("was provisioned using batch mode, and individual rules for this cannot be managed by this resource"),
+		},
+	})
+}
+
 func TestAccCdnFrontDoorRule_complete_unattachedRoute(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_rule", "test")
 	r := CdnFrontDoorRuleResource{}
@@ -1386,6 +1401,30 @@ resource "azurerm_cdn_frontdoor_rule" "import" {
 
 }
 `, config)
+}
+
+func (r CdnFrontDoorRuleResource) batchRuleImport(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+import {
+  id = "${azurerm_cdn_frontdoor_batch_rule_set.test.id}/rules/${azurerm_cdn_frontdoor_batch_rule_set.test.rule.0.name}"
+  to = azurerm_cdn_frontdoor_rule.test
+}
+
+resource "azurerm_cdn_frontdoor_rule" "test" {
+  name                      = "accTestRule%[2]d"
+  cdn_frontdoor_rule_set_id = azurerm_cdn_frontdoor_batch_rule_set.test.id
+
+  order = 0
+
+  actions {
+    route_configuration_override_action {
+      cache_behavior = "Disabled"
+    }
+  }
+}
+`, CdnFrontdoorBatchRuleSetResource{}.basicUnattachedRoute(data), data.RandomInteger)
 }
 
 func (r CdnFrontDoorRuleResource) complete(data acceptance.TestData, attachRoute bool) string {

--- a/internal/services/cdn/cdn_frontdoor_rule_set_data_source.go
+++ b/internal/services/cdn/cdn_frontdoor_rule_set_data_source.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/profiles"
@@ -62,6 +63,10 @@ func dataSourceCdnFrontDoorRuleSetRead(d *pluginsdk.ResourceData, meta interface
 			return fmt.Errorf("%s was not found", id)
 		}
 		return fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	if resp.Model != nil && resp.Model.Properties != nil && pointer.From(resp.Model.Properties.BatchMode) {
+		return fmt.Errorf("%s was provisioned using batch mode, and cannot be read by this data source, use `azurerm_cdn_frontdoor_batch_rule_set` instead", id)
 	}
 
 	d.SetId(id.ID())

--- a/internal/services/cdn/cdn_frontdoor_rule_set_data_source_test.go
+++ b/internal/services/cdn/cdn_frontdoor_rule_set_data_source_test.go
@@ -5,6 +5,7 @@ package cdn_test
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
@@ -41,6 +42,18 @@ func TestAccCdnFrontDoorRuleSetDataSource_basic_attachedRoute(t *testing.T) {
 	})
 }
 
+func TestAccCdnFrontDoorRuleSetDataSource_batchRuleSet(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_cdn_frontdoor_rule_set", "test")
+	d := CdnFrontDoorRuleSetDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config:      d.batchRuleSet(data),
+			ExpectError: regexp.MustCompile("was provisioned using batch mode, and cannot be read by this data source"),
+		},
+	})
+}
+
 func (CdnFrontDoorRuleSetDataSource) basic(data acceptance.TestData, attachRoute bool) string {
 	return fmt.Sprintf(`
 %s
@@ -51,4 +64,16 @@ data "azurerm_cdn_frontdoor_rule_set" "test" {
   resource_group_name = azurerm_cdn_frontdoor_profile.test.resource_group_name
 }
 `, CdnFrontDoorRuleSetResource{}.complete(data, attachRoute))
+}
+
+func (CdnFrontDoorRuleSetDataSource) batchRuleSet(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "azurerm_cdn_frontdoor_rule_set" "test" {
+  name                = azurerm_cdn_frontdoor_batch_rule_set.test.name
+  profile_name        = azurerm_cdn_frontdoor_profile.test.name
+  resource_group_name = azurerm_cdn_frontdoor_profile.test.resource_group_name
+}
+`, CdnFrontdoorBatchRuleSetResource{}.complete(data))
 }

--- a/internal/services/cdn/cdn_frontdoor_rule_set_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_rule_set_resource.go
@@ -4,10 +4,12 @@
 package cdn
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/profiles"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rulesets"
@@ -30,9 +32,31 @@ func resourceCdnFrontDoorRuleSet() *pluginsdk.Resource {
 			Delete: pluginsdk.DefaultTimeout(6 * time.Hour),
 		},
 
-		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+		Importer: pluginsdk.ImporterValidatingResourceIdThen(func(id string) error {
 			_, err := rulesets.ParseRuleSetID(id)
 			return err
+		}, func(ctx context.Context, d *pluginsdk.ResourceData, meta any) ([]*pluginsdk.ResourceData, error) {
+			client := meta.(*clients.Client).Cdn.FrontDoorRuleSetsClient
+
+			id, _ := rulesets.ParseRuleSetID(d.Id())
+			resp, err := client.Get(ctx, *id)
+			if err != nil {
+				return nil, fmt.Errorf("retrieving %s: %+v", id, err)
+			}
+
+			if resp.Model == nil {
+				return nil, fmt.Errorf("retrieving %s: `model` was nil`", id)
+			}
+
+			if resp.Model.Properties == nil {
+				return nil, fmt.Errorf("retrieving %s: `properties` was nil`", id)
+			}
+
+			if pointer.From(resp.Model.Properties.BatchMode) {
+				return nil, fmt.Errorf("%s was provisioned using batch mode and cannot be managed by this resource, use `azurerm_cdn_frontdoor_batch_rule_set` instead", id)
+			}
+
+			return []*pluginsdk.ResourceData{d}, nil
 		}),
 
 		Schema: map[string]*pluginsdk.Schema{

--- a/internal/services/cdn/cdn_frontdoor_rule_set_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_rule_set_resource_test.go
@@ -6,6 +6,7 @@ package cdn_test
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -57,6 +58,21 @@ func TestAccCdnFrontDoorRuleSet_requiresImport(t *testing.T) {
 			),
 		},
 		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func TestAccCdnFrontDoorRuleSet_importBatchRuleSet(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_rule_set", "test")
+	r := CdnFrontDoorRuleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: CdnFrontdoorBatchRuleSetResource{}.disableCacheAndNoOriginGroupWithTemplate(data),
+		},
+		{
+			Config:      r.batchRuleSetImport(data),
+			ExpectError: regexp.MustCompile("was provisioned using batch mode and cannot be managed by this resource"),
+		},
 	})
 }
 
@@ -129,6 +145,22 @@ resource "azurerm_cdn_frontdoor_rule_set" "import" {
   cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.test.id
 }
 `, config)
+}
+
+func (r CdnFrontDoorRuleSetResource) batchRuleSetImport(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+import {
+  id = azurerm_cdn_frontdoor_batch_rule_set.test.id
+  to = azurerm_cdn_frontdoor_rule_set.test
+}
+
+resource "azurerm_cdn_frontdoor_rule_set" "test" {
+  name                     = "acctestfdruleset%[2]d"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.test.id
+}
+`, CdnFrontdoorBatchRuleSetResource{}.basicUnattachedRoute(data), data.RandomInteger)
 }
 
 func (r CdnFrontDoorRuleSetResource) complete(data acceptance.TestData, attachRoute bool) string {

--- a/internal/services/cdn/cdn_frontdoor_rule_set_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_rule_set_resource_test.go
@@ -67,7 +67,7 @@ func TestAccCdnFrontDoorRuleSet_importBatchRuleSet(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: CdnFrontdoorBatchRuleSetResource{}.disableCacheAndNoOriginGroupWithTemplate(data),
+			Config: CdnFrontdoorBatchRuleSetResource{}.disableCacheAndNoOriginGroup(data),
 		},
 		{
 			Config:      r.batchRuleSetImport(data),

--- a/internal/services/cdn/registration.go
+++ b/internal/services/cdn/registration.go
@@ -54,12 +54,15 @@ func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 
 func (r Registration) DataSources() []sdk.DataSource {
 	return []sdk.DataSource{
+		CdnFrontDoorBatchRuleSetDataSource{},
 		CdnFrontDoorSecurityPolicyDataSource{},
 	}
 }
 
 func (r Registration) Resources() []sdk.Resource {
-	return []sdk.Resource{}
+	return []sdk.Resource{
+		CdnFrontDoorBatchRuleSetResource{},
+	}
 }
 
 // SupportedResources returns the supported Resources supported by this Service
@@ -106,5 +109,7 @@ func (r Registration) EphemeralResources() []func() ephemeral.EphemeralResource 
 }
 
 func (r Registration) ListResources() []sdk.FrameworkListWrappedResource {
-	return []sdk.FrameworkListWrappedResource{}
+	return []sdk.FrameworkListWrappedResource{
+		CdnFrontDoorBatchRuleSetListResource{},
+	}
 }

--- a/internal/tf/validation/pluginsdk.go
+++ b/internal/tf/validation/pluginsdk.go
@@ -324,3 +324,21 @@ func StringStartsWithOneOf(prefixs ...string) func(interface{}, string) ([]strin
 		return warnings, errors
 	}
 }
+
+func StringDoesNotStartWithOneOf(prefixes ...string) func(interface{}, string) ([]string, []error) {
+	return func(i interface{}, k string) (warnings []string, errors []error) {
+		v, ok := i.(string)
+		if !ok {
+			errors = append(errors, fmt.Errorf("expected type of `%s` to be string", k))
+			return warnings, errors
+		}
+
+		for _, val := range prefixes {
+			if strings.HasPrefix(v, val) {
+				errors = append(errors, fmt.Errorf("expected `%s` to not start with one of %s, got `%s`", k, strings.Join(prefixes, ", "), v))
+				return warnings, errors
+			}
+		}
+		return warnings, errors
+	}
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigingroups/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigingroups/README.md
@@ -1,0 +1,116 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigingroups` Documentation
+
+The `afdorigingroups` SDK allows for interaction with Azure Resource Manager `cdn` (API Version `2025-12-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigingroups"
+```
+
+
+### Client Initialization
+
+```go
+client := afdorigingroups.NewAFDOriginGroupsClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `AFDOriginGroupsClient.Create`
+
+```go
+ctx := context.TODO()
+id := afdorigingroups.NewOriginGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group", "profileName", "originGroupName")
+
+payload := afdorigingroups.AFDOriginGroup{
+	// ...
+}
+
+
+if err := client.CreateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `AFDOriginGroupsClient.Delete`
+
+```go
+ctx := context.TODO()
+id := afdorigingroups.NewOriginGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group", "profileName", "originGroupName")
+
+if err := client.DeleteThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `AFDOriginGroupsClient.Get`
+
+```go
+ctx := context.TODO()
+id := afdorigingroups.NewOriginGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group", "profileName", "originGroupName")
+
+read, err := client.Get(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `AFDOriginGroupsClient.ListByProfile`
+
+```go
+ctx := context.TODO()
+id := afdorigingroups.NewProfileID("12345678-1234-9876-4563-123456789012", "example-resource-group", "profileName")
+
+// alternatively `client.ListByProfile(ctx, id)` can be used to do batched pagination
+items, err := client.ListByProfileComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `AFDOriginGroupsClient.ListResourceUsage`
+
+```go
+ctx := context.TODO()
+id := afdorigingroups.NewOriginGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group", "profileName", "originGroupName")
+
+// alternatively `client.ListResourceUsage(ctx, id)` can be used to do batched pagination
+items, err := client.ListResourceUsageComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `AFDOriginGroupsClient.Update`
+
+```go
+ctx := context.TODO()
+id := afdorigingroups.NewOriginGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group", "profileName", "originGroupName")
+
+payload := afdorigingroups.AFDOriginGroupUpdateParameters{
+	// ...
+}
+
+
+if err := client.UpdateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigingroups/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigingroups/client.go
@@ -1,0 +1,26 @@
+package afdorigingroups
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AFDOriginGroupsClient struct {
+	Client *resourcemanager.Client
+}
+
+func NewAFDOriginGroupsClientWithBaseURI(sdkApi sdkEnv.Api) (*AFDOriginGroupsClient, error) {
+	client, err := resourcemanager.NewClient(sdkApi, "afdorigingroups", defaultApiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating AFDOriginGroupsClient: %+v", err)
+	}
+
+	return &AFDOriginGroupsClient{
+		Client: client,
+	}, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigingroups/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigingroups/constants.go
@@ -1,0 +1,315 @@
+package afdorigingroups
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AfdProvisioningState string
+
+const (
+	AfdProvisioningStateCreating  AfdProvisioningState = "Creating"
+	AfdProvisioningStateDeleting  AfdProvisioningState = "Deleting"
+	AfdProvisioningStateFailed    AfdProvisioningState = "Failed"
+	AfdProvisioningStateSucceeded AfdProvisioningState = "Succeeded"
+	AfdProvisioningStateUpdating  AfdProvisioningState = "Updating"
+)
+
+func PossibleValuesForAfdProvisioningState() []string {
+	return []string{
+		string(AfdProvisioningStateCreating),
+		string(AfdProvisioningStateDeleting),
+		string(AfdProvisioningStateFailed),
+		string(AfdProvisioningStateSucceeded),
+		string(AfdProvisioningStateUpdating),
+	}
+}
+
+func (s *AfdProvisioningState) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseAfdProvisioningState(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseAfdProvisioningState(input string) (*AfdProvisioningState, error) {
+	vals := map[string]AfdProvisioningState{
+		"creating":  AfdProvisioningStateCreating,
+		"deleting":  AfdProvisioningStateDeleting,
+		"failed":    AfdProvisioningStateFailed,
+		"succeeded": AfdProvisioningStateSucceeded,
+		"updating":  AfdProvisioningStateUpdating,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := AfdProvisioningState(input)
+	return &out, nil
+}
+
+type DeploymentStatus string
+
+const (
+	DeploymentStatusFailed     DeploymentStatus = "Failed"
+	DeploymentStatusInProgress DeploymentStatus = "InProgress"
+	DeploymentStatusNotStarted DeploymentStatus = "NotStarted"
+	DeploymentStatusSucceeded  DeploymentStatus = "Succeeded"
+)
+
+func PossibleValuesForDeploymentStatus() []string {
+	return []string{
+		string(DeploymentStatusFailed),
+		string(DeploymentStatusInProgress),
+		string(DeploymentStatusNotStarted),
+		string(DeploymentStatusSucceeded),
+	}
+}
+
+func (s *DeploymentStatus) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseDeploymentStatus(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseDeploymentStatus(input string) (*DeploymentStatus, error) {
+	vals := map[string]DeploymentStatus{
+		"failed":     DeploymentStatusFailed,
+		"inprogress": DeploymentStatusInProgress,
+		"notstarted": DeploymentStatusNotStarted,
+		"succeeded":  DeploymentStatusSucceeded,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := DeploymentStatus(input)
+	return &out, nil
+}
+
+type EnabledState string
+
+const (
+	EnabledStateDisabled EnabledState = "Disabled"
+	EnabledStateEnabled  EnabledState = "Enabled"
+)
+
+func PossibleValuesForEnabledState() []string {
+	return []string{
+		string(EnabledStateDisabled),
+		string(EnabledStateEnabled),
+	}
+}
+
+func (s *EnabledState) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseEnabledState(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseEnabledState(input string) (*EnabledState, error) {
+	vals := map[string]EnabledState{
+		"disabled": EnabledStateDisabled,
+		"enabled":  EnabledStateEnabled,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := EnabledState(input)
+	return &out, nil
+}
+
+type HealthProbeRequestType string
+
+const (
+	HealthProbeRequestTypeGET    HealthProbeRequestType = "GET"
+	HealthProbeRequestTypeHEAD   HealthProbeRequestType = "HEAD"
+	HealthProbeRequestTypeNotSet HealthProbeRequestType = "NotSet"
+)
+
+func PossibleValuesForHealthProbeRequestType() []string {
+	return []string{
+		string(HealthProbeRequestTypeGET),
+		string(HealthProbeRequestTypeHEAD),
+		string(HealthProbeRequestTypeNotSet),
+	}
+}
+
+func (s *HealthProbeRequestType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseHealthProbeRequestType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseHealthProbeRequestType(input string) (*HealthProbeRequestType, error) {
+	vals := map[string]HealthProbeRequestType{
+		"get":    HealthProbeRequestTypeGET,
+		"head":   HealthProbeRequestTypeHEAD,
+		"notset": HealthProbeRequestTypeNotSet,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := HealthProbeRequestType(input)
+	return &out, nil
+}
+
+type OriginAuthenticationType string
+
+const (
+	OriginAuthenticationTypeSystemAssignedIdentity OriginAuthenticationType = "SystemAssignedIdentity"
+	OriginAuthenticationTypeUserAssignedIdentity   OriginAuthenticationType = "UserAssignedIdentity"
+)
+
+func PossibleValuesForOriginAuthenticationType() []string {
+	return []string{
+		string(OriginAuthenticationTypeSystemAssignedIdentity),
+		string(OriginAuthenticationTypeUserAssignedIdentity),
+	}
+}
+
+func (s *OriginAuthenticationType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseOriginAuthenticationType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseOriginAuthenticationType(input string) (*OriginAuthenticationType, error) {
+	vals := map[string]OriginAuthenticationType{
+		"systemassignedidentity": OriginAuthenticationTypeSystemAssignedIdentity,
+		"userassignedidentity":   OriginAuthenticationTypeUserAssignedIdentity,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := OriginAuthenticationType(input)
+	return &out, nil
+}
+
+type ProbeProtocol string
+
+const (
+	ProbeProtocolHTTP   ProbeProtocol = "Http"
+	ProbeProtocolHTTPS  ProbeProtocol = "Https"
+	ProbeProtocolNotSet ProbeProtocol = "NotSet"
+)
+
+func PossibleValuesForProbeProtocol() []string {
+	return []string{
+		string(ProbeProtocolHTTP),
+		string(ProbeProtocolHTTPS),
+		string(ProbeProtocolNotSet),
+	}
+}
+
+func (s *ProbeProtocol) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseProbeProtocol(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseProbeProtocol(input string) (*ProbeProtocol, error) {
+	vals := map[string]ProbeProtocol{
+		"http":   ProbeProtocolHTTP,
+		"https":  ProbeProtocolHTTPS,
+		"notset": ProbeProtocolNotSet,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ProbeProtocol(input)
+	return &out, nil
+}
+
+type UsageUnit string
+
+const (
+	UsageUnitCount UsageUnit = "Count"
+)
+
+func PossibleValuesForUsageUnit() []string {
+	return []string{
+		string(UsageUnitCount),
+	}
+}
+
+func (s *UsageUnit) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseUsageUnit(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseUsageUnit(input string) (*UsageUnit, error) {
+	vals := map[string]UsageUnit{
+		"count": UsageUnitCount,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := UsageUnit(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigingroups/id_origingroup.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigingroups/id_origingroup.go
@@ -1,0 +1,139 @@
+package afdorigingroups
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&OriginGroupId{})
+}
+
+var _ resourceids.ResourceId = &OriginGroupId{}
+
+// OriginGroupId is a struct representing the Resource ID for a Origin Group
+type OriginGroupId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	ProfileName       string
+	OriginGroupName   string
+}
+
+// NewOriginGroupID returns a new OriginGroupId struct
+func NewOriginGroupID(subscriptionId string, resourceGroupName string, profileName string, originGroupName string) OriginGroupId {
+	return OriginGroupId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		ProfileName:       profileName,
+		OriginGroupName:   originGroupName,
+	}
+}
+
+// ParseOriginGroupID parses 'input' into a OriginGroupId
+func ParseOriginGroupID(input string) (*OriginGroupId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&OriginGroupId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := OriginGroupId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseOriginGroupIDInsensitively parses 'input' case-insensitively into a OriginGroupId
+// note: this method should only be used for API response data and not user input
+func ParseOriginGroupIDInsensitively(input string) (*OriginGroupId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&OriginGroupId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := OriginGroupId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *OriginGroupId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.ProfileName, ok = input.Parsed["profileName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "profileName", input)
+	}
+
+	if id.OriginGroupName, ok = input.Parsed["originGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "originGroupName", input)
+	}
+
+	return nil
+}
+
+// ValidateOriginGroupID checks that 'input' can be parsed as a Origin Group ID
+func ValidateOriginGroupID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseOriginGroupID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Origin Group ID
+func (id OriginGroupId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Cdn/profiles/%s/originGroups/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.ProfileName, id.OriginGroupName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Origin Group ID
+func (id OriginGroupId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftCdn", "Microsoft.Cdn", "Microsoft.Cdn"),
+		resourceids.StaticSegment("staticProfiles", "profiles", "profiles"),
+		resourceids.UserSpecifiedSegment("profileName", "profileName"),
+		resourceids.StaticSegment("staticOriginGroups", "originGroups", "originGroups"),
+		resourceids.UserSpecifiedSegment("originGroupName", "originGroupName"),
+	}
+}
+
+// String returns a human-readable description of this Origin Group ID
+func (id OriginGroupId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Profile Name: %q", id.ProfileName),
+		fmt.Sprintf("Origin Group Name: %q", id.OriginGroupName),
+	}
+	return fmt.Sprintf("Origin Group (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigingroups/id_profile.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigingroups/id_profile.go
@@ -1,0 +1,130 @@
+package afdorigingroups
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&ProfileId{})
+}
+
+var _ resourceids.ResourceId = &ProfileId{}
+
+// ProfileId is a struct representing the Resource ID for a Profile
+type ProfileId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	ProfileName       string
+}
+
+// NewProfileID returns a new ProfileId struct
+func NewProfileID(subscriptionId string, resourceGroupName string, profileName string) ProfileId {
+	return ProfileId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		ProfileName:       profileName,
+	}
+}
+
+// ParseProfileID parses 'input' into a ProfileId
+func ParseProfileID(input string) (*ProfileId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&ProfileId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := ProfileId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseProfileIDInsensitively parses 'input' case-insensitively into a ProfileId
+// note: this method should only be used for API response data and not user input
+func ParseProfileIDInsensitively(input string) (*ProfileId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&ProfileId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := ProfileId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *ProfileId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.ProfileName, ok = input.Parsed["profileName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "profileName", input)
+	}
+
+	return nil
+}
+
+// ValidateProfileID checks that 'input' can be parsed as a Profile ID
+func ValidateProfileID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseProfileID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Profile ID
+func (id ProfileId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Cdn/profiles/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.ProfileName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Profile ID
+func (id ProfileId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftCdn", "Microsoft.Cdn", "Microsoft.Cdn"),
+		resourceids.StaticSegment("staticProfiles", "profiles", "profiles"),
+		resourceids.UserSpecifiedSegment("profileName", "profileName"),
+	}
+}
+
+// String returns a human-readable description of this Profile ID
+func (id ProfileId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Profile Name: %q", id.ProfileName),
+	}
+	return fmt.Sprintf("Profile (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigingroups/method_create.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigingroups/method_create.go
@@ -1,0 +1,87 @@
+package afdorigingroups
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *AFDOriginGroup
+}
+
+// Create ...
+func (c AFDOriginGroupsClient) Create(ctx context.Context, id OriginGroupId, input AFDOriginGroup) (result CreateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusCreated,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPut,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// CreateThenPoll performs Create then polls until it's completed
+func (c AFDOriginGroupsClient) CreateThenPoll(ctx context.Context, id OriginGroupId, input AFDOriginGroup) error {
+	return c.CreateCallbackThenPoll(ctx, id, input, nil)
+}
+
+// CreateCallbackThenPoll performs Create, runs the optional callback function, then polls until it's completed
+func (c AFDOriginGroupsClient) CreateCallbackThenPoll(ctx context.Context, id OriginGroupId, input AFDOriginGroup, callback func() error) error {
+	result, err := c.Create(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing Create: %+v", err)
+	}
+
+	if callback != nil {
+		if err := callback(); err != nil {
+			return fmt.Errorf("executing callback function: %+v", err)
+		}
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Create: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigingroups/method_delete.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigingroups/method_delete.go
@@ -1,0 +1,71 @@
+package afdorigingroups
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeleteOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// Delete ...
+func (c AFDOriginGroupsClient) Delete(ctx context.Context, id OriginGroupId) (result DeleteOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusNoContent,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodDelete,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// DeleteThenPoll performs Delete then polls until it's completed
+func (c AFDOriginGroupsClient) DeleteThenPoll(ctx context.Context, id OriginGroupId) error {
+	result, err := c.Delete(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing Delete: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Delete: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigingroups/method_get.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigingroups/method_get.go
@@ -1,0 +1,53 @@
+package afdorigingroups
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *AFDOriginGroup
+}
+
+// Get ...
+func (c AFDOriginGroupsClient) Get(ctx context.Context, id OriginGroupId) (result GetOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model AFDOriginGroup
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigingroups/method_listbyprofile.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigingroups/method_listbyprofile.go
@@ -1,0 +1,105 @@
+package afdorigingroups
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListByProfileOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]AFDOriginGroup
+}
+
+type ListByProfileCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []AFDOriginGroup
+}
+
+type ListByProfileCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *ListByProfileCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// ListByProfile ...
+func (c AFDOriginGroupsClient) ListByProfile(ctx context.Context, id ProfileId) (result ListByProfileOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Pager:      &ListByProfileCustomPager{},
+		Path:       fmt.Sprintf("%s/originGroups", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]AFDOriginGroup `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListByProfileComplete retrieves all the results into a single object
+func (c AFDOriginGroupsClient) ListByProfileComplete(ctx context.Context, id ProfileId) (ListByProfileCompleteResult, error) {
+	return c.ListByProfileCompleteMatchingPredicate(ctx, id, AFDOriginGroupOperationPredicate{})
+}
+
+// ListByProfileCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c AFDOriginGroupsClient) ListByProfileCompleteMatchingPredicate(ctx context.Context, id ProfileId, predicate AFDOriginGroupOperationPredicate) (result ListByProfileCompleteResult, err error) {
+	items := make([]AFDOriginGroup, 0)
+
+	resp, err := c.ListByProfile(ctx, id)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListByProfileCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigingroups/method_listresourceusage.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigingroups/method_listresourceusage.go
@@ -1,0 +1,105 @@
+package afdorigingroups
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListResourceUsageOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]Usage
+}
+
+type ListResourceUsageCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []Usage
+}
+
+type ListResourceUsageCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *ListResourceUsageCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// ListResourceUsage ...
+func (c AFDOriginGroupsClient) ListResourceUsage(ctx context.Context, id OriginGroupId) (result ListResourceUsageOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Pager:      &ListResourceUsageCustomPager{},
+		Path:       fmt.Sprintf("%s/usages", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]Usage `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListResourceUsageComplete retrieves all the results into a single object
+func (c AFDOriginGroupsClient) ListResourceUsageComplete(ctx context.Context, id OriginGroupId) (ListResourceUsageCompleteResult, error) {
+	return c.ListResourceUsageCompleteMatchingPredicate(ctx, id, UsageOperationPredicate{})
+}
+
+// ListResourceUsageCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c AFDOriginGroupsClient) ListResourceUsageCompleteMatchingPredicate(ctx context.Context, id OriginGroupId, predicate UsageOperationPredicate) (result ListResourceUsageCompleteResult, err error) {
+	items := make([]Usage, 0)
+
+	resp, err := c.ListResourceUsage(ctx, id)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListResourceUsageCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigingroups/method_update.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigingroups/method_update.go
@@ -1,0 +1,86 @@
+package afdorigingroups
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpdateOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *AFDOriginGroup
+}
+
+// Update ...
+func (c AFDOriginGroupsClient) Update(ctx context.Context, id OriginGroupId, input AFDOriginGroupUpdateParameters) (result UpdateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPatch,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// UpdateThenPoll performs Update then polls until it's completed
+func (c AFDOriginGroupsClient) UpdateThenPoll(ctx context.Context, id OriginGroupId, input AFDOriginGroupUpdateParameters) error {
+	return c.UpdateCallbackThenPoll(ctx, id, input, nil)
+}
+
+// UpdateCallbackThenPoll performs Update, runs the optional callback function, then polls until it's completed
+func (c AFDOriginGroupsClient) UpdateCallbackThenPoll(ctx context.Context, id OriginGroupId, input AFDOriginGroupUpdateParameters, callback func() error) error {
+	result, err := c.Update(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing Update: %+v", err)
+	}
+
+	if callback != nil {
+		if err := callback(); err != nil {
+			return fmt.Errorf("executing callback function: %+v", err)
+		}
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Update: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigingroups/model_afdorigingroup.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigingroups/model_afdorigingroup.go
@@ -1,0 +1,16 @@
+package afdorigingroups
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/systemdata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AFDOriginGroup struct {
+	Id         *string                   `json:"id,omitempty"`
+	Name       *string                   `json:"name,omitempty"`
+	Properties *AFDOriginGroupProperties `json:"properties,omitempty"`
+	SystemData *systemdata.SystemData    `json:"systemData,omitempty"`
+	Type       *string                   `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigingroups/model_afdorigingroupproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigingroups/model_afdorigingroupproperties.go
@@ -1,0 +1,15 @@
+package afdorigingroups
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AFDOriginGroupProperties struct {
+	Authentication                                        *OriginAuthenticationProperties  `json:"authentication,omitempty"`
+	DeploymentStatus                                      *DeploymentStatus                `json:"deploymentStatus,omitempty"`
+	HealthProbeSettings                                   *HealthProbeParameters           `json:"healthProbeSettings,omitempty"`
+	LoadBalancingSettings                                 *LoadBalancingSettingsParameters `json:"loadBalancingSettings,omitempty"`
+	ProfileName                                           *string                          `json:"profileName,omitempty"`
+	ProvisioningState                                     *AfdProvisioningState            `json:"provisioningState,omitempty"`
+	SessionAffinityState                                  *EnabledState                    `json:"sessionAffinityState,omitempty"`
+	TrafficRestorationTimeToHealedOrNewEndpointsInMinutes *int64                           `json:"trafficRestorationTimeToHealedOrNewEndpointsInMinutes,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigingroups/model_afdorigingroupupdateparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigingroups/model_afdorigingroupupdateparameters.go
@@ -1,0 +1,8 @@
+package afdorigingroups
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AFDOriginGroupUpdateParameters struct {
+	Properties *AFDOriginGroupUpdatePropertiesParameters `json:"properties,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigingroups/model_afdorigingroupupdatepropertiesparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigingroups/model_afdorigingroupupdatepropertiesparameters.go
@@ -1,0 +1,13 @@
+package afdorigingroups
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AFDOriginGroupUpdatePropertiesParameters struct {
+	Authentication                                        *OriginAuthenticationProperties  `json:"authentication,omitempty"`
+	HealthProbeSettings                                   *HealthProbeParameters           `json:"healthProbeSettings,omitempty"`
+	LoadBalancingSettings                                 *LoadBalancingSettingsParameters `json:"loadBalancingSettings,omitempty"`
+	ProfileName                                           *string                          `json:"profileName,omitempty"`
+	SessionAffinityState                                  *EnabledState                    `json:"sessionAffinityState,omitempty"`
+	TrafficRestorationTimeToHealedOrNewEndpointsInMinutes *int64                           `json:"trafficRestorationTimeToHealedOrNewEndpointsInMinutes,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigingroups/model_healthprobeparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigingroups/model_healthprobeparameters.go
@@ -1,0 +1,11 @@
+package afdorigingroups
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type HealthProbeParameters struct {
+	ProbeIntervalInSeconds *int64                  `json:"probeIntervalInSeconds,omitempty"`
+	ProbePath              *string                 `json:"probePath,omitempty"`
+	ProbeProtocol          *ProbeProtocol          `json:"probeProtocol,omitempty"`
+	ProbeRequestType       *HealthProbeRequestType `json:"probeRequestType,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigingroups/model_loadbalancingsettingsparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigingroups/model_loadbalancingsettingsparameters.go
@@ -1,0 +1,10 @@
+package afdorigingroups
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type LoadBalancingSettingsParameters struct {
+	AdditionalLatencyInMilliseconds *int64 `json:"additionalLatencyInMilliseconds,omitempty"`
+	SampleSize                      *int64 `json:"sampleSize,omitempty"`
+	SuccessfulSamplesRequired       *int64 `json:"successfulSamplesRequired,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigingroups/model_originauthenticationproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigingroups/model_originauthenticationproperties.go
@@ -1,0 +1,10 @@
+package afdorigingroups
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type OriginAuthenticationProperties struct {
+	Scope                *string                   `json:"scope,omitempty"`
+	Type                 *OriginAuthenticationType `json:"type,omitempty"`
+	UserAssignedIdentity *ResourceReference        `json:"userAssignedIdentity,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigingroups/model_resourcereference.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigingroups/model_resourcereference.go
@@ -1,0 +1,8 @@
+package afdorigingroups
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ResourceReference struct {
+	Id *string `json:"id,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigingroups/model_usage.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigingroups/model_usage.go
@@ -1,0 +1,12 @@
+package afdorigingroups
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type Usage struct {
+	CurrentValue int64     `json:"currentValue"`
+	Id           *string   `json:"id,omitempty"`
+	Limit        int64     `json:"limit"`
+	Name         UsageName `json:"name"`
+	Unit         UsageUnit `json:"unit"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigingroups/model_usagename.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigingroups/model_usagename.go
@@ -1,0 +1,9 @@
+package afdorigingroups
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UsageName struct {
+	LocalizedValue *string `json:"localizedValue,omitempty"`
+	Value          *string `json:"value,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigingroups/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigingroups/predicates.go
@@ -1,0 +1,50 @@
+package afdorigingroups
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AFDOriginGroupOperationPredicate struct {
+	Id   *string
+	Name *string
+	Type *string
+}
+
+func (p AFDOriginGroupOperationPredicate) Matches(input AFDOriginGroup) bool {
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}
+
+type UsageOperationPredicate struct {
+	CurrentValue *int64
+	Id           *string
+	Limit        *int64
+}
+
+func (p UsageOperationPredicate) Matches(input Usage) bool {
+
+	if p.CurrentValue != nil && *p.CurrentValue != input.CurrentValue {
+		return false
+	}
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Limit != nil && *p.Limit != input.Limit {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigingroups/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigingroups/version.go
@@ -1,0 +1,14 @@
+package afdorigingroups
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2025-12-01"
+
+func userAgent() string {
+	return "hashicorp/go-azure-sdk/afdorigingroups/2025-12-01"
+}
+
+func AzureAPIVersion() string {
+	return defaultApiVersion
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigins/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigins/README.md
@@ -1,0 +1,99 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigins` Documentation
+
+The `afdorigins` SDK allows for interaction with Azure Resource Manager `cdn` (API Version `2025-12-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigins"
+```
+
+
+### Client Initialization
+
+```go
+client := afdorigins.NewAFDOriginsClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `AFDOriginsClient.Create`
+
+```go
+ctx := context.TODO()
+id := afdorigins.NewOriginGroupOriginID("12345678-1234-9876-4563-123456789012", "example-resource-group", "profileName", "originGroupName", "originName")
+
+payload := afdorigins.AFDOrigin{
+	// ...
+}
+
+
+if err := client.CreateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `AFDOriginsClient.Delete`
+
+```go
+ctx := context.TODO()
+id := afdorigins.NewOriginGroupOriginID("12345678-1234-9876-4563-123456789012", "example-resource-group", "profileName", "originGroupName", "originName")
+
+if err := client.DeleteThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `AFDOriginsClient.Get`
+
+```go
+ctx := context.TODO()
+id := afdorigins.NewOriginGroupOriginID("12345678-1234-9876-4563-123456789012", "example-resource-group", "profileName", "originGroupName", "originName")
+
+read, err := client.Get(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `AFDOriginsClient.ListByOriginGroup`
+
+```go
+ctx := context.TODO()
+id := afdorigins.NewOriginGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group", "profileName", "originGroupName")
+
+// alternatively `client.ListByOriginGroup(ctx, id)` can be used to do batched pagination
+items, err := client.ListByOriginGroupComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `AFDOriginsClient.Update`
+
+```go
+ctx := context.TODO()
+id := afdorigins.NewOriginGroupOriginID("12345678-1234-9876-4563-123456789012", "example-resource-group", "profileName", "originGroupName", "originName")
+
+payload := afdorigins.AFDOriginUpdateParameters{
+	// ...
+}
+
+
+if err := client.UpdateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigins/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigins/client.go
@@ -1,0 +1,26 @@
+package afdorigins
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AFDOriginsClient struct {
+	Client *resourcemanager.Client
+}
+
+func NewAFDOriginsClientWithBaseURI(sdkApi sdkEnv.Api) (*AFDOriginsClient, error) {
+	client, err := resourcemanager.NewClient(sdkApi, "afdorigins", defaultApiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating AFDOriginsClient: %+v", err)
+	}
+
+	return &AFDOriginsClient{
+		Client: client,
+	}, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigins/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigins/constants.go
@@ -1,0 +1,198 @@
+package afdorigins
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AfdProvisioningState string
+
+const (
+	AfdProvisioningStateCreating  AfdProvisioningState = "Creating"
+	AfdProvisioningStateDeleting  AfdProvisioningState = "Deleting"
+	AfdProvisioningStateFailed    AfdProvisioningState = "Failed"
+	AfdProvisioningStateSucceeded AfdProvisioningState = "Succeeded"
+	AfdProvisioningStateUpdating  AfdProvisioningState = "Updating"
+)
+
+func PossibleValuesForAfdProvisioningState() []string {
+	return []string{
+		string(AfdProvisioningStateCreating),
+		string(AfdProvisioningStateDeleting),
+		string(AfdProvisioningStateFailed),
+		string(AfdProvisioningStateSucceeded),
+		string(AfdProvisioningStateUpdating),
+	}
+}
+
+func (s *AfdProvisioningState) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseAfdProvisioningState(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseAfdProvisioningState(input string) (*AfdProvisioningState, error) {
+	vals := map[string]AfdProvisioningState{
+		"creating":  AfdProvisioningStateCreating,
+		"deleting":  AfdProvisioningStateDeleting,
+		"failed":    AfdProvisioningStateFailed,
+		"succeeded": AfdProvisioningStateSucceeded,
+		"updating":  AfdProvisioningStateUpdating,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := AfdProvisioningState(input)
+	return &out, nil
+}
+
+type DeploymentStatus string
+
+const (
+	DeploymentStatusFailed     DeploymentStatus = "Failed"
+	DeploymentStatusInProgress DeploymentStatus = "InProgress"
+	DeploymentStatusNotStarted DeploymentStatus = "NotStarted"
+	DeploymentStatusSucceeded  DeploymentStatus = "Succeeded"
+)
+
+func PossibleValuesForDeploymentStatus() []string {
+	return []string{
+		string(DeploymentStatusFailed),
+		string(DeploymentStatusInProgress),
+		string(DeploymentStatusNotStarted),
+		string(DeploymentStatusSucceeded),
+	}
+}
+
+func (s *DeploymentStatus) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseDeploymentStatus(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseDeploymentStatus(input string) (*DeploymentStatus, error) {
+	vals := map[string]DeploymentStatus{
+		"failed":     DeploymentStatusFailed,
+		"inprogress": DeploymentStatusInProgress,
+		"notstarted": DeploymentStatusNotStarted,
+		"succeeded":  DeploymentStatusSucceeded,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := DeploymentStatus(input)
+	return &out, nil
+}
+
+type EnabledState string
+
+const (
+	EnabledStateDisabled EnabledState = "Disabled"
+	EnabledStateEnabled  EnabledState = "Enabled"
+)
+
+func PossibleValuesForEnabledState() []string {
+	return []string{
+		string(EnabledStateDisabled),
+		string(EnabledStateEnabled),
+	}
+}
+
+func (s *EnabledState) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseEnabledState(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseEnabledState(input string) (*EnabledState, error) {
+	vals := map[string]EnabledState{
+		"disabled": EnabledStateDisabled,
+		"enabled":  EnabledStateEnabled,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := EnabledState(input)
+	return &out, nil
+}
+
+type SharedPrivateLinkResourceStatus string
+
+const (
+	SharedPrivateLinkResourceStatusApproved     SharedPrivateLinkResourceStatus = "Approved"
+	SharedPrivateLinkResourceStatusDisconnected SharedPrivateLinkResourceStatus = "Disconnected"
+	SharedPrivateLinkResourceStatusPending      SharedPrivateLinkResourceStatus = "Pending"
+	SharedPrivateLinkResourceStatusRejected     SharedPrivateLinkResourceStatus = "Rejected"
+	SharedPrivateLinkResourceStatusTimeout      SharedPrivateLinkResourceStatus = "Timeout"
+)
+
+func PossibleValuesForSharedPrivateLinkResourceStatus() []string {
+	return []string{
+		string(SharedPrivateLinkResourceStatusApproved),
+		string(SharedPrivateLinkResourceStatusDisconnected),
+		string(SharedPrivateLinkResourceStatusPending),
+		string(SharedPrivateLinkResourceStatusRejected),
+		string(SharedPrivateLinkResourceStatusTimeout),
+	}
+}
+
+func (s *SharedPrivateLinkResourceStatus) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseSharedPrivateLinkResourceStatus(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseSharedPrivateLinkResourceStatus(input string) (*SharedPrivateLinkResourceStatus, error) {
+	vals := map[string]SharedPrivateLinkResourceStatus{
+		"approved":     SharedPrivateLinkResourceStatusApproved,
+		"disconnected": SharedPrivateLinkResourceStatusDisconnected,
+		"pending":      SharedPrivateLinkResourceStatusPending,
+		"rejected":     SharedPrivateLinkResourceStatusRejected,
+		"timeout":      SharedPrivateLinkResourceStatusTimeout,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := SharedPrivateLinkResourceStatus(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigins/id_origingroup.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigins/id_origingroup.go
@@ -1,0 +1,139 @@
+package afdorigins
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&OriginGroupId{})
+}
+
+var _ resourceids.ResourceId = &OriginGroupId{}
+
+// OriginGroupId is a struct representing the Resource ID for a Origin Group
+type OriginGroupId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	ProfileName       string
+	OriginGroupName   string
+}
+
+// NewOriginGroupID returns a new OriginGroupId struct
+func NewOriginGroupID(subscriptionId string, resourceGroupName string, profileName string, originGroupName string) OriginGroupId {
+	return OriginGroupId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		ProfileName:       profileName,
+		OriginGroupName:   originGroupName,
+	}
+}
+
+// ParseOriginGroupID parses 'input' into a OriginGroupId
+func ParseOriginGroupID(input string) (*OriginGroupId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&OriginGroupId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := OriginGroupId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseOriginGroupIDInsensitively parses 'input' case-insensitively into a OriginGroupId
+// note: this method should only be used for API response data and not user input
+func ParseOriginGroupIDInsensitively(input string) (*OriginGroupId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&OriginGroupId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := OriginGroupId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *OriginGroupId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.ProfileName, ok = input.Parsed["profileName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "profileName", input)
+	}
+
+	if id.OriginGroupName, ok = input.Parsed["originGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "originGroupName", input)
+	}
+
+	return nil
+}
+
+// ValidateOriginGroupID checks that 'input' can be parsed as a Origin Group ID
+func ValidateOriginGroupID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseOriginGroupID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Origin Group ID
+func (id OriginGroupId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Cdn/profiles/%s/originGroups/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.ProfileName, id.OriginGroupName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Origin Group ID
+func (id OriginGroupId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftCdn", "Microsoft.Cdn", "Microsoft.Cdn"),
+		resourceids.StaticSegment("staticProfiles", "profiles", "profiles"),
+		resourceids.UserSpecifiedSegment("profileName", "profileName"),
+		resourceids.StaticSegment("staticOriginGroups", "originGroups", "originGroups"),
+		resourceids.UserSpecifiedSegment("originGroupName", "originGroupName"),
+	}
+}
+
+// String returns a human-readable description of this Origin Group ID
+func (id OriginGroupId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Profile Name: %q", id.ProfileName),
+		fmt.Sprintf("Origin Group Name: %q", id.OriginGroupName),
+	}
+	return fmt.Sprintf("Origin Group (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigins/id_origingrouporigin.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigins/id_origingrouporigin.go
@@ -1,0 +1,148 @@
+package afdorigins
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&OriginGroupOriginId{})
+}
+
+var _ resourceids.ResourceId = &OriginGroupOriginId{}
+
+// OriginGroupOriginId is a struct representing the Resource ID for a Origin Group Origin
+type OriginGroupOriginId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	ProfileName       string
+	OriginGroupName   string
+	OriginName        string
+}
+
+// NewOriginGroupOriginID returns a new OriginGroupOriginId struct
+func NewOriginGroupOriginID(subscriptionId string, resourceGroupName string, profileName string, originGroupName string, originName string) OriginGroupOriginId {
+	return OriginGroupOriginId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		ProfileName:       profileName,
+		OriginGroupName:   originGroupName,
+		OriginName:        originName,
+	}
+}
+
+// ParseOriginGroupOriginID parses 'input' into a OriginGroupOriginId
+func ParseOriginGroupOriginID(input string) (*OriginGroupOriginId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&OriginGroupOriginId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := OriginGroupOriginId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseOriginGroupOriginIDInsensitively parses 'input' case-insensitively into a OriginGroupOriginId
+// note: this method should only be used for API response data and not user input
+func ParseOriginGroupOriginIDInsensitively(input string) (*OriginGroupOriginId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&OriginGroupOriginId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := OriginGroupOriginId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *OriginGroupOriginId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.ProfileName, ok = input.Parsed["profileName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "profileName", input)
+	}
+
+	if id.OriginGroupName, ok = input.Parsed["originGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "originGroupName", input)
+	}
+
+	if id.OriginName, ok = input.Parsed["originName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "originName", input)
+	}
+
+	return nil
+}
+
+// ValidateOriginGroupOriginID checks that 'input' can be parsed as a Origin Group Origin ID
+func ValidateOriginGroupOriginID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseOriginGroupOriginID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Origin Group Origin ID
+func (id OriginGroupOriginId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Cdn/profiles/%s/originGroups/%s/origins/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.ProfileName, id.OriginGroupName, id.OriginName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Origin Group Origin ID
+func (id OriginGroupOriginId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftCdn", "Microsoft.Cdn", "Microsoft.Cdn"),
+		resourceids.StaticSegment("staticProfiles", "profiles", "profiles"),
+		resourceids.UserSpecifiedSegment("profileName", "profileName"),
+		resourceids.StaticSegment("staticOriginGroups", "originGroups", "originGroups"),
+		resourceids.UserSpecifiedSegment("originGroupName", "originGroupName"),
+		resourceids.StaticSegment("staticOrigins", "origins", "origins"),
+		resourceids.UserSpecifiedSegment("originName", "originName"),
+	}
+}
+
+// String returns a human-readable description of this Origin Group Origin ID
+func (id OriginGroupOriginId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Profile Name: %q", id.ProfileName),
+		fmt.Sprintf("Origin Group Name: %q", id.OriginGroupName),
+		fmt.Sprintf("Origin Name: %q", id.OriginName),
+	}
+	return fmt.Sprintf("Origin Group Origin (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigins/method_create.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigins/method_create.go
@@ -1,0 +1,87 @@
+package afdorigins
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *AFDOrigin
+}
+
+// Create ...
+func (c AFDOriginsClient) Create(ctx context.Context, id OriginGroupOriginId, input AFDOrigin) (result CreateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusCreated,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPut,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// CreateThenPoll performs Create then polls until it's completed
+func (c AFDOriginsClient) CreateThenPoll(ctx context.Context, id OriginGroupOriginId, input AFDOrigin) error {
+	return c.CreateCallbackThenPoll(ctx, id, input, nil)
+}
+
+// CreateCallbackThenPoll performs Create, runs the optional callback function, then polls until it's completed
+func (c AFDOriginsClient) CreateCallbackThenPoll(ctx context.Context, id OriginGroupOriginId, input AFDOrigin, callback func() error) error {
+	result, err := c.Create(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing Create: %+v", err)
+	}
+
+	if callback != nil {
+		if err := callback(); err != nil {
+			return fmt.Errorf("executing callback function: %+v", err)
+		}
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Create: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigins/method_delete.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigins/method_delete.go
@@ -1,0 +1,71 @@
+package afdorigins
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeleteOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// Delete ...
+func (c AFDOriginsClient) Delete(ctx context.Context, id OriginGroupOriginId) (result DeleteOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusNoContent,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodDelete,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// DeleteThenPoll performs Delete then polls until it's completed
+func (c AFDOriginsClient) DeleteThenPoll(ctx context.Context, id OriginGroupOriginId) error {
+	result, err := c.Delete(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing Delete: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Delete: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigins/method_get.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigins/method_get.go
@@ -1,0 +1,53 @@
+package afdorigins
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *AFDOrigin
+}
+
+// Get ...
+func (c AFDOriginsClient) Get(ctx context.Context, id OriginGroupOriginId) (result GetOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model AFDOrigin
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigins/method_listbyorigingroup.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigins/method_listbyorigingroup.go
@@ -1,0 +1,105 @@
+package afdorigins
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListByOriginGroupOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]AFDOrigin
+}
+
+type ListByOriginGroupCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []AFDOrigin
+}
+
+type ListByOriginGroupCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *ListByOriginGroupCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// ListByOriginGroup ...
+func (c AFDOriginsClient) ListByOriginGroup(ctx context.Context, id OriginGroupId) (result ListByOriginGroupOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Pager:      &ListByOriginGroupCustomPager{},
+		Path:       fmt.Sprintf("%s/origins", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]AFDOrigin `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListByOriginGroupComplete retrieves all the results into a single object
+func (c AFDOriginsClient) ListByOriginGroupComplete(ctx context.Context, id OriginGroupId) (ListByOriginGroupCompleteResult, error) {
+	return c.ListByOriginGroupCompleteMatchingPredicate(ctx, id, AFDOriginOperationPredicate{})
+}
+
+// ListByOriginGroupCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c AFDOriginsClient) ListByOriginGroupCompleteMatchingPredicate(ctx context.Context, id OriginGroupId, predicate AFDOriginOperationPredicate) (result ListByOriginGroupCompleteResult, err error) {
+	items := make([]AFDOrigin, 0)
+
+	resp, err := c.ListByOriginGroup(ctx, id)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListByOriginGroupCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigins/method_update.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigins/method_update.go
@@ -1,0 +1,86 @@
+package afdorigins
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpdateOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *AFDOrigin
+}
+
+// Update ...
+func (c AFDOriginsClient) Update(ctx context.Context, id OriginGroupOriginId, input AFDOriginUpdateParameters) (result UpdateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPatch,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// UpdateThenPoll performs Update then polls until it's completed
+func (c AFDOriginsClient) UpdateThenPoll(ctx context.Context, id OriginGroupOriginId, input AFDOriginUpdateParameters) error {
+	return c.UpdateCallbackThenPoll(ctx, id, input, nil)
+}
+
+// UpdateCallbackThenPoll performs Update, runs the optional callback function, then polls until it's completed
+func (c AFDOriginsClient) UpdateCallbackThenPoll(ctx context.Context, id OriginGroupOriginId, input AFDOriginUpdateParameters, callback func() error) error {
+	result, err := c.Update(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing Update: %+v", err)
+	}
+
+	if callback != nil {
+		if err := callback(); err != nil {
+			return fmt.Errorf("executing callback function: %+v", err)
+		}
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Update: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigins/model_afdorigin.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigins/model_afdorigin.go
@@ -1,0 +1,16 @@
+package afdorigins
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/systemdata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AFDOrigin struct {
+	Id         *string                `json:"id,omitempty"`
+	Name       *string                `json:"name,omitempty"`
+	Properties *AFDOriginProperties   `json:"properties,omitempty"`
+	SystemData *systemdata.SystemData `json:"systemData,omitempty"`
+	Type       *string                `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigins/model_afdoriginproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigins/model_afdoriginproperties.go
@@ -1,0 +1,20 @@
+package afdorigins
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AFDOriginProperties struct {
+	AzureOrigin                 *ResourceReference                   `json:"azureOrigin,omitempty"`
+	DeploymentStatus            *DeploymentStatus                    `json:"deploymentStatus,omitempty"`
+	EnabledState                *EnabledState                        `json:"enabledState,omitempty"`
+	EnforceCertificateNameCheck *bool                                `json:"enforceCertificateNameCheck,omitempty"`
+	HTTPPort                    *int64                               `json:"httpPort,omitempty"`
+	HTTPSPort                   *int64                               `json:"httpsPort,omitempty"`
+	HostName                    *string                              `json:"hostName,omitempty"`
+	OriginGroupName             *string                              `json:"originGroupName,omitempty"`
+	OriginHostHeader            *string                              `json:"originHostHeader,omitempty"`
+	Priority                    *int64                               `json:"priority,omitempty"`
+	ProvisioningState           *AfdProvisioningState                `json:"provisioningState,omitempty"`
+	SharedPrivateLinkResource   *SharedPrivateLinkResourceProperties `json:"sharedPrivateLinkResource,omitempty"`
+	Weight                      *int64                               `json:"weight,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigins/model_afdoriginupdateparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigins/model_afdoriginupdateparameters.go
@@ -1,0 +1,8 @@
+package afdorigins
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AFDOriginUpdateParameters struct {
+	Properties *AFDOriginUpdatePropertiesParameters `json:"properties,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigins/model_afdoriginupdatepropertiesparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigins/model_afdoriginupdatepropertiesparameters.go
@@ -1,0 +1,18 @@
+package afdorigins
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AFDOriginUpdatePropertiesParameters struct {
+	AzureOrigin                 *ResourceReference                   `json:"azureOrigin,omitempty"`
+	EnabledState                *EnabledState                        `json:"enabledState,omitempty"`
+	EnforceCertificateNameCheck *bool                                `json:"enforceCertificateNameCheck,omitempty"`
+	HTTPPort                    *int64                               `json:"httpPort,omitempty"`
+	HTTPSPort                   *int64                               `json:"httpsPort,omitempty"`
+	HostName                    *string                              `json:"hostName,omitempty"`
+	OriginGroupName             *string                              `json:"originGroupName,omitempty"`
+	OriginHostHeader            *string                              `json:"originHostHeader,omitempty"`
+	Priority                    *int64                               `json:"priority,omitempty"`
+	SharedPrivateLinkResource   *SharedPrivateLinkResourceProperties `json:"sharedPrivateLinkResource,omitempty"`
+	Weight                      *int64                               `json:"weight,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigins/model_resourcereference.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigins/model_resourcereference.go
@@ -1,0 +1,8 @@
+package afdorigins
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ResourceReference struct {
+	Id *string `json:"id,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigins/model_sharedprivatelinkresourceproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigins/model_sharedprivatelinkresourceproperties.go
@@ -1,0 +1,12 @@
+package afdorigins
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SharedPrivateLinkResourceProperties struct {
+	GroupId             *string                          `json:"groupId,omitempty"`
+	PrivateLink         *ResourceReference               `json:"privateLink,omitempty"`
+	PrivateLinkLocation *string                          `json:"privateLinkLocation,omitempty"`
+	RequestMessage      *string                          `json:"requestMessage,omitempty"`
+	Status              *SharedPrivateLinkResourceStatus `json:"status,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigins/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigins/predicates.go
@@ -1,0 +1,27 @@
+package afdorigins
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AFDOriginOperationPredicate struct {
+	Id   *string
+	Name *string
+	Type *string
+}
+
+func (p AFDOriginOperationPredicate) Matches(input AFDOrigin) bool {
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigins/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigins/version.go
@@ -1,0 +1,14 @@
+package afdorigins
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2025-12-01"
+
+func userAgent() string {
+	return "hashicorp/go-azure-sdk/afdorigins/2025-12-01"
+}
+
+func AzureAPIVersion() string {
+	return defaultApiVersion
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -374,6 +374,8 @@ github.com/hashicorp/go-azure-sdk/resource-manager/blueprints/2018-11-01-preview
 github.com/hashicorp/go-azure-sdk/resource-manager/botservice/2022-09-15/channel
 github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afddomains
 github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdendpoints
+github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigingroups
+github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigins
 github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/endpoints
 github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/profiles
 github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules

--- a/website/docs/d/cdn_frontdoor_batch_rule_set.html.markdown
+++ b/website/docs/d/cdn_frontdoor_batch_rule_set.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Gets information about an existing Front Door (standard/premium) Batch Rule Set.
 
--> **Note:** This data source can only read Rule Sets that were provisioned in batch mode. Use the `azurerm_cdn_frontdoor_rule_set` data source for Rule Sets that were not provisioned in batch mode.
+~> **Note:** This data source can only read Rule Sets that were provisioned in batch mode. Use the `azurerm_cdn_frontdoor_rule_set` data source for Rule Sets that were not provisioned in batch mode.
 
 ## Example Usage
 

--- a/website/docs/d/cdn_frontdoor_batch_rule_set.html.markdown
+++ b/website/docs/d/cdn_frontdoor_batch_rule_set.html.markdown
@@ -1,0 +1,380 @@
+---
+subcategory: "CDN"
+layout: "azurerm"
+page_title: "Azure Resource Manager: Data Source: azurerm_cdn_frontdoor_batch_rule_set"
+description: |-
+  Gets information about an existing Front Door (standard/premium) Batch Rule Set.
+---
+
+# Data Source: azurerm_cdn_frontdoor_batch_rule_set
+
+Gets information about an existing Front Door (standard/premium) Batch Rule Set.
+
+-> **Note:** This data source can only read Rule Sets that were provisioned in batch mode. Use the `azurerm_cdn_frontdoor_rule_set` data source for Rule Sets that were not provisioned in batch mode.
+
+## Example Usage
+
+```hcl
+data "azurerm_cdn_frontdoor_batch_rule_set" "example" {
+  name                = "existing"
+  profile_name        = "existing-profile"
+  resource_group_name = "existing-resources"
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the Front Door Batch Rule Set.
+
+* `profile_name` - (Required) The name of the Front Door Profile.
+
+* `resource_group_name` - (Required) The name of the Resource Group.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the Front Door Batch Rule Set.
+
+* `cdn_frontdoor_profile_id` - The ID of the Front Door Profile associated with this Front Door Batch Rule Set.
+
+* `rules` - A `rules` block as defined below.
+
+---
+
+A `rules` block exports the following:
+
+* `actions` - An `actions` block as defined below.
+
+* `behaviour_on_match` - Whether the rules engine continues processing after this rule matches.
+
+* `conditions` - A `conditions` block as defined below.
+
+* `name` - The name of the Front Door Batch Rule.
+
+* `order` - The order in which this rule is applied.
+
+---
+
+An `actions` block exports the following:
+
+* `modify_request_header` - One or more `modify_request_header` blocks as defined below.
+
+* `modify_response_header` - One or more `modify_response_header` blocks as defined below.
+
+* `route_configuration_override` - A `route_configuration_override` block as defined below.
+
+* `url_redirect` - A `url_redirect` block as defined below.
+
+* `url_rewrite` - A `url_rewrite` block as defined below.
+
+---
+
+A `modify_request_header` block exports the following:
+
+* `header_name` - The name of the request header.
+
+* `header_value` - The value associated with the request header action.
+
+* `operator` - The action applied to the request header.
+
+---
+
+A `modify_response_header` block exports the following:
+
+* `header_name` - The name of the response header.
+
+* `header_value` - The value associated with the response header action.
+
+* `operator` - The action applied to the response header.
+
+---
+
+A `route_configuration_override` block exports the following:
+
+* `caching` - A `caching` block as defined below.
+
+* `origin_group` - An `origin_group` block as defined below.
+
+---
+
+An `origin_group` block exports the following:
+
+* `cdn_frontdoor_origin_group_id` - The ID of the Front Door Origin Group associated with this action.
+
+* `forwarding_protocol` - The forwarding protocol applied to this action.
+
+---
+
+A `caching` block exports the following:
+
+* `behaviour` - The cache behaviour applied to this action.
+
+* `compression_enabled` - Whether compression is enabled.
+
+* `duration` - The cache duration applied to this action.
+
+* `query_string_behaviour` - The query string caching behaviour applied to this action.
+
+* `query_string_parameters` - The query string parameters associated with this action.
+
+---
+
+A `url_redirect` block exports the following:
+
+* `destination_fragment` - The destination fragment for the redirect action.
+
+* `destination_host_name` - The destination host name for the redirect action.
+
+* `destination_path` - The destination path for the redirect action.
+
+* `query_string` - The query string for the redirect action.
+
+* `redirect_protocol` - The redirect protocol for the redirect action.
+
+* `redirect_type` - The redirect type for the redirect action.
+
+---
+
+A `url_rewrite` block exports the following:
+
+* `destination_path` - The destination path for the rewrite action.
+
+* `preserve_unmatched_path_enabled` - Whether to preserve the unmatched part of the path.
+
+* `source_pattern` - The source pattern for the rewrite action.
+
+---
+
+A `conditions` block exports the following:
+
+* `client_port` - One or more `client_port` blocks as defined below.
+
+* `device_type` - One or more `device_type` blocks as defined below.
+
+* `host_name` - One or more `host_name` blocks as defined below.
+
+* `http_version` - One or more `http_version` blocks as defined below.
+
+* `post_argument` - One or more `post_argument` blocks as defined below.
+
+* `query_string` - One or more `query_string` blocks as defined below.
+
+* `remote_address` - One or more `remote_address` blocks as defined below.
+
+* `request_body` - One or more `request_body` blocks as defined below.
+
+* `request_cookies` - One or more `request_cookies` blocks as defined below.
+
+* `request_file_extension` - One or more `request_file_extension` blocks as defined below.
+
+* `request_filename` - One or more `request_filename` blocks as defined below.
+
+* `request_header` - One or more `request_header` blocks as defined below.
+
+* `request_method` - One or more `request_method` blocks as defined below.
+
+* `request_path` - One or more `request_path` blocks as defined below.
+
+* `request_scheme` - One or more `request_scheme` blocks as defined below.
+
+* `request_url` - One or more `request_url` blocks as defined below.
+
+* `server_port` - One or more `server_port` blocks as defined below.
+
+* `socket_address` - One or more `socket_address` blocks as defined below.
+
+* `ssl_protocol` - One or more `ssl_protocol` blocks as defined below.
+
+
+---
+
+A `client_port` block exports the following:
+
+* `operator` - The operator for this condition.
+
+* `values` - The client port values associated with this condition.
+
+---
+
+A `device_type` block exports the following:
+
+* `operator` - The operator for this condition.
+
+* `values` - The device types associated with this condition.
+
+---
+
+A `host_name` block exports the following:
+
+* `operator` - The operator for this condition.
+
+* `transforms` - The transforms associated with this condition.
+
+* `values` - The host names associated with this condition.
+
+---
+
+A `http_version` block exports the following:
+
+* `operator` - The operator for this condition.
+
+* `values` - The HTTP versions associated with this condition.
+
+---
+
+A `post_argument` block exports the following:
+
+* `name` - The POST argument name associated with this condition.
+
+* `operator` - The operator for this condition.
+
+* `transforms` - The transforms associated with this condition.
+
+* `values` - The POST argument values associated with this condition.
+
+---
+
+A `query_string` block exports the following:
+
+* `operator` - The operator for this condition.
+
+* `transforms` - The transforms associated with this condition.
+
+* `values` - The query string values associated with this condition.
+
+---
+
+A `remote_address` block exports the following:
+
+* `operator` - The operator for this condition.
+
+* `values` - The remote address values associated with this condition.
+
+---
+
+A `request_body` block exports the following:
+
+* `operator` - The operator for this condition.
+
+* `transforms` - The transforms associated with this condition.
+
+* `values` - The request body values associated with this condition.
+
+---
+
+A `request_cookies` block exports the following:
+
+* `name` - The cookie name associated with this condition.
+
+* `operator` - The operator for this condition.
+
+* `transforms` - The transforms associated with this condition.
+
+* `values` - The cookie values associated with this condition.
+
+---
+
+A `request_file_extension` block exports the following:
+
+* `operator` - The operator for this condition.
+
+* `transforms` - The transforms associated with this condition.
+
+* `values` - The request file extension values associated with this condition.
+
+---
+
+A `request_filename` block exports the following:
+
+* `operator` - The operator for this condition.
+
+* `transforms` - The transforms associated with this condition.
+
+* `values` - The request file name values associated with this condition.
+
+---
+
+A `request_header` block exports the following:
+
+* `name` - The request header name associated with this condition.
+
+* `operator` - The operator for this condition.
+
+* `transforms` - The transforms associated with this condition.
+
+* `values` - The request header values associated with this condition.
+
+---
+
+A `request_method` block exports the following:
+
+* `operator` - The operator for this condition.
+
+* `values` - The request methods associated with this condition.
+
+---
+
+A `request_path` block exports the following:
+
+* `operator` - The operator for this condition.
+
+* `transforms` - The transforms associated with this condition.
+
+* `values` - The request path values associated with this condition.
+
+---
+
+A `request_scheme` block exports the following:
+
+* `operator` - The operator for this condition.
+
+* `values` - The request schemes associated with this condition.
+
+---
+
+A `request_url` block exports the following:
+
+* `operator` - The operator for this condition.
+
+* `transforms` - The transforms associated with this condition.
+
+* `values` - The request URL values associated with this condition.
+
+---
+
+A `server_port` block exports the following:
+
+* `operator` - The operator for this condition.
+
+* `values` - The server port values associated with this condition.
+
+---
+
+A `socket_address` block exports the following:
+
+* `operator` - The operator for this condition.
+
+* `values` - The socket address values associated with this condition.
+
+---
+
+A `ssl_protocol` block exports the following:
+
+* `operator` - The operator for this condition.
+
+* `values` - The SSL protocol values associated with this condition.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/configure#define-operation-timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Front Door Batch Rule Set.
+
+## API Providers
+<!-- This section is generated, changes will be overwritten -->
+This data source uses the following Azure API Providers:
+
+* `Microsoft.Cdn` - 2025-12-01

--- a/website/docs/d/cdn_frontdoor_rule_set.html.markdown
+++ b/website/docs/d/cdn_frontdoor_rule_set.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Use this data source to access information about an existing Front Door (standard/premium) Rule Set.
 
+-> **Note:** This data source can only read Rule Sets that were not provisioned in batch mode. Use the `azurerm_cdn_frontdoor_batch_rule_set` data source for Rule Sets that were provisioned in batch mode.
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/d/cdn_frontdoor_rule_set.html.markdown
+++ b/website/docs/d/cdn_frontdoor_rule_set.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Use this data source to access information about an existing Front Door (standard/premium) Rule Set.
 
--> **Note:** This data source can only read Rule Sets that were not provisioned in batch mode. Use the `azurerm_cdn_frontdoor_batch_rule_set` data source for Rule Sets that were provisioned in batch mode.
+~> **Note:** This data source can only read Rule Sets that were not provisioned in batch mode. Use the `azurerm_cdn_frontdoor_batch_rule_set` data source for Rule Sets that were provisioned in batch mode.
 
 ## Example Usage
 

--- a/website/docs/list-resources/cdn_frontdoor_batch_rule_set.html.markdown
+++ b/website/docs/list-resources/cdn_frontdoor_batch_rule_set.html.markdown
@@ -1,0 +1,30 @@
+---
+subcategory: "CDN"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_batch_rule_set"
+description: |-
+  Lists Front Door (standard/premium) Batch Rule Set resources.
+---
+
+# List resource: azurerm_cdn_frontdoor_batch_rule_set
+
+Lists Front Door (standard/premium) Batch Rule Set resources.
+
+## Example Usage
+
+### List Front Door Batch Rule Sets for a Profile
+
+```hcl
+list "azurerm_cdn_frontdoor_batch_rule_set" "example" {
+  provider = azurerm
+  config {
+    cdn_frontdoor_profile_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1/providers/Microsoft.Cdn/profiles/profile1"
+  }
+}
+```
+
+## Argument Reference
+
+This list resource supports the following arguments:
+
+* `cdn_frontdoor_profile_id` - (Required) The resource ID of the Front Door Profile to query.

--- a/website/docs/r/cdn_frontdoor_batch_rule_set.html.markdown
+++ b/website/docs/r/cdn_frontdoor_batch_rule_set.html.markdown
@@ -1,0 +1,579 @@
+---
+subcategory: "CDN"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_batch_rule_set"
+description: |-
+  Manages a Front Door (standard/premium) Batch Rule Set.
+---
+
+# azurerm_cdn_frontdoor_batch_rule_set
+
+Manages a Front Door (standard/premium) Batch Rule Set.
+
+~> **Note:** This resource creates the Front Door Rule Set in batch mode and manages the full ordered batch rule collection for it. Any change to the configured `rule` blocks sends the desired final ordered rule list to the Resource Provider in a single request.
+
+~> **Note:** Use `azurerm_cdn_frontdoor_rule_set` together with `azurerm_cdn_frontdoor_rule` for the normal non-batch Rule Set path.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example-cdn-frontdoor"
+  location = "West Europe"
+}
+
+resource "azurerm_cdn_frontdoor_profile" "example" {
+  name                = "example-profile"
+  resource_group_name = azurerm_resource_group.example.name
+  sku_name            = "Premium_AzureFrontDoor"
+}
+
+resource "azurerm_cdn_frontdoor_endpoint" "example" {
+  name                     = "example-endpoint"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.example.id
+
+  tags = {
+    endpoint = "contoso.com"
+  }
+}
+
+resource "azurerm_cdn_frontdoor_origin_group" "example" {
+  name                     = "example-originGroup"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.example.id
+  session_affinity_enabled = true
+
+  restore_traffic_time_to_healed_or_new_endpoint_in_minutes = 10
+
+  health_probe {
+    interval_in_seconds = 240
+    path                = "/healthProbe"
+    protocol            = "Https"
+    request_type        = "GET"
+  }
+
+  load_balancing {
+    additional_latency_in_milliseconds = 0
+    sample_size                        = 16
+    successful_samples_required        = 3
+  }
+}
+
+resource "azurerm_cdn_frontdoor_origin" "example" {
+  name                          = "example-origin"
+  cdn_frontdoor_origin_group_id = azurerm_cdn_frontdoor_origin_group.example.id
+  enabled                       = true
+
+  certificate_name_check_enabled = false
+
+  host_name          = azurerm_cdn_frontdoor_endpoint.example.host_name
+  http_port          = 80
+  https_port         = 443
+  origin_host_header = "contoso.com"
+  priority           = 1
+  weight             = 500
+}
+
+resource "azurerm_cdn_frontdoor_batch_rule_set" "example" {
+  name                     = "examplebatchruleset"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.example.id
+
+  rule {
+    name               = "examplebatchrule"
+    order              = 1
+    behaviour_on_match = "Continue"
+
+    actions {
+      route_configuration_override {
+        origin_group {
+          cdn_frontdoor_origin_group_id = azurerm_cdn_frontdoor_origin_group.example.id
+          forwarding_protocol           = "HttpsOnly"
+        }
+
+        caching {
+          behaviour               = "OverrideIfOriginMissing"
+          duration                = "365.23:59:59"
+          compression_enabled     = true
+          query_string_behaviour  = "IncludeSpecifiedQueryStrings"
+          query_string_parameters = ["foo", "clientIp={client_ip}"]
+        }
+      }
+    }
+
+    conditions {
+      host_name {
+        operator   = "Equal"
+        values     = ["www.contoso.com", "images.contoso.com", "video.contoso.com"]
+        transforms = ["Lowercase", "Trim"]
+      }
+
+      device_type {
+        operator = "Equal"
+        values   = ["Mobile"]
+      }
+
+      post_argument {
+        name       = "customerName"
+        operator   = "BeginsWith"
+        values     = ["J", "K"]
+        transforms = ["Uppercase"]
+      }
+
+      request_method {
+        operator = "Equal"
+        values   = ["DELETE"]
+      }
+
+      request_filename {
+        operator   = "Equal"
+        values     = ["media.mp4"]
+        transforms = ["Lowercase", "RemoveNulls", "Trim"]
+      }
+    }
+  }
+}
+
+resource "azurerm_cdn_frontdoor_route" "example" {
+  name                          = "example-cdn-frontdoor-route"
+  cdn_frontdoor_endpoint_id     = azurerm_cdn_frontdoor_endpoint.example.id
+  cdn_frontdoor_origin_group_id = azurerm_cdn_frontdoor_origin_group.example.id
+  cdn_frontdoor_origin_ids      = [azurerm_cdn_frontdoor_origin.example.id]
+  cdn_frontdoor_rule_set_ids    = [azurerm_cdn_frontdoor_batch_rule_set.example.id]
+  patterns_to_match             = ["/*"]
+  supported_protocols           = ["Http", "Https"]
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name which should be used for this Front Door Batch Rule Set. Changing this forces a new resource to be created.
+
+* `cdn_frontdoor_profile_id` - (Required) The resource ID of the Front Door Profile where this Front Door Batch Rule Set should be created. Changing this forces a new resource to be created.
+
+* `rule` - (Required) One or more `rule` blocks as defined below. The configured blocks represent the complete set of rules managed for this Front Door Batch Rule Set. The final rule ordering is determined by each block's `order` value. A maximum of `100` `rule` blocks may be defined.
+
+~> **Note:** The `rule` blocks must be declared in ascending `order`, gaps between different rules are allowed. To insert, remove, or move a rule, update the full `rule` collection in the same ascending order that you want Terraform to store.
+
+~> **Note:** Each `rule` block must use a unique `name` value and a unique `order` value.
+
+~> **Note:** Each `rule` that enables caching (using the `route_configuration_override.caching` block with a `behaviour` other than `Disabled`) consumes two of the `100` available rule slots. The plan fails if the effective number of rule slots exceeds this service-side quota.
+
+---
+
+A `rule` block supports the following:
+
+* `actions` - (Required) An `actions` block as defined below.
+
+* `name` - (Required) The name which should be used for this Front Door Batch Rule.
+
+-> **Note:** `name` must be between `1` and `260` characters in length, begin with a letter, and may contain only letters and numbers.
+
+* `order` - (Required) The order in which this rule will be applied for the Front Door Endpoint. Rules with a lesser `order` value are applied before rules with a greater `order` value. Possible values are `0` or greater.
+
+* `behaviour_on_match` - (Optional) The behaviour on a condition match. Possible values are `Continue` and `Stop`. Defaults to `Continue`.
+
+* `conditions` - (Optional) A `conditions` block as defined below.
+
+---
+
+An `actions` block supports the following:
+
+~> **Note:** The `actions` block must define at least one action, and may include up to `5` separate actions in total.
+
+-> **Note:** Specific actions support Rule Set server variables, for more information reference [Azure Front Door Rule Set Server Variables](https://learn.microsoft.com/azure/frontdoor/rule-set-server-variables)
+
+* `modify_request_header` - (Optional) One or more `modify_request_header` blocks as defined below.
+
+* `modify_response_header` - (Optional) One or more `modify_response_header` blocks as defined below.
+
+* `route_configuration_override` - (Optional) A `route_configuration_override` block as defined below.
+
+~> **Note:** `route_configuration_override` conflicts with `url_redirect`.
+
+* `url_redirect` - (Optional) A `url_redirect` block as defined below.
+
+* `url_rewrite` - (Optional) A `url_rewrite` block as defined below.
+
+~> **Note:** `url_rewrite` conflicts with `url_redirect` and vice-versa.
+
+---
+
+A `modify_request_header` block supports the following:
+
+* `header_name` - (Required) The name of the header to modify.
+
+* `operator` - (Required) The action to take on `header_name`. Possible values are `Append`, `Overwrite`, and `Delete`.
+
+* `header_value` - (Optional) The value to append or overwrite.
+
+~> **Note:** `header_value` is required when `operator` is set to `Append` or `Overwrite`, and must not be set when `operator` is set to `Delete`.
+
+---
+
+A `modify_response_header` block supports the following:
+
+* `header_name` - (Required) The name of the header to modify.
+
+* `operator` - (Required) The action to take on `header_name`. Possible values are `Append`, `Overwrite`, and `Delete`.
+
+* `header_value` - (Optional) The value to append or overwrite.
+
+~> **Note:** `header_value` is required when `operator` is set to `Append` or `Overwrite`, and must not be set when `operator` is set to `Delete`.
+
+---
+
+A `route_configuration_override` block supports the following:
+
+* `caching` - (Required) A `caching` block as defined below.
+
+* `origin_group` - (Optional) An `origin_group` block as defined below.
+
+---
+
+An `origin_group` block supports the following:
+
+* `cdn_frontdoor_origin_group_id` - (Required) The Front Door Origin Group resource ID that the request should be routed to.
+
+~> **Note:** If you remove the `origin_group` block from a rule that currently points at the only enabled origin in an Origin Group, apply the Batch Rule Set update first and then remove or disable the last origin in a separate apply. The service rejects deleting or disabling the last origin while the Origin Group is still associated with a route or a rule.
+
+* `forwarding_protocol` - (Required) The forwarding protocol the request is redirected as. Possible values are `MatchRequest`, `HttpOnly`, and `HttpsOnly`.
+
+---
+
+A `caching` block supports the following:
+
+* `behaviour` - (Required) Controls how Front Door handles cache behaviour for the response. Possible values are `HonorOrigin`, `OverrideAlways`, `OverrideIfOriginMissing`, and `Disabled`.
+
+~> **Note:** If `behaviour` is set to `Disabled`, you cannot set `compression_enabled`, `duration`, `query_string_behaviour`, or `query_string_parameters`.
+
+-> **Note:** Enabling caching in a `route_configuration_override` block affects the service-side quota used for rule operations. Each rule that enables caching consumes two of the `100` available rule slots during an update.
+
+* `compression_enabled` - (Optional) Whether compression is enabled. Defaults to `false`.
+
+* `duration` - (Optional) When `behaviour` is set to `OverrideAlways` or `OverrideIfOriginMissing`, this field specifies the cache duration to use and is required. The maximum allowed value is `365.23:59:59`. If the desired maximum cache duration is less than `1` day, specify it in the `HH:MM:SS` format, for example `23:59:59`.
+
+~> **Note:** `duration` must not be set when `behaviour` is set to `HonorOrigin`.
+
+* `query_string_behaviour` - (Optional) Controls how query strings contribute to the cache key. Possible values are `IgnoreQueryString`, `UseQueryString`, `IgnoreSpecifiedQueryStrings`, and `IncludeSpecifiedQueryStrings`.
+
+~> **Note:** `query_string_behaviour` is required when `behaviour` is not set to `Disabled`.
+
+* `query_string_parameters` - (Optional) A list of query string parameter names. A maximum of `100` parameters may be defined.
+
+~> **Note:** `query_string_parameters` is required when `query_string_behaviour` is set to `IncludeSpecifiedQueryStrings` or `IgnoreSpecifiedQueryStrings`, and must not be set when `query_string_behaviour` is set to `UseQueryString` or `IgnoreQueryString`.
+
+---
+
+A `url_redirect` block supports the following:
+
+* `redirect_type` - (Required) The response type to return to the requestor. Possible values are `Moved`, `Found`, `TemporaryRedirect`, and `PermanentRedirect`.
+
+* `destination_fragment` - (Optional) The fragment to use in the redirect. The value must be a string between `1` and `1024` characters in length and must not start with `#`. Leave this unset to preserve the incoming fragment.
+
+* `destination_host_name` - (Optional) The host name you want the request to be redirected to. The value must be a string between `1` and `2048` characters in length. Leave this unset to preserve the incoming host.
+
+* `destination_path` - (Optional) The path to use in the redirect. The value must be a string and include the leading `/`. Leave this unset to preserve the incoming path.
+
+* `query_string` - (Optional) The query string used in the redirect URL. The value must be in the `<key>=<value>` or `<key>={<action_server_variable>}` format and must not include the leading `?`. Leave this unset to preserve the incoming query string. The maximum allowed length for this field is `2048` characters.
+
+* `redirect_protocol` - (Optional) The protocol the request is redirected as. Possible values are `MatchRequest`, `Http`, and `Https`. Defaults to `MatchRequest`.
+
+---
+
+A `url_rewrite` block supports the following:
+
+* `destination_path` - (Required) The destination path to use in the rewrite.
+
+* `source_pattern` - (Required) The source pattern in the URL path to replace.
+
+* `preserve_unmatched_path_enabled` - (Optional) Whether to append the remaining path after the source pattern to the new destination path. Defaults to `false`.
+
+---
+
+A `conditions` block supports the following:
+
+-> **Note:** You may include up to `10` separate conditions in the `conditions` block.
+
+* `client_port` - (Optional) One or more `client_port` blocks as defined below.
+
+* `device_type` - (Optional) One or more `device_type` blocks as defined below.
+
+* `host_name` - (Optional) One or more `host_name` blocks as defined below.
+
+* `http_version` - (Optional) One or more `http_version` blocks as defined below.
+
+* `post_argument` - (Optional) One or more `post_argument` blocks as defined below.
+
+* `query_string` - (Optional) One or more `query_string` blocks as defined below.
+
+* `remote_address` - (Optional) One or more `remote_address` blocks as defined below.
+
+* `request_body` - (Optional) One or more `request_body` blocks as defined below.
+
+* `request_cookies` - (Optional) One or more `request_cookies` blocks as defined below.
+
+* `request_file_extension` - (Optional) One or more `request_file_extension` blocks as defined below.
+
+* `request_filename` - (Optional) One or more `request_filename` blocks as defined below.
+
+* `request_header` - (Optional) One or more `request_header` blocks as defined below.
+
+* `request_method` - (Optional) One or more `request_method` blocks as defined below.
+
+* `request_path` - (Optional) One or more `request_path` blocks as defined below.
+
+* `request_scheme` - (Optional) One or more `request_scheme` blocks as defined below.
+
+* `request_url` - (Optional) One or more `request_url` blocks as defined below.
+
+* `server_port` - (Optional) One or more `server_port` blocks as defined below.
+
+* `socket_address` - (Optional) One or more `socket_address` blocks as defined below.
+
+* `ssl_protocol` - (Optional) One or more `ssl_protocol` blocks as defined below.
+
+---
+
+A `client_port` block supports the following:
+
+* `operator` - (Required) A condition operator. Possible values are `Any`, `Equal`, `Contains`, `BeginsWith`, `EndsWith`, `LessThan`, `LessThanOrEqual`, `GreaterThan`, `GreaterThanOrEqual`, `RegEx`, `NotAny`, `NotEqual`, `NotContains`, `NotBeginsWith`, `NotEndsWith`, `NotLessThan`, `NotLessThanOrEqual`, `NotGreaterThan`, `NotGreaterThanOrEqual`, and `NotRegEx`.
+
+* `values` - (Optional) One or more values representing the client port to match. A maximum of `25` values may be defined. If multiple values are specified, they are evaluated using `OR` logic.
+
+~> **Note:** `values` must not be set when `operator` is set to `Any` or `NotAny`, and is required for all other operators.
+
+---
+
+A `device_type` block supports the following:
+
+* `operator` - (Required) A condition operator. Possible values are `Equal` and `NotEqual`.
+
+* `values` - (Required) The device type to match. Possible values are `Mobile` and `Desktop`.
+
+~> **Note:** Currently, only a single value may be specified.
+
+---
+
+A `host_name` block supports the following:
+
+* `operator` - (Required) A condition operator. Possible values are `Any`, `Equal`, `Contains`, `BeginsWith`, `EndsWith`, `LessThan`, `LessThanOrEqual`, `GreaterThan`, `GreaterThanOrEqual`, `RegEx`, `NotAny`, `NotEqual`, `NotContains`, `NotBeginsWith`, `NotEndsWith`, `NotLessThan`, `NotLessThanOrEqual`, `NotGreaterThan`, `NotGreaterThanOrEqual`, and `NotRegEx`.
+
+* `transforms` - (Optional) A list of condition transforms. Possible values are `Lowercase`, `RemoveNulls`, `Trim`, `Uppercase`, `UrlDecode`, and `UrlEncode`. A maximum of `4` transforms may be defined.
+
+* `values` - (Optional) A list of one or more values representing the request hostname to match. A maximum of `25` values may be defined. If multiple values are specified, they are evaluated using `OR` logic.
+
+~> **Note:** `values` must not be set when `operator` is set to `Any` or `NotAny`, and is required for all other operators.
+
+---
+
+A `http_version` block supports the following:
+
+* `operator` - (Required) A condition operator. Possible values are `Equal` and `NotEqual`.
+
+* `values` - (Required) A list of one or more HTTP versions to match. Possible values are `2.0`, `1.1`, `1.0`, and `0.9`.
+
+---
+
+A `post_argument` block supports the following:
+
+* `name` - (Required) A string value representing the name of the `POST` argument.
+
+* `operator` - (Required) A condition operator. Possible values are `Any`, `Equal`, `Contains`, `BeginsWith`, `EndsWith`, `LessThan`, `LessThanOrEqual`, `GreaterThan`, `GreaterThanOrEqual`, `RegEx`, `NotAny`, `NotEqual`, `NotContains`, `NotBeginsWith`, `NotEndsWith`, `NotLessThan`, `NotLessThanOrEqual`, `NotGreaterThan`, `NotGreaterThanOrEqual`, and `NotRegEx`.
+
+* `transforms` - (Optional) A list of condition transforms. Possible values are `Lowercase`, `RemoveNulls`, `Trim`, `Uppercase`, `UrlDecode`, and `UrlEncode`. A maximum of `4` transforms may be defined.
+
+* `values` - (Optional) One or more values representing the `POST` argument value to match. A maximum of `25` values may be defined. If multiple values are specified, they are evaluated using `OR` logic.
+
+~> **Note:** `values` must not be set when `operator` is set to `Any` or `NotAny`, and is required for all other operators.
+
+---
+
+A `query_string` block supports the following:
+
+* `operator` - (Required) A condition operator. Possible values are `Any`, `Equal`, `Contains`, `BeginsWith`, `EndsWith`, `LessThan`, `LessThanOrEqual`, `GreaterThan`, `GreaterThanOrEqual`, `RegEx`, `NotAny`, `NotEqual`, `NotContains`, `NotBeginsWith`, `NotEndsWith`, `NotLessThan`, `NotLessThanOrEqual`, `NotGreaterThan`, `NotGreaterThanOrEqual`, and `NotRegEx`.
+
+* `transforms` - (Optional) A list of condition transforms. Possible values are `Lowercase`, `RemoveNulls`, `Trim`, `Uppercase`, `UrlDecode`, and `UrlEncode`. A maximum of `4` transforms may be defined.
+
+* `values` - (Optional) One or more values representing the query string value to match. A maximum of `25` values may be defined. If multiple values are specified, they are evaluated using `OR` logic.
+
+~> **Note:** `values` must not be set when `operator` is set to `Any` or `NotAny`, and is required for all other operators.
+
+---
+
+A `remote_address` block supports the following:
+
+* `operator` - (Required) The type of remote address to match. Possible values are `GeoMatch`, `IPMatch`, `NotGeoMatch`, and `NotIPMatch`.
+
+* `values` - (Required) A list of CIDR ranges or country codes. A maximum of `25` values may be defined. If multiple values are specified, they are evaluated using `OR` logic.
+
+~> **Note:** When `operator` is set to `GeoMatch` or `NotGeoMatch`, each value in `values` must be a two-letter uppercase country code.
+
+~> **Note:** When `operator` is set to `IPMatch` or `NotIPMatch`, each value in `values` must be a valid CIDR range.
+
+---
+
+A `request_body` block supports the following:
+
+-> **Note:** If a request body exceeds 64 KB, only the first 64 KB is considered for this condition.
+
+* `operator` - (Required) A condition operator. Possible values are `Any`, `Equal`, `Contains`, `BeginsWith`, `EndsWith`, `LessThan`, `LessThanOrEqual`, `GreaterThan`, `GreaterThanOrEqual`, `RegEx`, `NotAny`, `NotEqual`, `NotContains`, `NotBeginsWith`, `NotEndsWith`, `NotLessThan`, `NotLessThanOrEqual`, `NotGreaterThan`, `NotGreaterThanOrEqual`, and `NotRegEx`.
+
+* `transforms` - (Optional) A list of condition transforms. Possible values are `Lowercase`, `RemoveNulls`, `Trim`, `Uppercase`, `UrlDecode`, and `UrlEncode`. A maximum of `4` transforms may be defined.
+
+* `values` - (Optional) One or more values representing the request body text to match. A maximum of `25` values may be defined. If multiple values are specified, they are evaluated using `OR` logic.
+
+~> **Note:** `values` must not be set when `operator` is set to `Any` or `NotAny`, and is required for all other operators.
+
+---
+
+A `request_cookies` block supports the following:
+
+* `name` - (Required) The name of the cookie.
+
+* `operator` - (Required) A condition operator. Possible values are `Any`, `Equal`, `Contains`, `BeginsWith`, `EndsWith`, `LessThan`, `LessThanOrEqual`, `GreaterThan`, `GreaterThanOrEqual`, `RegEx`, `NotAny`, `NotEqual`, `NotContains`, `NotBeginsWith`, `NotEndsWith`, `NotLessThan`, `NotLessThanOrEqual`, `NotGreaterThan`, `NotGreaterThanOrEqual`, and `NotRegEx`.
+
+* `transforms` - (Optional) A list of condition transforms. Possible values are `Lowercase`, `RemoveNulls`, `Trim`, `Uppercase`, `UrlDecode`, and `UrlEncode`. A maximum of `4` transforms may be defined.
+
+* `values` - (Optional) One or more values representing the cookie value to match. A maximum of `25` values may be defined. If multiple values are specified, they are evaluated using `OR` logic.
+
+~> **Note:** `values` must not be set when `operator` is set to `Any` or `NotAny`, and is required for all other operators.
+
+---
+
+A `request_file_extension` block supports the following:
+
+-> **Note:** `request_file_extension` identifies requests that include the specified file extension. Do not include a leading period.
+
+* `operator` - (Required) A condition operator. Possible values are `Any`, `Equal`, `Contains`, `BeginsWith`, `EndsWith`, `LessThan`, `LessThanOrEqual`, `GreaterThan`, `GreaterThanOrEqual`, `RegEx`, `NotAny`, `NotEqual`, `NotContains`, `NotBeginsWith`, `NotEndsWith`, `NotLessThan`, `NotLessThanOrEqual`, `NotGreaterThan`, `NotGreaterThanOrEqual`, and `NotRegEx`.
+
+* `transforms` - (Optional) A list of condition transforms. Possible values are `Lowercase`, `RemoveNulls`, `Trim`, `Uppercase`, `UrlDecode`, and `UrlEncode`. A maximum of `4` transforms may be defined.
+
+* `values` - (Optional) One or more values representing the request file extension to match. A maximum of `25` values may be defined. If multiple values are specified, they are evaluated using `OR` logic.
+
+~> **Note:** `values` must not be set when `operator` is set to `Any` or `NotAny`, and is required for all other operators.
+
+---
+
+A `request_filename` block supports the following:
+
+* `operator` - (Required) A condition operator. Possible values are `Any`, `Equal`, `Contains`, `BeginsWith`, `EndsWith`, `LessThan`, `LessThanOrEqual`, `GreaterThan`, `GreaterThanOrEqual`, `RegEx`, `NotAny`, `NotEqual`, `NotContains`, `NotBeginsWith`, `NotEndsWith`, `NotLessThan`, `NotLessThanOrEqual`, `NotGreaterThan`, `NotGreaterThanOrEqual`, and `NotRegEx`.
+
+* `transforms` - (Optional) A list of condition transforms. Possible values are `Lowercase`, `RemoveNulls`, `Trim`, `Uppercase`, `UrlDecode`, and `UrlEncode`. A maximum of `4` transforms may be defined.
+
+* `values` - (Optional) One or more values representing the request file name to match. A maximum of `25` values may be defined. If multiple values are specified, they are evaluated using `OR` logic.
+
+~> **Note:** `values` must not be set when `operator` is set to `Any` or `NotAny`, and is required for all other operators.
+
+---
+
+A `request_header` block supports the following:
+
+* `name` - (Required) The name of the request header.
+
+* `operator` - (Required) A condition operator. Possible values are `Any`, `Equal`, `Contains`, `BeginsWith`, `EndsWith`, `LessThan`, `LessThanOrEqual`, `GreaterThan`, `GreaterThanOrEqual`, `RegEx`, `NotAny`, `NotEqual`, `NotContains`, `NotBeginsWith`, `NotEndsWith`, `NotLessThan`, `NotLessThanOrEqual`, `NotGreaterThan`, `NotGreaterThanOrEqual`, and `NotRegEx`.
+
+* `transforms` - (Optional) A list of condition transforms. Possible values are `Lowercase`, `RemoveNulls`, `Trim`, `Uppercase`, `UrlDecode`, and `UrlEncode`. A maximum of `4` transforms may be defined.
+
+* `values` - (Optional) One or more values representing the request header value to match. A maximum of `25` values may be defined. If multiple values are specified, they are evaluated using `OR` logic.
+
+~> **Note:** `values` must not be set when `operator` is set to `Any` or `NotAny`, and is required for all other operators.
+
+---
+
+A `request_method` block supports the following:
+
+* `operator` - (Required) A condition operator. Possible values are `Equal` and `NotEqual`.
+
+* `values` - (Required) A list of one or more HTTP methods. Possible values are `GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `OPTIONS`, and `TRACE`. A maximum of `7` values may be defined. If multiple values are specified, they are evaluated using `OR` logic.
+
+---
+
+A `request_path` block supports the following:
+
+* `operator` - (Required) A condition operator. Possible values are `Any`, `Equal`, `Contains`, `BeginsWith`, `EndsWith`, `LessThan`, `LessThanOrEqual`, `GreaterThan`, `GreaterThanOrEqual`, `RegEx`, `Wildcard`, `NotAny`, `NotEqual`, `NotContains`, `NotBeginsWith`, `NotEndsWith`, `NotLessThan`, `NotLessThanOrEqual`, `NotGreaterThan`, `NotGreaterThanOrEqual`, `NotRegEx`, and `NotWildcard`.
+
+* `transforms` - (Optional) A list of condition transforms. Possible values are `Lowercase`, `RemoveNulls`, `Trim`, `Uppercase`, `UrlDecode`, and `UrlEncode`. A maximum of `4` transforms may be defined.
+
+* `values` - (Optional) One or more values representing the request path to match. Do not include the leading slash (`/`). A maximum of `25` values may be defined. If multiple values are specified, they are evaluated using `OR` logic.
+
+~> **Note:** `values` must not be set when `operator` is set to `Any` or `NotAny`, and is required for all other operators.
+
+---
+
+A `request_scheme` block supports the following:
+
+* `operator` - (Required) A condition operator. Possible values are `Equal` and `NotEqual`.
+
+* `values` - (Required) The request protocol to match. Possible values are `HTTP` and `HTTPS`.
+
+~> **Note:** Currently, only a single value may be specified
+
+---
+
+A `request_url` block supports the following:
+
+* `operator` - (Required) A condition operator. Possible values are `Any`, `Equal`, `Contains`, `BeginsWith`, `EndsWith`, `LessThan`, `LessThanOrEqual`, `GreaterThan`, `GreaterThanOrEqual`, `RegEx`, `NotAny`, `NotEqual`, `NotContains`, `NotBeginsWith`, `NotEndsWith`, `NotLessThan`, `NotLessThanOrEqual`, `NotGreaterThan`, `NotGreaterThanOrEqual`, and `NotRegEx`.
+
+* `transforms` - (Optional) A list of condition transforms. Possible values are `Lowercase`, `RemoveNulls`, `Trim`, `Uppercase`, `UrlDecode`, and `UrlEncode`. A maximum of `4` transforms may be defined.
+
+* `values` - (Optional) One or more values representing the request URL to match. A maximum of `25` values may be defined. If multiple values are specified, they are evaluated using `OR` logic.
+
+~> **Note:** `values` must not be set when `operator` is set to `Any` or `NotAny`, and is required for all other operators.
+
+---
+
+A `server_port` block supports the following:
+
+* `operator` - (Required) A condition operator. Possible values are `Any`, `Equal`, `Contains`, `BeginsWith`, `EndsWith`, `LessThan`, `LessThanOrEqual`, `GreaterThan`, `GreaterThanOrEqual`, `RegEx`, `NotAny`, `NotEqual`, `NotContains`, `NotBeginsWith`, `NotEndsWith`, `NotLessThan`, `NotLessThanOrEqual`, `NotGreaterThan`, `NotGreaterThanOrEqual`, and `NotRegEx`.
+
+* `values` - (Optional) A list of one or more values representing the server port to match. Possible values are `80` and `443`. If multiple values are specified, they are evaluated using `OR` logic.
+
+---
+
+A `socket_address` block supports the following:
+
+* `operator` - (Required) The type of match. Possible values are `IPMatch` and `NotIPMatch`.
+
+* `values` - (Required) One or more IP address ranges. A maximum of `25` values may be defined. If multiple IP address ranges are specified, they are evaluated using `OR` logic.
+
+---
+
+A `ssl_protocol` block supports the following:
+
+-> **Note:** `ssl_protocol` identifies requests based on the SSL protocol of an established TLS connection.
+
+* `operator` - (Required) A condition operator. Possible values are `Equal` and `NotEqual`.
+
+* `values` - (Required) A list of one or more SSL protocol values. Possible values are `TLSv1`, `TLSv1.1`, and `TLSv1.2`.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the Front Door Batch Rule Set.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/configure#define-operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 4 hours) Used when creating the Front Door Batch Rule Set.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Front Door Batch Rule Set.
+* `update` - (Defaults to 4 hours) Used when updating the Front Door Batch Rule Set.
+* `delete` - (Defaults to 6 hours) Used when deleting the Front Door Batch Rule Set.
+
+## Import
+
+A Front Door Batch Rule Set can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_cdn_frontdoor_batch_rule_set.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1/providers/Microsoft.Cdn/profiles/profile1/ruleSets/ruleSet1
+```
+
+~> **Note:** Only Rule Sets that were provisioned in batch mode can be managed by this resource. Importing a Rule Set that was not provisioned in batch mode returns an error - use `azurerm_cdn_frontdoor_rule_set` instead.
+
+## API Providers
+<!-- This section is generated, changes will be overwritten -->
+This resource uses the following Azure API Providers:
+
+* `Microsoft.Cdn` - 2025-12-01

--- a/website/docs/r/cdn_frontdoor_batch_rule_set.html.markdown
+++ b/website/docs/r/cdn_frontdoor_batch_rule_set.html.markdown
@@ -12,8 +12,6 @@ Manages a Front Door (standard/premium) Batch Rule Set.
 
 ~> **Note:** This resource creates the Front Door Rule Set in batch mode and manages the full ordered batch rule collection for it. Any change to the configured `rule` blocks sends the desired final ordered rule list to the Resource Provider in a single request.
 
-~> **Note:** Use `azurerm_cdn_frontdoor_rule_set` together with `azurerm_cdn_frontdoor_rule` for the normal non-batch Rule Set path.
-
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/cdn_frontdoor_rule.html.markdown
+++ b/website/docs/r/cdn_frontdoor_rule.html.markdown
@@ -12,7 +12,7 @@ Manages a Front Door (standard/premium) Rule.
 
 !> **Note:** The Rules resource **must** include a `depends_on` meta-argument which references the `azurerm_cdn_frontdoor_origin` and the `azurerm_cdn_frontdoor_origin_group`.
 
-~> **Note:** Azure Front Door Rule operations are currently affected by a service-side regression where unattached rules or rule sets can fail with `400 Bad Request` until they are associated with a Front Door Route. As a result, unattached and attached scenarios can currently behave differently while the service-side fix is pending.
+~> **Note:** This resource cannot be used to manage individual rules for a rule set provisioned in batch mode, to manage rules for a batch mode rule set, use `azurerm_cdn_frontdoor_batch_rule_set`.
 
 ## Example Usage
 
@@ -151,6 +151,8 @@ The following arguments are supported:
 * `name` - (Required) The name which should be used for this Front Door Rule. Possible values must be between 1 and 260 characters in length, begin with a letter and may contain only letters and numbers. Changing this forces a new Front Door Rule to be created.
 
 * `cdn_frontdoor_rule_set_id` - (Required) The resource ID of the Front Door Rule Set for this Front Door Rule. Changing this forces a new Front Door Rule to be created.
+
+~> **Note:** The `cdn_frontdoor_rule_set_id` must reference a non-batch mode rule set, individual rules for batch mode rule sets cannot be managed by this resource. 
 
 * `order` - (Required) The order in which the rules will be applied for the Front Door Endpoint. The order value should be sequential and begin at `1`(e.g. `1`, `2`, `3`...). A Front Door Rule with a lesser order value will be applied before a rule with a greater order value.
 

--- a/website/docs/r/cdn_frontdoor_rule.html.markdown
+++ b/website/docs/r/cdn_frontdoor_rule.html.markdown
@@ -152,7 +152,7 @@ The following arguments are supported:
 
 * `cdn_frontdoor_rule_set_id` - (Required) The resource ID of the Front Door Rule Set for this Front Door Rule. Changing this forces a new Front Door Rule to be created.
 
-~> **Note:** The `cdn_frontdoor_rule_set_id` must reference a non-batch mode rule set, individual rules for batch mode rule sets cannot be managed by this resource. 
+~> **Note:** The `cdn_frontdoor_rule_set_id` must reference a non-batch mode rule set, individual rules for batch mode rule sets cannot be managed by this resource.
 
 * `order` - (Required) The order in which the rules will be applied for the Front Door Endpoint. The order value should be sequential and begin at `1`(e.g. `1`, `2`, `3`...). A Front Door Rule with a lesser order value will be applied before a rule with a greater order value.
 

--- a/website/docs/r/cdn_frontdoor_rule_set.html.markdown
+++ b/website/docs/r/cdn_frontdoor_rule_set.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Manages a Front Door (standard/premium) Rule Set.
 
+~> **Note:** This resource creates the Front Door Rule Set in non-batch mode and individual rules are managed using `azurerm_cdn_frontdoor_rule`.
+
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description




## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #30666, #22364


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
