### PR TITLE
`azurerm_snapshot`: `create_option` now supports `CopyStart`

### DIFF
--- a/internal/services/compute/custompoller/snapshot_copy_start_poller.go
+++ b/internal/services/compute/custompoller/snapshot_copy_start_poller.go
@@ -1,0 +1,53 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package custompoller
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-02/snapshots"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+)
+
+type snapshotCopyStartPoller struct {
+	client *snapshots.SnapshotsClient
+	id     snapshots.SnapshotId
+}
+
+var _ pollers.PollerType = &snapshotCopyStartPoller{}
+
+func NewSnapshotCopyStartPoller(client *snapshots.SnapshotsClient, id snapshots.SnapshotId) *snapshotCopyStartPoller {
+	return &snapshotCopyStartPoller{
+		client: client,
+		id:     id,
+	}
+}
+
+func (s snapshotCopyStartPoller) Poll(ctx context.Context) (*pollers.PollResult, error) {
+	resp, err := s.client.Get(ctx, s.id)
+	if err != nil {
+		return nil, fmt.Errorf("polling for the copy status of %s: %+v", s.id, err)
+	}
+
+	completionPercent := float64(0)
+	if model := resp.Model; model != nil && model.Properties != nil {
+		completionPercent = pointer.From(model.Properties.CompletionPercent)
+	}
+
+	log.Printf("[DEBUG] Snapshot %s copy completion is at %.1f%%", s.id, completionPercent)
+	if completionPercent < 100 {
+		return &pollers.PollResult{
+			Status:       pollers.PollingStatusInProgress,
+			PollInterval: 30 * time.Second,
+		}, nil
+	}
+
+	return &pollers.PollResult{
+		Status: pollers.PollingStatusSucceeded,
+	}, nil
+}

--- a/internal/services/compute/snapshot_resource.go
+++ b/internal/services/compute/snapshot_resource.go
@@ -16,9 +16,11 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-02/diskaccesses"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-02/snapshots"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/custompoller"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -71,11 +73,6 @@ func resourceSnapshot() *pluginsdk.Resource {
 					string(snapshots.DiskCreateOptionCopyStart),
 					string(snapshots.DiskCreateOptionImport),
 				}, false),
-			},
-
-			"completion_percent": {
-				Type:     pluginsdk.TypeFloat,
-				Computed: true,
 			},
 
 			"incremental_enabled": {
@@ -233,19 +230,10 @@ func resourceSnapshotCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 		// consume an incomplete snapshot.
 		if createOption == string(snapshots.DiskCreateOptionCopyStart) {
 			log.Printf("[DEBUG] Waiting for the copy of %s to complete", id)
-			timeout := 30 * time.Minute
-			if deadline, ok := ctx.Deadline(); ok {
-				timeout = time.Until(deadline)
-			}
-			stateConf := &pluginsdk.StateChangeConf{
-				Pending:    []string{"Copying"},
-				Target:     []string{"Complete"},
-				Refresh:    snapshotCopyCompletionRefreshFunc(ctx, client, id),
-				MinTimeout: 30 * time.Second,
-				Timeout:    timeout,
-			}
 
-			if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+			pollerType := custompoller.NewSnapshotCopyStartPoller(client, id)
+			poller := pollers.NewPoller(pollerType, 30*time.Second, pollers.DefaultNumberOfDroppedConnectionsToAllow)
+			if err := poller.PollUntilDone(ctx); err != nil {
 				return fmt.Errorf("waiting for the copy of %s to complete: %+v", id, err)
 			}
 		}
@@ -290,12 +278,6 @@ func resourceSnapshotRead(d *pluginsdk.ResourceData, meta interface{}) error {
 			d.Set("create_option", string(data.CreateOption))
 			d.Set("storage_account_id", data.StorageAccountId)
 			d.Set("disk_access_id", pointer.From(props.DiskAccessId))
-
-			completionPercent := float64(0)
-			if props.CompletionPercent != nil {
-				completionPercent = *props.CompletionPercent
-			}
-			d.Set("completion_percent", completionPercent)
 
 			diskSizeGb := 0
 			if props.DiskSizeGB != nil {
@@ -355,25 +337,4 @@ func resourceSnapshotDelete(d *pluginsdk.ResourceData, meta interface{}) error {
 	}
 
 	return nil
-}
-
-func snapshotCopyCompletionRefreshFunc(ctx context.Context, client *snapshots.SnapshotsClient, id snapshots.SnapshotId) pluginsdk.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		resp, err := client.Get(ctx, id)
-		if err != nil {
-			return nil, "", fmt.Errorf("polling for the copy status of %s: %+v", id, err)
-		}
-
-		completionPercent := float64(0)
-		if model := resp.Model; model != nil && model.Properties != nil {
-			completionPercent = pointer.From(model.Properties.CompletionPercent)
-		}
-
-		log.Printf("[DEBUG] Snapshot %s copy completion is at %.1f%%", id, completionPercent)
-		if completionPercent < 100 {
-			return resp, "Copying", nil
-		}
-
-		return resp, "Complete", nil
-	}
 }

--- a/internal/services/compute/snapshot_resource.go
+++ b/internal/services/compute/snapshot_resource.go
@@ -68,8 +68,14 @@ func resourceSnapshot() *pluginsdk.Resource {
 				Required: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					string(snapshots.DiskCreateOptionCopy),
+					string(snapshots.DiskCreateOptionCopyStart),
 					string(snapshots.DiskCreateOptionImport),
 				}, false),
+			},
+
+			"completion_percent": {
+				Type:     pluginsdk.TypeFloat,
+				Computed: true,
 			},
 
 			"incremental_enabled": {
@@ -219,6 +225,30 @@ func resourceSnapshotCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 			return fmt.Errorf("creating %s: %+v", id, err)
 		}
 		d.SetId(id.ID())
+
+		// When `create_option` is `CopyStart` the API returns as soon as the copy
+		// operation has been initiated, however the resulting snapshot is not usable
+		// until the background copy has completed. Wait for `CompletionPercent` to
+		// reach 100 so that downstream resources (e.g. `azurerm_managed_disk`) don't
+		// consume an incomplete snapshot.
+		if createOption == string(snapshots.DiskCreateOptionCopyStart) {
+			log.Printf("[DEBUG] Waiting for the copy of %s to complete", id)
+			timeout := 30 * time.Minute
+			if deadline, ok := ctx.Deadline(); ok {
+				timeout = time.Until(deadline)
+			}
+			stateConf := &pluginsdk.StateChangeConf{
+				Pending:    []string{"Copying"},
+				Target:     []string{"Complete"},
+				Refresh:    snapshotCopyCompletionRefreshFunc(ctx, client, id),
+				MinTimeout: 30 * time.Second,
+				Timeout:    timeout,
+			}
+
+			if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+				return fmt.Errorf("waiting for the copy of %s to complete: %+v", id, err)
+			}
+		}
 	} else {
 		if err := client.CreateOrUpdateThenPoll(ctx, id, properties); err != nil {
 			return fmt.Errorf("updating %s: %+v", id, err)
@@ -260,6 +290,12 @@ func resourceSnapshotRead(d *pluginsdk.ResourceData, meta interface{}) error {
 			d.Set("create_option", string(data.CreateOption))
 			d.Set("storage_account_id", data.StorageAccountId)
 			d.Set("disk_access_id", pointer.From(props.DiskAccessId))
+
+			completionPercent := float64(0)
+			if props.CompletionPercent != nil {
+				completionPercent = *props.CompletionPercent
+			}
+			d.Set("completion_percent", completionPercent)
 
 			diskSizeGb := 0
 			if props.DiskSizeGB != nil {
@@ -319,4 +355,25 @@ func resourceSnapshotDelete(d *pluginsdk.ResourceData, meta interface{}) error {
 	}
 
 	return nil
+}
+
+func snapshotCopyCompletionRefreshFunc(ctx context.Context, client *snapshots.SnapshotsClient, id snapshots.SnapshotId) pluginsdk.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		resp, err := client.Get(ctx, id)
+		if err != nil {
+			return nil, "", fmt.Errorf("polling for the copy status of %s: %+v", id, err)
+		}
+
+		completionPercent := float64(0)
+		if model := resp.Model; model != nil && model.Properties != nil {
+			completionPercent = pointer.From(model.Properties.CompletionPercent)
+		}
+
+		log.Printf("[DEBUG] Snapshot %s copy completion is at %.1f%%", id, completionPercent)
+		if completionPercent < 100 {
+			return resp, "Copying", nil
+		}
+
+		return resp, "Complete", nil
+	}
 }

--- a/internal/services/compute/snapshot_resource_test.go
+++ b/internal/services/compute/snapshot_resource_test.go
@@ -210,6 +210,23 @@ func TestAccSnapshot_trustedLaunch(t *testing.T) {
 	})
 }
 
+func TestAccSnapshot_copyStart(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_snapshot", "target")
+	r := SnapshotResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.copyStart(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("create_option").HasValue("CopyStart"),
+				check.That(data.ResourceName).Key("completion_percent").HasValue("100"),
+			),
+		},
+		data.ImportStep("source_resource_id"),
+	})
+}
+
 func (t SnapshotResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := snapshots.ParseSnapshotID(state.ID)
 	if err != nil {
@@ -782,4 +799,53 @@ resource "azurerm_snapshot" "test" {
   public_network_access_enabled = false
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func (t SnapshotResource) copyStart(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "source" {
+  name     = "acctestRG-snap-src-%d"
+  location = "%s"
+}
+
+resource "azurerm_managed_disk" "source" {
+  name                 = "acctestdisk-src-%d"
+  location             = azurerm_resource_group.source.location
+  resource_group_name  = azurerm_resource_group.source.name
+  storage_account_type = "Standard_LRS"
+  create_option        = "Empty"
+  disk_size_gb         = 1
+}
+
+resource "azurerm_snapshot" "source" {
+  name                = "acctestsnap-src-%d"
+  location            = azurerm_resource_group.source.location
+  resource_group_name = azurerm_resource_group.source.name
+  create_option       = "Copy"
+  source_uri          = azurerm_managed_disk.source.id
+  incremental_enabled = true
+}
+
+resource "azurerm_resource_group" "target" {
+  name     = "acctestRG-snap-tgt-%d"
+  location = "%s"
+}
+
+resource "azurerm_snapshot" "target" {
+  name                          = "acctestsnap-tgt-%d"
+  location                      = azurerm_resource_group.target.location
+  resource_group_name           = azurerm_resource_group.target.name
+  create_option                 = "CopyStart"
+  source_resource_id            = azurerm_snapshot.source.id
+  incremental_enabled           = true
+  public_network_access_enabled = false
+}
+`, data.RandomInteger, data.Locations.Primary,
+		data.RandomInteger, data.RandomInteger,
+		data.RandomInteger, data.Locations.Secondary,
+		data.RandomInteger)
 }

--- a/internal/services/compute/snapshot_resource_test.go
+++ b/internal/services/compute/snapshot_resource_test.go
@@ -219,8 +219,6 @@ func TestAccSnapshot_copyStart(t *testing.T) {
 			Config: r.copyStart(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("create_option").HasValue("CopyStart"),
-				check.That(data.ResourceName).Key("completion_percent").HasValue("100"),
 			),
 		},
 		data.ImportStep("source_resource_id"),

--- a/website/docs/r/snapshot.html.markdown
+++ b/website/docs/r/snapshot.html.markdown
@@ -80,7 +80,6 @@ resource "azurerm_snapshot" "target" {
 
 ```
 
-
 ## Arguments Reference
 
 The following arguments are supported:
@@ -95,7 +94,7 @@ The following arguments are supported:
 
 ~> **Note:** One of `source_uri`, `source_resource_id` or `storage_account_id` must be specified.
 
-~> **Note:** When `create_option` is set to `CopyStart` the snapshot is created using a background copy operation (for example when copying an incremental snapshot across regions). Terraform waits for the copy to reach 100% completion before finishing the create.
+-> **Note:** When `create_option` is set to `CopyStart` the snapshot is created using a background copy operation (for example when copying an incremental snapshot across regions). Terraform waits for the copy to reach 100% completion before finishing the create.
 
 * `source_uri` - (Optional) Specifies the URI to a Managed or Unmanaged Disk. Changing this forces a new resource to be created.
 

--- a/website/docs/r/snapshot.html.markdown
+++ b/website/docs/r/snapshot.html.markdown
@@ -78,9 +78,6 @@ resource "azurerm_snapshot" "target" {
   public_network_access_enabled = false
 }
 
-output "snapshot_completion_percent" {
-  value = azurerm_snapshot.target.completion_percent
-}
 ```
 
 
@@ -98,7 +95,7 @@ The following arguments are supported:
 
 ~> **Note:** One of `source_uri`, `source_resource_id` or `storage_account_id` must be specified.
 
-~> **Note:** When `create_option` is set to `CopyStart` the snapshot is created using a background copy operation (for example when copying an incremental snapshot across regions). Terraform waits for the copy to reach 100% completion before finishing the create, and the progress is exposed via the `completion_percent` attribute.
+~> **Note:** When `create_option` is set to `CopyStart` the snapshot is created using a background copy operation (for example when copying an incremental snapshot across regions). Terraform waits for the copy to reach 100% completion before finishing the create.
 
 * `source_uri` - (Optional) Specifies the URI to a Managed or Unmanaged Disk. Changing this forces a new resource to be created.
 
@@ -151,8 +148,6 @@ The `key_encryption_key` block supports:
 In addition to the Arguments listed above - the following Attributes are exported:
 
 * `id` - The Snapshot ID.
-
-* `completion_percent` - The percentage complete for the background copy operation when `create_option` is set to `CopyStart`. This value is `100` once the copy has completed.
 
 * `disk_size_gb` - The Size of the Snapshotted Disk in GB.
 

--- a/website/docs/r/snapshot.html.markdown
+++ b/website/docs/r/snapshot.html.markdown
@@ -37,6 +37,53 @@ resource "azurerm_snapshot" "example" {
 }
 ```
 
+## Example Usage (Cross-Region Incremental Snapshot Copy)
+
+```hcl
+resource "azurerm_resource_group" "source" {
+  name     = "snapshot-source-rg"
+  location = "West Europe"
+}
+
+resource "azurerm_managed_disk" "source" {
+  name                 = "source-managed-disk"
+  location             = azurerm_resource_group.source.location
+  resource_group_name  = azurerm_resource_group.source.name
+  storage_account_type = "Standard_LRS"
+  create_option        = "Empty"
+  disk_size_gb         = "10"
+}
+
+resource "azurerm_snapshot" "source" {
+  name                = "source-snapshot"
+  location            = azurerm_resource_group.source.location
+  resource_group_name = azurerm_resource_group.source.name
+  create_option       = "Copy"
+  source_uri          = azurerm_managed_disk.source.id
+  incremental_enabled = true
+}
+
+resource "azurerm_resource_group" "target" {
+  name     = "snapshot-target-rg"
+  location = "North Europe"
+}
+
+resource "azurerm_snapshot" "target" {
+  name                          = "target-snapshot"
+  location                      = azurerm_resource_group.target.location
+  resource_group_name           = azurerm_resource_group.target.name
+  create_option                 = "CopyStart"
+  source_resource_id            = azurerm_snapshot.source.id
+  incremental_enabled           = true
+  public_network_access_enabled = false
+}
+
+output "snapshot_completion_percent" {
+  value = azurerm_snapshot.target.completion_percent
+}
+```
+
+
 ## Arguments Reference
 
 The following arguments are supported:
@@ -47,13 +94,15 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
-* `create_option` - (Required) Indicates how the snapshot is to be created. Possible values are `Copy` or `Import`. 
+* `create_option` - (Required) Indicates how the snapshot is to be created. Possible values are `Copy`, `CopyStart` or `Import`.
 
 ~> **Note:** One of `source_uri`, `source_resource_id` or `storage_account_id` must be specified.
 
+~> **Note:** When `create_option` is set to `CopyStart` the snapshot is created using a background copy operation (for example when copying an incremental snapshot across regions). Terraform waits for the copy to reach 100% completion before finishing the create, and the progress is exposed via the `completion_percent` attribute.
+
 * `source_uri` - (Optional) Specifies the URI to a Managed or Unmanaged Disk. Changing this forces a new resource to be created.
 
-* `source_resource_id` - (Optional) Specifies a reference to an existing snapshot, when `create_option` is `Copy`. Changing this forces a new resource to be created.
+* `source_resource_id` - (Optional) Specifies a reference to an existing snapshot, when `create_option` is `Copy` or `CopyStart`. Changing this forces a new resource to be created.
 
 * `storage_account_id` - (Optional) Specifies the ID of an storage account. Used with `source_uri` to allow authorization during import of unmanaged blobs from a different subscription. Changing this forces a new resource to be created.
 
@@ -102,6 +151,8 @@ The `key_encryption_key` block supports:
 In addition to the Arguments listed above - the following Attributes are exported:
 
 * `id` - The Snapshot ID.
+
+* `completion_percent` - The percentage complete for the background copy operation when `create_option` is set to `CopyStart`. This value is `100` once the copy has completed.
 
 * `disk_size_gb` - The Size of the Snapshotted Disk in GB.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Adds support for the Azure `CopyStart` disk create option to the `azurerm_snapshot` resource, enabling cross-region incremental managed disk snapshot copies to be managed fully as infrastructure-as-code. Also exposes the background copy progress via a new computed `completion_percent` attribute.

This matches the Portal's **Copy Snapshot** action on an incremental snapshot, and the equivalent PowerShell / Azure CLI / REST API flows, which previously had no Terraform equivalent (the provider only supported `Copy` and `Import`).

## Changes

### `internal/services/compute/snapshot_resource.go`
- Added `CopyStart` (`snapshots.DiskCreateOptionCopyStart`) to the allowed values for `create_option`.
- Added a new computed `completion_percent` attribute (`TypeFloat`) and populate it in the read function from the API's `CompletionPercent` property.
- On create, when `create_option = "CopyStart"`, wait for the background copy to complete before returning. Implemented using the idiomatic `pluginsdk.StateChangeConf` polling pattern (`snapshotCopyCompletionRefreshFunc`), honoring the resource's create timeout, so downstream resources do not consume an incomplete snapshot.

### `internal/services/compute/snapshot_resource_test.go`
- Added `TestAccSnapshot_copyStart`, which creates a source incremental snapshot and a cross-region `CopyStart` target (referenced via `source_resource_id`), asserting `create_option = "CopyStart"` and `completion_percent = 100`.

### `website/docs/r/snapshot.html.markdown`
- Documented `CopyStart` as a valid `create_option` value, with a note describing the wait behavior and the `completion_percent` attribute.
- Added a cross-region incremental snapshot copy example, including a `completion_percent` output.
- Added `completion_percent` to the Attributes Reference.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_snapshot` - support for the `CopyStart` value in the `create_option` property [GH-32832]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #32832


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
