### PR TITLE
`azurerm_storage_queue`: State migration handle malformed `resource_manager_id`

### DIFF
--- a/internal/services/storage/migration/storage_queue_v1_to_v2.go
+++ b/internal/services/storage/migration/storage_queue_v1_to_v2.go
@@ -65,11 +65,12 @@ func (StorageQueueV1ToV2) UpgradeFunc() pluginsdk.StateUpgraderFunc {
 
 		storageAccountID := commonids.StorageAccountId{}
 		if !findAccount {
-			parsed, err := parse.StorageQueueResourceManagerID(resourceManagerID)
-			if err != nil {
-				return rawState, err
+			// The `resource_manager_id` can be malformed (see: #32950), in which case fallbacks to find account.
+			if parsed, err := parse.StorageQueueResourceManagerID(resourceManagerID); err != nil {
+				findAccount = true
+			} else {
+				storageAccountID = commonids.NewStorageAccountID(parsed.SubscriptionId, parsed.ResourceGroup, parsed.StorageAccountName)
 			}
-			storageAccountID = commonids.NewStorageAccountID(parsed.SubscriptionId, parsed.ResourceGroup, parsed.StorageAccountName)
 		}
 
 		if findAccount {

--- a/internal/services/storage/storage_queue_resource_v1_to_v2_test.go
+++ b/internal/services/storage/storage_queue_resource_v1_to_v2_test.go
@@ -54,6 +54,32 @@ func TestAccStorageQueue_V1ToV2_3380(t *testing.T) {
 	}, "3.38.0")
 }
 
+// TestAccStorageQueue_V1ToV2_4810_AzureADAuth covers https://github.com/hashicorp/terraform-provider-azurerm/issues/32950
+// A queue created in v4 using `storage_account_name` with `storage_use_azuread = true` persisted a
+// `resource_manager_id` containing an empty `resourceGroups` segment, because that Azure AD path never
+// resolved the Resource Group. This broke the v1->v2 state migration when upgrading to 5.x. It uses
+// v4.81.0 as the setup version because it is the last release where the resource was fully functional.
+func TestAccStorageQueue_V1ToV2_4810_AzureADAuth(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_queue", "test")
+	r := StorageQueueResource{}
+
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.azureADAuthV1(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("id").HasValue(fmt.Sprintf("https://acctestacc%s.queue.core.windows.net/acctestmysamplequeue-%d", data.RandomString, data.RandomInteger)),
+			),
+		},
+		{
+			Config: r.basicAzureADAuth(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("id").HasValue(fmt.Sprintf("/subscriptions/%[1]s/resourceGroups/acctestRG-%[2]d/providers/Microsoft.Storage/storageAccounts/acctestacc%[3]s/queueServices/default/queues/acctestmysamplequeue-%[2]d", data.Subscriptions.Primary, data.RandomInteger, data.RandomString)),
+			),
+		},
+	}, "4.81.0")
+}
+
 func (r StorageQueueResource) basicV1(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
@@ -63,4 +89,35 @@ resource "azurerm_storage_queue" "test" {
   storage_account_name = azurerm_storage_account.test.name
 }
 `, r.template(data), data.RandomInteger)
+}
+
+func (r StorageQueueResource) azureADAuthV1(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  storage_use_azuread = true
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctestacc%[3]s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  tags = {
+    environment = "staging"
+  }
+}
+
+resource "azurerm_storage_queue" "test" {
+  name                 = "acctestmysamplequeue-%[1]d"
+  storage_account_name = azurerm_storage_account.test.name
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Handle the malformed `resource_manager_id`, instead of error out, fallback to the `findAccount` logic.

See https://github.com/hashicorp/terraform-provider-azurerm/issues/32950#issuecomment-5188906502 for details.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [x] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

```shell
❯ TF_ACC=1 go test -v ./internal/services/storage -run='TestAccStorageQueue_V1ToV2_'
=== RUN   TestAccStorageQueue_V1ToV2_4810
=== PAUSE TestAccStorageQueue_V1ToV2_4810
=== RUN   TestAccStorageQueue_V1ToV2_3380
=== PAUSE TestAccStorageQueue_V1ToV2_3380
=== RUN   TestAccStorageQueue_V1ToV2_4810_AzureADAuth
=== PAUSE TestAccStorageQueue_V1ToV2_4810_AzureADAuth
=== CONT  TestAccStorageQueue_V1ToV2_4810
=== CONT  TestAccStorageQueue_V1ToV2_4810_AzureADAuth
=== CONT  TestAccStorageQueue_V1ToV2_3380
--- PASS: TestAccStorageQueue_V1ToV2_4810_AzureADAuth (227.94s)
--- PASS: TestAccStorageQueue_V1ToV2_4810 (230.41s)
--- PASS: TestAccStorageQueue_V1ToV2_3380 (231.76s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/storage	231.782s
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #32950


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
