### PR TITLE
Test Fix: `TestAccSpringCloudBuildPackBinding_requiresImport`

### DIFF
--- a/internal/services/springcloud/spring_cloud_build_pack_binding_resource_test.go
+++ b/internal/services/springcloud/spring_cloud_build_pack_binding_resource_test.go
@@ -135,7 +135,7 @@ resource "azurerm_spring_cloud_builder" "test" {
     version = "base"
   }
 }
-`, data.Locations.Primary, data.RandomInteger, data.RandomStringOfLength(5))
+`, data.Locations.Primary, data.RandomInteger, data.RandomString)
 }
 
 func (r SpringCloudBuildPackBindingResource) basic(data acceptance.TestData) string {
@@ -185,5 +185,5 @@ resource "azurerm_spring_cloud_build_pack_binding" "test" {
     }
   }
 }
-`, template, data.RandomStringOfLength(5))
+`, template, data.RandomString)
 }


### PR DESCRIPTION
```
Discovering tests for pr #32976  https://github.com/hashicorp/terraform-provider-azurerm/pull/32976
  changed service package files: 1
    internal/services/springcloud/spring_cloud_build_pack_binding_resource_test.go
  test files: 1
    internal/services/springcloud/spring_cloud_build_pack_binding_resource_test.go [CHANGED]
  springcloud: TestAccSpringCloudBuildPackBinding
triggering refs/pull/32976/merge[springcloud] 
```