### PR TITLE
`azurerm_dev_center_project` - normalize `dev_center_id` in Read

### DIFF
--- a/internal/services/devcenter/dev_center_project_resource.go
+++ b/internal/services/devcenter/dev_center_project_resource.go
@@ -181,15 +181,14 @@ func (r DevCenterProjectResource) Read() sdk.ResourceFunc {
 					schema.DevCenterUri = pointer.From(props.DevCenterUri)
 					schema.MaximumDevBoxesPerUser = pointer.From(props.MaxDevBoxesPerUser)
 
-					devCenterId := pointer.From(props.DevCenterId)
-					if devCenterId != "" {
-						parsedDevCenterId, err := devcenters.ParseDevCenterIDInsensitively(devCenterId)
-						if err != nil {
-							return fmt.Errorf("parsing `dev_center_id`: %+v", err)
-						}
-						devCenterId = parsedDevCenterId.ID()
+					if devCenterId := pointer.From(props.DevCenterId); devCenterId != "" {
+					
+					parsedDevCenterId, err := devcenters.ParseDevCenterIDInsensitively(devCenterId)
+					if err != nil {
+						return fmt.Errorf("parsing `dev_center_id`: %+v", err)
 					}
-					schema.DevCenterId = devCenterId
+					schema.DevCenterId = parsedDevCenterId.ID()
+					}
 				}
 			}
 

--- a/internal/services/devcenter/dev_center_project_resource.go
+++ b/internal/services/devcenter/dev_center_project_resource.go
@@ -180,14 +180,12 @@ func (r DevCenterProjectResource) Read() sdk.ResourceFunc {
 					schema.Description = pointer.From(props.Description)
 					schema.DevCenterUri = pointer.From(props.DevCenterUri)
 					schema.MaximumDevBoxesPerUser = pointer.From(props.MaxDevBoxesPerUser)
-
 					if devCenterId := pointer.From(props.DevCenterId); devCenterId != "" {
-					
-					parsedDevCenterId, err := devcenters.ParseDevCenterIDInsensitively(devCenterId)
-					if err != nil {
-						return fmt.Errorf("parsing `dev_center_id`: %+v", err)
-					}
-					schema.DevCenterId = parsedDevCenterId.ID()
+						parsedDevCenterId, err := devcenters.ParseDevCenterIDInsensitively(devCenterId)
+						if err != nil {
+							return err
+						}
+						schema.DevCenterId = parsedDevCenterId.ID()
 					}
 				}
 			}

--- a/internal/services/devcenter/dev_center_project_resource.go
+++ b/internal/services/devcenter/dev_center_project_resource.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/devcenter/2025-02-01/devcenters"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/devcenter/2025-02-01/projects"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -177,9 +178,18 @@ func (r DevCenterProjectResource) Read() sdk.ResourceFunc {
 
 				if props := model.Properties; props != nil {
 					schema.Description = pointer.From(props.Description)
-					schema.DevCenterId = pointer.From(props.DevCenterId)
 					schema.DevCenterUri = pointer.From(props.DevCenterUri)
 					schema.MaximumDevBoxesPerUser = pointer.From(props.MaxDevBoxesPerUser)
+
+					devCenterId := pointer.From(props.DevCenterId)
+					if devCenterId != "" {
+						parsedDevCenterId, err := devcenters.ParseDevCenterIDInsensitively(devCenterId)
+						if err != nil {
+							return fmt.Errorf("parsing `dev_center_id`: %+v", err)
+						}
+						devCenterId = parsedDevCenterId.ID()
+					}
+					schema.DevCenterId = devCenterId
 				}
 			}
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR is to normalize the `dev_center_id` property during Read for `azurerm_dev_center_project`. 

Dev Centers created through the Azure Portal using the lowercase resource ID segment (`devcenters`) while the provider only accepts cameral case. This cause casing mismatch when user importing existing resource from Portal. This PR is to solve the issue. Details see linked issue.  

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

<img width="810" height="681" alt="image" src="https://github.com/user-attachments/assets/4845e6ae-25da-4777-9184-958290861724" />

Failed tests also failed on main branch. 

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #32778


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
