### PR TITLE
azurerm_palo_alto_local_rulestack_rule - support port ranges and `any` in `protocol`/`protocol_ports` validation

### DIFF
--- a/internal/services/paloalto/palo_alto_local_rulestack_rule_resource.go
+++ b/internal/services/paloalto/palo_alto_local_rulestack_rule_resource.go
@@ -153,12 +153,9 @@ func (r LocalRuleStackRule) Arguments() map[string]*pluginsdk.Schema {
 		},
 
 		"protocol": {
-			Type:     pluginsdk.TypeString,
-			Optional: true,
-			ValidateFunc: validation.Any(
-				validate.ProtocolWithPort,
-				validation.StringInSlice([]string{protocolApplicationDefault}, false),
-			),
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: validate.ProtocolWithPort,
 			ExactlyOneOf: []string{"protocol", "protocol_ports"},
 		},
 

--- a/internal/services/paloalto/validate/protocol.go
+++ b/internal/services/paloalto/validate/protocol.go
@@ -9,6 +9,10 @@ import (
 	"strings"
 )
 
+// protocolWithPortStandaloneValues are values that `ProtocolWithPort` accepts on their
+// own, without a `TCP:`/`UDP:` prefix.
+var protocolWithPortStandaloneValues = []string{"any", "application-default"}
+
 func ProtocolWithPort(input interface{}, k string) (warnings []string, errors []error) {
 	v, ok := input.(string)
 	if !ok {
@@ -16,9 +20,15 @@ func ProtocolWithPort(input interface{}, k string) (warnings []string, errors []
 		return
 	}
 
-	parts := strings.Split(v, ":")
+	for _, standalone := range protocolWithPortStandaloneValues {
+		if v == standalone {
+			return
+		}
+	}
+
+	parts := strings.SplitN(v, ":", 2)
 	if len(parts) != 2 {
-		errors = append(errors, fmt.Errorf("expected %s to be a two part string separated by a `:`, e.g. TCP:80", k))
+		errors = append(errors, fmt.Errorf("expected %s to be `any`, `application-default`, or a two part string separated by a `:`, e.g. `TCP:80` or `TCP:1024-1206`, got %q", k, v))
 		return
 	}
 
@@ -26,10 +36,43 @@ func ProtocolWithPort(input interface{}, k string) (warnings []string, errors []
 		errors = append(errors, fmt.Errorf("protocol portion of %s must be one of `TCP` or `UDP`, got %q", k, parts[0]))
 	}
 
-	port, err := strconv.Atoi(parts[1])
-	if err != nil || port == 0 || port > 65535 {
-		errors = append(errors, fmt.Errorf("port in %s must me an integer value between 1 and 65535, got %q", k, parts[1]))
+	if err := validatePortOrPortRange(parts[1]); err != nil {
+		errors = append(errors, fmt.Errorf("port portion of %s is invalid: %s", k, err))
 	}
 
 	return
+}
+
+// validatePortOrPortRange validates that input is either a single port (`80`) or an
+// increasing range of ports (`1024-1206`), with each bound between 1 and 65535.
+func validatePortOrPortRange(input string) error {
+	bounds := strings.SplitN(input, "-", 2)
+
+	start, err := parsePort(bounds[0])
+	if err != nil {
+		return err
+	}
+
+	if len(bounds) == 1 {
+		return nil
+	}
+
+	end, err := parsePort(bounds[1])
+	if err != nil {
+		return err
+	}
+
+	if start > end {
+		return fmt.Errorf("range %q must start at or before its end", input)
+	}
+
+	return nil
+}
+
+func parsePort(input string) (int, error) {
+	port, err := strconv.Atoi(input)
+	if err != nil || port < 1 || port > 65535 {
+		return 0, fmt.Errorf("must be an integer value between 1 and 65535, got %q", input)
+	}
+	return port, nil
 }

--- a/internal/services/paloalto/validate/protocol_test.go
+++ b/internal/services/paloalto/validate/protocol_test.go
@@ -1,0 +1,101 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package validate
+
+import "testing"
+
+func TestProtocolWithPort(t *testing.T) {
+	testCases := []struct {
+		Input    string
+		Expected bool
+	}{
+		{
+			Input:    "TCP:80",
+			Expected: true,
+		},
+		{
+			Input:    "UDP:53",
+			Expected: true,
+		},
+		{
+			Input:    "TCP:1",
+			Expected: true,
+		},
+		{
+			Input:    "TCP:65535",
+			Expected: true,
+		},
+		{
+			Input:    "any",
+			Expected: true,
+		},
+		{
+			Input:    "application-default",
+			Expected: true,
+		},
+		{
+			Input:    "TCP:1024-1206",
+			Expected: true,
+		},
+		{
+			Input:    "UDP:5000-5100",
+			Expected: true,
+		},
+		{
+			Input:    "TCP:80-80",
+			Expected: true,
+		},
+		{
+			Input:    "TCP:0",
+			Expected: false,
+		},
+		{
+			Input:    "TCP:65536",
+			Expected: false,
+		},
+		{
+			Input:    "TCP:abc",
+			Expected: false,
+		},
+		{
+			Input:    "TCP:1206-1024",
+			Expected: false,
+		},
+		{
+			Input:    "TCP:1024-70000",
+			Expected: false,
+		},
+		{
+			Input:    "TCP:1024-",
+			Expected: false,
+		},
+		{
+			Input:    "ICMP:80",
+			Expected: false,
+		},
+		{
+			Input:    "TCP",
+			Expected: false,
+		},
+		{
+			Input:    "TCP:80:90",
+			Expected: false,
+		},
+		{
+			Input:    "",
+			Expected: false,
+		},
+		{
+			Input:    "Any",
+			Expected: false,
+		},
+	}
+	for _, v := range testCases {
+		_, errors := ProtocolWithPort(v.Input, "protocol_ports")
+		result := len(errors) == 0
+		if result != v.Expected {
+			t.Fatalf("Expected the result for %q to be %t but got %t (and %d errors)", v.Input, v.Expected, result, len(errors))
+		}
+	}
+}

--- a/website/docs/r/palo_alto_local_rulestack_rule.html.markdown
+++ b/website/docs/r/palo_alto_local_rulestack_rule.html.markdown
@@ -84,11 +84,11 @@ The following arguments are supported:
 
 * `negate_source` - (Optional) Should the inverse of the Source configuration be used. Defaults to `false`.
 
-* `protocol` - (Optional) The Protocol and port to use in the form `[protocol]:[port_number]` e.g. `TCP:8080` or `UDP:53`. Conflicts with `protocol_ports`.
+* `protocol` - (Optional) The Protocol and port to use in the form `[protocol]:[port_number]` e.g. `TCP:8080` or `UDP:53`, a port range in the form `[protocol]:[start_port]-[end_port]` e.g. `TCP:1024-1206`, or one of `any` and `application-default`. Conflicts with `protocol_ports`.
 
 ~> **Note:** In 4.0 or later versions, the default of `protocol` will no longer be set by provider, exactly one of `protocol` and `protocol_ports` must be specified. You need to explicitly specify `protocol="application-default"` to keep the the current default of the `protocol`.
- 
-* `protocol_ports` - (Optional) Specifies a list of Protocol:Port entries. E.g. `[ "TCP:80", "UDP:5431" ]`. Conflicts with `protocol`.
+
+* `protocol_ports` - (Optional) Specifies a list of Protocol:Port entries. E.g. `[ "TCP:80", "UDP:5431" ]`. Each entry may also be a port range in the form `[protocol]:[start_port]-[end_port]` e.g. `TCP:1024-1206`, or one of `any` and `application-default`. Conflicts with `protocol`.
 
 * `tags` - (Optional) A mapping of tags which should be assigned to the Palo Alto Local Rulestack Rule.
 


### PR DESCRIPTION
This PR was written in part with the assistance of generative AI.

#### Community Note

* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review

#### Description

`ProtocolWithPort` (used to validate both the `protocol` and `protocol_ports` attributes on `azurerm_palo_alto_local_rulestack_rule`) rejected two forms of input that the Azure API and PAN Cloud NGFW both accept:

1. Port ranges, e.g. `TCP:1024-1206` — previously rejected because the port portion was parsed with `strconv.Atoi`, which only handles a single integer.
2. The standalone value `any` — the validator only special-cased `application-default` (via a wrapper on the `protocol` field), and didn't recognize `any` at all, nor did the `protocol_ports` field recognize `application-default`.

Without range support, users have to enumerate every individual port. For a rule covering a range like 1024-1206 plus a few extra ports, that can produce 180+ separate `TCP:NNNN` entries, which exceeds PAN's per-rule service limit (~128) and causes `apply` to fail with a confusing downstream error from the PAN backend, even though the underlying `protocolPortList` API field accepts range syntax directly.

Changes:
- `ProtocolWithPort` now accepts `any` and `application-default` as standalone values, and accepts `TCP:`/`UDP:` prefixed port ranges in addition to single ports.
- Simplified the `protocol` field's `ValidateFunc` to just `validate.ProtocolWithPort`, since `application-default` handling is now built into the validator (previously wrapped with `validation.Any(..., validation.StringInSlice(...))`).
- Added unit test coverage in `protocol_test.go` for valid/invalid single ports, ranges, and the standalone values.
- Updated the resource documentation to describe the newly accepted formats.

This is a client-side validation change only — no SDK/API changes are needed since Azure already accepts this syntax.

#### Related Issue(s)

Fixes #32139, fixes #25907

#### Change Log

* `azurerm_palo_alto_local_rulestack_rule` - support port ranges and `any` in the `protocol` and `protocol_ports` properties

- [x] Bug Fix
