### PR TITLE
`azurerm_cognitive_account_rai_policy` - clarify `content_filter` supports one or more blocks

### DIFF
--- a/website/docs/r/cognitive_account_rai_policy.html.markdown
+++ b/website/docs/r/cognitive_account_rai_policy.html.markdown
@@ -54,7 +54,7 @@ The following arguments are supported:
 
 * `base_policy_name` - (Required) The name of the base policy to use for this RAI Policy. Changing this forces a new resource to be created.
 
-* `content_filter` - (Required) A `content_filter` block as defined below.
+* `content_filter` - (Required) One or more `content_filter` blocks as defined below.
 
 * `mode` - (Optional) The mode of the RAI Policy. Possible values are `Default`, `Deferred`, `Blocking` or `Asynchronous_filter`.
 


### PR DESCRIPTION
### Description

The `content_filter` argument documentation stated "A `content_filter` block", implying only one is allowed. However, the schema is a `TypeList` without `MaxItems`, so multiple `content_filter` blocks are supported (as shown in the resource's own example, which uses two). This updates the wording to reflect that.

Closes #30865