### PR TITLE
Test Fix: `PASS: TestAccBotChannelsRegistration_complete`

### DIFF
--- a/internal/services/bot/bot_channels_registration_resource_test.go
+++ b/internal/services/bot/bot_channels_registration_resource_test.go
@@ -209,7 +209,6 @@ resource "azurerm_bot_channels_registration" "test" {
   sku                     = "F0"
 
   endpoint                              = "https://example.com"
-  developer_app_insights_api_key        = azurerm_application_insights_api_key.test.api_key
   developer_app_insights_application_id = azurerm_application_insights.test.app_id
   developer_app_insights_key            = azurerm_application_insights.test.instrumentation_key
 

--- a/internal/services/bot/bot_channels_registration_resource_test.go
+++ b/internal/services/bot/bot_channels_registration_resource_test.go
@@ -209,6 +209,7 @@ resource "azurerm_bot_channels_registration" "test" {
   sku                     = "F0"
 
   endpoint                              = "https://example.com"
+  developer_app_insights_api_key        = "IamAFakeKeyToTestTheAttributeXXXXXXXXXXX"
   developer_app_insights_application_id = azurerm_application_insights.test.app_id
   developer_app_insights_key            = azurerm_application_insights.test.instrumentation_key
 

--- a/internal/services/bot/bot_channels_registration_resource_test.go
+++ b/internal/services/bot/bot_channels_registration_resource_test.go
@@ -209,7 +209,7 @@ resource "azurerm_bot_channels_registration" "test" {
   sku                     = "F0"
 
   endpoint                              = "https://example.com"
-  developer_app_insights_api_key        = "IamAFakeKeyToTestTheAttributeXXXXXXXXXXX"
+  developer_app_insights_api_key        = "IamAFakeKeyToTestTheAttribute00000000000"
   developer_app_insights_application_id = azurerm_application_insights.test.app_id
   developer_app_insights_key            = azurerm_application_insights.test.instrumentation_key
 


### PR DESCRIPTION
```
--- PASS: TestAccBotChannelsRegistration_complete (295.72s)

------- Stdout: -------
=== RUN   TestAccBotChannelsRegistration_complete
=== PAUSE TestAccBotChannelsRegistration_complete
=== CONT  TestAccBotChannelsRegistration_complete
    testcase.go:220: Step 1/2 error: Error running apply: exit status 1
        
        Error: creating Bot Channels Registration "acctestdf260805235753285988" (Resource Group "acctestRG-260805235753285988"): botservice.BotsClient#Create: Failure responding to request: StatusCode=400 -- Original Error: autorest/azure: Service returned an error. Status=400 Code="InvalidBotData" Message="Bot is not valid. Errors: The Developer App Insights API Key must be exactly 40 characters long.  See https://docs.microsoft.com/azure/bot-service/bot-service-resources-bot-framework-faq?view=azure-bot-service-4.0 for detailed requirements."
        
          with azurerm_bot_channels_registration.test,
          on terraform_plugin_test.tf line 144, in resource "azurerm_bot_channels_registration" "test":
         144: resource "azurerm_bot_channels_registration" "test" {
        
--- FAIL: TestAccBotChannelsRegistration_complete (324.25s)
FAIL
```