### PR TITLE
Virtual endpoints feature - restore pre-v4.15.0 automatic recreate behavior, now opt-in via feature gate

### DIFF
--- a/internal/features/defaults.go
+++ b/internal/features/defaults.go
@@ -77,6 +77,9 @@ func Default() UserFeatures {
 		PostgresqlFlexibleServer: PostgresqlFlexibleServerFeatures{
 			RestartServerOnConfigurationValueChange: true,
 		},
+		PostgresqlFlexibleServerVirtualEndpoint: PostgresqlFlexibleServerVirtualEndpointFeatures{
+			RecreateResourceAfterFailover: false,
+		},
 		MachineLearning: MachineLearningFeatures{
 			PurgeSoftDeletedWorkspaceOnDestroy: false,
 		},

--- a/internal/features/user_flags.go
+++ b/internal/features/user_flags.go
@@ -7,28 +7,28 @@ type UserFeatures struct {
 	PersistIDOnCreateBeforePollingForCompletion                 bool
 	SkipImportCheckOnCreateAndAllowOverwritingExistingResources bool
 
-	ApiManagement            ApiManagementFeatures
-	AppConfiguration         AppConfigurationFeatures
-	ApplicationInsights      ApplicationInsightFeatures
-	CognitiveAccount         CognitiveAccountFeatures
-	DatabricksWorkspace      DatabricksWorkspaceFeatures
-	EnhancedValidation       EnhancedValidationFeatures
-	KeyVault                 KeyVaultFeatures
-	LogAnalyticsWorkspace    LogAnalyticsWorkspaceFeatures
-	MachineLearning          MachineLearningFeatures
-	ManagedDisk              ManagedDiskFeatures
-	NetApp                   NetAppFeatures
-	PostgresqlFlexibleServer           PostgresqlFlexibleServerFeatures
+	ApiManagement                           ApiManagementFeatures
+	AppConfiguration                        AppConfigurationFeatures
+	ApplicationInsights                     ApplicationInsightFeatures
+	CognitiveAccount                        CognitiveAccountFeatures
+	DatabricksWorkspace                     DatabricksWorkspaceFeatures
+	EnhancedValidation                      EnhancedValidationFeatures
+	KeyVault                                KeyVaultFeatures
+	LogAnalyticsWorkspace                   LogAnalyticsWorkspaceFeatures
+	MachineLearning                         MachineLearningFeatures
+	ManagedDisk                             ManagedDiskFeatures
+	NetApp                                  NetAppFeatures
+	PostgresqlFlexibleServer                PostgresqlFlexibleServerFeatures
 	PostgresqlFlexibleServerVirtualEndpoint PostgresqlFlexibleServerVirtualEndpointFeatures
-	RecoveryService                    RecoveryServiceFeatures
-	RecoveryServicesVault    RecoveryServicesVault
-	ResourceGroup            ResourceGroupFeatures
-	Storage                  StorageFeatures
-	Subscription             SubscriptionFeatures
-	TemplateDeployment       TemplateDeploymentFeatures
-	VirtualMachine           VirtualMachineFeatures
-	VirtualMachineScaleSet   VirtualMachineScaleSetFeatures
-	ServiceBus               ServiceBusFeatures
+	RecoveryService                         RecoveryServiceFeatures
+	RecoveryServicesVault                   RecoveryServicesVault
+	ResourceGroup                           ResourceGroupFeatures
+	Storage                                 StorageFeatures
+	Subscription                            SubscriptionFeatures
+	TemplateDeployment                      TemplateDeploymentFeatures
+	VirtualMachine                          VirtualMachineFeatures
+	VirtualMachineScaleSet                  VirtualMachineScaleSetFeatures
+	ServiceBus                              ServiceBusFeatures
 }
 
 type CognitiveAccountFeatures struct {

--- a/internal/features/user_flags.go
+++ b/internal/features/user_flags.go
@@ -18,8 +18,9 @@ type UserFeatures struct {
 	MachineLearning          MachineLearningFeatures
 	ManagedDisk              ManagedDiskFeatures
 	NetApp                   NetAppFeatures
-	PostgresqlFlexibleServer PostgresqlFlexibleServerFeatures
-	RecoveryService          RecoveryServiceFeatures
+	PostgresqlFlexibleServer           PostgresqlFlexibleServerFeatures
+	PostgresqlFlexibleServerVirtualEndpoint PostgresqlFlexibleServerVirtualEndpointFeatures
+	RecoveryService                    RecoveryServiceFeatures
 	RecoveryServicesVault    RecoveryServicesVault
 	ResourceGroup            ResourceGroupFeatures
 	Storage                  StorageFeatures
@@ -113,6 +114,10 @@ type RecoveryServicesVault struct {
 
 type PostgresqlFlexibleServerFeatures struct {
 	RestartServerOnConfigurationValueChange bool
+}
+
+type PostgresqlFlexibleServerVirtualEndpointFeatures struct {
+	RecreateResourceAfterFailover bool
 }
 
 type MachineLearningFeatures struct {

--- a/internal/provider/features.go
+++ b/internal/provider/features.go
@@ -399,6 +399,22 @@ func schemaFeatures(supportLegacyTestSuite bool) *pluginsdk.Schema {
 			},
 		},
 
+		"postgresql_flexible_server_virtual_endpoint": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"recreate_resource_after_failover": {
+						Type:        pluginsdk.TypeBool,
+						Optional:    true,
+						Default:     false,
+						Description: "When enabled, the `azurerm_postgresql_flexible_server_virtual_endpoint` will be recreated after a failover is detected, restoring the pre-v4.15.0 behavior. Defaults to `false`.",
+					},
+				},
+			},
+		},
+
 		"machine_learning": {
 			Type:     pluginsdk.TypeList,
 			Optional: true,
@@ -830,6 +846,16 @@ func expandFeatures(input []interface{}) features.UserFeatures {
 			servicebusRaw := items[0].(map[string]interface{})
 			if v, ok := servicebusRaw["auto_delete_subscription_default_rule"]; ok {
 				featuresMap.ServiceBus.AutoDeleteSubscriptionDefaultRule = v.(bool)
+			}
+		}
+	}
+
+	if raw, ok := val["postgresql_flexible_server_virtual_endpoint"]; ok {
+		items := raw.([]interface{})
+		if len(items) > 0 {
+			virtualEndpointRaw := items[0].(map[string]interface{})
+			if v, ok := virtualEndpointRaw["recreate_resource_after_failover"]; ok {
+				featuresMap.PostgresqlFlexibleServerVirtualEndpoint.RecreateResourceAfterFailover = v.(bool)
 			}
 		}
 	}

--- a/internal/provider/features_test.go
+++ b/internal/provider/features_test.go
@@ -166,6 +166,11 @@ func TestExpandFeatures(t *testing.T) {
 							"restart_server_on_configuration_value_change": true,
 						},
 					},
+					"postgresql_flexible_server_virtual_endpoint": []interface{}{
+						map[string]interface{}{
+							"recreate_resource_after_failover": true,
+						},
+					},
 					"resource_group": []interface{}{
 						map[string]interface{}{
 							"prevent_deletion_if_contains_resources": true,
@@ -310,6 +315,9 @@ func TestExpandFeatures(t *testing.T) {
 				PostgresqlFlexibleServer: features.PostgresqlFlexibleServerFeatures{
 					RestartServerOnConfigurationValueChange: true,
 				},
+				PostgresqlFlexibleServerVirtualEndpoint: features.PostgresqlFlexibleServerVirtualEndpointFeatures{
+					RecreateResourceAfterFailover: true,
+				},
 				MachineLearning: features.MachineLearningFeatures{
 					PurgeSoftDeletedWorkspaceOnDestroy: true,
 				},
@@ -383,6 +391,11 @@ func TestExpandFeatures(t *testing.T) {
 					"postgresql_flexible_server": []interface{}{
 						map[string]interface{}{
 							"restart_server_on_configuration_value_change": false,
+						},
+					},
+					"postgresql_flexible_server_virtual_endpoint": []interface{}{
+						map[string]interface{}{
+							"recreate_resource_after_failover": false,
 						},
 					},
 					"resource_group": []interface{}{
@@ -528,6 +541,9 @@ func TestExpandFeatures(t *testing.T) {
 				},
 				PostgresqlFlexibleServer: features.PostgresqlFlexibleServerFeatures{
 					RestartServerOnConfigurationValueChange: false,
+				},
+				PostgresqlFlexibleServerVirtualEndpoint: features.PostgresqlFlexibleServerVirtualEndpointFeatures{
+					RecreateResourceAfterFailover: false,
 				},
 				MachineLearning: features.MachineLearningFeatures{
 					PurgeSoftDeletedWorkspaceOnDestroy: false,
@@ -2057,6 +2073,70 @@ func TestExpandFeaturesEnhancedValidation(t *testing.T) {
 		result := expandFeatures(testCase.Input)
 		if !reflect.DeepEqual(result.EnhancedValidation, testCase.Expected.EnhancedValidation) {
 			t.Fatalf("Expected %+v but got %+v", testCase.Expected.EnhancedValidation, result.EnhancedValidation)
+		}
+	}
+}
+
+func TestExpandFeaturesPostgresqlFlexibleServerVirtualEndpoint(t *testing.T) {
+	testData := []struct {
+		Name     string
+		Input    []interface{}
+		Expected features.UserFeatures
+	}{
+		{
+			Name: "Empty Block",
+			Input: []interface{}{
+				map[string]interface{}{
+					"postgresql_flexible_server_virtual_endpoint": []interface{}{},
+				},
+			},
+			Expected: features.UserFeatures{
+				PostgresqlFlexibleServerVirtualEndpoint: features.PostgresqlFlexibleServerVirtualEndpointFeatures{
+					RecreateResourceAfterFailover: false,
+				},
+			},
+		},
+		{
+			Name: "Recreate Resource After Failover Enabled",
+			Input: []interface{}{
+				map[string]interface{}{
+					"postgresql_flexible_server_virtual_endpoint": []interface{}{
+						map[string]interface{}{
+							"recreate_resource_after_failover": true,
+						},
+					},
+				},
+			},
+			Expected: features.UserFeatures{
+				PostgresqlFlexibleServerVirtualEndpoint: features.PostgresqlFlexibleServerVirtualEndpointFeatures{
+					RecreateResourceAfterFailover: true,
+				},
+			},
+		},
+		{
+			Name: "Recreate Resource After Failover Disabled",
+			Input: []interface{}{
+				map[string]interface{}{
+					"postgresql_flexible_server_virtual_endpoint": []interface{}{
+						map[string]interface{}{
+							"recreate_resource_after_failover": false,
+						},
+					},
+				},
+			},
+			Expected: features.UserFeatures{
+				PostgresqlFlexibleServerVirtualEndpoint: features.PostgresqlFlexibleServerVirtualEndpointFeatures{
+					RecreateResourceAfterFailover: false,
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testData {
+		t.Logf("[DEBUG] Test Case: %q", testCase.Name)
+		result := expandFeatures(testCase.Input)
+		if !reflect.DeepEqual(result.PostgresqlFlexibleServerVirtualEndpoint, testCase.Expected.PostgresqlFlexibleServerVirtualEndpoint) {
+			t.Fatalf("Expected %+v but got %+v", testCase.Expected.PostgresqlFlexibleServerVirtualEndpoint, result.PostgresqlFlexibleServerVirtualEndpoint)
 		}
 	}
 }

--- a/internal/provider/framework/config.go
+++ b/internal/provider/framework/config.go
@@ -465,6 +465,22 @@ func (p *ProviderConfig) Load(ctx context.Context, data *ProviderModel, tfVersio
 			f.PostgresqlFlexibleServer.RestartServerOnConfigurationValueChange = true
 		}
 
+		if !features.PostgresqlFlexibleServerVirtualEndpoint.IsNull() && !features.PostgresqlFlexibleServerVirtualEndpoint.IsUnknown() {
+			var feature []PostgresqlFlexibleServerVirtualEndpoint
+			d := features.PostgresqlFlexibleServerVirtualEndpoint.ElementsAs(ctx, &feature, true)
+			diags.Append(d...)
+			if diags.HasError() {
+				return
+			}
+
+			f.PostgresqlFlexibleServerVirtualEndpoint.RecreateResourceAfterFailover = false
+			if !feature[0].RecreateResourceAfterFailover.IsNull() && !feature[0].RecreateResourceAfterFailover.IsUnknown() {
+				f.PostgresqlFlexibleServerVirtualEndpoint.RecreateResourceAfterFailover = feature[0].RecreateResourceAfterFailover.ValueBool()
+			}
+		} else {
+			f.PostgresqlFlexibleServerVirtualEndpoint.RecreateResourceAfterFailover = false
+		}
+
 		if !features.RecoveryService.IsNull() && !features.RecoveryService.IsUnknown() {
 			var feature []RecoveryService
 			d := features.RecoveryService.ElementsAs(ctx, &feature, true)

--- a/internal/provider/framework/config_test.go
+++ b/internal/provider/framework/config_test.go
@@ -192,6 +192,10 @@ func TestProviderConfig_LoadDefault(t *testing.T) {
 		t.Errorf("expected postgresql.restart_server_on_configuration_value_change to be true")
 	}
 
+	if features.PostgresqlFlexibleServerVirtualEndpoint.RecreateResourceAfterFailover {
+		t.Errorf("expected postgresql_flexible_server_virtual_endpoint.recreate_resource_after_failover to be false")
+	}
+
 	if features.MachineLearning.PurgeSoftDeletedWorkspaceOnDestroy {
 		t.Errorf("expected machine_learning.PurgeSoftDeletedWorkspaceOnDestroy to be false")
 	}
@@ -320,6 +324,11 @@ func defaultFeaturesList() types.List {
 	})
 	postgresqlFlexibleServerList, _ := basetypes.NewListValue(types.ObjectType{}.WithAttributeTypes(PostgresqlFlexibleServerAttributes), []attr.Value{postgresqlFlexibleServer})
 
+	postgresqlFlexibleServerVirtualEndpoint, _ := basetypes.NewObjectValueFrom(context.Background(), PostgresqlFlexibleServerVirtualEndpointAttributes, map[string]attr.Value{
+		"recreate_resource_after_failover": basetypes.NewBoolNull(),
+	})
+	postgresqlFlexibleServerVirtualEndpointList, _ := basetypes.NewListValue(types.ObjectType{}.WithAttributeTypes(PostgresqlFlexibleServerVirtualEndpointAttributes), []attr.Value{postgresqlFlexibleServerVirtualEndpoint})
+
 	machineLearning, _ := basetypes.NewObjectValueFrom(context.Background(), MachineLearningAttributes, map[string]attr.Value{
 		"purge_soft_deleted_workspace_on_destroy": basetypes.NewBoolNull(),
 	})
@@ -381,8 +390,9 @@ func defaultFeaturesList() types.List {
 		"managed_disk":               managedDiskList,
 		"storage":                    storageList,
 		"subscription":               subscriptionList,
-		"postgresql_flexible_server": postgresqlFlexibleServerList,
-		"machine_learning":           machineLearningList,
+		"postgresql_flexible_server":                          postgresqlFlexibleServerList,
+		"postgresql_flexible_server_virtual_endpoint":         postgresqlFlexibleServerVirtualEndpointList,
+		"machine_learning":                                    machineLearningList,
 		"recovery_service":           recoveryServicesList,
 		"recovery_services_vaults":   recoveryServicesVaultsList,
 		"netapp":                     netappList,

--- a/internal/provider/framework/config_test.go
+++ b/internal/provider/framework/config_test.go
@@ -390,14 +390,14 @@ func defaultFeaturesList() types.List {
 		"managed_disk":               managedDiskList,
 		"storage":                    storageList,
 		"subscription":               subscriptionList,
-		"postgresql_flexible_server":                          postgresqlFlexibleServerList,
-		"postgresql_flexible_server_virtual_endpoint":         postgresqlFlexibleServerVirtualEndpointList,
-		"machine_learning":                                    machineLearningList,
-		"recovery_service":           recoveryServicesList,
-		"recovery_services_vaults":   recoveryServicesVaultsList,
-		"netapp":                     netappList,
-		"databricks_workspace":       databricksWorkspaceList,
-		"servicebus":                 servicebusList,
+		"postgresql_flexible_server": postgresqlFlexibleServerList,
+		"postgresql_flexible_server_virtual_endpoint": postgresqlFlexibleServerVirtualEndpointList,
+		"machine_learning":                            machineLearningList,
+		"recovery_service":                            recoveryServicesList,
+		"recovery_services_vaults":                    recoveryServicesVaultsList,
+		"netapp":                                      netappList,
+		"databricks_workspace":                        databricksWorkspaceList,
+		"servicebus":                                  servicebusList,
 	})
 
 	fmt.Printf("%+v", d)

--- a/internal/provider/framework/model.go
+++ b/internal/provider/framework/model.go
@@ -63,8 +63,9 @@ type Features struct {
 	ResourceGroup            types.List `tfsdk:"resource_group"`
 	Storage                  types.List `tfsdk:"storage"`
 	Subscription             types.List `tfsdk:"subscription"`
-	PostgresqlFlexibleServer types.List `tfsdk:"postgresql_flexible_server"`
-	RecoveryService          types.List `tfsdk:"recovery_service"`
+	PostgresqlFlexibleServer                types.List `tfsdk:"postgresql_flexible_server"`
+	PostgresqlFlexibleServerVirtualEndpoint types.List `tfsdk:"postgresql_flexible_server_virtual_endpoint"`
+	RecoveryService                         types.List `tfsdk:"recovery_service"`
 	RecoveryServicesVaults   types.List `tfsdk:"recovery_services_vaults"`
 	TemplateDeployment       types.List `tfsdk:"template_deployment"`
 	VirtualMachine           types.List `tfsdk:"virtual_machine"`
@@ -89,8 +90,9 @@ var FeaturesAttributes = map[string]attr.Type{
 	"machine_learning":           types.ListType{}.WithElementType(types.ObjectType{}.WithAttributeTypes(MachineLearningAttributes)),
 	"managed_disk":               types.ListType{}.WithElementType(types.ObjectType{}.WithAttributeTypes(ManagedDiskAttributes)),
 	"netapp":                     types.ListType{}.WithElementType(types.ObjectType{}.WithAttributeTypes(NetAppAttributes)),
-	"postgresql_flexible_server": types.ListType{}.WithElementType(types.ObjectType{}.WithAttributeTypes(PostgresqlFlexibleServerAttributes)),
-	"resource_group":             types.ListType{}.WithElementType(types.ObjectType{}.WithAttributeTypes(ResourceGroupAttributes)),
+	"postgresql_flexible_server":                          types.ListType{}.WithElementType(types.ObjectType{}.WithAttributeTypes(PostgresqlFlexibleServerAttributes)),
+	"postgresql_flexible_server_virtual_endpoint":         types.ListType{}.WithElementType(types.ObjectType{}.WithAttributeTypes(PostgresqlFlexibleServerVirtualEndpointAttributes)),
+	"resource_group":                                      types.ListType{}.WithElementType(types.ObjectType{}.WithAttributeTypes(ResourceGroupAttributes)),
 	"storage":                    types.ListType{}.WithElementType(types.ObjectType{}.WithAttributeTypes(StorageAttributes)),
 	"subscription":               types.ListType{}.WithElementType(types.ObjectType{}.WithAttributeTypes(SubscriptionAttributes)),
 	"recovery_service":           types.ListType{}.WithElementType(types.ObjectType{}.WithAttributeTypes(RecoveryServiceAttributes)),
@@ -249,6 +251,14 @@ type PostgresqlFlexibleServer struct {
 
 var PostgresqlFlexibleServerAttributes = map[string]attr.Type{
 	"restart_server_on_configuration_value_change": types.BoolType,
+}
+
+type PostgresqlFlexibleServerVirtualEndpoint struct {
+	RecreateResourceAfterFailover types.Bool `tfsdk:"recreate_resource_after_failover"`
+}
+
+var PostgresqlFlexibleServerVirtualEndpointAttributes = map[string]attr.Type{
+	"recreate_resource_after_failover": types.BoolType,
 }
 
 type MachineLearning struct {

--- a/internal/provider/framework/model.go
+++ b/internal/provider/framework/model.go
@@ -49,28 +49,28 @@ type Features struct {
 	PersistIDOnCreateBeforePollingForCompletion                 types.Bool `tfsdk:"persist_id_on_create_before_polling_for_completion"`
 	SkipImportCheckOnCreateAndAllowOverwritingExistingResources types.Bool `tfsdk:"skip_import_check_on_create_and_allow_overwriting_existing_resources"`
 
-	APIManagement            types.List `tfsdk:"api_management"`
-	AppConfiguration         types.List `tfsdk:"app_configuration"`
-	ApplicationInsights      types.List `tfsdk:"application_insights"`
-	CognitiveAccount         types.List `tfsdk:"cognitive_account"`
-	DatabricksWorkspace      types.List `tfsdk:"databricks_workspace"`
-	EnhancedValidation       types.List `tfsdk:"enhanced_validation"`
-	KeyVault                 types.List `tfsdk:"key_vault"`
-	LogAnalyticsWorkspace    types.List `tfsdk:"log_analytics_workspace"`
-	MachineLearning          types.List `tfsdk:"machine_learning"`
-	ManagedDisk              types.List `tfsdk:"managed_disk"`
-	NetApp                   types.List `tfsdk:"netapp"`
-	ResourceGroup            types.List `tfsdk:"resource_group"`
-	Storage                  types.List `tfsdk:"storage"`
-	Subscription             types.List `tfsdk:"subscription"`
+	APIManagement                           types.List `tfsdk:"api_management"`
+	AppConfiguration                        types.List `tfsdk:"app_configuration"`
+	ApplicationInsights                     types.List `tfsdk:"application_insights"`
+	CognitiveAccount                        types.List `tfsdk:"cognitive_account"`
+	DatabricksWorkspace                     types.List `tfsdk:"databricks_workspace"`
+	EnhancedValidation                      types.List `tfsdk:"enhanced_validation"`
+	KeyVault                                types.List `tfsdk:"key_vault"`
+	LogAnalyticsWorkspace                   types.List `tfsdk:"log_analytics_workspace"`
+	MachineLearning                         types.List `tfsdk:"machine_learning"`
+	ManagedDisk                             types.List `tfsdk:"managed_disk"`
+	NetApp                                  types.List `tfsdk:"netapp"`
+	ResourceGroup                           types.List `tfsdk:"resource_group"`
+	Storage                                 types.List `tfsdk:"storage"`
+	Subscription                            types.List `tfsdk:"subscription"`
 	PostgresqlFlexibleServer                types.List `tfsdk:"postgresql_flexible_server"`
 	PostgresqlFlexibleServerVirtualEndpoint types.List `tfsdk:"postgresql_flexible_server_virtual_endpoint"`
 	RecoveryService                         types.List `tfsdk:"recovery_service"`
-	RecoveryServicesVaults   types.List `tfsdk:"recovery_services_vaults"`
-	TemplateDeployment       types.List `tfsdk:"template_deployment"`
-	VirtualMachine           types.List `tfsdk:"virtual_machine"`
-	VirtualMachineScaleSet   types.List `tfsdk:"virtual_machine_scale_set"`
-	ServiceBus               types.List `tfsdk:"servicebus"`
+	RecoveryServicesVaults                  types.List `tfsdk:"recovery_services_vaults"`
+	TemplateDeployment                      types.List `tfsdk:"template_deployment"`
+	VirtualMachine                          types.List `tfsdk:"virtual_machine"`
+	VirtualMachineScaleSet                  types.List `tfsdk:"virtual_machine_scale_set"`
+	ServiceBus                              types.List `tfsdk:"servicebus"`
 }
 
 // FeaturesAttributes and the other block attribute vars are required for unit testing on the Load func
@@ -90,17 +90,17 @@ var FeaturesAttributes = map[string]attr.Type{
 	"machine_learning":           types.ListType{}.WithElementType(types.ObjectType{}.WithAttributeTypes(MachineLearningAttributes)),
 	"managed_disk":               types.ListType{}.WithElementType(types.ObjectType{}.WithAttributeTypes(ManagedDiskAttributes)),
 	"netapp":                     types.ListType{}.WithElementType(types.ObjectType{}.WithAttributeTypes(NetAppAttributes)),
-	"postgresql_flexible_server":                          types.ListType{}.WithElementType(types.ObjectType{}.WithAttributeTypes(PostgresqlFlexibleServerAttributes)),
-	"postgresql_flexible_server_virtual_endpoint":         types.ListType{}.WithElementType(types.ObjectType{}.WithAttributeTypes(PostgresqlFlexibleServerVirtualEndpointAttributes)),
-	"resource_group":                                      types.ListType{}.WithElementType(types.ObjectType{}.WithAttributeTypes(ResourceGroupAttributes)),
-	"storage":                    types.ListType{}.WithElementType(types.ObjectType{}.WithAttributeTypes(StorageAttributes)),
-	"subscription":               types.ListType{}.WithElementType(types.ObjectType{}.WithAttributeTypes(SubscriptionAttributes)),
-	"recovery_service":           types.ListType{}.WithElementType(types.ObjectType{}.WithAttributeTypes(RecoveryServiceAttributes)),
-	"recovery_services_vaults":   types.ListType{}.WithElementType(types.ObjectType{}.WithAttributeTypes(RecoveryServiceVaultsAttributes)),
-	"template_deployment":        types.ListType{}.WithElementType(types.ObjectType{}.WithAttributeTypes(TemplateDeploymentAttributes)),
-	"virtual_machine":            types.ListType{}.WithElementType(types.ObjectType{}.WithAttributeTypes(VirtualMachineAttributes)),
-	"virtual_machine_scale_set":  types.ListType{}.WithElementType(types.ObjectType{}.WithAttributeTypes(VirtualMachineScaleSetAttributes)),
-	"servicebus":                 types.ListType{}.WithElementType(types.ObjectType{}.WithAttributeTypes(ServiceBusAttributes)),
+	"postgresql_flexible_server": types.ListType{}.WithElementType(types.ObjectType{}.WithAttributeTypes(PostgresqlFlexibleServerAttributes)),
+	"postgresql_flexible_server_virtual_endpoint": types.ListType{}.WithElementType(types.ObjectType{}.WithAttributeTypes(PostgresqlFlexibleServerVirtualEndpointAttributes)),
+	"resource_group":            types.ListType{}.WithElementType(types.ObjectType{}.WithAttributeTypes(ResourceGroupAttributes)),
+	"storage":                   types.ListType{}.WithElementType(types.ObjectType{}.WithAttributeTypes(StorageAttributes)),
+	"subscription":              types.ListType{}.WithElementType(types.ObjectType{}.WithAttributeTypes(SubscriptionAttributes)),
+	"recovery_service":          types.ListType{}.WithElementType(types.ObjectType{}.WithAttributeTypes(RecoveryServiceAttributes)),
+	"recovery_services_vaults":  types.ListType{}.WithElementType(types.ObjectType{}.WithAttributeTypes(RecoveryServiceVaultsAttributes)),
+	"template_deployment":       types.ListType{}.WithElementType(types.ObjectType{}.WithAttributeTypes(TemplateDeploymentAttributes)),
+	"virtual_machine":           types.ListType{}.WithElementType(types.ObjectType{}.WithAttributeTypes(VirtualMachineAttributes)),
+	"virtual_machine_scale_set": types.ListType{}.WithElementType(types.ObjectType{}.WithAttributeTypes(VirtualMachineScaleSetAttributes)),
+	"servicebus":                types.ListType{}.WithElementType(types.ObjectType{}.WithAttributeTypes(ServiceBusAttributes)),
 }
 
 type APIManagement struct {

--- a/internal/provider/framework/provider.go
+++ b/internal/provider/framework/provider.go
@@ -449,6 +449,16 @@ func (p *azureRmFrameworkProvider) Schema(_ context.Context, _ provider.SchemaRe
 								},
 							},
 						},
+						"postgresql_flexible_server_virtual_endpoint": schema.ListNestedBlock{
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"recreate_resource_after_failover": schema.BoolAttribute{
+										Optional:    true,
+										Description: "When enabled, the `azurerm_postgresql_flexible_server_virtual_endpoint` will be recreated after a failover is detected, restoring the pre-v4.15.0 behavior. Defaults to `false`.",
+									},
+								},
+							},
+						},
 						"recovery_service": schema.ListNestedBlock{
 							NestedObject: schema.NestedBlockObject{
 								Attributes: map[string]schema.Attribute{

--- a/internal/services/postgres/postgresql_flexible_server_virtual_endpoint_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_virtual_endpoint_resource.go
@@ -236,7 +236,9 @@ func (r PostgresqlFlexibleServerVirtualEndpointResource) Read() sdk.ResourceFunc
 			}
 
 			// if a fail-over has occurred, the source/replica ids have swapped so we'll have to swap them back in Terraform to prevent a diff
-			if failOverHasOccurred {
+			// unless recreate_resource_after_failover is enabled, in which case we intentionally leave the IDs swapped so Terraform
+			// detects the change and recreates the resource (source_server_id has ForceNew: true)
+			if failOverHasOccurred && !metadata.Client.Features.PostgresqlFlexibleServerVirtualEndpoint.RecreateResourceAfterFailover {
 				state.SourceServerId, state.ReplicaServerId = state.ReplicaServerId, state.SourceServerId
 			}
 

--- a/internal/services/postgres/postgresql_flexible_server_virtual_endpoint_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_virtual_endpoint_resource.go
@@ -320,7 +320,7 @@ func (r PostgresqlFlexibleServerVirtualEndpointResource) Update() sdk.ResourceFu
 					if _, err = client.Get(ctx, virtualEndpointId); err != nil {
 						return fmt.Errorf("retrieving %s: %+v", virtualEndpointId, err)
 					}
-					return fmt.Errorf("a fail-over has occurred and the `source_server_id` in the config is no longer the SourceServerId for the virtual endpoint. If you wish to change the `replica_server_id`, remove this resource from state and reimport it back in with the `replica_server_id` and `source_server_id` swapped")
+					return fmt.Errorf("a fail-over has occurred and the `source_server_id` in the config is no longer the SourceServerId for the virtual endpoint. If you wish to change the `replica_server_id`, remove this resource from state and reimport it back in with the `replica_server_id` and `source_server_id` swapped. Alternatively, set `recreate_resource_after_failover = true` in the `postgresql_flexible_server_virtual_endpoint` block of the provider `features {}` configuration to have Terraform automatically handle failover recovery via resource recreation")
 				}
 				return fmt.Errorf("retrieving %s: %+v", virtualEndpointId, err)
 			}

--- a/website/docs/guides/features-block.html.markdown
+++ b/website/docs/guides/features-block.html.markdown
@@ -89,6 +89,10 @@ provider "azurerm" {
       restart_server_on_configuration_value_change = true
     }
 
+    postgresql_flexible_server_virtual_endpoint {
+      recreate_resource_after_failover = false
+    }
+
     recovery_service {
       vm_backup_stop_protection_and_retain_data_on_destroy    = true
       vm_backup_suspend_protection_and_retain_data_on_destroy = true
@@ -168,6 +172,8 @@ The `features` block supports the following:
 * `netapp` - (Optional) A `netapp` block as defined below.
 
 * `postgresql_flexible_server` - (Optional) A `postgresql_flexible_server` block as defined below.
+
+* `postgresql_flexible_server_virtual_endpoint` - (Optional) A `postgresql_flexible_server_virtual_endpoint` block as defined below.
 
 * `recovery_service` - (Optional) A `recovery_service` block as defined below.
 
@@ -301,6 +307,12 @@ The `netapp` block supports the following:
 The `postgresql_flexible_server` block supports the following:
 
 * `restart_server_on_configuration_value_change` - (Optional) Should the `postgresql_flexible_server` restart after static server parameter change or removal? Defaults to `true`.
+
+---
+
+The `postgresql_flexible_server_virtual_endpoint` block supports the following:
+
+* `recreate_resource_after_failover` - (Optional) Should the `azurerm_postgresql_flexible_server_virtual_endpoint` resource be recreated when a failover is detected (i.e. when `source_server_id` and `replica_server_id` are swapped in Azure)? When set to `true`, Terraform will destroy and recreate the virtual endpoint resource instead of silently updating state. This restores the behavior that was present prior to provider version 4.15.0. Defaults to `false`.
 
 ---
 

--- a/website/docs/r/postgresql_flexible_server_virtual_endpoint.html.markdown
+++ b/website/docs/r/postgresql_flexible_server_virtual_endpoint.html.markdown
@@ -69,7 +69,7 @@ The following arguments are supported:
 
 * `replica_server_id` - (Required) The Resource ID of the *Replica* Postgres Flexible Server this should be associated with
 
-~> **Note:** If a fail-over has occurred, you will be unable to update `replica_server_id`. You can remove the resource from state and reimport it back in with `source_server_id` and `replica_server_id` flipped and then update `replica_server_id`.
+~> **Note:** If a fail-over has occurred, you will be unable to update `replica_server_id`. You can remove the resource from state and reimport it back in with `source_server_id` and `replica_server_id` flipped and then update `replica_server_id`. Alternatively, set `recreate_resource_after_failover = true` in the `postgresql_flexible_server_virtual_endpoint` block of the provider `features {}` configuration to have Terraform automatically handle failover recovery via resource recreation — see the [features block documentation](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/features-block#postgresql_flexible_server_virtual_endpoint) for details.
 
 * `type` - (Required) The type of Virtual Endpoint. Currently only `ReadWrite` is supported. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know.

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Adds a `postgresql_flexible_server_virtual_endpoint` block to the provider `features {}` configuration, with a `recreate_resource_after_failover` attribute (bool, default `false`).

Prior to PR #29424, when a PostgreSQL Flexible Server failover was detected, the `azurerm_postgresql_flexible_server_virtual_endpoint` resource would be automatically recreated. That PR changed the behavior to silently swap `source_server_id`/`replica_server_id` back in state, preventing recreation. While correct for root-module usage, this makes the resource unsuitable for child modules where consumers do not have direct access to perform state manipulation, and where the `removed` block cannot be toggled dynamically (no `count`/`for_each` support).

This PR restores the pre-#29424 behavior as an opt-in feature flag. When `recreate_resource_after_failover = true`, the provider does not swap IDs back after failover detection, allowing Terraform to detect the `source_server_id` change and trigger a destroy+recreate via `ForceNew`. The default `false` preserves current behavior — this is a non-breaking change.

Example configuration:

```hcl
provider "azurerm" {
  features {
    postgresql_flexible_server_virtual_endpoint {
      recreate_resource_after_failover = true
    }
  }
}
```


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.
For example: "`resource_name_here` - description of change e.g. adding property `new_property_name_here`"


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (covered by issue #32750 and the description above).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.

> Acceptance tests for `azurerm_postgresql_flexible_server_virtual_endpoint` require a live Azure environment with failover capability and are not runnable locally without credentials. Unit tests for the feature flag plumbing pass locally (see Testing section below).


## Testing

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided.

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

Unit tests added and passing locally:

- `TestExpandFeaturesPostgresqlFlexibleServerVirtualEndpoint` — covers empty block (default `false`), enabled (`true`), and disabled (`false`) cases
- `TestExpandFeatures` Complete Enabled and Complete Disabled cases updated to include the new `postgresql_flexible_server_virtual_endpoint` block
- `internal/provider/framework/config_test.go` `defaultFeaturesList()` updated with the new block; assertion added in `TestProviderConfig_LoadDefault`

```
$ go test ./internal/provider/ -run "TestExpandFeatures" -count=1
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/provider	2.312s
```

Acceptance tests for failover behavior require a live Azure environment and cannot be run locally without credentials. The feature flag plumbing follows the identical pattern as existing feature flags (e.g. `postgresql_flexible_server`, `servicebus`) which are already tested by the acceptance suite.


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_postgresql_flexible_server_virtual_endpoint` - support for the `recreate_resource_after_failover` property in the `features` block [GH-32750]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Closes #32750


## AI Assistance Disclosure

<!--
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

GitHub Copilot (Claude Sonnet 4.6) was used for the full implementation: feature design, code generation across all modified files, unit test authorship, and documentation updates. All output was reviewed and approved by the human contributor. Future responses to reviewer feedback on this PR may also be assisted by AI.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

No changes to security controls. This PR only adds a provider-level feature flag that affects the reconciliation behavior of an existing resource.

> [!NOTE]
> If this PR changes meaningfully during the course of review please update the title and description as required.