### PR TITLE
5.0: `privatedns` - resolve TODO 4.0s

### DIFF
--- a/internal/services/containers/kubernetes_cluster_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_resource_test.go
@@ -1233,10 +1233,9 @@ resource "azurerm_private_dns_zone" "acr_private_dns_zone" {
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "dns_vnet_link_acr" {
-  name                  = "acctest-dns-vnet-link-acr"
-  private_dns_zone_name = azurerm_private_dns_zone.acr_private_dns_zone.name
-  resource_group_name   = azurerm_resource_group.test.name
-  virtual_network_id    = azurerm_virtual_network.vnet.id
+  name                = "acctest-dns-vnet-link-acr"
+  private_dns_zone_id = azurerm_private_dns_zone.acr_private_dns_zone.id
+  virtual_network_id  = azurerm_virtual_network.vnet.id
 }
 
 resource "azurerm_private_endpoint" "acr_private_endpoint" {

--- a/internal/services/databricks/databricks_workspace_private_endpoint_connection_data_source_test.go
+++ b/internal/services/databricks/databricks_workspace_private_endpoint_connection_data_source_test.go
@@ -172,8 +172,7 @@ resource "azurerm_private_dns_zone" "test" {
 
 resource "azurerm_private_dns_cname_record" "test" {
   name                = azurerm_databricks_workspace.test.workspace_url
-  zone_name           = azurerm_private_dns_zone.test.name
-  resource_group_name = azurerm_resource_group.test.name
+  private_dns_zone_id = azurerm_private_dns_zone.test.id
   ttl                 = 300
   record              = "eastus2-c2.azuredatabricks.net"
 }

--- a/internal/services/databricks/databricks_workspace_resource_test.go
+++ b/internal/services/databricks/databricks_workspace_resource_test.go
@@ -1960,8 +1960,7 @@ resource "azurerm_private_dns_zone" "test" {
 
 resource "azurerm_private_dns_cname_record" "test" {
   name                = azurerm_databricks_workspace.test.workspace_url
-  zone_name           = azurerm_private_dns_zone.test.name
-  resource_group_name = azurerm_resource_group.test.name
+  private_dns_zone_id = azurerm_private_dns_zone.test.id
   ttl                 = 300
   record              = "eastus2-c2.azuredatabricks.net"
 }
@@ -2952,8 +2951,7 @@ resource "azurerm_private_dns_zone" "test" {
 
 resource "azurerm_private_dns_cname_record" "test" {
   name                = azurerm_databricks_workspace.test.workspace_url
-  zone_name           = azurerm_private_dns_zone.test.name
-  resource_group_name = azurerm_resource_group.test.name
+  private_dns_zone_id = azurerm_private_dns_zone.test.id
   ttl                 = 300
   record              = "eastus2-c2.azuredatabricks.net"
 }

--- a/internal/services/machinelearning/machine_learning_compute_cluster_resource_test.go
+++ b/internal/services/machinelearning/machine_learning_compute_cluster_resource_test.go
@@ -627,10 +627,9 @@ resource "azurerm_private_dns_zone" "test" {
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "test" {
-  name                  = "test-vlink"
-  resource_group_name   = azurerm_resource_group.test.name
-  private_dns_zone_name = azurerm_private_dns_zone.test.name
-  virtual_network_id    = azurerm_virtual_network.test.id
+  name                = "test-vlink"
+  private_dns_zone_id = azurerm_private_dns_zone.test.id
+  virtual_network_id  = azurerm_virtual_network.test.id
 }
 
 resource "azurerm_private_endpoint" "test" {

--- a/internal/services/machinelearning/machine_learning_compute_instance_resource_test.go
+++ b/internal/services/machinelearning/machine_learning_compute_instance_resource_test.go
@@ -205,10 +205,9 @@ resource "azurerm_private_dns_zone" "test" {
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "test" {
-  name                  = "test-vlink"
-  resource_group_name   = azurerm_resource_group.test.name
-  private_dns_zone_name = azurerm_private_dns_zone.test.name
-  virtual_network_id    = azurerm_virtual_network.test.id
+  name                = "test-vlink"
+  private_dns_zone_id = azurerm_private_dns_zone.test.id
+  virtual_network_id  = azurerm_virtual_network.test.id
 }
 
 resource "azurerm_private_endpoint" "test" {

--- a/internal/services/mysql/mysql_flexible_server_resource_test.go
+++ b/internal/services/mysql/mysql_flexible_server_resource_test.go
@@ -789,10 +789,9 @@ resource "azurerm_private_dns_zone" "test" {
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "test" {
-  name                  = "acctestVnetZone%[2]d.com"
-  private_dns_zone_name = azurerm_private_dns_zone.test.name
-  virtual_network_id    = azurerm_virtual_network.test.id
-  resource_group_name   = azurerm_resource_group.test.name
+  name                = "acctestVnetZone%[2]d.com"
+  private_dns_zone_id = azurerm_private_dns_zone.test.id
+  virtual_network_id  = azurerm_virtual_network.test.id
 
   depends_on = [azurerm_subnet.test]
 }
@@ -875,10 +874,9 @@ resource "azurerm_private_dns_zone" "test" {
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "test" {
-  name                  = "acctestVnetZone%[2]d.com"
-  private_dns_zone_name = azurerm_private_dns_zone.test.name
-  virtual_network_id    = azurerm_virtual_network.test.id
-  resource_group_name   = azurerm_resource_group.test.name
+  name                = "acctestVnetZone%[2]d.com"
+  private_dns_zone_id = azurerm_private_dns_zone.test.id
+  virtual_network_id  = azurerm_virtual_network.test.id
 
   depends_on = [azurerm_subnet.test]
 }

--- a/internal/services/postgres/postgresql_flexible_server_resource_test.go
+++ b/internal/services/postgres/postgresql_flexible_server_resource_test.go
@@ -996,10 +996,9 @@ resource "azurerm_private_dns_zone" "test" {
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "test" {
-  name                  = "acctestVnetZone%[2]d.com"
-  private_dns_zone_name = azurerm_private_dns_zone.test.name
-  virtual_network_id    = azurerm_virtual_network.test.id
-  resource_group_name   = azurerm_resource_group.test.name
+  name                = "acctestVnetZone%[2]d.com"
+  private_dns_zone_id = azurerm_private_dns_zone.test.id
+  virtual_network_id  = azurerm_virtual_network.test.id
 
   depends_on = [azurerm_subnet.test]
 }
@@ -1073,10 +1072,9 @@ resource "azurerm_private_dns_zone" "test" {
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "test" {
-  name                  = "acctestVnetZone%[2]d.com"
-  private_dns_zone_name = azurerm_private_dns_zone.test.name
-  virtual_network_id    = azurerm_virtual_network.test.id
-  resource_group_name   = azurerm_resource_group.test.name
+  name                = "acctestVnetZone%[2]d.com"
+  private_dns_zone_id = azurerm_private_dns_zone.test.id
+  virtual_network_id  = azurerm_virtual_network.test.id
 
   depends_on = [azurerm_subnet.test]
 }

--- a/internal/services/postgres/postgresql_flexible_server_virtual_endpoint_resource_test.go
+++ b/internal/services/postgres/postgresql_flexible_server_virtual_endpoint_resource_test.go
@@ -340,10 +340,9 @@ resource "azurerm_virtual_network_peering" "primary" {
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "primary" {
-  name                  = "acctest%[1]d-primary-pdzvnetlink.com"
-  private_dns_zone_name = azurerm_private_dns_zone.primary.name
-  virtual_network_id    = azurerm_virtual_network.primary.id
-  resource_group_name   = azurerm_resource_group.primary.name
+  name                = "acctest%[1]d-primary-pdzvnetlink.com"
+  private_dns_zone_id = azurerm_private_dns_zone.primary.id
+  virtual_network_id  = azurerm_virtual_network.primary.id
 
   depends_on = [azurerm_virtual_network_peering.primary]
 }
@@ -451,10 +450,9 @@ resource "azurerm_virtual_network_peering" "secondary" {
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "secondary" {
-  name                  = "acctest%[1]d-secondary-pdzvnetlink.com"
-  private_dns_zone_name = azurerm_private_dns_zone.secondary.name
-  virtual_network_id    = azurerm_virtual_network.secondary.id
-  resource_group_name   = azurerm_resource_group.secondary.name
+  name                = "acctest%[1]d-secondary-pdzvnetlink.com"
+  private_dns_zone_id = azurerm_private_dns_zone.secondary.id
+  virtual_network_id  = azurerm_virtual_network.secondary.id
 
   depends_on = [azurerm_virtual_network_peering.secondary]
 }

--- a/internal/services/privatedns/private_dns_a_record_resource.go
+++ b/internal/services/privatedns/private_dns_a_record_resource.go
@@ -13,17 +13,16 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/privatedns/2024-06-01/privatedns"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/privatedns/2024-06-01/privatezones"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/privatedns/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
 
-//go:generate go run ../../tools/generator-tests resourceidentity -resource-name private_dns_a_record -properties "name,private_dns_zone_name:zone_name,resource_group_name" -compare-values "record_type:id"
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name private_dns_a_record -properties "name" -compare-values "subscription_id:private_dns_zone_id,resource_group_name:private_dns_zone_id,private_dns_zone_name:private_dns_zone_id,record_type:id"
 
 func resourcePrivateDnsARecord() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
@@ -47,23 +46,17 @@ func resourcePrivateDnsARecord() *pluginsdk.Resource {
 
 		Schema: map[string]*pluginsdk.Schema{
 			"name": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-				ForceNew: true,
-				// lower-cased due to the broken API https://github.com/Azure/azure-rest-api-specs/issues/6641
-				ValidateFunc: validate.LowerCasedString,
-			},
-
-			// TODO: in 4.0 make `name` case sensitive and replace `resource_group_name` and `zone_name` with `private_zone_id`
-
-			// TODO: make this case sensitive once the API's fixed https://github.com/Azure/azure-rest-api-specs/issues/6641
-			"resource_group_name": azure.SchemaResourceGroupNameDiffSuppress(),
-
-			"zone_name": {
 				Type:         pluginsdk.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringIsNotEmpty,
+				ValidateFunc: validation.StringIsNotWhiteSpace,
+			},
+
+			"private_dns_zone_id": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: privatezones.ValidatePrivateDnsZoneID,
 			},
 
 			"records": {
@@ -89,7 +82,7 @@ func resourcePrivateDnsARecord() *pluginsdk.Resource {
 	}
 }
 
-func resourcePrivateDnsARecordImporter(ctx context.Context, d *pluginsdk.ResourceData, meta interface{}) ([]*pluginsdk.ResourceData, error) {
+func resourcePrivateDnsARecordImporter(_ context.Context, d *pluginsdk.ResourceData, _ interface{}) ([]*pluginsdk.ResourceData, error) {
 	resourceId, err := privatedns.ParseRecordTypeID(d.Id())
 	if err != nil {
 		return []*pluginsdk.ResourceData{d}, err
@@ -102,11 +95,16 @@ func resourcePrivateDnsARecordImporter(ctx context.Context, d *pluginsdk.Resourc
 
 func resourcePrivateDnsARecordCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).PrivateDns.RecordSetsClient
-	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id := privatedns.NewRecordTypeID(subscriptionId, d.Get("resource_group_name").(string), d.Get("zone_name").(string), privatedns.RecordTypeA, d.Get("name").(string))
+	privateDNSZoneID, err := privatezones.ParsePrivateDnsZoneID(d.Get("private_dns_zone_id").(string))
+	if err != nil {
+		return err
+	}
+
+	id := privatedns.NewRecordTypeID(privateDNSZoneID.SubscriptionId, privateDNSZoneID.ResourceGroupName, privateDNSZoneID.PrivateDnsZoneName, privatedns.RecordTypeA, d.Get("name").(string))
 	if d.IsNewResource() {
 		if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
 			existing, err := client.RecordSetsGet(ctx, id)
@@ -172,8 +170,7 @@ func resourcePrivateDnsARecordRead(d *pluginsdk.ResourceData, meta interface{}) 
 
 func resourcePrivateDnsARecordFlatten(d *pluginsdk.ResourceData, id *privatedns.RecordTypeId, model *privatedns.RecordSet) error {
 	d.Set("name", id.RelativeRecordSetName)
-	d.Set("zone_name", id.PrivateDnsZoneName)
-	d.Set("resource_group_name", id.ResourceGroupName)
+	d.Set("private_dns_zone_id", privatezones.NewPrivateDnsZoneID(id.SubscriptionId, id.ResourceGroupName, id.PrivateDnsZoneName).ID())
 
 	if model != nil {
 		if props := model.Properties; props != nil {

--- a/internal/services/privatedns/private_dns_a_record_resource_identity_gen_test.go
+++ b/internal/services/privatedns/private_dns_a_record_resource_identity_gen_test.go
@@ -6,7 +6,6 @@ package privatedns_test
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
@@ -18,11 +17,11 @@ func TestAccPrivateDnsARecord_resourceIdentity(t *testing.T) {
 	r := PrivateDnsARecordResource{}
 
 	checkedFields := map[string]struct{}{
-		"subscription_id":       {},
 		"name":                  {},
 		"private_dns_zone_name": {},
-		"resource_group_name":   {},
 		"record_type":           {},
+		"resource_group_name":   {},
+		"subscription_id":       {},
 	}
 
 	data.ResourceIdentityTest(t, []acceptance.TestStep{
@@ -30,11 +29,11 @@ func TestAccPrivateDnsARecord_resourceIdentity(t *testing.T) {
 			Config: r.basic(data),
 			ConfigStateChecks: []statecheck.StateCheck{
 				customstatecheck.ExpectAllIdentityFieldsAreChecked("azurerm_private_dns_a_record.test", checkedFields),
-				statecheck.ExpectIdentityValue("azurerm_private_dns_a_record.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
 				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_private_dns_a_record.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_private_dns_a_record.test", tfjsonpath.New("private_dns_zone_name"), tfjsonpath.New("zone_name")),
-				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_private_dns_a_record.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_private_dns_a_record.test", tfjsonpath.New("private_dns_zone_name"), tfjsonpath.New("private_dns_zone_id")),
 				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_private_dns_a_record.test", tfjsonpath.New("record_type"), tfjsonpath.New("id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_private_dns_a_record.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("private_dns_zone_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_private_dns_a_record.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("private_dns_zone_id")),
 			},
 		},
 		data.ImportBlockWithResourceIdentityStep(false),

--- a/internal/services/privatedns/private_dns_a_record_resource_list.go
+++ b/internal/services/privatedns/private_dns_a_record_resource_list.go
@@ -92,7 +92,7 @@ func (r PrivateDnsARecordListResource) List(ctx context.Context, request list.Li
 
 			id, err := privatedns.ParseRecordTypeID(pointer.From(arecord.Id))
 			if err != nil {
-				sdk.SetErrorDiagnosticAndPushListResult(result, push, "parsing PrivateDns ARecord ID", err)
+				sdk.SetErrorDiagnosticAndPushListResult(result, push, "parsing Private DNS A Record ID", err)
 				return
 			}
 

--- a/internal/services/privatedns/private_dns_a_record_resource_list_test.go
+++ b/internal/services/privatedns/private_dns_a_record_resource_list_test.go
@@ -30,7 +30,7 @@ func TestAccPrivateDnsARecord_listByPrivateDnsZoneID(t *testing.T) {
 			},
 			{
 				Query:  true,
-				Config: r.basicQuery(data),
+				Config: r.basicQuery(),
 				QueryResultChecks: []querycheck.QueryResultCheck{
 					querycheck.ExpectLengthAtLeast("azurerm_private_dns_a_record.list", 1),
 					querycheck.ExpectIdentity(
@@ -49,7 +49,7 @@ func TestAccPrivateDnsARecord_listByPrivateDnsZoneID(t *testing.T) {
 	})
 }
 
-func (r PrivateDnsARecordResource) basicQuery(data acceptance.TestData) string {
+func (r PrivateDnsARecordResource) basicQuery() string {
 	return `
 list "azurerm_private_dns_a_record" "list" {
   provider = azurerm

--- a/internal/services/privatedns/private_dns_a_record_resource_test.go
+++ b/internal/services/privatedns/private_dns_a_record_resource_test.go
@@ -91,7 +91,7 @@ func TestAccPrivateDnsARecord_withTags(t *testing.T) {
 	})
 }
 
-func (t PrivateDnsARecordResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+func (r PrivateDnsARecordResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := privatedns.ParseRecordTypeID(state.ID)
 	if err != nil {
 		return nil, err
@@ -112,33 +112,31 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_private_dns_zone" "test" {
-  name                = "acctestzone%d.com"
+  name                = "acctestzone%[1]d.com"
   resource_group_name = azurerm_resource_group.test.name
 }
 
 resource "azurerm_private_dns_a_record" "test" {
-  name                = "myarecord%d"
-  resource_group_name = azurerm_resource_group.test.name
-  zone_name           = azurerm_private_dns_zone.test.name
+  name                = "myarecord%[1]d"
+  private_dns_zone_id = azurerm_private_dns_zone.test.id
   ttl                 = 300
   records             = ["1.2.3.4", "1.2.4.5"]
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func (r PrivateDnsARecordResource) requiresImport(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "azurerm_private_dns_a_record" "import" {
   name                = azurerm_private_dns_a_record.test.name
-  resource_group_name = azurerm_private_dns_a_record.test.resource_group_name
-  zone_name           = azurerm_private_dns_a_record.test.zone_name
+  private_dns_zone_id = azurerm_private_dns_a_record.test.private_dns_zone_id
   ttl                 = 300
   records             = ["1.2.3.4", "1.2.4.5"]
 }
@@ -152,23 +150,22 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_private_dns_zone" "test" {
-  name                = "acctestzone%d.com"
+  name                = "acctestzone%[1]d.com"
   resource_group_name = azurerm_resource_group.test.name
 }
 
 resource "azurerm_private_dns_a_record" "test" {
-  name                = "myarecord%d"
-  resource_group_name = azurerm_resource_group.test.name
-  zone_name           = azurerm_private_dns_zone.test.name
+  name                = "myarecord%[1]d"
+  private_dns_zone_id = azurerm_private_dns_zone.test.id
   ttl                 = 300
   records             = ["1.2.3.4", "1.2.4.5", "1.2.3.7"]
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func (PrivateDnsARecordResource) withTags(data acceptance.TestData) string {
@@ -178,19 +175,18 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_private_dns_zone" "test" {
-  name                = "acctestzone%d.com"
+  name                = "acctestzone%[1]d.com"
   resource_group_name = azurerm_resource_group.test.name
 }
 
 resource "azurerm_private_dns_a_record" "test" {
-  name                = "myarecord%d"
-  resource_group_name = azurerm_resource_group.test.name
-  zone_name           = azurerm_private_dns_zone.test.name
+  name                = "myarecord%[1]d"
+  private_dns_zone_id = azurerm_private_dns_zone.test.id
   ttl                 = 300
   records             = ["1.2.3.4", "1.2.4.5"]
 
@@ -199,7 +195,7 @@ resource "azurerm_private_dns_a_record" "test" {
     cost_center = "MSFT"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func (PrivateDnsARecordResource) withTagsUpdate(data acceptance.TestData) string {
@@ -209,19 +205,18 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_private_dns_zone" "test" {
-  name                = "acctestzone%d.com"
+  name                = "acctestzone%[1]d.com"
   resource_group_name = azurerm_resource_group.test.name
 }
 
 resource "azurerm_private_dns_a_record" "test" {
-  name                = "myarecord%d"
-  resource_group_name = azurerm_resource_group.test.name
-  zone_name           = azurerm_private_dns_zone.test.name
+  name                = "myarecord%[1]d"
+  private_dns_zone_id = azurerm_private_dns_zone.test.id
   ttl                 = 300
   records             = ["1.2.3.4", "1.2.4.5"]
 
@@ -229,5 +224,5 @@ resource "azurerm_private_dns_a_record" "test" {
     environment = "staging"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary)
 }

--- a/internal/services/privatedns/private_dns_aaaa_record_resource.go
+++ b/internal/services/privatedns/private_dns_aaaa_record_resource.go
@@ -12,11 +12,10 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/privatedns/2024-06-01/privatedns"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/privatedns/2024-06-01/privatezones"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
 
@@ -51,16 +50,11 @@ func resourcePrivateDnsAaaaRecord() *pluginsdk.Resource {
 				ForceNew: true,
 			},
 
-			// TODO: in 4.0 make `name` case sensitive and replace `resource_group_name` and `zone_name` with `private_zone_id`
-
-			// TODO: make this case sensitive once the API's fixed https://github.com/Azure/azure-rest-api-specs/issues/6641
-			"resource_group_name": azure.SchemaResourceGroupNameDiffSuppress(),
-
-			"zone_name": {
+			"private_dns_zone_id": {
 				Type:         pluginsdk.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringIsNotEmpty,
+				ValidateFunc: privatezones.ValidatePrivateDnsZoneID,
 			},
 
 			"records": {
@@ -87,11 +81,16 @@ func resourcePrivateDnsAaaaRecord() *pluginsdk.Resource {
 
 func resourcePrivateDnsAaaaRecordCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).PrivateDns.RecordSetsClient
-	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id := privatedns.NewRecordTypeID(subscriptionId, d.Get("resource_group_name").(string), d.Get("zone_name").(string), privatedns.RecordTypeAAAA, d.Get("name").(string))
+	privateDNSZoneID, err := privatezones.ParsePrivateDnsZoneID(d.Get("private_dns_zone_id").(string))
+	if err != nil {
+		return err
+	}
+
+	id := privatedns.NewRecordTypeID(privateDNSZoneID.SubscriptionId, privateDNSZoneID.ResourceGroupName, privateDNSZoneID.PrivateDnsZoneName, privatedns.RecordTypeAAAA, d.Get("name").(string))
 
 	if d.IsNewResource() {
 		if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
@@ -152,8 +151,7 @@ func resourcePrivateDnsAaaaRecordRead(d *pluginsdk.ResourceData, meta interface{
 	}
 
 	d.Set("name", id.RelativeRecordSetName)
-	d.Set("zone_name", id.PrivateDnsZoneName)
-	d.Set("resource_group_name", id.ResourceGroupName)
+	d.Set("private_dns_zone_id", privatezones.NewPrivateDnsZoneID(id.SubscriptionId, id.ResourceGroupName, id.PrivateDnsZoneName).ID())
 
 	if model := resp.Model; model != nil {
 		if props := model.Properties; props != nil {

--- a/internal/services/privatedns/private_dns_aaaa_record_resource_test.go
+++ b/internal/services/privatedns/private_dns_aaaa_record_resource_test.go
@@ -91,7 +91,7 @@ func TestAccPrivateDnsAaaaRecord_withTags(t *testing.T) {
 	})
 }
 
-func (t PrivateDnsAAAARecordResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+func (r PrivateDnsAAAARecordResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := privatedns.ParseRecordTypeID(state.ID)
 	if err != nil {
 		return nil, err
@@ -123,8 +123,7 @@ resource "azurerm_private_dns_zone" "test" {
 
 resource "azurerm_private_dns_aaaa_record" "test" {
   name                = "myaaaarecord%d"
-  resource_group_name = azurerm_resource_group.test.name
-  zone_name           = azurerm_private_dns_zone.test.name
+  private_dns_zone_id = azurerm_private_dns_zone.test.id
   ttl                 = 300
   records             = ["fd5d:70bc:930e:d008:0000:0000:0000:7334", "fd5d:70bc:930e:d008::7335"]
 }
@@ -137,8 +136,7 @@ func (r PrivateDnsAAAARecordResource) requiresImport(data acceptance.TestData) s
 
 resource "azurerm_private_dns_aaaa_record" "import" {
   name                = azurerm_private_dns_aaaa_record.test.name
-  resource_group_name = azurerm_private_dns_aaaa_record.test.resource_group_name
-  zone_name           = azurerm_private_dns_aaaa_record.test.zone_name
+  private_dns_zone_id = azurerm_private_dns_aaaa_record.test.private_dns_zone_id
   ttl                 = 300
   records             = ["fd5d:70bc:930e:d008:0000:0000:0000:7334", "fd5d:70bc:930e:d008::7335"]
 }
@@ -163,8 +161,7 @@ resource "azurerm_private_dns_zone" "test" {
 
 resource "azurerm_private_dns_aaaa_record" "test" {
   name                = "myaaaarecord%d"
-  resource_group_name = azurerm_resource_group.test.name
-  zone_name           = azurerm_private_dns_zone.test.name
+  private_dns_zone_id = azurerm_private_dns_zone.test.id
   ttl                 = 300
   records             = ["fd5d:70bc:930e:d008:0000:0000:0000:7334", "fd5d:70bc:930e:d008::7335", "fd73:5e76:3ab5:d2e9::1"]
 }
@@ -189,8 +186,7 @@ resource "azurerm_private_dns_zone" "test" {
 
 resource "azurerm_private_dns_aaaa_record" "test" {
   name                = "myaaaarecord%d"
-  resource_group_name = azurerm_resource_group.test.name
-  zone_name           = azurerm_private_dns_zone.test.name
+  private_dns_zone_id = azurerm_private_dns_zone.test.id
   ttl                 = 300
   records             = ["fd5d:70bc:930e:d008:0000:0000:0000:7334", "fd5d:70bc:930e:d008::7335"]
 
@@ -220,8 +216,7 @@ resource "azurerm_private_dns_zone" "test" {
 
 resource "azurerm_private_dns_aaaa_record" "test" {
   name                = "myaaaarecord%d"
-  resource_group_name = azurerm_resource_group.test.name
-  zone_name           = azurerm_private_dns_zone.test.name
+  private_dns_zone_id = azurerm_private_dns_zone.test.id
   ttl                 = 300
   records             = ["fd5d:70bc:930e:d008:0000:0000:0000:7334", "fd5d:70bc:930e:d008::7335"]
 

--- a/internal/services/privatedns/private_dns_cname_record_resource.go
+++ b/internal/services/privatedns/private_dns_cname_record_resource.go
@@ -14,17 +14,16 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/privatedns/2024-06-01/privatedns"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/privatedns/2024-06-01/privatezones"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/privatedns/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
 
-//go:generate go run ../../tools/generator-tests resourceidentity -resource-name private_dns_cname_record -properties "name,private_dns_zone_name:zone_name,resource_group_name" -compare-values "record_type:id"
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name private_dns_cname_record -properties "name" -compare-values "subscription_id:private_dns_zone_id,resource_group_name:private_dns_zone_id,private_dns_zone_name:private_dns_zone_id,record_type:id"
 
 const azurePrivateDnsCNameRecordResourceName = "azurerm_private_dns_cname_record"
 
@@ -50,23 +49,17 @@ func resourcePrivateDnsCNameRecord() *pluginsdk.Resource {
 
 		Schema: map[string]*pluginsdk.Schema{
 			"name": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-				ForceNew: true,
-				// lower-cased due to the broken API https://github.com/Azure/azure-rest-api-specs/issues/6641
-				ValidateFunc: validate.LowerCasedString,
-			},
-
-			// TODO: in 4.0 make `name` case sensitive and replace `resource_group_name` and `zone_name` with `private_zone_id`
-
-			// TODO: make this case sensitive once the API's fixed https://github.com/Azure/azure-rest-api-specs/issues/6641
-			"resource_group_name": azure.SchemaResourceGroupNameDiffSuppress(),
-
-			"zone_name": {
 				Type:         pluginsdk.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringIsNotEmpty,
+				ValidateFunc: validation.StringIsNotWhiteSpace,
+			},
+
+			"private_dns_zone_id": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: privatezones.ValidatePrivateDnsZoneID,
 			},
 
 			"record": {
@@ -91,7 +84,7 @@ func resourcePrivateDnsCNameRecord() *pluginsdk.Resource {
 	}
 }
 
-func resourcePrivateDnsCNameRecordImporter(ctx context.Context, d *pluginsdk.ResourceData, meta interface{}) ([]*pluginsdk.ResourceData, error) {
+func resourcePrivateDnsCNameRecordImporter(_ context.Context, d *pluginsdk.ResourceData, _ interface{}) ([]*pluginsdk.ResourceData, error) {
 	resourceId, err := privatedns.ParseRecordTypeID(d.Id())
 	if err != nil {
 		return []*pluginsdk.ResourceData{d}, err
@@ -104,11 +97,16 @@ func resourcePrivateDnsCNameRecordImporter(ctx context.Context, d *pluginsdk.Res
 
 func resourcePrivateDnsCNameRecordCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).PrivateDns.RecordSetsClient
-	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id := privatedns.NewRecordTypeID(subscriptionId, d.Get("resource_group_name").(string), d.Get("zone_name").(string), privatedns.RecordTypeCNAME, d.Get("name").(string))
+	privateDNSZoneID, err := privatezones.ParsePrivateDnsZoneID(d.Get("private_dns_zone_id").(string))
+	if err != nil {
+		return err
+	}
+
+	id := privatedns.NewRecordTypeID(privateDNSZoneID.SubscriptionId, privateDNSZoneID.ResourceGroupName, privateDNSZoneID.PrivateDnsZoneName, privatedns.RecordTypeCNAME, d.Get("name").(string))
 
 	if d.IsNewResource() {
 		if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
@@ -178,8 +176,7 @@ func resourcePrivateDnsCNameRecordRead(d *pluginsdk.ResourceData, meta interface
 
 func resourcePrivateDnsCNameRecordFlatten(d *pluginsdk.ResourceData, id *privatedns.RecordTypeId, model *privatedns.RecordSet) error {
 	d.Set("name", id.RelativeRecordSetName)
-	d.Set("zone_name", id.PrivateDnsZoneName)
-	d.Set("resource_group_name", id.ResourceGroupName)
+	d.Set("private_dns_zone_id", privatezones.NewPrivateDnsZoneID(id.SubscriptionId, id.ResourceGroupName, id.PrivateDnsZoneName).ID())
 
 	if model != nil {
 		if props := model.Properties; props != nil {

--- a/internal/services/privatedns/private_dns_cname_record_resource_identity_gen_test.go
+++ b/internal/services/privatedns/private_dns_cname_record_resource_identity_gen_test.go
@@ -6,7 +6,6 @@ package privatedns_test
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
@@ -18,11 +17,11 @@ func TestAccPrivateDnsCnameRecord_resourceIdentity(t *testing.T) {
 	r := PrivateDnsCnameRecordResource{}
 
 	checkedFields := map[string]struct{}{
-		"subscription_id":       {},
 		"name":                  {},
 		"private_dns_zone_name": {},
-		"resource_group_name":   {},
 		"record_type":           {},
+		"resource_group_name":   {},
+		"subscription_id":       {},
 	}
 
 	data.ResourceIdentityTest(t, []acceptance.TestStep{
@@ -30,11 +29,11 @@ func TestAccPrivateDnsCnameRecord_resourceIdentity(t *testing.T) {
 			Config: r.basic(data),
 			ConfigStateChecks: []statecheck.StateCheck{
 				customstatecheck.ExpectAllIdentityFieldsAreChecked("azurerm_private_dns_cname_record.test", checkedFields),
-				statecheck.ExpectIdentityValue("azurerm_private_dns_cname_record.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
 				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_private_dns_cname_record.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_private_dns_cname_record.test", tfjsonpath.New("private_dns_zone_name"), tfjsonpath.New("zone_name")),
-				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_private_dns_cname_record.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_private_dns_cname_record.test", tfjsonpath.New("private_dns_zone_name"), tfjsonpath.New("private_dns_zone_id")),
 				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_private_dns_cname_record.test", tfjsonpath.New("record_type"), tfjsonpath.New("id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_private_dns_cname_record.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("private_dns_zone_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_private_dns_cname_record.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("private_dns_zone_id")),
 			},
 		},
 		data.ImportBlockWithResourceIdentityStep(false),

--- a/internal/services/privatedns/private_dns_cname_record_resource_list_test.go
+++ b/internal/services/privatedns/private_dns_cname_record_resource_list_test.go
@@ -30,7 +30,7 @@ func TestAccPrivateDnsCNameRecord_listByPrivateDnsZoneID(t *testing.T) {
 			},
 			{
 				Query:  true,
-				Config: r.basicQuery(data),
+				Config: r.basicQuery(),
 				QueryResultChecks: []querycheck.QueryResultCheck{
 					querycheck.ExpectLengthAtLeast("azurerm_private_dns_cname_record.list", 1),
 					querycheck.ExpectIdentity(
@@ -49,7 +49,7 @@ func TestAccPrivateDnsCNameRecord_listByPrivateDnsZoneID(t *testing.T) {
 	})
 }
 
-func (r PrivateDnsCnameRecordResource) basicQuery(data acceptance.TestData) string {
+func (r PrivateDnsCnameRecordResource) basicQuery() string {
 	return `
 list "azurerm_private_dns_cname_record" "list" {
   provider = azurerm

--- a/internal/services/privatedns/private_dns_cname_record_resource_test.go
+++ b/internal/services/privatedns/private_dns_cname_record_resource_test.go
@@ -103,7 +103,7 @@ func TestAccPrivateDnsCNameRecord_withTags(t *testing.T) {
 	})
 }
 
-func (t PrivateDnsCnameRecordResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+func (r PrivateDnsCnameRecordResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := privatedns.ParseRecordTypeID(state.ID)
 	if err != nil {
 		return nil, err
@@ -124,33 +124,31 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_private_dns_zone" "test" {
-  name                = "acctestzone%d.com"
+  name                = "acctestzone%[1]d.com"
   resource_group_name = azurerm_resource_group.test.name
 }
 
 resource "azurerm_private_dns_cname_record" "test" {
-  name                = "acctestcname%d"
-  resource_group_name = azurerm_resource_group.test.name
-  zone_name           = azurerm_private_dns_zone.test.name
+  name                = "acctestcname%[1]d"
+  private_dns_zone_id = azurerm_private_dns_zone.test.id
   ttl                 = 300
   record              = "contoso.com"
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func (r PrivateDnsCnameRecordResource) requiresImport(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "azurerm_private_dns_cname_record" "import" {
   name                = azurerm_private_dns_cname_record.test.name
-  resource_group_name = azurerm_private_dns_cname_record.test.resource_group_name
-  zone_name           = azurerm_private_dns_cname_record.test.zone_name
+  private_dns_zone_id = azurerm_private_dns_cname_record.test.private_dns_zone_id
   ttl                 = 300
   record              = "contoso.com"
 }
@@ -164,23 +162,22 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_private_dns_zone" "test" {
-  name                = "acctestzone%d.com"
+  name                = "acctestzone%[1]d.com"
   resource_group_name = azurerm_resource_group.test.name
 }
 
 resource "azurerm_private_dns_cname_record" "test" {
-  name                = "acctestcname%d"
-  resource_group_name = azurerm_resource_group.test.name
-  zone_name           = azurerm_private_dns_zone.test.name
+  name                = "acctestcname%[1]d"
+  private_dns_zone_id = azurerm_private_dns_zone.test.id
   ttl                 = 0
   record              = "test.contoso.com"
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func (PrivateDnsCnameRecordResource) updateRecords(data acceptance.TestData) string {
@@ -190,23 +187,22 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_private_dns_zone" "test" {
-  name                = "acctestzone%d.com"
+  name                = "acctestzone%[1]d.com"
   resource_group_name = azurerm_resource_group.test.name
 }
 
 resource "azurerm_private_dns_cname_record" "test" {
-  name                = "acctestcname%d"
-  resource_group_name = azurerm_resource_group.test.name
-  zone_name           = azurerm_private_dns_zone.test.name
+  name                = "acctestcname%[1]d"
+  private_dns_zone_id = azurerm_private_dns_zone.test.id
   ttl                 = 300
   record              = "contoso.com"
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func (PrivateDnsCnameRecordResource) withTags(data acceptance.TestData) string {
@@ -216,19 +212,18 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_private_dns_zone" "test" {
-  name                = "acctestzone%d.com"
+  name                = "acctestzone%[1]d.com"
   resource_group_name = azurerm_resource_group.test.name
 }
 
 resource "azurerm_private_dns_cname_record" "test" {
-  name                = "acctestcname%d"
-  resource_group_name = azurerm_resource_group.test.name
-  zone_name           = azurerm_private_dns_zone.test.name
+  name                = "acctestcname%[1]d"
+  private_dns_zone_id = azurerm_private_dns_zone.test.id
   ttl                 = 300
   record              = "contoso.com"
 
@@ -237,7 +232,7 @@ resource "azurerm_private_dns_cname_record" "test" {
     cost_center = "MSFT"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func (PrivateDnsCnameRecordResource) withTagsUpdate(data acceptance.TestData) string {
@@ -247,19 +242,18 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_private_dns_zone" "test" {
-  name                = "acctestzone%d.com"
+  name                = "acctestzone%[1]d.com"
   resource_group_name = azurerm_resource_group.test.name
 }
 
 resource "azurerm_private_dns_cname_record" "test" {
-  name                = "acctestcname%d"
-  resource_group_name = azurerm_resource_group.test.name
-  zone_name           = azurerm_private_dns_zone.test.name
+  name                = "acctestcname%[1]d"
+  private_dns_zone_id = azurerm_private_dns_zone.test.id
   ttl                 = 300
   record              = "contoso.com"
 
@@ -267,5 +261,5 @@ resource "azurerm_private_dns_cname_record" "test" {
     environment = "staging"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary)
 }

--- a/internal/services/privatedns/private_dns_mx_record_resource.go
+++ b/internal/services/privatedns/private_dns_mx_record_resource.go
@@ -14,10 +14,9 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/privatedns/2024-06-01/privatedns"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/privatedns/2024-06-01/privatezones"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/privatedns/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
@@ -52,22 +51,16 @@ func resourcePrivateDnsMxRecord() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeString,
 				ForceNew: true,
 				// name is optional and defaults to root zone (@) if not set
-				Optional: true,
-				Default:  "@",
-				// lower-cased due to the broken API https://github.com/Azure/azure-rest-api-specs/issues/6641
-				ValidateFunc: validate.LowerCasedString,
+				Optional:     true,
+				Default:      "@",
+				ValidateFunc: validation.StringIsNotWhiteSpace,
 			},
 
-			// TODO: in 4.0 make `name` case sensitive and replace `resource_group_name` and `zone_name` with `private_zone_id`
-
-			// TODO: make this case sensitive once the API's fixed https://github.com/Azure/azure-rest-api-specs/issues/6641
-			"resource_group_name": azure.SchemaResourceGroupNameDiffSuppress(),
-
-			"zone_name": {
+			"private_dns_zone_id": {
 				Type:         pluginsdk.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringIsNotEmpty,
+				ValidateFunc: privatezones.ValidatePrivateDnsZoneID,
 			},
 
 			"record": {
@@ -108,11 +101,17 @@ func resourcePrivateDnsMxRecord() *pluginsdk.Resource {
 
 func resourcePrivateDnsMxRecordCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).PrivateDns.RecordSetsClient
-	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id := privatedns.NewRecordTypeID(subscriptionId, d.Get("resource_group_name").(string), d.Get("zone_name").(string), privatedns.RecordTypeMX, d.Get("name").(string))
+	privateDNSZoneID, err := privatezones.ParsePrivateDnsZoneID(d.Get("private_dns_zone_id").(string))
+	if err != nil {
+		return err
+	}
+
+	id := privatedns.NewRecordTypeID(privateDNSZoneID.SubscriptionId, privateDNSZoneID.ResourceGroupName, privateDNSZoneID.PrivateDnsZoneName, privatedns.RecordTypeMX, d.Get("name").(string))
+
 	if d.IsNewResource() {
 		if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
 			existing, err := client.RecordSetsGet(ctx, id)
@@ -173,8 +172,7 @@ func resourcePrivateDnsMxRecordRead(d *pluginsdk.ResourceData, meta interface{})
 	}
 
 	d.Set("name", id.RelativeRecordSetName)
-	d.Set("zone_name", id.PrivateDnsZoneName)
-	d.Set("resource_group_name", id.ResourceGroupName)
+	d.Set("private_dns_zone_id", privatezones.NewPrivateDnsZoneID(id.SubscriptionId, id.ResourceGroupName, id.PrivateDnsZoneName).ID())
 
 	if model := resp.Model; model != nil {
 		if props := model.Properties; props != nil {

--- a/internal/services/privatedns/private_dns_mx_record_resource_test.go
+++ b/internal/services/privatedns/private_dns_mx_record_resource_test.go
@@ -104,7 +104,7 @@ func TestAccPrivateDnsMxRecord_emptyName(t *testing.T) {
 	})
 }
 
-func (t PrivateDnsMxRecordResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+func (r PrivateDnsMxRecordResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := privatedns.ParseRecordTypeID(state.ID)
 	if err != nil {
 		return nil, err
@@ -125,19 +125,18 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-prvdns-%d"
-  location = "%s"
+  name     = "acctestRG-prvdns-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_private_dns_zone" "test" {
-  name                = "testzone%d.com"
+  name                = "testzone%[1]d.com"
   resource_group_name = azurerm_resource_group.test.name
 }
 
 resource "azurerm_private_dns_mx_record" "test" {
-  name                = "testaccmx%d"
-  resource_group_name = azurerm_resource_group.test.name
-  zone_name           = azurerm_private_dns_zone.test.name
+  name                = "testaccmx%[1]d"
+  private_dns_zone_id = azurerm_private_dns_zone.test.id
   ttl                 = 300
   record {
     preference = 10
@@ -149,7 +148,7 @@ resource "azurerm_private_dns_mx_record" "test" {
     exchange   = "mx2.contoso.com"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func (PrivateDnsMxRecordResource) emptyName(data acceptance.TestData) string {
@@ -159,18 +158,17 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-prvdns-%d"
-  location = "%s"
+  name     = "acctestRG-prvdns-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_private_dns_zone" "test" {
-  name                = "testzone%d.com"
+  name                = "testzone%[1]d.com"
   resource_group_name = azurerm_resource_group.test.name
 }
 
 resource "azurerm_private_dns_mx_record" "test" {
-  resource_group_name = azurerm_resource_group.test.name
-  zone_name           = azurerm_private_dns_zone.test.name
+  private_dns_zone_id = azurerm_private_dns_zone.test.id
   ttl                 = 300
   record {
     preference = 10
@@ -182,17 +180,16 @@ resource "azurerm_private_dns_mx_record" "test" {
     exchange   = "mx2.contoso.com"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func (r PrivateDnsMxRecordResource) requiresImport(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "azurerm_private_dns_mx_record" "import" {
   name                = azurerm_private_dns_mx_record.test.name
-  resource_group_name = azurerm_private_dns_mx_record.test.resource_group_name
-  zone_name           = azurerm_private_dns_mx_record.test.zone_name
+  private_dns_zone_id = azurerm_private_dns_mx_record.test.private_dns_zone_id
   ttl                 = 300
   record {
     preference = 10
@@ -213,19 +210,18 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-prvdns-%d"
-  location = "%s"
+  name     = "acctestRG-prvdns-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_private_dns_zone" "test" {
-  name                = "testzone%d.com"
+  name                = "testzone%[1]d.com"
   resource_group_name = azurerm_resource_group.test.name
 }
 
 resource "azurerm_private_dns_mx_record" "test" {
-  name                = "testaccmx%d"
-  resource_group_name = azurerm_resource_group.test.name
-  zone_name           = azurerm_private_dns_zone.test.name
+  name                = "testaccmx%[1]d"
+  private_dns_zone_id = azurerm_private_dns_zone.test.id
   ttl                 = 300
   record {
     preference = 10
@@ -240,7 +236,7 @@ resource "azurerm_private_dns_mx_record" "test" {
     exchange   = "backupmx.contoso.com"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func (PrivateDnsMxRecordResource) withTags(data acceptance.TestData) string {
@@ -250,19 +246,18 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-prvdns-%d"
-  location = "%s"
+  name     = "acctestRG-prvdns-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_private_dns_zone" "test" {
-  name                = "testzone%d.com"
+  name                = "testzone%[1]d.com"
   resource_group_name = azurerm_resource_group.test.name
 }
 
 resource "azurerm_private_dns_mx_record" "test" {
-  name                = "testaccmx%d"
-  resource_group_name = azurerm_resource_group.test.name
-  zone_name           = azurerm_private_dns_zone.test.name
+  name                = "testaccmx%[1]d"
+  private_dns_zone_id = azurerm_private_dns_zone.test.id
   ttl                 = 300
   record {
     preference = 10
@@ -278,7 +273,7 @@ resource "azurerm_private_dns_mx_record" "test" {
     cost_center = "MSFT"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func (PrivateDnsMxRecordResource) withTagsUpdate(data acceptance.TestData) string {
@@ -288,19 +283,18 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-prvdns-%d"
-  location = "%s"
+  name     = "acctestRG-prvdns-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_private_dns_zone" "test" {
-  name                = "testzone%d.com"
+  name                = "testzone%[1]d.com"
   resource_group_name = azurerm_resource_group.test.name
 }
 
 resource "azurerm_private_dns_mx_record" "test" {
-  name                = "testaccmx%d"
-  resource_group_name = azurerm_resource_group.test.name
-  zone_name           = azurerm_private_dns_zone.test.name
+  name                = "testaccmx%[1]d"
+  private_dns_zone_id = azurerm_private_dns_zone.test.id
   ttl                 = 300
   record {
     preference = 10
@@ -315,5 +309,5 @@ resource "azurerm_private_dns_mx_record" "test" {
     environment = "staging"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary)
 }

--- a/internal/services/privatedns/private_dns_ptr_record_resource.go
+++ b/internal/services/privatedns/private_dns_ptr_record_resource.go
@@ -13,10 +13,9 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/privatedns/2024-06-01/privatedns"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/privatedns/2024-06-01/privatezones"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/privatedns/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
@@ -48,23 +47,17 @@ func resourcePrivateDnsPtrRecord() *pluginsdk.Resource {
 
 		Schema: map[string]*pluginsdk.Schema{
 			"name": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-				ForceNew: true,
-				// lower-cased due to the broken API https://github.com/Azure/azure-rest-api-specs/issues/6641
-				ValidateFunc: validate.LowerCasedString,
-			},
-
-			// TODO: in 4.0 make `name` case sensitive and replace `resource_group_name` and `zone_name` with `private_zone_id`
-
-			// TODO: make this case sensitive once the API's fixed https://github.com/Azure/azure-rest-api-specs/issues/6641
-			"resource_group_name": azure.SchemaResourceGroupNameDiffSuppress(),
-
-			"zone_name": {
 				Type:         pluginsdk.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringIsNotEmpty,
+				ValidateFunc: validation.StringIsNotWhiteSpace,
+			},
+
+			"private_dns_zone_id": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: privatezones.ValidatePrivateDnsZoneID,
 			},
 
 			"records": {
@@ -92,11 +85,17 @@ func resourcePrivateDnsPtrRecord() *pluginsdk.Resource {
 
 func resourcePrivateDnsPtrRecordCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).PrivateDns.RecordSetsClient
-	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id := privatedns.NewRecordTypeID(subscriptionId, d.Get("resource_group_name").(string), d.Get("zone_name").(string), privatedns.RecordTypePTR, d.Get("name").(string))
+	privateDNSZoneID, err := privatezones.ParsePrivateDnsZoneID(d.Get("private_dns_zone_id").(string))
+	if err != nil {
+		return err
+	}
+
+	id := privatedns.NewRecordTypeID(meta.(*clients.Client).Account.SubscriptionId, privateDNSZoneID.ResourceGroupName, privateDNSZoneID.PrivateDnsZoneName, privatedns.RecordTypePTR, d.Get("name").(string))
+
 	if d.IsNewResource() {
 		if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
 			existing, err := client.RecordSetsGet(ctx, id)
@@ -156,8 +155,7 @@ func resourcePrivateDnsPtrRecordRead(d *pluginsdk.ResourceData, meta interface{}
 	}
 
 	d.Set("name", id.RelativeRecordSetName)
-	d.Set("zone_name", id.PrivateDnsZoneName)
-	d.Set("resource_group_name", id.ResourceGroupName)
+	d.Set("private_dns_zone_id", privatezones.NewPrivateDnsZoneID(id.SubscriptionId, id.ResourceGroupName, id.PrivateDnsZoneName).ID())
 
 	if model := resp.Model; model != nil {
 		if props := model.Properties; props != nil {

--- a/internal/services/privatedns/private_dns_ptr_record_resource_test.go
+++ b/internal/services/privatedns/private_dns_ptr_record_resource_test.go
@@ -90,7 +90,7 @@ func TestAccPrivateDnsPtrRecord_withTags(t *testing.T) {
 	})
 }
 
-func (t PrivateDnsPtrRecordResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+func (r PrivateDnsPtrRecordResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := privatedns.ParseRecordTypeID(state.ID)
 	if err != nil {
 		return nil, err
@@ -111,33 +111,31 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_private_dns_zone" "test" {
-  name                = "%d.0.10.in-addr.arpa"
+  name                = "%[1]d.0.10.in-addr.arpa"
   resource_group_name = azurerm_resource_group.test.name
 }
 
 resource "azurerm_private_dns_ptr_record" "test" {
-  name                = "%d"
-  resource_group_name = azurerm_resource_group.test.name
-  zone_name           = azurerm_private_dns_zone.test.name
+  name                = "%[1]d"
+  private_dns_zone_id = azurerm_private_dns_zone.test.id
   ttl                 = 300
   records             = ["test.contoso.com", "test2.contoso.com"]
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func (r PrivateDnsPtrRecordResource) requiresImport(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "azurerm_private_dns_ptr_record" "import" {
   name                = azurerm_private_dns_ptr_record.test.name
-  resource_group_name = azurerm_private_dns_ptr_record.test.resource_group_name
-  zone_name           = azurerm_private_dns_ptr_record.test.zone_name
+  private_dns_zone_id = azurerm_private_dns_ptr_record.test.private_dns_zone_id
   ttl                 = 300
   records             = ["test.contoso.com", "test2.contoso.com"]
 }
@@ -151,23 +149,22 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_private_dns_zone" "test" {
-  name                = "%d.0.10.in-addr.arpa"
+  name                = "%[1]d.0.10.in-addr.arpa"
   resource_group_name = azurerm_resource_group.test.name
 }
 
 resource "azurerm_private_dns_ptr_record" "test" {
-  name                = "%d"
-  resource_group_name = azurerm_resource_group.test.name
-  zone_name           = azurerm_private_dns_zone.test.name
+  name                = "%[1]d"
+  private_dns_zone_id = azurerm_private_dns_zone.test.id
   ttl                 = 300
   records             = ["test.contoso.com", "test2.contoso.com", "test3.contoso.com"]
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func (PrivateDnsPtrRecordResource) withTags(data acceptance.TestData) string {
@@ -177,19 +174,18 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_private_dns_zone" "test" {
-  name                = "%d.0.10.in-addr.arpa"
+  name                = "%[1]d.0.10.in-addr.arpa"
   resource_group_name = azurerm_resource_group.test.name
 }
 
 resource "azurerm_private_dns_ptr_record" "test" {
-  name                = "%d"
-  resource_group_name = azurerm_resource_group.test.name
-  zone_name           = azurerm_private_dns_zone.test.name
+  name                = "%[1]d"
+  private_dns_zone_id = azurerm_private_dns_zone.test.id
   ttl                 = 300
   records             = ["test.contoso.com", "test2.contoso.com"]
 
@@ -198,7 +194,7 @@ resource "azurerm_private_dns_ptr_record" "test" {
     cost_center = "MSFT"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func (PrivateDnsPtrRecordResource) withTagsUpdate(data acceptance.TestData) string {
@@ -208,19 +204,18 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_private_dns_zone" "test" {
-  name                = "%d.0.10.in-addr.arpa"
+  name                = "%[1]d.0.10.in-addr.arpa"
   resource_group_name = azurerm_resource_group.test.name
 }
 
 resource "azurerm_private_dns_ptr_record" "test" {
-  name                = "%d"
-  resource_group_name = azurerm_resource_group.test.name
-  zone_name           = azurerm_private_dns_zone.test.name
+  name                = "%[1]d"
+  private_dns_zone_id = azurerm_private_dns_zone.test.id
   ttl                 = 300
   records             = ["test.contoso.com", "test2.contoso.com"]
 
@@ -228,5 +223,5 @@ resource "azurerm_private_dns_ptr_record" "test" {
     environment = "staging"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary)
 }

--- a/internal/services/privatedns/private_dns_srv_record_resource.go
+++ b/internal/services/privatedns/private_dns_srv_record_resource.go
@@ -14,10 +14,9 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/privatedns/2024-06-01/privatedns"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/privatedns/2024-06-01/privatezones"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/privatedns/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
@@ -49,23 +48,17 @@ func resourcePrivateDnsSrvRecord() *pluginsdk.Resource {
 
 		Schema: map[string]*pluginsdk.Schema{
 			"name": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-				ForceNew: true,
-				// lower-cased due to the broken API https://github.com/Azure/azure-rest-api-specs/issues/6641
-				ValidateFunc: validate.LowerCasedString,
-			},
-
-			// TODO: in 4.0 make `name` case sensitive and replace `resource_group_name` and `zone_name` with `private_zone_id`
-
-			// TODO: make this case sensitive once the API's fixed https://github.com/Azure/azure-rest-api-specs/issues/6641
-			"resource_group_name": azure.SchemaResourceGroupNameDiffSuppress(),
-
-			"zone_name": {
 				Type:         pluginsdk.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringIsNotEmpty,
+				ValidateFunc: validation.StringIsNotWhiteSpace,
+			},
+
+			"private_dns_zone_id": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: privatezones.ValidatePrivateDnsZoneID,
 			},
 
 			"record": {
@@ -118,11 +111,17 @@ func resourcePrivateDnsSrvRecord() *pluginsdk.Resource {
 
 func resourcePrivateDnsSrvRecordCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).PrivateDns.RecordSetsClient
-	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id := privatedns.NewRecordTypeID(subscriptionId, d.Get("resource_group_name").(string), d.Get("zone_name").(string), privatedns.RecordTypeSRV, d.Get("name").(string))
+	privateDNSZoneID, err := privatezones.ParsePrivateDnsZoneID(d.Get("private_dns_zone_id").(string))
+	if err != nil {
+		return err
+	}
+
+	id := privatedns.NewRecordTypeID(meta.(*clients.Client).Account.SubscriptionId, privateDNSZoneID.ResourceGroupName, privateDNSZoneID.PrivateDnsZoneName, privatedns.RecordTypeSRV, d.Get("name").(string))
+
 	if d.IsNewResource() {
 		if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
 			existing, err := client.RecordSetsGet(ctx, id)
@@ -182,8 +181,7 @@ func resourcePrivateDnsSrvRecordRead(d *pluginsdk.ResourceData, meta interface{}
 	}
 
 	d.Set("name", id.RelativeRecordSetName)
-	d.Set("zone_name", id.PrivateDnsZoneName)
-	d.Set("resource_group_name", id.ResourceGroupName)
+	d.Set("private_dns_zone_id", privatezones.NewPrivateDnsZoneID(id.SubscriptionId, id.ResourceGroupName, id.PrivateDnsZoneName).ID())
 
 	if model := resp.Model; model != nil {
 		if props := model.Properties; props != nil {

--- a/internal/services/privatedns/private_dns_srv_record_resource_test.go
+++ b/internal/services/privatedns/private_dns_srv_record_resource_test.go
@@ -106,12 +106,11 @@ func (r PrivateDnsSrvRecordResource) Exists(ctx context.Context, clients *client
 
 func (r PrivateDnsSrvRecordResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "azurerm_private_dns_srv_record" "test" {
-  name                = "acctestsrv%d"
-  resource_group_name = azurerm_resource_group.test.name
-  zone_name           = azurerm_private_dns_zone.test.name
+  name                = "acctestsrv%[2]d"
+  private_dns_zone_id = azurerm_private_dns_zone.test.id
   ttl                 = 300
   record {
     priority = 1
@@ -132,12 +131,11 @@ resource "azurerm_private_dns_srv_record" "test" {
 
 func (r PrivateDnsSrvRecordResource) requiresImport(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "azurerm_private_dns_srv_record" "import" {
   name                = azurerm_private_dns_srv_record.test.name
-  resource_group_name = azurerm_private_dns_srv_record.test.resource_group_name
-  zone_name           = azurerm_private_dns_srv_record.test.zone_name
+  private_dns_zone_id = azurerm_private_dns_srv_record.test.private_dns_zone_id
   ttl                 = 300
   record {
     priority = 1
@@ -157,12 +155,11 @@ resource "azurerm_private_dns_srv_record" "import" {
 
 func (r PrivateDnsSrvRecordResource) updateRecords(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "azurerm_private_dns_srv_record" "test" {
-  name                = "acctestsrv%d"
-  resource_group_name = azurerm_resource_group.test.name
-  zone_name           = azurerm_private_dns_zone.test.name
+  name                = "acctestsrv%[2]d"
+  private_dns_zone_id = azurerm_private_dns_zone.test.id
   ttl                 = 300
   record {
     priority = 1
@@ -188,12 +185,11 @@ resource "azurerm_private_dns_srv_record" "test" {
 
 func (r PrivateDnsSrvRecordResource) withTags(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "azurerm_private_dns_srv_record" "test" {
-  name                = "acctestsrv%d"
-  resource_group_name = azurerm_resource_group.test.name
-  zone_name           = azurerm_private_dns_zone.test.name
+  name                = "acctestsrv%[2]d"
+  private_dns_zone_id = azurerm_private_dns_zone.test.id
   ttl                 = 300
   record {
     priority = 1
@@ -218,12 +214,11 @@ resource "azurerm_private_dns_srv_record" "test" {
 
 func (r PrivateDnsSrvRecordResource) withTagsUpdate(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "azurerm_private_dns_srv_record" "test" {
-  name                = "acctestsrv%d"
-  resource_group_name = azurerm_resource_group.test.name
-  zone_name           = azurerm_private_dns_zone.test.name
+  name                = "acctestsrv%[2]d"
+  private_dns_zone_id = azurerm_private_dns_zone.test.id
   ttl                 = 300
   record {
     priority = 1

--- a/internal/services/privatedns/private_dns_txt_record_resource.go
+++ b/internal/services/privatedns/private_dns_txt_record_resource.go
@@ -14,10 +14,9 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/privatedns/2024-06-01/privatedns"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/privatedns/2024-06-01/privatezones"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/privatedns/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
@@ -48,23 +47,17 @@ func resourcePrivateDnsTxtRecord() *pluginsdk.Resource {
 
 		Schema: map[string]*pluginsdk.Schema{
 			"name": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-				ForceNew: true,
-				// lower-cased due to the broken API https://github.com/Azure/azure-rest-api-specs/issues/6641
-				ValidateFunc: validate.LowerCasedString,
-			},
-
-			// TODO: in 4.0 make `name` case sensitive and replace `resource_group_name` and `zone_name` with `private_zone_id`
-
-			// TODO: make this case sensitive once the API's fixed https://github.com/Azure/azure-rest-api-specs/issues/6641
-			"resource_group_name": azure.SchemaResourceGroupNameDiffSuppress(),
-
-			"zone_name": {
 				Type:         pluginsdk.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringIsNotEmpty,
+				ValidateFunc: validation.StringIsNotWhiteSpace,
+			},
+
+			"private_dns_zone_id": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: privatezones.ValidatePrivateDnsZoneID,
 			},
 
 			"record": {
@@ -99,11 +92,17 @@ func resourcePrivateDnsTxtRecord() *pluginsdk.Resource {
 
 func resourcePrivateDnsTxtRecordCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).PrivateDns.RecordSetsClient
-	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id := privatedns.NewRecordTypeID(subscriptionId, d.Get("resource_group_name").(string), d.Get("zone_name").(string), privatedns.RecordTypeTXT, d.Get("name").(string))
+	privateDNSZoneID, err := privatezones.ParsePrivateDnsZoneID(d.Get("private_dns_zone_id").(string))
+	if err != nil {
+		return err
+	}
+
+	id := privatedns.NewRecordTypeID(meta.(*clients.Client).Account.SubscriptionId, privateDNSZoneID.ResourceGroupName, privateDNSZoneID.PrivateDnsZoneName, privatedns.RecordTypeTXT, d.Get("name").(string))
+
 	if d.IsNewResource() {
 		if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
 			existing, err := client.RecordSetsGet(ctx, id)
@@ -164,8 +163,7 @@ func resourcePrivateDnsTxtRecordRead(d *pluginsdk.ResourceData, meta interface{}
 	}
 
 	d.Set("name", id.RelativeRecordSetName)
-	d.Set("resource_group_name", id.ResourceGroupName)
-	d.Set("zone_name", id.PrivateDnsZoneName)
+	d.Set("private_dns_zone_id", privatezones.NewPrivateDnsZoneID(id.SubscriptionId, id.ResourceGroupName, id.PrivateDnsZoneName).ID())
 
 	if model := resp.Model; model != nil {
 		if props := model.Properties; props != nil {

--- a/internal/services/privatedns/private_dns_txt_record_resource_test.go
+++ b/internal/services/privatedns/private_dns_txt_record_resource_test.go
@@ -101,7 +101,7 @@ func TestAccPrivateDnsTxtRecord_withTags(t *testing.T) {
 	})
 }
 
-func (t PrivateDnsTxtRecordResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+func (r PrivateDnsTxtRecordResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := privatedns.ParseRecordTypeID(state.ID)
 	if err != nil {
 		return nil, err
@@ -109,7 +109,7 @@ func (t PrivateDnsTxtRecordResource) Exists(ctx context.Context, clients *client
 
 	resp, err := clients.PrivateDns.RecordSetsClient.RecordSetsGet(ctx, *id)
 	if err != nil {
-		return nil, fmt.Errorf("reading Private DNS TXT Record (%s): %+v", id.String(), err)
+		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
 	return pointer.To(resp.Model != nil), nil
@@ -122,19 +122,18 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-prvdns-%d"
-  location = "%s"
+  name     = "acctestRG-prvdns-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_private_dns_zone" "test" {
-  name                = "testzone%d.com"
+  name                = "testzone%[1]d.com"
   resource_group_name = azurerm_resource_group.test.name
 }
 
 resource "azurerm_private_dns_txt_record" "test" {
-  name                = "testacctxt%d"
-  resource_group_name = azurerm_resource_group.test.name
-  zone_name           = azurerm_private_dns_zone.test.name
+  name                = "testacctxt%[1]d"
+  private_dns_zone_id = azurerm_private_dns_zone.test.id
   ttl                 = 300
 
   record {
@@ -145,17 +144,16 @@ resource "azurerm_private_dns_txt_record" "test" {
     value = "A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func (r PrivateDnsTxtRecordResource) requiresImport(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "azurerm_private_dns_txt_record" "import" {
   name                = azurerm_private_dns_txt_record.test.name
-  resource_group_name = azurerm_private_dns_txt_record.test.resource_group_name
-  zone_name           = azurerm_private_dns_txt_record.test.zone_name
+  private_dns_zone_id = azurerm_private_dns_txt_record.test.private_dns_zone_id
   ttl                 = 300
 
   record {
@@ -176,19 +174,18 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-prvdns-%d"
-  location = "%s"
+  name     = "acctestRG-prvdns-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_private_dns_zone" "test" {
-  name                = "testzone%d.com"
+  name                = "testzone%[1]d.com"
   resource_group_name = azurerm_resource_group.test.name
 }
 
 resource "azurerm_private_dns_txt_record" "test" {
-  name                = "testacctxt%d"
-  resource_group_name = azurerm_resource_group.test.name
-  zone_name           = azurerm_private_dns_zone.test.name
+  name                = "testacctxt%[1]d"
+  private_dns_zone_id = azurerm_private_dns_zone.test.id
   ttl                 = 300
 
   record {
@@ -203,7 +200,7 @@ resource "azurerm_private_dns_txt_record" "test" {
     value = "I'm a record too'"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func (PrivateDnsTxtRecordResource) withTags(data acceptance.TestData) string {
@@ -213,19 +210,18 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-prvdns-%d"
-  location = "%s"
+  name     = "acctestRG-prvdns-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_private_dns_zone" "test" {
-  name                = "testzone%d.com"
+  name                = "testzone%[1]d.com"
   resource_group_name = azurerm_resource_group.test.name
 }
 
 resource "azurerm_private_dns_txt_record" "test" {
-  name                = "test%d"
-  resource_group_name = azurerm_resource_group.test.name
-  zone_name           = azurerm_private_dns_zone.test.name
+  name                = "test%[1]d"
+  private_dns_zone_id = azurerm_private_dns_zone.test.id
   ttl                 = 300
 
   record {
@@ -241,7 +237,7 @@ resource "azurerm_private_dns_txt_record" "test" {
     cost_center = "MSFT"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func (PrivateDnsTxtRecordResource) withTagsUpdate(data acceptance.TestData) string {
@@ -251,19 +247,18 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-prvdns-%d"
-  location = "%s"
+  name     = "acctestRG-prvdns-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_private_dns_zone" "test" {
-  name                = "testzone%d.com"
+  name                = "testzone%[1]d.com"
   resource_group_name = azurerm_resource_group.test.name
 }
 
 resource "azurerm_private_dns_txt_record" "test" {
-  name                = "test%d"
-  resource_group_name = azurerm_resource_group.test.name
-  zone_name           = azurerm_private_dns_zone.test.name
+  name                = "test%[1]d"
+  private_dns_zone_id = azurerm_private_dns_zone.test.id
   ttl                 = 300
 
   record {
@@ -278,5 +273,5 @@ resource "azurerm_private_dns_txt_record" "test" {
     environment = "staging"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary)
 }

--- a/internal/services/privatedns/private_dns_zone_virtual_network_link_data_source.go
+++ b/internal/services/privatedns/private_dns_zone_virtual_network_link_data_source.go
@@ -31,7 +31,6 @@ func dataSourcePrivateDnsZoneVirtualNetworkLink() *pluginsdk.Resource {
 				Required: true,
 			},
 
-			// TODO: in 4.0 switch this to `private_dns_zone_id`
 			"private_dns_zone_name": {
 				Type:     pluginsdk.TypeString,
 				Required: true,

--- a/internal/services/privatedns/private_dns_zone_virtual_network_link_data_source_test.go
+++ b/internal/services/privatedns/private_dns_zone_virtual_network_link_data_source_test.go
@@ -27,7 +27,7 @@ func TestAccDataSourcePrivateDnsZoneVirtualNetworkLink_basic(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("id").MatchesOtherKey(check.That(resourceName).Key("id")),
 				check.That(data.ResourceName).Key("name").MatchesOtherKey(check.That(resourceName).Key("name")),
-				check.That(data.ResourceName).Key("resource_group_name").MatchesOtherKey(check.That(resourceName).Key("resource_group_name")),
+				check.That(data.ResourceName).Key("resource_group_name").MatchesOtherKey(check.That(zoneName).Key("resource_group_name")),
 				check.That(data.ResourceName).Key("virtual_network_id").MatchesOtherKey(check.That(vnetName).Key("id")),
 				check.That(data.ResourceName).Key("private_dns_zone_name").MatchesOtherKey(check.That(zoneName).Key("name")),
 				check.That(data.ResourceName).Key("registration_enabled").HasValue("false"),
@@ -51,7 +51,7 @@ func TestAccDataSourcePrivateDnsZoneVirtualNetworkLink_resolutionPolicy(t *testi
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("id").MatchesOtherKey(check.That(resourceName).Key("id")),
 				check.That(data.ResourceName).Key("name").MatchesOtherKey(check.That(resourceName).Key("name")),
-				check.That(data.ResourceName).Key("resource_group_name").MatchesOtherKey(check.That(resourceName).Key("resource_group_name")),
+				check.That(data.ResourceName).Key("resource_group_name").MatchesOtherKey(check.That(zoneName).Key("resource_group_name")),
 				check.That(data.ResourceName).Key("virtual_network_id").MatchesOtherKey(check.That(vnetName).Key("id")),
 				check.That(data.ResourceName).Key("private_dns_zone_name").MatchesOtherKey(check.That(zoneName).Key("name")),
 				check.That(data.ResourceName).Key("resolution_policy").HasValue("NxDomainRedirect"),

--- a/internal/services/privatedns/private_dns_zone_virtual_network_link_resource.go
+++ b/internal/services/privatedns/private_dns_zone_virtual_network_link_resource.go
@@ -13,19 +13,18 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/privatedns/2024-06-01/privatezones"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/privatedns/2024-06-01/virtualnetworklinks"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
 
-//go:generate go run ../../tools/generator-tests resourceidentity -resource-name private_dns_zone_virtual_network_link -service-package-name privatedns -properties "name,private_dns_zone_name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name private_dns_zone_virtual_network_link -properties "name" -compare-values "subscription_id:private_dns_zone_id,resource_group_name:private_dns_zone_id,private_dns_zone_name:private_dns_zone_id"
 
 func resourcePrivateDnsZoneVirtualNetworkLink() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
@@ -47,25 +46,18 @@ func resourcePrivateDnsZoneVirtualNetworkLink() *pluginsdk.Resource {
 		},
 
 		Schema: map[string]*pluginsdk.Schema{
-			// TODO: these can become case-sensitive with a state migration
 			"name": {
 				Type:     pluginsdk.TypeString,
 				Required: true,
 				ForceNew: true,
-				// TODO: make this case sensitive once the API's fixed https://github.com/Azure/azure-rest-api-specs/issues/10933
-				DiffSuppressFunc: suppress.CaseDifference,
 			},
 
-			// TODO: in 4.0 switch this to `private_dns_zone_id`
-			"private_dns_zone_name": {
+			"private_dns_zone_id": {
 				Type:         pluginsdk.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringIsNotEmpty,
+				ValidateFunc: privatezones.ValidatePrivateDnsZoneID,
 			},
-
-			// TODO: make this case sensitive once the API's fixed https://github.com/Azure/azure-rest-api-specs/issues/10933
-			"resource_group_name": azure.SchemaResourceGroupNameDiffSuppress(),
 
 			"virtual_network_id": {
 				Type:         pluginsdk.TypeString,
@@ -94,11 +86,16 @@ func resourcePrivateDnsZoneVirtualNetworkLink() *pluginsdk.Resource {
 
 func resourcePrivateDnsZoneVirtualNetworkLinkCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).PrivateDns.VirtualNetworkLinksClient
-	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id := virtualnetworklinks.NewVirtualNetworkLinkID(subscriptionId, d.Get("resource_group_name").(string), d.Get("private_dns_zone_name").(string), d.Get("name").(string))
+	privateDNSZoneID, err := privatezones.ParsePrivateDnsZoneID(d.Get("private_dns_zone_id").(string))
+	if err != nil {
+		return err
+	}
+
+	id := virtualnetworklinks.NewVirtualNetworkLinkID(privateDNSZoneID.SubscriptionId, privateDNSZoneID.ResourceGroupName, privateDNSZoneID.PrivateDnsZoneName, d.Get("name").(string))
+
 	if d.IsNewResource() {
 		if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
 			existing, err := client.Get(ctx, id)
@@ -174,8 +171,7 @@ func resourcePrivateDnsZoneVirtualNetworkLinkRead(d *pluginsdk.ResourceData, met
 
 func resourcePrivateDnsZoneVirtualNetworkLinkFlatten(d *pluginsdk.ResourceData, id *virtualnetworklinks.VirtualNetworkLinkId, model *virtualnetworklinks.VirtualNetworkLink) error {
 	d.Set("name", id.VirtualNetworkLinkName)
-	d.Set("private_dns_zone_name", id.PrivateDnsZoneName)
-	d.Set("resource_group_name", id.ResourceGroupName)
+	d.Set("private_dns_zone_id", privatezones.NewPrivateDnsZoneID(id.SubscriptionId, id.ResourceGroupName, id.PrivateDnsZoneName).ID())
 
 	if model != nil {
 		if props := model.Properties; props != nil {

--- a/internal/services/privatedns/private_dns_zone_virtual_network_link_resource_identity_gen_test.go
+++ b/internal/services/privatedns/private_dns_zone_virtual_network_link_resource_identity_gen_test.go
@@ -6,7 +6,6 @@ package privatedns_test
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
@@ -18,10 +17,10 @@ func TestAccPrivateDnsZoneVirtualNetworkLink_resourceIdentity(t *testing.T) {
 	r := PrivateDnsZoneVirtualNetworkLinkResource{}
 
 	checkedFields := map[string]struct{}{
-		"subscription_id":       {},
 		"name":                  {},
 		"private_dns_zone_name": {},
 		"resource_group_name":   {},
+		"subscription_id":       {},
 	}
 
 	data.ResourceIdentityTest(t, []acceptance.TestStep{
@@ -29,10 +28,10 @@ func TestAccPrivateDnsZoneVirtualNetworkLink_resourceIdentity(t *testing.T) {
 			Config: r.basic(data),
 			ConfigStateChecks: []statecheck.StateCheck{
 				customstatecheck.ExpectAllIdentityFieldsAreChecked("azurerm_private_dns_zone_virtual_network_link.test", checkedFields),
-				statecheck.ExpectIdentityValue("azurerm_private_dns_zone_virtual_network_link.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
 				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_private_dns_zone_virtual_network_link.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_private_dns_zone_virtual_network_link.test", tfjsonpath.New("private_dns_zone_name"), tfjsonpath.New("private_dns_zone_name")),
-				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_private_dns_zone_virtual_network_link.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_private_dns_zone_virtual_network_link.test", tfjsonpath.New("private_dns_zone_name"), tfjsonpath.New("private_dns_zone_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_private_dns_zone_virtual_network_link.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("private_dns_zone_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_private_dns_zone_virtual_network_link.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("private_dns_zone_id")),
 			},
 		},
 		data.ImportBlockWithResourceIdentityStep(false),

--- a/internal/services/privatedns/private_dns_zone_virtual_network_link_resource_test.go
+++ b/internal/services/privatedns/private_dns_zone_virtual_network_link_resource_test.go
@@ -140,7 +140,7 @@ func TestAccPrivateDnsZoneVirtualNetworkLink_toggleResolutionPolicy(t *testing.T
 	})
 }
 
-func (t PrivateDnsZoneVirtualNetworkLinkResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+func (r PrivateDnsZoneVirtualNetworkLinkResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := virtualnetworklinks.ParseVirtualNetworkLinkID(state.ID)
 	if err != nil {
 		return nil, err
@@ -161,12 +161,12 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_virtual_network" "test" {
-  name                = "vnet%d"
+  name                = "vnet%[1]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   address_space       = ["10.0.0.0/16"]
@@ -178,17 +178,16 @@ resource "azurerm_virtual_network" "test" {
 }
 
 resource "azurerm_private_dns_zone" "test" {
-  name                = "acctestzone%d.com"
+  name                = "acctestzone%[1]d.com"
   resource_group_name = azurerm_resource_group.test.name
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "test" {
-  name                  = "acctestVnetZone%d.com"
-  private_dns_zone_name = azurerm_private_dns_zone.test.name
-  virtual_network_id    = azurerm_virtual_network.test.id
-  resource_group_name   = azurerm_resource_group.test.name
+  name                = "acctestVnetZone%[1]d.com"
+  private_dns_zone_id = azurerm_private_dns_zone.test.id
+  virtual_network_id  = azurerm_virtual_network.test.id
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func (PrivateDnsZoneVirtualNetworkLinkResource) complete(data acceptance.TestData) string {
@@ -198,12 +197,12 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_virtual_network" "test" {
-  name                = "vnet%d"
+  name                = "vnet%[1]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   address_space       = ["10.0.0.0/16"]
@@ -215,18 +214,17 @@ resource "azurerm_virtual_network" "test" {
 }
 
 resource "azurerm_private_dns_zone" "test" {
-  name                = "acctestzone%d.com"
+  name                = "acctestzone%[1]d.com"
   resource_group_name = azurerm_resource_group.test.name
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "test" {
-  name                  = "acctestVnetZone%d.com"
-  private_dns_zone_name = azurerm_private_dns_zone.test.name
-  virtual_network_id    = azurerm_virtual_network.test.id
-  resource_group_name   = azurerm_resource_group.test.name
-  registration_enabled  = true
+  name                 = "acctestVnetZone%[1]d.com"
+  private_dns_zone_id  = azurerm_private_dns_zone.test.id
+  virtual_network_id   = azurerm_virtual_network.test.id
+  registration_enabled = true
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func (PrivateDnsZoneVirtualNetworkLinkResource) crossTenant(data acceptance.TestData, altTenantId, subscriptionIdAltTenant string) string {
@@ -276,23 +274,21 @@ resource "azurerm_private_dns_zone" "test" {
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "test" {
-  name                  = "acctestVnetZone%[3]d.com"
-  resource_group_name   = azurerm_resource_group.test.name
-  private_dns_zone_name = azurerm_private_dns_zone.test.name
-  virtual_network_id    = azurerm_virtual_network.test_alt.id
+  name                = "acctestVnetZone%[3]d.com"
+  private_dns_zone_id = azurerm_private_dns_zone.test.id
+  virtual_network_id  = azurerm_virtual_network.test_alt.id
 }
 `, altTenantId, subscriptionIdAltTenant, data.RandomInteger, data.Locations.Primary)
 }
 
 func (r PrivateDnsZoneVirtualNetworkLinkResource) requiresImport(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "azurerm_private_dns_zone_virtual_network_link" "import" {
-  name                  = azurerm_private_dns_zone_virtual_network_link.test.name
-  private_dns_zone_name = azurerm_private_dns_zone_virtual_network_link.test.private_dns_zone_name
-  virtual_network_id    = azurerm_private_dns_zone_virtual_network_link.test.virtual_network_id
-  resource_group_name   = azurerm_private_dns_zone_virtual_network_link.test.resource_group_name
+  name                = azurerm_private_dns_zone_virtual_network_link.test.name
+  private_dns_zone_id = azurerm_private_dns_zone_virtual_network_link.test.private_dns_zone_id
+  virtual_network_id  = azurerm_private_dns_zone_virtual_network_link.test.virtual_network_id
 }
 `, r.basic(data))
 }
@@ -304,12 +300,12 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_virtual_network" "test" {
-  name                = "vnet%d"
+  name                = "vnet%[1]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   address_space       = ["10.0.0.0/16"]
@@ -321,22 +317,21 @@ resource "azurerm_virtual_network" "test" {
 }
 
 resource "azurerm_private_dns_zone" "test" {
-  name                = "acctestzone%d.com"
+  name                = "acctestzone%[1]d.com"
   resource_group_name = "${azurerm_resource_group.test.name}"
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "test" {
-  name                  = "acctestVnetZone%d.com"
-  private_dns_zone_name = azurerm_private_dns_zone.test.name
-  virtual_network_id    = azurerm_virtual_network.test.id
-  resource_group_name   = azurerm_resource_group.test.name
+  name                = "acctestVnetZone%[1]d.com"
+  private_dns_zone_id = azurerm_private_dns_zone.test.id
+  virtual_network_id  = azurerm_virtual_network.test.id
 
   tags = {
     environment = "Production"
     cost_center = "MSFT"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func (PrivateDnsZoneVirtualNetworkLinkResource) withTagsUpdate(data acceptance.TestData) string {
@@ -346,12 +341,12 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_virtual_network" "test" {
-  name                = "vnet%d"
+  name                = "vnet%[1]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   address_space       = ["10.0.0.0/16"]
@@ -363,25 +358,24 @@ resource "azurerm_virtual_network" "test" {
 }
 
 resource "azurerm_private_dns_zone" "test" {
-  name                = "acctestzone%d.com"
+  name                = "acctestzone%[1]d.com"
   resource_group_name = "${azurerm_resource_group.test.name}"
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "test" {
-  name                  = "acctestVnetZone%d.com"
-  private_dns_zone_name = azurerm_private_dns_zone.test.name
-  virtual_network_id    = azurerm_virtual_network.test.id
-  resource_group_name   = azurerm_resource_group.test.name
+  name                = "acctestVnetZone%[1]d.com"
+  private_dns_zone_id = azurerm_private_dns_zone.test.id
+  virtual_network_id  = azurerm_virtual_network.test.id
 
   tags = {
     environment = "staging"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func (PrivateDnsZoneVirtualNetworkLinkResource) resolutionPolicy(data acceptance.TestData, resolution string) string {
-	resolutionBlock := fmt.Sprintf(`  resolution_policy     = "%s"`, resolution)
+	resolutionBlock := fmt.Sprintf(`  resolution_policy    = "%s"`, resolution)
 	if resolution == "" {
 		resolutionBlock = ``
 	}
@@ -414,11 +408,10 @@ resource "azurerm_private_dns_zone" "test" {
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "test" {
-  name                  = "linktest%[1]d"
-  private_dns_zone_name = azurerm_private_dns_zone.test.name
-  virtual_network_id    = azurerm_virtual_network.test.id
-  resource_group_name   = azurerm_resource_group.test.name
-  registration_enabled  = true
+  name                 = "linktest%[1]d"
+  private_dns_zone_id  = azurerm_private_dns_zone.test.id
+  virtual_network_id   = azurerm_virtual_network.test.id
+  registration_enabled = true
   %[3]s
 }
 `, data.RandomInteger, data.Locations.Primary, resolutionBlock)

--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -1345,7 +1345,6 @@ func resourceStorageAccount() *pluginsdk.Resource {
 									Required:     true,
 									ValidateFunc: validation.StringIsNotEmpty,
 								},
-								// TODO 4.0: Remove this property and determine whether to enable based on existence of the out side block.
 								"enabled": {
 									Type:     pluginsdk.TypeBool,
 									Required: true,

--- a/website/docs/5.0-upgrade-guide.html.markdown
+++ b/website/docs/5.0-upgrade-guide.html.markdown
@@ -722,6 +722,46 @@ Please follow the format in the example below for listing breaking changes in re
 
 * The `mode` property now defaults to `Gen2`.
 
+### `azurerm_private_dns_a_record`
+
+* The `resource_group_name` property has been removed in favour of the `private_dns_zone_id` property.
+* The `zone_name` property has been removed in favour of the `private_dns_zone_id` property.
+
+### `azurerm_private_dns_aaaa_record`
+
+* The `resource_group_name` property has been removed in favour of the `private_dns_zone_id` property.
+* The `zone_name` property has been removed in favour of the `private_dns_zone_id` property.
+
+### `azurerm_private_dns_cname_record`
+
+* The `resource_group_name` property has been removed in favour of the `private_dns_zone_id` property.
+* The `zone_name` property has been removed in favour of the `private_dns_zone_id` property.
+
+### `azurerm_private_dns_mx_record`
+
+* The `resource_group_name` property has been removed in favour of the `private_dns_zone_id` property.
+* The `zone_name` property has been removed in favour of the `private_dns_zone_id` property.
+
+### `azurerm_private_dns_ptr_record`
+
+* The `resource_group_name` property has been removed in favour of the `private_dns_zone_id` property.
+* The `zone_name` property has been removed in favour of the `private_dns_zone_id` property.
+
+### `azurerm_private_dns_srv_record`
+
+* The `resource_group_name` property has been removed in favour of the `private_dns_zone_id` property.
+* The `zone_name` property has been removed in favour of the `private_dns_zone_id` property.
+
+### `azurerm_private_dns_txt_record`
+
+* The `resource_group_name` property has been removed in favour of the `private_dns_zone_id` property.
+* The `zone_name` property has been removed in favour of the `private_dns_zone_id` property.
+
+### `azurerm_private_dns_zone_virtual_network_link`
+
+* The `private_dns_zone_name` property has been removed in favour of the `private_dns_zone_id` property.
+* The `resource_group_name` property has been removed in favour of the `private_dns_zone_id` property.
+
 ### `azurerm_private_link_service`
 
 * The deprecated `enable_proxy_protocol` property has been removed in favour of the `proxy_protocol_enabled` property.

--- a/website/docs/d/private_dns_aaaa_record.html.markdown
+++ b/website/docs/d/private_dns_aaaa_record.html.markdown
@@ -15,10 +15,10 @@ Use this data source to access information about an existing Private DNS AAAA Re
 ## Example Usage
 
 ```hcl
-resource "azurerm_private_dns_aaaa_record" "example" {
-  name                = "test"
-  zone_name           = "test-zone"
-  resource_group_name = "test-rg"
+data "azurerm_private_dns_aaaa_record" "example" {
+  name                = "example"
+  zone_name           = "example-zone"
+  resource_group_name = "example-rg"
 }
 
 output "private_dns_aaaa_record_id" {

--- a/website/docs/d/private_dns_cname_record.html.markdown
+++ b/website/docs/d/private_dns_cname_record.html.markdown
@@ -15,10 +15,10 @@ Use this data source to access information about an existing Private DNS CNAME R
 ## Example Usage
 
 ```hcl
-resource "azurerm_private_dns_cname_record" "example" {
-  name                = "test"
-  zone_name           = "test-zone"
-  resource_group_name = "test-rg"
+data "azurerm_private_dns_cname_record" "example" {
+  name                = "example"
+  zone_name           = "example-zone"
+  resource_group_name = "example-rg"
 }
 
 output "private_dns_cname_record_id" {

--- a/website/docs/d/private_dns_mx_record.html.markdown
+++ b/website/docs/d/private_dns_mx_record.html.markdown
@@ -15,10 +15,10 @@ Use this data source to access information about an existing Private DNS MX Reco
 ## Example Usage
 
 ```hcl
-resource "azurerm_private_dns_mx_record" "example" {
-  name                = "test"
-  zone_name           = "test-zone"
-  resource_group_name = "test-rg"
+data "azurerm_private_dns_mx_record" "example" {
+  name                = "example"
+  zone_name           = "example-zone"
+  resource_group_name = "example-rg"
 }
 
 output "private_dns_mx_record_id" {

--- a/website/docs/d/private_dns_ptr_record.html.markdown
+++ b/website/docs/d/private_dns_ptr_record.html.markdown
@@ -15,10 +15,10 @@ Use this data source to access information about an existing Private DNS PTR Rec
 ## Example Usage
 
 ```hcl
-resource "azurerm_private_dns_ptr_record" "example" {
-  name                = "test"
-  zone_name           = "test-zone"
-  resource_group_name = "test-rg"
+data "azurerm_private_dns_ptr_record" "example" {
+  name                = "example"
+  zone_name           = "example-zone"
+  resource_group_name = "example-rg"
 }
 
 output "private_dns_ptr_record_id" {

--- a/website/docs/d/private_dns_srv_record.html.markdown
+++ b/website/docs/d/private_dns_srv_record.html.markdown
@@ -15,10 +15,10 @@ Use this data source to access information about an existing Private DNS SRV Rec
 ## Example Usage
 
 ```hcl
-resource "azurerm_private_dns_srv_record" "example" {
-  name                = "test"
-  zone_name           = "test-zone"
-  resource_group_name = "test-rg"
+data "azurerm_private_dns_srv_record" "example" {
+  name                = "example"
+  zone_name           = "example-zone"
+  resource_group_name = "example-rg"
 }
 
 output "private_dns_srv_record_id" {

--- a/website/docs/d/private_dns_txt_record.html.markdown
+++ b/website/docs/d/private_dns_txt_record.html.markdown
@@ -15,10 +15,10 @@ Use this data source to access information about an existing Private DNS TXT Rec
 ## Example Usage
 
 ```hcl
-resource "azurerm_private_dns_txt_record" "example" {
-  name                = "test"
-  zone_name           = "test-zone"
-  resource_group_name = "test-rg"
+data "azurerm_private_dns_txt_record" "example" {
+  name                = "example"
+  zone_name           = "example-zone"
+  resource_group_name = "example-rg"
 }
 
 output "private_dns_txt_record_id" {

--- a/website/docs/r/mssql_managed_instance_failover_group.html.markdown
+++ b/website/docs/r/mssql_managed_instance_failover_group.html.markdown
@@ -58,10 +58,9 @@ resource "azurerm_virtual_network" "primary" {
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "primary" {
-  name                  = "primary-link"
-  resource_group_name   = azurerm_resource_group.primary.name
-  private_dns_zone_name = azurerm_private_dns_zone.example.name
-  virtual_network_id    = azurerm_virtual_network.primary.id
+  name                = "primary-link"
+  private_dns_zone_id = azurerm_private_dns_zone.example.id
+  virtual_network_id  = azurerm_virtual_network.primary.id
 }
 
 resource "azurerm_subnet" "primary" {
@@ -142,10 +141,9 @@ resource "azurerm_virtual_network" "failover" {
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "failover" {
-  name                  = "failover-link"
-  resource_group_name   = azurerm_private_dns_zone.example.resource_group_name
-  private_dns_zone_name = azurerm_private_dns_zone.example.name
-  virtual_network_id    = azurerm_virtual_network.failover.id
+  name                = "failover-link"
+  private_dns_zone_id = azurerm_private_dns_zone.example.id
+  virtual_network_id  = azurerm_virtual_network.failover.id
 }
 
 resource "azurerm_subnet" "default" {

--- a/website/docs/r/mysql_flexible_server.html.markdown
+++ b/website/docs/r/mysql_flexible_server.html.markdown
@@ -52,10 +52,9 @@ resource "azurerm_private_dns_zone" "example" {
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "example" {
-  name                  = "exampleVnetZone.com"
-  private_dns_zone_name = azurerm_private_dns_zone.example.name
-  virtual_network_id    = azurerm_virtual_network.example.id
-  resource_group_name   = azurerm_resource_group.example.name
+  name                = "exampleVnetZone.com"
+  private_dns_zone_id = azurerm_private_dns_zone.example.id
+  virtual_network_id  = azurerm_virtual_network.example.id
 }
 
 resource "azurerm_mysql_flexible_server" "example" {

--- a/website/docs/r/postgresql_flexible_server.html.markdown
+++ b/website/docs/r/postgresql_flexible_server.html.markdown
@@ -51,11 +51,10 @@ resource "azurerm_private_dns_zone" "example" {
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "example" {
-  name                  = "exampleVnetZone.com"
-  private_dns_zone_name = azurerm_private_dns_zone.example.name
-  virtual_network_id    = azurerm_virtual_network.example.id
-  resource_group_name   = azurerm_resource_group.example.name
-  depends_on            = [azurerm_subnet.example]
+  name                = "exampleVnetZone.com"
+  private_dns_zone_id = azurerm_private_dns_zone.example.id
+  virtual_network_id  = azurerm_virtual_network.example.id
+  depends_on          = [azurerm_subnet.example]
 }
 
 resource "azurerm_postgresql_flexible_server" "example" {

--- a/website/docs/r/private_dns_a_record.html.markdown
+++ b/website/docs/r/private_dns_a_record.html.markdown
@@ -25,8 +25,7 @@ resource "azurerm_private_dns_zone" "example" {
 
 resource "azurerm_private_dns_a_record" "example" {
   name                = "test"
-  zone_name           = azurerm_private_dns_zone.example.name
-  resource_group_name = azurerm_resource_group.example.name
+  private_dns_zone_id = azurerm_private_dns_zone.example.id
   ttl                 = 300
   records             = ["10.0.180.17"]
 }
@@ -38,9 +37,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the DNS A Record. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) Specifies the resource group where the Private DNS Zone exists. Changing this forces a new resource to be created.
-
-* `zone_name` - (Required) Specifies the Private DNS Zone where the resource exists. Changing this forces a new resource to be created.
+* `private_dns_zone_id` - (Required) Specifies the ID of the Private DNS Zone where the resource exists. Changing this forces a new resource to be created.
 
 * `ttl` - (Required) The Time To Live (TTL) of the DNS record in seconds.
 

--- a/website/docs/r/private_dns_aaaa_record.html.markdown
+++ b/website/docs/r/private_dns_aaaa_record.html.markdown
@@ -25,8 +25,7 @@ resource "azurerm_private_dns_zone" "test" {
 
 resource "azurerm_private_dns_aaaa_record" "test" {
   name                = "test"
-  zone_name           = azurerm_private_dns_zone.test.name
-  resource_group_name = azurerm_resource_group.example.name
+  private_dns_zone_id = azurerm_private_dns_zone.test.id
   ttl                 = 300
   records             = ["fd5d:70bc:930e:d008:0000:0000:0000:7334", "fd5d:70bc:930e:d008::7335"]
 }
@@ -38,9 +37,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the DNS A Record. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) Specifies the resource group where the resource exists. Changing this forces a new resource to be created.
-
-* `zone_name` - (Required) Specifies the Private DNS Zone where the resource exists. Changing this forces a new resource to be created.
+* `private_dns_zone_id` - (Required) Specifies the ID of the Private DNS Zone where the resource exists. Changing this forces a new resource to be created.
 
 * `ttl` - (Required) The Time To Live (TTL) of the DNS record in seconds.
 

--- a/website/docs/r/private_dns_cname_record.html.markdown
+++ b/website/docs/r/private_dns_cname_record.html.markdown
@@ -25,8 +25,7 @@ resource "azurerm_private_dns_zone" "example" {
 
 resource "azurerm_private_dns_cname_record" "example" {
   name                = "test"
-  zone_name           = azurerm_private_dns_zone.example.name
-  resource_group_name = azurerm_resource_group.example.name
+  private_dns_zone_id = azurerm_private_dns_zone.example.id
   ttl                 = 300
   record              = "contoso.com"
 }
@@ -38,9 +37,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the DNS CNAME Record. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) Specifies the resource group where the resource exists. Changing this forces a new resource to be created.
-
-* `zone_name` - (Required) Specifies the Private DNS Zone where the resource exists. Changing this forces a new resource to be created.
+* `private_dns_zone_id` - (Required) Specifies the ID of the Private DNS Zone where the resource exists. Changing this forces a new resource to be created.
 
 * `ttl` - (Required) The Time To Live (TTL) of the DNS record in seconds. Possible values are between `0` and `2147483647`.
 

--- a/website/docs/r/private_dns_mx_record.html.markdown
+++ b/website/docs/r/private_dns_mx_record.html.markdown
@@ -25,8 +25,7 @@ resource "azurerm_private_dns_zone" "example" {
 
 resource "azurerm_private_dns_mx_record" "example" {
   name                = "example"
-  resource_group_name = azurerm_resource_group.example.name
-  zone_name           = azurerm_private_dns_zone.example.name
+  private_dns_zone_id = azurerm_private_dns_zone.example.id
   ttl                 = 300
 
   record {
@@ -51,9 +50,7 @@ The following arguments are supported:
 
 * `name` - (Optional) The name of the DNS MX Record. Changing this forces a new resource to be created. Default to '@' for root zone entry.
 
-* `resource_group_name` - (Required) Specifies the resource group where the resource exists. Changing this forces a new resource to be created.
-
-* `zone_name` - (Required) Specifies the Private DNS Zone where the resource exists. Changing this forces a new resource to be created.
+* `private_dns_zone_id` - (Required) Specifies the ID of the Private DNS Zone where the resource exists. Changing this forces a new resource to be created.
 
 * `record` - (Required) One or more `record` blocks as defined below.
 

--- a/website/docs/r/private_dns_ptr_record.html.markdown
+++ b/website/docs/r/private_dns_ptr_record.html.markdown
@@ -25,8 +25,7 @@ resource "azurerm_private_dns_zone" "example" {
 
 resource "azurerm_private_dns_ptr_record" "example" {
   name                = "15"
-  zone_name           = azurerm_private_dns_zone.example.name
-  resource_group_name = azurerm_resource_group.example.name
+  private_dns_zone_id = azurerm_private_dns_zone.example.id
   ttl                 = 300
   records             = ["test.example.com"]
 }
@@ -38,9 +37,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the DNS PTR Record. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) Specifies the resource group where the resource exists. Changing this forces a new resource to be created.
-
-* `zone_name` - (Required) Specifies the Private DNS Zone where the resource exists. Changing this forces a new resource to be created.
+* `private_dns_zone_id` - (Required) Specifies the ID of the Private DNS Zone where the resource exists. Changing this forces a new resource to be created.
 
 * `ttl` - (Required) The Time To Live (TTL) of the DNS record in seconds.
 

--- a/website/docs/r/private_dns_srv_record.html.markdown
+++ b/website/docs/r/private_dns_srv_record.html.markdown
@@ -25,8 +25,7 @@ resource "azurerm_private_dns_zone" "example" {
 
 resource "azurerm_private_dns_srv_record" "example" {
   name                = "test"
-  resource_group_name = azurerm_resource_group.example.name
-  zone_name           = azurerm_private_dns_zone.example.name
+  private_dns_zone_id = azurerm_private_dns_zone.example.id
   ttl                 = 300
 
   record {
@@ -55,9 +54,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the DNS SRV Record. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) Specifies the resource group where the resource exists. Changing this forces a new resource to be created.
-
-* `zone_name` - (Required) Specifies the Private DNS Zone where the resource exists. Changing this forces a new resource to be created.
+* `private_dns_zone_id` - (Required) Specifies the ID of the Private DNS Zone where the resource exists. Changing this forces a new resource to be created.
 
 * `record` - (Required) One or more `record` blocks as defined below.
 

--- a/website/docs/r/private_dns_txt_record.html.markdown
+++ b/website/docs/r/private_dns_txt_record.html.markdown
@@ -25,8 +25,7 @@ resource "azurerm_private_dns_zone" "example" {
 
 resource "azurerm_private_dns_txt_record" "example" {
   name                = "test"
-  resource_group_name = azurerm_resource_group.example.name
-  zone_name           = azurerm_private_dns_zone.example.name
+  private_dns_zone_id = azurerm_private_dns_zone.example.id
   ttl                 = 300
 
   record {
@@ -41,9 +40,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the DNS TXT Record. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) Specifies the resource group where the resource exists. Changing this forces a new resource to be created.
-
-* `zone_name` - (Required) Specifies the Private DNS Zone where the resource exists. Changing this forces a new resource to be created.
+* `private_dns_zone_id` - (Required) Specifies the ID of the Private DNS Zone where the resource exists. Changing this forces a new resource to be created.
 
 * `record` - (Required) One or more `record` blocks as defined below.
 

--- a/website/docs/r/private_dns_zone_virtual_network_link.html.markdown
+++ b/website/docs/r/private_dns_zone_virtual_network_link.html.markdown
@@ -24,10 +24,9 @@ resource "azurerm_private_dns_zone" "example" {
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "example" {
-  name                  = "test"
-  resource_group_name   = azurerm_resource_group.example.name
-  private_dns_zone_name = azurerm_private_dns_zone.example.name
-  virtual_network_id    = azurerm_virtual_network.example.id
+  name                = "test"
+  private_dns_zone_id = azurerm_private_dns_zone.example.id
+  virtual_network_id  = azurerm_virtual_network.example.id
 }
 
 resource "azurerm_virtual_network" "example" {
@@ -44,9 +43,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the Private DNS Zone Virtual Network Link. Changing this forces a new resource to be created.
 
-* `private_dns_zone_name` - (Required) The name of the Private DNS zone (without a terminating dot). Changing this forces a new resource to be created.
-
-* `resource_group_name` - (Required) Specifies the resource group where the Private DNS Zone exists. Changing this forces a new resource to be created.
+* `private_dns_zone_id` - (Required) Specifies the ID of the Private DNS Zone where the resource exists. Changing this forces a new resource to be created.
 
 * `virtual_network_id` - (Required) The ID of the Virtual Network that should be linked to the DNS Zone. Changing this forces a new resource to be created.
 

--- a/website/docs/r/private_endpoint.html.markdown
+++ b/website/docs/r/private_endpoint.html.markdown
@@ -183,10 +183,9 @@ resource "azurerm_private_dns_zone" "example" {
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "example" {
-  name                  = "example-link"
-  resource_group_name   = azurerm_resource_group.example.name
-  private_dns_zone_name = azurerm_private_dns_zone.example.name
-  virtual_network_id    = azurerm_virtual_network.example.id
+  name                = "example-link"
+  private_dns_zone_id = azurerm_private_dns_zone.example.id
+  virtual_network_id  = azurerm_virtual_network.example.id
 }
 ```
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

- Resolves TODO 4.0s in the `privatedns` service
- Removes 1 already resolved TODO 4.0 comment from the storage account resource

To be merged after the final 4.x release.

## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change




## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
