### PR TITLE
workflows: replace  go tool with in-repo shell script that links all linked isses

### DIFF
--- a/.github/workflows/milestone-link.yaml
+++ b/.github/workflows/milestone-link.yaml
@@ -1,8 +1,8 @@
 ---
 name: Link Milestone
 
-# When a PR merges to main, assigns it and its linked issues to the current
-# milestone using stephybun/link-milestone.
+# When a PR merges to main, assigns it and all issues it closes to the next
+# unreleased milestone via scripts/automation/milestone-link.sh.
 
 permissions: {}
 
@@ -20,14 +20,11 @@ jobs:
       pull-requests: write
       issues: write
     steps:
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
-        with:
-          # we cannot use go-version-file here because no repositories are checked out so there is no file to reference
-          go-version: '1.26'
-      - run: |
-          go install github.com/stephybun/link-milestone@1e48f06f81570d223831a9fca0fd8bb0ad11c7da
-          link-milestone
+      # pull_request_target checks out the base branch (main), not the PR head
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v6
+      - name: "Link Milestone"
+        shell: bash
+        run: bash ./scripts/automation/milestone-link.sh
         env:
           PR_NUMBER: ${{ github.event.number }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/automation/milestone-link.sh
+++ b/scripts/automation/milestone-link.sh
@@ -45,6 +45,7 @@ assign_milestone "${pr_number}"
 
 # every issue this PR closes, whether via closing keywords or linked manually in
 # the UI - not just the first one mentioned in the PR body
+# shellcheck disable=SC2016 # $owner/$repo/$pr below are GraphQL variables, not shell
 linked_issues=$(gh api graphql \
   -F owner="${repo%/*}" -F repo="${repo#*/}" -F pr="${pr_number}" \
   -f query='

--- a/scripts/automation/milestone-link.sh
+++ b/scripts/automation/milestone-link.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Copyright IBM Corp. 2014, 2025
+# SPDX-License-Identifier: MPL-2.0
+
+# Assigns a merged PR and all issues it closes to the next unreleased milestone
+# (the lowest open vX.Y.0 milestone). Run from the milestone-link workflow.
+#
+# Required environment:
+#   GH_TOKEN          - token with issues:write and pull-requests:write
+#   GITHUB_REPOSITORY - owner/repo (set automatically by GitHub Actions)
+#   PR_NUMBER         - number of the merged pull request
+
+set -euo pipefail
+
+repo="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY must be set}"
+pr_number="${PR_NUMBER:?PR_NUMBER must be set}"
+
+milestone=$(gh api "repos/${repo}/milestones?state=open&per_page=100" \
+  --jq '[.[] | select(.title | test("^v[0-9]+\\.[0-9]+\\.0$"))]
+        | sort_by(.title | ltrimstr("v") | split(".") | map(tonumber))
+        | first // empty')
+
+if [[ -z "${milestone}" ]]; then
+  echo "No open vX.Y.0 milestones found, nothing to do"
+  exit 0
+fi
+
+milestone_number=$(jq -r '.number' <<<"${milestone}")
+milestone_title=$(jq -r '.title' <<<"${milestone}")
+echo "Next unreleased milestone: ${milestone_title}"
+
+assign_milestone() {
+  local number="$1"
+  local existing
+  existing=$(gh api "repos/${repo}/issues/${number}" --jq '.milestone.title // empty')
+  if [[ -n "${existing}" ]]; then
+    echo "#${number} is already in milestone ${existing}, skipping"
+    return
+  fi
+  gh api --silent -X PATCH "repos/${repo}/issues/${number}" -F milestone="${milestone_number}"
+  echo "#${number} added to milestone ${milestone_title}"
+}
+
+assign_milestone "${pr_number}"
+
+# every issue this PR closes, whether via closing keywords or linked manually in
+# the UI - not just the first one mentioned in the PR body
+linked_issues=$(gh api graphql \
+  -F owner="${repo%/*}" -F repo="${repo#*/}" -F pr="${pr_number}" \
+  -f query='
+    query($owner: String!, $repo: String!, $pr: Int!) {
+      repository(owner: $owner, name: $repo) {
+        pullRequest(number: $pr) {
+          closingIssuesReferences(first: 100) {
+            nodes { number repository { nameWithOwner } }
+          }
+        }
+      }
+    }' \
+  --jq ".data.repository.pullRequest.closingIssuesReferences.nodes[]
+        | select(.repository.nameWithOwner == \"${repo}\") | .number")
+
+for issue in ${linked_issues}; do
+  assign_milestone "${issue}"
+done


### PR DESCRIPTION
Replaces the external Link Milestone workflow with a shell script in this repo (`scripts/automation/milestone-link.sh`, alongside the existing `milestone-increment.sh`), using the `gh` CLI.

Behaviour is the same, on merge to `main`, the PR and the issues it closes are added to the lowest open `vX.Y.0` milestone - with two fixes over the Go tool:

* **All** closed issues are milestoned, not just the first: linked issues are resolved via GitHub's GraphQL `closingIssuesReferences` (closing keywords anywhere in the PR body *and* issues linked manually in the UI) instead of regex-matching the first `fixes #N` in the body.
* When no open `vX.Y.0` milestone exists the run logs and exits cleanly instead of failing.

The workflow no longer needs `setup-go` or a pinned external tool install. Trigger and gating are unchanged (`pull_request_target` + `merged == true`); the checkout runs the base branch (`main`), so the new path takes effect on the first merge after this lands.

