### PR TITLE
[Contribution Guide Update] Adding List guidance for sub-resources

### DIFF
--- a/contributing/topics/guide-list-resource.md
+++ b/contributing/topics/guide-list-resource.md
@@ -476,6 +476,19 @@ Before adding a List Resource, the resource must have Resource Identity implemen
     * `subscription_id` - (Optional) The Subscription ID to query. Defaults to the value specified in the Provider Configuration.
     ````
 
+## Handling List for Sub-resources
+
+Some resources can be listed only beneath a parent resource, rather than at the subscription or resource group scope. Treat this as a scoping concern, not a typed versus untyped implementation detail.
+
+For these sub-resources:
+
+* Do not expose `subscription_id` or `resource_group_name`.
+* Accept the immediate parent resource ID as a required argument.
+* Parse that parent ID and call the API that lists directly beneath that parent.
+* Apply the same rule to deeper hierarchies by taking the ID of the immediate parent resource at each level.
+
+Example: see [mysql_flexible_database_resource_list.go](../../internal/services/mysql/mysql_flexible_database_resource_list.go) and [mysql_flexible_database.html.markdown](../../website/docs/list-resources/mysql_flexible_database.html.markdown).
+
 ## Known Issues and Considerations
 
 ### Cancelled Context

--- a/contributing/topics/guide-list-resource.md
+++ b/contributing/topics/guide-list-resource.md
@@ -478,7 +478,7 @@ Before adding a List Resource, the resource must have Resource Identity implemen
 
 ## Handling List for Sub-resources
 
-Some resources can be listed only beneath a parent resource, rather than at the subscription or resource group scope. Treat this as a scoping concern, not a typed versus untyped implementation detail.
+Some resources can be listed only beneath a parent resource, rather than at the subscription or resource group scope.
 
 For these sub-resources:
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Update the List Resource contributor guide to document how sub-resources should be handled.

This change adds a dedicated `Handling List for Sub-resources` section to `contributing/topics/guide-list-resource.md` and clarifies that:

- sub-resources should be listed at the immediate parent scope
- `subscription_id` and `resource_group_name` should not be exposed when the API only supports parent-scoped listing
- the immediate parent resource ID should be used as the required input
- the same pattern applies to deeper hierarchies

The new guidance is kept separate from the typed vs untyped implementation sections and includes a short implementation/doc reference example.

## Testing

This is a documentation-only change.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change
