### PR TITLE
`azurerm_application_gateway` - support for the `header_value_matcher` block in `response_header_configuration`

### DIFF
--- a/internal/services/network/application_gateway_data_source.go
+++ b/internal/services/network/application_gateway_data_source.go
@@ -1073,6 +1073,26 @@ func dataSourceApplicationGateway() *pluginsdk.Resource {
 													Type:     pluginsdk.TypeString,
 													Computed: true,
 												},
+												"header_value_matcher": {
+													Type:     pluginsdk.TypeList,
+													Computed: true,
+													Elem: &pluginsdk.Resource{
+														Schema: map[string]*pluginsdk.Schema{
+															"pattern": {
+																Type:     pluginsdk.TypeString,
+																Computed: true,
+															},
+															"ignore_case": {
+																Type:     pluginsdk.TypeBool,
+																Computed: true,
+															},
+															"negate": {
+																Type:     pluginsdk.TypeBool,
+																Computed: true,
+															},
+														},
+													},
+												},
 											},
 										},
 									},

--- a/internal/services/network/application_gateway_resource.go
+++ b/internal/services/network/application_gateway_resource.go
@@ -1310,6 +1310,30 @@ func resourceApplicationGateway() *pluginsdk.Resource {
 													Type:     pluginsdk.TypeString,
 													Required: true,
 												},
+												"header_value_matcher": {
+													Type:     pluginsdk.TypeList,
+													Optional: true,
+													MaxItems: 1,
+													Elem: &pluginsdk.Resource{
+														Schema: map[string]*pluginsdk.Schema{
+															"pattern": {
+																Type:         pluginsdk.TypeString,
+																Required:     true,
+																ValidateFunc: validation.StringIsNotEmpty,
+															},
+															"ignore_case": {
+																Type:     pluginsdk.TypeBool,
+																Optional: true,
+																Default:  false,
+															},
+															"negate": {
+																Type:     pluginsdk.TypeBool,
+																Optional: true,
+																Default:  false,
+															},
+														},
+													},
+												},
 											},
 										},
 									},
@@ -4009,6 +4033,18 @@ func expandApplicationGatewayRewriteRuleSets(d *pluginsdk.ResourceData) (*[]appl
 					HeaderName:  pointer.To(c["header_name"].(string)),
 					HeaderValue: pointer.To(c["header_value"].(string)),
 				}
+				if matchers := c["header_value_matcher"].([]interface{}); len(matchers) > 0 {
+					m := matchers[0].(map[string]interface{})
+					negate := m["negate"].(bool)
+					if negate && strings.Contains(c["header_value"].(string), "{capt_header_value_matcher_") {
+						return nil, fmt.Errorf("`header_value` cannot reference `header_value_matcher` capture variables (`{capt_header_value_matcher_N}`) when `header_value_matcher.negate` is set to `true`")
+					}
+					config.HeaderValueMatcher = &applicationgateways.HeaderValueMatcher{
+						Pattern:    pointer.To(m["pattern"].(string)),
+						IgnoreCase: pointer.To(m["ignore_case"].(bool)),
+						Negate:     pointer.To(negate),
+					}
+				}
 				responseConfigurations = append(responseConfigurations, config)
 			}
 
@@ -4148,6 +4184,16 @@ func flattenApplicationGatewayRewriteRuleSets(input *[]applicationgateways.Appli
 								if config.HeaderValue != nil {
 									responseConfig["header_value"] = *config.HeaderValue
 								}
+
+								matchers := make([]interface{}, 0)
+								if m := config.HeaderValueMatcher; m != nil && pointer.From(m.Pattern) != "" {
+									matchers = append(matchers, map[string]interface{}{
+										"pattern":     pointer.From(m.Pattern),
+										"ignore_case": pointer.From(m.IgnoreCase),
+										"negate":      pointer.From(m.Negate),
+									})
+								}
+								responseConfig["header_value_matcher"] = matchers
 
 								responseConfigs = append(responseConfigs, responseConfig)
 							}

--- a/internal/services/network/application_gateway_resource_test.go
+++ b/internal/services/network/application_gateway_resource_test.go
@@ -412,6 +412,57 @@ func TestAccApplicationGateway_rewriteRuleSets_backend(t *testing.T) {
 	})
 }
 
+func TestAccApplicationGateway_rewriteRuleSets_responseHeaderValueMatcher(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_application_gateway", "test")
+	r := ApplicationGatewayResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.rewriteRuleSets_responseHeaderValueMatcher(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("rewrite_rule_set.0.name").Exists(),
+				check.That(data.ResourceName).Key("rewrite_rule_set.0.rewrite_rule.0.response_header_configuration.0.header_value_matcher.0.pattern").HasValue("^(.*)Domain=foo.com(.*)$"),
+				check.That(data.ResourceName).Key("rewrite_rule_set.0.rewrite_rule.0.response_header_configuration.0.header_value_matcher.0.ignore_case").HasValue("true"),
+				check.That(data.ResourceName).Key("rewrite_rule_set.0.rewrite_rule.0.response_header_configuration.0.header_value_matcher.0.negate").HasValue("false"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.rewriteRuleSets_responseHeaderValueMatcherUpdate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("rewrite_rule_set.0.name").Exists(),
+				check.That(data.ResourceName).Key("rewrite_rule_set.0.rewrite_rule.0.response_header_configuration.0.header_value_matcher.0.pattern").HasValue("^(.*)Domain=updated.foo.com(.*)$"),
+				check.That(data.ResourceName).Key("rewrite_rule_set.0.rewrite_rule.0.response_header_configuration.0.header_value_matcher.0.ignore_case").HasValue("false"),
+				check.That(data.ResourceName).Key("rewrite_rule_set.0.rewrite_rule.0.response_header_configuration.0.header_value_matcher.0.negate").HasValue("true"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.rewriteRuleSets_backend(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("rewrite_rule_set.0.name").Exists(),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.rewriteRuleSets_responseHeaderValueMatcherDefaults(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("rewrite_rule_set.0.rewrite_rule.0.response_header_configuration.#").HasValue("2"),
+				check.That(data.ResourceName).Key("rewrite_rule_set.0.rewrite_rule.0.response_header_configuration.0.header_value_matcher.0.pattern").HasValue("^(.*)Domain=foo.com(.*)$"),
+				check.That(data.ResourceName).Key("rewrite_rule_set.0.rewrite_rule.0.response_header_configuration.0.header_value_matcher.0.ignore_case").HasValue("false"),
+				check.That(data.ResourceName).Key("rewrite_rule_set.0.rewrite_rule.0.response_header_configuration.0.header_value_matcher.0.negate").HasValue("false"),
+				check.That(data.ResourceName).Key("rewrite_rule_set.0.rewrite_rule.0.response_header_configuration.1.header_value_matcher.#").HasValue("0"),
+				check.That("data.azurerm_application_gateway.test").Key("rewrite_rule_set.0.rewrite_rule.0.response_header_configuration.0.header_value_matcher.0.pattern").HasValue("^(.*)Domain=foo.com(.*)$"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccApplicationGateway_rewriteRuleSets_redirect(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_application_gateway", "test")
 	r := ApplicationGatewayResource{}
@@ -6693,6 +6744,323 @@ resource "azurerm_application_gateway" "test" {
       request_header_configuration {
         header_name  = "X-custom"
         header_value = "customvalue"
+      }
+    }
+  }
+}
+`, r.template(data), data.RandomInteger, data.RandomInteger)
+}
+
+func (r ApplicationGatewayResource) rewriteRuleSets_responseHeaderValueMatcher(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+# since these variables are re-used - a locals block makes this more maintainable
+locals {
+  backend_address_pool_name      = "${azurerm_virtual_network.test.name}-beap"
+  frontend_port_name             = "${azurerm_virtual_network.test.name}-feport"
+  frontend_ip_configuration_name = "${azurerm_virtual_network.test.name}-feip"
+  http_setting_name              = "${azurerm_virtual_network.test.name}-be-htst"
+  listener_name                  = "${azurerm_virtual_network.test.name}-httplstn"
+  request_routing_rule_name      = "${azurerm_virtual_network.test.name}-rqrt"
+  rewrite_rule_set_name          = "${azurerm_virtual_network.test.name}-rwset"
+  rewrite_rule_name              = "${azurerm_virtual_network.test.name}-rwrule"
+}
+
+resource "azurerm_public_ip" "test_standard" {
+  name                = "acctest-pubip-%d-standard"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Standard"
+  allocation_method   = "Static"
+}
+
+resource "azurerm_application_gateway" "test" {
+  name                = "acctestag-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  sku {
+    name     = "Standard_v2"
+    tier     = "Standard_v2"
+    capacity = 2
+  }
+
+  gateway_ip_configuration {
+    name      = "my-gateway-ip-configuration"
+    subnet_id = azurerm_subnet.test.id
+  }
+
+  frontend_port {
+    name = local.frontend_port_name
+    port = 80
+  }
+
+  frontend_ip_configuration {
+    name                 = local.frontend_ip_configuration_name
+    public_ip_address_id = azurerm_public_ip.test_standard.id
+  }
+
+  backend_address_pool {
+    name  = local.backend_address_pool_name
+    fqdns = ["foo.com", "bar.com"]
+  }
+
+  backend_http_settings {
+    name                  = local.http_setting_name
+    cookie_based_affinity = "Disabled"
+    port                  = 80
+    protocol              = "Http"
+    request_timeout       = 1
+  }
+
+  http_listener {
+    name                           = local.listener_name
+    frontend_ip_configuration_name = local.frontend_ip_configuration_name
+    frontend_port_name             = local.frontend_port_name
+    protocol                       = "Http"
+  }
+
+  request_routing_rule {
+    name                       = local.request_routing_rule_name
+    rule_type                  = "Basic"
+    http_listener_name         = local.listener_name
+    backend_address_pool_name  = local.backend_address_pool_name
+    backend_http_settings_name = local.http_setting_name
+    rewrite_rule_set_name      = local.rewrite_rule_set_name
+    priority                   = 10
+  }
+
+  rewrite_rule_set {
+    name = local.rewrite_rule_set_name
+
+    rewrite_rule {
+      name          = local.rewrite_rule_name
+      rule_sequence = 1
+
+      response_header_configuration {
+        header_name  = "Set-Cookie"
+        header_value = "{capt_header_value_matcher_1}Domain=bar.com{capt_header_value_matcher_2}"
+
+        header_value_matcher {
+          pattern     = "^(.*)Domain=foo.com(.*)$"
+          ignore_case = true
+          negate      = false
+        }
+      }
+    }
+  }
+}
+`, r.template(data), data.RandomInteger, data.RandomInteger)
+}
+
+func (r ApplicationGatewayResource) rewriteRuleSets_responseHeaderValueMatcherDefaults(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+# since these variables are re-used - a locals block makes this more maintainable
+locals {
+  backend_address_pool_name      = "${azurerm_virtual_network.test.name}-beap"
+  frontend_port_name             = "${azurerm_virtual_network.test.name}-feport"
+  frontend_ip_configuration_name = "${azurerm_virtual_network.test.name}-feip"
+  http_setting_name              = "${azurerm_virtual_network.test.name}-be-htst"
+  listener_name                  = "${azurerm_virtual_network.test.name}-httplstn"
+  request_routing_rule_name      = "${azurerm_virtual_network.test.name}-rqrt"
+  rewrite_rule_set_name          = "${azurerm_virtual_network.test.name}-rwset"
+  rewrite_rule_name              = "${azurerm_virtual_network.test.name}-rwrule"
+}
+
+resource "azurerm_public_ip" "test_standard" {
+  name                = "acctest-pubip-%d-standard"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Standard"
+  allocation_method   = "Static"
+}
+
+resource "azurerm_application_gateway" "test" {
+  name                = "acctestag-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  sku {
+    name     = "Standard_v2"
+    tier     = "Standard_v2"
+    capacity = 2
+  }
+
+  gateway_ip_configuration {
+    name      = "my-gateway-ip-configuration"
+    subnet_id = azurerm_subnet.test.id
+  }
+
+  frontend_port {
+    name = local.frontend_port_name
+    port = 80
+  }
+
+  frontend_ip_configuration {
+    name                 = local.frontend_ip_configuration_name
+    public_ip_address_id = azurerm_public_ip.test_standard.id
+  }
+
+  backend_address_pool {
+    name  = local.backend_address_pool_name
+    fqdns = ["foo.com", "bar.com"]
+  }
+
+  backend_http_settings {
+    name                  = local.http_setting_name
+    cookie_based_affinity = "Disabled"
+    port                  = 80
+    protocol              = "Http"
+    request_timeout       = 1
+  }
+
+  http_listener {
+    name                           = local.listener_name
+    frontend_ip_configuration_name = local.frontend_ip_configuration_name
+    frontend_port_name             = local.frontend_port_name
+    protocol                       = "Http"
+  }
+
+  request_routing_rule {
+    name                       = local.request_routing_rule_name
+    rule_type                  = "Basic"
+    http_listener_name         = local.listener_name
+    backend_address_pool_name  = local.backend_address_pool_name
+    backend_http_settings_name = local.http_setting_name
+    rewrite_rule_set_name      = local.rewrite_rule_set_name
+    priority                   = 10
+  }
+
+  rewrite_rule_set {
+    name = local.rewrite_rule_set_name
+
+    rewrite_rule {
+      name          = local.rewrite_rule_name
+      rule_sequence = 1
+
+      response_header_configuration {
+        header_name  = "Set-Cookie"
+        header_value = "{capt_header_value_matcher_1}Domain=bar.com{capt_header_value_matcher_2}"
+
+        header_value_matcher {
+          pattern = "^(.*)Domain=foo.com(.*)$"
+        }
+      }
+
+      response_header_configuration {
+        header_name  = "X-Custom"
+        header_value = "customvalue"
+      }
+    }
+  }
+}
+
+data "azurerm_application_gateway" "test" {
+  name                = azurerm_application_gateway.test.name
+  resource_group_name = azurerm_application_gateway.test.resource_group_name
+}
+`, r.template(data), data.RandomInteger, data.RandomInteger)
+}
+
+func (r ApplicationGatewayResource) rewriteRuleSets_responseHeaderValueMatcherUpdate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+# since these variables are re-used - a locals block makes this more maintainable
+locals {
+  backend_address_pool_name      = "${azurerm_virtual_network.test.name}-beap"
+  frontend_port_name             = "${azurerm_virtual_network.test.name}-feport"
+  frontend_ip_configuration_name = "${azurerm_virtual_network.test.name}-feip"
+  http_setting_name              = "${azurerm_virtual_network.test.name}-be-htst"
+  listener_name                  = "${azurerm_virtual_network.test.name}-httplstn"
+  request_routing_rule_name      = "${azurerm_virtual_network.test.name}-rqrt"
+  rewrite_rule_set_name          = "${azurerm_virtual_network.test.name}-rwset"
+  rewrite_rule_name              = "${azurerm_virtual_network.test.name}-rwrule"
+}
+
+resource "azurerm_public_ip" "test_standard" {
+  name                = "acctest-pubip-%d-standard"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Standard"
+  allocation_method   = "Static"
+}
+
+resource "azurerm_application_gateway" "test" {
+  name                = "acctestag-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  sku {
+    name     = "Standard_v2"
+    tier     = "Standard_v2"
+    capacity = 2
+  }
+
+  gateway_ip_configuration {
+    name      = "my-gateway-ip-configuration"
+    subnet_id = azurerm_subnet.test.id
+  }
+
+  frontend_port {
+    name = local.frontend_port_name
+    port = 80
+  }
+
+  frontend_ip_configuration {
+    name                 = local.frontend_ip_configuration_name
+    public_ip_address_id = azurerm_public_ip.test_standard.id
+  }
+
+  backend_address_pool {
+    name  = local.backend_address_pool_name
+    fqdns = ["foo.com", "bar.com"]
+  }
+
+  backend_http_settings {
+    name                  = local.http_setting_name
+    cookie_based_affinity = "Disabled"
+    port                  = 80
+    protocol              = "Http"
+    request_timeout       = 1
+  }
+
+  http_listener {
+    name                           = local.listener_name
+    frontend_ip_configuration_name = local.frontend_ip_configuration_name
+    frontend_port_name             = local.frontend_port_name
+    protocol                       = "Http"
+  }
+
+  request_routing_rule {
+    name                       = local.request_routing_rule_name
+    rule_type                  = "Basic"
+    http_listener_name         = local.listener_name
+    backend_address_pool_name  = local.backend_address_pool_name
+    backend_http_settings_name = local.http_setting_name
+    rewrite_rule_set_name      = local.rewrite_rule_set_name
+    priority                   = 10
+  }
+
+  rewrite_rule_set {
+    name = local.rewrite_rule_set_name
+
+    rewrite_rule {
+      name          = local.rewrite_rule_name
+      rule_sequence = 1
+
+      response_header_configuration {
+        header_name  = "Set-Cookie"
+        header_value = "Domain=updated.bar.com"
+
+        header_value_matcher {
+          pattern     = "^(.*)Domain=updated.foo.com(.*)$"
+          ignore_case = false
+          negate      = true
+        }
       }
     }
   }

--- a/website/docs/d/application_gateway.html.markdown
+++ b/website/docs/d/application_gateway.html.markdown
@@ -689,6 +689,18 @@ A `response_header_configuration` block exports the following:
 
 * `header_value` - Header value of the header configuration.
 
+* `header_value_matcher` - A `header_value_matcher` block as defined below.
+
+---
+
+A `header_value_matcher` block exports the following:
+
+* `pattern` - The regular expression that evaluates the truthfulness of the header value match.
+
+* `ignore_case` - Whether a case insensitive comparison is performed.
+
+* `negate` - Whether the result of the pattern evaluation is negated.
+
 ---
 
 A `url` block exports the following:

--- a/website/docs/r/application_gateway.html.markdown
+++ b/website/docs/r/application_gateway.html.markdown
@@ -745,7 +745,23 @@ A `response_header_configuration` block supports the following:
 
 * `header_name` - (Required) Header name of the header configuration.
 
-* `header_value` - (Required) Header value of the header configuration. To delete a response header set this property to an empty string.
+* `header_value` - (Required) Header value of the header configuration. To delete a response header set this property to an empty string. When `header_value_matcher` is specified, the sub-strings captured by its `pattern` can be referenced with `{capt_header_value_matcher_1}`, `{capt_header_value_matcher_2}`, etc.
+
+* `header_value_matcher` - (Optional) A `header_value_matcher` block as defined below. This allows rewriting only the header values that match the given pattern, e.g. when multiple headers with the same name exist. [More info on header value matching](https://learn.microsoft.com/azure/application-gateway/rewrite-http-headers-url#pattern-matching-and-capturing)
+
+~> **Note:** `header_value_matcher` is currently only supported by Azure for the `Set-Cookie` response header.
+
+---
+
+A `header_value_matcher` block supports the following:
+
+* `pattern` - (Required) The regular expression that evaluates the truthfulness of the header value match.
+
+* `ignore_case` - (Optional) Perform a case in-sensitive comparison. Defaults to `false`.
+
+* `negate` - (Optional) Negate the result of the pattern evaluation. Defaults to `false`.
+
+~> **Note:** The `{capt_header_value_matcher_N}` capture variables cannot be referenced in `header_value` when `negate` is set to `true`.
 
 ---
 


### PR DESCRIPTION
## Community Note
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Azure Application Gateway supports an optional `HeaderValueMatcher` on rewrite rule header configurations. It allows a rewrite action to target one specific header value when multiple response headers with the same name exist — the primary use case being rewriting the `Domain` attribute of one of several `Set-Cookie` response headers, using capture group references (`{capt_header_value_matcher_N}`) in the rewritten value.

The provider currently drops this field in both expand and flatten, so it can neither be configured nor read. This PR adds:

* a new optional `header_value_matcher` block (`pattern`, `ignore_case`, `negate`) inside `response_header_configuration` of `rewrite_rule` in the `azurerm_application_gateway` resource
* the matching computed block in the `azurerm_application_gateway` data source (it shares the flatten function with the resource)
* plan-time validation rejecting the combination of `negate = true` with `{capt_header_value_matcher_N}` capture references in `header_value`, which the Azure API refuses (`ApplicationGatewayRewriteRuleSetActionSetHeaderValueMatcherCaptureVariableUseNotAllowedWithNegate`) — this surfaces a clear error instead of an opaque 400
* documentation for both resource and data source, including the capture-variable syntax and the API restriction that the matcher is currently only supported for the `Set-Cookie` response header

The scope is limited to `response_header_configuration`: per the Azure API documentation, `headerValueMatcher` is currently only supported for the `Set-Cookie` response header, so it is not added to `request_header_configuration`.

No SDK/vendoring changes required — `HeaderValueMatcher` already exists in the vendored `network/2025-01-01/applicationgateways` models.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.


## Testing

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

New acceptance test `TestAccApplicationGateway_rewriteRuleSets_responseHeaderValueMatcher` covering: create with matcher and capture variables, update of all matcher fields (including the `negate` path without capture variables), removal of the matcher, re-adding a minimal matcher relying on defaults, a mixed list of `response_header_configuration` blocks with and without a matcher, and a data source read of the new attribute — with an import step after every apply.

```
make acctests SERVICE='network' TESTARGS='-run=TestAccApplicationGateway_rewriteRuleSets_responseHeaderValueMatcher' TESTTIMEOUT='120m'
TF_ACC=1 go test -v ./internal/services/network -run=TestAccApplicationGateway_rewriteRuleSets_responseHeaderValueMatcher -timeout 120m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccApplicationGateway_rewriteRuleSets_responseHeaderValueMatcher
=== PAUSE TestAccApplicationGateway_rewriteRuleSets_responseHeaderValueMatcher
=== CONT  TestAccApplicationGateway_rewriteRuleSets_responseHeaderValueMatcher
--- PASS: TestAccApplicationGateway_rewriteRuleSets_responseHeaderValueMatcher (1077.75s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/network    1079.855s
```

The change was additionally verified with a successful terraform plan and apply cycle with manual testing and inspection with a locally built provider (dev overrides) against a real, existing Application Gateway deployment.

## Change Log

* `azurerm_application_gateway` - support for the `header_value_matcher` block in the `rewrite_rule_set.rewrite_rule.response_header_configuration` block [GH-00000]

This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #32820


## AI Assistance Disclosure

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

Code, acceptance tests, and documentation were written with the assistance of Claude Code (Anthropic), guided and reviewed by the author. Acceptance tests and the real-infrastructure verification were executed and validated by the author. Responses to review comments will be written by the author (possibly with AI assistance, which will be disclosed if used).

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

No. This change only adds an optional configuration block for HTTP response header rewriting in Application Gateway; no changes to access controls, encryption, or logging.