### PR TITLE
`azurerm_user_assigned_identity` - Add post-create polling to mitigate potential eventual consistency issue

### DIFF
--- a/internal/services/managedidentity/custompollers/user_assigned_identity_create_poller.go
+++ b/internal/services/managedidentity/custompollers/user_assigned_identity_create_poller.go
@@ -1,0 +1,68 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package custompollers
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/managedidentity/2024-11-30/identities"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+)
+
+var _ pollers.PollerType = &userAssignedIdentityCreatePoller{}
+
+const defaultSuccessCount = 5
+
+var (
+	pollingSuccess = &pollers.PollResult{
+		PollInterval: 5 * time.Second,
+		Status:       pollers.PollingStatusSucceeded,
+	}
+	pollingInProgress = &pollers.PollResult{
+		HttpResponse: nil,
+		PollInterval: 5 * time.Second,
+		Status:       pollers.PollingStatusInProgress,
+	}
+	pollingFailed = &pollers.PollResult{
+		HttpResponse: nil,
+		PollInterval: 5 * time.Second,
+		Status:       pollers.PollingStatusFailed,
+	}
+)
+
+type userAssignedIdentityCreatePoller struct {
+	client       *identities.IdentitiesClient
+	id           commonids.UserAssignedIdentityId
+	successCount int
+}
+
+func NewUserAssignedIdentityCreatePoller(client *identities.IdentitiesClient, id commonids.UserAssignedIdentityId) *userAssignedIdentityCreatePoller {
+	return &userAssignedIdentityCreatePoller{
+		client:       client,
+		id:           id,
+		successCount: defaultSuccessCount,
+	}
+}
+
+func (p *userAssignedIdentityCreatePoller) Poll(ctx context.Context) (*pollers.PollResult, error) {
+	resp, err := p.client.UserAssignedIdentitiesGet(ctx, p.id)
+	if err != nil {
+		if response.WasNotFound(resp.HttpResponse) {
+			p.successCount = defaultSuccessCount
+			return pollingInProgress, nil
+		}
+		return pollingFailed, fmt.Errorf("retrieving %s: %+v", p.id, err)
+	}
+
+	if p.successCount > 1 {
+		p.successCount--
+		return pollingInProgress, nil
+	}
+
+	return pollingSuccess, nil
+}

--- a/internal/services/managedidentity/user_assigned_identity_resource.go
+++ b/internal/services/managedidentity/user_assigned_identity_resource.go
@@ -143,9 +143,42 @@ func (r UserAssignedIdentityResource) Create() sdk.ResourceFunc {
 				return fmt.Errorf("creating %s: %+v", id, err)
 			}
 
+			deadline, ok := ctx.Deadline()
+			if !ok {
+				return fmt.Errorf("internal-error: context had no deadline")
+			}
+
+			// The User Assigned Identity is eventually consistent, so a Get immediately after creation can return a 404. Poll until it becomes available.
+			stateConf := &pluginsdk.StateChangeConf{
+				Pending:                   []string{"404"},
+				Target:                    []string{"200"},
+				Refresh:                   userAssignedIdentityCreateRefreshFunc(ctx, client, id),
+				MinTimeout:                5 * time.Second,
+				ContinuousTargetOccurence: 5,
+				Timeout:                   time.Until(deadline),
+			}
+
+			if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+				return fmt.Errorf("waiting for %s to become available: %+v", id, err)
+			}
+
 			metadata.SetID(id)
 			return nil
 		},
+	}
+}
+
+func userAssignedIdentityCreateRefreshFunc(ctx context.Context, client *identities.IdentitiesClient, id commonids.UserAssignedIdentityId) pluginsdk.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		resp, err := client.UserAssignedIdentitiesGet(ctx, id)
+		if err != nil {
+			if response.WasNotFound(resp.HttpResponse) {
+				return resp, "404", nil
+			}
+			return resp, "", fmt.Errorf("retrieving %s: %+v", id, err)
+		}
+
+		return resp, "200", nil
 	}
 }
 

--- a/internal/services/managedidentity/user_assigned_identity_resource.go
+++ b/internal/services/managedidentity/user_assigned_identity_resource.go
@@ -15,7 +15,9 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/managedidentity/2024-11-30/identities"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/managedidentity/custompollers"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/managedidentity/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -143,42 +145,16 @@ func (r UserAssignedIdentityResource) Create() sdk.ResourceFunc {
 				return fmt.Errorf("creating %s: %+v", id, err)
 			}
 
-			deadline, ok := ctx.Deadline()
-			if !ok {
-				return fmt.Errorf("internal-error: context had no deadline")
-			}
-
 			// The User Assigned Identity is eventually consistent, so a Get immediately after creation can return a 404. Poll until it becomes available.
-			stateConf := &pluginsdk.StateChangeConf{
-				Pending:                   []string{"404"},
-				Target:                    []string{"200"},
-				Refresh:                   userAssignedIdentityCreateRefreshFunc(ctx, client, id),
-				MinTimeout:                5 * time.Second,
-				ContinuousTargetOccurence: 5,
-				Timeout:                   time.Until(deadline),
-			}
-
-			if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+			pollerType := custompollers.NewUserAssignedIdentityCreatePoller(client, id)
+			poller := pollers.NewPoller(pollerType, 5*time.Second, pollers.DefaultNumberOfDroppedConnectionsToAllow)
+			if err := poller.PollUntilDone(ctx); err != nil {
 				return fmt.Errorf("waiting for %s to become available: %+v", id, err)
 			}
 
 			metadata.SetID(id)
 			return nil
 		},
-	}
-}
-
-func userAssignedIdentityCreateRefreshFunc(ctx context.Context, client *identities.IdentitiesClient, id commonids.UserAssignedIdentityId) pluginsdk.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		resp, err := client.UserAssignedIdentitiesGet(ctx, id)
-		if err != nil {
-			if response.WasNotFound(resp.HttpResponse) {
-				return resp, "404", nil
-			}
-			return resp, "", fmt.Errorf("retrieving %s: %+v", id, err)
-		}
-
-		return resp, "200", nil
 	}
 }
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR adds a post-create polling to mitigate potential eventual consistency issue for `azurerm_user_assigned_identity`.

The issue was reported in internal channel of MSFT by a cx, where the service team confirmed this is due to the read-after-create timeframe issue and suggest the downstream client to retry the read-after-create on 404.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.



## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


```shell
terraform-provider-azurerm uai_poll*​ ≡1m45s
❯ TF_ACC=1 go test -v -timeout=20h -run='TestAccUserAssignedIdentity_' ./internal/services/managedidentity
=== RUN   TestAccUserAssignedIdentity_basic
=== PAUSE TestAccUserAssignedIdentity_basic
=== RUN   TestAccUserAssignedIdentity_requiresImport
=== PAUSE TestAccUserAssignedIdentity_requiresImport
=== RUN   TestAccUserAssignedIdentity_complete
=== PAUSE TestAccUserAssignedIdentity_complete
=== RUN   TestAccUserAssignedIdentity_update
=== PAUSE TestAccUserAssignedIdentity_update
=== CONT  TestAccUserAssignedIdentity_basic
=== CONT  TestAccUserAssignedIdentity_complete
=== CONT  TestAccUserAssignedIdentity_update
=== CONT  TestAccUserAssignedIdentity_requiresImport
--- PASS: TestAccUserAssignedIdentity_complete (93.36s)
--- PASS: TestAccUserAssignedIdentity_basic (94.19s)
--- PASS: TestAccUserAssignedIdentity_requiresImport (95.91s)
--- PASS: TestAccUserAssignedIdentity_update (124.94s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/managedidentity	124.965s

```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
