### PR TITLE
azurerm_monitor_data_collection_rule: support kind = "Direct"

### DIFF
--- a/internal/services/monitor/monitor_data_collection_rule_resource.go
+++ b/internal/services/monitor/monitor_data_collection_rule_resource.go
@@ -39,6 +39,8 @@ type DataCollectionRule struct {
 	Destinations             []Destination          `tfschema:"destinations"`
 	ImmutableId              string                 `tfschema:"immutable_id"`
 	Kind                     string                 `tfschema:"kind"`
+	LogsIngestionEndpoint    string                 `tfschema:"logs_ingestion_endpoint"`
+	MetricsIngestionEndpoint string                 `tfschema:"metrics_ingestion_endpoint"`
 	Name                     string                 `tfschema:"name"`
 	Location                 string                 `tfschema:"location"`
 	ResourceGroupName        string                 `tfschema:"resource_group_name"`
@@ -867,6 +869,7 @@ func (r DataCollectionRuleResource) Arguments() map[string]*pluginsdk.Schema {
 					"Windows",
 					"AgentDirectToStore",
 					"WorkspaceTransforms",
+					"Direct",
 				},
 				false,
 			),
@@ -912,6 +915,16 @@ func (r DataCollectionRuleResource) Arguments() map[string]*pluginsdk.Schema {
 func (r DataCollectionRuleResource) Attributes() map[string]*pluginsdk.Schema {
 	return map[string]*pluginsdk.Schema{
 		"immutable_id": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"logs_ingestion_endpoint": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"metrics_ingestion_endpoint": {
 			Type:     pluginsdk.TypeString,
 			Computed: true,
 		},
@@ -1011,6 +1024,7 @@ func (r DataCollectionRuleResource) Read() sdk.ResourceFunc {
 			}
 
 			var dataCollectionEndpointId, description, immutableId, kind, loc string
+			var logsIngestionEndpoint, metricsIngestionEndpoint string
 			var tag map[string]interface{}
 			var dataFlows []DataFlow
 			var dataSources []DataSource
@@ -1039,6 +1053,11 @@ func (r DataCollectionRuleResource) Read() sdk.ResourceFunc {
 					destinations = flattenDataCollectionRuleDestinations(prop.Destinations)
 					immutableId = flattenStringPtr(prop.ImmutableId)
 					streamDeclaration = flattenDataCollectionRuleStreamDeclarations(prop.StreamDeclarations)
+
+					if prop.Endpoints != nil {
+						logsIngestionEndpoint = flattenStringPtr(prop.Endpoints.LogsIngestion)
+						metricsIngestionEndpoint = flattenStringPtr(prop.Endpoints.MetricsIngestion)
+					}
 				}
 			}
 
@@ -1053,6 +1072,8 @@ func (r DataCollectionRuleResource) Read() sdk.ResourceFunc {
 				ImmutableId:              immutableId,
 				Kind:                     kind,
 				Location:                 loc,
+				LogsIngestionEndpoint:    logsIngestionEndpoint,
+				MetricsIngestionEndpoint: metricsIngestionEndpoint,
 				StreamDeclaration:        streamDeclaration,
 				Tags:                     tag,
 			})
@@ -2188,6 +2209,25 @@ func (r DataCollectionRuleResource) CustomizeDiff() sdk.ResourceFunc {
 					return err
 				}
 			}
+
+			if kind := metadata.ResourceDiff.Get("kind").(string); kind == "Direct" {
+				if v := metadata.ResourceDiff.Get("data_sources").([]interface{}); len(v) > 0 {
+					return fmt.Errorf("`data_sources` cannot be used when `kind` is set to `Direct`")
+				}
+
+				if v := metadata.ResourceDiff.Get("destinations.0.event_hub_direct").([]interface{}); len(v) > 0 {
+					return fmt.Errorf("`event_hub_direct`, `storage_blob_direct`, and `storage_table_direct` destinations cannot be used when `kind` is set to `Direct`")
+				}
+
+				if v := metadata.ResourceDiff.Get("destinations.0.storage_blob_direct").([]interface{}); len(v) > 0 {
+					return fmt.Errorf("`event_hub_direct`, `storage_blob_direct`, and `storage_table_direct` destinations cannot be used when `kind` is set to `Direct`")
+				}
+
+				if v := metadata.ResourceDiff.Get("destinations.0.storage_table_direct").([]interface{}); len(v) > 0 {
+					return fmt.Errorf("`event_hub_direct`, `storage_blob_direct`, and `storage_table_direct` destinations cannot be used when `kind` is set to `Direct`")
+				}
+			}
+
 			return nil
 		},
 	}

--- a/internal/services/monitor/monitor_data_collection_rule_resource_test.go
+++ b/internal/services/monitor/monitor_data_collection_rule_resource_test.go
@@ -81,6 +81,25 @@ func TestAccMonitorDataCollectionRule_kindWorkspaceTransforms(t *testing.T) {
 	})
 }
 
+func TestAccMonitorDataCollectionRule_kindDirect(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_monitor_data_collection_rule", "test")
+	r := MonitorDataCollectionRuleResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.kindDirect(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("logs_ingestion_endpoint").IsNotEmpty(),
+				check.That(data.ResourceName).Key("metrics_ingestion_endpoint").IsNotEmpty(),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+
+
 func TestAccMonitorDataCollectionRule_identity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_monitor_data_collection_rule", "test")
 	r := MonitorDataCollectionRuleResource{}
@@ -1161,4 +1180,37 @@ resource "azurerm_resource_group" "test" {
 }
 
 `, data.RandomInteger, data.Locations.Primary)
+}
+
+func (r MonitorDataCollectionRuleResource) kindDirect(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_log_analytics_workspace" "test" {
+  name                = "acctestlaw-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  sku                 = "PerGB2018"
+  retention_in_days   = 30
+}
+
+resource "azurerm_monitor_data_collection_rule" "test" {
+  name                = "acctestmdcr-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  kind                = "Direct"
+
+  destinations {
+    log_analytics {
+      workspace_resource_id = azurerm_log_analytics_workspace.test.id
+      name                  = "dest-la"
+    }
+  }
+
+  data_flow {
+    streams      = ["Microsoft-Syslog"]
+    destinations = ["dest-la"]
+  }
+}
+`, r.template(data), data.RandomInteger)
 }

--- a/internal/services/monitor/monitor_data_collection_rule_resource_test.go
+++ b/internal/services/monitor/monitor_data_collection_rule_resource_test.go
@@ -98,8 +98,6 @@ func TestAccMonitorDataCollectionRule_kindDirect(t *testing.T) {
 	})
 }
 
-
-
 func TestAccMonitorDataCollectionRule_identity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_monitor_data_collection_rule", "test")
 	r := MonitorDataCollectionRuleResource{}

--- a/website/docs/r/monitor_data_collection_rule.html.markdown
+++ b/website/docs/r/monitor_data_collection_rule.html.markdown
@@ -232,9 +232,11 @@ The following arguments are supported:
 
 * `identity` - (Optional) An `identity` block as defined below.
 
-* `kind` - (Optional) The kind of the Data Collection Rule. Possible values are `Linux`, `Windows`, `AgentDirectToStore` and `WorkspaceTransforms`. A rule of kind `Linux` does not allow for `windows_event_log` data sources. And a rule of kind `Windows` does not allow for `syslog` data sources. If kind is not specified, all kinds of data sources are allowed.
+* `kind` - (Optional) The kind of the Data Collection Rule. Possible values are `Linux`, `Windows`, `AgentDirectToStore`, `WorkspaceTransforms` and `Direct`. A rule of kind `Linux` does not allow for `windows_event_log` data sources. And a rule of kind `Windows` does not allow for `syslog` data sources. If kind is not specified, all kinds of data sources are allowed.
 
 ~> **Note:** Once `kind` has been set, changing it forces a new Data Collection Rule to be created.
+
+~> **Note:** When `kind` is set to `Direct`, `data_sources` must not be configured, and the destination types `event_hub_direct`, `storage_blob_direct`, and `storage_table_direct` are not permitted. Azure will automatically generate the `logs_ingestion_endpoint` and `metrics_ingestion_endpoint` values.
 
 * `stream_declaration` - (Optional) A `stream_declaration` block as defined below.
 
@@ -318,7 +320,7 @@ A `destinations` block supports the following:
 
 * `storage_table_direct` - (Optional) One or more `storage_table_direct` blocks as defined below.
 
--> **Note:** `event_hub_direct`, `storage_blob_direct`, and `storage_table_direct` are only available for rules of kind `AgentDirectToStore`.
+-> **Note:** `event_hub_direct`, `storage_blob_direct`, and `storage_table_direct` are only available for rules of kind `AgentDirectToStore` and are not permitted for `Direct`.
 
 -> **Note:** At least one of `azure_monitor_metrics`, `event_hub`, `event_hub_direct`, `log_analytics`, `monitor_account`, `storage_blob`, `storage_blob_direct`,and `storage_table_direct` blocks must be specified.
 
@@ -539,6 +541,10 @@ In addition to the Arguments listed above - the following Attributes are exporte
 * `id` - The ID of the Data Collection Rule.
 
 * `immutable_id` - The immutable ID of the Data Collection Rule.
+
+* `logs_ingestion_endpoint` - The endpoint URL for sending logs via the Logs Ingestion API. Only populated when `kind` is set to `Direct`.
+
+* `metrics_ingestion_endpoint` - The endpoint URL for sending metrics via the Metrics Ingestion API. Only populated when `kind` is set to `Direct`.
 
 ---
 


### PR DESCRIPTION
- Add "Direct" to the kind field ValidateFunc
- Add CustomizeDiff plan-time guards: data_sources is forbidden and event_hub_direct/storage_blob_direct/storage_table_direct destinations are forbidden when kind is set to Direct
- Add logs_ingestion_endpoint and metrics_ingestion_endpoint as computed attributes, populated from properties.endpoints returned by the API
- Add acceptance test TestAccMonitorDataCollectionRule_kindDirect
- Update documentation

Fixes: https://github.com/hashicorp/terraform-provider-azurerm/issues/28697

<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This PR adds support for `kind = "Direct"` on the `azurerm_monitor_data_collection_rule` resource.

Direct Data Collection Rules enable the **Logs Ingestion API** scenario — where applications push logs and metrics directly to Azure Monitor without an agent. Previously, Terraform rejected this value at the schema validation layer before any API call was made.

### Background — why no SDK or API version change is needed

The `kind` field in the Azure REST API spec (`2023-03-11` and `2024-03-11`) is declared with `"x-ms-enum": { "modelAsString": true }`. This is an intentional signal that the enum is open/extensible — the listed values (`Linux`, `Windows`) are not exhaustive. go-azure-sdk correctly generates a best-effort fallback for this pattern:

```go
// otherwise presume it's an undefined value and best-effort it
out := KnownDataCollectionRuleResourceKind(input)
return &out, nil
```

`AgentDirectToStore` and `WorkspaceTransforms` — already shipped in the provider — are also absent from the spec enum and work through this exact same fallback. `Direct` is identical. No vendor file edit, no go-azure-sdk PR, and no API version bump is needed.

### API behaviour — confirmed by live testing

The following was verified against `api-version=2023-03-11` on a live Azure subscription:

- `destinations` and `dataFlows` are **required** for `Direct` — same as all other kinds. The existing `Required: true` schema is correct.
- `data_sources` of any type are **forbidden** — API returns `InvalidDataSource: Allowed types: .`
- `event_hub_direct`, `storage_blob_direct`, `storage_table_direct` destinations are **forbidden** — API returns `UnsupportedDestination`
- Azure auto-generates `properties.endpoints.logsIngestion` and `properties.endpoints.metricsIngestion` URLs on every successful create
- `kind` is immutable at the API level — consistent with the existing `ForceNew` behaviour

### Changes made

- Add `"Direct"` to the `kind` field `ValidateFunc`
- Extend `CustomizeDiff` with plan-time guards: return a clear error if `data_sources` is configured or if `event_hub_direct` / `storage_blob_direct` / `storage_table_direct` destinations are set when `kind = "Direct"`, rather than surfacing a cryptic apply-time API error
- Add `logs_ingestion_endpoint` and `metrics_ingestion_endpoint` as `Computed` string attributes populated from `properties.endpoints` in the Read function. This follows the same flat string pattern used in the sibling `azurerm_monitor_data_collection_endpoint` resource
- Add acceptance test `TestAccMonitorDataCollectionRule_kindDirect`
- Update documentation

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

All relevant acceptance tests were run locally against a live Azure subscription (`api-version=2023-03-11`).

| Test | Result |
|---|---|
| `TestAccMonitorDataCollectionRule_kindDirect` ← new | ✅ PASS |
| `TestAccMonitorDataCollectionRule_basic` | ✅ PASS |
| `TestAccMonitorDataCollectionRule_requiresImport` | ✅ PASS |
| `TestAccMonitorDataCollectionRule_identity` | ✅ PASS |
| `TestAccMonitorDataCollectionRule_kindWorkspaceTransforms` | ✅ PASS |
| `TestAccMonitorDataCollectionRule_complete` | ✅ PASS |
| `TestAccMonitorDataCollectionRule_update` | ✅ PASS |
| `TestAccMonitorDataCollectionRule_kindDirectToStore` | ❌ Pre-existing failure — unrelated |

The `kindDirectToStore` failure is pre-existing in `main` and unrelated to this change. Azure has deprecated `kind = "AgentDirectToStore"` at the service level and now rejects creation with:

```
InvalidResource: Creation of new Data Collection Rules with kind 'AgentDirectToStore' is not allowed.
```

This breakage exists before this PR and affects all branches equally.

---

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_monitor_data_collection_rule` - support for `kind` value `Direct` and new computed attributes `logs_ingestion_endpoint` and `metrics_ingestion_endpoint` [GH-28697]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #28697


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
