### PR TITLE
`azurerm_portal_dashboard` - wait for eventual consistency after create to prevent `Provider produced inconsistent result` errors

### DIFF
--- a/internal/services/portal/portal_dashboard_resource.go
+++ b/internal/services/portal/portal_dashboard_resource.go
@@ -108,6 +108,34 @@ func resourcePortalDashboardCreateUpdate(d *pluginsdk.ResourceData, meta interfa
 
 	if d.IsNewResource() {
 		d.SetId(id.ID())
+
+		// The API is eventually consistent - a `Get` immediately following `CreateOrUpdate` can 404 before the
+		// platform has finished propagating the newly created Dashboard, which surfaces to users as `Provider
+		// produced inconsistent result after apply`.
+		deadline, ok := ctx.Deadline()
+		if !ok {
+			return fmt.Errorf("internal error: context had no deadline")
+		}
+		log.Printf("[DEBUG] Waiting for %s to become available..", id)
+		stateConf := &pluginsdk.StateChangeConf{
+			Pending:    []string{"404"},
+			Target:     []string{"200"},
+			MinTimeout: 10 * time.Second,
+			Timeout:    time.Until(deadline),
+			Refresh: func() (interface{}, string, error) {
+				resp, err := client.Get(ctx, id)
+				if err != nil {
+					if response.WasNotFound(resp.HttpResponse) {
+						return resp, "404", nil
+					}
+					return nil, "", fmt.Errorf("polling for %s: %+v", id, err)
+				}
+				return resp, "200", nil
+			},
+		}
+		if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+			return fmt.Errorf("waiting for %s to become available: %+v", id, err)
+		}
 	}
 
 	return resourcePortalDashboardRead(d, meta)


### PR DESCRIPTION
This PR was written in part with the assistance of generative AI.

#### Community Note

* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review

#### PR Checklist

- [x] Have you followed the guidelines in our Contributing Documentation?
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
- [x] Have you used a meaningful PR description to help maintainers and other users understand this change and help prevent duplicate work?
- [x] Do your changes close any open issues? If so please include appropriate closing keywords below.

#### Changes to existing Resource / Data Source

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your resource or datasource changes? Not added — this is a timing/eventual-consistency race that isn't reliably reproducible against the live API in a recorded acceptance test (it depends on how quickly the platform propagates the newly created Dashboard). The fix is a narrow, well-precedented poll that doesn't change any other behavior of `Create`.
- [ ] Have you successfully run tests with your changes locally? `go build ./...`, `go vet`, `golangci-lint run`, and `tfproviderlint` all pass for the affected package. Acceptance tests were not run since reproducing the race requires hitting the live API at the right moment; I don't have a reliable way to force the 404 window on demand.

#### Description

`azurerm_portal_dashboard`'s `Create` calls `CreateOrUpdate` and then immediately calls `Read`, which does a `Get`. The Azure Portal Dashboards API is eventually consistent for creates: `CreateOrUpdate` can return success before the resource is fully propagated, so the immediate `Get` in `Read` can still return `404`. Terraform Core surfaces this as:

```
Error: Provider produced inconsistent result after apply

When applying changes to azurerm_portal_dashboard.dashboard, provider
"provider[\"registry.terraform.io/hashicorp/azurerm\"]" produced an
unexpected new value: Root object was present, but now absent.
```

Confusingly, the Dashboard *was* actually created — a follow-up `terraform apply` fails with "already exists" (not added to state by the failed run) because Terraform never persisted state after the phantom 404. This was confirmed by two independent reporters in the linked issue's comments, one of whom also saw the same class of failure on other resources with fast Create -> Read cycles.

This PR adds a `pluginsdk.StateChangeConf` poll after `CreateOrUpdate` on new resources — waiting for `Get` to move from `404` to `200` (bounded by the remaining `Create` timeout) — before calling `Read`. This mirrors an already-merged pattern used for the same class of bug elsewhere in this codebase, e.g. `waitForPolicyAssignmentToStabilize` in `internal/services/policy/assignment.go` and the delete-side poller in `internal/services/monitor/monitor_diagnostic_setting_resource.go`, rather than introducing a new pattern.

I intentionally did not rely on the retry/poller approach proposed in #32105 for a different resource (`azurerm_security_center_automation`), since that PR is still open and unreviewed — I instead based this fix on patterns already merged into `main`.

#### Related Issue(s)

Fixes #32317

#### Change Log

* `azurerm_portal_dashboard` - prevent a `Provider produced inconsistent result after apply` error caused by eventual consistency in the Dashboards API after `Create` [GH-00000]

- [x] Bug Fix
- [ ] New Feature
