### PR TITLE
`azurerm_container_registry` - Deprecated `trust_policy_enabled`

### DIFF
--- a/internal/services/containers/container_registry_resource.go
+++ b/internal/services/containers/container_registry_resource.go
@@ -328,7 +328,7 @@ func resourceContainerRegistry() *pluginsdk.Resource {
 
 					// Can't enable `trustPolicy` for new creation.
 					if d.GetRawState().IsNull() {
-						return errors.New("`trust_policy_enabled` can't be enabled as it is deprecated by the service")
+						return errors.New("`trust_policy_enabled` cannot be enabled as it is deprecated by the service")
 					}
 				}
 			}

--- a/internal/services/containers/container_registry_resource.go
+++ b/internal/services/containers/container_registry_resource.go
@@ -34,6 +34,233 @@ import (
 )
 
 func resourceContainerRegistry() *pluginsdk.Resource {
+	schema := map[string]*pluginsdk.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: containerValidate.ContainerRegistryName,
+		},
+
+		"resource_group_name": commonschema.ResourceGroupName(),
+
+		"location": commonschema.Location(),
+
+		"sku": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				string(registries.SkuNameBasic),
+				string(registries.SkuNameStandard),
+				string(registries.SkuNamePremium),
+			}, false),
+		},
+
+		"admin_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Default:  false,
+		},
+
+		"georeplications": {
+			// Don't make this a TypeSet since TypeSet has bugs when there is a nested property using `StateFunc`.
+			// See: https://github.com/hashicorp/terraform-plugin-sdk/issues/160
+			Type:       pluginsdk.TypeList,
+			Optional:   true,
+			ConfigMode: pluginsdk.SchemaConfigModeAuto,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"location": commonschema.LocationWithoutForceNew(),
+
+					"zone_redundancy_enabled": {
+						Type:     pluginsdk.TypeBool,
+						Optional: true,
+						Default:  false,
+					},
+
+					"regional_endpoint_enabled": {
+						Type:     pluginsdk.TypeBool,
+						Optional: true,
+					},
+
+					"tags": commonschema.Tags(),
+				},
+			},
+		},
+
+		"public_network_access_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Default:  true,
+		},
+
+		"login_server": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"admin_username": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"admin_password": {
+			Type:      pluginsdk.TypeString,
+			Computed:  true,
+			Sensitive: true,
+		},
+
+		"identity": commonschema.SystemAssignedUserAssignedIdentityOptional(),
+
+		"encryption": {
+			Type:       pluginsdk.TypeList,
+			Optional:   true,
+			ConfigMode: pluginsdk.SchemaConfigModeAttr,
+			MaxItems:   1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"identity_client_id": {
+						Type:         pluginsdk.TypeString,
+						Required:     true,
+						ValidateFunc: validation.IsUUID,
+					},
+					"key_vault_key_id": {
+						Type:         pluginsdk.TypeString,
+						Required:     true,
+						ValidateFunc: keyvault.ValidateNestedItemID(keyvault.VersionTypeAny, keyvault.NestedItemTypeKey),
+					},
+				},
+			},
+		},
+
+		"network_rule_set": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			Computed: true,
+			// ConfigModeAttr ensures we can set this to an empty array for Premium -> Basic
+			ConfigMode: pluginsdk.SchemaConfigModeAttr,
+			MaxItems:   1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"default_action": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						Default:  registries.DefaultActionAllow,
+						ValidateFunc: validation.StringInSlice([]string{
+							string(registries.DefaultActionAllow),
+							string(registries.DefaultActionDeny),
+						}, false),
+					},
+
+					"ip_rule": {
+						Type:       pluginsdk.TypeSet,
+						Optional:   true,
+						Computed:   true,
+						ConfigMode: pluginsdk.SchemaConfigModeAttr,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"action": {
+									Type:     pluginsdk.TypeString,
+									Required: true,
+									ValidateFunc: validation.StringInSlice([]string{
+										string(registries.ActionAllow),
+									}, false),
+								},
+								"ip_range": {
+									Type:         pluginsdk.TypeString,
+									Required:     true,
+									ValidateFunc: validate.CIDR,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+
+		"quarantine_policy_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+		},
+
+		"retention_policy_in_days": {
+			Type:         pluginsdk.TypeInt,
+			Optional:     true,
+			ValidateFunc: validation.IntBetween(0, 365),
+		},
+
+		"export_policy_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Default:  true,
+		},
+
+		"azuread_authentication_as_arm_policy_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Default:  true,
+		},
+
+		"zone_redundancy_enabled": {
+			Type:     pluginsdk.TypeBool,
+			ForceNew: true,
+			Optional: true,
+			Default:  false,
+		},
+
+		"anonymous_pull_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+		},
+
+		"data_endpoint_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+		},
+
+		"data_endpoint_host_names": {
+			Type:     pluginsdk.TypeSet,
+			Computed: true,
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+			},
+		},
+
+		"network_rule_bypass_option": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				string(registries.NetworkRuleBypassOptionsAzureServices),
+				string(registries.NetworkRuleBypassOptionsNone),
+			}, false),
+			Default: string(registries.NetworkRuleBypassOptionsAzureServices),
+		},
+
+		"network_rule_bypass_for_tasks_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Default:  false,
+		},
+
+		"role_assignment_mode": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.StringInSlice(registries.PossibleValuesForRoleAssignmentMode(), false),
+			Default:      registries.RoleAssignmentModeLegacyRegistryPermissions,
+		},
+
+		"tags": commonschema.Tags(),
+	}
+
+	if !features.FivePointOh() {
+		schema["trust_policy_enabled"] = &pluginsdk.Schema{
+			Type:       pluginsdk.TypeBool,
+			Deprecated: "This attribute is deprecated by the service and will be completely removed on March 31, 2028",
+			Optional:   true,
+			Default:    false,
+		}
+	}
+
 	r := &pluginsdk.Resource{
 		Create: resourceContainerRegistryCreate,
 		Read:   resourceContainerRegistryRead,
@@ -58,229 +285,7 @@ func resourceContainerRegistry() *pluginsdk.Resource {
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 
-		Schema: map[string]*pluginsdk.Schema{
-			"name": {
-				Type:         pluginsdk.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: containerValidate.ContainerRegistryName,
-			},
-
-			"resource_group_name": commonschema.ResourceGroupName(),
-
-			"location": commonschema.Location(),
-
-			"sku": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(registries.SkuNameBasic),
-					string(registries.SkuNameStandard),
-					string(registries.SkuNamePremium),
-				}, false),
-			},
-
-			"admin_enabled": {
-				Type:     pluginsdk.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-
-			"georeplications": {
-				// Don't make this a TypeSet since TypeSet has bugs when there is a nested property using `StateFunc`.
-				// See: https://github.com/hashicorp/terraform-plugin-sdk/issues/160
-				Type:       pluginsdk.TypeList,
-				Optional:   true,
-				ConfigMode: pluginsdk.SchemaConfigModeAuto,
-				Elem: &pluginsdk.Resource{
-					Schema: map[string]*pluginsdk.Schema{
-						"location": commonschema.LocationWithoutForceNew(),
-
-						"zone_redundancy_enabled": {
-							Type:     pluginsdk.TypeBool,
-							Optional: true,
-							Default:  false,
-						},
-
-						"regional_endpoint_enabled": {
-							Type:     pluginsdk.TypeBool,
-							Optional: true,
-						},
-
-						"tags": commonschema.Tags(),
-					},
-				},
-			},
-
-			"public_network_access_enabled": {
-				Type:     pluginsdk.TypeBool,
-				Optional: true,
-				Default:  true,
-			},
-
-			"login_server": {
-				Type:     pluginsdk.TypeString,
-				Computed: true,
-			},
-
-			"admin_username": {
-				Type:     pluginsdk.TypeString,
-				Computed: true,
-			},
-
-			"admin_password": {
-				Type:      pluginsdk.TypeString,
-				Computed:  true,
-				Sensitive: true,
-			},
-
-			"identity": commonschema.SystemAssignedUserAssignedIdentityOptional(),
-
-			"encryption": {
-				Type:       pluginsdk.TypeList,
-				Optional:   true,
-				ConfigMode: pluginsdk.SchemaConfigModeAttr,
-				MaxItems:   1,
-				Elem: &pluginsdk.Resource{
-					Schema: map[string]*pluginsdk.Schema{
-						"identity_client_id": {
-							Type:         pluginsdk.TypeString,
-							Required:     true,
-							ValidateFunc: validation.IsUUID,
-						},
-						"key_vault_key_id": {
-							Type:         pluginsdk.TypeString,
-							Required:     true,
-							ValidateFunc: keyvault.ValidateNestedItemID(keyvault.VersionTypeAny, keyvault.NestedItemTypeKey),
-						},
-					},
-				},
-			},
-
-			"network_rule_set": {
-				Type:     pluginsdk.TypeList,
-				Optional: true,
-				Computed: true,
-				// ConfigModeAttr ensures we can set this to an empty array for Premium -> Basic
-				ConfigMode: pluginsdk.SchemaConfigModeAttr,
-				MaxItems:   1,
-				Elem: &pluginsdk.Resource{
-					Schema: map[string]*pluginsdk.Schema{
-						"default_action": {
-							Type:     pluginsdk.TypeString,
-							Optional: true,
-							Default:  registries.DefaultActionAllow,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(registries.DefaultActionAllow),
-								string(registries.DefaultActionDeny),
-							}, false),
-						},
-
-						"ip_rule": {
-							Type:       pluginsdk.TypeSet,
-							Optional:   true,
-							Computed:   true,
-							ConfigMode: pluginsdk.SchemaConfigModeAttr,
-							Elem: &pluginsdk.Resource{
-								Schema: map[string]*pluginsdk.Schema{
-									"action": {
-										Type:     pluginsdk.TypeString,
-										Required: true,
-										ValidateFunc: validation.StringInSlice([]string{
-											string(registries.ActionAllow),
-										}, false),
-									},
-									"ip_range": {
-										Type:         pluginsdk.TypeString,
-										Required:     true,
-										ValidateFunc: validate.CIDR,
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-
-			"quarantine_policy_enabled": {
-				Type:     pluginsdk.TypeBool,
-				Optional: true,
-			},
-
-			"retention_policy_in_days": {
-				Type:         pluginsdk.TypeInt,
-				Optional:     true,
-				ValidateFunc: validation.IntBetween(0, 365),
-			},
-
-			"trust_policy_enabled": {
-				Type:     pluginsdk.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-
-			"export_policy_enabled": {
-				Type:     pluginsdk.TypeBool,
-				Optional: true,
-				Default:  true,
-			},
-
-			"azuread_authentication_as_arm_policy_enabled": {
-				Type:     pluginsdk.TypeBool,
-				Optional: true,
-				Default:  true,
-			},
-
-			"zone_redundancy_enabled": {
-				Type:     pluginsdk.TypeBool,
-				ForceNew: true,
-				Optional: true,
-				Default:  false,
-			},
-
-			"anonymous_pull_enabled": {
-				Type:     pluginsdk.TypeBool,
-				Optional: true,
-			},
-
-			"data_endpoint_enabled": {
-				Type:     pluginsdk.TypeBool,
-				Optional: true,
-			},
-
-			"data_endpoint_host_names": {
-				Type:     pluginsdk.TypeSet,
-				Computed: true,
-				Elem: &pluginsdk.Schema{
-					Type: pluginsdk.TypeString,
-				},
-			},
-
-			"network_rule_bypass_option": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(registries.NetworkRuleBypassOptionsAzureServices),
-					string(registries.NetworkRuleBypassOptionsNone),
-				}, false),
-				Default: string(registries.NetworkRuleBypassOptionsAzureServices),
-			},
-
-			"network_rule_bypass_for_tasks_enabled": {
-				Type:     pluginsdk.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-
-			"role_assignment_mode": {
-				Type:         pluginsdk.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringInSlice(registries.PossibleValuesForRoleAssignmentMode(), false),
-				Default:      registries.RoleAssignmentModeLegacyRegistryPermissions,
-			},
-
-			"tags": commonschema.Tags(),
-		},
+		Schema: schema,
 
 		CustomizeDiff: pluginsdk.CustomizeDiffShim(func(ctx context.Context, d *pluginsdk.ResourceDiff, v interface{}) error {
 			sku := d.Get("sku").(string)
@@ -314,9 +319,18 @@ func resourceContainerRegistry() *pluginsdk.Resource {
 				return errors.New("an ACR retention policy can only be applied when using the Premium Sku. If you are downgrading from a Premium SKU please unset `retention_policy_in_days`")
 			}
 
-			trustPolicyEnabled, ok := d.GetOk("trust_policy_enabled")
-			if ok && trustPolicyEnabled.(bool) && !strings.EqualFold(sku, string(registries.SkuNamePremium)) {
-				return errors.New("an ACR trust policy can only be applied when using the Premium Sku. If you are downgrading from a Premium SKU please unset `trust_policy_enabled` or set `trust_policy_enabled = false`")
+			if !features.FivePointOh() {
+				trustPolicyEnabled, ok := d.GetOk("trust_policy_enabled")
+				if ok && trustPolicyEnabled.(bool) {
+					if !strings.EqualFold(sku, string(registries.SkuNamePremium)) {
+						return errors.New("an ACR trust policy can only be applied when using the Premium Sku. If you are downgrading from a Premium SKU please unset `trust_policy_enabled` or set `trust_policy_enabled = false`")
+					}
+
+					// Can't enable `trustPolicy` for new creation.
+					if d.GetRawState().IsNull() {
+						return errors.New("`trust_policy_enabled` can't be enabled as it is deprecated by the service")
+					}
+				}
 			}
 
 			exportPolicyEnabled := d.Get("export_policy_enabled").(bool)
@@ -422,11 +436,6 @@ func resourceContainerRegistryCreate(d *pluginsdk.ResourceData, meta interface{}
 		retentionPolicy.Status = pointer.To(registries.PolicyStatusEnabled)
 	}
 
-	trustPolicy := &registries.TrustPolicy{}
-	if v, ok := d.GetOk("trust_policy_enabled"); ok && v.(bool) {
-		trustPolicy.Status = pointer.To(registries.PolicyStatusEnabled)
-	}
-
 	parameters := registries.Registry{
 		Location: location.Normalize(d.Get("location").(string)),
 		Sku: registries.Sku{
@@ -441,7 +450,6 @@ func resourceContainerRegistryCreate(d *pluginsdk.ResourceData, meta interface{}
 			Policies: &registries.Policies{
 				QuarantinePolicy:                 expandQuarantinePolicy(d.Get("quarantine_policy_enabled").(bool)),
 				RetentionPolicy:                  retentionPolicy,
-				TrustPolicy:                      trustPolicy,
 				ExportPolicy:                     expandExportPolicy(d.Get("export_policy_enabled").(bool)),
 				AzureADAuthenticationAsArmPolicy: expandAadAuthAsArmPolicy(d.Get("azuread_authentication_as_arm_policy_enabled").(bool)),
 			},
@@ -455,6 +463,14 @@ func resourceContainerRegistryCreate(d *pluginsdk.ResourceData, meta interface{}
 		},
 
 		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
+	}
+
+	if !features.FivePointOh() {
+		trustPolicy := &registries.TrustPolicy{}
+		if v, ok := d.GetOk("trust_policy_enabled"); ok && v.(bool) {
+			trustPolicy.Status = pointer.To(registries.PolicyStatusEnabled)
+		}
+		parameters.Properties.Policies.TrustPolicy = trustPolicy
 	}
 
 	if err := client.CreateCallbackThenPoll(ctx, id, parameters, sdk.SetIDCallback(meta, &id, d)); err != nil {
@@ -546,6 +562,9 @@ func resourceContainerRegistryUpdate(d *pluginsdk.ResourceData, meta interface{}
 	}
 
 	policyKeys = append(policyKeys, []string{"retention_policy_in_days", "trust_policy_enabled"}...)
+	if !features.FivePointOh() {
+		policyKeys = append(policyKeys, "trust_policy_enabled")
+	}
 
 	if d.HasChanges(policyKeys...) {
 		payload.Properties.Policies = &registries.Policies{}
@@ -564,14 +583,16 @@ func resourceContainerRegistryUpdate(d *pluginsdk.ResourceData, meta interface{}
 		}
 	}
 
-	if d.HasChange("trust_policy_enabled") {
-		payload.Properties.Policies.TrustPolicy = &registries.TrustPolicy{
-			Status: pointer.To(registries.PolicyStatusDisabled),
-		}
-
-		if v := d.Get("trust_policy_enabled").(bool); v {
+	if !features.FivePointOh() {
+		if d.HasChange("trust_policy_enabled") {
 			payload.Properties.Policies.TrustPolicy = &registries.TrustPolicy{
-				Status: pointer.To(registries.PolicyStatusEnabled),
+				Status: pointer.To(registries.PolicyStatusDisabled),
+			}
+
+			if v := d.Get("trust_policy_enabled").(bool); v {
+				payload.Properties.Policies.TrustPolicy = &registries.TrustPolicy{
+					Status: pointer.To(registries.PolicyStatusEnabled),
+				}
 			}
 		}
 	}
@@ -881,9 +902,11 @@ func resourceContainerRegistryRead(d *pluginsdk.ResourceData, meta interface{}) 
 				}
 				d.Set("retention_policy_in_days", retentionInDays)
 
-				if policies.TrustPolicy != nil && policies.TrustPolicy.Status != nil {
-					policyEnabled := *policies.TrustPolicy.Status == registries.PolicyStatusEnabled
-					d.Set("trust_policy_enabled", policyEnabled)
+				if !features.FivePointOh() {
+					if policies.TrustPolicy != nil && policies.TrustPolicy.Status != nil {
+						policyEnabled := *policies.TrustPolicy.Status == registries.PolicyStatusEnabled
+						d.Set("trust_policy_enabled", policyEnabled)
+					}
 				}
 				d.Set("quarantine_policy_enabled", flattenQuarantinePolicy(props.Policies))
 				d.Set("export_policy_enabled", flattenExportPolicy(props.Policies))

--- a/internal/services/containers/container_registry_resource.go
+++ b/internal/services/containers/container_registry_resource.go
@@ -561,7 +561,7 @@ func resourceContainerRegistryUpdate(d *pluginsdk.ResourceData, meta interface{}
 		"azuread_authentication_as_arm_policy_enabled",
 	}
 
-	policyKeys = append(policyKeys, []string{"retention_policy_in_days", "trust_policy_enabled"}...)
+	policyKeys = append(policyKeys, "retention_policy_in_days")
 	if !features.FivePointOh() {
 		policyKeys = append(policyKeys, "trust_policy_enabled")
 	}

--- a/internal/services/containers/container_registry_resource.go
+++ b/internal/services/containers/container_registry_resource.go
@@ -255,7 +255,7 @@ func resourceContainerRegistry() *pluginsdk.Resource {
 	if !features.FivePointOh() {
 		schema["trust_policy_enabled"] = &pluginsdk.Schema{
 			Type:       pluginsdk.TypeBool,
-			Deprecated: "This attribute is deprecated by the service and will be completely removed on March 31, 2028",
+			Deprecated: "the `trust_policy_enabled` property is deprecated by the service and will be removed in v5.0 of the AzureRM Provider",
 			Optional:   true,
 			Default:    false,
 		}

--- a/internal/services/containers/container_registry_resource_test.go
+++ b/internal/services/containers/container_registry_resource_test.go
@@ -494,7 +494,6 @@ resource "azurerm_container_registry" "test" {
   public_network_access_enabled                = false
   quarantine_policy_enabled                    = true
   retention_policy_in_days                     = 10
-  trust_policy_enabled                         = true
   export_policy_enabled                        = false
   azuread_authentication_as_arm_policy_enabled = false
   anonymous_pull_enabled                       = true
@@ -545,7 +544,6 @@ resource "azurerm_container_registry" "test" {
   public_network_access_enabled                = true
   quarantine_policy_enabled                    = false
   retention_policy_in_days                     = 15
-  trust_policy_enabled                         = false
   export_policy_enabled                        = true
   azuread_authentication_as_arm_policy_enabled = true
   anonymous_pull_enabled                       = false

--- a/website/docs/5.0-upgrade-guide.html.markdown
+++ b/website/docs/5.0-upgrade-guide.html.markdown
@@ -472,6 +472,7 @@ Please follow the format in the example below for listing breaking changes in re
 ### `azurerm_container_registry`
 
 * The `encryption` block is no longer Computed. It now defaults to empty, meaning encryption will be disabled.
+* The deprecated `trust_policy_enabled` property has been removed as it is no longer supported by the service.
 
 ### `azurerm_cosmosdb_account`
 

--- a/website/docs/r/container_registry.html.markdown
+++ b/website/docs/r/container_registry.html.markdown
@@ -162,15 +162,13 @@ The following arguments are supported:
 
 * `retention_policy_in_days` - (Optional) The number of days to retain and untagged manifest after which it gets purged.
 
-* `trust_policy_enabled` - (Optional) Boolean value that indicated whether trust policy is enabled. Defaults to `false`.
-
 * `zone_redundancy_enabled` - (Optional) Whether zone redundancy is enabled for this Container Registry? Changing this forces a new resource to be created. Defaults to `false`.
 
 * `export_policy_enabled` - (Optional) Boolean value that indicates whether export policy is enabled. Defaults to `true`. In order to set it to `false`, make sure the `public_network_access_enabled` is also set to `false`.
 
 * `azuread_authentication_as_arm_policy_enabled` - (Optional) Whether to use Azure Resource Manager audience token for this Container Registry? Defaults to `true`.
 
-~> **Note:** `quarantine_policy_enabled`, `retention_policy_in_days`, `trust_policy_enabled`, `export_policy_enabled` and `zone_redundancy_enabled` are only supported on resources with the `Premium` SKU.
+~> **Note:** `quarantine_policy_enabled`, `retention_policy_in_days`, `export_policy_enabled` and `zone_redundancy_enabled` are only supported on resources with the `Premium` SKU.
 
 * `identity` - (Optional) An `identity` block as defined below.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR deprecates the `trust_policy_enabled` for `azurerm_container_registry`. At least on new create request, if a user specified the `trustPolicy=enabled`, API raises the following error:

```
╷
│ Error: creating Registry (Subscription: "cb563ee9-7df0-468e-81d5-166968d1f89a"
│ Resource Group Name: "acctestRG-acrfoo"
│ Registry Name: "abcdefghij012321"): performing Create: unexpected status 400 (400 Bad Request) with error: ContentTrustUnsupported: The value 'enabled' for property 'status' in 'trustPolicy' is not supported. Content Trust is being deprecated and will be completely removed on March 31, 2028. Refer to https://aka.ms/acr/dctdeprecation for details and transition guidance.
│
│   with azurerm_container_registry.test,
│   on main.tf line 26, in resource "azurerm_container_registry" "test":
│   26: resource "azurerm_container_registry" "test" {
│
```

The change was made to avoid a (untested) case that any existing ACR can still update this `trust_policy_enabled` without an error. Therefore, we still keep the possibility to update it, while block it for new resource.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

```shell
terraform-provider-azurerm acr_deprecate_trust_policy_enabled*​ ≡
❯ TF_ACC=1 go test -v -timeout=20h -run=TestAccContainerRegistry_ ./internal/ser
vices/containers
=== RUN   TestAccContainerRegistry_basic
=== PAUSE TestAccContainerRegistry_basic
=== RUN   TestAccContainerRegistry_requiresImport
=== PAUSE TestAccContainerRegistry_requiresImport
=== RUN   TestAccContainerRegistry_basicManagedStandard
=== PAUSE TestAccContainerRegistry_basicManagedStandard
=== RUN   TestAccContainerRegistry_basicManagedPremium
=== PAUSE TestAccContainerRegistry_basicManagedPremium
=== RUN   TestAccContainerRegistry_basic2Premium2basic
=== PAUSE TestAccContainerRegistry_basic2Premium2basic
=== RUN   TestAccContainerRegistry_complete
=== PAUSE TestAccContainerRegistry_complete
=== RUN   TestAccContainerRegistry_update
=== PAUSE TestAccContainerRegistry_update
=== RUN   TestAccContainerRegistry_geoReplicationLocation
=== PAUSE TestAccContainerRegistry_geoReplicationLocation
=== RUN   TestAccContainerRegistry_networkAccessProfileIp
=== PAUSE TestAccContainerRegistry_networkAccessProfileIp
=== RUN   TestAccContainerRegistry_networkAccessProfileUpdate
=== PAUSE TestAccContainerRegistry_networkAccessProfileUpdate
=== RUN   TestAccContainerRegistry_zoneRedundancy
=== PAUSE TestAccContainerRegistry_zoneRedundancy
=== RUN   TestAccContainerRegistry_geoReplicationZoneRedundancy
=== PAUSE TestAccContainerRegistry_geoReplicationZoneRedundancy
=== RUN   TestAccContainerRegistry_geoReplicationRegionEndpoint
=== PAUSE TestAccContainerRegistry_geoReplicationRegionEndpoint
=== RUN   TestAccContainerRegistry_anonymousPull
=== PAUSE TestAccContainerRegistry_anonymousPull
=== RUN   TestAccContainerRegistry_dataEndpoint
=== PAUSE TestAccContainerRegistry_dataEndpoint
=== RUN   TestAccContainerRegistry_networkRuleBypassOption
=== PAUSE TestAccContainerRegistry_networkRuleBypassOption
=== RUN   TestAccContainerRegistry_encryption
=== PAUSE TestAccContainerRegistry_encryption
=== CONT  TestAccContainerRegistry_basic
=== CONT  TestAccContainerRegistry_networkAccessProfileUpdate
=== CONT  TestAccContainerRegistry_complete
=== CONT  TestAccContainerRegistry_networkAccessProfileIp
=== CONT  TestAccContainerRegistry_basic2Premium2basic
=== CONT  TestAccContainerRegistry_basicManagedPremium
=== CONT  TestAccContainerRegistry_geoReplicationLocation
=== CONT  TestAccContainerRegistry_update
=== CONT  TestAccContainerRegistry_encryption
=== CONT  TestAccContainerRegistry_basicManagedStandard
=== CONT  TestAccContainerRegistry_requiresImport
=== CONT  TestAccContainerRegistry_anonymousPull
--- PASS: TestAccContainerRegistry_requiresImport (87.69s)
=== CONT  TestAccContainerRegistry_networkRuleBypassOption
--- PASS: TestAccContainerRegistry_basicManagedPremium (103.31s)
=== CONT  TestAccContainerRegistry_dataEndpoint
--- PASS: TestAccContainerRegistry_complete (105.14s)
=== CONT  TestAccContainerRegistry_geoReplicationZoneRedundancy
--- PASS: TestAccContainerRegistry_basic (108.64s)
=== CONT  TestAccContainerRegistry_geoReplicationRegionEndpoint
--- PASS: TestAccContainerRegistry_basicManagedStandard (108.65s)
=== CONT  TestAccContainerRegistry_zoneRedundancy
--- PASS: TestAccContainerRegistry_networkAccessProfileIp (131.81s)
--- PASS: TestAccContainerRegistry_networkAccessProfileUpdate (134.43s)
--- PASS: TestAccContainerRegistry_anonymousPull (153.72s)
--- PASS: TestAccContainerRegistry_basic2Premium2basic (167.04s)
--- PASS: TestAccContainerRegistry_update (186.95s)
--- PASS: TestAccContainerRegistry_zoneRedundancy (95.09s)
--- PASS: TestAccContainerRegistry_networkRuleBypassOption (140.35s)
--- PASS: TestAccContainerRegistry_dataEndpoint (139.58s)
--- PASS: TestAccContainerRegistry_geoReplicationZoneRedundancy (178.72s)
--- PASS: TestAccContainerRegistry_geoReplicationRegionEndpoint (176.28s)
--- PASS: TestAccContainerRegistry_encryption (290.64s)
--- PASS: TestAccContainerRegistry_geoReplicationLocation (486.73s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/containers	486.758s


❯ ARM_FIVEPOINTZERO_BETA=true TF_ACC=1 go test -v -timeout=20h -run=TestAccContainerRegistry_ ./internal/services/containers
=== RUN   TestAccContainerRegistry_basic
=== PAUSE TestAccContainerRegistry_basic
=== RUN   TestAccContainerRegistry_requiresImport
=== PAUSE TestAccContainerRegistry_requiresImport
=== RUN   TestAccContainerRegistry_basicManagedStandard
=== PAUSE TestAccContainerRegistry_basicManagedStandard
=== RUN   TestAccContainerRegistry_basicManagedPremium
=== PAUSE TestAccContainerRegistry_basicManagedPremium
=== RUN   TestAccContainerRegistry_basic2Premium2basic
=== PAUSE TestAccContainerRegistry_basic2Premium2basic
=== RUN   TestAccContainerRegistry_complete
=== PAUSE TestAccContainerRegistry_complete
=== RUN   TestAccContainerRegistry_update
=== PAUSE TestAccContainerRegistry_update
=== RUN   TestAccContainerRegistry_geoReplicationLocation
=== PAUSE TestAccContainerRegistry_geoReplicationLocation
=== RUN   TestAccContainerRegistry_networkAccessProfileIp
=== PAUSE TestAccContainerRegistry_networkAccessProfileIp
=== RUN   TestAccContainerRegistry_networkAccessProfileUpdate
=== PAUSE TestAccContainerRegistry_networkAccessProfileUpdate
=== RUN   TestAccContainerRegistry_zoneRedundancy
=== PAUSE TestAccContainerRegistry_zoneRedundancy
=== RUN   TestAccContainerRegistry_geoReplicationZoneRedundancy
=== PAUSE TestAccContainerRegistry_geoReplicationZoneRedundancy
=== RUN   TestAccContainerRegistry_geoReplicationRegionEndpoint
=== PAUSE TestAccContainerRegistry_geoReplicationRegionEndpoint
=== RUN   TestAccContainerRegistry_anonymousPull
=== PAUSE TestAccContainerRegistry_anonymousPull
=== RUN   TestAccContainerRegistry_dataEndpoint
=== PAUSE TestAccContainerRegistry_dataEndpoint
=== RUN   TestAccContainerRegistry_networkRuleBypassOption
=== PAUSE TestAccContainerRegistry_networkRuleBypassOption
=== RUN   TestAccContainerRegistry_encryption
=== PAUSE TestAccContainerRegistry_encryption
=== CONT  TestAccContainerRegistry_basic
=== CONT  TestAccContainerRegistry_networkAccessProfileUpdate
=== CONT  TestAccContainerRegistry_complete
=== CONT  TestAccContainerRegistry_basic2Premium2basic
=== CONT  TestAccContainerRegistry_basicManagedPremium
=== CONT  TestAccContainerRegistry_encryption
=== CONT  TestAccContainerRegistry_geoReplicationLocation
=== CONT  TestAccContainerRegistry_basicManagedStandard
=== CONT  TestAccContainerRegistry_requiresImport
=== CONT  TestAccContainerRegistry_anonymousPull
=== CONT  TestAccContainerRegistry_networkAccessProfileIp
=== CONT  TestAccContainerRegistry_networkRuleBypassOption
--- PASS: TestAccContainerRegistry_requiresImport (78.81s)
=== CONT  TestAccContainerRegistry_dataEndpoint
--- PASS: TestAccContainerRegistry_basic (95.96s)
=== CONT  TestAccContainerRegistry_update
--- PASS: TestAccContainerRegistry_basicManagedStandard (96.52s)
=== CONT  TestAccContainerRegistry_geoReplicationZoneRedundancy
--- PASS: TestAccContainerRegistry_basicManagedPremium (98.03s)
=== CONT  TestAccContainerRegistry_geoReplicationRegionEndpoint
--- PASS: TestAccContainerRegistry_complete (98.12s)
=== CONT  TestAccContainerRegistry_zoneRedundancy
--- PASS: TestAccContainerRegistry_networkAccessProfileUpdate (119.94s)
--- PASS: TestAccContainerRegistry_networkRuleBypassOption (139.88s)
--- PASS: TestAccContainerRegistry_anonymousPull (142.77s)
--- PASS: TestAccContainerRegistry_basic2Premium2basic (155.58s)
--- PASS: TestAccContainerRegistry_networkAccessProfileIp (171.11s)
--- PASS: TestAccContainerRegistry_zoneRedundancy (90.31s)
--- PASS: TestAccContainerRegistry_dataEndpoint (138.95s)
--- PASS: TestAccContainerRegistry_update (161.18s)
--- PASS: TestAccContainerRegistry_geoReplicationZoneRedundancy (164.87s)
--- PASS: TestAccContainerRegistry_geoReplicationRegionEndpoint (166.11s)
--- PASS: TestAccContainerRegistry_encryption (286.19s)
--- PASS: TestAccContainerRegistry_geoReplicationLocation (421.68s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/containers	421.701s
```

(Note the 5.0 test was run without the change added in https://github.com/hashicorp/terraform-provider-azurerm/pull/32260 as it introduced provider schema validation issue)


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
