### PR TITLE
`azurerm_storage_table` - fix bug in 4.x path for storage_account_name to storage_account_id change

### DIFF
--- a/internal/services/storage/helpers/legacy_customize_diff.go
+++ b/internal/services/storage/helpers/legacy_customize_diff.go
@@ -1,0 +1,43 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package helpers
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+func LegacyStorageAccountResourceCustomizeDiff(_ context.Context, diff *pluginsdk.ResourceDiff, _ any) error {
+	if strings.HasPrefix(diff.Id(), "/subscriptions/") && diff.HasChange("storage_account_id") {
+		return diff.ForceNew("storage_account_id")
+	}
+
+	if diff.Id() != "" && !strings.HasPrefix(diff.Id(), "/subscriptions/") && diff.HasChange("storage_account_name") {
+		oldAccountId, newAccountId := diff.GetChange("storage_account_id")
+		oldName, newName := diff.GetChange("storage_account_name")
+
+		if oldAccountId.(string) != "" && newName.(string) != "" {
+			return diff.ForceNew("storage_account_name")
+		}
+
+		if oldName.(string) != "" && newName.(string) != "" {
+			return diff.ForceNew("storage_account_name")
+		}
+
+		if oldName.(string) != "" && newName.(string) == "" && newAccountId.(string) != "" {
+			parsedId, err := commonids.ParseStorageAccountID(newAccountId.(string))
+			if err != nil {
+				return err
+			}
+			if !strings.EqualFold(parsedId.StorageAccountName, oldName.(string)) {
+				return diff.ForceNew("storage_account_id")
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/services/storage/storage_container_resource.go
+++ b/internal/services/storage/storage_container_resource.go
@@ -4,7 +4,6 @@
 package storage
 
 import (
-	"context"
 	"fmt"
 	"log"
 	"strings"
@@ -156,29 +155,7 @@ func resourceStorageContainer() *pluginsdk.Resource {
 			Deprecated: "this property has been deprecated in favour of `id` and will be removed in version 5.0 of the Provider.",
 		}
 
-		r.CustomizeDiff = func(ctx context.Context, diff *pluginsdk.ResourceDiff, i interface{}) error {
-			// Resource Manager ID in use, but change to `storage_account_id` should recreate - won't trigger on create as diff.Id() will be ""
-			if strings.HasPrefix(diff.Id(), "/subscriptions/") && diff.HasChange("storage_account_id") {
-				return diff.ForceNew("storage_account_id")
-			}
-
-			// using legacy Data Plane ID but attempting to change the storage_account_name should recreate - won't trigger on create as diff.Id() will be ""
-			if diff.Id() != "" && !strings.HasPrefix(diff.Id(), "/subscriptions/") && diff.HasChange("storage_account_name") {
-				// converting from storage_account_id to the deprecated storage_account_name is not supported
-				oldAccountId, _ := diff.GetChange("storage_account_id")
-				oldName, newName := diff.GetChange("storage_account_name")
-
-				if oldAccountId.(string) != "" && newName.(string) != "" {
-					return diff.ForceNew("storage_account_name")
-				}
-
-				if oldName.(string) != "" && newName.(string) != "" {
-					return diff.ForceNew("storage_account_name")
-				}
-			}
-
-			return nil
-		}
+		r.CustomizeDiff = helpers.LegacyStorageAccountResourceCustomizeDiff
 	}
 
 	return r

--- a/internal/services/storage/storage_container_resource_test.go
+++ b/internal/services/storage/storage_container_resource_test.go
@@ -589,15 +589,3 @@ func TestValidateStorageContainerName(t *testing.T) {
 		}
 	}
 }
-
-func (r StorageContainerResource) withAccountName(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-%s
-
-resource "azurerm_storage_container" "test" {
-  name                  = "vhds"
-  storage_account_name  = azurerm_storage_account.test.name
-  container_access_type = "private"
-}
-`, r.template(data))
-}

--- a/internal/services/storage/storage_container_resource_test.go
+++ b/internal/services/storage/storage_container_resource_test.go
@@ -6,7 +6,6 @@ package storage_test
 import (
 	"context"
 	"fmt"
-	"regexp"
 	"strings"
 	"testing"
 
@@ -191,61 +190,6 @@ func TestAccStorageContainer_web(t *testing.T) {
 			),
 		},
 		data.ImportStep(),
-	})
-}
-
-func TestAccStorageContainer_migrateToStorageID(t *testing.T) {
-	if features.FivePointOh() {
-		t.Skip("skipping as test is not valid in 5.0")
-	}
-	data := acceptance.BuildTestData(t, "azurerm_storage_container", "test")
-	r := StorageContainerResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.withAccountName(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("storage_account_name").IsSet(),
-				check.That(data.ResourceName).Key("storage_account_id").DoesNotExist(),
-				check.That(data.ResourceName).Key("id").MatchesRegex(regexp.MustCompile("https:*")),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.basic(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("storage_account_name").IsEmpty(),
-				check.That(data.ResourceName).Key("storage_account_id").IsSet(),
-				check.That(data.ResourceName).Key("id").MatchesRegex(regexp.MustCompile("/subscriptions/*")),
-			),
-		},
-		data.ImportStep(),
-	})
-}
-
-func TestAccStorageContainer_migrateFromStorageIDShouldFail(t *testing.T) {
-	if features.FivePointOh() {
-		t.Skip("skipping as test is not valid in 5.0")
-	}
-	data := acceptance.BuildTestData(t, "azurerm_storage_container", "test")
-	r := StorageContainerResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.basic(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("storage_account_name").IsEmpty(),
-				check.That(data.ResourceName).Key("storage_account_id").IsSet(),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config:      r.withAccountName(data),
-			ExpectError: regexp.MustCompile("expected action to not be Replace"),
-		},
 	})
 }
 

--- a/internal/services/storage/storage_container_resource_test.go
+++ b/internal/services/storage/storage_container_resource_test.go
@@ -393,17 +393,6 @@ resource "azurerm_storage_container" "test" {
 }
 
 func (r StorageContainerResource) requiresImport(data acceptance.TestData) string {
-	if !features.FivePointOh() {
-		return fmt.Sprintf(`
-	%s
-
-resource "azurerm_storage_container" "import" {
-  name                  = azurerm_storage_container.test.name
-  storage_account_name  = azurerm_storage_container.test.storage_account_name
-  container_access_type = azurerm_storage_container.test.container_access_type
-}
-	`, r.basic(data))
-	}
 	return fmt.Sprintf(`
 %s
 

--- a/internal/services/storage/storage_queue_resource.go
+++ b/internal/services/storage/storage_queue_resource.go
@@ -4,7 +4,6 @@
 package storage
 
 import (
-	"context"
 	"fmt"
 	"log"
 	"strings"
@@ -107,29 +106,7 @@ func resourceStorageQueue() *pluginsdk.Resource {
 			Deprecated: "the `resource_manager_id` property has been deprecated in favour of `id` and will be removed in version 5.0 of the Provider.",
 		}
 
-		r.CustomizeDiff = func(ctx context.Context, diff *pluginsdk.ResourceDiff, i interface{}) error {
-			// Resource Manager ID in use, but change to `storage_account_id` should recreate
-			if strings.HasPrefix(diff.Id(), "/subscriptions/") && diff.HasChange("storage_account_id") {
-				return diff.ForceNew("storage_account_id")
-			}
-
-			// using legacy Data Plane ID but attempting to change the storage_account_name should recreate
-			if diff.Id() != "" && !strings.HasPrefix(diff.Id(), "/subscriptions/") && diff.HasChange("storage_account_name") {
-				// converting from storage_account_id to the deprecated storage_account_name is not supported
-				oldAccountId, _ := diff.GetChange("storage_account_id")
-				oldName, newName := diff.GetChange("storage_account_name")
-
-				if oldAccountId.(string) != "" && newName.(string) != "" {
-					return diff.ForceNew("storage_account_name")
-				}
-
-				if oldName.(string) != "" && newName.(string) != "" {
-					return diff.ForceNew("storage_account_name")
-				}
-			}
-
-			return nil
-		}
+		r.CustomizeDiff = helpers.LegacyStorageAccountResourceCustomizeDiff
 	}
 
 	return r

--- a/internal/services/storage/storage_queue_resource_test.go
+++ b/internal/services/storage/storage_queue_resource_test.go
@@ -162,8 +162,8 @@ func (r StorageQueueResource) basic(data acceptance.TestData) string {
 %s
 
 resource "azurerm_storage_queue" "test" {
-  name                 = "acctestmysamplequeue-%d"
-  storage_account_name = azurerm_storage_account.test.name
+  name               = "acctestmysamplequeue-%d"
+  storage_account_id = azurerm_storage_account.test.id
 }
 `, r.template(data), data.RandomInteger)
 }

--- a/internal/services/storage/storage_queue_resource_test.go
+++ b/internal/services/storage/storage_queue_resource_test.go
@@ -121,30 +121,6 @@ func TestAccStorageQueue_migrateToStorageID(t *testing.T) {
 	})
 }
 
-func TestAccStorageQueue_migrateFromStorageIDShouldFail(t *testing.T) {
-	if features.FivePointOh() {
-		t.Skip("skipping as test is not valid in 5.0")
-	}
-	data := acceptance.BuildTestData(t, "azurerm_storage_queue", "test")
-	r := StorageQueueResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.basic(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("storage_account_id").IsSet(),
-				check.That(data.ResourceName).Key("storage_account_name").IsEmpty(),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config:      r.basic(data),
-			ExpectError: regexp.MustCompile("expected action to not be Replace"),
-		},
-	})
-}
-
 func (r StorageQueueResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	if !features.FivePointOh() && !strings.HasPrefix(state.ID, "/subscriptions") {
 		id, err := queues.ParseQueueID(state.ID, client.Storage.StorageDomainSuffix)
@@ -183,7 +159,6 @@ func (r StorageQueueResource) Exists(ctx context.Context, client *clients.Client
 
 func (r StorageQueueResource) basic(data acceptance.TestData) string {
 	if !features.FivePointOh() {
-		template := r.template(data)
 		return fmt.Sprintf(`
 	%s
 
@@ -191,9 +166,8 @@ resource "azurerm_storage_queue" "test" {
   name                 = "acctestmysamplequeue-%d"
   storage_account_name = azurerm_storage_account.test.name
 }
-	`, template, data.RandomInteger)
+`, r.template(data), data.RandomInteger)
 	}
-	template := r.template(data)
 	return fmt.Sprintf(`
 %s
 
@@ -201,7 +175,7 @@ resource "azurerm_storage_queue" "test" {
   name               = "acctestmysamplequeue-%d"
   storage_account_id = azurerm_storage_account.test.id
 }
-`, template, data.RandomInteger)
+`, r.template(data), data.RandomInteger)
 }
 
 func (r StorageQueueResource) basicAzureADAuth(data acceptance.TestData) string {

--- a/internal/services/storage/storage_queue_resource_test.go
+++ b/internal/services/storage/storage_queue_resource_test.go
@@ -99,7 +99,7 @@ func TestAccStorageQueue_migrateToStorageID(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.basic(data),
+			Config: r.withAccountName(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("storage_account_name").IsSet(),
@@ -158,22 +158,23 @@ func (r StorageQueueResource) Exists(ctx context.Context, client *clients.Client
 }
 
 func (r StorageQueueResource) basic(data acceptance.TestData) string {
-	if !features.FivePointOh() {
-		return fmt.Sprintf(`
-	%s
+	return fmt.Sprintf(`
+%s
 
 resource "azurerm_storage_queue" "test" {
   name                 = "acctestmysamplequeue-%d"
   storage_account_name = azurerm_storage_account.test.name
 }
 `, r.template(data), data.RandomInteger)
-	}
+}
+
+func (r StorageQueueResource) withAccountName(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
 resource "azurerm_storage_queue" "test" {
-  name               = "acctestmysamplequeue-%d"
-  storage_account_id = azurerm_storage_account.test.id
+  name                 = "acctestmysamplequeue-%d"
+  storage_account_name = azurerm_storage_account.test.name
 }
 `, r.template(data), data.RandomInteger)
 }
@@ -240,18 +241,6 @@ resource "azurerm_storage_queue" "test" {
 }
 
 func (r StorageQueueResource) requiresImport(data acceptance.TestData) string {
-	if !features.FivePointOh() {
-		template := r.basic(data)
-		return fmt.Sprintf(`
-	%s
-
-resource "azurerm_storage_queue" "import" {
-  name                 = azurerm_storage_queue.test.name
-  storage_account_name = azurerm_storage_queue.test.storage_account_name
-}
-	`, template)
-	}
-	template := r.basic(data)
 	return fmt.Sprintf(`
 %s
 
@@ -259,12 +248,11 @@ resource "azurerm_storage_queue" "import" {
   name               = azurerm_storage_queue.test.name
   storage_account_id = azurerm_storage_queue.test.storage_account_id
 }
-`, template)
+`, r.basic(data))
 }
 
 func (r StorageQueueResource) metaData(data acceptance.TestData) string {
 	if !features.FivePointOh() {
-		template := r.template(data)
 		return fmt.Sprintf(`
 	%s
 
@@ -276,9 +264,8 @@ resource "azurerm_storage_queue" "test" {
     hello = "world"
   }
 }
-	`, template, data.RandomInteger)
+`, r.template(data), data.RandomInteger)
 	}
-	template := r.template(data)
 	return fmt.Sprintf(`
 %s
 
@@ -290,12 +277,11 @@ resource "azurerm_storage_queue" "test" {
     hello = "world"
   }
 }
-`, template, data.RandomInteger)
+`, r.template(data), data.RandomInteger)
 }
 
 func (r StorageQueueResource) metaDataUpdated(data acceptance.TestData) string {
 	if !features.FivePointOh() {
-		template := r.template(data)
 		return fmt.Sprintf(`
 	%s
 
@@ -308,9 +294,8 @@ resource "azurerm_storage_queue" "test" {
     rick  = "M0rty"
   }
 }
-	`, template, data.RandomInteger)
+`, r.template(data), data.RandomInteger)
 	}
-	template := r.template(data)
 	return fmt.Sprintf(`
 %s
 
@@ -323,7 +308,7 @@ resource "azurerm_storage_queue" "test" {
     rick  = "M0rty"
   }
 }
-`, template, data.RandomInteger)
+`, r.template(data), data.RandomInteger)
 }
 
 func (r StorageQueueResource) template(data acceptance.TestData) string {

--- a/internal/services/storage/storage_share_resource.go
+++ b/internal/services/storage/storage_share_resource.go
@@ -4,7 +4,6 @@
 package storage
 
 import (
-	"context"
 	"fmt"
 	"log"
 	"strings"
@@ -189,29 +188,7 @@ func resourceStorageShare() *pluginsdk.Resource {
 			Deprecated: "this property is deprecated and will be removed 5.0 and replaced by the `id` property.",
 		}
 
-		r.CustomizeDiff = func(ctx context.Context, diff *pluginsdk.ResourceDiff, i interface{}) error {
-			// Resource Manager ID in use, but change to `storage_account_id` should recreate
-			if strings.HasPrefix(diff.Id(), "/subscriptions/") && diff.HasChange("storage_account_id") {
-				return diff.ForceNew("storage_account_id")
-			}
-
-			// using legacy Data Plane ID but attempting to change the storage_account_name should recreate
-			if diff.Id() != "" && !strings.HasPrefix(diff.Id(), "/subscriptions/") && diff.HasChange("storage_account_name") {
-				// converting from storage_account_id to the deprecated storage_account_name is not supported
-				oldAccountId, _ := diff.GetChange("storage_account_id")
-				oldName, newName := diff.GetChange("storage_account_name")
-
-				if oldAccountId.(string) != "" && newName.(string) != "" {
-					return diff.ForceNew("storage_account_name")
-				}
-
-				if oldName.(string) != "" && newName.(string) != "" {
-					return diff.ForceNew("storage_account_name")
-				}
-			}
-
-			return nil
-		}
+		r.CustomizeDiff = helpers.LegacyStorageAccountResourceCustomizeDiff
 	}
 
 	return r

--- a/internal/services/storage/storage_share_resource_test.go
+++ b/internal/services/storage/storage_share_resource_test.go
@@ -10,6 +10,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2025-08-01/fileshares"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
@@ -297,7 +300,7 @@ func TestAccStorageShare_migrateFromStorageIDShouldFail(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_share", "test")
 	r := StorageShareResource{}
 
-	data.ResourceTest(t, r, []acceptance.TestStep{
+	data.ResourceTestIgnoreRecreate(t, r, []acceptance.TestStep{
 		{
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -308,8 +311,12 @@ func TestAccStorageShare_migrateFromStorageIDShouldFail(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			Config:      r.withAccountName(data),
-			ExpectError: regexp.MustCompile("expected action to not be Replace"),
+			Config: r.withAccountName(data),
+			ConfigPlanChecks: resource.ConfigPlanChecks{
+				PreApply: []plancheck.PlanCheck{
+					plancheck.ExpectResourceAction(data.ResourceName, plancheck.ResourceActionReplace),
+				},
+			},
 		},
 	})
 }
@@ -385,9 +392,9 @@ func (r StorageShareResource) basic(data acceptance.TestData) string {
 	%s
 
 resource "azurerm_storage_share" "test" {
-  name                 = "testshare%s"
-  storage_account_name = azurerm_storage_account.test.name
-  quota                = 5
+  name               = "testshare%s"
+  storage_account_id = azurerm_storage_account.test.id
+  quota              = 5
 }
 `, r.template(data), data.RandomString)
 }

--- a/internal/services/storage/storage_share_resource_test.go
+++ b/internal/services/storage/storage_share_resource_test.go
@@ -10,11 +10,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/plancheck"
-
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2025-08-01/fileshares"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"

--- a/internal/services/storage/storage_share_resource_test.go
+++ b/internal/services/storage/storage_share_resource_test.go
@@ -381,24 +381,13 @@ func (r StorageShareResource) Destroy(ctx context.Context, client *clients.Clien
 }
 
 func (r StorageShareResource) basic(data acceptance.TestData) string {
-	if !features.FivePointOh() {
-		return fmt.Sprintf(`
+	return fmt.Sprintf(`
 	%s
 
 resource "azurerm_storage_share" "test" {
   name                 = "testshare%s"
   storage_account_name = azurerm_storage_account.test.name
   quota                = 5
-}
-	`, r.template(data), data.RandomString)
-	}
-	return fmt.Sprintf(`
-%s
-
-resource "azurerm_storage_share" "test" {
-  name               = "testshare%s"
-  storage_account_id = azurerm_storage_account.test.id
-  quota              = 5
 }
 `, r.template(data), data.RandomString)
 }

--- a/internal/services/storage/storage_share_resource_test.go
+++ b/internal/services/storage/storage_share_resource_test.go
@@ -633,17 +633,6 @@ resource "azurerm_storage_share" "test" {
 }
 
 func (r StorageShareResource) requiresImport(data acceptance.TestData) string {
-	if !features.FivePointOh() {
-		return fmt.Sprintf(`
-	%s
-
-resource "azurerm_storage_share" "import" {
-  name                 = azurerm_storage_share.test.name
-  storage_account_name = azurerm_storage_share.test.storage_account_name
-  quota                = azurerm_storage_share.test.quota
-}
-	`, r.basic(data))
-	}
 	return fmt.Sprintf(`
 %s
 

--- a/internal/services/storage/storage_table_resource.go
+++ b/internal/services/storage/storage_table_resource.go
@@ -4,7 +4,6 @@
 package storage
 
 import (
-	"context"
 	"fmt"
 	"log"
 	"strings"
@@ -138,36 +137,7 @@ func resourceStorageTable() *pluginsdk.Resource {
 			ExactlyOneOf: []string{"storage_account_id", "storage_account_name"},
 		}
 
-		r.CustomizeDiff = func(ctx context.Context, diff *pluginsdk.ResourceDiff, i interface{}) error {
-			if strings.HasPrefix(diff.Id(), "/subscriptions/") && diff.HasChange("storage_account_id") {
-				return diff.ForceNew("storage_account_id")
-			}
-
-			if diff.Id() != "" && !strings.HasPrefix(diff.Id(), "/subscriptions/") && diff.HasChange("storage_account_name") {
-				oldAccountId, newAccountId := diff.GetChange("storage_account_id")
-				oldName, newName := diff.GetChange("storage_account_name")
-
-				if oldAccountId.(string) != "" && newName.(string) != "" {
-					return diff.ForceNew("storage_account_name")
-				}
-
-				if oldName.(string) != "" && newName.(string) != "" {
-					return diff.ForceNew("storage_account_name")
-				}
-
-				if oldName.(string) != "" && newName.(string) == "" && newAccountId.(string) != "" {
-					parsedId, err := commonids.ParseStorageAccountID(newAccountId.(string))
-					if err != nil {
-						return err
-					}
-					if !strings.EqualFold(parsedId.StorageAccountName, oldName.(string)) {
-						return diff.ForceNew("storage_account_id")
-					}
-				}
-			}
-
-			return nil
-		}
+		r.CustomizeDiff = helpers.LegacyStorageAccountResourceCustomizeDiff
 		r.SchemaVersion = 2
 		r.StateUpgraders = pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
 			0: migration.TableV0ToV1{},

--- a/internal/services/storage/storage_table_resource.go
+++ b/internal/services/storage/storage_table_resource.go
@@ -126,7 +126,6 @@ func resourceStorageTable() *pluginsdk.Resource {
 		r.Schema["storage_account_name"] = &pluginsdk.Schema{
 			Type:         pluginsdk.TypeString,
 			Optional:     true,
-			ForceNew:     true,
 			ValidateFunc: validate.StorageAccountName,
 			ExactlyOneOf: []string{"storage_account_id", "storage_account_name"},
 			Deprecated:   "the `storage_account_name` property has been deprecated in favour of `storage_account_id` and will be removed in version 5.0 of the Provider.",
@@ -135,7 +134,6 @@ func resourceStorageTable() *pluginsdk.Resource {
 		r.Schema["storage_account_id"] = &pluginsdk.Schema{
 			Type:         pluginsdk.TypeString,
 			Optional:     true,
-			ForceNew:     true,
 			ValidateFunc: commonids.ValidateStorageAccountID,
 			ExactlyOneOf: []string{"storage_account_id", "storage_account_name"},
 		}
@@ -146,7 +144,7 @@ func resourceStorageTable() *pluginsdk.Resource {
 			}
 
 			if diff.Id() != "" && !strings.HasPrefix(diff.Id(), "/subscriptions/") && diff.HasChange("storage_account_name") {
-				oldAccountId, _ := diff.GetChange("storage_account_id")
+				oldAccountId, newAccountId := diff.GetChange("storage_account_id")
 				oldName, newName := diff.GetChange("storage_account_name")
 
 				if oldAccountId.(string) != "" && newName.(string) != "" {
@@ -155,6 +153,16 @@ func resourceStorageTable() *pluginsdk.Resource {
 
 				if oldName.(string) != "" && newName.(string) != "" {
 					return diff.ForceNew("storage_account_name")
+				}
+
+				if oldName.(string) != "" && newName.(string) == "" && newAccountId.(string) != "" {
+					parsedId, err := commonids.ParseStorageAccountID(newAccountId.(string))
+					if err != nil {
+						return err
+					}
+					if !strings.EqualFold(parsedId.StorageAccountName, oldName.(string)) {
+						return diff.ForceNew("storage_account_id")
+					}
 				}
 			}
 

--- a/internal/services/storage/storage_table_resource_test.go
+++ b/internal/services/storage/storage_table_resource_test.go
@@ -6,6 +6,7 @@ package storage_test
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -107,8 +108,32 @@ func TestAccStorageTable_acl(t *testing.T) {
 	})
 }
 
+func TestAccStorageTable_migrationToStorageID(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("skipping test as the `storage_account_name` property is removed in 5.0")
+	}
+
+	data := acceptance.BuildTestData(t, "azurerm_storage_table", "test")
+	r := StorageTableResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.migrationInitial(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		{
+			Config: r.migrationUpdated(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+	})
+}
+
 func (r StorageTableResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
-	if !features.FivePointOh() {
+	if !features.FivePointOh() && !strings.HasPrefix(state.ID, "/subscriptions/") {
 		id, err := legacytables.ParseTableID(state.ID, client.Storage.StorageDomainSuffix)
 		if err != nil {
 			return nil, err
@@ -579,6 +604,66 @@ resource "azurerm_storage_table" "test" {
       expiry      = "2019-07-02T10:38:21.0000000Z"
     }
   }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger)
+}
+
+func (r StorageTableResource) migrationInitial(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctestacc%s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  tags = {
+    environment = "staging"
+  }
+}
+
+resource "azurerm_storage_table" "test" {
+  name                 = "acctestst%d"
+  storage_account_name = azurerm_storage_account.test.name
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger)
+}
+
+func (r StorageTableResource) migrationUpdated(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctestacc%s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  tags = {
+    environment = "staging"
+  }
+}
+
+resource "azurerm_storage_table" "test" {
+  name               = "acctestst%d"
+  storage_account_id = azurerm_storage_account.test.id
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger)
 }


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_storage_table` - fix `ForceNew` bug in 4.x path for storage_account_name to storage_account_id change


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

closes #32684
supersedes #32697


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
