### PR TITLE
Test Fix: `TestAccGalleryApplicationVersion_basic`

### DIFF
--- a/internal/services/compute/gallery_application_version_resource_test.go
+++ b/internal/services/compute/gallery_application_version_resource_test.go
@@ -275,6 +275,11 @@ func (r GalleryApplicationVersionResource) Exists(ctx context.Context, client *c
 
 func (r GalleryApplicationVersionResource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctest-compute-%[2]d"
   location = "%[1]s"


### PR DESCRIPTION
```
--- PASS: TestAccGalleryApplicationVersion_basic (797.37s)

------- Stdout: -------
=== RUN   TestAccGalleryApplicationVersion_basic
=== PAUSE TestAccGalleryApplicationVersion_basic
=== CONT  TestAccGalleryApplicationVersion_basic
    testcase.go:225: Step 1/2 error: Error running pre-apply plan: exit status 1
        
        Error: Invalid provider configuration
        
        Provider "registry.terraform.io/hashicorp/azurerm" requires explicit
        configuration. Add a provider block to the root module and configure the
        provider's required arguments as described in the provider documentation.
        
        
        Error: Missing required argument
        
          with provider["registry.terraform.io/hashicorp/azurerm"],
          on <empty> line 0:
          (source code not available)
        
        The argument "features" is required, but no definition was found.
--- FAIL: TestAccGalleryApplicationVersion_basic (19.70s)
FAIL
```