### PR TITLE
`azurerm_storage_queue` - add a state migration for the `id` field

### DIFF
--- a/internal/services/storage/migration/storage_queue_v1_to_v2.go
+++ b/internal/services/storage/migration/storage_queue_v1_to_v2.go
@@ -1,0 +1,121 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package migration
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2025-08-01/storagequeues"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+var _ pluginsdk.StateUpgrade = StorageQueueV1ToV2{}
+
+type StorageQueueV1ToV2 struct{}
+
+func (StorageQueueV1ToV2) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+		},
+		"storage_account_id": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+		},
+		"metadata": {
+			Type:     pluginsdk.TypeMap,
+			Optional: true,
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+			},
+		},
+		"url": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+	}
+}
+
+func (StorageQueueV1ToV2) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		oldID, ok := rawState["id"].(string)
+		if !ok {
+			return rawState, fmt.Errorf("expected `id` to be of type string, got %T", rawState["id"])
+		}
+
+		// Some instances of this resource may already be using the resource manager ID, in which case this is a no-op
+		if _, err := storagequeues.ParseQueueID(oldID); err == nil {
+			return rawState, nil
+		}
+
+		findAccount := false
+		resourceManagerID, ok := rawState["resource_manager_id"].(string)
+		if !ok {
+			findAccount = true
+		}
+
+		storageAccountID := commonids.StorageAccountId{}
+		if !findAccount {
+			parsed, err := parse.StorageQueueResourceManagerID(resourceManagerID)
+			if err != nil {
+				return rawState, err
+			}
+			storageAccountID = commonids.NewStorageAccountID(parsed.SubscriptionId, parsed.ResourceGroup, parsed.StorageAccountName)
+		}
+
+		if findAccount {
+			// `resource_manager_id` was introduced in v3.39.0
+			// The find account logic is only here for edge cases where users upgrade from < v3.39.0 directly to >= 5.0.0
+			client := meta.(*clients.Client).Storage
+			subscriptionID := meta.(*clients.Client).Account.SubscriptionId
+
+			storageAccountNameRaw, ok := rawState["storage_account_name"]
+			if !ok {
+				return rawState, errors.New("expected a `storage_account_name` attribute to be present in state")
+			}
+
+			storageAccountName, ok := storageAccountNameRaw.(string)
+			if !ok {
+				return rawState, fmt.Errorf("expected a `storage_account_name` to be of type string, got %T", storageAccountNameRaw)
+			}
+
+			// This may seem like an excessive timeout, however, populating the accounts via the list API could take a significant amount of time
+			// when the subscription contains a large number of accounts and the account cache is not already populated.
+			findCtx, cancel := context.WithTimeout(ctx, 1*time.Hour)
+			defer cancel()
+
+			log.Printf("[DEBUG] searching for storage account by name (`%s`) in subscription (%s)", storageAccountName, subscriptionID)
+			account, err := client.FindAccount(findCtx, subscriptionID, storageAccountName)
+			if err != nil || account == nil {
+				return rawState, fmt.Errorf("locating a storage account by name (`%s`) in subscription (%s): %w", storageAccountName, subscriptionID, err)
+			}
+
+			storageAccountID = account.StorageAccountId
+		}
+
+		nameRaw, ok := rawState["name"]
+		if !ok {
+			return rawState, errors.New("expected a `name` attribute to be present")
+		}
+
+		name, ok := nameRaw.(string)
+		if !ok {
+			return rawState, fmt.Errorf("expected a `name` to be of type string, got %T", nameRaw)
+		}
+
+		rawState["id"] = storagequeues.NewQueueID(storageAccountID.SubscriptionId, storageAccountID.ResourceGroupName, storageAccountID.StorageAccountName, name).ID()
+		rawState["storage_account_id"] = storageAccountID.ID()
+		rawState["storage_account_name"] = nil
+
+		return rawState, nil
+	}
+}

--- a/internal/services/storage/migration/storage_queue_v1_to_v2.go
+++ b/internal/services/storage/migration/storage_queue_v1_to_v2.go
@@ -85,7 +85,7 @@ func (StorageQueueV1ToV2) UpgradeFunc() pluginsdk.StateUpgraderFunc {
 
 			storageAccountName, ok := storageAccountNameRaw.(string)
 			if !ok {
-				return rawState, fmt.Errorf("expected a `storage_account_name` to be of type string, got %T", storageAccountNameRaw)
+				return rawState, fmt.Errorf("expected `storage_account_name` to be of type string, got %T", storageAccountNameRaw)
 			}
 
 			// This may seem like an excessive timeout, however, populating the accounts via the list API could take a significant amount of time
@@ -93,7 +93,7 @@ func (StorageQueueV1ToV2) UpgradeFunc() pluginsdk.StateUpgraderFunc {
 			findCtx, cancel := context.WithTimeout(ctx, 1*time.Hour)
 			defer cancel()
 
-			log.Printf("[DEBUG] searching for storage account by name (`%s`) in subscription (`%s`)", storageAccountName, subscriptionID)
+			log.Printf("[DEBUG] searching for a storage account by name (`%s`) in subscription (`%s`)", storageAccountName, subscriptionID)
 			account, err := client.FindAccount(findCtx, subscriptionID, storageAccountName)
 			if err != nil || account == nil {
 				return rawState, fmt.Errorf("locating a storage account by name (`%s`) in subscription (`%s`): %w", storageAccountName, subscriptionID, err)
@@ -109,12 +109,12 @@ func (StorageQueueV1ToV2) UpgradeFunc() pluginsdk.StateUpgraderFunc {
 
 		name, ok := nameRaw.(string)
 		if !ok {
-			return rawState, fmt.Errorf("expected a `name` to be of type string, got %T", nameRaw)
+			return rawState, fmt.Errorf("expected `name` to be of type string, got %T", nameRaw)
 		}
 
 		rawState["id"] = storagequeues.NewQueueID(storageAccountID.SubscriptionId, storageAccountID.ResourceGroupName, storageAccountID.StorageAccountName, name).ID()
 		rawState["storage_account_id"] = storageAccountID.ID()
-		rawState["storage_account_name"] = nil
+		delete(rawState, "storage_account_name")
 
 		return rawState, nil
 	}

--- a/internal/services/storage/migration/storage_queue_v1_to_v2.go
+++ b/internal/services/storage/migration/storage_queue_v1_to_v2.go
@@ -93,10 +93,10 @@ func (StorageQueueV1ToV2) UpgradeFunc() pluginsdk.StateUpgraderFunc {
 			findCtx, cancel := context.WithTimeout(ctx, 1*time.Hour)
 			defer cancel()
 
-			log.Printf("[DEBUG] searching for storage account by name (`%s`) in subscription (%s)", storageAccountName, subscriptionID)
+			log.Printf("[DEBUG] searching for storage account by name (`%s`) in subscription (`%s`)", storageAccountName, subscriptionID)
 			account, err := client.FindAccount(findCtx, subscriptionID, storageAccountName)
 			if err != nil || account == nil {
-				return rawState, fmt.Errorf("locating a storage account by name (`%s`) in subscription (%s): %w", storageAccountName, subscriptionID, err)
+				return rawState, fmt.Errorf("locating a storage account by name (`%s`) in subscription (`%s`): %w", storageAccountName, subscriptionID, err)
 			}
 
 			storageAccountID = account.StorageAccountId

--- a/internal/services/storage/storage_queue_resource.go
+++ b/internal/services/storage/storage_queue_resource.go
@@ -48,9 +48,10 @@ func resourceStorageQueue() *pluginsdk.Resource {
 			return err
 		}),
 
-		SchemaVersion: 1,
+		SchemaVersion: 2,
 		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
 			0: migration.QueueV0ToV1{},
+			1: migration.StorageQueueV1ToV2{},
 		}),
 
 		Timeouts: &pluginsdk.ResourceTimeout{

--- a/internal/services/storage/storage_queue_resource_v1_to_v2_test.go
+++ b/internal/services/storage/storage_queue_resource_v1_to_v2_test.go
@@ -1,0 +1,66 @@
+package storage_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+)
+
+// TestAccStorageQueue_V1ToV2_4810 tests the regular migration path that uses `resource_manager_id`
+// It uses v4.81.0 as the setup version because it is the last release where the resource was fully functional.
+func TestAccStorageQueue_V1ToV2_4810(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_queue", "test")
+	r := StorageQueueResource{}
+
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicV1(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("id").HasValue(fmt.Sprintf("https://acctestacc%s.queue.core.windows.net/acctestmysamplequeue-%d", data.RandomString, data.RandomInteger)),
+			),
+		},
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("id").HasValue(fmt.Sprintf("/subscriptions/%[1]s/resourceGroups/acctestRG-%[2]d/providers/Microsoft.Storage/storageAccounts/acctestacc%[3]s/queueServices/default/queues/acctestmysamplequeue-%[2]d", data.Subscriptions.Primary, data.RandomInteger, data.RandomString)),
+			),
+		},
+	}, "4.81.0")
+}
+
+// TestAccStorageQueue_V1ToV2_3380 tests the fallback `FindAccount` path of the state migration
+// It uses v3.38.0 as the setup version because `resource_manager_id` was introduced in v3.39.0.
+func TestAccStorageQueue_V1ToV2_3380(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_queue", "test")
+	r := StorageQueueResource{}
+
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicV1(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("id").HasValue(fmt.Sprintf("https://acctestacc%s.queue.core.windows.net/acctestmysamplequeue-%d", data.RandomString, data.RandomInteger)),
+			),
+		},
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("id").HasValue(fmt.Sprintf("/subscriptions/%[1]s/resourceGroups/acctestRG-%[2]d/providers/Microsoft.Storage/storageAccounts/acctestacc%[3]s/queueServices/default/queues/acctestmysamplequeue-%[2]d", data.Subscriptions.Primary, data.RandomInteger, data.RandomString)),
+			),
+		},
+	}, "3.38.0")
+}
+
+func (r StorageQueueResource) basicV1(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_storage_queue" "test" {
+  name                 = "acctestmysamplequeue-%d"
+  storage_account_name = azurerm_storage_account.test.name
+}
+`, r.template(data), data.RandomInteger)
+}


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Fixes the upgrade path from <5.0.0 to 5.0.0 for `azurerm_storage_queue`.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [x] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.

State migration evidence below for these scenarios:
- <3.39 to > 5.0.0+ dev-build
- 4.x to > 5.0.0+ dev-build


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


### State Migration - v3.38.0 -> dev build

<details>
<summary>manual migration steps</summary>

```
➜ tf version
Terraform v1.15.2
on darwin_arm64
+ provider registry.terraform.io/hashicorp/azuread v3.9.0
+ provider registry.terraform.io/hashicorp/azurerm v3.38.0

Your version of Terraform is out of date! The latest version
is 1.15.8. You can update by downloading from https://developer.hashicorp.com/terraform/install

➜ tfa
data.azurerm_client_config.current: Reading...
azurerm_resource_group.test: Refreshing state... [id=/subscriptions/{subscriptionID}/resourceGroups/mattdev6]
data.azurerm_client_config.current: Read complete after 0s [id={clientConfigID}]

Terraform used the selected providers to generate the following execution plan. Resource actions are
indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # azurerm_storage_queue.example will be created
  + resource "azurerm_storage_queue" "example" {
      + id                   = (known after apply)
      + name                 = "examplequeue"
      + storage_account_name = "mpexamplestorageacc0729"
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

azurerm_storage_queue.example: Creating...
azurerm_storage_queue.example: Creation complete after 3s [id=https://mpexamplestorageacc0729.queue.core.windows.net/examplequeue]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
➜ tf state show azurerm_storage_queue.example
# azurerm_storage_queue.example:
resource "azurerm_storage_queue" "example" {
    id                   = "https://mpexamplestorageacc0729.queue.core.windows.net/examplequeue"
    name                 = "examplequeue"
    storage_account_name = "mpexamplestorageacc0729"
}

➜ tfa
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - hashicorp/azurerm in ~/go/1.26.5/bin
│
│ The behavior may therefore not match any released version of the provider and applying changes may
│ cause the state to become incompatible with published releases.
╵
data.azurerm_client_config.current: Reading...
azurerm_resource_group.test: Refreshing state... [id=/subscriptions/{subscriptionID}/resourceGroups/mattdev6]
data.azurerm_client_config.current: Read complete after 0s [id={clientConfigID}]
azurerm_storage_queue.example: Refreshing state... [id=/subscriptions/{subscriptionID}/resourceGroups/mattdev6/providers/Microsoft.Storage/storageAccounts/mpexamplestorageacc0729/queueServices/default/queues/examplequeue]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences,
so no changes are needed.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
➜ tf state show azurerm_storage_queue.example
# azurerm_storage_queue.example:
resource "azurerm_storage_queue" "example" {
    id                 = "/subscriptions/{subscriptionID}/resourceGroups/mattdev6/providers/Microsoft.Storage/storageAccounts/mpexamplestorageacc0729/queueServices/default/queues/examplequeue"
    metadata           = {}
    name               = "examplequeue"
    storage_account_id = "/subscriptions/{subscriptionID}/resourceGroups/mattdev6/providers/Microsoft.Storage/storageAccounts/mpexamplestorageacc0729"
    url                = "https://mpexamplestorageacc0729.queue.core.windows.net/examplequeue"
}
```

</details>

### State Migration - v4.81.0 -> dev build

<details>
<summary>manual migration steps</summary>

```
➜ tf version
Terraform v1.15.2
on darwin_arm64
+ provider registry.terraform.io/hashicorp/azuread v3.9.0
+ provider registry.terraform.io/hashicorp/azurerm v4.81.0

Your version of Terraform is out of date! The latest version
is 1.15.8. You can update by downloading from https://developer.hashicorp.com/terraform/install
➜ tfa
data.azurerm_client_config.current: Reading...
azurerm_resource_group.test: Refreshing state... [id=/subscriptions/{subscriptionID}/resourceGroups/mattdev6]
data.azurerm_client_config.current: Read complete after 0s [id={clientConfigID}]

Terraform used the selected providers to generate the following execution plan. Resource actions are
indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # azurerm_storage_queue.example will be created
  + resource "azurerm_storage_queue" "example" {
      + id                   = (known after apply)
      + name                 = "examplequeue"
      + resource_manager_id  = (known after apply)
      + storage_account_name = "mpexamplestorageacc0729"
      + url                  = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.
╷
│ Warning: Argument is deprecated
│
│   with azurerm_storage_queue.example,
│   on main.tf line 89, in resource "azurerm_storage_queue" "example":
│   89:   storage_account_name = "mpexamplestorageacc0729" // azurerm_storage_account.example.name
│
│ the `storage_account_name` property has been deprecated in favour of `storage_account_id` and will
│ be removed in version 5.0 of the Provider.
│
│ (and one more similar warning elsewhere)
╵

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

azurerm_storage_queue.example: Creating...
azurerm_storage_queue.example: Creation complete after 4s [id=https://mpexamplestorageacc0729.queue.core.windows.net/examplequeue]
╷
│ Warning: Argument is deprecated
│
│   with azurerm_storage_queue.example,
│   on main.tf line 89, in resource "azurerm_storage_queue" "example":
│   89:   storage_account_name = "mpexamplestorageacc0729" // azurerm_storage_account.example.name
│
│ the `storage_account_name` property has been deprecated in favour of `storage_account_id` and will
│ be removed in version 5.0 of the Provider.
╵

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
➜ tf state show azurerm_storage_queue.example
# azurerm_storage_queue.example:
resource "azurerm_storage_queue" "example" {
    id                   = "https://mpexamplestorageacc0729.queue.core.windows.net/examplequeue"
    name                 = "examplequeue"
    resource_manager_id  = "/subscriptions/{subscriptionID}/resourceGroups/mattdev6/providers/Microsoft.Storage/storageAccounts/mpexamplestorageacc0729/queueServices/default/queues/examplequeue"
    storage_account_name = "mpexamplestorageacc0729"
    url                  = "https://mpexamplestorageacc0729.queue.core.windows.net/examplequeue"
}
➜ tfa
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - hashicorp/azurerm in ~/go/1.26.5/bin
│
│ The behavior may therefore not match any released version of the provider and applying changes may
│ cause the state to become incompatible with published releases.
╵
data.azurerm_client_config.current: Reading...
azurerm_resource_group.test: Refreshing state... [id=/subscriptions/{subscriptionID}/resourceGroups/mattdev6]
azurerm_storage_queue.example: Refreshing state... [id=/subscriptions/{subscriptionID}/resourceGroups/mattdev6/providers/Microsoft.Storage/storageAccounts/mpexamplestorageacc0729/queueServices/default/queues/examplequeue]
data.azurerm_client_config.current: Read complete after 0s [id={clientConfigID}]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences,
so no changes are needed.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
➜ tf state show azurerm_storage_queue.example
# azurerm_storage_queue.example:
resource "azurerm_storage_queue" "example" {
    id                 = "/subscriptions/{subscriptionID}/resourceGroups/mattdev6/providers/Microsoft.Storage/storageAccounts/mpexamplestorageacc0729/queueServices/default/queues/examplequeue"
    metadata           = {}
    name               = "examplequeue"
    storage_account_id = "/subscriptions/{subscriptionID}/resourceGroups/mattdev6/providers/Microsoft.Storage/storageAccounts/mpexamplestorageacc0729"
    url                = "https://mpexamplestorageacc0729.queue.core.windows.net/examplequeue"
}
```

</details>

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #32903


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
