### PR TITLE
Poll NSP association operations to completion

### DIFF
--- a/internal/services/network/network_security_perimeter_association_resource.go
+++ b/internal/services/network/network_security_perimeter_association_resource.go
@@ -122,7 +122,9 @@ func (r NetworkSecurityPerimeterAssociationResource) Create() sdk.ResourceFunc {
 				},
 			}
 
-			if _, err := client.CreateOrUpdate(ctx, id, param); err != nil {
+			// NSP association validation continues after Azure accepts the initial PUT,
+			// so wait for the terminal provisioning state before recording the resource.
+			if err := client.CreateOrUpdateThenPoll(ctx, id, param); err != nil {
 				return fmt.Errorf("creating %s: %+v", id, err)
 			}
 
@@ -165,7 +167,9 @@ func (r NetworkSecurityPerimeterAssociationResource) Update() sdk.ResourceFunc {
 				existing.Model.Properties.AccessMode = pointer.To(networksecurityperimeterassociations.AssociationAccessMode(config.AccessMode))
 			}
 
-			if _, err := client.CreateOrUpdate(ctx, *id, *existing.Model); err != nil {
+			// Updates use the same asynchronous validation path as creates and must not
+			// return success while Azure can still move the association to Failed.
+			if err := client.CreateOrUpdateThenPoll(ctx, *id, *existing.Model); err != nil {
 				return fmt.Errorf("updating %s: %+v", id, err)
 			}
 

--- a/internal/services/network/network_security_perimeter_association_resource.go
+++ b/internal/services/network/network_security_perimeter_association_resource.go
@@ -122,9 +122,7 @@ func (r NetworkSecurityPerimeterAssociationResource) Create() sdk.ResourceFunc {
 				},
 			}
 
-			// NSP association validation continues after Azure accepts the initial PUT,
-			// so wait for the terminal provisioning state before recording the resource.
-			if err := client.CreateOrUpdateThenPoll(ctx, id, param); err != nil {
+			if err := client.CreateOrUpdateCallbackThenPoll(ctx, id, param, metadata.SetIDCallback(&id)); err != nil {
 				return fmt.Errorf("creating %s: %+v", id, err)
 			}
 
@@ -167,8 +165,6 @@ func (r NetworkSecurityPerimeterAssociationResource) Update() sdk.ResourceFunc {
 				existing.Model.Properties.AccessMode = pointer.To(networksecurityperimeterassociations.AssociationAccessMode(config.AccessMode))
 			}
 
-			// Updates use the same asynchronous validation path as creates and must not
-			// return success while Azure can still move the association to Failed.
 			if err := client.CreateOrUpdateThenPoll(ctx, *id, *existing.Model); err != nil {
 				return fmt.Errorf("updating %s: %+v", id, err)
 			}

--- a/internal/services/network/network_security_perimeter_association_resource_test.go
+++ b/internal/services/network/network_security_perimeter_association_resource_test.go
@@ -3,6 +3,7 @@ package network_test
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -64,6 +65,18 @@ func TestAccNetworkSecurityPerimeterAssociation_update(t *testing.T) {
 			),
 		},
 		data.ImportStep(),
+	})
+}
+
+func TestAccNetworkSecurityPerimeterAssociation_surfacesAsynchronousFailure(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_network_security_perimeter_association", "test")
+	r := NetworkSecurityPerimeterAssociationTestResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config:      r.withObjectReplication(data),
+			ExpectError: regexp.MustCompile(`(?i)object replication policy`),
+		},
 	})
 }
 
@@ -169,4 +182,87 @@ resource "azurerm_network_security_perimeter_association" "test" {
   access_mode = "Enforced"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func (NetworkSecurityPerimeterAssociationTestResource) withObjectReplication(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_network_security_perimeter" "test" {
+  name                = "acctestNsp-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_network_security_perimeter_profile" "test" {
+  name                          = "acctestProfile-%[1]d"
+  network_security_perimeter_id = azurerm_network_security_perimeter.test.id
+}
+
+resource "azurerm_storage_account" "source" {
+  name                     = "acctestsrc%[3]s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  blob_properties {
+    versioning_enabled  = true
+    change_feed_enabled = true
+  }
+}
+
+resource "azurerm_storage_container" "source" {
+  name                  = "source"
+  storage_account_id    = azurerm_storage_account.source.id
+  container_access_type = "private"
+}
+
+resource "azurerm_storage_account" "destination" {
+  name                     = "acctestdst%[3]s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  blob_properties {
+    versioning_enabled  = true
+    change_feed_enabled = true
+  }
+}
+
+resource "azurerm_storage_container" "destination" {
+  name                  = "destination"
+  storage_account_id    = azurerm_storage_account.destination.id
+  container_access_type = "private"
+}
+
+resource "azurerm_storage_object_replication" "test" {
+  source_storage_account_id      = azurerm_storage_account.source.id
+  destination_storage_account_id = azurerm_storage_account.destination.id
+
+  rules {
+    source_container_name      = azurerm_storage_container.source.name
+    destination_container_name = azurerm_storage_container.destination.name
+  }
+}
+
+resource "azurerm_network_security_perimeter_association" "test" {
+  name                                  = "acctestassoc-%[1]d"
+  network_security_perimeter_profile_id = azurerm_network_security_perimeter_profile.test.id
+  resource_id                           = azurerm_storage_account.source.id
+  access_mode                           = "Learning"
+
+  # The association PUT is accepted before Azure asynchronously rejects storage
+  # accounts that use object replication, so this dependency preserves that order.
+  depends_on = [azurerm_storage_object_replication.test]
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

Azure accepts Network Security Perimeter association create and update requests before completing their asynchronous validation. The `azurerm_network_security_perimeter_association` resource called `CreateOrUpdate` and recorded success immediately after the initial response, so a later terminal `Failed` state was not surfaced by `terraform apply`. A subsequent refresh could then find that the failed association no longer existed and plan to create it again.

This change uses the generated SDK's `CreateOrUpdateThenPoll` method for both create and update operations. Terraform now waits for Azure's terminal provisioning state and returns the underlying Azure error during apply.

The new acceptance test configures an object replication policy on a storage account before attempting an NSP association. Azure accepts that association request asynchronously and then rejects it, which verifies that the resource waits and surfaces the terminal failure.

## PR Checklist

- [x] I have followed the guidelines in the [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues; I did not find a matching issue.
- [x] I have updated/added documentation as required. No user-facing documentation change is needed because this does not change the resource schema or configuration.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.

## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them.
- [x] I have written a regression test for the resource change; no user-facing documentation change is required.
- [x] I have successfully run the relevant package tests locally.
- [x] State migration testing is not applicable because this change does not alter schema or state.

## Testing

- [x] My submission includes acceptance-test coverage for the asynchronous failure path.

```text
$ go test -mod=vendor ./internal/services/network -count=1
ok github.com/hashicorp/terraform-provider-azurerm/internal/services/network 2.112s
```

The new acceptance test was compiled by the package test above. It was not executed against a live Azure subscription locally because that requires `TF_ACC=1` and creates billable Azure resources.

## Change Log

* `azurerm_network_security_perimeter_association` - wait for create and update operations to reach a terminal provisioning state [GH-32742]

This is a:

- [x] Bug Fix
- [ ] New Feature
- [ ] Enhancement
- [ ] Breaking Change

## Related Issue(s)

No related issue found.

## AI Assistance Disclosure

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

Codex assisted with root-cause analysis, implementation, regression-test authoring, and preparation of this pull request description. The contributor reviewed the resulting code and test changes.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

No. This changes only how the provider waits for the terminal result of an existing Azure Resource Manager operation.

> [!NOTE]
> If this PR changes meaningfully during the course of review please update the title and description as required.
