### PR TITLE
`azurerm_subnet`/`azurerm_virtual_network` - prevent service endpoint ordering diffs

### DIFF
--- a/internal/services/network/subnet_resource.go
+++ b/internal/services/network/subnet_resource.go
@@ -179,7 +179,7 @@ func resourceSubnet() *pluginsdk.Resource {
 			},
 
 			"service_endpoint": {
-				Type:     pluginsdk.TypeList,
+				Type:     pluginsdk.TypeSet,
 				Optional: true,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
@@ -411,7 +411,7 @@ func resourceSubnetCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 			IPamPoolPrefixAllocations:         expandSubnetIPAddressPool(d.Get("ip_address_pool").([]interface{})),
 			PrivateEndpointNetworkPolicies:    pointer.ToEnum[subnets.VirtualNetworkPrivateEndpointNetworkPolicies](d.Get("private_endpoint_network_policies").(string)),
 			PrivateLinkServiceNetworkPolicies: expandSubnetNetworkPolicy(d.Get("private_link_service_network_policies_enabled").(bool)),
-			ServiceEndpoints:                  expandSubnetServiceEndpoint(d.Get("service_endpoint").([]interface{})),
+			ServiceEndpoints:                  expandSubnetServiceEndpoint(d.Get("service_endpoint").(*pluginsdk.Set).List()),
 			ServiceEndpointPolicies:           expandSubnetServiceEndpointPolicies(d.Get("service_endpoint_policy_ids").(*pluginsdk.Set).List()),
 			SharingScope:                      pointer.ToEnum[subnets.SharingScope](d.Get("sharing_scope").(string)),
 
@@ -618,7 +618,7 @@ func resourceSubnetUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	}
 
 	if d.HasChange("service_endpoint") {
-		props.ServiceEndpoints = expandSubnetServiceEndpoint(d.Get("service_endpoint").([]interface{}))
+		props.ServiceEndpoints = expandSubnetServiceEndpoint(d.Get("service_endpoint").(*pluginsdk.Set).List())
 	}
 
 	if d.HasChange("service_endpoint_policy_ids") {

--- a/internal/services/network/subnet_resource_test.go
+++ b/internal/services/network/subnet_resource_test.go
@@ -532,9 +532,6 @@ func TestAccSubnet_serviceEndpointBlockMultiple(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("service_endpoint.#").HasValue("3"),
-				check.That(data.ResourceName).Key("service_endpoint.0.service").HasValue("Microsoft.Sql"),
-				check.That(data.ResourceName).Key("service_endpoint.1.service").HasValue("Microsoft.Storage"),
-				check.That(data.ResourceName).Key("service_endpoint.2.service").HasValue("Microsoft.KeyVault"),
 			),
 		},
 		data.ImportStep(),
@@ -543,10 +540,6 @@ func TestAccSubnet_serviceEndpointBlockMultiple(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("service_endpoint.#").HasValue("3"),
-				check.That(data.ResourceName).Key("service_endpoint.0.service").HasValue("Microsoft.Sql"),
-				check.That(data.ResourceName).Key("service_endpoint.1.service").HasValue("Microsoft.Storage"),
-				check.That(data.ResourceName).Key("service_endpoint.1.network_identifier").Exists(),
-				check.That(data.ResourceName).Key("service_endpoint.2.service").HasValue("Microsoft.ServiceBus"),
 			),
 		},
 		data.ImportStep(),

--- a/internal/services/network/subnet_resource_test.go
+++ b/internal/services/network/subnet_resource_test.go
@@ -534,6 +534,10 @@ func TestAccSubnet_serviceEndpointBlockMultiple(t *testing.T) {
 				check.That(data.ResourceName).Key("service_endpoint.#").HasValue("3"),
 			),
 		},
+		{
+			Config:   r.serviceEndpointBlockMultipleReordered(data),
+			PlanOnly: true,
+		},
 		data.ImportStep(),
 		{
 			Config: r.serviceEndpointBlockMultipleUpdated(data),
@@ -1495,6 +1499,31 @@ resource "azurerm_subnet" "test" {
 
   service_endpoint {
     service = "Microsoft.KeyVault"
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r SubnetResource) serviceEndpointBlockMultipleReordered(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctest-%d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.2.0/24"]
+
+  service_endpoint {
+    service = "Microsoft.KeyVault"
+  }
+
+  service_endpoint {
+    service = "Microsoft.Sql"
+  }
+
+  service_endpoint {
+    service = "Microsoft.Storage"
   }
 }
 `, r.template(data), data.RandomInteger)

--- a/internal/services/network/virtual_network_resource.go
+++ b/internal/services/network/virtual_network_resource.go
@@ -299,7 +299,7 @@ func resourceVirtualNetworkSchema() map[string]*pluginsdk.Schema {
 					},
 
 					"service_endpoint": {
-						Type:       pluginsdk.TypeList,
+						Type:       pluginsdk.TypeSet,
 						Optional:   true,
 						ConfigMode: pluginsdk.SchemaConfigModeAttr,
 						Elem: &pluginsdk.Resource{
@@ -809,7 +809,7 @@ func expandVirtualNetworkSubnets(ctx context.Context, client virtualnetworks.Vir
 		}
 
 		subnetObj.Properties.ServiceEndpointPolicies = expandVirtualNetworkSubnetServiceEndpointPolicies(subnet["service_endpoint_policy_ids"].(*pluginsdk.Set).List())
-		subnetObj.Properties.ServiceEndpoints = expandVirtualNetworkSubnetServiceEndpoint(subnet["service_endpoint"].([]interface{}))
+		subnetObj.Properties.ServiceEndpoints = expandVirtualNetworkSubnetServiceEndpoint(subnet["service_endpoint"].(*pluginsdk.Set).List())
 
 		if secGroup := subnet["security_group"].(string); secGroup != "" {
 			subnetObj.Properties.NetworkSecurityGroup = &virtualnetworks.NetworkSecurityGroup{
@@ -883,7 +883,7 @@ func expandVirtualNetworkProperties(ctx context.Context, client virtualnetworks.
 			}
 
 			subnetObj.Properties.ServiceEndpointPolicies = expandVirtualNetworkSubnetServiceEndpointPolicies(subnet["service_endpoint_policy_ids"].(*pluginsdk.Set).List())
-			subnetObj.Properties.ServiceEndpoints = expandVirtualNetworkSubnetServiceEndpoint(subnet["service_endpoint"].([]interface{}))
+			subnetObj.Properties.ServiceEndpoints = expandVirtualNetworkSubnetServiceEndpoint(subnet["service_endpoint"].(*pluginsdk.Set).List())
 
 			if secGroup := subnet["security_group"].(string); secGroup != "" {
 				subnetObj.Properties.NetworkSecurityGroup = &virtualnetworks.NetworkSecurityGroup{


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Azure does not guarantee the order in which subnet service endpoints are returned. In v5, `service_endpoint` was changed from an unordered set of service names to an ordered list of nested objects to support `network_identifier`. As a result, changes in API response order cause persistent Terraform diffs.

This changes `service_endpoint` to a set of nested objects for both `azurerm_subnet` and inline subnets in `azurerm_virtual_network`. `TypeSet` supports nested resources, so both `service` and `network_identifier` remain available while endpoint ordering is ignored.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_subnet` - prevent persistent diffs when Azure returns service_endpoint blocks in a different order - GH-32951
* `azurerm_virtual_network` - prevent persistent diffs when Azure returns inline subnet service_endpoint blocks in a different order - GH-32951


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [x] Breaking Change


## Related Issue(s)

Fixes #32951.


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

AI was used to analyze the reported ordering regression, inspect the Plugin SDK schema behavior, implement the schema and test changes, and assist with validation and PR preparation. All changes were reviewed by the contributor.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

No changes to security controls.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
