### PR TITLE
`r/network_interface_security_group_association`: consistently locking on the Name not the Resource ID

### DIFF
--- a/internal/services/network/network_interface_security_group_association_resource.go
+++ b/internal/services/network/network_interface_security_group_association_resource.go
@@ -66,16 +66,16 @@ func resourceNetworkInterfaceSecurityGroupAssociationCreate(d *pluginsdk.Resourc
 		return err
 	}
 
-	locks.ByID(nicId.ID())
-	defer locks.UnlockByID(nicId.ID())
+	locks.ByName(nicId.NetworkInterfaceName, networkInterfaceResourceName)
+	defer locks.UnlockByName(nicId.NetworkInterfaceName, networkInterfaceResourceName)
 
 	nsgId, err := networksecuritygroups.ParseNetworkSecurityGroupID(d.Get("network_security_group_id").(string))
 	if err != nil {
 		return err
 	}
 
-	locks.ByID(nsgId.ID())
-	defer locks.UnlockByID(nsgId.ID())
+	locks.ByName(nsgId.NetworkSecurityGroupName, networkSecurityGroupResourceName)
+	defer locks.UnlockByName(nsgId.NetworkSecurityGroupName, networkSecurityGroupResourceName)
 
 	read, err := client.Get(ctx, *nicId, networkinterfaces.DefaultGetOperationOptions())
 	if err != nil {
@@ -160,8 +160,8 @@ func resourceNetworkInterfaceSecurityGroupAssociationDelete(d *pluginsdk.Resourc
 		return err
 	}
 
-	locks.ByID(id.First.ID())
-	defer locks.UnlockByID(id.First.ID())
+	locks.ByName(id.First.NetworkInterfaceName, networkInterfaceResourceName)
+	defer locks.UnlockByName(id.First.NetworkInterfaceName, networkInterfaceResourceName)
 
 	read, err := client.Get(ctx, *id.First, networkinterfaces.DefaultGetOperationOptions())
 	if err != nil {


### PR DESCRIPTION

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This commit fixes a regression introduced in #32847 where the Resource Name is used for locking in most of the association resources, but the `azurerm_network_interface_security_group_association` resource uses a lock on the Resource ID and not the Resource Name, which means when you update the NIC in question, associating a Network Security Group knocks out any other changes.

Confirmation of the issue:

```
┌────────────────────────────────────────────┬─────────────────────────────────────────────────┬───────────────────────────────────────────┐
│                  Resource                  │                    Lock call                    │                 Mutex key                 │
├────────────────────────────────────────────┼─────────────────────────────────────────────────┼───────────────────────────────────────────┤
│ ..._security_group_association             │ locks.ByID(nicId.ID())                          │ /subscriptions/…/networkInterfaces/tf-nic │
├────────────────────────────────────────────┼─────────────────────────────────────────────────┼───────────────────────────────────────────┤
│ ..._backend_address_pool_association       │ locks.ByName(name, "azurerm_network_interface") │ azurerm_network_interface.tf-nic          │
├────────────────────────────────────────────┼─────────────────────────────────────────────────┼───────────────────────────────────────────┤
│ ..._nat_rule_association                   │ locks.ByName(…)                                 │ azurerm_network_interface.tf-nic          │
├────────────────────────────────────────────┼─────────────────────────────────────────────────┼───────────────────────────────────────────┤
│ ..._application_security_group_association │ locks.ByName(…)                                 │ azurerm_network_interface.tf-nic          │
└────────────────────────────────────────────┴─────────────────────────────────────────────────┴───────────────────────────────────────────┘
```

ByID and ByName (resourceType + "." + name) produce different keys in the same armMutexKV, so the NSG association acquires a different mutex than the other three. On the same NIC they run concurrently. The race:

1. NSG assoc: GET nic (v0, no NSG) → set NSG → PUT.
2. Backend-pool assoc (concurrent, different lock): GET nic (v0) → add pool → PUT.
3. The backend-pool PUT was built from v0, so it omits networkSecurityGroup. NIC PUT is intentionally replace-on-omit for top-level networkSecurityGroup (that's how the provider dissociates), so it strips the NSG.
4. NSG assoc's post-create readback GET sees no NSG → Read clears the ID → "Root object was present, but now absent."

This was working in the latest v4.x release and I can confirm that this fix solves the issue.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `network_interface_security_group_association` - fixing a regression where the lock was on the Resource ID and not the Resource Name, differing from the other association resources [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix

## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
