### PR TITLE
azurerm_kusto_cluster: fix perpetual diff on trusted_external_tenants

### DIFF
--- a/internal/services/kusto/identity.go
+++ b/internal/services/kusto/identity.go
@@ -37,3 +37,27 @@ func flattenTrustedExternalTenants(input *[]clusters.TrustedExternalTenant) []in
 
 	return output
 }
+
+// trustedExternalTenantsEqual reports whether two `trusted_external_tenants` lists contain the same
+// set of tenant IDs, ignoring order and duplicates. It is used to suppress the perpetual diff caused
+// by the Azure Data Explorer API returning the tenants in a different order than configured.
+func trustedExternalTenantsEqual(a, b []interface{}) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	counts := make(map[string]int, len(a))
+	for _, v := range a {
+		counts[v.(string)]++
+	}
+	for _, v := range b {
+		counts[v.(string)]--
+	}
+	for _, c := range counts {
+		if c != 0 {
+			return false
+		}
+	}
+
+	return true
+}

--- a/internal/services/kusto/identity.go
+++ b/internal/services/kusto/identity.go
@@ -39,22 +39,27 @@ func flattenTrustedExternalTenants(input *[]clusters.TrustedExternalTenant) []in
 }
 
 // trustedExternalTenantsEqual reports whether two `trusted_external_tenants` lists contain the same
-// set of tenant IDs, ignoring order and duplicates. It is used to suppress the perpetual diff caused
-// by the Azure Data Explorer API returning the tenants in a different order than configured.
+// set of tenant IDs, ignoring both order and duplicates. It is used to suppress the perpetual diff
+// caused by the Azure Data Explorer API returning the tenants in a different order than configured.
+// The attribute is semantically set-valued (and a `TypeSet` in 5.0, which deduplicates), so only the
+// unique values are compared.
 func trustedExternalTenantsEqual(a, b []interface{}) bool {
-	if len(a) != len(b) {
+	setA := make(map[string]struct{}, len(a))
+	for _, v := range a {
+		setA[v.(string)] = struct{}{}
+	}
+
+	setB := make(map[string]struct{}, len(b))
+	for _, v := range b {
+		setB[v.(string)] = struct{}{}
+	}
+
+	if len(setA) != len(setB) {
 		return false
 	}
 
-	counts := make(map[string]int, len(a))
-	for _, v := range a {
-		counts[v.(string)]++
-	}
-	for _, v := range b {
-		counts[v.(string)]--
-	}
-	for _, c := range counts {
-		if c != 0 {
+	for k := range setA {
+		if _, ok := setB[k]; !ok {
 			return false
 		}
 	}

--- a/internal/services/kusto/identity.go
+++ b/internal/services/kusto/identity.go
@@ -37,3 +37,31 @@ func flattenTrustedExternalTenants(input *[]clusters.TrustedExternalTenant) []in
 
 	return output
 }
+
+// trustedExternalTenantsEqual reports whether two `trusted_external_tenants` lists contain the same
+// set of tenant IDs, ignoring both order and duplicates. It is used to suppress the perpetual diff
+// caused by the Azure Data Explorer API returning the tenants in a different order than configured.
+// The attribute is semantically set-valued, so only the unique values are compared.
+func trustedExternalTenantsEqual(a, b []interface{}) bool {
+	setA := make(map[string]struct{}, len(a))
+	for _, v := range a {
+		setA[v.(string)] = struct{}{}
+	}
+
+	setB := make(map[string]struct{}, len(b))
+	for _, v := range b {
+		setB[v.(string)] = struct{}{}
+	}
+
+	if len(setA) != len(setB) {
+		return false
+	}
+
+	for k := range setA {
+		if _, ok := setB[k]; !ok {
+			return false
+		}
+	}
+
+	return true
+}

--- a/internal/services/kusto/identity_test.go
+++ b/internal/services/kusto/identity_test.go
@@ -54,6 +54,24 @@ func TestTrustedExternalTenantsEqual(t *testing.T) {
 			b:        []interface{}{"", "*"},
 			expected: true,
 		},
+		{
+			name:     "duplicate collapses to same set",
+			a:        []interface{}{"tenant-a"},
+			b:        []interface{}{"tenant-a", "tenant-a"},
+			expected: true,
+		},
+		{
+			name:     "duplicates reordered same set",
+			a:        []interface{}{"tenant-a", "tenant-b", "tenant-a"},
+			b:        []interface{}{"tenant-b", "tenant-a", "tenant-b"},
+			expected: true,
+		},
+		{
+			name:     "duplicate masking missing member",
+			a:        []interface{}{"tenant-a", "tenant-a"},
+			b:        []interface{}{"tenant-a", "tenant-b"},
+			expected: false,
+		},
 	}
 
 	for _, tc := range cases {

--- a/internal/services/kusto/identity_test.go
+++ b/internal/services/kusto/identity_test.go
@@ -1,0 +1,66 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package kusto
+
+import "testing"
+
+func TestTrustedExternalTenantsEqual(t *testing.T) {
+	cases := []struct {
+		name     string
+		a        []interface{}
+		b        []interface{}
+		expected bool
+	}{
+		{
+			name:     "both empty",
+			a:        []interface{}{},
+			b:        []interface{}{},
+			expected: true,
+		},
+		{
+			name:     "same order",
+			a:        []interface{}{"tenant-a", "tenant-b", "tenant-c"},
+			b:        []interface{}{"tenant-a", "tenant-b", "tenant-c"},
+			expected: true,
+		},
+		{
+			name:     "different order same set",
+			a:        []interface{}{"tenant-a", "tenant-b", "tenant-c"},
+			b:        []interface{}{"tenant-c", "tenant-a", "tenant-b"},
+			expected: true,
+		},
+		{
+			name:     "different lengths",
+			a:        []interface{}{"tenant-a", "tenant-b"},
+			b:        []interface{}{"tenant-a", "tenant-b", "tenant-c"},
+			expected: false,
+		},
+		{
+			name:     "disjoint sets",
+			a:        []interface{}{"tenant-a", "tenant-b"},
+			b:        []interface{}{"tenant-c", "tenant-d"},
+			expected: false,
+		},
+		{
+			name:     "same length different members",
+			a:        []interface{}{"tenant-a", "tenant-b", "tenant-c"},
+			b:        []interface{}{"tenant-a", "tenant-b", "tenant-d"},
+			expected: false,
+		},
+		{
+			name:     "wildcard and empty string reordered",
+			a:        []interface{}{"*", ""},
+			b:        []interface{}{"", "*"},
+			expected: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := trustedExternalTenantsEqual(tc.a, tc.b); got != tc.expected {
+				t.Fatalf("trustedExternalTenantsEqual(%v, %v) = %t, want %t", tc.a, tc.b, got, tc.expected)
+			}
+		})
+	}
+}

--- a/internal/services/kusto/identity_test.go
+++ b/internal/services/kusto/identity_test.go
@@ -1,0 +1,84 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package kusto
+
+import "testing"
+
+func TestTrustedExternalTenantsEqual(t *testing.T) {
+	cases := []struct {
+		name     string
+		a        []interface{}
+		b        []interface{}
+		expected bool
+	}{
+		{
+			name:     "both empty",
+			a:        []interface{}{},
+			b:        []interface{}{},
+			expected: true,
+		},
+		{
+			name:     "same order",
+			a:        []interface{}{"tenant-a", "tenant-b", "tenant-c"},
+			b:        []interface{}{"tenant-a", "tenant-b", "tenant-c"},
+			expected: true,
+		},
+		{
+			name:     "different order same set",
+			a:        []interface{}{"tenant-a", "tenant-b", "tenant-c"},
+			b:        []interface{}{"tenant-c", "tenant-a", "tenant-b"},
+			expected: true,
+		},
+		{
+			name:     "different lengths",
+			a:        []interface{}{"tenant-a", "tenant-b"},
+			b:        []interface{}{"tenant-a", "tenant-b", "tenant-c"},
+			expected: false,
+		},
+		{
+			name:     "disjoint sets",
+			a:        []interface{}{"tenant-a", "tenant-b"},
+			b:        []interface{}{"tenant-c", "tenant-d"},
+			expected: false,
+		},
+		{
+			name:     "same length different members",
+			a:        []interface{}{"tenant-a", "tenant-b", "tenant-c"},
+			b:        []interface{}{"tenant-a", "tenant-b", "tenant-d"},
+			expected: false,
+		},
+		{
+			name:     "wildcard and empty string reordered",
+			a:        []interface{}{"*", ""},
+			b:        []interface{}{"", "*"},
+			expected: true,
+		},
+		{
+			name:     "duplicate collapses to same set",
+			a:        []interface{}{"tenant-a"},
+			b:        []interface{}{"tenant-a", "tenant-a"},
+			expected: true,
+		},
+		{
+			name:     "duplicates reordered same set",
+			a:        []interface{}{"tenant-a", "tenant-b", "tenant-a"},
+			b:        []interface{}{"tenant-b", "tenant-a", "tenant-b"},
+			expected: true,
+		},
+		{
+			name:     "duplicate masking missing member",
+			a:        []interface{}{"tenant-a", "tenant-a"},
+			b:        []interface{}{"tenant-a", "tenant-b"},
+			expected: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := trustedExternalTenantsEqual(tc.a, tc.b); got != tc.expected {
+				t.Fatalf("trustedExternalTenantsEqual(%v, %v) = %t, want %t", tc.a, tc.b, got, tc.expected)
+			}
+		})
+	}
+}

--- a/internal/services/kusto/kusto_cluster_resource.go
+++ b/internal/services/kusto/kusto_cluster_resource.go
@@ -225,27 +225,47 @@ func resourceKustoCluster() *pluginsdk.Resource {
 		},
 
 		CustomizeDiff: pluginsdk.CustomizeDiffShim(func(_ context.Context, d *pluginsdk.ResourceDiff, _ interface{}) error {
-			// `trusted_external_tenants` is semantically an unordered set of tenant IDs, but it is modelled
-			// as a `TypeList` and the Azure Data Explorer API returns the tenants in its own canonical
-			// order, which frequently differs from the configured order. That reordering surfaces as a
-			// permanent no-op diff, so suppress it when the configured set matches what is already in
-			// state; a genuine add/removal changes the set and still applies.
-			//
-			// Only compare when the configured collection and all its elements are known. `GetChange`
-			// can expose an unknown (known-after-apply) list as its zero value (`[]interface{}{}`); if
-			// state is also empty the sets would compare equal and `SetNew` would incorrectly replace
-			// the unknown planned value with the old state, suppressing a legitimate change.
-			rawTrustedExternalTenants, diags := d.GetRawConfigAt(sdk.ConstructCtyPath("trusted_external_tenants"))
-			if !diags.HasError() && rawTrustedExternalTenants.IsWhollyKnown() {
-				oldTenants, newTenants := d.GetChange("trusted_external_tenants")
-				if oldList, ok := oldTenants.([]interface{}); ok {
-					if newList, ok := newTenants.([]interface{}); ok {
-						if trustedExternalTenantsEqual(oldList, newList) {
-							if err := d.SetNew("trusted_external_tenants", oldList); err != nil {
-								return err
-							}
-						}
-					}
+			// `trusted_external_tenants` is semantically an unordered set of tenant IDs, but it is
+			// modelled as a `TypeList` and the Azure Data Explorer API returns the tenants in its own
+			// canonical order, which frequently differs from the configured order. That reordering
+			// surfaces as a permanent no-op diff, so suppress it when the configured set matches what
+			// is already in state; a genuine add/removal changes the set and still applies.
+
+			// Only reconcile an existing cluster - at create time there is nothing in state to compare
+			// against and, since this property is O+C, `SetNew` would replace a legitimate
+			// `(known after apply)` plan with an empty list.
+			if d.Id() == "" {
+				return nil
+			}
+
+			// Only compare when the property is set in the config and is wholly known. `GetChange`
+			// surfaces an unknown (known-after-apply) list as its zero value (`[]interface{}{}`), which
+			// would compare equal to an empty state and cause `SetNew` to suppress a legitimate change.
+			// Note that `IsWhollyKnown` returns `true` for a null value, so `IsNull` is checked first.
+			rawConfig := d.GetRawConfig()
+			if rawConfig.IsNull() {
+				return nil
+			}
+
+			rawTrustedExternalTenants := rawConfig.GetAttr("trusted_external_tenants")
+			if rawTrustedExternalTenants.IsNull() || !rawTrustedExternalTenants.IsWhollyKnown() {
+				return nil
+			}
+
+			oldTenants, newTenants := d.GetChange("trusted_external_tenants")
+			oldList, ok := oldTenants.([]interface{})
+			if !ok {
+				return nil
+			}
+
+			newList, ok := newTenants.([]interface{})
+			if !ok {
+				return nil
+			}
+
+			if trustedExternalTenantsEqual(oldList, newList) {
+				if err := d.SetNew("trusted_external_tenants", oldList); err != nil {
+					return fmt.Errorf("setting new value for `trusted_external_tenants`: %+v", err)
 				}
 			}
 

--- a/internal/services/kusto/kusto_cluster_resource.go
+++ b/internal/services/kusto/kusto_cluster_resource.go
@@ -4,6 +4,7 @@
 package kusto
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -222,6 +223,34 @@ func resourceKustoCluster() *pluginsdk.Resource {
 
 			"tags": commonschema.Tags(),
 		},
+
+		CustomizeDiff: pluginsdk.CustomizeDiffShim(func(_ context.Context, d *pluginsdk.ResourceDiff, _ interface{}) error {
+			// `trusted_external_tenants` is semantically an unordered set of tenant IDs, but it is modelled
+			// as a `TypeList` and the Azure Data Explorer API returns the tenants in its own canonical
+			// order, which frequently differs from the configured order. That reordering surfaces as a
+			// permanent no-op diff, so suppress it when the configured set matches what is already in
+			// state; a genuine add/removal changes the set and still applies.
+			//
+			// Only compare when the configured collection and all its elements are known. `GetChange`
+			// can expose an unknown (known-after-apply) list as its zero value (`[]interface{}{}`); if
+			// state is also empty the sets would compare equal and `SetNew` would incorrectly replace
+			// the unknown planned value with the old state, suppressing a legitimate change.
+			rawTrustedExternalTenants, diags := d.GetRawConfigAt(sdk.ConstructCtyPath("trusted_external_tenants"))
+			if !diags.HasError() && rawTrustedExternalTenants.IsWhollyKnown() {
+				oldTenants, newTenants := d.GetChange("trusted_external_tenants")
+				if oldList, ok := oldTenants.([]interface{}); ok {
+					if newList, ok := newTenants.([]interface{}); ok {
+						if trustedExternalTenantsEqual(oldList, newList) {
+							if err := d.SetNew("trusted_external_tenants", oldList); err != nil {
+								return err
+							}
+						}
+					}
+				}
+			}
+
+			return nil
+		}),
 	}
 }
 

--- a/internal/services/kusto/kusto_cluster_resource.go
+++ b/internal/services/kusto/kusto_cluster_resource.go
@@ -325,12 +325,20 @@ func resourceKustoCluster() *pluginsdk.Resource {
 			// surfaces as a permanent no-op diff. Suppress the diff when the configured set matches what
 			// is already in state; a genuine add/removal changes the set and still applies. In 5.0 the
 			// attribute is a `TypeSet`, so this normalization is not needed (and is not wired up there).
-			oldTenants, newTenants := d.GetChange("trusted_external_tenants")
-			if oldList, ok := oldTenants.([]interface{}); ok {
-				if newList, ok := newTenants.([]interface{}); ok {
-					if trustedExternalTenantsEqual(oldList, newList) {
-						if err := d.SetNew("trusted_external_tenants", oldList); err != nil {
-							return err
+			//
+			// Only compare when the configured collection and all its elements are known. `GetChange`
+			// can expose an unknown (known-after-apply) list as its zero value (`[]interface{}{}`); if
+			// state is also empty the sets would compare equal and `SetNew` would incorrectly replace
+			// the unknown planned value with the old state, suppressing a legitimate change.
+			rawTrustedExternalTenants, diags := d.GetRawConfigAt(sdk.ConstructCtyPath("trusted_external_tenants"))
+			if !diags.HasError() && rawTrustedExternalTenants.IsWhollyKnown() {
+				oldTenants, newTenants := d.GetChange("trusted_external_tenants")
+				if oldList, ok := oldTenants.([]interface{}); ok {
+					if newList, ok := newTenants.([]interface{}); ok {
+						if trustedExternalTenantsEqual(oldList, newList) {
+							if err := d.SetNew("trusted_external_tenants", oldList); err != nil {
+								return err
+							}
 						}
 					}
 				}

--- a/internal/services/kusto/kusto_cluster_resource.go
+++ b/internal/services/kusto/kusto_cluster_resource.go
@@ -300,6 +300,23 @@ func resourceKustoCluster() *pluginsdk.Resource {
 		}
 
 		resource.CustomizeDiff = func(_ context.Context, d *pluginsdk.ResourceDiff, _ interface{}) error {
+			// `trusted_external_tenants` is semantically an unordered set of tenant IDs. The Azure Data
+			// Explorer API returns the tenants in its own canonical order, which frequently differs from
+			// the configured order, and because the attribute is a `TypeList` in 4.x that reordering
+			// surfaces as a permanent no-op diff. Suppress the diff when the configured set matches what
+			// is already in state; a genuine add/removal changes the set and still applies. In 5.0 the
+			// attribute is a `TypeSet`, so this normalization is not needed (and is not wired up there).
+			oldTenants, newTenants := d.GetChange("trusted_external_tenants")
+			if oldList, ok := oldTenants.([]interface{}); ok {
+				if newList, ok := newTenants.([]interface{}); ok {
+					if trustedExternalTenantsEqual(oldList, newList) {
+						if err := d.SetNew("trusted_external_tenants", oldList); err != nil {
+							return err
+						}
+					}
+				}
+			}
+
 			rawLanguageExtensions, diags := d.GetRawConfigAt(sdk.ConstructCtyPath("language_extensions"))
 			if diags.HasError() {
 				return nil
@@ -325,6 +342,23 @@ func resourceKustoCluster() *pluginsdk.Resource {
 			}
 
 			return nil
+		}
+	}
+
+	if features.FivePointOh() {
+		// `trusted_external_tenants` is an unordered set of tenant IDs. The Azure Data Explorer API
+		// returns them in its own canonical order, which frequently differs from the configured order.
+		// Modelling the attribute as a `TypeSet` (in 5.0) makes ordering irrelevant and removes the
+		// perpetual diff. In 4.x it stays a `TypeList` with a `CustomizeDiff` that suppresses
+		// ordering-only diffs, since changing the type there would be a breaking change.
+		resource.Schema["trusted_external_tenants"] = &pluginsdk.Schema{
+			Type:     pluginsdk.TypeSet,
+			Optional: true,
+			Computed: true,
+			Elem: &pluginsdk.Schema{
+				Type:         pluginsdk.TypeString,
+				ValidateFunc: validation.Any(validation.IsUUID, validation.StringIsEmpty, validation.StringInSlice([]string{"*"}, false)),
+			},
 		}
 	}
 
@@ -392,7 +426,7 @@ func resourceKustoClusterCreate(d *pluginsdk.ResourceData, meta interface{}) err
 		EnablePurge:            pointer.To(d.Get("purge_enabled").(bool)),
 		PublicNetworkAccess:    &publicNetworkAccess,
 		PublicIPType:           &publicIPType,
-		TrustedExternalTenants: expandTrustedExternalTenants(d.Get("trusted_external_tenants").([]interface{})),
+		TrustedExternalTenants: expandTrustedExternalTenants(trustedExternalTenantsInput(d.Get("trusted_external_tenants"))),
 	}
 
 	if !features.FivePointOh() {
@@ -609,7 +643,7 @@ func resourceKustoClusterUpdate(d *pluginsdk.ResourceData, meta interface{}) err
 	}
 
 	if d.HasChange("trusted_external_tenants") {
-		props.TrustedExternalTenants = expandTrustedExternalTenants(d.Get("trusted_external_tenants").([]interface{}))
+		props.TrustedExternalTenants = expandTrustedExternalTenants(trustedExternalTenantsInput(d.Get("trusted_external_tenants")))
 	}
 
 	if !features.FivePointOh() {
@@ -783,6 +817,20 @@ func expandKustoListString(input []interface{}) *[]string {
 	}
 
 	return &result
+}
+
+// trustedExternalTenantsInput normalizes the raw `trusted_external_tenants` attribute value to a
+// slice, tolerating both the 4.x `TypeList` (`[]interface{}`) and the 5.0 `TypeSet` (`*schema.Set`)
+// representations.
+func trustedExternalTenantsInput(input interface{}) []interface{} {
+	switch v := input.(type) {
+	case *schema.Set:
+		return v.List()
+	case []interface{}:
+		return v
+	default:
+		return nil
+	}
 }
 
 func expandKustoClusterSku(input []interface{}) (*clusters.AzureSku, error) {

--- a/internal/services/kusto/kusto_cluster_resource.go
+++ b/internal/services/kusto/kusto_cluster_resource.go
@@ -111,11 +111,16 @@ func resourceKustoCluster() *pluginsdk.Resource {
 				},
 			},
 
+			// `trusted_external_tenants` is an unordered set of tenant IDs. The Azure Data Explorer API
+			// returns them in its own canonical order, which frequently differs from the configured
+			// order. Modelling the attribute as a `TypeSet` makes ordering irrelevant and removes the
+			// perpetual diff. In 4.x it stays a `TypeList` (see the `!features.FivePointOh()` block
+			// below) with a `CustomizeDiff` that suppresses ordering-only diffs, since changing the
+			// type there would be a breaking change.
 			"trusted_external_tenants": {
-				Type:       pluginsdk.TypeList,
-				Optional:   true,
-				Computed:   true,
-				ConfigMode: pluginsdk.SchemaConfigModeAttr,
+				Type:     pluginsdk.TypeSet,
+				Optional: true,
+				Computed: true,
 				Elem: &pluginsdk.Schema{
 					Type:         pluginsdk.TypeString,
 					ValidateFunc: validation.Any(validation.IsUUID, validation.StringIsEmpty, validation.StringInSlice([]string{"*"}, false)),
@@ -227,6 +232,20 @@ func resourceKustoCluster() *pluginsdk.Resource {
 	}
 
 	if !features.FivePointOh() {
+		// In 4.x `trusted_external_tenants` remains a `TypeList`; the ordering-only perpetual diff is
+		// instead suppressed by the `CustomizeDiff` below. Switching to a `TypeSet` here would be a
+		// breaking change, so the 5.0 type change is confined to the main schema map.
+		resource.Schema["trusted_external_tenants"] = &pluginsdk.Schema{
+			Type:       pluginsdk.TypeList,
+			Optional:   true,
+			Computed:   true,
+			ConfigMode: pluginsdk.SchemaConfigModeAttr,
+			Elem: &pluginsdk.Schema{
+				Type:         pluginsdk.TypeString,
+				ValidateFunc: validation.Any(validation.IsUUID, validation.StringIsEmpty, validation.StringInSlice([]string{"*"}, false)),
+			},
+		}
+
 		resource.Schema["language_extension"] = &pluginsdk.Schema{
 			Type:          pluginsdk.TypeList,
 			Optional:      true,
@@ -342,23 +361,6 @@ func resourceKustoCluster() *pluginsdk.Resource {
 			}
 
 			return nil
-		}
-	}
-
-	if features.FivePointOh() {
-		// `trusted_external_tenants` is an unordered set of tenant IDs. The Azure Data Explorer API
-		// returns them in its own canonical order, which frequently differs from the configured order.
-		// Modelling the attribute as a `TypeSet` (in 5.0) makes ordering irrelevant and removes the
-		// perpetual diff. In 4.x it stays a `TypeList` with a `CustomizeDiff` that suppresses
-		// ordering-only diffs, since changing the type there would be a breaking change.
-		resource.Schema["trusted_external_tenants"] = &pluginsdk.Schema{
-			Type:     pluginsdk.TypeSet,
-			Optional: true,
-			Computed: true,
-			Elem: &pluginsdk.Schema{
-				Type:         pluginsdk.TypeString,
-				ValidateFunc: validation.Any(validation.IsUUID, validation.StringIsEmpty, validation.StringInSlice([]string{"*"}, false)),
-			},
 		}
 	}
 

--- a/internal/services/kusto/kusto_cluster_resource_test.go
+++ b/internal/services/kusto/kusto_cluster_resource_test.go
@@ -296,9 +296,15 @@ func TestAccKustoCluster_trustedExternalTenants(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			// Re-applying the same set of trusted tenants in a different order must be a no-op. The ADX
-			// API returns the tenants in its own canonical order, which previously produced a perpetual
-			// diff (see https://github.com/hashicorp/terraform-provider-azurerm/issues/32793).
+			// Re-applying the same set of trusted tenants in either order must be a no-op. The ADX API
+			// returns the tenants in its own canonical order, which previously produced a perpetual diff
+			// (see https://github.com/hashicorp/terraform-provider-azurerm/issues/32793). Plan-only steps
+			// do not update state, so exercising both orderings guarantees that at least one differs from
+			// Azure's ordering; without the fix that permutation would produce a non-empty plan.
+			Config:   r.trustedExternalTenants(data, "[\"*\", data.azurerm_client_config.current.tenant_id]"),
+			PlanOnly: true,
+		},
+		{
 			Config:   r.trustedExternalTenants(data, "[data.azurerm_client_config.current.tenant_id, \"*\"]"),
 			PlanOnly: true,
 		},

--- a/internal/services/kusto/kusto_cluster_resource_test.go
+++ b/internal/services/kusto/kusto_cluster_resource_test.go
@@ -287,6 +287,26 @@ func TestAccKustoCluster_trustedExternalTenants(t *testing.T) {
 			),
 		},
 		data.ImportStep(),
+		{
+			Config: r.trustedExternalTenants(data, "[\"*\", data.azurerm_client_config.current.tenant_id]"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			// Re-applying the same set of trusted tenants in either order must be a no-op. The ADX API
+			// returns the tenants in its own canonical order, which previously produced a perpetual diff
+			// (see https://github.com/hashicorp/terraform-provider-azurerm/issues/32793). Plan-only steps
+			// do not update state, so exercising both orderings guarantees that at least one differs from
+			// Azure's ordering; without the fix that permutation would produce a non-empty plan.
+			Config:   r.trustedExternalTenants(data, "[\"*\", data.azurerm_client_config.current.tenant_id]"),
+			PlanOnly: true,
+		},
+		{
+			Config:   r.trustedExternalTenants(data, "[data.azurerm_client_config.current.tenant_id, \"*\"]"),
+			PlanOnly: true,
+		},
 	})
 }
 

--- a/internal/services/kusto/kusto_cluster_resource_test.go
+++ b/internal/services/kusto/kusto_cluster_resource_test.go
@@ -288,6 +288,20 @@ func TestAccKustoCluster_trustedExternalTenants(t *testing.T) {
 			),
 		},
 		data.ImportStep(),
+		{
+			Config: r.trustedExternalTenants(data, "[\"*\", data.azurerm_client_config.current.tenant_id]"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			// Re-applying the same set of trusted tenants in a different order must be a no-op. The ADX
+			// API returns the tenants in its own canonical order, which previously produced a perpetual
+			// diff (see https://github.com/hashicorp/terraform-provider-azurerm/issues/32793).
+			Config:   r.trustedExternalTenants(data, "[data.azurerm_client_config.current.tenant_id, \"*\"]"),
+			PlanOnly: true,
+		},
 	})
 }
 

--- a/website/docs/guides/5.0-upgrade-guide.html.markdown
+++ b/website/docs/guides/5.0-upgrade-guide.html.markdown
@@ -691,6 +691,7 @@ The `security_policies.firewall.association.domain.cdn_frontdoor_domain_id` prop
 
 * The deprecated `language_extensions` property has been removed in favour of the `language_extension` property.
 * The deprecated `virtual_network_configuration` block has been removed as it is no longer supported by the resource.
+* The `trusted_external_tenants` property's type has changed from a List to a Set, meaning its values are unordered and can no longer be referenced by numeric index.
 
 ### `azurerm_kusto_eventgrid_data_connection`
 

--- a/website/docs/r/kusto_cluster.html.markdown
+++ b/website/docs/r/kusto_cluster.html.markdown
@@ -80,6 +80,8 @@ The following arguments are supported:
 
 ~> **Note:** In v3.0 of `azurerm` a new or updated Kusto Cluster will only allow your own tenant by default. Explicit configuration of this setting will change from `trusted_external_tenants = ["MyTenantOnly"]` to `trusted_external_tenants = []`.
 
+~> **Note:** The order of `trusted_external_tenants` is not significant. The Azure Data Explorer API returns the trusted tenants in its own canonical order, so the provider compares the configured and existing values as an unordered set to avoid a spurious diff.
+
 * `zones` - (Optional) Specifies a list of Availability Zones in which this Kusto Cluster should be located. Changing this forces a new Kusto Cluster to be created.
 
 ---


### PR DESCRIPTION
## Community Note

* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

`azurerm_kusto_cluster.trusted_external_tenants` produces a permanent, no-op plan diff. The Azure Data Explorer API returns the trusted tenants in its **own canonical order**, which frequently differs from the order submitted in configuration. Because the attribute is an order-significant `TypeList`, that reordering surfaces as a perpetual diff (typically a single-element rotation). Client-side normalization (`sort()` / `reverse(sort())`) in configuration cannot fix it, because the API's order is not derivable from the tenant values.

Trust relationships are semantically an unordered set, so a `CustomizeDiff` now compares the old and new values as sets and, when they match, resets the planned value back to state. A genuine add/removal changes the set and still applies normally, so the attribute stays fully manageable.

The comparison is skipped unless the configured collection is wholly known: `GetChange` can surface an unknown (known-after-apply) list as an empty slice, and if state is also empty the two would compare equal and `SetNew` would incorrectly suppress a legitimate change.

`trustedExternalTenantsEqual` compares the two lists by their **unique** tenant IDs — set equality, ignoring order *and* duplicates.

The attribute's schema type is unchanged. An earlier revision of this PR switched it to a `TypeSet` under the next major version flag; that has been dropped so this remains a non-breaking bug fix.

## PR Checklist

- [x] I have followed the guidelines in our Contributing Documentation.
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate closing keywords below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.

## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them.
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. (Unit test + `go build`/`go vet`/`gofmt` pass locally; the acceptance test requires Azure credentials and has not been run end-to-end — see Testing.)

## Testing

- `TestTrustedExternalTenantsEqual` unit-tests the set-equality helper, including duplicate handling (a duplicate collapsing to the same set, reordered duplicates, and a duplicate masking a missing member). Passes locally:

```
--- PASS: TestTrustedExternalTenantsEqual (0.00s)
    --- PASS: TestTrustedExternalTenantsEqual/both_empty
    --- PASS: TestTrustedExternalTenantsEqual/same_order
    --- PASS: TestTrustedExternalTenantsEqual/different_order_same_set
    --- PASS: TestTrustedExternalTenantsEqual/different_lengths
    --- PASS: TestTrustedExternalTenantsEqual/disjoint_sets
    --- PASS: TestTrustedExternalTenantsEqual/same_length_different_members
    --- PASS: TestTrustedExternalTenantsEqual/wildcard_and_empty_string_reordered
    --- PASS: TestTrustedExternalTenantsEqual/duplicate_collapses_to_same_set
    --- PASS: TestTrustedExternalTenantsEqual/duplicates_reordered_same_set
    --- PASS: TestTrustedExternalTenantsEqual/duplicate_masking_missing_member
ok  github.com/hashicorp/terraform-provider-azurerm/internal/services/kusto
```

- `TestAccKustoCluster_trustedExternalTenants` re-applies the same set of tenants and then asserts an empty plan (`PlanOnly: true`) for **both** orderings — `["*", tenant_id]` and `[tenant_id, "*"]`. Because plan-only steps do not update state, at least one permutation is guaranteed to differ from Azure's canonical ordering, so the step reliably catches the perpetual diff regardless of which order the API returns. I do not have an Azure subscription set up to run the acceptance test end-to-end; happy for a maintainer to run it or for guidance.
- `go build ./internal/services/kusto/...`, `go vet ./internal/services/kusto/...`, `gofmt`, and `TestProvider` schema validation are clean.

## Change Log

* `azurerm_kusto_cluster` - prevent a perpetual diff on `trusted_external_tenants` caused by the Azure Data Explorer API returning the tenants in a different order than configured [GH-32794]

This is a (please select all that apply):

- [x] Bug Fix

## Related Issue(s)

Fixes #32793

## AI Assistance Disclosure

- [x] AI/LLM assistance was used for this contribution.

Extent of AI usage: the code change, the unit/acceptance tests, and this PR description were drafted with the help of an AI coding assistant (GitHub Copilot). All changes were reviewed by me, and the unit tests, `go build`, `go vet`, and `gofmt` were run locally to validate them. Responses to review feedback on this PR may also be prepared with AI assistance.
