### PR TITLE
Test Fix: `TestAccLogicAppStandard_storageKeyVaultSecret`

### DIFF
--- a/internal/services/logic/logic_app_standard_resource_test.go
+++ b/internal/services/logic/logic_app_standard_resource_test.go
@@ -2751,6 +2751,7 @@ resource "azurerm_key_vault" "test" {
   tenant_id                  = data.azurerm_client_config.current.tenant_id
   sku_name                   = "standard"
   soft_delete_retention_days = 7
+  rbac_authorization_enabled = false
 
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id

--- a/internal/services/logic/logic_app_standard_resource_test.go
+++ b/internal/services/logic/logic_app_standard_resource_test.go
@@ -2846,6 +2846,7 @@ resource "azurerm_key_vault" "test" {
   tenant_id                  = data.azurerm_client_config.current.tenant_id
   sku_name                   = "standard"
   soft_delete_retention_days = 7
+  rbac_authorization_enabled = false
 
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id


### PR DESCRIPTION
```
--- PASS: TestAccLogicAppStandard_storageKeyVaultSecret (443.08s)
--- PASS: TestAccLogicAppStandard_storageKeyVaultSecretUpdate (829.86s)

------- Stdout: -------
=== RUN   TestAccLogicAppStandard_storageKeyVaultSecret
=== PAUSE TestAccLogicAppStandard_storageKeyVaultSecret
=== CONT  TestAccLogicAppStandard_storageKeyVaultSecret
    testcase.go:220: Step 1/2 error: Error running pre-apply plan: exit status 1
        
        Error: Missing required argument
        
          on terraform_plugin_test.tf line 75, in resource "azurerm_key_vault" "test":
          75: resource "azurerm_key_vault" "test" {
        
        The argument "rbac_authorization_enabled" is required, but no definition was
        found.
--- FAIL: TestAccLogicAppStandard_storageKeyVaultSecret (9.78s)
FAIL

------- Stdout: -------
=== RUN   TestAccLogicAppStandard_storageKeyVaultSecretUpdate
=== PAUSE TestAccLogicAppStandard_storageKeyVaultSecretUpdate
=== CONT  TestAccLogicAppStandard_storageKeyVaultSecretUpdate
    testcase.go:220: Step 1/8 error: Error running pre-apply plan: exit status 1
        
        Error: Missing required argument
        
          on terraform_plugin_test.tf line 74, in resource "azurerm_key_vault" "test":
          74: resource "azurerm_key_vault" "test" {
        
        The argument "rbac_authorization_enabled" is required, but no definition was
        found.
--- FAIL: TestAccLogicAppStandard_storageKeyVaultSecretUpdate (17.07s)
FAIL
```