### PR TITLE
Provider Auth: MSI authorizer custom headers based on environment

### DIFF
--- a/internal/provider/framework/config.go
+++ b/internal/provider/framework/config.go
@@ -103,6 +103,7 @@ func (p *ProviderConfig) Load(ctx context.Context, data *ProviderModel, tfVersio
 
 		CustomManagedIdentityEndpoint:   getEnvStringOrDefault(data.MSIEndpoint, "ARM_MSI_ENDPOINT", ""),
 		CustomManagedIdentityAPIVersion: getEnvStringOrDefault(data.MSIAPIVersion, "ARM_MSI_API_VERSION", ""),
+		CustomManagedIdentityHeaders:    provider.ManagedIdentityCustomHeaders(),
 
 		AzureCliSubscriptionIDHint: subscriptionId,
 

--- a/internal/provider/managed_identity.go
+++ b/internal/provider/managed_identity.go
@@ -1,0 +1,108 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+// The Managed Identity source detection and header logic in this file references the Go MSAL
+// library apps/managedidentity/managedidentity.go
+// (github.com/AzureAD/microsoft-authentication-library-for-go).
+
+package provider
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// managedIdentitySource mirrors the Managed Identity sources detected by the Azure Identity
+// libraries. The hosting environment is determined by inspecting a well-known set of environment
+// variables so the correct token request can be issued.
+type managedIdentitySource string
+
+const (
+	managedIdentitySourceDefaultToIMDS managedIdentitySource = "DefaultToIMDS"
+	managedIdentitySourceAzureArc      managedIdentitySource = "AzureArc"
+	managedIdentitySourceServiceFabric managedIdentitySource = "ServiceFabric"
+	managedIdentitySourceCloudShell    managedIdentitySource = "CloudShell"
+	managedIdentitySourceAzureML       managedIdentitySource = "AzureML"
+	managedIdentitySourceAppService    managedIdentitySource = "AppService"
+)
+
+const (
+	identityEndpointEnvVar         = "IDENTITY_ENDPOINT"
+	identityHeaderEnvVar           = "IDENTITY_HEADER"
+	identityServerThumbprintEnvVar = "IDENTITY_SERVER_THUMBPRINT"
+	msiEndpointEnvVar              = "MSI_ENDPOINT"
+	msiSecretEnvVar                = "MSI_SECRET"
+	imdsEndpointEnvVar             = "IMDS_ENDPOINT"
+)
+
+// managedIdentitySourceFromEnvironment detects the Managed Identity source available in the current
+// environment, replicating the detection logic used by the Azure Identity libraries.
+func managedIdentitySourceFromEnvironment() managedIdentitySource {
+	identityEndpoint := os.Getenv(identityEndpointEnvVar)
+	identityHeader := os.Getenv(identityHeaderEnvVar)
+	identityServerThumbprint := os.Getenv(identityServerThumbprintEnvVar)
+	msiEndpoint := os.Getenv(msiEndpointEnvVar)
+	msiSecret := os.Getenv(msiSecretEnvVar)
+	imdsEndpoint := os.Getenv(imdsEndpointEnvVar)
+
+	switch {
+	case identityEndpoint != "" && identityHeader != "":
+		if identityServerThumbprint != "" {
+			return managedIdentitySourceServiceFabric
+		}
+		return managedIdentitySourceAppService
+	case msiEndpoint != "":
+		if msiSecret != "" {
+			return managedIdentitySourceAzureML
+		}
+		return managedIdentitySourceCloudShell
+	case isAzureArcEnvironment(identityEndpoint, imdsEndpoint):
+		return managedIdentitySourceAzureArc
+	}
+
+	return managedIdentitySourceDefaultToIMDS
+}
+
+func isAzureArcEnvironment(identityEndpoint, imdsEndpoint string) bool {
+	if identityEndpoint != "" && imdsEndpoint != "" {
+		return true
+	}
+
+	himdsFilePath := azureArcHimdsFilePath(runtime.GOOS)
+	if himdsFilePath != "" {
+		if _, err := os.Stat(himdsFilePath); err == nil {
+			return true
+		}
+	}
+
+	return false
+}
+
+func azureArcHimdsFilePath(platform string) string {
+	switch platform {
+	case "windows":
+		return filepath.Join(os.Getenv("ProgramData"), "AzureConnectedMachineAgent", "himds.exe")
+	case "linux":
+		return "/opt/azcmagent/bin/himds"
+	default:
+		return ""
+	}
+}
+
+// ManagedIdentityCustomHeaders returns the HTTP headers required to request a Managed Identity token
+// for the current hosting environment.
+func ManagedIdentityCustomHeaders() map[string][]string {
+	switch managedIdentitySourceFromEnvironment() {
+	case managedIdentitySourceAppService:
+		return map[string][]string{
+			"X-IDENTITY-HEADER": {os.Getenv(identityHeaderEnvVar)},
+		}
+	case managedIdentitySourceServiceFabric:
+		return map[string][]string{
+			"Secret": {os.Getenv(identityHeaderEnvVar)},
+		}
+	}
+
+	return nil
+}

--- a/internal/provider/managed_identity_test.go
+++ b/internal/provider/managed_identity_test.go
@@ -1,0 +1,135 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestManagedIdentitySourceFromEnvironment(t *testing.T) {
+	testCases := []struct {
+		name     string
+		env      map[string]string
+		expected managedIdentitySource
+	}{
+		{
+			name:     "no environment variables defaults to IMDS",
+			env:      map[string]string{},
+			expected: managedIdentitySourceDefaultToIMDS,
+		},
+		{
+			name: "app service / container apps",
+			env: map[string]string{
+				identityEndpointEnvVar: "http://localhost/token",
+				identityHeaderEnvVar:   "header-value",
+			},
+			expected: managedIdentitySourceAppService,
+		},
+		{
+			name: "service fabric",
+			env: map[string]string{
+				identityEndpointEnvVar:         "http://localhost/token",
+				identityHeaderEnvVar:           "header-value",
+				identityServerThumbprintEnvVar: "thumbprint",
+			},
+			expected: managedIdentitySourceServiceFabric,
+		},
+		{
+			name: "azure ml",
+			env: map[string]string{
+				msiEndpointEnvVar: "http://localhost/token",
+				msiSecretEnvVar:   "secret",
+			},
+			expected: managedIdentitySourceAzureML,
+		},
+		{
+			name: "cloud shell",
+			env: map[string]string{
+				msiEndpointEnvVar: "http://localhost/token",
+			},
+			expected: managedIdentitySourceCloudShell,
+		},
+		{
+			name: "azure arc",
+			env: map[string]string{
+				identityEndpointEnvVar: "http://localhost/token",
+				imdsEndpointEnvVar:     "http://localhost/imds",
+			},
+			expected: managedIdentitySourceAzureArc,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			for _, envVar := range []string{identityEndpointEnvVar, identityHeaderEnvVar, identityServerThumbprintEnvVar, msiEndpointEnvVar, msiSecretEnvVar, imdsEndpointEnvVar} {
+				t.Setenv(envVar, "")
+			}
+			for k, v := range testCase.env {
+				t.Setenv(k, v)
+			}
+
+			if actual := managedIdentitySourceFromEnvironment(); actual != testCase.expected {
+				t.Fatalf("expected source %q but got %q", testCase.expected, actual)
+			}
+		})
+	}
+}
+
+func TestManagedIdentityCustomHeaders(t *testing.T) {
+	testCases := []struct {
+		name     string
+		env      map[string]string
+		expected map[string][]string
+	}{
+		{
+			name:     "no environment variables returns no headers",
+			env:      map[string]string{},
+			expected: nil,
+		},
+		{
+			name: "app service / container apps",
+			env: map[string]string{
+				identityEndpointEnvVar: "http://localhost/token",
+				identityHeaderEnvVar:   "header-value",
+			},
+			expected: map[string][]string{
+				"X-IDENTITY-HEADER": {"header-value"},
+			},
+		},
+		{
+			name: "service fabric",
+			env: map[string]string{
+				identityEndpointEnvVar:         "http://localhost/token",
+				identityHeaderEnvVar:           "header-value",
+				identityServerThumbprintEnvVar: "thumbprint",
+			},
+			expected: map[string][]string{
+				"Secret": {"header-value"},
+			},
+		},
+		{
+			name: "cloud shell returns no headers",
+			env: map[string]string{
+				msiEndpointEnvVar: "http://localhost/token",
+			},
+			expected: nil,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			for _, envVar := range []string{identityEndpointEnvVar, identityHeaderEnvVar, identityServerThumbprintEnvVar, msiEndpointEnvVar, msiSecretEnvVar, imdsEndpointEnvVar} {
+				t.Setenv(envVar, "")
+			}
+			for k, v := range testCase.env {
+				t.Setenv(k, v)
+			}
+
+			if actual := ManagedIdentityCustomHeaders(); !reflect.DeepEqual(actual, testCase.expected) {
+				t.Fatalf("expected headers %+v but got %+v", testCase.expected, actual)
+			}
+		})
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -479,6 +479,7 @@ func providerConfigure(p *schema.Provider, testName string) schema.ConfigureCont
 
 			CustomManagedIdentityEndpoint:   d.Get("msi_endpoint").(string),
 			CustomManagedIdentityAPIVersion: d.Get("msi_api_version").(string),
+			CustomManagedIdentityHeaders:    ManagedIdentityCustomHeaders(),
 
 			AzureCliSubscriptionIDHint: subscriptionId,
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

To solve the issues below:

- https://github.com/hashicorp/terraform/issues/37268
- https://github.com/hashicorp/terraform-provider-azurerm/issues/33001

There are three ways to do (ordered from topest):

1. Expose a new provider config as is requested in #33001
2. (The current solution) Handle the runtime detection at the provider level and set the `CustomManagedIdentityHeaders` (provided from go-azure-sdk)
3. Handle the runtime detection at the `go-azure-sdk` level (which makes the `CustomManagedIdentityHeaders` useless).  The benefit of doing this is it can easily cover https://github.com/hashicorp/terraform/issues/37268. 

The detail of the current PR: The `auth.Credentials` (`authConfig`) constructed in both the SDKv2 provider (`internal/provider/provider.go`) and the framework provider (`internal/provider/framework/config.go`) never populated `CustomManagedIdentityHeaders`. Some hosting environments — notably Azure Container Apps / App Service and Service Fabric — expose their Managed Identity token endpoint via the `IDENTITY_ENDPOINT` / `IDENTITY_HEADER` environment variables and require the `IDENTITY_HEADER` value to be sent as an authenticating header, which was not happening.

This change adds Managed Identity source detection (mirroring the Go MSAL library's `GetSource()` logic) and, based on the detected source, sets the appropriate token request headers on `authConfig` for both provider implementations:

- **App Service / Container Apps** → `X-IDENTITY-HEADER`
- **Service Fabric** → `Secret`
- All other sources (AzureML, CloudShell, Azure Arc, IMDS) are unchanged.

The header is not exposed as a provider configuration option; it is derived automatically from the environment.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

With a well setup ACA and the newly built provider and setting the following env var:

```shell
export ARM_USE_MSI=true
export ARM_MSI_ENDPOINT=$MSI_ENDPOINT
export ARM_MSI_API_VERSION="2019-08-01"
```

Run the following terraform config:

```hcl
provider "azurerm" {
  features {}
}

data "azurerm_resource_group" "test" {
  name = "magodo-aca"
}
```


```shell
root@magodo-aca--0000005-6679dc6977-62dvw:~/tf# terraform apply
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - hashicorp/azurerm in /root
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
data.azurerm_resource_group.test: Reading...
data.azurerm_resource_group.test: Read complete after 0s [id=/subscriptions/xxxx/resourceGroups/magodo-aca]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
root@magodo-aca--0000005-6679dc6977-62dvw:~/tf# terraform show
# data.azurerm_resource_group.test:
data "azurerm_resource_group" "test" {
    id         = "/subscriptions/xxxx/resourceGroups/magodo-aca"
    location   = "westus2"
    managed_by = null
    name       = "magodo-aca"
    tags       = {}
}
```


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #33001


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
