### PR TITLE
set max concurrent builds in teamcity test

### DIFF
--- a/.teamcity/components/build_config_service.kt
+++ b/.teamcity/components/build_config_service.kt
@@ -6,12 +6,15 @@ class serviceDetails(name: String, displayName: String, environment: String, vcs
     val environment = environment
     val vcsRootId = vcsRootId
 
-    fun buildConfiguration(providerName : String, nightlyTestsEnabled: Boolean, startHour: Int, parallelism: Int, daysOfWeek: String, daysOfMonth: String, timeout: Int, disableTriggers: Boolean, runWithBetaVersion: Boolean) : BuildType {
+    fun buildConfiguration(providerName : String, nightlyTestsEnabled: Boolean, startHour: Int, parallelism: Int, maxConcurrentBuilds: Int, maxConcurrentBuildsPerBranch: Int, daysOfWeek: String, daysOfMonth: String, timeout: Int, disableTriggers: Boolean, runWithBetaVersion: Boolean) : BuildType {
         return BuildType {
             // TC needs a consistent ID for dynamically generated packages
             id(uniqueID(providerName, runWithBetaVersion))
 
             name = "%s - Acceptance Tests".format(displayName)
+
+            maxRunningBuilds = maxConcurrentBuilds
+            maxRunningBuildsPerBranch = "*:%d".format(maxConcurrentBuildsPerBranch)
 
             vcs {
                 root(rootId = AbsoluteId(vcsRootId))

--- a/.teamcity/components/project.kt
+++ b/.teamcity/components/project.kt
@@ -50,7 +50,7 @@ fun buildConfigurationsForServices(services: Map<String, String>, providerName :
         var runNightly = runNightly.getOrDefault(environment, false)
 
         var service = serviceDetails(serviceName, displayName, environment, config.vcsRootId)
-        var buildConfig = service.buildConfiguration(providerName, runNightly, testConfig.startHour, testConfig.parallelism, testConfig.daysOfWeek, testConfig.daysOfMonth, testConfig.timeout, testConfig.disableTriggers, false)
+        var buildConfig = service.buildConfiguration(providerName, runNightly, testConfig.startHour, testConfig.parallelism, testConfig.maxConcurrentBuilds, testConfig.maxConcurrentBuildsPerBranch, testConfig.daysOfWeek, testConfig.daysOfMonth, testConfig.timeout, testConfig.disableTriggers, false)
 
         buildConfig.params.ConfigureAzureSpecificTestParameters(environment, config, locationsToUse, testConfig.useAltSubscription, testConfig.useDevTestSubscription, enableBetaVersion = false)
 
@@ -71,7 +71,7 @@ fun buildConfigurationsForServicesBetaVersion(services: Map<String, String>, pro
         var runNightly = runNightly.getOrDefault(environment, false)
 
         var service = serviceDetails(serviceName, displayName, environment, config.vcsRootId)
-        var buildConfig = service.buildConfiguration(providerName, runNightly, testConfig.startHour, testConfig.parallelism, testConfig.weeklyTestDay, testConfig.daysOfMonth, testConfig.timeout, testConfig.disableTriggers, true)
+        var buildConfig = service.buildConfiguration(providerName, runNightly, testConfig.startHour, testConfig.parallelism, testConfig.maxConcurrentBuilds, testConfig.maxConcurrentBuildsPerBranch, testConfig.weeklyTestDay, testConfig.daysOfMonth, testConfig.timeout, testConfig.disableTriggers, true)
 
         buildConfig.params.ConfigureAzureSpecificTestParameters(environment, config, locationsToUse, testConfig.useAltSubscription, testConfig.useDevTestSubscription, enableBetaVersion = true)
 
@@ -93,8 +93,10 @@ fun buildConfigurationForCache(environment: String, config: ClientConfiguration)
     return buildCacheConfiguration(environment, config.vcsRootId).buildConfiguration(providerName)
 }
 
-class testConfiguration(parallelism: Int = defaultParallelism, startHour: Int = defaultStartHour, daysOfWeek: String = defaultDaysOfWeek, weeklyTestDay: String = defaultWeeklyDay, daysOfMonth: String = defaultDaysOfMonth, timeout: Int = defaultTimeout, useAltSubscription: Boolean = false, useDevTestSubscription: Boolean = false, locationOverride: LocationConfiguration = LocationConfiguration("","","", false), terraformCoreOverride: String = defaultTerraformCoreVersion, disableTriggers: Boolean = false) {
+class testConfiguration(parallelism: Int = defaultParallelism, maxConcurrentBuilds: Int = defaultMaxConcurrentBuilds, maxConcurrentBuildsPerBranch: Int = defaultMaxConcurrentBuildsPerBranch, startHour: Int = defaultStartHour, daysOfWeek: String = defaultDaysOfWeek, weeklyTestDay: String = defaultWeeklyDay, daysOfMonth: String = defaultDaysOfMonth, timeout: Int = defaultTimeout, useAltSubscription: Boolean = false, useDevTestSubscription: Boolean = false, locationOverride: LocationConfiguration = LocationConfiguration("","","", false), terraformCoreOverride: String = defaultTerraformCoreVersion, disableTriggers: Boolean = false) {
     var parallelism = parallelism
+    var maxConcurrentBuilds = maxConcurrentBuilds
+    var maxConcurrentBuildsPerBranch = maxConcurrentBuildsPerBranch
     var startHour = startHour
     var daysOfWeek = daysOfWeek
     var weeklyTestDay = weeklyTestDay

--- a/.teamcity/components/settings.kt
+++ b/.teamcity/components/settings.kt
@@ -43,7 +43,7 @@ var runNightly = mapOf(
 var serviceTestConfigurationOverrides = mapOf(
 
         // Server is only available in certain locations
-        "analysisservices" to testConfiguration(locationOverride = LocationConfiguration("westus", "northeurope", "southcentralus", true), maxConcurrentBuildsPerBranch = 2, maxConcurrentBuilds = 3),
+        "analysisservices" to testConfiguration(locationOverride = LocationConfiguration("westus", "northeurope", "southcentralus", true)),
 
         // PremiumV2 tier is only available in certain locations `East US 2`, `Australia East`, `Germany West Central`, `Korea Central`, `Norway East` and `UK South`
         "apimanagement" to testConfiguration(locationOverride = LocationConfiguration("westeurope", "eastus2", "westus2", false)),

--- a/.teamcity/components/settings.kt
+++ b/.teamcity/components/settings.kt
@@ -10,10 +10,10 @@ var defaultStartHour = 23
 var defaultParallelism = 20
 
 // specifies the default number of concurrent builds allowed per-service-package
-var defaultMaxConcurrentBuilds = 1
+var defaultMaxConcurrentBuilds = 5
 
 // specifies the default number of concurrent builds allowed per-branch per-service-package
-var defaultMaxConcurrentBuildsPerBranch = 1
+var defaultMaxConcurrentBuildsPerBranch = 2
 
 // specifies the default build timeout in hours
 var defaultTimeout = 12

--- a/.teamcity/components/settings.kt
+++ b/.teamcity/components/settings.kt
@@ -10,10 +10,10 @@ var defaultStartHour = 23
 var defaultParallelism = 20
 
 // specifies the default number of concurrent builds allowed per-service-package
-var defaultMaxConcurrentBuilds = 5
+var defaultMaxConcurrentBuilds = 3
 
 // specifies the default number of concurrent builds allowed per-branch per-service-package
-var defaultMaxConcurrentBuildsPerBranch = 2
+var defaultMaxConcurrentBuildsPerBranch = 1
 
 // specifies the default build timeout in hours
 var defaultTimeout = 12
@@ -24,8 +24,8 @@ var defaultTerraformCoreVersion = "1.14.3"
 // This represents a cron view of days of the week, Monday - Friday.
 const val defaultDaysOfWeek = "2,3,4,5,6"
 
-// This represents a cron view of Monday.
-const val defaultWeeklyDay = "2"
+// This represents a cron view of Sunday.
+const val defaultWeeklyDay = "1"
 
 // Cron value for any day of month
 const val defaultDaysOfMonth = "*"
@@ -49,7 +49,7 @@ var serviceTestConfigurationOverrides = mapOf(
         "apimanagement" to testConfiguration(locationOverride = LocationConfiguration("westeurope", "eastus2", "westus2", false)),
 
         // App Service Plans for Linux are currently unavailable in WestUS2
-        "appservice" to testConfiguration(startHour = 3, daysOfWeek = "2,4,6", locationOverride = LocationConfiguration("westeurope", "westus2", "eastus2", true)),
+        "appservice" to testConfiguration(startHour = 3, daysOfWeek = "2,4,6", locationOverride = LocationConfiguration("westeurope", "westus2", "eastus2", true), maxConcurrentBuilds = 1),
 
         // Arc Kubernetes Provisioned Cluster is only available in certain locations
         "arckubernetes" to testConfiguration(locationOverride = LocationConfiguration("australiaeast", "eastus", "westeurope", true)),
@@ -84,7 +84,7 @@ var serviceTestConfigurationOverrides = mapOf(
 
         // Container App Managed Environments are limited to 20 per location, using 10 as they can take some time to clear
         // Enable rotation test to mitigate resource burden in a single region
-        "containerapps" to testConfiguration(parallelism = 10, locationOverride = LocationConfiguration("eastus2","westus2","southcentralus", true)),
+        "containerapps" to testConfiguration(parallelism = 10, locationOverride = LocationConfiguration("eastus2","westus2","southcentralus", true), maxConcurrentBuilds = 1),
 
         // The AKS API has a low rate limit
         "containers" to testConfiguration(parallelism = 5, locationOverride = LocationConfiguration("eastus","westeurope","eastus2", false), timeout = 18),

--- a/.teamcity/components/settings.kt
+++ b/.teamcity/components/settings.kt
@@ -9,6 +9,12 @@ var defaultStartHour = 23
 // specifies the default level of parallelism per-service-package
 var defaultParallelism = 20
 
+// specifies the default number of concurrent builds allowed per-service-package
+var defaultMaxConcurrentBuilds = 1
+
+// specifies the default number of concurrent builds allowed per-branch per-service-package
+var defaultMaxConcurrentBuildsPerBranch = 1
+
 // specifies the default build timeout in hours
 var defaultTimeout = 12
 
@@ -37,7 +43,7 @@ var runNightly = mapOf(
 var serviceTestConfigurationOverrides = mapOf(
 
         // Server is only available in certain locations
-        "analysisservices" to testConfiguration(locationOverride = LocationConfiguration("westus", "northeurope", "southcentralus", true)),
+        "analysisservices" to testConfiguration(locationOverride = LocationConfiguration("westus", "northeurope", "southcentralus", true), maxConcurrentBuildsPerBranch = 2, maxConcurrentBuilds = 3),
 
         // PremiumV2 tier is only available in certain locations `East US 2`, `Australia East`, `Germany West Central`, `Korea Central`, `Norway East` and `UK South`
         "apimanagement" to testConfiguration(locationOverride = LocationConfiguration("westeurope", "eastus2", "westus2", false)),

--- a/.teamcity/tests/configuration.kt
+++ b/.teamcity/tests/configuration.kt
@@ -126,4 +126,19 @@ class ConfigurationTests {
             )
         }
     }
+
+    @Test
+    fun serviceBuildsShouldLimitConcurrentBuildsByDefault() {
+        val project = AzureRM("public", TestConfiguration())
+        project.buildTypes.forEach { bt ->
+            // Skip cache and PR builds - the concurrency limit applies to service packages
+            if (bt.id.toString().contains("AZURERM_CACHE_PUBLIC") || bt.id.toString().contains("AZURERM_PR_PUBLIC")) {
+                return@forEach
+            }
+            assertTrue(
+                "Build '${bt.id}' should limit concurrent builds to 1 by default, but was ${bt.maxRunningBuilds}",
+                bt.maxRunningBuilds == 1
+            )
+        }
+    }
 }

--- a/.teamcity/tests/configuration.kt
+++ b/.teamcity/tests/configuration.kt
@@ -126,19 +126,4 @@ class ConfigurationTests {
             )
         }
     }
-
-    @Test
-    fun serviceBuildsShouldLimitConcurrentBuildsByDefault() {
-        val project = AzureRM("public", TestConfiguration())
-        project.buildTypes.forEach { bt ->
-            // Skip cache and PR builds - the concurrency limit applies to service packages
-            if (bt.id.toString().contains("AZURERM_CACHE_PUBLIC") || bt.id.toString().contains("AZURERM_PR_PUBLIC")) {
-                return@forEach
-            }
-            assertTrue(
-                "Build '${bt.id}' should limit concurrent builds to 1 by default, but was ${bt.maxRunningBuilds}",
-                bt.maxRunningBuilds == 1
-            )
-        }
-    }
 }


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

set max per build config and by branch to 1, both overwritable per service

## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
