### PR TITLE
authorization: support agent principal types in role assignments

### DIFF
--- a/internal/services/authorization/role_assignment_resource.go
+++ b/internal/services/authorization/role_assignment_resource.go
@@ -110,6 +110,8 @@ func resourceArmRoleAssignment() *pluginsdk.Resource {
 				Computed: true,
 				ForceNew: true,
 				ValidateFunc: validation.StringInSlice([]string{
+					"AgentServicePrincipal",
+					"AgentUser",
 					"User",
 					"Group",
 					"ServicePrincipal",

--- a/internal/services/authorization/role_assignment_resource_unit_test.go
+++ b/internal/services/authorization/role_assignment_resource_unit_test.go
@@ -1,0 +1,30 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package authorization
+
+import "testing"
+
+func TestRoleAssignmentPrincipalType(t *testing.T) {
+	schema := resourceArmRoleAssignment().Schema["principal_type"]
+
+	for _, value := range []string{
+		"AgentServicePrincipal",
+		"AgentUser",
+		"Group",
+		"ServicePrincipal",
+		"User",
+	} {
+		t.Run(value, func(t *testing.T) {
+			_, errors := schema.ValidateFunc(value, "principal_type")
+			if len(errors) != 0 {
+				t.Fatalf("expected %q to be a valid principal_type, got: %v", value, errors)
+			}
+		})
+	}
+
+	_, errors := schema.ValidateFunc("Unknown", "principal_type")
+	if len(errors) == 0 {
+		t.Fatal("expected an unknown principal_type to be rejected")
+	}
+}

--- a/website/docs/r/role_assignment.html.markdown
+++ b/website/docs/r/role_assignment.html.markdown
@@ -185,11 +185,11 @@ The following arguments are supported:
 
 ~> **Note:** Either `role_definition_id` or `role_definition_name` must be set.
 
-* `principal_id` - (Required) The ID of the Principal (User, Group or Service Principal) to assign the Role Definition to. Changing this forces a new resource to be created.
+* `principal_id` - (Required) The ID of the Principal to assign the Role Definition to. Supported principal types are documented by `principal_type`. Changing this forces a new resource to be created.
 
 -> **Note:** The Principal ID is also known as the Object ID (i.e. not the "Application ID" for applications).
 
-* `principal_type` - (Optional) The type of the `principal_id`. Possible values are `User`, `Group` and `ServicePrincipal`. Changing this forces a new resource to be created. It is necessary to explicitly set this attribute when creating role assignments if the principal creating the assignment is constrained by ABAC rules that filters on the PrincipalType attribute.
+* `principal_type` - (Optional) The type of the `principal_id`. Possible values are `AgentServicePrincipal`, `AgentUser`, `User`, `Group` and `ServicePrincipal`. Changing this forces a new resource to be created. It is necessary to explicitly set this attribute when creating role assignments if the principal creating the assignment is constrained by ABAC rules that filters on the PrincipalType attribute.
 
 * `condition` - (Optional) The condition that limits the resources that the role can be assigned to. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
## Summary
- allow `AgentUser` and `AgentServicePrincipal` in `azurerm_role_assignment.principal_type`
- document the new supported values
- add deterministic schema validation coverage

The existing SDK, refresh, import, and data-source paths already preserve extensible principal type strings.

## Testing
- `go test -v ./internal/services/authorization -run TestRoleAssignmentPrincipalType -timeout 10m`

The values are part of the stable `2022-04-01` Authorization contract after Azure/azure-rest-api-specs#44846.