### PR TITLE
[FIX:] `azurerm_cdn_frontdoor_custom_domain` - allow wildcard `host_name` with `ManagedCertificate`

### DIFF
--- a/internal/services/cdn/cdn_frontdoor_custom_domain_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_custom_domain_resource.go
@@ -720,10 +720,6 @@ func frontDoorCustomDomainHostNameCustomizeDiff(_ context.Context, diff *plugins
 		return errors.New("`host_name` cannot be longer than 64 characters when `tls.certificate_type` is `ManagedCertificate`")
 	}
 
-	if strings.HasPrefix(hostName, "*.") {
-		return errors.New("`host_name` cannot be a wildcard domain when `tls.certificate_type` is `ManagedCertificate`")
-	}
-
 	return nil
 }
 

--- a/internal/services/cdn/cdn_frontdoor_custom_domain_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_custom_domain_resource_test.go
@@ -157,7 +157,7 @@ func TestAccCdnFrontDoorCustomDomain_cipherSuites_validation(t *testing.T) {
 	data.ResourceTest(t, r, testSteps)
 }
 
-func TestAccCdnFrontDoorCustomDomain_managedCertificate_validation(t *testing.T) {
+func TestAccCdnFrontDoorCustomDomain_managedCertificate_hostNameConstraints(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_custom_domain", "test")
 	r := CdnFrontDoorCustomDomainResource{}
 	r.preCheck(t)
@@ -168,9 +168,12 @@ func TestAccCdnFrontDoorCustomDomain_managedCertificate_validation(t *testing.T)
 			ExpectError: regexp.MustCompile("`host_name` cannot be longer than 64 characters when `tls\\.certificate_type` is `ManagedCertificate`"),
 		},
 		{
-			Config:      r.managedCertificateWildcardDomain(data),
-			ExpectError: regexp.MustCompile("`host_name` cannot be a wildcard domain when `tls\\.certificate_type` is `ManagedCertificate`"),
+			Config: r.managedCertificateWildcardDomain(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
 		},
+		data.ImportStep(),
 	})
 }
 
@@ -880,5 +883,5 @@ resource "azurerm_cdn_frontdoor_custom_domain" "test" {
     minimum_version  = "TLS12"
   }
 }
-`, r.validationTemplate(data), data.RandomInteger)
+`, r.template(data), data.RandomInteger)
 }

--- a/internal/services/cdn/cdn_frontdoor_custom_domain_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_custom_domain_resource_test.go
@@ -447,6 +447,66 @@ resource "azurerm_dns_txt_record" "validation" {
 `, data.RandomInteger, data.Locations.Primary, dnsZoneName, dnsZoneRG, childZoneSuffix)
 }
 
+func (r CdnFrontDoorCustomDomainResource) templateWildcard(data acceptance.TestData) string {
+	dnsZoneName := os.Getenv("ARM_TEST_DNS_ZONE")
+	dnsZoneRG := os.Getenv("ARM_TEST_DATA_RESOURCE_GROUP")
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-cdn-afdx-%[1]d"
+  location = "%[2]s"
+}
+
+data "azurerm_dns_zone" "test" {
+  name                = "%[3]s"
+  resource_group_name = "%[4]s"
+}
+
+locals {
+  # Create a delegated child zone inside the test RG.
+  # NOTE: ARM_TEST_DNS_ZONE / ARM_TEST_DATA_RESOURCE_GROUP must refer to a real, delegated parent zone.
+  child_zone_label = "%[5]s"
+  child_zone_name  = join(".", [local.child_zone_label, data.azurerm_dns_zone.test.name])
+}
+
+resource "azurerm_dns_zone" "child" {
+  name                = local.child_zone_name
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_dns_ns_record" "delegation" {
+  name                = local.child_zone_label
+  resource_group_name = data.azurerm_dns_zone.test.resource_group_name
+  zone_name           = data.azurerm_dns_zone.test.name
+  ttl                 = 300
+
+  records = azurerm_dns_zone.child.name_servers
+}
+
+resource "azurerm_cdn_frontdoor_profile" "test" {
+  name                = "acctestcdnfdprofile-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  sku_name            = "Standard_AzureFrontDoor"
+}
+
+resource "azurerm_dns_txt_record" "validation" {
+  depends_on = [azurerm_dns_ns_record.delegation]
+
+  name                = "_dnsauth"
+  zone_name           = azurerm_dns_zone.child.name
+  resource_group_name = azurerm_resource_group.test.name
+  ttl                 = 300
+
+  record {
+    value = azurerm_cdn_frontdoor_custom_domain.test.validation_token
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, dnsZoneName, dnsZoneRG, data.RandomString)
+}
+
 func (r CdnFrontDoorCustomDomainResource) validationTemplate(data acceptance.TestData) string {
 	dnsZoneName := os.Getenv("ARM_TEST_DNS_ZONE")
 	dnsZoneRG := os.Getenv("ARM_TEST_DATA_RESOURCE_GROUP")
@@ -883,5 +943,5 @@ resource "azurerm_cdn_frontdoor_custom_domain" "test" {
     minimum_version  = "TLS12"
   }
 }
-`, r.template(data), data.RandomInteger)
+`, r.templateWildcard(data), data.RandomInteger)
 }

--- a/website/docs/r/cdn_frontdoor_custom_domain.html.markdown
+++ b/website/docs/r/cdn_frontdoor_custom_domain.html.markdown
@@ -176,7 +176,7 @@ A `tls` block supports the following:
 
 -> **Note:** It may take up to 15 minutes for the Front Door Service to validate the state and domain ownership of the Custom Domain.
 
-~> **Note:** When `certificate_type` is `ManagedCertificate`, `host_name` must not exceed 64 characters. Azure Front Door supports managed certificates for apex domains, but apex-domain certificate rotation can require revalidation of domain ownership. Wildcard domains require `CustomerCertificate`. Use `CustomerCertificate` for wildcard domains or host names longer than 64 characters.
+~> **Note:** When `certificate_type` is `ManagedCertificate`, `host_name` must not exceed 64 characters. Azure Front Door supports managed certificates for apex and wildcard domains, but apex-domain certificate rotation can require revalidation of domain ownership and wildcard-domain managed certificates are not rotated automatically.
 
 * `cipher_suite` - (Optional) A `cipher_suite` block as defined below.
 


### PR DESCRIPTION
## What does this PR do?

This PR removes the provider-side validation that rejected wildcard `host_name` values when `tls.certificate_type` is `ManagedCertificate`.

Azure Front Door now supports managed certificates for wildcard custom domains, so the existing validation was blocking a valid configuration at plan time.

## Changes in this PR

- remove the wildcard `ManagedCertificate` rejection from custom domain validation
- keep the existing 64-character `host_name` limit for `ManagedCertificate`
- update acceptance coverage to keep the negative long-hostname case and add a positive wildcard managed-certificate case
- update the resource documentation to reflect that wildcard managed certificates are supported

## Why is this needed?

Before this change, a configuration such as a wildcard custom domain with:

```hcl
tls {
  certificate_type = "ManagedCertificate"
}
```

## Related Issue(s)
Fixes #32730