### PR TITLE
Fix Kusto name validation error messages citing the wrong length bound

### DIFF
--- a/internal/services/kusto/validate/cluster_principal_assignment_name.go
+++ b/internal/services/kusto/validate/cluster_principal_assignment_name.go
@@ -20,7 +20,7 @@ func ClusterPrincipalAssignmentName(v interface{}, k string) (warnings []string,
 	}
 
 	if len(name) > 260 {
-		errors = append(errors, fmt.Errorf("%q must be (inclusive) between 4 and 22 characters long but is %d", k, len(name)))
+		errors = append(errors, fmt.Errorf("%q must be (inclusive) between 1 and 260 characters long but is %d", k, len(name)))
 	}
 
 	return warnings, errors

--- a/internal/services/kusto/validate/name.go
+++ b/internal/services/kusto/validate/name.go
@@ -70,7 +70,7 @@ func DatabaseName(v interface{}, k string) (warnings []string, errors []error) {
 	}
 
 	if len(name) > 260 {
-		errors = append(errors, fmt.Errorf("%q must be (inclusive) between 4 and 22 characters long but is %d", k, len(name)))
+		errors = append(errors, fmt.Errorf("%q must be (inclusive) between 1 and 260 characters long but is %d", k, len(name)))
 	}
 
 	return warnings, errors
@@ -88,7 +88,7 @@ func DatabasePrincipalAssignmentName(v interface{}, k string) (warnings []string
 	}
 
 	if len(name) > 260 {
-		errors = append(errors, fmt.Errorf("%q must be (inclusive) between 4 and 22 characters long but is %d", k, len(name)))
+		errors = append(errors, fmt.Errorf("%q must be (inclusive) between 1 and 260 characters long but is %d", k, len(name)))
 	}
 
 	return warnings, errors

--- a/internal/services/kusto/validate/name_test.go
+++ b/internal/services/kusto/validate/name_test.go
@@ -1,0 +1,60 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package validate
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDatabaseName(t *testing.T) {
+	cases := []struct {
+		Name  string
+		Input string
+		Valid bool
+	}{
+		{Name: "simple", Input: "my-database", Valid: true},
+		{Name: "short", Input: "ab", Valid: true},
+		{Name: "at max length", Input: strings.Repeat("a", 260), Valid: true},
+		{Name: "too long", Input: strings.Repeat("a", 261), Valid: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			_, errs := DatabaseName(tc.Input, "name")
+			if (len(errs) == 0) != tc.Valid {
+				t.Fatalf("expected valid=%t for %q but got errors: %v", tc.Valid, tc.Input, errs)
+			}
+			for _, err := range errs {
+				if strings.Contains(err.Error(), "between 4 and 22") {
+					t.Fatalf("error message cites the wrong length bound: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestDatabasePrincipalAssignmentName(t *testing.T) {
+	_, errs := DatabasePrincipalAssignmentName(strings.Repeat("a", 261), "name")
+	if len(errs) == 0 {
+		t.Fatal("expected an error for a name longer than 260 characters")
+	}
+	for _, err := range errs {
+		if strings.Contains(err.Error(), "between 4 and 22") {
+			t.Fatalf("error message cites the wrong length bound: %v", err)
+		}
+	}
+}
+
+func TestClusterPrincipalAssignmentName(t *testing.T) {
+	_, errs := ClusterPrincipalAssignmentName(strings.Repeat("a", 261), "name")
+	if len(errs) == 0 {
+		t.Fatal("expected an error for a name longer than 260 characters")
+	}
+	for _, err := range errs {
+		if strings.Contains(err.Error(), "between 4 and 22") {
+			t.Fatalf("error message cites the wrong length bound: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
### Bug

Three Kusto name validators enforce a 260-character maximum but return an error message copy-pasted from `ClusterName`, telling the user the limit is "between 4 and 22 characters":

- `DatabaseName` (`internal/services/kusto/validate/name.go`) — checks `len(name) > 260`, message says `must be (inclusive) between 4 and 22 characters long`
- `DatabasePrincipalAssignmentName` (same file) — same
- `ClusterPrincipalAssignmentName` (`internal/services/kusto/validate/cluster_principal_assignment_name.go`) — same

A user who supplies a valid 30-character database name gets no error, but a 261-character name is rejected with *"must be between 4 and 22 characters long but is 261"* — which is doubly wrong: the real maximum is 260, and no 4-character minimum is enforced (`DatabaseName("ab")` is accepted). `ClusterName` (the correct sibling) genuinely checks `len < 4 || len > 22` and its "4 and 22" message is right — these three kept that message after changing the bound to 260.

### Fix

Correct the three messages to "between 1 and 260 characters" to match the enforced bound (mirroring the existing `DataConnectionName` / `EntityName` "between 1 and N" style in the same file). No behavior change — only the error text.

### Test

This PR is structured as two commits so the failure is visible in CI:
- **Commit 1** adds `name_test.go` asserting the messages do not cite the wrong "4 and 22" bound — it fails against the current code.
- **Commit 2** applies the message fix — CI then passes.

Unit-only, no Azure credentials required.
