### PR TITLE
fix: normalize null/empty string for `secret.value` in container app secrets schema (#32923)

### DIFF
--- a/internal/services/containerapps/helpers/container_apps.go
+++ b/internal/services/containerapps/helpers/container_apps.go
@@ -2886,6 +2886,7 @@ func SecretsSchema() *pluginsdk.Schema {
 					Type:        pluginsdk.TypeString,
 					Optional:    true,
 					Sensitive:   true,
+					Default:     "",
 					Description: "The value for this secret.",
 				},
 			},

--- a/internal/services/containerapps/helpers/container_apps_test.go
+++ b/internal/services/containerapps/helpers/container_apps_test.go
@@ -5,6 +5,11 @@ package helpers
 
 import (
 	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerapps"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/jobs"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
 func TestValidateContainerAppRegistry(t *testing.T) {
@@ -65,5 +70,78 @@ func TestValidateContainerAppRegistry(t *testing.T) {
 		if tc.Valid != valid {
 			t.Fatalf("Expected %t but got %t for %s", tc.Valid, valid, tc.Input)
 		}
+	}
+}
+
+// TestFlattenContainerAppSecrets_keyVaultValueIsEmptyString verifies that a
+// Key Vault-backed secret is always flattened with value="" rather than a
+// non-empty string. This ensures the flattened state is consistent with the
+// schema Default:"" added to fix #32923 (null vs "" TypeSet hash mismatch).
+func TestFlattenContainerAppSecrets_keyVaultValueIsEmptyString(t *testing.T) {
+	input := &containerapps.SecretsCollection{
+		Value: []containerapps.ContainerAppSecret{
+			{
+				Name:        pointer.To("kv-secret"),
+				Identity:    pointer.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id"),
+				KeyVaultURL: pointer.To("https://example.vault.azure.net/secrets/my-secret"),
+				Value:       nil, // Azure never returns the value for KV-backed secrets
+			},
+		},
+	}
+
+	result := FlattenContainerAppSecrets(input)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 secret, got %d", len(result))
+	}
+
+	if result[0].Value != "" {
+		t.Errorf("expected value to be empty string for KV-backed secret, got %q", result[0].Value)
+	}
+}
+
+// TestFlattenContainerAppJobSecrets_keyVaultValueIsEmptyString is the same
+// check for azurerm_container_app_job (uses jobs.JobSecretsCollection).
+func TestFlattenContainerAppJobSecrets_keyVaultValueIsEmptyString(t *testing.T) {
+	input := &jobs.JobSecretsCollection{
+		Value: []jobs.Secret{
+			{
+				Name:        pointer.To("kv-secret"),
+				Identity:    pointer.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id"),
+				KeyVaultURL: pointer.To("https://example.vault.azure.net/secrets/my-secret"),
+				Value:       nil,
+			},
+		},
+	}
+
+	result := FlattenContainerAppJobSecrets(input)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 secret, got %d", len(result))
+	}
+
+	if result[0].Value != "" {
+		t.Errorf("expected value to be empty string for KV-backed secret, got %q", result[0].Value)
+	}
+}
+
+// TestSecretsSchema_valueDefaultIsEmptyString verifies that the schema default
+// for the value field is "" so that Terraform treats an omitted value the same
+// way the flatten functions do, preventing the TypeSet null/empty hash mismatch
+// described in #32923.
+func TestSecretsSchema_valueDefaultIsEmptyString(t *testing.T) {
+	s := SecretsSchema()
+	resource, ok := s.Elem.(*pluginsdk.Resource)
+	if !ok {
+		t.Fatal("expected Elem to be *pluginsdk.Resource")
+	}
+
+	valueSchema, ok := resource.Schema["value"]
+	if !ok {
+		t.Fatal("expected 'value' key in secret schema")
+	}
+
+	if valueSchema.Default != "" {
+		t.Errorf("expected Default to be empty string, got %v", valueSchema.Default)
 	}
 }


### PR DESCRIPTION
## Description

Fixes #32923

### Problem

When a `secret` block uses `key_vault_secret_id` and omits `value` (valid per the schema), the provider produces an "inconsistent final plan" error during apply-time re-expansion if any other `secret` element has an apply-time unknown value.
Root cause
The `value` field in `SecretsSchema()` is `Optional` with no default. When
`value` is omitted from config, Terraform's diff logic marks it as
`NewRemoved`, so the *planned* value becomes `null` — while the *state*
(saved from a prior apply) holds `""` (empty string).

Normally this mismatch is invisible: if nothing else in the set changed,
Terraform short-circuits the plan back to the prior state, hiding the
null-vs-empty-string difference. It only surfaces when the same set also
contains an apply-time unknown value elsewhere, which forces a real
(non-short-circuited) plan — so the raw `null` gets saved as-is. At apply
time, Terraform re-plans and this time *does* take the short-circuit,
producing `""`. Core then compares the plan-time `null` against the
apply-time `""` and fails with "inconsistent final plan."

(Thanks to @Vieran  for the precise trace through diffString/NewRemoved
and the short-circuit behavior — corrects an earlier, less accurate
explanation involving hash mismatches.)

Fix
Add Default: "" to the value field in SecretsSchema(). This makes
Terraform substitute "" for an omitted value at both plan and apply
time, so the two never diverge regardless of which code path triggers
the mismatch.

### Affected Resources

All three resources share `SecretsSchema()`:
- `azurerm_container_app_job`
- `azurerm_container_app`
- `azurerm_container_app_environment_dapr_component`