### PR TITLE
network: allow spaces in `azurerm_private_endpoint` `subresource_names`

### DIFF
--- a/internal/services/network/validate/private_link_subresource_name.go
+++ b/internal/services/network/validate/private_link_subresource_name.go
@@ -11,9 +11,9 @@ import (
 
 func PrivateLinkSubResourceName(i interface{}, k string) (_ []string, errors []error) {
 	// empty is valid; otherwise the name must begin and end with an alphanumeric character, be between
-	// 3 and 63 characters in length and only contain letters, numbers, underscores, periods, and dashes
+	// 3 and 63 characters in length and only contain letters, numbers, underscores, periods, dashes, and spaces
 	return validation.Any(
 		validation.StringIsEmpty,
-		validation.StringMatch(regexp.MustCompile(`^([a-zA-Z0-9])([\w\.-]{1,61})([a-zA-Z0-9])$`), "must begin and end with a alphanumeric character, be between 3 and 63 characters in length, only contain letters, numbers, underscores, periods, and dashes"),
+		validation.StringMatch(regexp.MustCompile(`^([a-zA-Z0-9])([\w .-]{1,61})([a-zA-Z0-9])$`), "must begin and end with an alphanumeric character, be between 3 and 63 characters in length, only contain letters, numbers, underscores, periods, dashes, and spaces"),
 	)(i, k)
 }

--- a/internal/services/network/validate/private_link_subresource_name.go
+++ b/internal/services/network/validate/private_link_subresource_name.go
@@ -17,8 +17,8 @@ func PrivateLinkSubResourceName(i interface{}, k string) (_ []string, errors []e
 	}
 
 	if len(strings.TrimSpace(v)) >= 3 {
-		if m, _ := validate.RegExHelper(i, k, `^([a-zA-Z0-9])([\w\.-]{1,61})([a-zA-Z0-9])$`); !m {
-			errors = append(errors, fmt.Errorf("%s must begin and end with a alphanumeric character, be between 3 and 63 characters in length, only contain letters, numbers, underscores, periods, and dashes", k))
+		if m, _ := validate.RegExHelper(i, k, `^([a-zA-Z0-9])([\w .-]{1,61})([a-zA-Z0-9])$`); !m {
+			errors = append(errors, fmt.Errorf("%s must begin and end with a alphanumeric character, be between 3 and 63 characters in length, only contain letters, numbers, underscores, periods, dashes, and spaces", k))
 		}
 	} else if len(v) != 0 {
 		errors = append(errors, fmt.Errorf("%s must be at least 3 character in length", k))

--- a/internal/services/network/validate/private_link_subresource_name_test.go
+++ b/internal/services/network/validate/private_link_subresource_name_test.go
@@ -51,6 +51,31 @@ func TestPrivateLinkSubResourceName(t *testing.T) {
 		{
 			Name:  "Blob Space Secondary",
 			Input: "blob secondary",
+			Valid: true,
+		},
+		{
+			Name:  "ADME Sub-Resource With Spaces",
+			Input: "Azure Data Manager for Energy",
+			Valid: true,
+		},
+		{
+			Name:  "App Service Environment Sub-Resource With Space",
+			Input: "hosting environment",
+			Valid: true,
+		},
+		{
+			Name:  "Power BI Sub-Resource With Space",
+			Input: "Power BI",
+			Valid: true,
+		},
+		{
+			Name:  "Start With Space",
+			Input: " SqlServer",
+			Valid: false,
+		},
+		{
+			Name:  "End With Space",
+			Input: "SqlServer ",
 			Valid: false,
 		},
 		{


### PR DESCRIPTION
## Community Note

* Please vote on this PR by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize this request
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize the request

## Description

Several valid private-link sub-resource (group) IDs contain spaces, but `PrivateLinkSubResourceName` rejects any value containing a space before the request reaches ARM, so these sub-resources cannot be used with `azurerm_private_endpoint` at all. Affected sub-resources reported in #25309 and elsewhere:

- `hosting environment` — App Service Environment v3
- `Power BI` — `Microsoft.PowerBI/privateLinkServicesForPowerBI`
- `Azure Data Manager for Energy` — `Microsoft.OpenEnergyPlatform/energyServices` ([documented default target sub-resource](https://learn.microsoft.com/en-us/azure/energy-data-services/how-to-set-up-private-links))

The current validation regex is:

```
^([a-zA-Z0-9])([\w\.-]{1,61})([a-zA-Z0-9])$
```

`\w` excludes the space character, so the value is wrongly rejected even though ARM accepts it. This PR permits interior spaces while keeping the alphanumeric start/end anchors (leading/trailing spaces remain invalid) and updates the error message accordingly.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/hashicorp/terraform-provider-azurerm/pulls) for the same update/change.
- [x] I have used a meaningful PR description to help maintainers and other users understand this change and refer to any relevant issues.
- [x] I have used the changelog to reflect the change. (Left to maintainers per the contributing guide.)

## Changes to existing Resource / Data Source

- `azurerm_private_endpoint` — `private_service_connection.subresource_names` now accepts values containing interior spaces.

## Testing

```
go test ./internal/services/network/validate/ -run TestPrivateLinkSubResourceName
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate
```

## Related Issue(s)

Fixes #25309
