### PR TITLE
Test Fix: `TestAccKustoEventGridDataConnection_mappingRule`

### DIFF
--- a/internal/services/kusto/kusto_eventgrid_data_connection_resource_test.go
+++ b/internal/services/kusto/kusto_eventgrid_data_connection_resource_test.go
@@ -442,7 +442,7 @@ resource "azurerm_eventhub_consumer_group" "test" {
 resource "azurerm_eventgrid_event_subscription" "test" {
   name                  = "acctest-eg-%d"
   scope                 = azurerm_storage_account.test.id
-  eventhub_endpoint_id  = azurerm_eventhub.test.id
+  eventhub_id           = azurerm_eventhub.test.id
   event_delivery_schema = "EventGridSchema"
   included_event_types  = ["Microsoft.Storage.BlobCreated", "Microsoft.Storage.BlobRenamed"]
 


### PR DESCRIPTION
```
--- PASS: TestAccKustoEventGridDataConnection_mappingRule (1320.92s)

------- Stdout: -------
=== RUN   TestAccKustoEventGridDataConnection_mappingRule
=== PAUSE TestAccKustoEventGridDataConnection_mappingRule
=== CONT  TestAccKustoEventGridDataConnection_mappingRule
    testcase.go:220: Step 1/2 error: Error running pre-apply plan: exit status 1
        
        Error: Unsupported argument
        
          on terraform_plugin_test.tf line 105, in resource "azurerm_eventgrid_event_subscription" "test":
         105:   eventhub_endpoint_id  = azurerm_eventhub.test.id
        
        An argument named "eventhub_endpoint_id" is not expected here.
--- FAIL: TestAccKustoEventGridDataConnection_mappingRule (4.72s)
FAIL


------- Stdout: -------
=== RUN   TestAccKustoEventGridDataConnection_requiresImport
=== PAUSE TestAccKustoEventGridDataConnection_requiresImport
=== CONT  TestAccKustoEventGridDataConnection_requiresImport
    testcase.go:220: Step 1/2 error: Error running pre-apply plan: exit status 1
        
        Error: Unsupported argument
        
          on terraform_plugin_test.tf line 105, in resource "azurerm_eventgrid_event_subscription" "test":
         105:   eventhub_endpoint_id  = azurerm_eventhub.test.id
        
        An argument named "eventhub_endpoint_id" is not expected here.
--- FAIL: TestAccKustoEventGridDataConnection_requiresImport (5.01s)
FAIL


------- Stdout: -------
=== RUN   TestAccKustoEventGridDataConnection_systemAssignedIdentity
=== PAUSE TestAccKustoEventGridDataConnection_systemAssignedIdentity
=== CONT  TestAccKustoEventGridDataConnection_systemAssignedIdentity
    testcase.go:220: Step 1/2 error: Error running pre-apply plan: exit status 1
        
        Error: Unsupported argument
        
          on terraform_plugin_test.tf line 105, in resource "azurerm_eventgrid_event_subscription" "test":
         105:   eventhub_endpoint_id  = azurerm_eventhub.test.id
        
        An argument named "eventhub_endpoint_id" is not expected here.
--- FAIL: TestAccKustoEventGridDataConnection_systemAssignedIdentity (6.16s)
FAIL
```