### PR TITLE
`azurerm_network_interface_security_group_association` - wait for eventual consistency after create to prevent `Provider produced inconsistent result` errors

### DIFF
--- a/internal/services/network/network_interface_security_group_association_resource.go
+++ b/internal/services/network/network_interface_security_group_association_resource.go
@@ -4,6 +4,7 @@
 package network
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"time"
@@ -110,6 +111,26 @@ func resourceNetworkInterfaceSecurityGroupAssociationCreate(d *pluginsdk.Resourc
 
 	d.SetId(id.ID())
 
+	// The Network Interfaces API can be eventually consistent - even once the poller above reports the update as
+	// complete, an immediately following `Get` (such as the one in Read, below) can still return a stale response
+	// without the Security Group attached. Read then interprets that as the association having been removed and
+	// clears the resource from state, which surfaces to users as `Provider produced inconsistent result after apply`.
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return fmt.Errorf("internal error: context had no deadline")
+	}
+	log.Printf("[DEBUG] Waiting for Security Group Association for %s to become available..", *nicId)
+	stateConf := &pluginsdk.StateChangeConf{
+		Pending:    []string{"Waiting"},
+		Target:     []string{"Associated"},
+		MinTimeout: 15 * time.Second,
+		Timeout:    time.Until(deadline),
+		Refresh:    networkInterfaceSecurityGroupAssociationRefreshFunc(ctx, client, *nicId),
+	}
+	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+		return fmt.Errorf("waiting for Security Group Association for %s to become available: %+v", *nicId, err)
+	}
+
 	return resourceNetworkInterfaceSecurityGroupAssociationRead(d, meta)
 }
 
@@ -186,4 +207,19 @@ func resourceNetworkInterfaceSecurityGroupAssociationDelete(d *pluginsdk.Resourc
 	}
 
 	return nil
+}
+
+func networkInterfaceSecurityGroupAssociationRefreshFunc(ctx context.Context, client *networkinterfaces.NetworkInterfacesClient, id commonids.NetworkInterfaceId) pluginsdk.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		resp, err := client.Get(ctx, id, networkinterfaces.DefaultGetOperationOptions())
+		if err != nil {
+			return nil, "", fmt.Errorf("polling for %s: %+v", id, err)
+		}
+
+		if resp.Model != nil && resp.Model.Properties != nil && resp.Model.Properties.NetworkSecurityGroup != nil && resp.Model.Properties.NetworkSecurityGroup.Id != nil {
+			return resp, "Associated", nil
+		}
+
+		return resp, "Waiting", nil
+	}
 }


### PR DESCRIPTION
This PR was written in part with the assistance of generative AI.

#### Community Note

* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review

#### PR Checklist

- [x] Have you followed the guidelines in our Contributing Documentation?
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
- [x] Have you used a meaningful PR description to help maintainers and other users understand this change and help prevent duplicate work?
- [x] Do your changes close any open issues? If so please include appropriate closing keywords below.

#### Changes to existing Resource / Data Source

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your resource or datasource changes? Not added — this is a timing/eventual-consistency race against the live API that isn't reliably reproducible in a recorded acceptance test.
- [ ] Have you successfully run tests with your changes locally? `go build ./...`, `go vet`, `golangci-lint run`, `tfproviderlint`, and `make fmtcheck` all pass for the affected package. Acceptance tests were not run (require a live Azure subscription and the race is intermittent).

#### Description

`resourceNetworkInterfaceSecurityGroupAssociationCreate` calls `client.CreateOrUpdateCallbackThenPoll(...)`, which polls the Azure long-running-operation status until it reports done, then immediately calls `Read`. `Read` does a `Get` on the Network Interface and, if `properties.networkSecurityGroup` is nil, treats the association as removed and clears the resource from state (`d.SetId("")`).

The Network Interfaces API appears to be eventually consistent here: the LRO-completion poller finishing doesn't guarantee a subsequent `Get` reflects the change yet, so that immediate `Read` can intermittently see a stale response with no Security Group attached — producing:

```
Error: Provider produced inconsistent result after apply

When applying changes to azurerm_network_interface_security_group_association.main,
provider "provider[\"registry.terraform.io/hashicorp/azurerm\"]" produced an
unexpected new value: Root object was present, but now absent.
```

...even though the association was actually created successfully.

This mirrors a bug already fixed for the sibling resource `azurerm_subnet_network_security_group_association`, which guards against exactly this by polling the Subnet's (and parent Virtual Network's) `provisioningState` back to `Succeeded` after `CreateOrUpdateCallbackThenPoll` and before calling `Read` (`internal/services/network/subnet_network_security_group_association_resource.go`). `azurerm_network_interface_security_group_association` had no equivalent wait.

This PR adds the same class of guard: after `CreateOrUpdateCallbackThenPoll` on create, poll (`pluginsdk.StateChangeConf`) until a `Get` on the Network Interface reflects the Security Group association, before calling `Read`. The refresh logic is extracted into a named `networkInterfaceSecurityGroupAssociationRefreshFunc`, matching the naming/structuring convention already used for this kind of poller elsewhere in the same package (e.g. `SubnetProvisioningStateRefreshFunc`, `VirtualNetworkProvisioningStateRefreshFunc` in `subnet_resource.go` / `virtual_network_resource.go`).

#### Related Issue(s)

Fixes #33003

#### Change Log

* `azurerm_network_interface_security_group_association` - prevent a `Provider produced inconsistent result after apply` error caused by eventual consistency in the Network Interfaces API after `Create` [GH-00000]

- [x] Bug Fix
- [ ] New Feature
