### PR TITLE
Support versionless key_vault_key_id in azurerm_kubernetes_cluster key_management_service block (new AKS KMS/CMK)

### DIFF
--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -1093,9 +1093,12 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
 						"key_vault_key_id": {
-							Type:         pluginsdk.TypeString,
-							Required:     true,
-							ValidateFunc: keyvault.ValidateNestedItemID(keyvault.VersionTypeVersioned, keyvault.NestedItemTypeKey),
+							Type:     pluginsdk.TypeString,
+							Required: true,
+							ValidateFunc: validation.Any(
+								keyvault.ValidateNestedItemID(keyvault.VersionTypeVersioned, keyvault.NestedItemTypeKey),
+								keyvault.ValidateNestedItemID(keyvault.VersionTypeVersionless, keyvault.NestedItemTypeKey),
+							),
 						},
 						"key_vault_network_access": {
 							Type:         pluginsdk.TypeString,
@@ -1790,7 +1793,10 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 			}, false),
 		}
 
-		resource.Schema["key_management_service"].Elem.(*pluginsdk.Resource).Schema["key_vault_key_id"].ValidateFunc = keyvault.ValidateNestedItemID(keyvault.VersionTypeVersioned, keyvault.NestedItemTypeAny)
+		resource.Schema["key_management_service"].Elem.(*pluginsdk.Resource).Schema["key_vault_key_id"].ValidateFunc = validation.Any(
+			keyvault.ValidateNestedItemID(keyvault.VersionTypeVersioned, keyvault.NestedItemTypeAny),
+			keyvault.ValidateNestedItemID(keyvault.VersionTypeVersionless, keyvault.NestedItemTypeAny),
+		)
 
 		resource.Schema["default_node_pool"].Elem.(*pluginsdk.Resource).Schema["kubelet_config"].Elem.(*pluginsdk.Resource).Schema["container_log_max_line"] = &pluginsdk.Schema{
 			Type:          pluginsdk.TypeInt,
@@ -4395,7 +4401,7 @@ func expandKubernetesClusterAzureKeyVaultKms(ctx context.Context, keyVaultsClien
 			nestedItemType = keyvault.NestedItemTypeAny
 		}
 
-		keyVaultKeyId, err := keyvault.ParseNestedItemID(*azureKeyVaultKms.KeyId, keyvault.VersionTypeVersioned, nestedItemType)
+		keyVaultKeyId, err := keyvault.ParseNestedItemID(*azureKeyVaultKms.KeyId, keyvault.VersionTypeAny, nestedItemType)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/services/containers/kubernetes_cluster_resource_schema_test.go
+++ b/internal/services/containers/kubernetes_cluster_resource_schema_test.go
@@ -1,0 +1,48 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package containers
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+func TestKubernetesClusterKeyVaultKeyIDValidation(t *testing.T) {
+	validateFunc := resourceKubernetesCluster().
+		Schema["key_management_service"].
+		Elem.(*pluginsdk.Resource).
+		Schema["key_vault_key_id"].
+		ValidateFunc
+
+	testCases := map[string]struct {
+		input string
+		valid bool
+	}{
+		"versioned": {
+			input: "https://example.vault.azure.net/keys/key-name/0123456789abcdef0123456789abcdef",
+			valid: true,
+		},
+		"versionless": {
+			input: "https://example.vault.azure.net/keys/key-name",
+			valid: true,
+		},
+		"invalid": {
+			input: "not-a-key-vault-key-id",
+			valid: false,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			_, errors := validateFunc(testCase.input, "key_vault_key_id")
+			if testCase.valid && len(errors) != 0 {
+				t.Fatalf("expected %q to be valid, got errors: %v", testCase.input, errors)
+			}
+			if !testCase.valid && len(errors) == 0 {
+				t.Fatalf("expected %q to be invalid", testCase.input)
+			}
+		})
+	}
+}

--- a/internal/services/containers/kubernetes_cluster_resource_schema_test.go
+++ b/internal/services/containers/kubernetes_cluster_resource_schema_test.go
@@ -1,16 +1,18 @@
 // Copyright IBM Corp. 2014, 2025
 // SPDX-License-Identifier: MPL-2.0
 
-package containers
+package containers_test
 
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/containers"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
 func TestKubernetesClusterKeyVaultKeyIDValidation(t *testing.T) {
-	validateFunc := resourceKubernetesCluster().
+	validateFunc := (containers.Registration{}).
+		SupportedResources()["azurerm_kubernetes_cluster"].
 		Schema["key_management_service"].
 		Elem.(*pluginsdk.Resource).
 		Schema["key_vault_key_id"].

--- a/internal/services/containers/kubernetes_cluster_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_resource_test.go
@@ -981,7 +981,7 @@ func (KubernetesClusterResource) azureKeyVaultKms(data acceptance.TestData, cont
 	if enabled {
 		kmsBlock = `
   key_management_service {
-    key_vault_key_id = azurerm_key_vault_key.test.id
+    key_vault_key_id = azurerm_key_vault_key.test.versionless_id
   }`
 	}
 


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note

- Please vote on this PR by adding a 👍 reaction to the original PR to help the community and maintainers prioritize for review
- Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

This PR relaxes validation of `key_management_service.key_vault_key_id` on `azurerm_kubernetes_cluster` to support the new AKS KMS (CMK data encryption) feature:
https://learn.microsoft.com/en-us/azure/aks/kms-data-encryption?pivots=cmk-public

Today, `key_vault_key_id` is validated with `ValidateNestedItemID(VersionTypeVersioned, NestedItemTypeKey)`, which rejects versionless key IDs at plan time. Legacy KMS requires a **versioned** key; the new CMK experience uses a **versionless** key (to support automatic key rotation).

This change relaxes the validator so `key_vault_key_id` accepts **both** versioned and versionless key IDs. Versioned IDs remain valid with unchanged meaning, so this is an **additive, non-breaking** behavior change.

The AKS RP authoritatively decides legacy-vs-CMK (based on Kubernetes version / feature enablement) and validates the key shape server-side. The provider therefore accepts both shapes and defers correctness to the RP, rather than enforcing a mode-specific rule it cannot determine at plan time.

Closes #32946

## PR Checklist

- [x] I have followed the guidelines in our Contributing Documentation.
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate closing keywords below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.

## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider. — *N/A, no state migration*

## Testing

- [ ] My submission includes Test coverage as described in the Contribution Guide and the tests pass.

<!-- Paste your actual acceptance test output here, e.g.: -->
```
$ TF_ACC=1 go test ./internal/services/containers -run TestAccKubernetesCluster_keyVaultKms -v -timeout 180m
```
<!-- If you could not run acceptance tests (needs Azure creds), state that explicitly and which unit tests you ran instead. -->

## Change Log

- `azurerm_kubernetes_cluster` - the `key_management_service.key_vault_key_id` property now accepts versionless Key Vault key IDs (in addition to versioned) to support the new AKS KMS (CMK) data encryption feature [GH-32946]

This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change

## Related Issue(s)

Closes #32946

## AI Assistance Disclosure

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

This PR affects how the `key_management_service` (KMS etcd encryption) key is specified. It **relaxes input validation** to also accept versionless Key Vault key IDs, enabling the new AKS CMK data-encryption experience with automatic key rotation. It does not weaken any security control: the key still must be a valid Key Vault key ID, and the AKS RP authoritatively validates whether the supplied key shape is permitted for the cluster's encryption mode. Versioned key IDs and their existing behavior are unchanged.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
