### PR TITLE
Test Fix: 'TestAccApiManagementLogger_applicationInsightsSystemAssignedIdentity'

### DIFF
--- a/internal/services/apimanagement/api_management_logger_resource_test.go
+++ b/internal/services/apimanagement/api_management_logger_resource_test.go
@@ -682,7 +682,7 @@ resource "azurerm_application_insights" "test" {
   location                      = azurerm_resource_group.test.location
   resource_group_name           = azurerm_resource_group.test.name
   application_type              = "other"
-  local_authentication_disabled = true
+  local_authentication_enabled  = false
 }
 
 resource "azurerm_user_assigned_identity" "test" {
@@ -746,7 +746,7 @@ resource "azurerm_application_insights" "test" {
   location                      = azurerm_resource_group.test.location
   resource_group_name           = azurerm_resource_group.test.name
   application_type              = "other"
-  local_authentication_disabled = true
+  local_authentication_enabled  = false
 }
 
 resource "azurerm_api_management" "test" {
@@ -801,7 +801,7 @@ resource "azurerm_application_insights" "test" {
   location                      = azurerm_resource_group.test.location
   resource_group_name           = azurerm_resource_group.test.name
   application_type              = "other"
-  local_authentication_disabled = true
+  local_authentication_enabled  = false
 }
 
 resource "azurerm_user_assigned_identity" "test" {

--- a/internal/services/apimanagement/api_management_logger_resource_test.go
+++ b/internal/services/apimanagement/api_management_logger_resource_test.go
@@ -678,11 +678,11 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_application_insights" "test" {
-  name                          = "acctestappinsights-%[1]d"
-  location                      = azurerm_resource_group.test.location
-  resource_group_name           = azurerm_resource_group.test.name
-  application_type              = "other"
-  local_authentication_enabled  = false
+  name                         = "acctestappinsights-%[1]d"
+  location                     = azurerm_resource_group.test.location
+  resource_group_name          = azurerm_resource_group.test.name
+  application_type             = "other"
+  local_authentication_enabled = false
 }
 
 resource "azurerm_user_assigned_identity" "test" {
@@ -742,11 +742,11 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_application_insights" "test" {
-  name                          = "acctestappinsights-%[1]d"
-  location                      = azurerm_resource_group.test.location
-  resource_group_name           = azurerm_resource_group.test.name
-  application_type              = "other"
-  local_authentication_enabled  = false
+  name                         = "acctestappinsights-%[1]d"
+  location                     = azurerm_resource_group.test.location
+  resource_group_name          = azurerm_resource_group.test.name
+  application_type             = "other"
+  local_authentication_enabled = false
 }
 
 resource "azurerm_api_management" "test" {
@@ -797,11 +797,11 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_application_insights" "test" {
-  name                          = "acctestappinsights-%[1]d"
-  location                      = azurerm_resource_group.test.location
-  resource_group_name           = azurerm_resource_group.test.name
-  application_type              = "other"
-  local_authentication_enabled  = false
+  name                         = "acctestappinsights-%[1]d"
+  location                     = azurerm_resource_group.test.location
+  resource_group_name          = azurerm_resource_group.test.name
+  application_type             = "other"
+  local_authentication_enabled = false
 }
 
 resource "azurerm_user_assigned_identity" "test" {


### PR DESCRIPTION
```
--- PASS: TestAccApiManagementLogger_applicationInsightsSystemAssignedIdentity (381.22s)
--- PASS: TestAccApiManagementLogger_applicationInsightsUpdateWithUserAssignedIdentity (461.70s)
--- PASS: TestAccApiManagementLogger_applicationInsightsUserAssignedIdentity (408.69s)

------- Stdout: -------
=== RUN   TestAccApiManagementLogger_applicationInsightsSystemAssignedIdentity
=== PAUSE TestAccApiManagementLogger_applicationInsightsSystemAssignedIdentity
=== CONT  TestAccApiManagementLogger_applicationInsightsSystemAssignedIdentity
    testcase.go:220: Step 1/2 error: Error running pre-apply plan: exit status 1
        
        Error: Unsupported argument
        
          on terraform_plugin_test.tf line 49, in resource "azurerm_application_insights" "test":
          49:   local_authentication_disabled = true
        
        An argument named "local_authentication_disabled" is not expected here.
--- FAIL: TestAccApiManagementLogger_applicationInsightsSystemAssignedIdentity (5.65s)
FAIL

------- Stdout: -------
=== RUN   TestAccApiManagementLogger_applicationInsightsUpdateWithUserAssignedIdentity
=== PAUSE TestAccApiManagementLogger_applicationInsightsUpdateWithUserAssignedIdentity
=== CONT  TestAccApiManagementLogger_applicationInsightsUpdateWithUserAssignedIdentity
    testcase.go:220: Step 1/3 error: Error running pre-apply plan: exit status 1
        
        Error: Unsupported argument
        
          on terraform_plugin_test.tf line 49, in resource "azurerm_application_insights" "test":
          49:   local_authentication_disabled = true
        
        An argument named "local_authentication_disabled" is not expected here.
--- FAIL: TestAccApiManagementLogger_applicationInsightsUpdateWithUserAssignedIdentity (7.19s)
FAIL

------- Stdout: -------
=== RUN   TestAccApiManagementLogger_applicationInsightsUserAssignedIdentity
=== PAUSE TestAccApiManagementLogger_applicationInsightsUserAssignedIdentity
=== CONT  TestAccApiManagementLogger_applicationInsightsUserAssignedIdentity
    testcase.go:220: Step 1/2 error: Error running pre-apply plan: exit status 1
        
        Error: Unsupported argument
        
          on terraform_plugin_test.tf line 49, in resource "azurerm_application_insights" "test":
          49:   local_authentication_disabled = true
        
        An argument named "local_authentication_disabled" is not expected here.
--- FAIL: TestAccApiManagementLogger_applicationInsightsUserAssignedIdentity (5.66s)
FAIL
```