### PR TITLE
`azurerm_advanced_threat_protection` - replace unsupported Storage tests with Cosmos DB

### DIFF
--- a/internal/services/securitycenter/advanced_threat_protection_resource.go
+++ b/internal/services/securitycenter/advanced_threat_protection_resource.go
@@ -4,6 +4,7 @@
 package securitycenter
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -92,6 +93,15 @@ func resourceAdvancedThreatProtectionCreateUpdate(d *pluginsdk.ResourceData, met
 		return fmt.Errorf("updating Advanced Threat protection for %q: %+v", id.TargetResourceID, err)
 	}
 
+	if err := waitForAdvancedThreatProtectionState(ctx, client, id.TargetResourceID, d.Get("enabled").(bool)); err != nil {
+		return err
+	}
+
+	d.SetId(id.ID())
+	return resourceAdvancedThreatProtectionRead(d, meta)
+}
+
+func waitForAdvancedThreatProtectionState(ctx context.Context, client *security.AdvancedThreatProtectionClient, targetResourceID string, enabled bool) error {
 	deadline, ok := ctx.Deadline()
 	if !ok {
 		return fmt.Errorf("internal-error: context had no deadline")
@@ -102,17 +112,16 @@ func resourceAdvancedThreatProtectionCreateUpdate(d *pluginsdk.ResourceData, met
 		Pending: []string{"diff"},
 		Target:  []string{"consistent"},
 		Refresh: func() (result interface{}, state string, err error) {
-			resp, err := client.Get(ctx, id.TargetResourceID)
+			resp, err := client.Get(ctx, targetResourceID)
 			if err != nil {
 				return resp, "error", err
 			}
 			if atpp := resp.AdvancedThreatProtectionProperties; atpp != nil {
 				respEnabled := atpp.IsEnabled != nil && *atpp.IsEnabled
-				if respEnabled == d.Get("enabled").(bool) {
+				if respEnabled == enabled {
 					return resp, "consistent", nil
-				} else {
-					return resp, "diff", nil
 				}
+				return resp, "diff", nil
 			}
 			return resp, "error", errors.New("properties was nil")
 		},
@@ -125,8 +134,7 @@ func resourceAdvancedThreatProtectionCreateUpdate(d *pluginsdk.ResourceData, met
 		return fmt.Errorf("waiting for provisioning state of advanced threat protection: %+v", err)
 	}
 
-	d.SetId(id.ID())
-	return resourceAdvancedThreatProtectionRead(d, meta)
+	return nil
 }
 
 func resourceAdvancedThreatProtectionRead(d *pluginsdk.ResourceData, meta interface{}) error {
@@ -179,5 +187,5 @@ func resourceAdvancedThreatProtectionDelete(d *pluginsdk.ResourceData, meta inte
 		return fmt.Errorf("removing Advanced Threat Protection for %q: %+v", id.TargetResourceID, err)
 	}
 
-	return nil
+	return waitForAdvancedThreatProtectionState(ctx, client, id.TargetResourceID, false)
 }

--- a/internal/services/securitycenter/advanced_threat_protection_resource.go
+++ b/internal/services/securitycenter/advanced_threat_protection_resource.go
@@ -4,7 +4,6 @@
 package securitycenter
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -93,15 +92,6 @@ func resourceAdvancedThreatProtectionCreateUpdate(d *pluginsdk.ResourceData, met
 		return fmt.Errorf("updating Advanced Threat protection for %q: %+v", id.TargetResourceID, err)
 	}
 
-	if err := waitForAdvancedThreatProtectionState(ctx, client, id.TargetResourceID, d.Get("enabled").(bool)); err != nil {
-		return err
-	}
-
-	d.SetId(id.ID())
-	return resourceAdvancedThreatProtectionRead(d, meta)
-}
-
-func waitForAdvancedThreatProtectionState(ctx context.Context, client *security.AdvancedThreatProtectionClient, targetResourceID string, enabled bool) error {
 	deadline, ok := ctx.Deadline()
 	if !ok {
 		return fmt.Errorf("internal-error: context had no deadline")
@@ -112,16 +102,17 @@ func waitForAdvancedThreatProtectionState(ctx context.Context, client *security.
 		Pending: []string{"diff"},
 		Target:  []string{"consistent"},
 		Refresh: func() (result interface{}, state string, err error) {
-			resp, err := client.Get(ctx, targetResourceID)
+			resp, err := client.Get(ctx, id.TargetResourceID)
 			if err != nil {
 				return resp, "error", err
 			}
 			if atpp := resp.AdvancedThreatProtectionProperties; atpp != nil {
 				respEnabled := atpp.IsEnabled != nil && *atpp.IsEnabled
-				if respEnabled == enabled {
+				if respEnabled == d.Get("enabled").(bool) {
 					return resp, "consistent", nil
+				} else {
+					return resp, "diff", nil
 				}
-				return resp, "diff", nil
 			}
 			return resp, "error", errors.New("properties was nil")
 		},
@@ -134,7 +125,8 @@ func waitForAdvancedThreatProtectionState(ctx context.Context, client *security.
 		return fmt.Errorf("waiting for provisioning state of advanced threat protection: %+v", err)
 	}
 
-	return nil
+	d.SetId(id.ID())
+	return resourceAdvancedThreatProtectionRead(d, meta)
 }
 
 func resourceAdvancedThreatProtectionRead(d *pluginsdk.ResourceData, meta interface{}) error {
@@ -187,5 +179,5 @@ func resourceAdvancedThreatProtectionDelete(d *pluginsdk.ResourceData, meta inte
 		return fmt.Errorf("removing Advanced Threat Protection for %q: %+v", id.TargetResourceID, err)
 	}
 
-	return waitForAdvancedThreatProtectionState(ctx, client, id.TargetResourceID, false)
+	return nil
 }

--- a/internal/services/securitycenter/advanced_threat_protection_resource_test.go
+++ b/internal/services/securitycenter/advanced_threat_protection_resource_test.go
@@ -86,11 +86,11 @@ func checkAdvancedThreatProtectionIsFalse(ctx context.Context, clients *clients.
 		return fmt.Errorf("reading Advanced Threat Protection (%s): %+v", targetResourceID, err)
 	}
 
-	if resp.AdvancedThreatProtectionProperties == nil || resp.AdvancedThreatProtectionProperties.IsEnabled == nil {
+	if resp.AdvancedThreatProtectionProperties == nil || resp.IsEnabled == nil {
 		return fmt.Errorf("Advanced Threat Protection (%s) properties is nil", targetResourceID)
 	}
 
-	if *resp.AdvancedThreatProtectionProperties.IsEnabled {
+	if *resp.IsEnabled {
 		return fmt.Errorf("Advanced Threat Protection (%s) properties is still enabled", targetResourceID)
 	}
 

--- a/internal/services/securitycenter/advanced_threat_protection_resource_test.go
+++ b/internal/services/securitycenter/advanced_threat_protection_resource_test.go
@@ -18,38 +18,8 @@ import (
 
 type AdvancedThreatProtectionResource struct{}
 
-func TestAccAdvancedThreatProtection_storageAccount(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_advanced_threat_protection", "test")
-	r := AdvancedThreatProtectionResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.storageAccount(data, true),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("enabled").HasValue("true"),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.storageAccount(data, false),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("enabled").HasValue("false"),
-			),
-		},
-		data.ImportStep(),
-	})
-}
-
 func TestAccAdvancedThreatProtection_cosmosAccount(t *testing.T) {
-	// the API errors on deleting the cosmos DB account some of the time so lets skip this test for now
-	// TODO: remove once this is fixed: https://github.com/Azure/azure-sdk-for-go/issues/6310
-	// run it multiple times in a row as it only fails 50% of the time
-	t.Skip()
-
 	data := acceptance.BuildTestData(t, "azurerm_advanced_threat_protection", "test")
-
 	r := AdvancedThreatProtectionResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -72,7 +42,7 @@ func TestAccAdvancedThreatProtection_cosmosAccount(t *testing.T) {
 		{
 			Config: r.cosmosAccount(data, false, false),
 			Check: acceptance.ComposeTestCheckFunc(
-				data.CheckWithClient(checkAdvancedThreatProtectionIsFalse),
+				data.CheckWithClientForResource(checkAdvancedThreatProtectionIsFalse, "azurerm_cosmosdb_account.test"),
 			),
 		},
 	})
@@ -84,7 +54,7 @@ func TestAccAdvancedThreatProtection_requiresImport(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.storageAccount(data, true),
+			Config: r.cosmosAccount(data, true, true),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("enabled").HasValue("true"),
@@ -109,31 +79,26 @@ func (AdvancedThreatProtectionResource) Exists(ctx context.Context, clients *cli
 	return pointer.To(resp.AdvancedThreatProtectionProperties != nil), nil
 }
 
-// nolint unused
 func checkAdvancedThreatProtectionIsFalse(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) error {
-	id, err := parse.AdvancedThreatProtectionID(state.ID)
+	targetResourceID := state.ID
+	resp, err := clients.SecurityCenter.AdvancedThreatProtectionClient.Get(ctx, targetResourceID)
 	if err != nil {
-		return err
-	}
-
-	resp, err := clients.SecurityCenter.AdvancedThreatProtectionClient.Get(ctx, id.TargetResourceID)
-	if err != nil {
-		return fmt.Errorf("reading Advanced Threat Protection (%s): %+v", id.TargetResourceID, err)
+		return fmt.Errorf("reading Advanced Threat Protection (%s): %+v", targetResourceID, err)
 	}
 
 	if resp.AdvancedThreatProtectionProperties == nil || resp.AdvancedThreatProtectionProperties.IsEnabled == nil {
-		return fmt.Errorf("Advanced Threat Protection (%s) properties is nil", id.TargetResourceID)
+		return fmt.Errorf("Advanced Threat Protection (%s) properties is nil", targetResourceID)
 	}
 
 	if *resp.AdvancedThreatProtectionProperties.IsEnabled {
-		return fmt.Errorf("Advanced Threat Protection (%s) properties is still enabled", id.TargetResourceID)
+		return fmt.Errorf("Advanced Threat Protection (%s) properties is still enabled", targetResourceID)
 	}
 
 	return nil
 }
 
 func (AdvancedThreatProtectionResource) requiresImport(data acceptance.TestData) string {
-	template := AdvancedThreatProtectionResource{}.storageAccount(data, true)
+	template := AdvancedThreatProtectionResource{}.cosmosAccount(data, true, true)
 	return fmt.Sprintf(`
 %s
 
@@ -144,38 +109,6 @@ resource "azurerm_advanced_threat_protection" "import" {
 `, template)
 }
 
-func (AdvancedThreatProtectionResource) storageAccount(data acceptance.TestData, enabled bool) string {
-	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-ATP-%d"
-  location = "%s"
-}
-
-resource "azurerm_storage_account" "test" {
-  name                = "acctest%s"
-  resource_group_name = azurerm_resource_group.test.name
-
-  location                 = azurerm_resource_group.test.location
-  account_tier             = "Standard"
-  account_replication_type = "LRS"
-
-  tags = {
-    environment = "production"
-  }
-}
-
-resource "azurerm_advanced_threat_protection" "test" {
-  target_resource_id = "${azurerm_storage_account.test.id}"
-  enabled            = %t
-}
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, enabled)
-}
-
-// nolint unused - mistakenly marked as unused
 func (AdvancedThreatProtectionResource) cosmosAccount(data acceptance.TestData, hasResource, enabled bool) string {
 	atp := ""
 	if hasResource {

--- a/website/docs/r/advanced_threat_protection.html.markdown
+++ b/website/docs/r/advanced_threat_protection.html.markdown
@@ -18,21 +18,24 @@ resource "azurerm_resource_group" "example" {
   location = "West Europe"
 }
 
-resource "azurerm_storage_account" "example" {
-  name                = "examplestorage"
+resource "azurerm_cosmosdb_account" "example" {
+  name                = "example-cosmosdb"
+  location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
+  offer_type          = "Standard"
 
-  location                 = azurerm_resource_group.example.location
-  account_tier             = "Standard"
-  account_replication_type = "LRS"
+  consistency_policy {
+    consistency_level = "Eventual"
+  }
 
-  tags = {
-    environment = "example"
+  geo_location {
+    location          = azurerm_resource_group.example.location
+    failover_priority = 0
   }
 }
 
 resource "azurerm_advanced_threat_protection" "example" {
-  target_resource_id = azurerm_storage_account.example.id
+  target_resource_id = azurerm_cosmosdb_account.example.id
   enabled            = true
 }
 ```
@@ -65,5 +68,5 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 Advanced Threat Protection can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_advanced_threat_protection.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/exampleResourceGroup/providers/Microsoft.Storage/storageAccounts/exampleaccount/providers/Microsoft.Security/advancedThreatProtectionSettings/default
+terraform import azurerm_advanced_threat_protection.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/exampleResourceGroup/providers/Microsoft.DocumentDB/databaseAccounts/exampleaccount/providers/Microsoft.Security/advancedThreatProtectionSettings/default
 ```

--- a/website/docs/r/advanced_threat_protection.html.markdown
+++ b/website/docs/r/advanced_threat_protection.html.markdown
@@ -19,7 +19,7 @@ resource "azurerm_resource_group" "example" {
 }
 
 resource "azurerm_cosmosdb_account" "example" {
-  name                = "example-cosmosdb"
+  name                = "example-cosmosdb-account"
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
   offer_type          = "Standard"
@@ -68,5 +68,5 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 Advanced Threat Protection can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_advanced_threat_protection.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/exampleResourceGroup/providers/Microsoft.DocumentDB/databaseAccounts/exampleaccount/providers/Microsoft.Security/advancedThreatProtectionSettings/default
+terraform import azurerm_advanced_threat_protection.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1/providers/Microsoft.DocumentDB/databaseAccounts/databaseAccount1/providers/Microsoft.Security/advancedThreatProtectionSettings/default
 ```


### PR DESCRIPTION
## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Azure no longer allows Defender for Storage (classic) to be enabled on newly created Storage Accounts, causing the `azurerm_advanced_threat_protection` acceptance tests to fail with `400 BadRequest`. Related doc is [here](https://learn.microsoft.com/en-us/azure/defender-for-cloud/defender-for-storage-classic-migrate).
```
Original Error: autorest/azure: Service returned an error. Status=400 Code="BadRequest" Message="Error: Failed to enable the Defender for Storage (classic) plan on the storage account 'acctesttcgty' - This plan is no longer available for new subscriptions and storage accounts, subscriptions already using the new or classic per storage account plans, or re-enabling. Please use the latest API to protect your storage account. If you have enabled the new plan, disable any policies attempting to re-enable the classic plan. For more information, visit: https://aka.ms/DF-Storage/NewPlanMigration`
```

This PR:

- moves the acceptance test configurations and documentation from Storage Accounts to Cosmos DB, because Azure no longer allows Defender for Storage (classic) to be enabled on newly created Storage Accounts
- re-enables the existing Cosmos DB lifecycle test and verifies that ATP is disabled after the Terraform ATP resource is removede

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 

<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.

## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass.
```
TF_ACC=1 go test -v ./internal/services/securitycenter -run="^(TestAccAdvancedThreatProtection_cosmosAccount)$" -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAdvancedThreatProtection_cosmosAccount
=== PAUSE TestAccAdvancedThreatProtection_cosmosAccount
=== CONT  TestAccAdvancedThreatProtection_cosmosAccount
--- PASS: TestAccAdvancedThreatProtection_cosmosAccount (1111.05s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/securitycenter	1111.092s
TF_ACC=1 go test -v ./internal/services/securitycenter -run="^(TestAccAdvancedThreatProtection_requiresImport)$" -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAdvancedThreatProtection_requiresImport
=== PAUSE TestAccAdvancedThreatProtection_requiresImport
=== CONT  TestAccAdvancedThreatProtection_requiresImport
--- PASS: TestAccAdvancedThreatProtection_requiresImport (863.23s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/securitycenter	863.264s
```

## Change Log

N/A - acceptance test and documentation updates only.

This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

NA

## Changes to Security Controls

NA
