### PR TITLE
`testing` - regression test should not allow recreate

### DIFF
--- a/internal/acceptance/testcase.go
+++ b/internal/acceptance/testcase.go
@@ -174,6 +174,11 @@ func (td TestData) ResourceRegressionTest(t *testing.T, testResource types.TestR
 
 	steps[1].ExternalProviders = td.externalProviders()
 	steps[1].ProtoV5ProviderFactories = framework.ProtoV5ProviderFactoriesInitWithTestName(context.Background(), t.Name(), "azurerm", "azurerm-alt")
+	steps[1].ConfigPlanChecks = resource.ConfigPlanChecks{
+		PreApply: []plancheck.PlanCheck{
+			helpers.IsNotResourceAction(td.ResourceName, plancheck.ResourceActionReplace),
+		},
+	}
 
 	testCase := resource.TestCase{
 		PreCheck: func() { PreCheck(t) },


### PR DESCRIPTION
example failure:
```
    testcase.go:195: Step 2/2 error: Pre-apply plan check(s) failed:
        'azurerm_resource_group.test' - expected action to not be Replace, path: [[name]] tried to update a value that is ForceNew
```