### PR TITLE
azurerm_storage_share_file: support inline content via source_content

### DIFF
--- a/internal/services/storage/storage_share_file_resource.go
+++ b/internal/services/storage/storage_share_file_resource.go
@@ -73,10 +73,19 @@ func resourceStorageShareFile() *pluginsdk.Resource {
 		},
 
 		"source": {
-			Type:         pluginsdk.TypeString,
-			Optional:     true,
-			ValidateFunc: validation.StringIsNotEmpty,
-			ForceNew:     true,
+			Type:          pluginsdk.TypeString,
+			Optional:      true,
+			ValidateFunc:  validation.StringIsNotEmpty,
+			ForceNew:      true,
+			ConflictsWith: []string{"source_content"},
+		},
+
+		"source_content": {
+			Type:          pluginsdk.TypeString,
+			Optional:      true,
+			ValidateFunc:  validation.StringIsNotEmpty,
+			ForceNew:      true,
+			ConflictsWith: []string{"source"},
 		},
 
 		"content_length": {
@@ -213,7 +222,21 @@ func resourceStorageShareFileCreate(d *pluginsdk.ResourceData, meta interface{})
 		if err != nil {
 			return fmt.Errorf("opening file: %s", err)
 		}
+		defer file.Close()
+	} else if v, ok := d.GetOk("source_content"); ok {
+		file, err = os.CreateTemp(os.TempDir(), "share-file-")
+		if err != nil {
+			return fmt.Errorf("creating temporary file: %s", err)
+		}
+		defer os.Remove(file.Name())
+		defer file.Close()
 
+		if _, err = file.WriteString(v.(string)); err != nil {
+			return fmt.Errorf("writing `source_content` to temporary file: %s", err)
+		}
+	}
+
+	if file != nil {
 		info, err := file.Stat()
 		if err != nil {
 			return fmt.Errorf("'stat'-ing File %q (File Share %q / Account %q): %v", fileName, storageShareId.ShareName, storageShareId.AccountId.AccountName, err)

--- a/internal/services/storage/storage_share_file_resource.go
+++ b/internal/services/storage/storage_share_file_resource.go
@@ -239,11 +239,11 @@ func resourceStorageShareFileCreate(d *pluginsdk.ResourceData, meta interface{})
 	if file != nil {
 		info, err := file.Stat()
 		if err != nil {
-			return fmt.Errorf("could not stat file %q: %v", file.Name(), err)
+			return fmt.Errorf("'stat'-ing File %q (File Share %q / Account %q): %v", fileName, storageShareId.ShareName, storageShareId.AccountId.AccountName, err)
 		}
 
 		if info.Size() == 0 {
-			return fmt.Errorf("file %q is empty", file.Name())
+			return fmt.Errorf("file %q (File Share %q / Account %q) is empty", fileName, storageShareId.ShareName, storageShareId.AccountId.AccountName)
 		}
 
 		input.ContentLength = info.Size()

--- a/internal/services/storage/storage_share_file_resource.go
+++ b/internal/services/storage/storage_share_file_resource.go
@@ -239,11 +239,11 @@ func resourceStorageShareFileCreate(d *pluginsdk.ResourceData, meta interface{})
 	if file != nil {
 		info, err := file.Stat()
 		if err != nil {
-			return fmt.Errorf("'stat'-ing File %q (File Share %q / Account %q): %v", fileName, storageShareId.ShareName, storageShareId.AccountId.AccountName, err)
+			return fmt.Errorf("'stat'-ing source file %q for File %q (File Share %q / Account %q): %v", file.Name(), fileName, storageShareId.ShareName, storageShareId.AccountId.AccountName, err)
 		}
 
 		if info.Size() == 0 {
-			return fmt.Errorf("file %q (File Share %q / Account %q) is empty", fileName, storageShareId.ShareName, storageShareId.AccountId.AccountName)
+			return fmt.Errorf("source file %q for File %q (File Share %q / Account %q) is empty", file.Name(), fileName, storageShareId.ShareName, storageShareId.AccountId.AccountName)
 		}
 
 		input.ContentLength = info.Size()

--- a/internal/services/storage/storage_share_file_resource.go
+++ b/internal/services/storage/storage_share_file_resource.go
@@ -239,11 +239,11 @@ func resourceStorageShareFileCreate(d *pluginsdk.ResourceData, meta interface{})
 	if file != nil {
 		info, err := file.Stat()
 		if err != nil {
-			return fmt.Errorf("'stat'-ing source file %q for File %q (File Share %q / Account %q): %v", file.Name(), fileName, storageShareId.ShareName, storageShareId.AccountId.AccountName, err)
+			return fmt.Errorf("could not stat file %q: %v", file.Name(), err)
 		}
 
 		if info.Size() == 0 {
-			return fmt.Errorf("source file %q for File %q (File Share %q / Account %q) is empty", file.Name(), fileName, storageShareId.ShareName, storageShareId.AccountId.AccountName)
+			return fmt.Errorf("file %q is empty", file.Name())
 		}
 
 		input.ContentLength = info.Size()

--- a/internal/services/storage/storage_share_file_resource_deprecated_test.go
+++ b/internal/services/storage/storage_share_file_resource_deprecated_test.go
@@ -176,7 +176,7 @@ func TestAccAzureRMStorageShareFile_withEmptyFile_deprecated(t *testing.T) {
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config:      r.withFile(data, sourceBlob.Name()),
-			ExpectError: regexp.MustCompile(`Error: file .* is empty`),
+			ExpectError: regexp.MustCompile(`source file .* is empty`),
 		},
 	})
 }

--- a/internal/services/storage/storage_share_file_resource_deprecated_test.go
+++ b/internal/services/storage/storage_share_file_resource_deprecated_test.go
@@ -176,7 +176,7 @@ func TestAccAzureRMStorageShareFile_withEmptyFile_deprecated(t *testing.T) {
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config:      r.withFile(data, sourceBlob.Name()),
-			ExpectError: regexp.MustCompile(`source file .* is empty`),
+			ExpectError: regexp.MustCompile(`Error: file .* is empty`),
 		},
 	})
 }

--- a/internal/services/storage/storage_share_file_resource_test.go
+++ b/internal/services/storage/storage_share_file_resource_test.go
@@ -8,7 +8,9 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
@@ -139,12 +141,15 @@ func TestAccAzureRMStorageShareFile_withSourceContent(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_share_file", "test")
 	r := StorageShareFileResource{}
 
+	content := "My shopping list:\n* eggs\n* bananas\n* kiwis\n* milk tea\n"
+
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.withSourceContent(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("content_length").Exists(),
+				data.CheckWithClient(r.fileMatchesContent([]byte(content))),
 			),
 		},
 		data.ImportStep("source_content"),
@@ -163,7 +168,7 @@ func TestAccAzureRMStorageShareFile_withEmptyFile(t *testing.T) {
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config:      r.withFile(data, sourceBlob.Name()),
-			ExpectError: regexp.MustCompile(`Error: file .* is empty`),
+			ExpectError: regexp.MustCompile(`source file .* is empty`),
 		},
 	})
 }
@@ -240,6 +245,52 @@ func (StorageShareFileResource) Exists(ctx context.Context, clients *clients.Cli
 	}
 
 	return pointer.To(true), nil
+}
+
+func (StorageShareFileResource) fileMatchesContent(expectedContents []byte) func(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) error {
+	return func(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) error {
+		if _, ok := ctx.Deadline(); !ok {
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithDeadline(ctx, time.Now().Add(10*time.Minute))
+			defer cancel()
+		}
+
+		id, err := files.ParseFileID(state.ID, clients.Storage.StorageDomainSuffix)
+		if err != nil {
+			return err
+		}
+
+		account, err := clients.Storage.FindAccount(ctx, clients.Account.SubscriptionId, id.AccountId.AccountName)
+		if err != nil {
+			return fmt.Errorf("retrieving Account %q for File %q (Share %q): %s", id.AccountId.AccountName, id.FileName, id.ShareName, err)
+		}
+		if account == nil {
+			return fmt.Errorf("unable to locate Storage Account %q", id.AccountId.AccountName)
+		}
+
+		client, err := clients.Storage.FileShareFilesDataPlaneClient(ctx, *account, clients.Storage.DataPlaneOperationSupportingAnyAuthMethod())
+		if err != nil {
+			return fmt.Errorf("building File Share Files Client: %s", err)
+		}
+
+		resp, err := client.GetByteRange(ctx, id.ShareName, id.DirectoryPath, id.FileName, files.GetByteRangeInput{
+			StartBytes: 0,
+			EndBytes:   4 * 1024,
+		})
+		if err != nil {
+			return fmt.Errorf("retrieving File %q (File Share %q in %s): %+v", id.FileName, id.ShareName, account.StorageAccountId, err)
+		}
+
+		if resp.Contents == nil {
+			return fmt.Errorf("bad: File %q (File Share %q) returned nil contents", id.FileName, id.ShareName)
+		}
+
+		if strings.TrimSpace(string(*resp.Contents)) != strings.TrimSpace(string(expectedContents)) {
+			return fmt.Errorf("bad: File %q (File Share %q) content does not match expected content", id.FileName, id.ShareName)
+		}
+
+		return nil
+	}
 }
 
 func (StorageShareFileResource) template(data acceptance.TestData) string {

--- a/internal/services/storage/storage_share_file_resource_test.go
+++ b/internal/services/storage/storage_share_file_resource_test.go
@@ -168,7 +168,7 @@ func TestAccAzureRMStorageShareFile_withEmptyFile(t *testing.T) {
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config:      r.withFile(data, sourceBlob.Name()),
-			ExpectError: regexp.MustCompile(`source file .* is empty`),
+			ExpectError: regexp.MustCompile(`Error: file .* is empty`),
 		},
 	})
 }

--- a/internal/services/storage/storage_share_file_resource_test.go
+++ b/internal/services/storage/storage_share_file_resource_test.go
@@ -135,6 +135,22 @@ func TestAccAzureRMStorageShareFile_withFile(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMStorageShareFile_withSourceContent(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_share_file", "test")
+	r := StorageShareFileResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.withSourceContent(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("content_length").Exists(),
+			),
+		},
+		data.ImportStep("source_content"),
+	})
+}
+
 func TestAccAzureRMStorageShareFile_withEmptyFile(t *testing.T) {
 	sourceBlob, err := os.CreateTemp("", "")
 	if err != nil {
@@ -356,6 +372,29 @@ resource "azurerm_storage_share_file" "test" {
   }
 }
 `, r.template(data), fileName)
+}
+
+func (r StorageShareFileResource) withSourceContent(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_storage_share_file" "test" {
+  name              = "my-shopping-list.txt"
+  storage_share_url = azurerm_storage_share.test.url
+
+  source_content = <<-EOT
+My shopping list:
+* eggs
+* bananas
+* kiwis
+* milk tea
+EOT
+
+  metadata = {
+    hello = "world"
+  }
+}
+`, r.template(data))
 }
 
 func (r StorageShareFileResource) withPath(data acceptance.TestData) string {

--- a/website/docs/r/storage_share_file.html.markdown
+++ b/website/docs/r/storage_share_file.html.markdown
@@ -63,7 +63,7 @@ The following arguments are supported:
 
 * `content_md5` - (Optional) The MD5 sum of the file contents. Changing this forces a new resource to be created.
 
-~> **Note:** This property is intended to be used with the Terraform internal [filemd5](https://www.terraform.io/docs/configuration/functions/filemd5.html) and [md5](https://www.terraform.io/docs/configuration/functions/md5.html) functions when `source` is defined.
+~> **Note:** This property is intended to be used with the Terraform internal [filemd5](https://www.terraform.io/docs/configuration/functions/filemd5.html) function when `source` is defined, or the [md5](https://www.terraform.io/docs/configuration/functions/md5.html) function when `source_content` is defined.
 
 * `content_encoding` - (Optional) Specifies which content encodings have been applied to the file.
 

--- a/website/docs/r/storage_share_file.html.markdown
+++ b/website/docs/r/storage_share_file.html.markdown
@@ -59,6 +59,8 @@ The following arguments are supported:
 
 ~> **Note:** The content specified with `source_content` can not be empty.
 
+~> **Note:** The content specified with `source_content` is written to a temporary file on the local system before being uploaded, which may require sufficient available disk space for large content.
+
 * `content_type` - (Optional) The content type of the share file. Defaults to `application/octet-stream`.
 
 * `content_md5` - (Optional) The MD5 sum of the file contents. Changing this forces a new resource to be created.

--- a/website/docs/r/storage_share_file.html.markdown
+++ b/website/docs/r/storage_share_file.html.markdown
@@ -51,9 +51,13 @@ The following arguments are supported:
 
 * `path` - (Optional) The storage share directory that you would like the file placed into. Changing this forces a new resource to be created. Defaults to `""`.
 
-* `source` - (Optional) An absolute path to a file on the local system. Changing this forces a new resource to be created.
+* `source` - (Optional) An absolute path to a file on the local system. Changing this forces a new resource to be created. Conflicts with `source_content`.
 
 ~> **Note:** The file specified with `source` can not be empty.
+
+* `source_content` - (Optional) The content for this file specified inline. Changing this forces a new resource to be created. Conflicts with `source`.
+
+~> **Note:** The content specified with `source_content` can not be empty.
 
 * `content_type` - (Optional) The content type of the share file. Defaults to `application/octet-stream`.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Adds a new `source_content` argument to the `azurerm_storage_share_file` resource, allowing file contents to be defined inline in the Terraform configuration instead of only referencing a file on the local filesystem via `source`.

When `source_content` is set, the content is written to a temporary file which is then uploaded using the existing upload path (the underlying giovanni SDK `PutFile` helper requires an `*os.File`). The temporary file is cleaned up after the upload completes.

`source` and `source_content` are mutually exclusive (`ConflictsWith`), as a file has exactly one content source.

## Changes

- `internal/services/storage/storage_share_file_resource.go`
  - Added the `source_content` schema field (`Optional`, `ForceNew`), mutually exclusive with `source`.
  - Updated the create flow to write inline `source_content` to a temporary file and upload it via the existing `PutFile` path.
- `internal/services/storage/storage_share_file_resource_test.go`
  - Added `TestAccAzureRMStorageShareFile_withSourceContent` acceptance test.
- `website/docs/r/storage_share_file.html.markdown`
  - Documented the new `source_content` argument and its conflict with `source`.

## Acceptance Tests

```
$ make acctests SERVICE='storage' TESTARGS='-run=TestAccAzureRMStorageShareFile_' TESTTIMEOUT='60m'
```

All `TestAccAzureRMStorageShareFile_` tests pass, including the new `withSourceContent` test.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_storage_share_file` - support for inline content via source_content property [GH-9927]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #9927


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
