### PR TITLE
Test Fix: `TestAccSentinelAutomationRule_trigger`

### DIFF
--- a/internal/services/sentinel/sentinel_automation_rule_resource_test.go
+++ b/internal/services/sentinel/sentinel_automation_rule_resource_test.go
@@ -335,7 +335,7 @@ resource "azuread_service_principal" "test" {
 }
 
 resource "azuread_service_principal_password" "test" {
-  service_principal_id = azuread_service_principal.test.object_id
+  service_principal_id = azuread_service_principal.test.id
 }
 
 
@@ -406,7 +406,7 @@ data "azurerm_role_definition" "sentinel" {
 }
 
 data "azuread_service_principal" "sentinel" {
-  application_id = "98785600-1bb7-4fb9-b9fa-19afe2c8a360"
+  client_id = "98785600-1bb7-4fb9-b9fa-19afe2c8a360"
 }
 
 resource "azurerm_role_assignment" "test" {


### PR DESCRIPTION
```
--- PASS: TestAccSentinelAutomationRule_trigger (326.79s)

------- Stdout: -------
=== RUN   TestAccSentinelAutomationRule_trigger
=== PAUSE TestAccSentinelAutomationRule_trigger
=== CONT  TestAccSentinelAutomationRule_trigger
    testcase.go:220: Step 5/6 error: Error running pre-apply plan: exit status 1
        
        Error: Unsupported argument
        
          on terraform_plugin_test.tf line 144, in data "azuread_service_principal" "sentinel":
         144:   application_id = "98785600-1bb7-4fb9-b9fa-19afe2c8a360"
        
        An argument named "application_id" is not expected here.
    panic.go:694: Error running post-test destroy, there may be dangling resources: exit status 1
        
        Error: Unsupported argument
        
          on terraform_plugin_test.tf line 144, in data "azuread_service_principal" "sentinel":
         144:   application_id = "98785600-1bb7-4fb9-b9fa-19afe2c8a360"
        
        An argument named "application_id" is not expected here.
--- FAIL: TestAccSentinelAutomationRule_trigger (235.63s)
FAIL
```