### PR TITLE
`azurerm_kubernetes_cluster_node_pool` - support `artifact_streaming_enabled`

### DIFF
--- a/internal/services/containers/kubernetes_artifact_streaming_resource_test.go
+++ b/internal/services/containers/kubernetes_artifact_streaming_resource_test.go
@@ -1,0 +1,77 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package containers_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+)
+
+func TestAccKubernetesCluster_defaultNodePoolArtifactStreaming(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
+	r := KubernetesClusterResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.defaultNodePoolArtifactStreaming(data, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("default_node_pool.0.artifact_streaming_enabled").HasValue("true"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.defaultNodePoolArtifactStreaming(data, false),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("default_node_pool.0.artifact_streaming_enabled").HasValue("false"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (KubernetesClusterResource) defaultNodePoolArtifactStreaming(data acceptance.TestData, enabled bool) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%[1]d"
+
+  default_node_pool {
+    name                       = "default"
+    vm_size                    = "Standard_D2s_v3"
+    node_count                 = 1
+    os_sku                     = "AzureLinux"
+    artifact_streaming_enabled = %[3]t
+
+    upgrade_settings {
+      max_surge = "10%%"
+    }
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  node_provisioning_profile {
+    mode               = "Manual"
+    default_node_pools = "Auto"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, enabled)
+}

--- a/internal/services/containers/kubernetes_artifact_streaming_test.go
+++ b/internal/services/containers/kubernetes_artifact_streaming_test.go
@@ -99,8 +99,8 @@ func TestArtifactStreamingDefaultNodePoolDisable(t *testing.T) {
 	var updated *managedclusters.AgentPoolArtifactStreamingProfile
 	resource := &schema.Resource{
 		Schema: map[string]*schema.Schema{"default_node_pool": containers.SchemaDefaultNodePool()},
-		Update: func(data *schema.ResourceData, _ interface{}) error {
-			profiles, err := containers.ExpandDefaultNodePool(data)
+		Update: func(d *schema.ResourceData, _ interface{}) error {
+			profiles, err := containers.ExpandDefaultNodePool(d)
 			if err == nil {
 				updated = (*profiles)[0].ArtifactStreamingProfile
 			}

--- a/internal/services/containers/kubernetes_artifact_streaming_test.go
+++ b/internal/services/containers/kubernetes_artifact_streaming_test.go
@@ -1,0 +1,135 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package containers_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2026-04-01/managedclusters"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/containers"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+func TestArtifactStreamingSchema(t *testing.T) {
+	schemas := map[string]*pluginsdk.Schema{
+		"default_node_pool": containers.SchemaDefaultNodePool().Elem.(*pluginsdk.Resource).Schema["artifact_streaming_enabled"],
+		"node_pool":         containers.Registration{}.SupportedResources()["azurerm_kubernetes_cluster_node_pool"].Schema["artifact_streaming_enabled"],
+	}
+	for name, schema := range schemas {
+		t.Run(name, func(t *testing.T) {
+			if schema == nil || schema.Type != pluginsdk.TypeBool || !schema.Optional || schema.ForceNew || schema.Computed {
+				t.Fatal("artifact streaming must be an optional, updatable boolean on both node pool schemas")
+			}
+		})
+	}
+}
+
+func TestArtifactStreamingDefaultNodePoolExpand(t *testing.T) {
+	for _, enabled := range []bool{true, false} {
+		data := schema.TestResourceDataRaw(t, map[string]*pluginsdk.Schema{
+			"default_node_pool": containers.SchemaDefaultNodePool(),
+		}, map[string]interface{}{
+			"default_node_pool": []interface{}{map[string]interface{}{
+				"name":                       "default",
+				"node_count":                 1,
+				"vm_size":                    "Standard_D2s_v3",
+				"artifact_streaming_enabled": enabled,
+			}},
+		})
+		data.MarkNewResource()
+		profiles, err := containers.ExpandDefaultNodePool(data)
+		if err != nil {
+			t.Fatal(err)
+		}
+		profile := (*profiles)[0].ArtifactStreamingProfile
+		if enabled {
+			if profile == nil || !pointer.From(profile.Enabled) {
+				t.Fatal("enabled artifact streaming must be sent during creation")
+			}
+		} else if profile != nil {
+			t.Fatal("disabled artifact streaming must be omitted during creation")
+		}
+	}
+}
+
+func TestArtifactStreamingDefaultNodePoolRoundTrip(t *testing.T) {
+	for name, profile := range map[string]*managedclusters.AgentPoolArtifactStreamingProfile{
+		"omitted":  nil,
+		"empty":    {},
+		"enabled":  {Enabled: pointer.To(true)},
+		"disabled": {Enabled: pointer.To(false)},
+	} {
+		t.Run(name, func(t *testing.T) {
+			profiles := []managedclusters.ManagedClusterAgentPoolProfile{{
+				Name:                     "default",
+				Mode:                     pointer.To(managedclusters.AgentPoolModeSystem),
+				ArtifactStreamingProfile: profile,
+			}}
+			pool := containers.ConvertDefaultNodePoolToAgentPool(&profiles)
+			if profile == nil {
+				if pool.Properties.ArtifactStreamingProfile != nil {
+					t.Fatal("omitted artifact streaming profile must remain omitted")
+				}
+			} else if got := pool.Properties.ArtifactStreamingProfile; got == nil || got.Enabled != profile.Enabled {
+				t.Fatal("conversion must preserve the artifact streaming value, including explicit false and nil")
+			}
+			data := schema.TestResourceDataRaw(t, map[string]*pluginsdk.Schema{
+				"default_node_pool": containers.SchemaDefaultNodePool(),
+			}, map[string]interface{}{
+				"default_node_pool": []interface{}{map[string]interface{}{"name": "default"}},
+			})
+			flattened, err := containers.FlattenDefaultNodePool(&profiles, data)
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := profile != nil && pointer.From(profile.Enabled)
+			if got := (*flattened)[0].(map[string]interface{})["artifact_streaming_enabled"]; got != want {
+				t.Fatalf("unexpected flattened value: got %v, want %t", got, want)
+			}
+		})
+	}
+}
+
+func TestArtifactStreamingDefaultNodePoolDisable(t *testing.T) {
+	var updated *managedclusters.AgentPoolArtifactStreamingProfile
+	resource := &schema.Resource{
+		Schema: map[string]*schema.Schema{"default_node_pool": containers.SchemaDefaultNodePool()},
+		Update: func(data *schema.ResourceData, _ interface{}) error {
+			profiles, err := containers.ExpandDefaultNodePool(data)
+			if err == nil {
+				updated = (*profiles)[0].ArtifactStreamingProfile
+			}
+			return err
+		},
+	}
+	raw := map[string]interface{}{
+		"default_node_pool": []interface{}{map[string]interface{}{
+			"name":                       "default",
+			"vm_size":                    "Standard_D2s_v3",
+			"node_count":                 1,
+			"artifact_streaming_enabled": true,
+		}},
+	}
+	data := schema.TestResourceDataRaw(t, resource.Schema, raw)
+	data.SetId("cluster")
+	state := data.State()
+	raw["default_node_pool"].([]interface{})[0].(map[string]interface{})["artifact_streaming_enabled"] = false
+	diff, err := resource.Diff(context.Background(), state, terraform.NewResourceConfigRaw(raw), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff == nil || diff.RequiresNew() {
+		t.Fatal("disabling artifact streaming must produce an in-place update")
+	}
+	if _, diags := resource.Apply(context.Background(), state, diff, nil); diags.HasError() {
+		t.Fatal(diags)
+	}
+	if updated == nil || updated.Enabled == nil || *updated.Enabled {
+		t.Fatal("disabling artifact streaming must send an explicit false")
+	}
+}

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -204,6 +204,11 @@ func resourceKubernetesClusterNodePoolSchema() map[string]*pluginsdk.Schema {
 		},
 
 		// Optional
+		"artifact_streaming_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+		},
+
 		"capacity_reservation_group_id": {
 			Type:         pluginsdk.TypeString,
 			Optional:     true,
@@ -594,6 +599,12 @@ func resourceKubernetesClusterNodePoolCreate(d *pluginsdk.ResourceData, meta int
 		Count: pointer.To(int64(count)),
 	}
 
+	if d.Get("artifact_streaming_enabled").(bool) {
+		profile.ArtifactStreamingProfile = &agentpools.AgentPoolArtifactStreamingProfile{
+			Enabled: pointer.To(true),
+		}
+	}
+
 	if gpuInstanceProfile := d.Get("gpu_instance").(string); gpuInstanceProfile != "" {
 		profile.GpuInstanceProfile = pointer.To(agentpools.GPUInstanceProfile(gpuInstanceProfile))
 	}
@@ -822,6 +833,12 @@ func resourceKubernetesClusterNodePoolUpdate(d *pluginsdk.ResourceData, meta int
 	if d.HasChange("auto_scaling_enabled") {
 		enableAutoScaling = d.Get("auto_scaling_enabled").(bool)
 		props.EnableAutoScaling = pointer.To(enableAutoScaling)
+	}
+
+	if d.HasChange("artifact_streaming_enabled") {
+		props.ArtifactStreamingProfile = &agentpools.AgentPoolArtifactStreamingProfile{
+			Enabled: pointer.To(d.Get("artifact_streaming_enabled").(bool)),
+		}
 	}
 
 	if d.HasChange("fips_enabled") {
@@ -1135,6 +1152,11 @@ func resourceKubernetesClusterNodePoolRead(d *pluginsdk.ResourceData, meta inter
 		d.Set("zones", zones.FlattenUntyped(props.AvailabilityZones))
 
 		d.Set("auto_scaling_enabled", props.EnableAutoScaling)
+		artifactStreamingEnabled := false
+		if props.ArtifactStreamingProfile != nil {
+			artifactStreamingEnabled = pointer.From(props.ArtifactStreamingProfile.Enabled)
+		}
+		d.Set("artifact_streaming_enabled", artifactStreamingEnabled)
 		d.Set("node_public_ip_enabled", props.EnableNodePublicIP)
 		d.Set("host_encryption_enabled", props.EnableEncryptionAtHost)
 		d.Set("fips_enabled", props.EnableFIPS)

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -158,6 +158,11 @@ func resourceKubernetesClusterNodePoolSchema() map[string]*pluginsdk.Schema {
 		},
 
 		// Optional
+		"artifact_streaming_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+		},
+
 		"capacity_reservation_group_id": {
 			Type:         pluginsdk.TypeString,
 			Optional:     true,
@@ -546,6 +551,12 @@ func resourceKubernetesClusterNodePoolCreate(d *pluginsdk.ResourceData, meta int
 		Count: pointer.To(int64(count)),
 	}
 
+	if d.Get("artifact_streaming_enabled").(bool) {
+		profile.ArtifactStreamingProfile = &agentpools.AgentPoolArtifactStreamingProfile{
+			Enabled: pointer.To(true),
+		}
+	}
+
 	if gpuInstanceProfile := d.Get("gpu_instance").(string); gpuInstanceProfile != "" {
 		profile.GpuInstanceProfile = pointer.ToEnum[agentpools.GPUInstanceProfile](gpuInstanceProfile)
 	}
@@ -767,6 +778,12 @@ func resourceKubernetesClusterNodePoolUpdate(d *pluginsdk.ResourceData, meta int
 	if d.HasChange("auto_scaling_enabled") {
 		enableAutoScaling = d.Get("auto_scaling_enabled").(bool)
 		props.EnableAutoScaling = pointer.To(enableAutoScaling)
+	}
+
+	if d.HasChange("artifact_streaming_enabled") {
+		props.ArtifactStreamingProfile = &agentpools.AgentPoolArtifactStreamingProfile{
+			Enabled: pointer.To(d.Get("artifact_streaming_enabled").(bool)),
+		}
 	}
 
 	if d.HasChange("fips_enabled") {
@@ -1074,6 +1091,11 @@ func resourceKubernetesClusterNodePoolRead(d *pluginsdk.ResourceData, meta inter
 		d.Set("zones", zones.FlattenUntyped(props.AvailabilityZones))
 
 		d.Set("auto_scaling_enabled", props.EnableAutoScaling)
+		artifactStreamingEnabled := false
+		if props.ArtifactStreamingProfile != nil {
+			artifactStreamingEnabled = pointer.From(props.ArtifactStreamingProfile.Enabled)
+		}
+		d.Set("artifact_streaming_enabled", artifactStreamingEnabled)
 		d.Set("node_public_ip_enabled", props.EnableNodePublicIP)
 		d.Set("host_encryption_enabled", props.EnableEncryptionAtHost)
 		d.Set("fips_enabled", props.EnableFIPS)

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -25,6 +25,30 @@ import (
 
 type KubernetesClusterNodePoolResource struct{}
 
+func TestAccKubernetesClusterNodePool_artifactStreaming(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster_node_pool", "test")
+	r := KubernetesClusterNodePoolResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.artifactStreaming(data, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("artifact_streaming_enabled").HasValue("true"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.artifactStreaming(data, false),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("artifact_streaming_enabled").HasValue("false"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccKubernetesClusterNodePool_autoScale(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster_node_pool", "test")
 	r := KubernetesClusterNodePoolResource{}
@@ -2834,6 +2858,29 @@ resource "azurerm_kubernetes_cluster" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func (r KubernetesClusterNodePoolResource) artifactStreaming(data acceptance.TestData, enabled bool) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_kubernetes_cluster_node_pool" "test" {
+  name                       = "artifact"
+  kubernetes_cluster_id      = azurerm_kubernetes_cluster.test.id
+  vm_size                    = "Standard_D2s_v3"
+  node_count                 = 1
+  os_sku                     = "AzureLinux"
+  artifact_streaming_enabled = %t
+
+  upgrade_settings {
+    max_surge = "10%%"
+  }
+}
+`, r.templateConfig(data), enabled)
 }
 
 func (KubernetesClusterNodePoolResource) templateVirtualNetworkConfig(data acceptance.TestData) string {

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -26,6 +26,30 @@ import (
 
 type KubernetesClusterNodePoolResource struct{}
 
+func TestAccKubernetesClusterNodePool_artifactStreaming(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster_node_pool", "test")
+	r := KubernetesClusterNodePoolResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.artifactStreaming(data, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("artifact_streaming_enabled").HasValue("true"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.artifactStreaming(data, false),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("artifact_streaming_enabled").HasValue("false"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccKubernetesClusterNodePool_autoScale(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster_node_pool", "test")
 	r := KubernetesClusterNodePoolResource{}
@@ -2977,6 +3001,29 @@ resource "azurerm_kubernetes_cluster" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func (r KubernetesClusterNodePoolResource) artifactStreaming(data acceptance.TestData, enabled bool) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_kubernetes_cluster_node_pool" "test" {
+  name                       = "artifact"
+  kubernetes_cluster_id      = azurerm_kubernetes_cluster.test.id
+  vm_size                    = "Standard_D2s_v3"
+  node_count                 = 1
+  os_sku                     = "AzureLinux"
+  artifact_streaming_enabled = %t
+
+  upgrade_settings {
+    max_surge = "10%%"
+  }
+}
+`, r.templateConfig(data), enabled)
 }
 
 func (KubernetesClusterNodePoolResource) templateVirtualNetworkConfig(data acceptance.TestData) string {

--- a/internal/services/containers/kubernetes_nodepool.go
+++ b/internal/services/containers/kubernetes_nodepool.go
@@ -77,6 +77,11 @@ func SchemaDefaultNodePool() *pluginsdk.Schema {
 						ValidateFunc: capacityreservationgroups.ValidateCapacityReservationGroupID,
 					},
 
+					"artifact_streaming_enabled": {
+						Type:     pluginsdk.TypeBool,
+						Optional: true,
+					},
+
 					"kubelet_config": schemaNodePoolKubeletConfig(),
 
 					"linux_os_config": schemaNodePoolLinuxOSConfig(),
@@ -707,6 +712,11 @@ func ConvertDefaultNodePoolToAgentPool(input *[]managedclusters.ManagedClusterAg
 		},
 	}
 
+	if artifactStreaming := defaultCluster.ArtifactStreamingProfile; artifactStreaming != nil {
+		agentpool.Properties.ArtifactStreamingProfile = &agentpools.AgentPoolArtifactStreamingProfile{
+			Enabled: artifactStreaming.Enabled,
+		}
+	}
 	if osDisktypeNodePool := defaultCluster.OsDiskType; osDisktypeNodePool != nil {
 		osDisktype := agentpools.OSDiskType(string(*osDisktypeNodePool))
 		agentpool.Properties.OsDiskType = &osDisktype
@@ -868,6 +878,12 @@ func ExpandDefaultNodePool(d *pluginsdk.ResourceData) (*[]managedclusters.Manage
 		// // TODO: support these in time
 		// ScaleSetEvictionPolicy: "",
 		// ScaleSetPriority:       "",
+	}
+
+	if enabled := raw["artifact_streaming_enabled"].(bool); enabled || (!d.IsNewResource() && d.HasChange("default_node_pool.0.artifact_streaming_enabled")) {
+		profile.ArtifactStreamingProfile = &managedclusters.AgentPoolArtifactStreamingProfile{
+			Enabled: pointer.To(enabled),
+		}
 	}
 
 	zones := zones.ExpandUntyped(raw["zones"].(*schema.Set).List())
@@ -1332,7 +1348,13 @@ func FlattenDefaultNodePool(input *[]managedclusters.ManagedClusterAgentPoolProf
 
 	networkProfile := flattenClusterPoolNetworkProfile(agentPool.NetworkProfile)
 
+	artifactStreamingEnabled := false
+	if agentPool.ArtifactStreamingProfile != nil {
+		artifactStreamingEnabled = pointer.From(agentPool.ArtifactStreamingProfile.Enabled)
+	}
+
 	out := map[string]interface{}{
+		"artifact_streaming_enabled":    artifactStreamingEnabled,
 		"auto_scaling_enabled":          enableAutoScaling,
 		"fips_enabled":                  enableFIPS,
 		"gpu_instance":                  gpuInstanceProfile,

--- a/internal/services/containers/migration/kubernetes_cluster_node_pool.go
+++ b/internal/services/containers/migration/kubernetes_cluster_node_pool.go
@@ -8,7 +8,7 @@ import (
 	"log"
 
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
-	"github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2025-10-01/agentpools"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2026-04-01/agentpools"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -379,6 +379,10 @@ A `default_node_pool` block supports the following:
 
 * `vm_size` - (Optional) The size of the Virtual Machine, such as `Standard_DS2_v2`. `temporary_name_for_rotation` must be specified when attempting a resize.
 
+* `artifact_streaming_enabled` - (Optional) Whether artifact streaming is enabled for the default node pool. Defaults to `false`.
+
+-> **Note:** Artifact streaming requires a supported Linux AMD64 node image (Ubuntu or Azure Linux) and Kubernetes version `1.25` or later. To stream images, use an integrated Premium Azure Container Registry with artifact streaming enabled. Windows, ARM64 and Azure Container Linux node images are not supported. Disabling streaming on existing nodes takes effect after a node image upgrade. See the [Azure documentation](https://learn.microsoft.com/azure/aks/artifact-streaming) for image and registry requirements.
+
 * `capacity_reservation_group_id` - (Optional) Specifies the ID of the Capacity Reservation Group within which this AKS Cluster should be created. Changing this forces a new resource to be created.
 
 * `auto_scaling_enabled` - (Optional) Should [the Kubernetes Auto Scaler](https://docs.microsoft.com/azure/aks/cluster-autoscaler) be enabled for this Node Pool?

--- a/website/docs/r/kubernetes_cluster_node_pool.html.markdown
+++ b/website/docs/r/kubernetes_cluster_node_pool.html.markdown
@@ -72,6 +72,8 @@ The following arguments are supported:
 
 ---
 
+* `artifact_streaming_enabled` - (Optional) Whether `artifact streaming` is enabled. Defaults to `false`.
+
 * `capacity_reservation_group_id` - (Optional) Specifies the ID of the Capacity Reservation Group where this Node Pool should exist. Changing this forces a new resource to be created.
 
 * `auto_scaling_enabled` - (Optional) Whether to enable [auto-scaler](https://docs.microsoft.com/azure/aks/cluster-autoscaler).

--- a/website/docs/r/kubernetes_cluster_node_pool.html.markdown
+++ b/website/docs/r/kubernetes_cluster_node_pool.html.markdown
@@ -74,6 +74,8 @@ The following arguments are supported:
 
 * `artifact_streaming_enabled` - (Optional) Whether `artifact streaming` is enabled. Defaults to `false`.
 
+-> **Note:** Artifact streaming requires a supported Linux AMD64 node image (Ubuntu or Azure Linux) and Kubernetes version `1.25` or later. To stream images, use an integrated Premium Azure Container Registry with artifact streaming enabled. Windows, ARM64 and Azure Container Linux node images are not supported. Disabling streaming on existing nodes takes effect after a node image upgrade. See the [Azure documentation](https://learn.microsoft.com/azure/aks/artifact-streaming) for image and registry requirements.
+
 * `capacity_reservation_group_id` - (Optional) Specifies the ID of the Capacity Reservation Group where this Node Pool should exist. Changing this forces a new resource to be created.
 
 * `auto_scaling_enabled` - (Optional) Whether to enable [auto-scaler](https://docs.microsoft.com/azure/aks/cluster-autoscaler).


### PR DESCRIPTION
## Community Note
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

Adds the optional `artifact_streaming_enabled` property to `azurerm_kubernetes_cluster_node_pool`. The property maps to the AKS agent pool Artifact Streaming profile and supports enabling the feature during creation, reading it into state, and enabling or disabling it in place.

This PR is stacked on #32928, which updates the Container Service SDK to API version `2026-04-01`. It can be retargeted to `main` after that dependency is merged.

## PR Checklist

- [x] I have followed the guidelines in the Contributing Documentation.
- [x] I have checked to ensure there are no other open pull requests for the same provider change.
- [x] I have updated the documentation.
- [x] I have used a meaningful PR title.

## Changes to existing Resource / Data Source

- [x] I have explained the behavior and reason for the change.
- [x] I have added focused acceptance coverage and updated the relevant documentation.
- [ ] I have successfully run the acceptance test locally. The local test tenant currently fails authentication with `AADSTS5000229` before Terraform can plan.

## Testing

Historical local checks and limitations (retained):

- `make build`
- `make website-lint`
- `make tfproviderlint`
- `golangci-lint run ./internal/services/containers/...` (`0 issues`)
- `go test ./internal/services/containers -run=^$`
- `make acctests SERVICE=containers TESTARGS=-run=TestAccKubernetesClusterNodePool_artifactStreaming TESTTIMEOUT=60m` - blocked before planning by the expired local test tenant (`AADSTS5000229`)

### Current-head verification — 12 September 2026

- **TeamCity #743432: 2 passed, 2 failed.** Tested merge `238b252444159f35bdfbd57579727038a7e6d4c0` is tree-identical to current head `f99456e618b76cea9f302ce24195fa406a46d9a1`. The run used #32928's `mstroob/update-containers-api-version` base at `3980ab8fd8c45aec65df97a469285dbdd5d0affd`, with Container Service API `2026-04-01`.
- **Failed feature tests:** `TestAccKubernetesCluster_defaultNodePoolArtifactStreaming` and `TestAccKubernetesClusterNodePool_artifactStreaming` both received Azure HTTP 400 `UnmarshalError`: `json: unknown field "artifactStreamingProfile"`, during managed-cluster/default-pool and standalone-pool creation, respectively.
- **Passed controls:** `TestAccKubernetesCluster_basicVMSS` and `TestAccKubernetesClusterNodePool_manualScaleUpdate`.
- Contract checks confirm the current SDK, published April Swagger and Azure CLI use `artifactStreamingProfile.enabled`. The stable API remains blocked; the controlled live comparison below identifies the stable-versus-preview difference.
- This run and the contract checks do **not** prove actual image streaming, the integrated Premium ACR/image data path, or streaming performance.

### Controlled live API investigation - 13 September 2026

Identical direct ARM create payloads in East US failed with the same unknown-field error on stable APIs `2026-03-01`, `2026-04-01` and `2026-06-01`. Changing only the API to `2026-06-02-preview` provisioned the cluster successfully with streaming enabled.

For the existing node pool, the same retrieved payload with `enabled=false` failed on April stable but completed successfully on `2026-04-02-preview`. Stable April/May GETs omitted the stored profile; preview GETs returned it. The legacy streaming preview registration remained unregistered throughout.

This establishes a stable-versus-preview service contract mismatch in the tested environment, rather than a Terraform serialization defect. Updating only the write API would be insufficient because stable Read also omits the field. The PR remains draft on its existing April dependency; no silent preview retarget was made. The four existing unit tests passed again.

All disposable resources were deleted. These checks prove configuration behaviour, not ACR image streaming or performance.

## Change Log

* `azurerm_kubernetes_cluster_node_pool` - support for the `artifact_streaming_enabled` property

This is a:

- [ ] Bug Fix
- [ ] New Feature
- [x] Enhancement
- [ ] Breaking Change

## Related Pull Request

Depends on #32928.

## Rollback Plan

If a change needs to be reverted, an updated version of the provider will be published.

## Changes to Security Controls

There are no changes to security controls in this pull request.