### PR TITLE
`azurerm_container_app` - clarify `registry.server` is an FQDN, not a hostname

### DIFF
--- a/website/docs/d/container_app.html.markdown
+++ b/website/docs/d/container_app.html.markdown
@@ -359,7 +359,7 @@ A `dapr` block exports the following:
 
 A `registry` block exports the following:
 
-* `server` - The hostname for the Container Registry.
+* `server` - The FQDN for the Container Registry.
 
 * `identity` - Resource ID for the User Assigned Managed identity to use when pulling from the Container Registry.
 

--- a/website/docs/r/container_app.html.markdown
+++ b/website/docs/r/container_app.html.markdown
@@ -472,7 +472,7 @@ A `dapr` block supports the following:
 
 A `registry` block supports the following:
 
-* `server` - (Required) The hostname for the Container Registry.
+* `server` - (Required) The FQDN for the Container Registry.
 
 The authentication details must also be supplied, `identity` and `username`/`password_secret_name` are mutually exclusive.
 


### PR DESCRIPTION
### Description

The `registry.server` attribute documentation for both the `azurerm_container_app` resource and data source described the field as a "hostname", which is inaccurate — the value is expected to be an FQDN. This updates the wording in both docs to say "FQDN" instead.

Closes #32308