### PR TITLE
`azurerm_recovery_service_replicated_vm` - fix `managed_disk` for dynamic block

### DIFF
--- a/internal/services/recoveryservices/site_recovery_replicated_vm_resource.go
+++ b/internal/services/recoveryservices/site_recovery_replicated_vm_resource.go
@@ -306,6 +306,13 @@ func resourceSiteRecoveryReplicatedVMCustomizeDiff(_ context.Context, diff *plug
 		return nil
 	}
 
+	managedDisks := rawConfig.GetAttr("managed_disk")
+	if diff.Id() == "" && !managedDisks.IsNull() && !managedDisks.IsWhollyKnown() {
+		if err := diff.SetNewComputed("managed_disk"); err != nil {
+			return fmt.Errorf("marking `managed_disk` as computed: %+v", err)
+		}
+	}
+
 	networkInterfaces := rawConfig.GetAttr("network_interface")
 	if !networkInterfaces.IsKnown() || networkInterfaces.IsNull() {
 		return nil

--- a/internal/services/recoveryservices/site_recovery_replicated_vm_resource_test.go
+++ b/internal/services/recoveryservices/site_recovery_replicated_vm_resource_test.go
@@ -35,6 +35,22 @@ func TestAccSiteRecoveryReplicatedVm_basic(t *testing.T) {
 	})
 }
 
+func TestAccSiteRecoveryReplicatedVm_managedDiskDynamicBlock(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_site_recovery_replicated_vm", "test")
+	r := SiteRecoveryReplicatedVmResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.managedDiskDynamicBlock(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("managed_disk.#").HasValue("3"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccSiteRecoveryReplicatedVm_withTFOSettings(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_site_recovery_replicated_vm", "test")
 	r := SiteRecoveryReplicatedVmResource{}
@@ -939,6 +955,76 @@ resource "azurerm_site_recovery_replicated_vm" "test" {
     target_resource_group_id   = azurerm_resource_group.test2.id
     target_disk_type           = "Premium_LRS"
     target_replica_disk_type   = "Premium_LRS"
+  }
+
+  depends_on = [
+    azurerm_site_recovery_protection_container_mapping.test,
+    azurerm_site_recovery_network_mapping.test,
+  ]
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r SiteRecoveryReplicatedVmResource) managedDiskDynamicBlock(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_managed_disk" "test" {
+  count = 2
+
+  name                 = "data-disk-%[2]d-${count.index}"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  storage_account_type = "Standard_LRS"
+  create_option        = "Empty"
+  disk_size_gb         = 10
+}
+
+resource "azurerm_virtual_machine_data_disk_attachment" "test" {
+  count = 2
+
+  managed_disk_id    = azurerm_managed_disk.test[count.index].id
+  virtual_machine_id = azurerm_virtual_machine.test.id
+  lun                = count.index
+  caching            = "None"
+}
+
+resource "terraform_data" "data_disk_ids" {
+  input      = azurerm_managed_disk.test[*].id
+  depends_on = [azurerm_virtual_machine_data_disk_attachment.test]
+}
+
+resource "azurerm_site_recovery_replicated_vm" "test" {
+  name                                      = "repl-%[2]d"
+  resource_group_name                       = azurerm_resource_group.test2.name
+  recovery_vault_name                       = azurerm_recovery_services_vault.test.name
+  source_vm_id                              = azurerm_virtual_machine.test.id
+  source_recovery_fabric_name               = azurerm_site_recovery_fabric.test1.name
+  recovery_replication_policy_id            = azurerm_site_recovery_replication_policy.test.id
+  source_recovery_protection_container_name = azurerm_site_recovery_protection_container.test1.name
+
+  target_resource_group_id                = azurerm_resource_group.test2.id
+  target_recovery_fabric_id               = azurerm_site_recovery_fabric.test2.id
+  target_recovery_protection_container_id = azurerm_site_recovery_protection_container.test2.id
+
+  managed_disk {
+    disk_id                    = azurerm_virtual_machine.test.storage_os_disk[0].managed_disk_id
+    staging_storage_account_id = azurerm_storage_account.test.id
+    target_resource_group_id   = azurerm_resource_group.test2.id
+    target_disk_type           = "Premium_LRS"
+    target_replica_disk_type   = "Premium_LRS"
+  }
+
+  dynamic "managed_disk" {
+    for_each = terraform_data.data_disk_ids.output
+
+    content {
+      disk_id                    = managed_disk.value
+      staging_storage_account_id = azurerm_storage_account.test.id
+      target_resource_group_id   = azurerm_resource_group.test2.id
+      target_disk_type           = "Standard_LRS"
+      target_replica_disk_type   = "Standard_LRS"
+    }
   }
 
   depends_on = [


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

when the `managed_disk` is a dynamic block, e.g.:
```
  dynamic "managed_disk" {
    for_each = terraform_data.deferred_data_disk_ids.output

    content {
      disk_id                    = managed_disk.value
      staging_storage_account_id = local.cache_storage_account_id
      target_resource_group_id   = local.target_resource_group_id
      target_disk_type           = "Premium_LRS"
      target_replica_disk_type   = "Premium_LRS"
    }
  }
```
and the source is only known during apply time
```
resource "terraform_data" "deferred_data_disk_ids" {
  input = [
    for key in sort(keys(azurerm_managed_disk.data)) : azurerm_managed_disk.data[key].id
  ]

  depends_on = [azurerm_virtual_machine_data_disk_attachment.data]
}
```
It will produce an error
```
│ Error: Provider produced inconsistent final plan
│
│ When expanding the plan for azurerm_site_recovery_replicated_vm.repro to include new values learned so far during apply,
│ provider "registry.terraform.io/hashicorp/azurerm" produced an invalid new value for .managed_disk: length changed from 2 to 3.
│
│ This is a bug in the provider, which should be reported in the provider's own issue tracker.
```
thus set this block to computed and retain the value at apply time.

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

```
in progress
```

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_recovery_service_replicated_vm` - fix `managed_disk` for dynamic block [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
