### PR TITLE
`azurerm_storage_table_entity` - add a state migration for `storage_table_id`

### DIFF
--- a/internal/services/storage/migration/storage_table_entity_v0_to_v1.go
+++ b/internal/services/storage/migration/storage_table_entity_v0_to_v1.go
@@ -1,0 +1,84 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package migration
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2025-06-01/tables"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	legacyTables "github.com/jackofallops/giovanni/storage/2023-11-03/table/tables"
+)
+
+var _ pluginsdk.StateUpgrade = StorageTableEntityV0ToV1{}
+
+type StorageTableEntityV0ToV1 struct{}
+
+func (StorageTableEntityV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"storage_table_id": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+		},
+
+		"partition_key": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+		},
+
+		"row_key": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+		},
+
+		"entity": {
+			Type:     pluginsdk.TypeMap,
+			Required: true,
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+			},
+		},
+	}
+}
+
+func (StorageTableEntityV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		rawStorageTableID, ok := rawState["storage_table_id"].(string)
+		if !ok {
+			return rawState, fmt.Errorf("expected `storage_table_id` to be of type string, got %T", rawState["storage_table_id"])
+		}
+
+		// Some instances of this resource may already be using the resource manager ID, in which case this is a no-op
+		if _, err := tables.ParseTableID(rawStorageTableID); err == nil {
+			return rawState, nil
+		}
+
+		client := meta.(*clients.Client).Storage
+		subscriptionID := meta.(*clients.Client).Account.SubscriptionId
+
+		legacyStorageTableID, err := legacyTables.ParseTableID(rawStorageTableID, client.StorageDomainSuffix)
+		if err != nil {
+			return rawState, err
+		}
+
+		// This may seem like an excessive timeout, however, populating the accounts via the list API could take a significant amount of time
+		// when the subscription contains a large number of accounts and the account cache is not already populated.
+		findCtx, cancel := context.WithTimeout(ctx, 1*time.Hour)
+		defer cancel()
+
+		log.Printf("[DEBUG] searching for a storage account by name (`%s`) in subscription (`%s`)", legacyStorageTableID.AccountId.AccountName, subscriptionID)
+		account, err := client.FindAccount(findCtx, subscriptionID, legacyStorageTableID.AccountId.AccountName)
+		if err != nil || account == nil {
+			return rawState, fmt.Errorf("locating a storage account by name (`%s`) in subscription (`%s`): %w", legacyStorageTableID.AccountId.AccountName, subscriptionID, err)
+		}
+
+		rawState["storage_table_id"] = tables.NewTableID(account.StorageAccountId.SubscriptionId, account.StorageAccountId.ResourceGroupName, account.StorageAccountId.StorageAccountName, legacyStorageTableID.TableName).ID()
+
+		return rawState, nil
+	}
+}

--- a/internal/services/storage/storage_table_entity_resource.go
+++ b/internal/services/storage/storage_table_entity_resource.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/client"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/helpers"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
@@ -41,6 +42,11 @@ func resourceStorageTableEntity() *pluginsdk.Resource {
 			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
+
+		SchemaVersion: 1,
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.StorageTableEntityV0ToV1{},
+		}),
 
 		Schema: map[string]*pluginsdk.Schema{
 			"storage_table_id": {

--- a/internal/services/storage/storage_table_entity_resource_v0_to_v1_test.go
+++ b/internal/services/storage/storage_table_entity_resource_v0_to_v1_test.go
@@ -1,0 +1,71 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package storage_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+)
+
+// TestAccStorageTableEntity_V0ToV1_4810 tests the migration from a data plane URL to a resource manager ID for `storage_table_id`
+// It uses v4.81.0 as the setup version because it is the last release where the data plane URL format was accepted.
+func TestAccStorageTableEntity_V0ToV1_4810(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_table_entity", "test")
+	r := StorageTableEntityResource{}
+
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicV0(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("storage_table_id").HasValue(fmt.Sprintf("https://acctestsa%s.table.core.windows.net/Tables('acctestst%d')", data.RandomString, data.RandomInteger)),
+			),
+		},
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("storage_table_id").HasValue(fmt.Sprintf("/subscriptions/%[1]s/resourceGroups/acctestRG-%[2]d/providers/Microsoft.Storage/storageAccounts/acctestsa%[3]s/tableServices/default/tables/acctestst%[2]d", data.Subscriptions.Primary, data.RandomInteger, data.RandomString)),
+			),
+		},
+	}, "4.81.0")
+}
+
+func (r StorageTableEntityResource) basicV0(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctestsa%[3]s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_storage_table" "test" {
+  name                 = "acctestst%[1]d"
+  storage_account_name = azurerm_storage_account.test.name
+}
+
+resource "azurerm_storage_table_entity" "test" {
+  storage_table_id = azurerm_storage_table.test.id
+
+  partition_key = "test_partition%[1]d"
+  row_key       = "test_row%[1]d"
+  entity = {
+    Foo = "Bar"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}


### PR DESCRIPTION

<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Adds a state migration that is required for users to be able to upgrade from 4.x (where `storage_table_id` may have a data plane ID) to 5.x


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [x] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Related to #32903


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
