### PR TITLE
teamcity add more detailed failure information in comment

### DIFF
--- a/.teamcity/scripts/post_github_comment.sh
+++ b/.teamcity/scripts/post_github_comment.sh
@@ -4,7 +4,7 @@ POST_GITHUB_COMMENT="%POST_GITHUB_COMMENT%"
 GITHUB_REPO="%env.GITHUB_REPO%"
 GIT_PAT="%env.GIT_PAT%"
 TEAMCITY_TOKEN="%env.TEAMCITY_TOKEN%"
-TEAMCITY_SERVER_URL=%teamcity.serverUrl%
+TEAMCITY_SERVER_URL="%teamcity.serverUrl%"
 # BUILD_START_TIME is set in the first build step: $(date +%s)
 BUILD_ID="%teamcity.build.id%"
 BUILD_TYPE_ID="%system.teamcity.buildType.id%"
@@ -169,8 +169,6 @@ BUILD_HOURS=$((BUILD_DURATION / 3600))
 BUILD_MINUTES=$(((BUILD_DURATION % 3600) / 60))
 BUILD_SECONDS=$((BUILD_DURATION % 60))
 
-# Build per-test history data: "name|failure_rate|first_failure|last_failure"
-# This is collected for ALL tests that appear in RAW_TEST_RESULTS_JSON (pass or fail).
 TEST_HISTORY=""
 if [ -z "$TEAMCITY_ERROR" ] && [ -n "$MAIN_TEST_ID_MAP" ]; then
   echo "Fetching per-test history..."
@@ -195,7 +193,6 @@ if [ -z "$TEAMCITY_ERROR" ] && [ -n "$MAIN_TEST_ID_MAP" ]; then
       -H "Authorization: Bearer $TEAMCITY_TOKEN" \
       -H "Accept: application/json")
 
-    # Extract rate and raw TC startDate strings (format: 20240315T143022+0000)
     HISTORY_STATS=$(echo "$HISTORY_JSON" | jq -r '
       ([ .testOccurrence[]? | select(.status=="SUCCESS") ] | length) as $s |
       ([ .testOccurrence[]? | select(.status=="FAILURE") ] | length) as $f |

--- a/.teamcity/scripts/post_github_comment.sh
+++ b/.teamcity/scripts/post_github_comment.sh
@@ -231,7 +231,7 @@ if [ -z "$TEAMCITY_ERROR" ]; then
       ($recent | map(select(.status=="SUCCESS")) | length) as $s |
       ($recent | map(select(.status=="FAILURE")) | length) as $f |
       ($s + $f) as $total |
-      (if $total > 0 then (($s * 100 / $total | floor | tostring) + "%") else "N/A" end) as $rate |
+      (if $total > 0 then (($f * 100 / $total | floor | tostring) + "%") else "N/A" end) as $rate |
       ([ .testOccurrence[]?
           | select(.status=="FAILURE" and (.build.startDate // "") != "")
           | (.build.startDate | gsub("\\+(?:[0-9]{4})$"; "Z") | strptime("%Y%m%dT%H%M%SZ") | mktime)
@@ -304,12 +304,12 @@ $1 == "" { next }
         fail_rate  = (n_hist >= 1) ? hf[1] : "N/A"
         first_fail = (n_hist >= 2) ? hf[2] : "N/A"
         last_fail  = (n_hist >= 3) ? hf[3] : "N/A"
-        is_new     = (n_hist >= 4) ? hf[4] : "false"
+        is_new     = (n_hist >= 4) ? hf[4] : "true"
     } else {
         fail_rate  = "N/A"
         first_fail = "N/A"
         last_fail  = "N/A"
-        is_new     = "false"
+        is_new     = "true"
     }
 
     if (status == "PASS") {
@@ -335,8 +335,8 @@ PR: #$PR_NUMBER
 <details>
 <summary>Test Details</summary>
 
-| Status | Test Name | Duration | % Success | First Failure (main) | Last Failure (main) |
-| :--- | :--- | ---: | ---: | ---: | ---: |
+| Status | Test Name | Duration | %❌ | First | Last |
+| :--- | :--- | ---: | --- | --- | --- |
 ${TABLE_ROWS}
 </details>
 "

--- a/.teamcity/scripts/post_github_comment.sh
+++ b/.teamcity/scripts/post_github_comment.sh
@@ -219,11 +219,13 @@ if [ -z "$TEAMCITY_ERROR" ]; then
 
     CUTOFF_S=$(( CURRENT_TIME_S - 100 * 86400 ))
 
-    MAIN_STATS=$(echo "$MAIN_HISTORY_JSON" | CUTOFF_S="$CUTOFF_S" CURRENT_TIME_S="$CURRENT_TIME_S" jq -r '
+    PCT="%"
+    TC_DATE_FMT="${PCT}Y${PCT}m${PCT}dT${PCT}H${PCT}M${PCT}SZ"
+    MAIN_STATS=$(echo "$MAIN_HISTORY_JSON" | CUTOFF_S="$CUTOFF_S" CURRENT_TIME_S="$CURRENT_TIME_S" jq -r --arg fmt "$TC_DATE_FMT" '
       [ .testOccurrence[]?
         | select(
             (.build.startDate // "") != "" and
-            (.build.startDate | gsub("\\+(?:[0-9]{4})$"; "Z") | strptime("%Y%m%dT%H%M%SZ") | mktime) >= (env.CUTOFF_S | tonumber)
+            (.build.startDate | gsub("\\+(?:[0-9]{4})$"; "Z") | strptime($fmt) | mktime) >= (env.CUTOFF_S | tonumber)
           )
       ] as $recent |
       ($recent | map(select(.status=="SUCCESS")) | length) as $s |
@@ -232,7 +234,7 @@ if [ -z "$TEAMCITY_ERROR" ]; then
       (if $total > 0 then (($f * 100 / $total | floor | tostring) + "%") else "N/A" end) as $rate |
       ([ .testOccurrence[]?
           | select(.status=="FAILURE" and (.build.startDate // "") != "")
-          | (.build.startDate | gsub("\\+(?:[0-9]{4})$"; "Z") | strptime("%Y%m%dT%H%M%SZ") | mktime)
+          | (.build.startDate | gsub("\\+(?:[0-9]{4})$"; "Z") | strptime($fmt) | mktime)
         ]) as $fail_ts_list |
       ($fail_ts_list | min // null) as $oldest_fail_ts |
       ($fail_ts_list | max // null) as $newest_fail_ts |

--- a/.teamcity/scripts/post_github_comment.sh
+++ b/.teamcity/scripts/post_github_comment.sh
@@ -32,7 +32,6 @@ fi
 
 echo "Tracking ID: $TRACKING_ID"
 
-
 github_api_request() {
   local endpoint="$1"
   curl -s \
@@ -89,7 +88,7 @@ TEAMCITY_ERROR=""
 RAW_TEST_RESULTS_JSON=$(curl -sS -f \
   -H "Authorization: Bearer $TEAMCITY_TOKEN" \
   -H "Accept: application/json" \
-  "$TEAMCITY_SERVER_URL/app/rest/testOccurrences?locator=build:(id:$BUILD_ID),count:100000&fields=testOccurrence(name,status,duration,id)")
+  "$TEAMCITY_SERVER_URL/app/rest/testOccurrences?locator=build:(id:$BUILD_ID),count:100000&fields=testOccurrence(name,status,duration,newFailure,test(id),firstFailed(build(id,number,branchName)))")
 
 if [ $? -ne 0 ] || [ -z "$RAW_TEST_RESULTS_JSON" ]; then
   TEAMCITY_ERROR="Failed to fetch test results from TeamCity for build $BUILD_ID."
@@ -170,10 +169,10 @@ BUILD_MINUTES=$(((BUILD_DURATION % 3600) / 60))
 BUILD_SECONDS=$((BUILD_DURATION % 60))
 
 TEST_HISTORY=""
-if [ -z "$TEAMCITY_ERROR" ] && [ -n "$MAIN_TEST_ID_MAP" ]; then
-  echo "Fetching per-test history..."
+HAS_NEW_FAILURES="false"
+if [ -z "$TEAMCITY_ERROR" ]; then
+  echo "Fetching per-test main branch history..."
 
-  # Collect all test names from the current build
   ALL_TEST_NAMES=$(echo "$RAW_TEST_RESULTS_JSON" \
     | jq -r '(.testOccurrence // [])[] | select(.status == "SUCCESS" or .status == "FAILURE") | .name' \
     2>/dev/null || echo "")
@@ -181,39 +180,86 @@ if [ -z "$TEAMCITY_ERROR" ] && [ -n "$MAIN_TEST_ID_MAP" ]; then
   while IFS= read -r test_name; do
     [ -z "$test_name" ] && continue
 
-    # Look up the test entity id from the main-branch id map
-    TEST_ID=$(echo "$MAIN_TEST_ID_MAP" | AWK_NAME="$test_name" awk -F'|' '$1 == ENVIRON["AWK_NAME"] {print $2; exit}')
+    TEST_ID=$(echo "$RAW_TEST_RESULTS_JSON" \
+      | TEST_NAME="$test_name" jq -r '
+          (.testOccurrence // [])[]
+          | select(.name == env.TEST_NAME)
+          | .test.id // empty
+        ' 2>/dev/null | head -1)
+
+    PR_STATUS=$(echo "$RAW_TEST_RESULTS_JSON" \
+      | TEST_NAME="$test_name" jq -r '
+          (.testOccurrence // [])[]
+          | select(.name == env.TEST_NAME)
+          | .status
+        ' 2>/dev/null | head -1)
+
     if [ -z "$TEST_ID" ]; then
-      TEST_HISTORY+="${test_name}|N/A|N/A|N/A"$'\n'
+      TEST_HISTORY+="${test_name}|N/A|N/A|N/A|false"$'\n'
       continue
     fi
 
-    HISTORY_JSON=$(curl -s -X GET \
-      "$TEAMCITY_SERVER_URL/app/rest/testOccurrences?locator=test:(id:${TEST_ID}),count:1000&fields=testOccurrence(status,build(startDate))" \
+    MAIN_HISTORY_JSON=$(curl -s \
       -H "Authorization: Bearer $TEAMCITY_TOKEN" \
-      -H "Accept: application/json")
+      -H "Accept: application/json" \
+      "$TEAMCITY_SERVER_URL/app/rest/testOccurrences?locator=test:(id:${TEST_ID}),branch:refs/heads/main,count:1000&fields=testOccurrence(status,build(startDate))")
 
-    HISTORY_STATS=$(echo "$HISTORY_JSON" | jq -r '
-      ([ .testOccurrence[]? | select(.status=="SUCCESS") ] | length) as $s |
-      ([ .testOccurrence[]? | select(.status=="FAILURE") ] | length) as $f |
+    IS_NEW="false"
+    if [ "$PR_STATUS" = "FAILURE" ]; then
+      LAST_MAIN_STATUS=$(echo "$MAIN_HISTORY_JSON" | jq -r '
+        [ .testOccurrence[]?
+          | select((.build.startDate // "") != "")
+        ]
+        | sort_by(.build.startDate)
+        | last
+        | .status // ""
+      ' 2>/dev/null)
+      if [ "$LAST_MAIN_STATUS" = "SUCCESS" ]; then
+        IS_NEW="true"
+        HAS_NEW_FAILURES="true"
+      fi
+    fi
+    CUTOFF_S=$(( CURRENT_TIME_S - 100 * 86400 ))
+
+    MAIN_STATS=$(echo "$MAIN_HISTORY_JSON" | CUTOFF_S="$CUTOFF_S" CURRENT_TIME_S="$CURRENT_TIME_S" jq -r '
+      [ .testOccurrence[]?
+        | select(
+            (.build.startDate // "") != "" and
+            (.build.startDate | gsub("\\+(?:[0-9]{4})$"; "Z") | strptime("%Y%m%dT%H%M%SZ") | mktime) >= (env.CUTOFF_S | tonumber)
+          )
+      ] as $recent |
+      ($recent | map(select(.status=="SUCCESS")) | length) as $s |
+      ($recent | map(select(.status=="FAILURE")) | length) as $f |
       ($s + $f) as $total |
-      (if $total > 0 then (($s| tostring) + "/" + ($f| tostring)) else "N/A" end) as $rate |
-      ([ .testOccurrence[]? | select(.status=="FAILURE") ] | last  | .build.startDate // "") as $first_raw |
-      ([ .testOccurrence[]? | select(.status=="FAILURE") ] | first | .build.startDate // "") as $last_raw |
-      "\($rate)|\($first_raw)|\($last_raw)"
-    ' 2>/dev/null || echo "N/A||")
+      (if $total > 0 then (($s * 100 / $total | floor | tostring) + "%") else "N/A" end) as $rate |
+      ([ .testOccurrence[]?
+          | select(.status=="FAILURE" and (.build.startDate // "") != "")
+          | (.build.startDate | gsub("\\+(?:[0-9]{4})$"; "Z") | strptime("%Y%m%dT%H%M%SZ") | mktime)
+        ]) as $fail_ts_list |
+      ($fail_ts_list | min // null) as $oldest_fail_ts |
+      ($fail_ts_list | max // null) as $newest_fail_ts |
+      (if $oldest_fail_ts != null
+        then (((env.CURRENT_TIME_S | tonumber) - $oldest_fail_ts) / 86400 | floor | tostring) + "d"
+        else ""
+      end) as $first_ago |
+      (if $newest_fail_ts != null
+        then (((env.CURRENT_TIME_S | tonumber) - $newest_fail_ts) / 86400 | floor | tostring) + "d"
+        else ""
+      end) as $last_ago |
+      "\($rate)|\($first_ago)|\($last_ago)"
+    ' 2>/dev/null || echo "N/A|")
 
     # Parse the three pipe-delimited fields from HISTORY_STATS
-    HIST_RATE=$(echo "$HISTORY_STATS"  | cut -d'|' -f1)
-    FIRST_RAW=$(echo "$HISTORY_STATS"  | cut -d'|' -f2)
-    LAST_RAW=$(echo "$HISTORY_STATS"   | cut -d'|' -f3)
+    HIST_RATE=$(echo "$MAIN_STATS" | cut -d'|' -f1)
+    FIRST_AGO=$(echo "$MAIN_STATS" | cut -d'|' -f2)
+    LAST_AGO=$(echo "$MAIN_STATS"  | cut -d'|' -f3)
 
     HIST_RATE_LINK="[$HIST_RATE]($TEAMCITY_SERVER_URL/test/${TEST_ID}?currentProjectId=TF_AzureRM)"
 
-    FIRST_FAILURE=$(( (CURRENT_TIME_S - $(date -d "$FIRST_RAW" +%s)) / 86400 ))
-    LAST_FAILURE=$(( (CURRENT_TIME_S - $(date -d "$LAST_RAW" +%s)) / 86400 ))
+    FIRST_DISPLAY="${FIRST_AGO:-N/A}"
+    LAST_DISPLAY="${LAST_AGO:-N/A}"
 
-    TEST_HISTORY+="${test_name}|${HIST_RATE_LINK}|${FIRST_FAILURE}d|${LAST_FAILURE}d"$'\n'
+    TEST_HISTORY+="${test_name}|${HIST_RATE_LINK}|${FIRST_DISPLAY}|${LAST_DISPLAY}|${IS_NEW}"$'\n'
   done <<< "$ALL_TEST_NAMES"
 fi
 
@@ -226,35 +272,25 @@ PR: #$PR_NUMBER
 Unable to collect test details for this run. Please check TeamCity build logs.
 "
 else
-  TABLE_ROWS=$(echo "$TEST_RESULTS" | NEW_FAILURES="$NEW_FAILURES" TEST_HISTORY="$TEST_HISTORY" awk -F'|' '
+  TABLE_ROWS=$(echo "$TEST_RESULTS" | TEST_HISTORY="$TEST_HISTORY" awk -F'|' '
 BEGIN {
-    # Build array of new failure test names
-    n = split(ENVIRON["NEW_FAILURES"], nf_array, "\n")
-    for (i = 1; i <= n; i++) {
-        if (nf_array[i] != "") new_fail[nf_array[i]] = 1
-    }
-    # Build history lookup: hist[name] = "rate|first|last"
     m = split(ENVIRON["TEST_HISTORY"], h_array, "\n")
     for (i = 1; i <= m; i++) {
         if (h_array[i] == "") continue
-        # Each entry is "name|rate|first|last" — split on first three pipes
         line = h_array[i]
-        # Find positions of the last 3 pipe-delimited fields from the right
-        # by reversing: count pipes from right
-        last3 = ""
         name_part = ""
         pipe_count = 0
         for (j = length(line); j >= 1; j--) {
             if (substr(line, j, 1) == "|") {
                 pipe_count++
-                if (pipe_count == 3) {
+                if (pipe_count == 4) {
                     name_part = substr(line, 1, j - 1)
-                    last3 = substr(line, j + 1)
+                    last4 = substr(line, j + 1)
                     break
                 }
             }
         }
-        if (name_part != "") hist[name_part] = last3
+        if (name_part != "") hist[name_part] = last4
     }
 }
 $1 == "" { next }
@@ -263,24 +299,24 @@ $1 == "" { next }
     status = $2
     duration = $3
 
-    # Look up history fields (rate|first|last)
     if (test_name in hist) {
         n_hist = split(hist[test_name], hf, "|")
-        fail_rate   = (n_hist >= 1) ? hf[1] : "N/A"
-        first_fail  = (n_hist >= 2) ? hf[2] : "N/A"
-        last_fail   = (n_hist >= 3) ? hf[3] : "N/A"
+        fail_rate  = (n_hist >= 1) ? hf[1] : "N/A"
+        first_fail = (n_hist >= 2) ? hf[2] : "N/A"
+        last_fail  = (n_hist >= 3) ? hf[3] : "N/A"
+        is_new     = (n_hist >= 4) ? hf[4] : "false"
     } else {
         fail_rate  = "N/A"
         first_fail = "N/A"
         last_fail  = "N/A"
+        is_new     = "false"
     }
 
-    if (status == "PASS"){
+    if (status == "PASS") {
       label = "✅ PASS"
-    }
-    else if (test_name in new_fail) {
-      label = "❌ NEW FAILURE ❌"}
-    else {
+    } else if (is_new == "true") {
+      label = "❌ NEW"
+    } else {
       label = "❌ FAIL"
     }
 
@@ -299,7 +335,7 @@ PR: #$PR_NUMBER
 <details>
 <summary>Test Details</summary>
 
-| Status | Test Name | Duration | Success/Failure | First Failure | Last Failure |
+| Status | Test Name | Duration | % Success | First Failure (main) | Last Failure (main) |
 | :--- | :--- | ---: | ---: | ---: | ---: |
 ${TABLE_ROWS}
 </details>
@@ -315,11 +351,11 @@ if [ -z "$TEAMCITY_ERROR" ] && [ "$FAIL_COUNT" -gt 0 ]; then
   if [ -z "$PR_AUTHOR" ] || [ "$PR_AUTHOR" = "null" ]; then
     echo "Warning: Could not fetch PR author"
   else
-    if [ -z "$NEW_FAILURES" ]; then
-      AUTHOR_MESSAGE="@${PR_AUTHOR} - One or more tests failed in this PR. Please review the failures.
+    if [ "$HAS_NEW_FAILURES" = "true" ]; then
+      AUTHOR_MESSAGE="@${PR_AUTHOR} - One or more tests newly failed in this PR. Please review the failures.
       "
     else
-      AUTHOR_MESSAGE="@${PR_AUTHOR} - One or more tests newly failed in this PR. Please review the failures.
+      AUTHOR_MESSAGE="@${PR_AUTHOR} - One or more tests failed in this PR. Please review the failures.
       "
     fi
   fi

--- a/.teamcity/scripts/post_github_comment.sh
+++ b/.teamcity/scripts/post_github_comment.sh
@@ -194,8 +194,21 @@ if [ -z "$TEAMCITY_ERROR" ]; then
           | .status
         ' 2>/dev/null | head -1)
 
+    FIRST_FAILED_BRANCH=$(echo "$RAW_TEST_RESULTS_JSON" \
+      | TEST_NAME="$test_name" jq -r '
+          (.testOccurrence // [])[]
+          | select(.name == env.TEST_NAME)
+          | .firstFailed.build.branchName // ""
+        ' 2>/dev/null | head -1)
+
+    IS_NEW="false"
+    if [ "$PR_STATUS" = "FAILURE" ] && [ "$FIRST_FAILED_BRANCH" != "refs/heads/main" ] && [ -n "$FIRST_FAILED_BRANCH" ]; then
+      IS_NEW="true"
+      HAS_NEW_FAILURES="true"
+    fi
+
     if [ -z "$TEST_ID" ]; then
-      TEST_HISTORY+="${test_name}|N/A|N/A|N/A|false"$'\n'
+      TEST_HISTORY+="${test_name}|N/A|N/A|N/A|${IS_NEW}"$'\n'
       continue
     fi
 
@@ -204,21 +217,6 @@ if [ -z "$TEAMCITY_ERROR" ]; then
       -H "Accept: application/json" \
       "$TEAMCITY_SERVER_URL/app/rest/testOccurrences?locator=test:(id:${TEST_ID}),branch:refs/heads/main,count:1000&fields=testOccurrence(status,build(startDate))")
 
-    IS_NEW="false"
-    if [ "$PR_STATUS" = "FAILURE" ]; then
-      LAST_MAIN_STATUS=$(echo "$MAIN_HISTORY_JSON" | jq -r '
-        [ .testOccurrence[]?
-          | select((.build.startDate // "") != "")
-        ]
-        | sort_by(.build.startDate)
-        | last
-        | .status // ""
-      ' 2>/dev/null)
-      if [ "$LAST_MAIN_STATUS" = "SUCCESS" ]; then
-        IS_NEW="true"
-        HAS_NEW_FAILURES="true"
-      fi
-    fi
     CUTOFF_S=$(( CURRENT_TIME_S - 100 * 86400 ))
 
     MAIN_STATS=$(echo "$MAIN_HISTORY_JSON" | CUTOFF_S="$CUTOFF_S" CURRENT_TIME_S="$CURRENT_TIME_S" jq -r '

--- a/.teamcity/scripts/post_github_comment.sh
+++ b/.teamcity/scripts/post_github_comment.sh
@@ -4,7 +4,10 @@ POST_GITHUB_COMMENT="%POST_GITHUB_COMMENT%"
 GITHUB_REPO="%env.GITHUB_REPO%"
 GIT_PAT="%env.GIT_PAT%"
 TEAMCITY_TOKEN="%env.TEAMCITY_TOKEN%"
+TEAMCITY_SERVER_URL=%teamcity.serverUrl%
 # BUILD_START_TIME is set in the first build step: $(date +%s)
+BUILD_ID="%teamcity.build.id%"
+BUILD_TYPE_ID="%system.teamcity.buildType.id%"
 BUILD_START_TIME="%env.BUILD_START_TIME%"
 BETA_VERSION_ENV_VAR="%env.BETA_VERSION_ENV_VAR%"
 TEAMCITY_BUILD_BRANCH="%teamcity.build.branch%"
@@ -13,6 +16,7 @@ LABEL_FAILURE="%env.LABEL_FAILURE%"
 LABEL_OUTDATED="%env.LABEL_OUTDATED%"
 LABEL_NEW_FAILURE="%env.LABEL_NEW_FAILURE%"
 APPLY_TESTING_LABELS_ENABLED="%env.APPLY_TESTING_LABELS_ENABLED%"
+TRACKING_ID="%TRACKING_ID%"
 
 if [ "$POST_GITHUB_COMMENT" != "true" ]; then
   echo "GitHub commenting disabled — skipping."
@@ -22,14 +26,12 @@ fi
 if [[ "$TEAMCITY_BUILD_BRANCH" =~ refs/pull/([0-9]+)/merge ]]; then
   PR_NUMBER="${BASH_REMATCH[1]}"
 else
-  echo "Not a PR merge branch: %teamcity.build.branch%"
+  echo "Not a PR merge branch: $TEAMCITY_BUILD_BRANCH"
   exit 0
 fi
 
-TRACKING_ID="%TRACKING_ID%"
 echo "Tracking ID: $TRACKING_ID"
 
-BUILD_ID="%teamcity.build.id%"
 
 github_api_request() {
   local endpoint="$1"
@@ -87,7 +89,7 @@ TEAMCITY_ERROR=""
 RAW_TEST_RESULTS_JSON=$(curl -sS -f \
   -H "Authorization: Bearer $TEAMCITY_TOKEN" \
   -H "Accept: application/json" \
-  "%teamcity.serverUrl%/app/rest/testOccurrences?locator=build:(id:$BUILD_ID),count:100000&fields=testOccurrence(name,status,duration)")
+  "$TEAMCITY_SERVER_URL/app/rest/testOccurrences?locator=build:(id:$BUILD_ID),count:100000&fields=testOccurrence(name,status,duration,id)")
 
 if [ $? -ne 0 ] || [ -z "$RAW_TEST_RESULTS_JSON" ]; then
   TEAMCITY_ERROR="Failed to fetch test results from TeamCity for build $BUILD_ID."
@@ -110,6 +112,7 @@ TOTAL=$((PASS_COUNT + FAIL_COUNT))
 # Fetch main branch test results early to identify new failures for comment marking
 NEW_FAILURES=""
 MAIN_TEST_RESULTS=""
+MAIN_TEST_ID_MAP=""
 if [ -z "$TEAMCITY_ERROR" ] && [ "$FAIL_COUNT" -gt 0 ]; then
   echo "Fetching main branch test results for comparison..."
 
@@ -117,21 +120,30 @@ if [ -z "$TEAMCITY_ERROR" ] && [ "$FAIL_COUNT" -gt 0 ]; then
   MAIN_BUILD_INFO=$(curl -s \
     -H "Authorization: Bearer $TEAMCITY_TOKEN" \
     -H "Accept: application/json" \
-    "%teamcity.serverUrl%/app/rest/builds?locator=buildType:(id:%system.teamcity.buildType.id%),branch:refs/heads/main,status:SUCCESS,count:1")
+    "$TEAMCITY_SERVER_URL/app/rest/builds?locator=buildType:(id:$BUILD_TYPE_ID),branch:refs/heads/main,status:SUCCESS,count:1")
 
   MAIN_BUILD_ID=$(echo "$MAIN_BUILD_INFO" | jq -r '.build[0].id // empty')
 
   if [ -n "$MAIN_BUILD_ID" ]; then
     echo "Found main branch build: $MAIN_BUILD_ID"
 
-    # Fetch test results from main branch build via the TeamCity REST API
-    MAIN_TEST_RESULTS=$(curl -s \
+    # Fetch test results from main branch build via the TeamCity REST API.
+    MAIN_RAW_JSON=$(curl -s \
       -H "Authorization: Bearer $TEAMCITY_TOKEN" \
       -H "Accept: application/json" \
-      "%teamcity.serverUrl%/app/rest/testOccurrences?locator=build:(id:$MAIN_BUILD_ID),count:100000&fields=testOccurrence(name,status)" \
-      | jq -r '.testOccurrence[]
+      "$TEAMCITY_SERVER_URL/app/rest/testOccurrences?locator=build:(id:$MAIN_BUILD_ID),count:100000&fields=testOccurrence(name,status,test(id))")
+
+    # Build name→status pairs (for new-failure detection)
+    MAIN_TEST_RESULTS=$(echo "$MAIN_RAW_JSON" \
+      | jq -r '(.testOccurrence // [])[]
           | select(.status == "SUCCESS" or .status == "FAILURE")
           | "\(.name)|\(if .status == "SUCCESS" then "PASS" else "FAIL" end)"' 2>/dev/null || echo "")
+
+    # Build name→test-entity-id pairs (for history queries)
+    MAIN_TEST_ID_MAP=$(echo "$MAIN_RAW_JSON" \
+      | jq -r '(.testOccurrence // [])[]
+          | select(.test.id != null)
+          | "\(.name)|\(.test.id)"' 2>/dev/null || echo "")
 
     if [ -n "$MAIN_TEST_RESULTS" ]; then
       # Extract failed test names from current PR
@@ -150,7 +162,6 @@ if [ -z "$TEAMCITY_ERROR" ] && [ "$FAIL_COUNT" -gt 0 ]; then
   fi
 fi
 
-
 CURRENT_TIME_S=$(date +%s)
 BUILD_DURATION=$((CURRENT_TIME_S - BUILD_START_TIME))
 
@@ -158,8 +169,59 @@ BUILD_HOURS=$((BUILD_DURATION / 3600))
 BUILD_MINUTES=$(((BUILD_DURATION % 3600) / 60))
 BUILD_SECONDS=$((BUILD_DURATION % 60))
 
+# Build per-test history data: "name|failure_rate|first_failure|last_failure"
+# This is collected for ALL tests that appear in RAW_TEST_RESULTS_JSON (pass or fail).
+TEST_HISTORY=""
+if [ -z "$TEAMCITY_ERROR" ] && [ -n "$MAIN_TEST_ID_MAP" ]; then
+  echo "Fetching per-test history..."
+
+  # Collect all test names from the current build
+  ALL_TEST_NAMES=$(echo "$RAW_TEST_RESULTS_JSON" \
+    | jq -r '(.testOccurrence // [])[] | select(.status == "SUCCESS" or .status == "FAILURE") | .name' \
+    2>/dev/null || echo "")
+
+  while IFS= read -r test_name; do
+    [ -z "$test_name" ] && continue
+
+    # Look up the test entity id from the main-branch id map
+    TEST_ID=$(echo "$MAIN_TEST_ID_MAP" | AWK_NAME="$test_name" awk -F'|' '$1 == ENVIRON["AWK_NAME"] {print $2; exit}')
+    if [ -z "$TEST_ID" ]; then
+      TEST_HISTORY+="${test_name}|N/A|N/A|N/A"$'\n'
+      continue
+    fi
+
+    HISTORY_JSON=$(curl -s -X GET \
+      "$TEAMCITY_SERVER_URL/app/rest/testOccurrences?locator=test:(id:${TEST_ID}),count:1000&fields=testOccurrence(status,build(startDate))" \
+      -H "Authorization: Bearer $TEAMCITY_TOKEN" \
+      -H "Accept: application/json")
+
+    # Extract rate and raw TC startDate strings (format: 20240315T143022+0000)
+    HISTORY_STATS=$(echo "$HISTORY_JSON" | jq -r '
+      ([ .testOccurrence[]? | select(.status=="SUCCESS") ] | length) as $s |
+      ([ .testOccurrence[]? | select(.status=="FAILURE") ] | length) as $f |
+      ($s + $f) as $total |
+      (if $total > 0 then (($s| tostring) + "/" + ($f| tostring)) else "N/A" end) as $rate |
+      ([ .testOccurrence[]? | select(.status=="FAILURE") ] | last  | .build.startDate // "") as $first_raw |
+      ([ .testOccurrence[]? | select(.status=="FAILURE") ] | first | .build.startDate // "") as $last_raw |
+      "\($rate)|\($first_raw)|\($last_raw)"
+    ' 2>/dev/null || echo "N/A||")
+
+    # Parse the three pipe-delimited fields from HISTORY_STATS
+    HIST_RATE=$(echo "$HISTORY_STATS"  | cut -d'|' -f1)
+    FIRST_RAW=$(echo "$HISTORY_STATS"  | cut -d'|' -f2)
+    LAST_RAW=$(echo "$HISTORY_STATS"   | cut -d'|' -f3)
+
+    HIST_RATE_LINK="[$HIST_RATE]($TEAMCITY_SERVER_URL/test/${TEST_ID}?currentProjectId=TF_AzureRM)"
+
+    FIRST_FAILURE=$(( (CURRENT_TIME_S - $(date -d "$FIRST_RAW" +%s)) / 86400 ))
+    LAST_FAILURE=$(( (CURRENT_TIME_S - $(date -d "$LAST_RAW" +%s)) / 86400 ))
+
+    TEST_HISTORY+="${test_name}|${HIST_RATE_LINK}|${FIRST_FAILURE}d|${LAST_FAILURE}d"$'\n'
+  done <<< "$ALL_TEST_NAMES"
+fi
+
 if [ -n "$TEAMCITY_ERROR" ]; then
-  COMMENT="Build: [$BUILD_ID](%teamcity.serverUrl%/viewLog.html?buildId=$BUILD_ID)
+  COMMENT="Build: [$BUILD_ID]($TEAMCITY_SERVER_URL/viewLog.html?buildId=$BUILD_ID)
 PR: #$PR_NUMBER
 
 **TeamCity Error:** $TEAMCITY_ERROR
@@ -167,7 +229,69 @@ PR: #$PR_NUMBER
 Unable to collect test details for this run. Please check TeamCity build logs.
 "
 else
-  COMMENT="Build: [$BUILD_ID](%teamcity.serverUrl%/viewLog.html?buildId=$BUILD_ID)
+  TABLE_ROWS=$(echo "$TEST_RESULTS" | NEW_FAILURES="$NEW_FAILURES" TEST_HISTORY="$TEST_HISTORY" awk -F'|' '
+BEGIN {
+    # Build array of new failure test names
+    n = split(ENVIRON["NEW_FAILURES"], nf_array, "\n")
+    for (i = 1; i <= n; i++) {
+        if (nf_array[i] != "") new_fail[nf_array[i]] = 1
+    }
+    # Build history lookup: hist[name] = "rate|first|last"
+    m = split(ENVIRON["TEST_HISTORY"], h_array, "\n")
+    for (i = 1; i <= m; i++) {
+        if (h_array[i] == "") continue
+        # Each entry is "name|rate|first|last" — split on first three pipes
+        line = h_array[i]
+        # Find positions of the last 3 pipe-delimited fields from the right
+        # by reversing: count pipes from right
+        last3 = ""
+        name_part = ""
+        pipe_count = 0
+        for (j = length(line); j >= 1; j--) {
+            if (substr(line, j, 1) == "|") {
+                pipe_count++
+                if (pipe_count == 3) {
+                    name_part = substr(line, 1, j - 1)
+                    last3 = substr(line, j + 1)
+                    break
+                }
+            }
+        }
+        if (name_part != "") hist[name_part] = last3
+    }
+}
+$1 == "" { next }
+{
+    test_name = $1
+    status = $2
+    duration = $3
+
+    # Look up history fields (rate|first|last)
+    if (test_name in hist) {
+        n_hist = split(hist[test_name], hf, "|")
+        fail_rate   = (n_hist >= 1) ? hf[1] : "N/A"
+        first_fail  = (n_hist >= 2) ? hf[2] : "N/A"
+        last_fail   = (n_hist >= 3) ? hf[3] : "N/A"
+    } else {
+        fail_rate  = "N/A"
+        first_fail = "N/A"
+        last_fail  = "N/A"
+    }
+
+    if (status == "PASS"){
+      label = "✅ PASS"
+    }
+    else if (test_name in new_fail) {
+      label = "❌ NEW FAILURE ❌"}
+    else {
+      label = "❌ FAIL"
+    }
+
+    print "| " label " | " test_name " | " duration "s | " fail_rate " | " first_fail " | " last_fail " |"
+}
+')
+
+  COMMENT="Build: [$BUILD_ID]($TEAMCITY_SERVER_URL/viewLog.html?buildId=$BUILD_ID)
 PR: #$PR_NUMBER
 
 **Total:** $TOTAL
@@ -178,40 +302,9 @@ PR: #$PR_NUMBER
 <details>
 <summary>Test Details</summary>
 
-<table>
-<tr><td><b>Status</b></td><td><b>Test Name</b></td><td><b>Duration</b></td></tr>
-"
-
-TABLE_ROWS=$(echo "$TEST_RESULTS" | awk -F'|' -v new_failures="$NEW_FAILURES" '
-BEGIN {
-    # Build array of new failure test names
-    n = split(new_failures, nf_array, "\n")
-    for (i = 1; i <= n; i++) {
-        if (nf_array[i] != "") new_fail[nf_array[i]] = 1
-    }
-}
-$1 == "" { next }
-{
-    test_name = $1
-    status = $2
-    duration = $3
-
-    if (status == "PASS") {
-        print "<tr><td>✅ PASS</td><td>" test_name "</td><td>" duration "s</td></tr>"
-    } else if (status == "FAIL") {
-        # Check if this is a new failure
-        if (test_name in new_fail) {
-            print "<tr><td>❌ FAIL 🆕</td><td>" test_name "</td><td>" duration "s</td></tr>"
-        } else {
-            print "<tr><td>❌ FAIL</td><td>" test_name "</td><td>" duration "s</td></tr>"
-        }
-    }
-}
-')
-
-  COMMENT+="$TABLE_ROWS"
-
-  COMMENT+="</table>
+| Status | Test Name | Duration | Success/Failure | First Failure | Last Failure |
+| :--- | :--- | ---: | ---: | ---: | ---: |
+${TABLE_ROWS}
 </details>
 "
 fi


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
