### PR TITLE
GHA - update tctest build type configuration

### DIFF
--- a/.github/workflows/teamcity-run-tests-on-comment.yaml
+++ b/.github/workflows/teamcity-run-tests-on-comment.yaml
@@ -98,6 +98,7 @@ jobs:
       TCTEST_SKIP_QUEUE: 'true'
       TCTEST_TOKEN_TC: ${{ secrets.TCTEST_TOKEN_TC }}
       TCTEST_BUILD_TYPE_ID: TF_AzureRM_AZURERM_SERVICE_PUBLIC
+      TCTEST_BUILD_TYPE_ID_ADD_SERVICE_SUFFIX: 'true'
       TCTEST_REPO: terraform-providers/terraform-provider-azurerm
     steps:
       - name: Setup Go


### PR DESCRIPTION
## Description

The TeamCity comment workflow currently uses the deprecated `TCTEST_BUILDTYPEID` setting. Current `tctest` releases no longer append the per-service suffix for that setting, so `/test` attempts to trigger `TF_AzureRM_AZURERM_SERVICE_PUBLIC` and TeamCity returns 404.

This switches to `TCTEST_BUILD_TYPE_ID` and explicitly enables the service suffix so discovered tests target the existing per-service build configurations.

## Testing

- `GOTOOLCHAIN=go1.26.5 go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -ignore 'github\.event\.comment\.body.*potentially untrusted' .github/workflows/teamcity-run-tests-on-comment.yaml`
- `git diff --check`

## Change Log

No provider changelog entry is required.
