### PR TITLE
`azurerm_synapse_spark_pool` - `spark_config` use remote object as default value for updating

### DIFF
--- a/internal/services/synapse/synapse_spark_pool_resource.go
+++ b/internal/services/synapse/synapse_spark_pool_resource.go
@@ -402,7 +402,20 @@ func resourceSynapseSparkPoolUpdate(d *pluginsdk.ResourceData, meta interface{})
 		return fmt.Errorf("reading Synapse workspace %q (Workspace %q / Resource Group %q): %+v", id.WorkspaceName, id.WorkspaceName, id.ResourceGroup, err)
 	}
 
+	current, err := client.Get(ctx, id.ResourceGroup, id.WorkspaceName, id.BigDataPoolName)
+	if err != nil {
+		return fmt.Errorf("retrieving current %s: %+v", *id, err)
+	}
+
 	autoScale := expandArmSparkPoolAutoScaleProperties(d.Get("auto_scale").([]interface{}))
+	sparkConfigProperties := expandSparkPoolSparkConfig(d.Get("spark_config").([]interface{}))
+	if current.BigDataPoolResourceProperties != nil {
+		sparkConfigProperties = current.BigDataPoolResourceProperties.SparkConfigProperties
+	}
+	if d.HasChange("spark_config") {
+		sparkConfigProperties = expandSparkPoolSparkConfig(d.Get("spark_config").([]interface{}))
+	}
+
 	bigDataPoolInfo := synapse.BigDataPoolResourceInfo{
 		Location: workspace.Location,
 		BigDataPoolResourceProperties: &synapse.BigDataPoolResourceProperties{
@@ -420,7 +433,7 @@ func resourceSynapseSparkPoolUpdate(d *pluginsdk.ResourceData, meta interface{})
 			NodeSize:                    synapse.NodeSize(d.Get("node_size").(string)),
 			NodeSizeFamily:              synapse.NodeSizeFamily(d.Get("node_size_family").(string)),
 			SessionLevelPackagesEnabled: pointer.To(d.Get("session_level_packages_enabled").(bool)),
-			SparkConfigProperties:       expandSparkPoolSparkConfig(d.Get("spark_config").([]interface{})),
+			SparkConfigProperties:       sparkConfigProperties,
 			SparkEventsFolder:           pointer.To(d.Get("spark_events_folder").(string)),
 			SparkVersion:                pointer.To(d.Get("spark_version").(string)),
 		},

--- a/internal/services/synapse/synapse_spark_pool_resource.go
+++ b/internal/services/synapse/synapse_spark_pool_resource.go
@@ -410,7 +410,7 @@ func resourceSynapseSparkPoolUpdate(d *pluginsdk.ResourceData, meta interface{})
 	autoScale := expandArmSparkPoolAutoScaleProperties(d.Get("auto_scale").([]interface{}))
 	sparkConfigProperties := expandSparkPoolSparkConfig(d.Get("spark_config").([]interface{}))
 	if current.BigDataPoolResourceProperties != nil {
-		sparkConfigProperties = current.BigDataPoolResourceProperties.SparkConfigProperties
+		sparkConfigProperties = current.SparkConfigProperties
 	}
 	if d.HasChange("spark_config") {
 		sparkConfigProperties = expandSparkPoolSparkConfig(d.Get("spark_config").([]interface{}))

--- a/internal/services/synapse/synapse_spark_pool_resource.go
+++ b/internal/services/synapse/synapse_spark_pool_resource.go
@@ -457,7 +457,7 @@ func resourceSynapseSparkPoolUpdate(d *pluginsdk.ResourceData, meta interface{})
 		current.Tags = tags.Expand(d.Get("tags").(map[string]interface{}))
 	}
 	if d.HasChanges("node_count", "auto_scale") {
-		if current.AutoScale != nil && current.AutoScale.Enabled != nil && !*current.AutoScale.Enabled {
+		if _, ok := d.GetOk("auto_scale"); !ok {
 			current.NodeCount = pointer.To(int32(d.Get("node_count").(int)))
 		} else {
 			current.NodeCount = nil

--- a/internal/services/synapse/synapse_spark_pool_resource.go
+++ b/internal/services/synapse/synapse_spark_pool_resource.go
@@ -414,11 +414,20 @@ func resourceSynapseSparkPoolUpdate(d *pluginsdk.ResourceData, meta interface{})
 		current.IsComputeIsolationEnabled = pointer.To(d.Get("compute_isolation_enabled").(bool))
 	}
 	if d.HasChanges("dynamic_executor_allocation_enabled", "min_executors", "max_executors") {
-		current.DynamicExecutorAllocation = &synapse.DynamicExecutorAllocation{
-			Enabled:      pointer.To(d.Get("dynamic_executor_allocation_enabled").(bool)),
-			MinExecutors: pointer.To(int32(d.Get("min_executors").(int))),
-			MaxExecutors: pointer.To(int32(d.Get("max_executors").(int))),
+		dynamicExecutorAllocation := current.DynamicExecutorAllocation
+		if dynamicExecutorAllocation == nil {
+			dynamicExecutorAllocation = &synapse.DynamicExecutorAllocation{}
 		}
+		if d.HasChange("dynamic_executor_allocation_enabled") {
+			dynamicExecutorAllocation.Enabled = pointer.To(d.Get("dynamic_executor_allocation_enabled").(bool))
+		}
+		if d.HasChange("min_executors") {
+			dynamicExecutorAllocation.MinExecutors = pointer.To(int32(d.Get("min_executors").(int)))
+		}
+		if d.HasChange("max_executors") {
+			dynamicExecutorAllocation.MaxExecutors = pointer.To(int32(d.Get("max_executors").(int)))
+		}
+		current.DynamicExecutorAllocation = dynamicExecutorAllocation
 	}
 	if d.HasChange("spark_config") {
 		current.SparkConfigProperties = expandSparkPoolSparkConfig(d.Get("spark_config").([]interface{}))

--- a/internal/services/synapse/synapse_spark_pool_resource.go
+++ b/internal/services/synapse/synapse_spark_pool_resource.go
@@ -388,7 +388,6 @@ func resourceSynapseSparkPoolRead(d *pluginsdk.ResourceData, meta interface{}) e
 
 func resourceSynapseSparkPoolUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Synapse.SparkPoolClient
-	workspaceClient := meta.(*clients.Client).Synapse.WorkspaceClient
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -397,54 +396,67 @@ func resourceSynapseSparkPoolUpdate(d *pluginsdk.ResourceData, meta interface{})
 		return err
 	}
 
-	workspace, err := workspaceClient.Get(ctx, id.ResourceGroup, id.WorkspaceName)
-	if err != nil {
-		return fmt.Errorf("reading Synapse workspace %q (Workspace %q / Resource Group %q): %+v", id.WorkspaceName, id.WorkspaceName, id.ResourceGroup, err)
-	}
-
 	current, err := client.Get(ctx, id.ResourceGroup, id.WorkspaceName, id.BigDataPoolName)
 	if err != nil {
 		return fmt.Errorf("retrieving current %s: %+v", *id, err)
 	}
 
-	autoScale := expandArmSparkPoolAutoScaleProperties(d.Get("auto_scale").([]interface{}))
-	sparkConfigProperties := expandSparkPoolSparkConfig(d.Get("spark_config").([]interface{}))
-	if current.BigDataPoolResourceProperties != nil {
-		sparkConfigProperties = current.SparkConfigProperties
+	if d.HasChange("auto_pause") {
+		current.AutoPause = expandArmSparkPoolAutoPauseProperties(d.Get("auto_pause").([]interface{}))
+	}
+	if d.HasChange("auto_scale") {
+		current.AutoScale = expandArmSparkPoolAutoScaleProperties(d.Get("auto_scale").([]interface{}))
+	}
+	if d.HasChange("cache_size") {
+		current.CacheSize = pointer.To(int32(d.Get("cache_size").(int)))
+	}
+	if d.HasChange("compute_isolation_enabled") {
+		current.IsComputeIsolationEnabled = pointer.To(d.Get("compute_isolation_enabled").(bool))
+	}
+	if d.HasChanges("dynamic_executor_allocation_enabled", "min_executors", "max_executors") {
+		current.DynamicExecutorAllocation = &synapse.DynamicExecutorAllocation{
+			Enabled:      pointer.To(d.Get("dynamic_executor_allocation_enabled").(bool)),
+			MinExecutors: pointer.To(int32(d.Get("min_executors").(int))),
+			MaxExecutors: pointer.To(int32(d.Get("max_executors").(int))),
+		}
 	}
 	if d.HasChange("spark_config") {
-		sparkConfigProperties = expandSparkPoolSparkConfig(d.Get("spark_config").([]interface{}))
+		current.SparkConfigProperties = expandSparkPoolSparkConfig(d.Get("spark_config").([]interface{}))
 	}
-
-	bigDataPoolInfo := synapse.BigDataPoolResourceInfo{
-		Location: workspace.Location,
-		BigDataPoolResourceProperties: &synapse.BigDataPoolResourceProperties{
-			AutoPause:                 expandArmSparkPoolAutoPauseProperties(d.Get("auto_pause").([]interface{})),
-			AutoScale:                 autoScale,
-			CacheSize:                 pointer.To(int32(d.Get("cache_size").(int))),
-			IsComputeIsolationEnabled: pointer.To(d.Get("compute_isolation_enabled").(bool)),
-			DynamicExecutorAllocation: &synapse.DynamicExecutorAllocation{
-				Enabled:      pointer.To(d.Get("dynamic_executor_allocation_enabled").(bool)),
-				MinExecutors: pointer.To(int32(d.Get("min_executors").(int))),
-				MaxExecutors: pointer.To(int32(d.Get("max_executors").(int))),
-			},
-			DefaultSparkLogFolder:       pointer.To(d.Get("spark_log_folder").(string)),
-			LibraryRequirements:         expandArmSparkPoolLibraryRequirements(d.Get("library_requirement").([]interface{})),
-			NodeSize:                    synapse.NodeSize(d.Get("node_size").(string)),
-			NodeSizeFamily:              synapse.NodeSizeFamily(d.Get("node_size_family").(string)),
-			SessionLevelPackagesEnabled: pointer.To(d.Get("session_level_packages_enabled").(bool)),
-			SparkConfigProperties:       sparkConfigProperties,
-			SparkEventsFolder:           pointer.To(d.Get("spark_events_folder").(string)),
-			SparkVersion:                pointer.To(d.Get("spark_version").(string)),
-		},
-		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
+	if d.HasChange("spark_log_folder") {
+		current.DefaultSparkLogFolder = pointer.To(d.Get("spark_log_folder").(string))
 	}
-	if !*autoScale.Enabled {
-		bigDataPoolInfo.NodeCount = pointer.To(int32(d.Get("node_count").(int)))
+	if d.HasChange("library_requirement") {
+		current.LibraryRequirements = expandArmSparkPoolLibraryRequirements(d.Get("library_requirement").([]interface{}))
+	}
+	if d.HasChange("node_size") {
+		current.NodeSize = synapse.NodeSize(d.Get("node_size").(string))
+	}
+	if d.HasChange("node_size_family") {
+		current.NodeSizeFamily = synapse.NodeSizeFamily(d.Get("node_size_family").(string))
+	}
+	if d.HasChange("session_level_packages_enabled") {
+		current.SessionLevelPackagesEnabled = pointer.To(d.Get("session_level_packages_enabled").(bool))
+	}
+	if d.HasChange("spark_events_folder") {
+		current.SparkEventsFolder = pointer.To(d.Get("spark_events_folder").(string))
+	}
+	if d.HasChange("spark_version") {
+		current.SparkVersion = pointer.To(d.Get("spark_version").(string))
+	}
+	if d.HasChange("tags") {
+		current.Tags = tags.Expand(d.Get("tags").(map[string]interface{}))
+	}
+	if d.HasChanges("node_count", "auto_scale") {
+		if current.AutoScale != nil && current.AutoScale.Enabled != nil && !*current.AutoScale.Enabled {
+			current.NodeCount = pointer.To(int32(d.Get("node_count").(int)))
+		} else {
+			current.NodeCount = nil
+		}
 	}
 
 	force := pointer.To(false)
-	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.WorkspaceName, id.BigDataPoolName, bigDataPoolInfo, force)
+	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.WorkspaceName, id.BigDataPoolName, current, force)
 	if err != nil {
 		return fmt.Errorf("updating %s: %+v", *id, err)
 	}


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

`azurerm_synapse_spark_pool` resource use local config as default value when updating, which cause the issue when user using `ignore_changes` life cycle config, it still trying to update the `spark_config` with local config.  Detail see the related GH issue. 

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

<img width="1001" height="576" alt="image" src="https://github.com/user-attachments/assets/930d65b6-aebe-40aa-ab5b-a86e8cfcdb5a" />

with ARM_FIVEPOINTZERO_BETA = true
<img width="1014" height="592" alt="image" src="https://github.com/user-attachments/assets/f7dfeccb-6810-4bf6-ab41-df8e33ce3baa" />

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #32725


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
