### PR TITLE
`azurerm_hdinsight_*` - Fix `disk_encryption` property population

### DIFF
--- a/internal/services/hdinsight/hdinsight_hadoop_cluster_resource.go
+++ b/internal/services/hdinsight/hdinsight_hadoop_cluster_resource.go
@@ -297,11 +297,20 @@ func resourceHDInsightHadoopClusterCreate(d *pluginsdk.ResourceData, meta interf
 	}
 
 	if diskEncryptionPropertiesRaw, ok := d.GetOk("disk_encryption"); ok {
-		diskEncryptionProperties, err := ExpandHDInsightsDiskEncryptionProperties(diskEncryptionPropertiesRaw.([]interface{}))
+		diskEncryptionProperties, diskEncryptionIdentity, err := ExpandHDInsightsDiskEncryptionProperties(diskEncryptionPropertiesRaw.([]interface{}))
 		if err != nil {
 			return err
 		}
 		payload.Properties.DiskEncryptionProperties = diskEncryptionProperties
+		if diskEncryptionIdentity != nil {
+			if payload.Identity == nil {
+				payload.Identity = diskEncryptionIdentity
+			} else {
+				for k, v := range diskEncryptionIdentity.IdentityIds {
+					payload.Identity.IdentityIds[k] = v
+				}
+			}
+		}
 	}
 
 	if v, ok := d.GetOk("security_profile"); ok {

--- a/internal/services/hdinsight/hdinsight_hadoop_cluster_resource.go
+++ b/internal/services/hdinsight/hdinsight_hadoop_cluster_resource.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
-	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/hdinsight/2021-06-01/applications"
@@ -305,28 +304,16 @@ func resourceHDInsightHadoopClusterCreate(d *pluginsdk.ResourceData, meta interf
 		}
 		payload.Properties.DiskEncryptionProperties = diskEncryptionProperties
 		if diskEncryptionIdentity != nil {
-			if payload.Identity == nil {
-				payload.Identity = diskEncryptionIdentity
-			} else {
-				for k, v := range diskEncryptionIdentity.IdentityIds {
-					payload.Identity.IdentityIds[k] = v
-				}
+			for identityId := range diskEncryptionIdentity.IdentityIds {
+				payload.Identity = addHDInsightUserAssignedIdentity(payload.Identity, identityId)
 			}
 		}
 	}
 
 	if v, ok := d.GetOk("security_profile"); ok {
 		payload.Properties.SecurityProfile = ExpandHDInsightSecurityProfile(v.([]interface{}))
-
-		// @tombuildsstuff: this behaviour is likely wrong and wants reevaluating - users should need to explicitly define this in the config?
-		payload.Identity = &identity.SystemAndUserAssignedMap{
-			Type:        identity.TypeUserAssigned,
-			IdentityIds: make(map[string]identity.UserAssignedIdentityDetails),
-		}
 		if payload.Properties.SecurityProfile != nil && payload.Properties.SecurityProfile.MsiResourceId != nil {
-			payload.Identity.IdentityIds[*payload.Properties.SecurityProfile.MsiResourceId] = identity.UserAssignedIdentityDetails{
-				// intentionally empty
-			}
+			payload.Identity = addHDInsightUserAssignedIdentity(payload.Identity, *payload.Properties.SecurityProfile.MsiResourceId)
 		}
 	}
 

--- a/internal/services/hdinsight/hdinsight_hadoop_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_hadoop_cluster_resource_test.go
@@ -2076,7 +2076,7 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
   }
 
   disk_encryption {
-    encryption_at_host            = true
+    encryption_at_host_enabled    = true
     encryption_algorithm          = "RSA-OAEP"
     key_vault_key_id              = azurerm_key_vault_key.test.id
     key_vault_managed_identity_id = azurerm_user_assigned_identity.test.id

--- a/internal/services/hdinsight/hdinsight_hbase_cluster_resource.go
+++ b/internal/services/hdinsight/hdinsight_hbase_cluster_resource.go
@@ -253,9 +253,19 @@ func resourceHDInsightHBaseClusterCreate(d *pluginsdk.ResourceData, meta interfa
 	}
 
 	if diskEncryptionPropertiesRaw, ok := d.GetOk("disk_encryption"); ok {
-		params.Properties.DiskEncryptionProperties, err = ExpandHDInsightsDiskEncryptionProperties(diskEncryptionPropertiesRaw.([]interface{}))
+		diskEncryptionProperties, diskEncryptionIdentity, err := ExpandHDInsightsDiskEncryptionProperties(diskEncryptionPropertiesRaw.([]interface{}))
 		if err != nil {
 			return err
+		}
+		params.Properties.DiskEncryptionProperties = diskEncryptionProperties
+		if diskEncryptionIdentity != nil {
+			if params.Identity == nil {
+				params.Identity = diskEncryptionIdentity
+			} else {
+				for k, v := range diskEncryptionIdentity.IdentityIds {
+					params.Identity.IdentityIds[k] = v
+				}
+			}
 		}
 	}
 

--- a/internal/services/hdinsight/hdinsight_hbase_cluster_resource.go
+++ b/internal/services/hdinsight/hdinsight_hbase_cluster_resource.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
-	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/hdinsight/2021-06-01/clusters"
@@ -241,16 +240,8 @@ func resourceHDInsightHBaseClusterCreate(d *pluginsdk.ResourceData, meta interfa
 
 	if v, ok := d.GetOk("security_profile"); ok {
 		params.Properties.SecurityProfile = ExpandHDInsightSecurityProfile(v.([]interface{}))
-
-		// @tombuildsstuff: this behaviour is likely wrong and wants reevaluating - users should need to explicitly define this in the config?
-		params.Identity = &identity.SystemAndUserAssignedMap{
-			Type:        identity.TypeUserAssigned,
-			IdentityIds: make(map[string]identity.UserAssignedIdentityDetails),
-		}
 		if params.Properties.SecurityProfile != nil && params.Properties.SecurityProfile.MsiResourceId != nil {
-			params.Identity.IdentityIds[*params.Properties.SecurityProfile.MsiResourceId] = identity.UserAssignedIdentityDetails{
-				// intentionally empty
-			}
+			params.Identity = addHDInsightUserAssignedIdentity(params.Identity, *params.Properties.SecurityProfile.MsiResourceId)
 		}
 	}
 
@@ -261,12 +252,8 @@ func resourceHDInsightHBaseClusterCreate(d *pluginsdk.ResourceData, meta interfa
 		}
 		params.Properties.DiskEncryptionProperties = diskEncryptionProperties
 		if diskEncryptionIdentity != nil {
-			if params.Identity == nil {
-				params.Identity = diskEncryptionIdentity
-			} else {
-				for k, v := range diskEncryptionIdentity.IdentityIds {
-					params.Identity.IdentityIds[k] = v
-				}
+			for identityId := range diskEncryptionIdentity.IdentityIds {
+				params.Identity = addHDInsightUserAssignedIdentity(params.Identity, identityId)
 			}
 		}
 	}

--- a/internal/services/hdinsight/hdinsight_hbase_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_hbase_cluster_resource_test.go
@@ -1543,6 +1543,92 @@ func (r HDInsightHBaseClusterResource) diskEncryption(data acceptance.TestData) 
 	return fmt.Sprintf(`
 %s
 
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acctestidentity-%s"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_key_vault" "test" {
+  name                        = "acctestkv-%s"
+  location                    = azurerm_resource_group.test.location
+  resource_group_name         = azurerm_resource_group.test.name
+  tenant_id                   = data.azurerm_client_config.current.tenant_id
+  enabled_for_disk_encryption = true
+  sku_name                    = "standard"
+  soft_delete_retention_days  = 7
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+
+    key_permissions = [
+      "Create",
+      "Delete",
+      "Get",
+      "Purge",
+      "Recover",
+      "Update",
+      "SetRotationPolicy",
+      "GetRotationPolicy",
+      "UnwrapKey",
+      "WrapKey",
+    ]
+
+    secret_permissions = [
+      "Delete",
+      "Get",
+      "Set",
+    ]
+  }
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = azurerm_user_assigned_identity.test.principal_id
+
+    key_permissions = [
+      "Create",
+      "Delete",
+      "Get",
+      "Purge",
+      "Recover",
+      "Update",
+      "SetRotationPolicy",
+      "GetRotationPolicy",
+      "UnwrapKey",
+      "WrapKey",
+    ]
+
+    secret_permissions = [
+      "Delete",
+      "Get",
+      "Set",
+    ]
+  }
+
+  tags = {
+    environment = "Production"
+  }
+}
+
+resource "azurerm_key_vault_key" "test" {
+  name         = "key-%s"
+  key_vault_id = azurerm_key_vault.test.id
+  key_type     = "RSA"
+  key_size     = 2048
+
+  key_opts = [
+    "sign",
+    "verify",
+    "encrypt",
+    "decrypt",
+    "wrapKey",
+    "unwrapKey",
+  ]
+}
+
 resource "azurerm_hdinsight_hbase_cluster" "test" {
   name                = "acctesthdi-%d"
   resource_group_name = azurerm_resource_group.test.name
@@ -1567,7 +1653,10 @@ resource "azurerm_hdinsight_hbase_cluster" "test" {
   }
 
   disk_encryption {
-    encryption_at_host_enabled = true
+    encryption_at_host            = true
+    encryption_algorithm          = "RSA-OAEP"
+    key_vault_key_id              = azurerm_key_vault_key.test.id
+    key_vault_managed_identity_id = azurerm_user_assigned_identity.test.id
   }
 
   roles {

--- a/internal/services/hdinsight/hdinsight_hbase_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_hbase_cluster_resource_test.go
@@ -1680,7 +1680,7 @@ resource "azurerm_hdinsight_hbase_cluster" "test" {
     }
   }
 }
-`, r.template(data), data.RandomInteger)
+`, r.template(data), data.RandomString, data.RandomString, data.RandomString, data.RandomInteger)
 }
 
 func (r HDInsightHBaseClusterResource) allMetastores(data acceptance.TestData) string {

--- a/internal/services/hdinsight/hdinsight_hbase_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_hbase_cluster_resource_test.go
@@ -1681,7 +1681,7 @@ resource "azurerm_hdinsight_hbase_cluster" "test" {
   }
 
   disk_encryption {
-    encryption_at_host            = true
+    encryption_at_host_enabled    = true
     encryption_algorithm          = "RSA-OAEP"
     key_vault_key_id              = azurerm_key_vault_key.test.id
     key_vault_managed_identity_id = azurerm_user_assigned_identity.test.id

--- a/internal/services/hdinsight/hdinsight_interactive_query_cluster_resource.go
+++ b/internal/services/hdinsight/hdinsight_interactive_query_cluster_resource.go
@@ -251,9 +251,19 @@ func resourceHDInsightInteractiveQueryClusterCreate(d *pluginsdk.ResourceData, m
 	}
 
 	if diskEncryptionPropertiesRaw, ok := d.GetOk("disk_encryption"); ok {
-		params.Properties.DiskEncryptionProperties, err = ExpandHDInsightsDiskEncryptionProperties(diskEncryptionPropertiesRaw.([]interface{}))
+		diskEncryptionProperties, diskEncryptionIdentity, err := ExpandHDInsightsDiskEncryptionProperties(diskEncryptionPropertiesRaw.([]interface{}))
 		if err != nil {
 			return err
+		}
+		params.Properties.DiskEncryptionProperties = diskEncryptionProperties
+		if diskEncryptionIdentity != nil {
+			if params.Identity == nil {
+				params.Identity = diskEncryptionIdentity
+			} else {
+				for k, v := range diskEncryptionIdentity.IdentityIds {
+					params.Identity.IdentityIds[k] = v
+				}
+			}
 		}
 	}
 

--- a/internal/services/hdinsight/hdinsight_interactive_query_cluster_resource.go
+++ b/internal/services/hdinsight/hdinsight_interactive_query_cluster_resource.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
-	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/hdinsight/2021-06-01/clusters"
@@ -259,28 +258,16 @@ func resourceHDInsightInteractiveQueryClusterCreate(d *pluginsdk.ResourceData, m
 		}
 		params.Properties.DiskEncryptionProperties = diskEncryptionProperties
 		if diskEncryptionIdentity != nil {
-			if params.Identity == nil {
-				params.Identity = diskEncryptionIdentity
-			} else {
-				for k, v := range diskEncryptionIdentity.IdentityIds {
-					params.Identity.IdentityIds[k] = v
-				}
+			for identityId := range diskEncryptionIdentity.IdentityIds {
+				params.Identity = addHDInsightUserAssignedIdentity(params.Identity, identityId)
 			}
 		}
 	}
 
 	if v, ok := d.GetOk("security_profile"); ok {
 		params.Properties.SecurityProfile = ExpandHDInsightSecurityProfile(v.([]interface{}))
-
-		// @tombuildsstuff: this behaviour is likely wrong and wants reevaluating - users should need to explicitly define this in the config?
-		params.Identity = &identity.SystemAndUserAssignedMap{
-			Type:        identity.TypeUserAssigned,
-			IdentityIds: make(map[string]identity.UserAssignedIdentityDetails),
-		}
 		if params.Properties.SecurityProfile != nil && params.Properties.SecurityProfile.MsiResourceId != nil {
-			params.Identity.IdentityIds[*params.Properties.SecurityProfile.MsiResourceId] = identity.UserAssignedIdentityDetails{
-				// intentionally empty
-			}
+			params.Identity = addHDInsightUserAssignedIdentity(params.Identity, *params.Properties.SecurityProfile.MsiResourceId)
 		}
 	}
 

--- a/internal/services/hdinsight/hdinsight_interactive_query_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_interactive_query_cluster_resource_test.go
@@ -1641,6 +1641,92 @@ func (r HDInsightInteractiveQueryClusterResource) diskEncryption(data acceptance
 	return fmt.Sprintf(`
 %s
 
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acctestidentity-%s"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_key_vault" "test" {
+  name                        = "acctestkv-%s"
+  location                    = azurerm_resource_group.test.location
+  resource_group_name         = azurerm_resource_group.test.name
+  tenant_id                   = data.azurerm_client_config.current.tenant_id
+  enabled_for_disk_encryption = true
+  sku_name                    = "standard"
+  soft_delete_retention_days  = 7
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+
+    key_permissions = [
+      "Create",
+      "Delete",
+      "Get",
+      "Purge",
+      "Recover",
+      "Update",
+      "SetRotationPolicy",
+      "GetRotationPolicy",
+      "UnwrapKey",
+      "WrapKey",
+    ]
+
+    secret_permissions = [
+      "Delete",
+      "Get",
+      "Set",
+    ]
+  }
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = azurerm_user_assigned_identity.test.principal_id
+
+    key_permissions = [
+      "Create",
+      "Delete",
+      "Get",
+      "Purge",
+      "Recover",
+      "Update",
+      "SetRotationPolicy",
+      "GetRotationPolicy",
+      "UnwrapKey",
+      "WrapKey",
+    ]
+
+    secret_permissions = [
+      "Delete",
+      "Get",
+      "Set",
+    ]
+  }
+
+  tags = {
+    environment = "Production"
+  }
+}
+
+resource "azurerm_key_vault_key" "test" {
+  name         = "key-%s"
+  key_vault_id = azurerm_key_vault.test.id
+  key_type     = "RSA"
+  key_size     = 2048
+
+  key_opts = [
+    "sign",
+    "verify",
+    "encrypt",
+    "decrypt",
+    "wrapKey",
+    "unwrapKey",
+  ]
+}
+
 resource "azurerm_hdinsight_interactive_query_cluster" "test" {
   name                = "acctesthdi-%d"
   resource_group_name = azurerm_resource_group.test.name
@@ -1654,7 +1740,10 @@ resource "azurerm_hdinsight_interactive_query_cluster" "test" {
   }
 
   disk_encryption {
-    encryption_at_host_enabled = true
+    encryption_at_host            = true
+    encryption_algorithm          = "RSA-OAEP"
+    key_vault_key_id              = azurerm_key_vault_key.test.id
+    key_vault_managed_identity_id = azurerm_user_assigned_identity.test.id
   }
 
   gateway {
@@ -1689,7 +1778,7 @@ resource "azurerm_hdinsight_interactive_query_cluster" "test" {
     }
   }
 }
-`, r.template(data), data.RandomInteger)
+`, r.template(data), data.RandomString, data.RandomString, data.RandomString, data.RandomInteger)
 }
 
 func (r HDInsightInteractiveQueryClusterResource) allMetastores(data acceptance.TestData) string {

--- a/internal/services/hdinsight/hdinsight_interactive_query_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_interactive_query_cluster_resource_test.go
@@ -1707,7 +1707,7 @@ resource "azurerm_hdinsight_interactive_query_cluster" "test" {
   }
 
   disk_encryption {
-    encryption_at_host            = true
+      encryption_at_host_enabled    = true
     encryption_algorithm          = "RSA-OAEP"
     key_vault_key_id              = azurerm_key_vault_key.test.id
     key_vault_managed_identity_id = azurerm_user_assigned_identity.test.id

--- a/internal/services/hdinsight/hdinsight_interactive_query_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_interactive_query_cluster_resource_test.go
@@ -1707,7 +1707,7 @@ resource "azurerm_hdinsight_interactive_query_cluster" "test" {
   }
 
   disk_encryption {
-      encryption_at_host_enabled    = true
+    encryption_at_host_enabled    = true
     encryption_algorithm          = "RSA-OAEP"
     key_vault_key_id              = azurerm_key_vault_key.test.id
     key_vault_managed_identity_id = azurerm_user_assigned_identity.test.id

--- a/internal/services/hdinsight/hdinsight_kafka_cluster_resource.go
+++ b/internal/services/hdinsight/hdinsight_kafka_cluster_resource.go
@@ -296,9 +296,19 @@ func resourceHDInsightKafkaClusterCreate(d *pluginsdk.ResourceData, meta interfa
 	}
 
 	if diskEncryptionPropertiesRaw, ok := d.GetOk("disk_encryption"); ok {
-		payload.Properties.DiskEncryptionProperties, err = ExpandHDInsightsDiskEncryptionProperties(diskEncryptionPropertiesRaw.([]interface{}))
+		diskEncryptionProperties, diskEncryptionIdentity, err := ExpandHDInsightsDiskEncryptionProperties(diskEncryptionPropertiesRaw.([]interface{}))
 		if err != nil {
 			return err
+		}
+		payload.Properties.DiskEncryptionProperties = diskEncryptionProperties
+		if diskEncryptionIdentity != nil {
+			if payload.Identity == nil {
+				payload.Identity = diskEncryptionIdentity
+			} else {
+				for k, v := range diskEncryptionIdentity.IdentityIds {
+					payload.Identity.IdentityIds[k] = v
+				}
+			}
 		}
 	}
 

--- a/internal/services/hdinsight/hdinsight_kafka_cluster_resource.go
+++ b/internal/services/hdinsight/hdinsight_kafka_cluster_resource.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
-	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/hdinsight/2021-06-01/clusters"
@@ -304,28 +303,16 @@ func resourceHDInsightKafkaClusterCreate(d *pluginsdk.ResourceData, meta interfa
 		}
 		payload.Properties.DiskEncryptionProperties = diskEncryptionProperties
 		if diskEncryptionIdentity != nil {
-			if payload.Identity == nil {
-				payload.Identity = diskEncryptionIdentity
-			} else {
-				for k, v := range diskEncryptionIdentity.IdentityIds {
-					payload.Identity.IdentityIds[k] = v
-				}
+			for identityId := range diskEncryptionIdentity.IdentityIds {
+				payload.Identity = addHDInsightUserAssignedIdentity(payload.Identity, identityId)
 			}
 		}
 	}
 
 	if v, ok := d.GetOk("security_profile"); ok {
 		payload.Properties.SecurityProfile = ExpandHDInsightSecurityProfile(v.([]interface{}))
-
-		// @tombuildsstuff: this behaviour is likely wrong and wants reevaluating - users should need to explicitly define this in the config?
-		payload.Identity = &identity.SystemAndUserAssignedMap{
-			Type:        identity.TypeUserAssigned,
-			IdentityIds: make(map[string]identity.UserAssignedIdentityDetails),
-		}
 		if payload.Properties.SecurityProfile != nil && payload.Properties.SecurityProfile.MsiResourceId != nil {
-			payload.Identity.IdentityIds[*payload.Properties.SecurityProfile.MsiResourceId] = identity.UserAssignedIdentityDetails{
-				// intentionally empty
-			}
+			payload.Identity = addHDInsightUserAssignedIdentity(payload.Identity, *payload.Properties.SecurityProfile.MsiResourceId)
 		}
 	}
 

--- a/internal/services/hdinsight/hdinsight_kafka_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_kafka_cluster_resource_test.go
@@ -1885,6 +1885,92 @@ func (r HDInsightKafkaClusterResource) diskEncryption(data acceptance.TestData) 
 	return fmt.Sprintf(`
 %s
 
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acctestidentity-%s"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_key_vault" "test" {
+  name                        = "acctestkv-%s"
+  location                    = azurerm_resource_group.test.location
+  resource_group_name         = azurerm_resource_group.test.name
+  tenant_id                   = data.azurerm_client_config.current.tenant_id
+  enabled_for_disk_encryption = true
+  sku_name                    = "standard"
+  soft_delete_retention_days  = 7
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+
+    key_permissions = [
+      "Create",
+      "Delete",
+      "Get",
+      "Purge",
+      "Recover",
+      "Update",
+      "SetRotationPolicy",
+      "GetRotationPolicy",
+      "UnwrapKey",
+      "WrapKey",
+    ]
+
+    secret_permissions = [
+      "Delete",
+      "Get",
+      "Set",
+    ]
+  }
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = azurerm_user_assigned_identity.test.principal_id
+
+    key_permissions = [
+      "Create",
+      "Delete",
+      "Get",
+      "Purge",
+      "Recover",
+      "Update",
+      "SetRotationPolicy",
+      "GetRotationPolicy",
+      "UnwrapKey",
+      "WrapKey",
+    ]
+
+    secret_permissions = [
+      "Delete",
+      "Get",
+      "Set",
+    ]
+  }
+
+  tags = {
+    environment = "Production"
+  }
+}
+
+resource "azurerm_key_vault_key" "test" {
+  name         = "key-%s"
+  key_vault_id = azurerm_key_vault.test.id
+  key_type     = "RSA"
+  key_size     = 2048
+
+  key_opts = [
+    "sign",
+    "verify",
+    "encrypt",
+    "decrypt",
+    "wrapKey",
+    "unwrapKey",
+  ]
+}
+
 resource "azurerm_hdinsight_kafka_cluster" "test" {
   name                = "acctesthdi-%d"
   resource_group_name = azurerm_resource_group.test.name
@@ -1908,7 +1994,10 @@ resource "azurerm_hdinsight_kafka_cluster" "test" {
   }
 
   disk_encryption {
-    encryption_at_host_enabled = true
+    encryption_at_host            = true
+    encryption_algorithm          = "RSA-OAEP"
+    key_vault_key_id              = azurerm_key_vault_key.test.id
+    key_vault_managed_identity_id = azurerm_user_assigned_identity.test.id
   }
 
   roles {
@@ -1933,7 +2022,7 @@ resource "azurerm_hdinsight_kafka_cluster" "test" {
     }
   }
 }
-`, r.template(data), data.RandomInteger)
+`, r.template(data), data.RandomString, data.RandomString, data.RandomString, data.RandomInteger)
 }
 
 func (r HDInsightKafkaClusterResource) encryptionInTransitEnabled(data acceptance.TestData) string {

--- a/internal/services/hdinsight/hdinsight_kafka_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_kafka_cluster_resource_test.go
@@ -1967,7 +1967,7 @@ resource "azurerm_hdinsight_kafka_cluster" "test" {
   }
 
   disk_encryption {
-    encryption_at_host            = true
+      encryption_at_host_enabled    = true
     encryption_algorithm          = "RSA-OAEP"
     key_vault_key_id              = azurerm_key_vault_key.test.id
     key_vault_managed_identity_id = azurerm_user_assigned_identity.test.id

--- a/internal/services/hdinsight/hdinsight_kafka_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_kafka_cluster_resource_test.go
@@ -1967,7 +1967,7 @@ resource "azurerm_hdinsight_kafka_cluster" "test" {
   }
 
   disk_encryption {
-      encryption_at_host_enabled    = true
+    encryption_at_host_enabled    = true
     encryption_algorithm          = "RSA-OAEP"
     key_vault_key_id              = azurerm_key_vault_key.test.id
     key_vault_managed_identity_id = azurerm_user_assigned_identity.test.id

--- a/internal/services/hdinsight/hdinsight_spark_cluster_resource.go
+++ b/internal/services/hdinsight/hdinsight_spark_cluster_resource.go
@@ -255,9 +255,19 @@ func resourceHDInsightSparkClusterCreate(d *pluginsdk.ResourceData, meta interfa
 	}
 
 	if diskEncryptionPropertiesRaw, ok := d.GetOk("disk_encryption"); ok {
-		payload.Properties.DiskEncryptionProperties, err = ExpandHDInsightsDiskEncryptionProperties(diskEncryptionPropertiesRaw.([]interface{}))
+		diskEncryptionProperties, diskEncryptionIdentity, err := ExpandHDInsightsDiskEncryptionProperties(diskEncryptionPropertiesRaw.([]interface{}))
 		if err != nil {
 			return err
+		}
+		payload.Properties.DiskEncryptionProperties = diskEncryptionProperties
+		if diskEncryptionIdentity != nil {
+			if payload.Identity == nil {
+				payload.Identity = diskEncryptionIdentity
+			} else {
+				for k, v := range diskEncryptionIdentity.IdentityIds {
+					payload.Identity.IdentityIds[k] = v
+				}
+			}
 		}
 	}
 

--- a/internal/services/hdinsight/hdinsight_spark_cluster_resource.go
+++ b/internal/services/hdinsight/hdinsight_spark_cluster_resource.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
-	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/zones"
@@ -263,28 +262,16 @@ func resourceHDInsightSparkClusterCreate(d *pluginsdk.ResourceData, meta interfa
 		}
 		payload.Properties.DiskEncryptionProperties = diskEncryptionProperties
 		if diskEncryptionIdentity != nil {
-			if payload.Identity == nil {
-				payload.Identity = diskEncryptionIdentity
-			} else {
-				for k, v := range diskEncryptionIdentity.IdentityIds {
-					payload.Identity.IdentityIds[k] = v
-				}
+			for identityId := range diskEncryptionIdentity.IdentityIds {
+				payload.Identity = addHDInsightUserAssignedIdentity(payload.Identity, identityId)
 			}
 		}
 	}
 
 	if v, ok := d.GetOk("security_profile"); ok {
 		payload.Properties.SecurityProfile = ExpandHDInsightSecurityProfile(v.([]interface{}))
-
-		// @tombuildsstuff: this behaviour is likely wrong and wants reevaluating - users should need to explicitly define this in the config?
-		payload.Identity = &identity.SystemAndUserAssignedMap{
-			Type:        identity.TypeUserAssigned,
-			IdentityIds: make(map[string]identity.UserAssignedIdentityDetails),
-		}
 		if payload.Properties.SecurityProfile != nil && payload.Properties.SecurityProfile.MsiResourceId != nil {
-			payload.Identity.IdentityIds[*payload.Properties.SecurityProfile.MsiResourceId] = identity.UserAssignedIdentityDetails{
-				// intentionally empty
-			}
+			payload.Identity = addHDInsightUserAssignedIdentity(payload.Identity, *payload.Properties.SecurityProfile.MsiResourceId)
 		}
 	}
 

--- a/internal/services/hdinsight/hdinsight_spark_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_spark_cluster_resource_test.go
@@ -1945,7 +1945,7 @@ resource "azurerm_hdinsight_spark_cluster" "test" {
     }
   }
 }
-`, r.template(data), data.RandomInteger)
+`, r.template(data), data.RandomString, data.RandomString, data.RandomString, data.RandomInteger)
 }
 
 func (r HDInsightSparkClusterResource) allMetastores(data acceptance.TestData) string {

--- a/internal/services/hdinsight/hdinsight_spark_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_spark_cluster_resource_test.go
@@ -1807,6 +1807,92 @@ func (r HDInsightSparkClusterResource) diskEncryption(data acceptance.TestData) 
 	return fmt.Sprintf(`
 %s
 
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acctestidentity-%s"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_key_vault" "test" {
+  name                        = "acctestkv-%s"
+  location                    = azurerm_resource_group.test.location
+  resource_group_name         = azurerm_resource_group.test.name
+  tenant_id                   = data.azurerm_client_config.current.tenant_id
+  enabled_for_disk_encryption = true
+  sku_name                    = "standard"
+  soft_delete_retention_days  = 7
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+
+    key_permissions = [
+      "Create",
+      "Delete",
+      "Get",
+      "Purge",
+      "Recover",
+      "Update",
+      "SetRotationPolicy",
+      "GetRotationPolicy",
+      "UnwrapKey",
+      "WrapKey",
+    ]
+
+    secret_permissions = [
+      "Delete",
+      "Get",
+      "Set",
+    ]
+  }
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = azurerm_user_assigned_identity.test.principal_id
+
+    key_permissions = [
+      "Create",
+      "Delete",
+      "Get",
+      "Purge",
+      "Recover",
+      "Update",
+      "SetRotationPolicy",
+      "GetRotationPolicy",
+      "UnwrapKey",
+      "WrapKey",
+    ]
+
+    secret_permissions = [
+      "Delete",
+      "Get",
+      "Set",
+    ]
+  }
+
+  tags = {
+    environment = "Production"
+  }
+}
+
+resource "azurerm_key_vault_key" "test" {
+  name         = "key-%s"
+  key_vault_id = azurerm_key_vault.test.id
+  key_type     = "RSA"
+  key_size     = 2048
+
+  key_opts = [
+    "sign",
+    "verify",
+    "encrypt",
+    "decrypt",
+    "wrapKey",
+    "unwrapKey",
+  ]
+}
+
 resource "azurerm_hdinsight_spark_cluster" "test" {
   name                = "acctesthdi-%d"
   resource_group_name = azurerm_resource_group.test.name
@@ -1832,7 +1918,10 @@ resource "azurerm_hdinsight_spark_cluster" "test" {
   }
 
   disk_encryption {
-    encryption_at_host_enabled = true
+    encryption_at_host            = true
+    encryption_algorithm          = "RSA-OAEP"
+    key_vault_key_id              = azurerm_key_vault_key.test.id
+    key_vault_managed_identity_id = azurerm_user_assigned_identity.test.id
   }
 
   roles {

--- a/internal/services/hdinsight/hdinsight_spark_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_spark_cluster_resource_test.go
@@ -1883,7 +1883,7 @@ resource "azurerm_hdinsight_spark_cluster" "test" {
   }
 
   disk_encryption {
-      encryption_at_host_enabled    = true
+    encryption_at_host_enabled    = true
     encryption_algorithm          = "RSA-OAEP"
     key_vault_key_id              = azurerm_key_vault_key.test.id
     key_vault_managed_identity_id = azurerm_user_assigned_identity.test.id

--- a/internal/services/hdinsight/hdinsight_spark_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_spark_cluster_resource_test.go
@@ -1883,7 +1883,7 @@ resource "azurerm_hdinsight_spark_cluster" "test" {
   }
 
   disk_encryption {
-    encryption_at_host            = true
+      encryption_at_host_enabled    = true
     encryption_algorithm          = "RSA-OAEP"
     key_vault_key_id              = azurerm_key_vault_key.test.id
     key_vault_managed_identity_id = azurerm_user_assigned_identity.test.id

--- a/internal/services/hdinsight/schema.go
+++ b/internal/services/hdinsight/schema.go
@@ -1060,6 +1060,26 @@ func ExpandHDInsightsDiskEncryptionProperties(input []interface{}) (*clusters.Di
 	return diskEncryptionProps, clusterIdentity, nil
 }
 
+func addHDInsightUserAssignedIdentity(clusterIdentity *identity.SystemAndUserAssignedMap, identityId string) *identity.SystemAndUserAssignedMap {
+	if clusterIdentity == nil {
+		clusterIdentity = &identity.SystemAndUserAssignedMap{}
+	}
+
+	switch clusterIdentity.Type {
+	case identity.TypeSystemAssigned:
+		clusterIdentity.Type = identity.TypeSystemAssignedUserAssigned
+	case identity.TypeNone, "":
+		clusterIdentity.Type = identity.TypeUserAssigned
+	}
+
+	if clusterIdentity.IdentityIds == nil {
+		clusterIdentity.IdentityIds = make(map[string]identity.UserAssignedIdentityDetails)
+	}
+	clusterIdentity.IdentityIds[identityId] = identity.UserAssignedIdentityDetails{}
+
+	return clusterIdentity
+}
+
 func flattenHDInsightsDiskEncryptionProperties(input *clusters.DiskEncryptionProperties) (*[]interface{}, error) {
 	if input == nil {
 		return pointer.To(make([]interface{}, 0)), nil

--- a/internal/services/hdinsight/schema_test.go
+++ b/internal/services/hdinsight/schema_test.go
@@ -3,7 +3,11 @@
 
 package hdinsight
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
+)
 
 func TestHDInsightClusterVersionDiffSuppress(t *testing.T) {
 	tests := []struct {
@@ -48,6 +52,55 @@ func TestHDInsightClusterVersionDiffSuppress(t *testing.T) {
 			wasSuppressed := hdinsightClusterVersionDiffSuppressFunc("", tt.userInput, tt.azureResponse, nil)
 			if tt.suppressed != wasSuppressed {
 				t.Errorf("Expected %q to be %t but got %t", tt.name, tt.suppressed, wasSuppressed)
+			}
+		})
+	}
+}
+
+func TestAddHDInsightUserAssignedIdentity(t *testing.T) {
+	tests := []struct {
+		name             string
+		input            *identity.SystemAndUserAssignedMap
+		expectedType     identity.Type
+		expectedIdentity int
+	}{
+		{
+			name:             "empty identity",
+			expectedType:     identity.TypeUserAssigned,
+			expectedIdentity: 1,
+		},
+		{
+			name: "user assigned identity",
+			input: &identity.SystemAndUserAssignedMap{
+				Type: identity.TypeUserAssigned,
+				IdentityIds: map[string]identity.UserAssignedIdentityDetails{
+					"existing": {},
+				},
+			},
+			expectedType:     identity.TypeUserAssigned,
+			expectedIdentity: 2,
+		},
+		{
+			name: "system assigned identity",
+			input: &identity.SystemAndUserAssignedMap{
+				Type: identity.TypeSystemAssigned,
+			},
+			expectedType:     identity.TypeSystemAssignedUserAssigned,
+			expectedIdentity: 1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := addHDInsightUserAssignedIdentity(test.input, "added")
+			if result.Type != test.expectedType {
+				t.Fatalf("expected identity type %q, got %q", test.expectedType, result.Type)
+			}
+			if len(result.IdentityIds) != test.expectedIdentity {
+				t.Fatalf("expected %d identities, got %d", test.expectedIdentity, len(result.IdentityIds))
+			}
+			if _, ok := result.IdentityIds["added"]; !ok {
+				t.Fatal("expected added identity to be present")
 			}
 		})
 	}


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

HDInsight resources previously replaced or incorrectly merged cluster identities while processing disk encryption and security profiles. This could:

- Drop an existing system-assigned identity.
- Lose user-assigned identities required by disk encryption.
- Write into an uninitialized identity map.
- Send an incorrect identity type to Azure.

A shared identity-merging helper now safely preserves existing identities, initializes the identity map, and promotes system-assigned identities to combined system-and-user-assigned identities when required. The fix applies consistently to Hadoop, HBase, Interactive Query, Kafka, and Spark clusters.

Unit tests cover empty, user-assigned, and system-assigned identity configurations. Acceptance fixtures now use the correct `encryption_at_host_enabled` field and valid Terraform indentation.

## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
