### PR TITLE
`azurerm_storage_table` - Fully support AAD auth

### DIFF
--- a/internal/acceptance/testclient/client.go
+++ b/internal/acceptance/testclient/client.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"sync"
 
 	"github.com/hashicorp/go-azure-sdk/sdk/auth"
@@ -73,7 +74,7 @@ func BuildWithTestName(testName string) (*clients.Client, error) {
 			AuthConfig:        &authConfig,
 			TerraformVersion:  os.Getenv("TERRAFORM_CORE_VERSION"),
 			Features:          features.Default(),
-			StorageUseAzureAD: false,
+			StorageUseAzureAD: strings.EqualFold(os.Getenv("ARM_STORAGE_USE_AZUREAD"), "true"),
 			SubscriptionID:    os.Getenv("ARM_SUBSCRIPTION_ID"),
 			TestName:          testName,
 		}

--- a/internal/services/storage/storage_table_data_source.go
+++ b/internal/services/storage/storage_table_data_source.go
@@ -195,7 +195,7 @@ func (k storageTableDataSource) Read() sdk.ResourceFunc {
 
 			id := tables.NewTableID(*accountId, model.Name)
 
-			aclClient, err := storageClient.TablesDataPlaneClient(ctx, *account, storageClient.DataPlaneOperationSupportingOnlySharedKeyAuth())
+			aclClient, err := storageClient.TablesDataPlaneClient(ctx, *account, storageClient.DataPlaneOperationSupportingAnyAuthMethod())
 			if err != nil {
 				return fmt.Errorf("building Tables Client: %v", err)
 			}

--- a/internal/services/storage/storage_table_data_source_test.go
+++ b/internal/services/storage/storage_table_data_source_test.go
@@ -29,6 +29,25 @@ func TestAccDataSourceStorageTable_basic(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceStorageTable_basicAzureADAuth(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_storage_table", "test")
+
+	// This is instruct the test client to use AAD auth.
+	t.Setenv("ARM_STORAGE_USE_AZUREAD", "true")
+
+	// This test is sequential due to we set the env above.
+	data.DataSourceTestInSequence(t, []acceptance.TestStep{
+		{
+			Config: StorageTableDataSource{}.basicAzureADAuthWithDataSource(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("acl.#").HasValue("1"),
+				check.That(data.ResourceName).Key("acl.0.id").HasValue("MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI"),
+				check.That(data.ResourceName).Key("acl.0.access_policy.0.permissions").HasValue("raud"),
+			),
+		},
+	})
+}
+
 func (d StorageTableDataSource) basic(data acceptance.TestData) string {
 	if !features.FivePointOh() {
 		return fmt.Sprintf(`
@@ -123,4 +142,50 @@ data "azurerm_storage_table" "test" {
   storage_account_id = azurerm_storage_table.test.storage_account_id
 }
 `, config)
+}
+
+func (d StorageTableDataSource) basicAzureADAuthWithDataSource(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+  storage_use_azuread = true
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                      = "acctestacc%[3]s"
+  resource_group_name       = azurerm_resource_group.test.name
+  location                  = azurerm_resource_group.test.location
+  account_tier              = "Standard"
+  account_replication_type  = "LRS"
+  shared_access_key_enabled = false
+
+  tags = {
+    environment = "staging"
+  }
+}
+
+resource "azurerm_storage_table" "test" {
+  name               = "acctestst%[1]d"
+  storage_account_id = azurerm_storage_account.test.id
+  acl {
+    id = "MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI"
+
+    access_policy {
+      permissions = "raud"
+      start       = "2020-11-26T08:49:37.0000000Z"
+      expiry      = "2020-11-27T08:49:37.0000000Z"
+    }
+  }
+}
+
+data "azurerm_storage_table" "test" {
+  name               = azurerm_storage_table.test.name
+  storage_account_id = azurerm_storage_table.test.storage_account_id
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }

--- a/internal/services/storage/storage_table_resource.go
+++ b/internal/services/storage/storage_table_resource.go
@@ -252,8 +252,7 @@ func resourceStorageTableCreate(d *pluginsdk.ResourceData, meta interface{}) err
 
 	d.SetId(id.ID())
 
-	// Setting ACLs only supports shared key authentication (@manicminer, 2024-02-29)
-	aclClient, err := storageClient.TablesDataPlaneClient(ctx, *account, storageClient.DataPlaneOperationSupportingOnlySharedKeyAuth())
+	aclClient, err := storageClient.TablesDataPlaneClient(ctx, *account, storageClient.DataPlaneOperationSupportingAnyAuthMethod())
 	if err != nil {
 		return fmt.Errorf("building Tables Client: %v", err)
 	}
@@ -370,8 +369,7 @@ func resourceStorageTableRead(d *pluginsdk.ResourceData, meta interface{}) error
 		return nil
 	}
 
-	// Retrieving ACLs only supports shared key authentication (@manicminer, 2024-02-29)
-	aclClient, err := storageClient.TablesDataPlaneClient(ctx, *account, storageClient.DataPlaneOperationSupportingOnlySharedKeyAuth())
+	aclClient, err := storageClient.TablesDataPlaneClient(ctx, *account, storageClient.DataPlaneOperationSupportingAnyAuthMethod())
 	if err != nil {
 		return fmt.Errorf("building Tables Client: %v", err)
 	}
@@ -536,8 +534,7 @@ func resourceStorageTableUpdate(d *pluginsdk.ResourceData, meta interface{}) err
 		aclsRaw := d.Get("acl").(*pluginsdk.Set).List()
 		acls := expandStorageTableACLs(aclsRaw)
 
-		// Setting ACLs only supports shared key authentication (@manicminer, 2024-02-29)
-		aclClient, err := storageClient.TablesDataPlaneClient(ctx, *account, storageClient.DataPlaneOperationSupportingOnlySharedKeyAuth())
+		aclClient, err := storageClient.TablesDataPlaneClient(ctx, *account, storageClient.DataPlaneOperationSupportingAnyAuthMethod())
 		if err != nil {
 			return fmt.Errorf("building Tables Client: %v", err)
 		}

--- a/internal/services/storage/storage_table_resource_test.go
+++ b/internal/services/storage/storage_table_resource_test.go
@@ -41,7 +41,11 @@ func TestAccStorageTable_basicAzureADAuth(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_table", "test")
 	r := StorageTableResource{}
 
-	data.ResourceTest(t, r, []acceptance.TestStep{
+	// This is instruct the test client to use AAD auth.
+	t.Setenv("ARM_STORAGE_USE_AZUREAD", "true")
+
+	// This test is sequential due to we set the env above.
+	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.basicAzureADAuth(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -332,11 +336,12 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_storage_account" "test" {
-  name                     = "acctestacc%s"
-  resource_group_name      = azurerm_resource_group.test.name
-  location                 = azurerm_resource_group.test.location
-  account_tier             = "Standard"
-  account_replication_type = "LRS"
+  name                      = "acctestacc%s"
+  resource_group_name       = azurerm_resource_group.test.name
+  location                  = azurerm_resource_group.test.location
+  account_tier              = "Standard"
+  account_replication_type  = "LRS"
+  shared_access_key_enabled = false
 
   tags = {
     environment = "staging"
@@ -393,11 +398,12 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_storage_account" "test" {
-  name                     = "acctestacc%s"
-  resource_group_name      = azurerm_resource_group.test.name
-  location                 = azurerm_resource_group.test.location
-  account_tier             = "Standard"
-  account_replication_type = "LRS"
+  name                      = "acctestacc%s"
+  resource_group_name       = azurerm_resource_group.test.name
+  location                  = azurerm_resource_group.test.location
+  account_tier              = "Standard"
+  account_replication_type  = "LRS"
+  shared_access_key_enabled = false
 
   tags = {
     environment = "staging"
@@ -407,6 +413,15 @@ resource "azurerm_storage_account" "test" {
 resource "azurerm_storage_table" "test" {
   name               = "acctestst%d"
   storage_account_id = azurerm_storage_account.test.id
+  acl {
+    id = "MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI"
+
+    access_policy {
+      permissions = "raud"
+      start       = "2020-11-26T08:49:37.0000000Z"
+      expiry      = "2020-11-27T08:49:37.0000000Z"
+    }
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger)
 }

--- a/website/docs/r/storage_table.html.markdown
+++ b/website/docs/r/storage_table.html.markdown
@@ -10,8 +10,6 @@ description: |-
 
 Manages a Table within an Azure Storage Account.
 
-~> **Note:** Shared Key authentication will always be used for this resource, as AzureAD authentication is not supported when setting or retrieving ACLs for Tables.
-
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

https://github.com/hashicorp/terraform-provider-azurerm/pull/24798 supports for AAD authentication for all data plane APIs, except:

> `azurerm_storage_share` and `azurerm_storage_table` will continue to use shared key authentication due to API limitations ([official docs](https://learn.microsoft.com/en-us/rest/api/storageservices/authorize-with-azure-active-directory))

The API limitation of `azurerm_storage_table` is resolved now: https://azure.microsoft.com/en-us/updates/?id=496287

This PR relaxes the data plane client auth method to allow both key-based and AAD-based. Note that I only changed the part of the v5 branch, as the other branch will be deleted at last.

The acctest is updated to explicitly disable key based auth at the account level, add ACL for the update step. Also, the test client requires to use AAD-based auth (since the account disables the key based auth), which I use the env var to opt in the `storage_use_aad`. As a result, the test case is changed from parallel to sequential. Arguably, we shall always set the `storage_use_aad` as true for the test client.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

```shell
❯ TF_ACC=1 go test -v ./internal/services/storage -run=TestAccStorageTable_basicAzureADAuth
=== RUN   TestAccStorageTable_basicAzureADAuth
--- PASS: TestAccStorageTable_basicAzureADAuth (172.70s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/storage	172.720s
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #15083 


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
