### PR TITLE
`azurerm_api_management_api_operation` - fix perpetual diff on `example` blocks caused by non-deterministic map ordering

### DIFF
--- a/internal/services/apimanagement/schemaz/api_management.go
+++ b/internal/services/apimanagement/schemaz/api_management.go
@@ -6,6 +6,7 @@ package schemaz
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -421,8 +422,17 @@ func FlattenApiManagementOperationParameterExampleContract(input map[string]apio
 		return []interface{}{}, nil
 	}
 
+	// `input` is a map, so its iteration order is non-deterministic - since `example` is a `TypeList` (order-sensitive)
+	// this would otherwise produce a perpetual diff. Sort by name (the map key) to keep the order stable.
+	names := make([]string, 0, len(input))
+	for k := range input {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+
 	outputs := make([]interface{}, 0)
-	for k, v := range input {
+	for _, k := range names {
+		v := input[k]
 		output := map[string]interface{}{}
 
 		output["name"] = k


### PR DESCRIPTION
This PR was written in part with the assistance of generative AI.

#### Community Note

* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review

#### PR Checklist

- [x] Have you followed the guidelines in our Contributing Documentation?
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
- [x] Have you used a meaningful PR description to help maintainers and other users understand this change and help prevent duplicate work?
- [x] Do your changes close any open issues? If so please include appropriate closing keywords below.

#### Changes to existing Resource / Data Source

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your resource or datasource changes? Not added — this is a pure ordering fix inside a flatten function with no observable schema/behavior change beyond stabilizing list order, and the existing acceptance tests for `azurerm_api_management_api_operation` already exercise `example` blocks; a new deterministic unit test isn't practical here since the non-determinism came from live Go map iteration order against a real API response.
- [ ] Have you successfully run tests with your changes locally? `go build ./...`, `go vet`, `golangci-lint run`, `tfproviderlint`, and `make fmtcheck`/`make test-compile` all pass for the affected package. Acceptance tests were not run (require a live Azure subscription).

#### Description

`FlattenApiManagementOperationParameterExampleContract` (`internal/services/apimanagement/schemaz/api_management.go`) builds the `example` list for `azurerm_api_management_api_operation`'s `request`/`response` → `representation` blocks by ranging directly over a `map[string]apioperation.ParameterExampleContract`. Go map iteration order is non-deterministic, but `example` is defined as a `TypeList` (order-sensitive schema type), so every `plan`/`apply` could reorder the `example` blocks and produce a diff even when nothing had actually changed:

```
~ example {
    ~ name    = "NoMatch" -> "UniqueMatch"
    ...
}
~ example {
    ~ name    = "UniqueMatch" -> "NoMatch"
    ...
}
```

A contributor already diagnosed the exact root cause in the linked issue and pointed at the existing sort-for-stability pattern used for `georeplications` in `container_registry_resource.go`. This PR applies the same fix here: collect the map keys, sort them, and build the `example` list in that stable order — mirroring the sorted map-key iteration already used in `internal/services/automation/helper/automation_job_schedule.go`.

The change is scoped to a single flatten function; its only two callers are both within this same file, both feeding `azurerm_api_management_api_operation`.

#### Related Issue(s)

Fixes #31925

#### Change Log

* `azurerm_api_management_api_operation` - fix a perpetual diff on `example` blocks caused by non-deterministic ordering [GH-00000]

- [x] Bug Fix
- [ ] New Feature
