### PR TITLE
Test Fix: `TestAccBotWebApp_update`

### DIFF
--- a/internal/services/bot/bot_web_app_resource_test.go
+++ b/internal/services/bot/bot_web_app_resource_test.go
@@ -185,7 +185,7 @@ resource "azurerm_bot_web_app" "test" {
   sku                     = "F0"
 
   endpoint                              = "https://example.com"
-  developer_app_insights_api_key        = azurerm_application_insights_api_key.test.api_key
+  developer_app_insights_api_key        = "IamAFakeKeyToTestTheAttribute00000000000"
   developer_app_insights_application_id = azurerm_application_insights.test.app_id
   developer_app_insights_key            = azurerm_application_insights.test.instrumentation_key
 


### PR DESCRIPTION
```
--- PASS: TestAccBotWebApp_update (155.51s)

------- Stdout: -------
=== RUN   TestAccBotWebApp_update
=== PAUSE TestAccBotWebApp_update
=== CONT  TestAccBotWebApp_update
    testcase.go:220: Step 3/6 error: Error running apply: exit status 1
        
        Error: updating Web App Bot "acctestdf260806000242352194" (Resource Group "acctestRG-260806000242352194"): botservice.BotsClient#Update: Failure responding to request: StatusCode=400 -- Original Error: autorest/azure: Service returned an error. Status=400 Code="InvalidBotData" Message="The Developer App Insights API Key must be exactly 40 characters long. "
        
          with azurerm_bot_web_app.test,
          on terraform_plugin_test.tf line 65, in resource "azurerm_bot_web_app" "test":
          65: resource "azurerm_bot_web_app" "test" {
        
--- FAIL: TestAccBotWebApp_update (270.30s)
FAIL
```
