### PR TITLE
`azurerm_cdn_frontdoor_secret` - fix an incorrect type assertion

### DIFF
--- a/internal/services/cdn/cdn_frontdoor_secret_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_secret_resource.go
@@ -209,9 +209,10 @@ func resourceCdnFrontDoorSecretDelete(d *pluginsdk.ResourceData, meta interface{
 func expandCdnFrontDoorSecretParameters(ctx context.Context, input []interface{}, clients *clients.Client) (secrets.SecretParameters, error) {
 	v := input[0].(map[string]interface{})
 
-	cc := v["customer_certificate"].(map[string]interface{})
+	cc := v["customer_certificate"].([]interface{})
+	cc0 := cc[0].(map[string]interface{})
 
-	certificateId, err := keyvault.ParseNestedItemID(cc["key_vault_certificate_id"].(string), keyvault.VersionTypeAny, keyvault.NestedItemTypeCertificate)
+	certificateId, err := keyvault.ParseNestedItemID(cc0["key_vault_certificate_id"].(string), keyvault.VersionTypeAny, keyvault.NestedItemTypeCertificate)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

The test configurations for this resource are incomplete, and after looking into it, cannot be tested at this time as we don't currently have the ability to generate a certificate that meets the requirements as it must be signed by specific CAs. Self-signed chains are invalid and rejected by the API.

Tested locally using a self-signed cert to show the expand function works as expected now:

```
Terraform will perform the following actions:

  # azurerm_cdn_frontdoor_secret.test will be created
  + resource "azurerm_cdn_frontdoor_secret" "test" {
      + cdn_frontdoor_profile_id   = "/subscriptions/{subscription_id}/resourceGroups/mattdev6/providers/Microsoft.Cdn/profiles/accTestProfile-0805"
      + cdn_frontdoor_profile_name = (known after apply)
      + id                         = (known after apply)
      + name                       = "accTestSecret-0805"

      + secret {
          + customer_certificate {
              + expiration_date           = (known after apply)
              + key_vault_certificate_id  = "https://{vault_base_url}/certificates/acctestcert0805/dcd03970f0914dfdb82965feb51d5268"
              + subject_alternative_names = (known after apply)
            }
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.
azurerm_cdn_frontdoor_secret.test: Creating...
azurerm_cdn_frontdoor_secret.test: Still creating... [00m10s elapsed]
azurerm_cdn_frontdoor_secret.test: Still creating... [00m20s elapsed]
azurerm_cdn_frontdoor_secret.test: Still creating... [00m30s elapsed]
azurerm_cdn_frontdoor_secret.test: Still creating... [00m40s elapsed]
azurerm_cdn_frontdoor_secret.test: Still creating... [00m50s elapsed]
azurerm_cdn_frontdoor_secret.test: Still creating... [01m00s elapsed]
azurerm_cdn_frontdoor_secret.test: Still creating... [01m10s elapsed]
azurerm_cdn_frontdoor_secret.test: Still creating... [01m20s elapsed]
azurerm_cdn_frontdoor_secret.test: Still creating... [01m30s elapsed]
azurerm_cdn_frontdoor_secret.test: Still creating... [01m40s elapsed]
azurerm_cdn_frontdoor_secret.test: Still creating... [01m50s elapsed]
azurerm_cdn_frontdoor_secret.test: Still creating... [02m00s elapsed]
azurerm_cdn_frontdoor_secret.test: Still creating... [02m10s elapsed]
azurerm_cdn_frontdoor_secret.test: Still creating... [02m20s elapsed]
╷
│ Error: creating Secret (Subscription: "{subscription_id}"
│ Resource Group Name: "mattdev6"
│ Profile Name: "accTestProfile-0805"
│ Secret Name: "accTestSecret-0805"): performing Create: unexpected status 400 (400 Bad Request) with error: BadRequest: The certificate chain includes an invalid number of certificates. The number of certificates should be at least  2.
│
│   with azurerm_cdn_frontdoor_secret.test,
│   on main.tf line 178, in resource "azurerm_cdn_frontdoor_secret" "test":
│  178: resource "azurerm_cdn_frontdoor_secret" "test" {
│
```

(error expected as the cert doesn't meet the Azure Front Door requirements)

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #32981


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
