### PR TITLE
Container Apps - fix inconsistent final plan when a `secret` block omits `value`

### DIFF
--- a/internal/services/containerapps/container_app_job_resource_test.go
+++ b/internal/services/containerapps/container_app_job_resource_test.go
@@ -296,6 +296,30 @@ func TestAccContainerAppJob_withKeyVaultSecret(t *testing.T) {
 	})
 }
 
+func TestAccContainerAppJob_withKeyVaultSecretResolvedDuringApply(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_app_job", "test")
+	r := ContainerAppJobResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.withKeyVaultSecretResolvedDuringApply(data, "first"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			// Changing the Key Vault defers the data source read until apply, leaving one
+			// `secret` element unknown in the saved plan while the other stays known.
+			Config: r.withKeyVaultSecretResolvedDuringApply(data, "second"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccContainerAppJob_withKeyVaultSecretVersioningUpdate(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_container_app_job", "test")
 	r := ContainerAppJobResource{}
@@ -894,6 +918,124 @@ resource "azurerm_container_app_job" "test" {
   }
 }
 `, template, data.RandomInteger, data.RandomString)
+}
+
+func (r ContainerAppJobResource) withKeyVaultSecretResolvedDuringApply(data acceptance.TestData, revision string) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy    = true
+      recover_soft_deleted_key_vaults = true
+    }
+  }
+}
+
+%[1]s
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acct-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_key_vault" "test" {
+  name                       = "acctest-kv-%[3]s"
+  resource_group_name        = azurerm_resource_group.test.name
+  rbac_authorization_enabled = false
+  location                   = azurerm_resource_group.test.location
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "premium"
+  soft_delete_retention_days = 7
+
+  tags = {
+    revision = "%[4]s"
+  }
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+    key_permissions = [
+      "Create",
+      "Get",
+    ]
+    secret_permissions = [
+      "Set",
+      "Get",
+      "Delete",
+      "Purge",
+      "Recover"
+    ]
+  }
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = azurerm_user_assigned_identity.test.principal_id
+    secret_permissions = [
+      "Get",
+    ]
+  }
+}
+
+resource "azurerm_key_vault_secret" "test" {
+  name         = "secret-%[3]s"
+  value        = "test-secret"
+  key_vault_id = azurerm_key_vault.test.id
+}
+
+data "azurerm_key_vault" "test" {
+  name                = azurerm_key_vault.test.name
+  resource_group_name = azurerm_resource_group.test.name
+
+  depends_on = [azurerm_key_vault.test]
+}
+
+resource "azurerm_container_app_job" "test" {
+  name                         = "acctest-cajob%[2]d"
+  resource_group_name          = azurerm_resource_group.test.name
+  location                     = azurerm_resource_group.test.location
+  container_app_environment_id = azurerm_container_app_environment.test.id
+
+  replica_timeout_in_seconds = 10
+  replica_retry_limit        = 10
+  manual_trigger_config {
+    parallelism              = 4
+    replica_completion_count = 1
+  }
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.test.id]
+  }
+
+  template {
+    container {
+      image  = "jackofallops/azure-containerapps-python-acctest:v0.0.1"
+      name   = "testcontainerappsjob0"
+      cpu    = 0.5
+      memory = "1Gi"
+      env {
+        name        = "key-vault-secret"
+        secret_name = "key-vault-secret"
+      }
+    }
+  }
+
+  secret {
+    name                = "key-vault-secret"
+    identity            = azurerm_user_assigned_identity.test.id
+    key_vault_secret_id = azurerm_key_vault_secret.test.versionless_id
+  }
+
+  secret {
+    name                = "key-vault-secret-deferred"
+    identity            = azurerm_user_assigned_identity.test.id
+    key_vault_secret_id = "${trimsuffix(data.azurerm_key_vault.test.vault_uri, "/")}/secrets/${azurerm_key_vault_secret.test.name}"
+  }
+}
+`, template, data.RandomInteger, data.RandomString, revision)
 }
 
 func (r ContainerAppJobResource) withKeyVaultSecretVersionless(data acceptance.TestData) string {

--- a/internal/services/containerapps/helpers/container_apps.go
+++ b/internal/services/containerapps/helpers/container_apps.go
@@ -2883,8 +2883,10 @@ func SecretsSchema() *pluginsdk.Schema {
 				},
 
 				"value": {
-					Type:        pluginsdk.TypeString,
-					Optional:    true,
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					// NOTE: O+C Azure doesn't return a value for Key Vault backed secrets, so an omitted value would be planned as null and the set element no longer correlates during apply
+					Computed:    true,
 					Sensitive:   true,
 					Description: "The value for this secret.",
 				},


### PR DESCRIPTION
## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description
Issue: `secret` is an `Optional` only `TypeSet`. For a Key Vault-backed secret the user omits `value` (null in config), but `Read` stores `""` in state because Azure never returns the value for a Key Vault reference. The legacy Plugin SDK plans an omitted `value` as `null`. A no-change plan normally hides this change by short-circuiting back to prior state.

It becomes visible when the same `secret` set also contains an element that is only resolved during apply, e.g. a `key_vault_secret_id` built from a deferred `data.azurerm_key_vault` read:

- **plan** - the set contains an unknown, so the plan is not a no-op and `null` is written into the saved plan
- **apply** - everything is known and equals prior state, so it short-circuits back to `""`

Terraform Core cannot correlate the set element across the two plans and fails with `Provider produced inconsistent final plan`.

Fix: Marking `value` as `O+C` allowed the omitted `value` resolve to `""` during apply.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.

## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

```
TF_ACC=1 go test -v ./internal/services/containerapps -run="^(TestAccContainerAppJob_withKeyVaultSecretResolvedDuringApply)$" -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccContainerAppJob_withKeyVaultSecretResolvedDuringApply
=== PAUSE TestAccContainerAppJob_withKeyVaultSecretResolvedDuringApply
=== CONT  TestAccContainerAppJob_withKeyVaultSecretResolvedDuringApply
--- PASS: TestAccContainerAppJob_withKeyVaultSecretResolvedDuringApply (1442.94s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/containerapps	1442.974s
```

## Change Log

* `azurerm_container_app` - fix an issue where a `secret` block that omits `value` could produce an inconsistent final plan [GH-32964]
* `azurerm_container_app_job` - fix an issue where a `secret` block that omits `value` could produce an inconsistent final plan [GH-32964]

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

## Rollback Plan

NA

## Changes to Security Controls

NA