### PR TITLE
Test Fix: `TestAccHealthCareMedTechServiceFhirDestination_updateFhir`

### DIFF
--- a/internal/services/healthcare/healthcare_medtech_service_resource_test.go
+++ b/internal/services/healthcare/healthcare_medtech_service_resource_test.go
@@ -303,19 +303,17 @@ resource "azurerm_eventhub_namespace" "test" {
 }
 
 resource "azurerm_eventhub" "test" {
-  name                = "acctest-eh-%d"
-  namespace_name      = azurerm_eventhub_namespace.test.name
-  resource_group_name = azurerm_resource_group.test.name
-  partition_count     = 1
-  message_retention   = 1
+  name              = "acctest-eh-%d"
+  namespace_id      =  azurerm_eventhub_namespace.test.id
+  partition_count   = 1
+  message_retention = 1
 }
 
 resource "azurerm_eventhub" "test1" {
-  name                = "acctest-eh1-%d"
-  namespace_name      = azurerm_eventhub_namespace.test.name
-  resource_group_name = azurerm_resource_group.test.name
-  partition_count     = 1
-  message_retention   = 1
+  name              = "acctest-eh1-%d"
+  namespace_id      =  azurerm_eventhub_namespace.test.id
+  partition_count   = 1
+  message_retention = 1
 }
 
 resource "azurerm_eventhub_consumer_group" "test" {

--- a/internal/services/healthcare/healthcare_medtech_service_resource_test.go
+++ b/internal/services/healthcare/healthcare_medtech_service_resource_test.go
@@ -304,14 +304,14 @@ resource "azurerm_eventhub_namespace" "test" {
 
 resource "azurerm_eventhub" "test" {
   name              = "acctest-eh-%d"
-  namespace_id      =  azurerm_eventhub_namespace.test.id
+  namespace_id      = azurerm_eventhub_namespace.test.id
   partition_count   = 1
   message_retention = 1
 }
 
 resource "azurerm_eventhub" "test1" {
   name              = "acctest-eh1-%d"
-  namespace_id      =  azurerm_eventhub_namespace.test.id
+  namespace_id      = azurerm_eventhub_namespace.test.id
   partition_count   = 1
   message_retention = 1
 }


### PR DESCRIPTION
```
------- Stdout: -------
=== RUN   TestAccHealthCareMedTechServiceFhirDestination_updateFhir
=== PAUSE TestAccHealthCareMedTechServiceFhirDestination_updateFhir
=== CONT  TestAccHealthCareMedTechServiceFhirDestination_updateFhir
    testcase.go:225: Step 1/4 error: Error running pre-apply plan: exit status 1
        
        Error: Missing required argument
        
          on terraform_plugin_test.tf line 54, in resource "azurerm_eventhub" "test":
          54: resource "azurerm_eventhub" "test" {
        
        The argument "namespace_id" is required, but no definition was found.
        
        Error: Unsupported argument
        
          on terraform_plugin_test.tf line 56, in resource "azurerm_eventhub" "test":
          56:   namespace_name      = azurerm_eventhub_namespace.test.name
        
        An argument named "namespace_name" is not expected here.
        
        Error: Unsupported argument
        
          on terraform_plugin_test.tf line 57, in resource "azurerm_eventhub" "test":
          57:   resource_group_name = azurerm_resource_group.test.name
        
        An argument named "resource_group_name" is not expected here.
        
        Error: Missing required argument
        
          on terraform_plugin_test.tf line 62, in resource "azurerm_eventhub" "test1":
          62: resource "azurerm_eventhub" "test1" {
        
        The argument "namespace_id" is required, but no definition was found.
        
        Error: Unsupported argument
        
          on terraform_plugin_test.tf line 64, in resource "azurerm_eventhub" "test1":
          64:   namespace_name      = azurerm_eventhub_namespace.test.name
        
        An argument named "namespace_name" is not expected here.
        
        Error: Unsupported argument
        
          on terraform_plugin_test.tf line 65, in resource "azurerm_eventhub" "test1":
          65:   resource_group_name = azurerm_resource_group.test.name
        
        An argument named "resource_group_name" is not expected here.
--- FAIL: TestAccHealthCareMedTechServiceFhirDestination_updateFhir (39.39s)
FAIL
```