### PR TITLE
Network function - fix acceptance tests

### DIFF
--- a/.teamcity/components/settings.kt
+++ b/.teamcity/components/settings.kt
@@ -156,7 +156,7 @@ var serviceTestConfigurationOverrides = mapOf(
         "newrelic" to testConfiguration(locationOverride = LocationConfiguration("centraluseuap", "eastus", "eastus", false)),
 
         // Network Function is only available in certain locations
-        "networkfunction" to testConfiguration(locationOverride = LocationConfiguration("southeastasia", "eastus2", "westeurope", false)),
+        "networkfunction" to testConfiguration(locationOverride = LocationConfiguration("southeastasia", "eastus2", "westeurope", true)),
 
         // Network Regional Tire Public IP is only available in
         "network" to testConfiguration(locationOverride = LocationConfiguration("westeurope", "eastus2", "westus", false), timeout = 24),

--- a/.teamcity/components/settings.kt
+++ b/.teamcity/components/settings.kt
@@ -156,7 +156,7 @@ var serviceTestConfigurationOverrides = mapOf(
         "newrelic" to testConfiguration(locationOverride = LocationConfiguration("centraluseuap", "eastus", "eastus", false)),
 
         // Network Function is only available in certain locations
-        "networkfunction" to testConfiguration(locationOverride = LocationConfiguration("westus2", "eastus2", "westeurope", false)),
+        "networkfunction" to testConfiguration(locationOverride = LocationConfiguration("southeastasia", "eastus2", "westeurope", false)),
 
         // Network Regional Tire Public IP is only available in
         "network" to testConfiguration(locationOverride = LocationConfiguration("westeurope", "eastus2", "westus", false), timeout = 24),


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Network function acceptance tests fail possibly due to quota issue. The error shown below does not reveal the root cause clearly. To try fixing the issue, the TeamCity test location is changed and location rotation is enabled.

```
    testcase.go:163: Step 1/2 error: Error running apply: exit status 1
        
        Error: creating Azure Traffic Collector (Subscription: "*******"
        Resource Group Name: "REDACTED"
        Azure Traffic Collector Name: "REDACTED"): polling after CreateOrUpdate: polling failed: the Azure API returned the following error:
        
        Status: "InternalServerError"
        Code: ""
        Message: "Internal Server Error"
        Activity Id: ""
        
        ---
        
        API Response:
        
        ----|[start|]----
        {
          "error": {
            "code": "InternalServerError",
            "message": "Internal Server Error"
          },
          "status": "Failed"
        }
        -----|[end|]-----
        
        
          with azurerm_network_function_azure_traffic_collector.test,
          on terraform_plugin_test.tf line 46, in resource "azurerm_network_function_azure_traffic_collector" "test":
          46: resource "azurerm_network_function_azure_traffic_collector" "test" {
        
        creating Azure Traffic Collector (Subscription:|n        "*******"
        Resource Group Name: "REDACTED"
        Azure Traffic Collector Name: "REDACTED"): polling
        after CreateOrUpdate: polling failed: the Azure API returned the following
        error:
        
        Status: "InternalServerError"
        Code: ""
        Message: "Internal Server Error"
        Activity Id: ""
        
        ---
        
        API Response:
        
        ----|[start|]----
        {
          "error": {
            "code": "InternalServerError",
            "message": "Internal Server Error"
          },
          "status": "Failed"
        }
        -----|[end|]-----
        
    panic.go:694: Error running post-test destroy, there may be dangling resources: exit status 1
        
        Error: deleting Resource Group "REDACTED": the Resource Group still contains Resources.
        
        Terraform is configured to check for Resources within the Resource Group when deleting the Resource Group - and
        raise an error if nested Resources still exist to avoid unintentionally deleting these Resources.
        
        Terraform has detected that the following Resources still exist within the Resource Group:
        
        `/subscriptions/*******/resourceGroups/REDACTED/providers/Microsoft.NetworkFunction/azureTrafficCollectors/REDACTED`
                
                This feature is intended to avoid the unintentional destruction of nested Resources provisioned through some
        other means (for example, an ARM Template Deployment) - as such you must either remove these Resources, or
        disable this behaviour using the feature flag `prevent_deletion_if_contains_resources` within the `features`
        block when configuring the Provider, for example:
        
        provider "azurerm" {
          features {
            resource_group {
              prevent_deletion_if_contains_resources = false
            }
          }
        }
        
        When that feature flag is set, Terraform will skip checking for any Resources within the Resource Group and
        delete this using the Azure API directly (which will clear up any nested resources).
        
        More information on the `features` block can be found in the documentation:
        https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/features-block
```


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] ~I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.~
- [ ] ~I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.~
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] ~I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).~
- [ ] ~I have written new tests for my resource or datasource changes & updated any relevant documentation.~
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] ~(For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.~


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_NETWORKFUNCTION/709840?buildTab=overview


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* Network function - fix `TestAccNetworkFunctionAzureTrafficCollector_*`


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
