### PR TITLE
`azurerm_managed_devops_pool` - support `CreatorOnly` in `permission.kind`

### DIFF
--- a/internal/services/manageddevopspools/managed_devops_pool_resource.go
+++ b/internal/services/manageddevopspools/managed_devops_pool_resource.go
@@ -116,13 +116,12 @@ func (ManagedDevOpsPoolResource) Arguments() map[string]*pluginsdk.Schema {
 						MaxItems: 1,
 						Elem: &pluginsdk.Resource{
 							Schema: map[string]*pluginsdk.Schema{
-								// "CreatorOnly" is excluded because it silently behaves as "Inherit" when authenticated via Service Principal.
-								// Ref: https://github.com/Azure/azure-rest-api-specs/issues/41786
 								"kind": {
 									Type:     pluginsdk.TypeString,
 									Required: true,
 									ForceNew: true,
 									ValidateFunc: validation.StringInSlice([]string{
+										string(pools.AzureDevOpsPermissionTypeCreatorOnly),
 										string(pools.AzureDevOpsPermissionTypeInherit),
 										string(pools.AzureDevOpsPermissionTypeSpecificAccounts),
 									}, false),

--- a/internal/services/manageddevopspools/managed_devops_pool_resource_test.go
+++ b/internal/services/manageddevopspools/managed_devops_pool_resource_test.go
@@ -154,6 +154,23 @@ func TestAccManagedDevOpsPool_CompleteWithPermission(t *testing.T) {
 	})
 }
 
+func TestAccManagedDevOpsPool_creatorOnlyPermission(t *testing.T) {
+	requiresBasicEnvVars(t)
+
+	data := acceptance.BuildTestData(t, "azurerm_managed_devops_pool", "test")
+	r := ManagedDevOpsPoolResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.creatorOnlyPermission(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (ManagedDevOpsPoolResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := pools.ParsePoolID(state.ID)
 	if err != nil {
@@ -337,6 +354,45 @@ resource "azurerm_managed_devops_pool" "test" {
     organization {
       parallelism = 1
       url         = "%s"
+    }
+  }
+
+  stateless_agent {}
+
+  virtual_machine_scale_set_fabric {
+    image {
+      well_known_image_name = "ubuntu-24.04/latest"
+    }
+    sku_name = "Standard_B1s"
+  }
+}
+`, r.template(data), data.RandomInteger, os.Getenv("ARM_MANAGED_DEVOPS_ORG_URL"))
+}
+
+func (r ManagedDevOpsPoolResource) creatorOnlyPermission(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_managed_devops_pool" "test" {
+  name                = "acctest-pool-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  maximum_concurrency   = 1
+  dev_center_project_id = azurerm_dev_center_project.test.id
+
+  azure_devops_organization {
+    organization {
+      parallelism = 1
+      url         = "%s"
+    }
+
+    permission {
+      kind = "CreatorOnly"
     }
   }
 

--- a/website/docs/r/managed_devops_pool.html.markdown
+++ b/website/docs/r/managed_devops_pool.html.markdown
@@ -201,7 +201,9 @@ An `organization` block supports the following:
 
 A `permission` block supports the following:
 
-* `kind` - (Required) Determines who has admin permissions to the Azure DevOps pool. Possible values are `Inherit` and `SpecificAccounts`. Changing this forces a new resource to be created.
+* `kind` - (Required) Determines who has admin permissions to the Azure DevOps pool. Possible values are `CreatorOnly`, `Inherit`, and `SpecificAccounts`. Changing this forces a new resource to be created.
+
+~> **Note:** When `kind` is set to `CreatorOnly` and the pool is created using a service principal, the service principal is not automatically granted the administrator role on the Azure DevOps pool.
 
 * `administrator_account` - (Optional) An `administrator_account` block as defined below. This block is only valid when `kind` is set to `SpecificAccounts`. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Adds `CreatorOnly` to the accepted values for `azure_devops_organization.permission.kind`.

`CreatorOnly` is the Azure default when no `permission` block is set, so pools created outside Terraform return `CreatorOnly` and previously could not be imported without a forced replacement. This adds the value so import/read succeeds for them.

Previously, creating a `CreatorOnly` pool set the agent pool's inheritance to `On`, which conflicts with the [documented behavior](https://learn.microsoft.com/en-us/azure/devops/managed-devops-pools/configure-security?view=azure-devops#configure-pool-administration-permissions) (`CreatorOnly` should set inheritance to `Off`). That is now fixed on the Azure side — `CreatorOnly` sets inheritance to `Off` as documented and round-trips cleanly (state matches config; omitting `permission` returns nil with no diff).

The service principal is still not assigned the pool administrator role when creating with `CreatorOnly`, but that is Azure DevOps behavior, not a Terraform/API issue, and is noted on the `kind` field. See Azure/azure-rest-api-specs#41786.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

<img width="1343" height="291" alt="image" src="https://github.com/user-attachments/assets/a777e57b-8f1a-42e3-b270-98399d2150e3" />


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_managed_devops_pool` - support `CreatorOnly` in `permission.kind`

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #32630 


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.**
