### PR TITLE
`CI` - refactor to composite build for "nightly" jobs

### DIFF
--- a/.teamcity/components/build_components.kt
+++ b/.teamcity/components/build_components.kt
@@ -44,7 +44,6 @@ fun BuildSteps.CheckScheduleConstraints() {
                 if [[ ! ",%DAYS_OF_WEEK%," =~ ",${'$'}{DAY_NUM}," && "%DAYS_OF_WEEK%" != "*" ]]; then
                     echo "Today is day ${'$'}{DAY_NUM}. This job is constrained to run only on days: %DAYS_OF_WEEK%."
                     echo "Skipping test execution for this service."
-                    
                     # Tell TeamCity to skip subsequent steps using a service message
                     echo "##teamcity[setParameter name='env.SCHEDULE_MATCHES' value='false']"
                 else

--- a/.teamcity/components/build_components.kt
+++ b/.teamcity/components/build_components.kt
@@ -30,10 +30,41 @@ fun BuildFeatures.BuildCacheFeature() {
         })
 }
 
+// Ensure that daysOfWeek constraints in the overrides are honoured.
+fun BuildSteps.CheckScheduleConstraints() {
+    step(ScriptBuildStep {
+        name = "Check Schedule Constraints"
+        scriptContent = """
+            #!/bin/bash
+            # TeamCity days: 1=Sun, 2=Mon, 3=Tue, 4=Wed, 5=Thu, 6=Fri, 7=Sat
+            DAY_NUM=${'$'}(( ${'$'}(date +%w) + 1 ))
+
+            # manual/gh trigger should bypass the daysOfWeek overrides.
+            if [[ "%env.IS_NIGHTLY_RUN%" == "true" ]]; then
+                if [[ ! ",%DAYS_OF_WEEK%," =~ ",${'$'}{DAY_NUM}," && "%DAYS_OF_WEEK%" != "*" ]]; then
+                    echo "Today is day ${'$'}{DAY_NUM}. This job is constrained to run only on days: %DAYS_OF_WEEK%."
+                    echo "Skipping test execution for this service."
+                    
+                    # Tell TeamCity to skip subsequent steps using a service message
+                    echo "##teamcity[setParameter name='env.SCHEDULE_MATCHES' value='false']"
+                else
+                    echo "Schedule matches. Proceeding with tests."
+                fi
+            else
+                echo "This is not a scheduled nightly run (likely triggered manually or via PR chat-ops)."
+                echo "Bypassing schedule constraints."
+            fi
+        """.trimIndent()
+    })
+}
+
 fun BuildSteps.SetBuildStartTime() {
     step(ScriptBuildStep {
         name = "Set Build Start Time"
         scriptContent = File("scripts/set_build_start_time.sh").readText()
+        conditions {
+            equals("env.SCHEDULE_MATCHES", "true")
+        }
     })
 }
 
@@ -41,6 +72,9 @@ fun BuildSteps.ConfigureGoEnv() {
     step(ScriptBuildStep {
         name = "Configure Go Version"
         scriptContent = "goenv install -s \$(goenv local) && goenv rehash"
+        conditions {
+            equals("env.SCHEDULE_MATCHES", "true")
+        }
     })
 }
 
@@ -50,6 +84,9 @@ fun BuildSteps.DownloadTerraformBinary() {
     step(ScriptBuildStep {
         name = "Download Terraform Core v%env.TERRAFORM_CORE_VERSION%.."
         scriptContent = "mkdir -p tools && wget -O tf.zip %s && unzip tf.zip && mv terraform tools/".format(terraformUrl)
+        conditions {
+            equals("env.SCHEDULE_MATCHES", "true")
+        }
     })
 }
 
@@ -65,12 +102,18 @@ fun BuildSteps.RunAcceptanceTests(packageName: String) {
     step(ScriptBuildStep {
         name          = "Determine Working Directory for this Package"
         scriptContent = "if [ -d \"%s/tests\" ]; then echo \"%s\"; fi".format(packagePath, withTestsDirectoryPath)
+        conditions {
+            equals("env.SCHEDULE_MATCHES", "true")
+        }
     })
 
     if (useTeamCityGoTest) {
         step(ScriptBuildStep {
             name = "Run Tests"
             scriptContent = "go test -v \"%SERVICE_PATH%\" -timeout=\"%TIMEOUT%h\" -test.parallel=\"%PARALLELISM%\" -run=\"%TEST_PREFIX%\" -json"
+            conditions {
+                equals("env.SCHEDULE_MATCHES", "true")
+            }
         })
     } else {
         step(ScriptBuildStep {
@@ -81,6 +124,9 @@ fun BuildSteps.RunAcceptanceTests(packageName: String) {
                             go test -c -o test-binary
                             """.trimIndent()
             workingDir = "%SERVICE_PATH%"
+            conditions {
+                equals("env.SCHEDULE_MATCHES", "true")
+            }
         })
 
         step(ScriptBuildStep {
@@ -88,6 +134,9 @@ fun BuildSteps.RunAcceptanceTests(packageName: String) {
             name = "Run via jen20/teamcity-go-test"
             scriptContent = "./test-binary -test.list=\"%TEST_PREFIX%\" | teamcity-go-test -test ./test-binary -parallelism \"%PARALLELISM%\" -timeout \"%TIMEOUT%h\""
             workingDir = "%SERVICE_PATH%"
+            conditions {
+                equals("env.SCHEDULE_MATCHES", "true")
+            }
         })
     }
 }
@@ -98,17 +147,26 @@ fun BuildSteps.RunAcceptanceTestsForPullRequest(packageName: String) {
         step(ScriptBuildStep {
             name = "Run Tests"
             scriptContent = "go test -v \"$servicePath\" -timeout=\"%TIMEOUT%h\" -test.parallel=\"%PARALLELISM%\" -run=\"%TEST_PREFIX%\" -json"
+            conditions {
+                equals("env.SCHEDULE_MATCHES", "true")
+            }
         })
     } else {
         // Building a binary with teamcity-go-test doesn't work for multiple packages, so fallback to this
         step(ScriptBuildStep {
             name = "Install tombuildsstuff/teamcity-go-test-json"
             scriptContent = "wget https://github.com/tombuildsstuff/teamcity-go-test-json/releases/download/v0.2.0/teamcity-go-test-json_linux_amd64 && chmod +x teamcity-go-test-json_linux_amd64"
+            conditions {
+                equals("env.SCHEDULE_MATCHES", "true")
+            }
         })
 
         step(ScriptBuildStep {
             name = "Run Tests"
             scriptContent = "GOFLAGS=\"-mod=vendor\" ./teamcity-go-test-json_linux_amd64 -scope \"$servicePath\" -prefix \"%TEST_PREFIX%\" -count=1 -parallelism=%PARALLELISM% -timeout %TIMEOUT% | tee results.txt"
+            conditions {
+                equals("env.SCHEDULE_MATCHES", "true")
+            }
         })
     }
 }
@@ -118,6 +176,9 @@ fun BuildSteps.PostTestResultsToGitHubPullRequest() {
         name = "Post Test Results to GitHub Pull Request"
         scriptContent = File("scripts/post_github_comment.sh").readText()
         workingDir = "%SERVICE_PATH%"
+        conditions {
+            equals("env.SCHEDULE_MATCHES", "true")
+        }
     })
 }
 

--- a/.teamcity/components/build_config_service.kt
+++ b/.teamcity/components/build_config_service.kt
@@ -19,6 +19,7 @@ class serviceDetails(name: String, displayName: String, environment: String, vcs
             }
 
             steps {
+                CheckScheduleConstraints()
                 SetBuildStartTime()
                 ConfigureGoEnv()
                 DownloadTerraformBinary()
@@ -45,11 +46,12 @@ class serviceDetails(name: String, displayName: String, environment: String, vcs
                 WorkingDirectory(packageName)
                 GoCache()
                 BuildStartTime()
+                text("DAYS_OF_WEEK", daysOfWeek)
+                text("env.SCHEDULE_MATCHES", "true")
+                text("env.IS_NIGHTLY_RUN", "false")
             }
 
-            triggers {
-                RunNightly(nightlyTestsEnabled, startHour, daysOfWeek, daysOfMonth, disableTriggers)
-            }
+            // Triggers are now managed by the top-level Composite Build Chain
         }
     }
 

--- a/.teamcity/components/project.kt
+++ b/.teamcity/components/project.kt
@@ -1,5 +1,7 @@
 import jetbrains.buildServer.configs.kotlin.BuildType
 import jetbrains.buildServer.configs.kotlin.Project
+import jetbrains.buildServer.configs.kotlin.BuildTypeSettings
+import jetbrains.buildServer.configs.kotlin.FailureAction
 
 const val providerName = "azurerm"
 var enableTestTriggersGlobally = false
@@ -19,6 +21,10 @@ fun AzureRM(environment: String, configuration : ClientConfiguration) : Project 
         buildConfigs.forEach { buildConfiguration ->
             buildType(buildConfiguration)
         }
+        
+        var buildChain = AcceptanceTestsBuildChain(providerName, environment, configuration, buildConfigs, false)
+        buildType(buildChain)
+
         if (configuration.createBetaProject) {
             subProject(AzureRMBetaVersion(environment, configuration))
         }
@@ -36,6 +42,9 @@ fun AzureRMBetaVersion(environment: String, configuration : ClientConfiguration)
         buildConfigs.forEach { buildConfiguration ->
             buildType(buildConfiguration)
         }
+        
+        var buildChain = AcceptanceTestsBuildChain(providerName, environment, configuration, buildConfigs, true)
+        buildType(buildChain)
     }
 }
 
@@ -105,4 +114,53 @@ class testConfiguration(parallelism: Int = defaultParallelism, startHour: Int = 
     var locationOverride = locationOverride
     var terraformCoreOverride = terraformCoreOverride
     var disableTriggers = disableTriggers
+}
+
+fun AcceptanceTestsBuildChain(providerName: String, environment: String, config: ClientConfiguration, buildConfigs: List<BuildType>, runWithBetaVersion: Boolean): BuildType {
+    return BuildType {
+        if (runWithBetaVersion) {
+            id("%s_BETA_VERSION_BUILDCHAIN_%s".format(providerName.uppercase(), environment.uppercase()))
+            name = "Acceptance Tests (Beta Version) - All Services Build Chain"
+        } else {
+            id("%s_BUILDCHAIN_%s".format(providerName.uppercase(), environment.uppercase()))
+            name = "Acceptance Tests - All Services Build Chain"
+        }
+        
+        type = BuildTypeSettings.Type.COMPOSITE
+        
+        // Trigger all builds nightly via this composite build
+        var runNightlyEnv = runNightly.getOrDefault(environment, false)
+        triggers {
+            RunNightly(runNightlyEnv, defaultStartHour, defaultDaysOfWeek, defaultDaysOfMonth, false)
+        }
+
+        // Snapshot depend on all service configurations
+        dependencies {
+            buildConfigs.forEach { buildConfig ->
+                snapshot(buildConfig) {
+                    onDependencyFailure = FailureAction.IGNORE
+                    onDependencyCancel = FailureAction.IGNORE
+                }
+            }
+        }
+        
+        params {
+            // This parameter is passed down to all dependencies in the chain.
+            // If a service test is triggered directly (e.g. via GitHub Chat-Ops),
+            // it will not receive this parameter and can bypass schedule constraints.
+            // specifically any daysOfWeek overrides.
+            text("reverse.dep.*.env.IS_NIGHTLY_RUN", "true")
+        }
+        
+        // -------------------------------------------------------------------------
+        // DALEK JOB LINKAGE:
+        //  // TODO - hook Dalek in here rather than daily cron
+        // triggers {
+        //     finishBuildTrigger {
+        //         buildType = "${'$'}{id?.value}"
+        //         successfulOnly = false
+        //     }
+        // }
+        // -------------------------------------------------------------------------
+    }
 }

--- a/.teamcity/components/settings.kt
+++ b/.teamcity/components/settings.kt
@@ -13,7 +13,7 @@ var defaultParallelism = 20
 var defaultTimeout = 12
 
 // specifies the default version of Terraform Core which should be used for testing
-var defaultTerraformCoreVersion = "1.14.3"
+var defaultTerraformCoreVersion = "1.15.8"
 
 // This represents a cron view of days of the week, Monday - Friday.
 const val defaultDaysOfWeek = "2,3,4,5,6"

--- a/.teamcity/tests/configuration.kt
+++ b/.teamcity/tests/configuration.kt
@@ -126,4 +126,32 @@ class ConfigurationTests {
             )
         }
     }
+
+    @Test
+    fun buildChainShouldBeCompositeAndHaveDependencies() {
+        val config = TestConfiguration()
+        val project = AzureRM("public", config)
+        
+        val buildChain = project.buildTypes.find { it.name.contains("All Services Build Chain") }
+        assertTrue("Build chain must exist", buildChain != null)
+        assertTrue("Build chain must be a COMPOSITE build", buildChain!!.type == jetbrains.buildServer.configs.kotlin.BuildTypeSettings.Type.COMPOSITE)
+        assertTrue("Build chain must have snapshot dependencies", buildChain.dependencies.items.isNotEmpty())
+        
+        val isNightlyParam = buildChain.params.findRawParam("reverse.dep.*.env.IS_NIGHTLY_RUN")?.value
+        assertTrue("Build chain must pass down reverse.dep.*.env.IS_NIGHTLY_RUN parameter", isNightlyParam == "true")
+    }
+
+    @Test
+    fun betaBuildChainShouldBeCompositeAndHaveDependencies() {
+        val config = TestConfiguration()
+        val project = AzureRMBetaVersion("public", config)
+        
+        val buildChain = project.buildTypes.find { it.name.contains("All Services Build Chain") }
+        assertTrue("Beta Build chain must exist", buildChain != null)
+        assertTrue("Beta Build chain must be a COMPOSITE build", buildChain!!.type == jetbrains.buildServer.configs.kotlin.BuildTypeSettings.Type.COMPOSITE)
+        assertTrue("Beta Build chain must have snapshot dependencies", buildChain.dependencies.items.isNotEmpty())
+        
+        val isNightlyParam = buildChain.params.findRawParam("reverse.dep.*.env.IS_NIGHTLY_RUN")?.value
+        assertTrue("Beta Build chain must pass down reverse.dep.*.env.IS_NIGHTLY_RUN parameter", isNightlyParam == "true")
+    }
 }


### PR DESCRIPTION
This PR updates the daily build jobs into a composite build that allows the auto-scheduler to effectively order, run and prioritise builds. It also opens the door to chain the Azure Dalek job to run post build, which will avoid timing challenges with that existing process.