### PR TITLE
Test Fix: `TestAccBotChannelsRegistration_update`

### DIFF
--- a/internal/services/bot/bot_channels_registration_resource_test.go
+++ b/internal/services/bot/bot_channels_registration_resource_test.go
@@ -170,7 +170,7 @@ resource "azurerm_bot_channels_registration" "test" {
   sku                     = "F0"
 
   endpoint                              = "https://example2.com"
-  developer_app_insights_api_key        = azurerm_application_insights_api_key.test2.api_key
+  developer_app_insights_api_key        = "IamAFakeKeyToTestTheAttribute00000000000"
   developer_app_insights_application_id = azurerm_application_insights.test2.app_id
   developer_app_insights_key            = azurerm_application_insights.test2.instrumentation_key
 
@@ -209,7 +209,7 @@ resource "azurerm_bot_channels_registration" "test" {
   sku                     = "F0"
 
   endpoint                              = "https://example.com"
-  developer_app_insights_api_key        = azurerm_application_insights_api_key.test.api_key
+  developer_app_insights_api_key        = "IamAFakeKeyToTestTheAttribute00000000000"
   developer_app_insights_application_id = azurerm_application_insights.test.app_id
   developer_app_insights_key            = azurerm_application_insights.test.instrumentation_key
 
@@ -248,7 +248,7 @@ resource "azurerm_bot_channels_registration" "test" {
   sku                     = "F0"
 
   endpoint                              = "https://example2.com"
-  developer_app_insights_api_key        = azurerm_application_insights_api_key.test2.api_key
+  developer_app_insights_api_key        = "IamAFakeKeyToTestTheAttribute00000000000"
   developer_app_insights_application_id = azurerm_application_insights.test2.app_id
   developer_app_insights_key            = azurerm_application_insights.test2.instrumentation_key
 

--- a/internal/services/bot/bot_service_azure_bot_resource_test.go
+++ b/internal/services/bot/bot_service_azure_bot_resource_test.go
@@ -228,7 +228,7 @@ resource "azurerm_bot_service_azure_bot" "test" {
   public_network_access_enabled         = false
   icon_url                              = "https://registry.terraform.io/images/providers/azure.png"
   endpoint                              = "https://example.com"
-  developer_app_insights_api_key        = azurerm_application_insights_api_key.test.api_key
+  developer_app_insights_api_key        = "IamAFakeKeyToTestTheAttribute00000000000"
   developer_app_insights_application_id = azurerm_application_insights.test.app_id
 
   tags = {


### PR DESCRIPTION
```
--- PASS: TestAccBotChannelsRegistration_update (364.94s)
--- PASS: TestAccBotServiceAzureBot_completeUpdate (110.74s)

------- Stdout: -------
=== RUN   TestAccBotChannelsRegistration_update
=== PAUSE TestAccBotChannelsRegistration_update
=== CONT  TestAccBotChannelsRegistration_update
    testcase.go:220: Step 3/10 error: Error running apply: exit status 1
        
        Error: updating Bot Channels Registration "acctestdf260805235753263671" (Resource Group "acctestRG-260805235753263671"): botservice.BotsClient#Update: Failure responding to request: StatusCode=400 -- Original Error: autorest/azure: Service returned an error. Status=400 Code="InvalidBotData" Message="The Developer App Insights API Key must be exactly 40 characters long. "
        
          with azurerm_bot_channels_registration.test,
          on terraform_plugin_test.tf line 144, in resource "azurerm_bot_channels_registration" "test":
         144: resource "azurerm_bot_channels_registration" "test" {
        
--- FAIL: TestAccBotChannelsRegistration_update (466.84s)
FAIL

------- Stdout: -------
=== RUN   TestAccBotServiceAzureBot_completeUpdate
=== PAUSE TestAccBotServiceAzureBot_completeUpdate
=== CONT  TestAccBotServiceAzureBot_completeUpdate
    testcase.go:220: Step 3/4 error: Error running apply: exit status 1
        
        Error: updating Bot Service: (Name "acctestdf260806000214084822" / Resource Group "acctestRG-260806000214084822"): botservice.BotsClient#Update: Failure responding to request: StatusCode=400 -- Original Error: autorest/azure: Service returned an error. Status=400 Code="InvalidBotData" Message="The Developer App Insights API Key must be exactly 40 characters long. "
        
          with azurerm_bot_service_azure_bot.test,
          on terraform_plugin_test.tf line 64, in resource "azurerm_bot_service_azure_bot" "test":
          64: resource "azurerm_bot_service_azure_bot" "test" {
        
        updating Bot Service: (Name "acctestdf260806000214084822" / Resource Group
        "acctestRG-260806000214084822"): botservice.BotsClient#Update: Failure
        responding to request: StatusCode=400 -- Original Error: autorest/azure:
        Service returned an error. Status=400 Code="InvalidBotData" Message="The
        Developer App Insights API Key must be exactly 40 characters long. "
--- FAIL: TestAccBotServiceAzureBot_completeUpdate (280.62s)
FAIL
```