### PR TITLE
`azurerm_cdn_frontdoor_origin` - add a state migration for an edge case with imported resource IDs

### DIFF
--- a/internal/acceptance/testcase.go
+++ b/internal/acceptance/testcase.go
@@ -150,31 +150,30 @@ func (td TestData) ResourceSequentialTest(t *testing.T, testResource types.TestR
 }
 
 // ResourceRegressionTest runs an acceptance test for resource regression.
-// It expects one or two steps. If only one step is supplied it will be duplicated for the 2nd verification step resulting in an identical config being set for the locally built resource.
-// The first step uses a specified previous provider version constraint. If an empty string is supplied, the test will use the version in ./version/VERSION from the root of the project
+// It expects one or multiple steps. If only one step is supplied it will be duplicated for the 2nd verification step resulting in an identical config being set for the locally built resource.
+// All steps except the final step use a specified previous provider version constraint. If an empty string is supplied, the test will use the version in ./version/VERSION from the root of the project
 // For StateMigration testing, this should be the last version that has the previous `SchemaVersion` value.
-// The second step uses the locally built provider code.
+// The final step uses the locally built provider code.
 func (td TestData) ResourceRegressionTest(t *testing.T, testResource types.TestResource, steps []TestStep, previousVersion string) {
-	if len(steps) != 2 {
-		if len(steps) == 1 {
-			// duplicate step[0] for second stage - this is all that _should_ be required for breaking change testing
-			steps = append(steps, steps[0])
-		} else {
-			t.Fatal("expected exactly 2 steps for Regression test. Setup and Check")
-		}
+	l := len(steps)
+	if l == 1 {
+		// duplicate step[0] for second stage - this is all that _should_ be required for breaking change testing
+		steps = append(steps, steps[0])
 	}
 
 	os.Setenv("TF_ACC_REFRESH_AFTER_APPLY", "true")
 
-	steps[0].ExternalProviders = td.externalProviders()
-	steps[0].ExternalProviders["azurerm"] = resource.ExternalProvider{
-		VersionConstraint: providerRelease([]string{previousVersion}...),
-		Source:            "hashicorp/azurerm",
+	for i := range steps[:l-1] {
+		steps[i].ExternalProviders = td.externalProviders()
+		steps[i].ExternalProviders["azurerm"] = resource.ExternalProvider{
+			VersionConstraint: providerRelease([]string{previousVersion}...),
+			Source:            "hashicorp/azurerm",
+		}
 	}
 
-	steps[1].ExternalProviders = td.externalProviders()
-	steps[1].ProtoV5ProviderFactories = framework.ProtoV5ProviderFactoriesInitWithTestName(context.Background(), t.Name(), "azurerm", "azurerm-alt")
-	steps[1].ConfigPlanChecks = resource.ConfigPlanChecks{
+	steps[l-1].ExternalProviders = td.externalProviders()
+	steps[l-1].ProtoV5ProviderFactories = framework.ProtoV5ProviderFactoriesInitWithTestName(context.Background(), t.Name(), "azurerm", "azurerm-alt")
+	steps[l-1].ConfigPlanChecks = resource.ConfigPlanChecks{
 		PreApply: []plancheck.PlanCheck{
 			helpers.IsNotResourceAction(td.ResourceName, plancheck.ResourceActionReplace),
 		},

--- a/internal/acceptance/testcase.go
+++ b/internal/acceptance/testcase.go
@@ -150,15 +150,60 @@ func (td TestData) ResourceSequentialTest(t *testing.T, testResource types.TestR
 }
 
 // ResourceRegressionTest runs an acceptance test for resource regression.
-// It expects one or multiple steps. If only one step is supplied it will be duplicated for the 2nd verification step resulting in an identical config being set for the locally built resource.
+// It expects one or two steps. If only one step is supplied it will be duplicated for the 2nd verification step resulting in an identical config being set for the locally built resource.
+// The first step uses a specified previous provider version constraint. If an empty string is supplied, the test will use the version in ./version/VERSION from the root of the project
+// For StateMigration testing, this should be the last version that has the previous `SchemaVersion` value.
+// The second step uses the locally built provider code.
+func (td TestData) ResourceRegressionTest(t *testing.T, testResource types.TestResource, steps []TestStep, previousVersion string) {
+	if len(steps) != 2 {
+		if len(steps) == 1 {
+			// duplicate step[0] for second stage - this is all that _should_ be required for breaking change testing
+			steps = append(steps, steps[0])
+		} else {
+			t.Fatal("expected exactly 2 steps for Regression test. Setup and Check")
+		}
+	}
+
+	os.Setenv("TF_ACC_REFRESH_AFTER_APPLY", "true")
+
+	steps[0].ExternalProviders = td.externalProviders()
+	steps[0].ExternalProviders["azurerm"] = resource.ExternalProvider{
+		VersionConstraint: providerRelease([]string{previousVersion}...),
+		Source:            "hashicorp/azurerm",
+	}
+
+	steps[1].ExternalProviders = td.externalProviders()
+	steps[1].ProtoV5ProviderFactories = framework.ProtoV5ProviderFactoriesInitWithTestName(context.Background(), t.Name(), "azurerm", "azurerm-alt")
+	steps[1].ConfigPlanChecks = resource.ConfigPlanChecks{
+		PreApply: []plancheck.PlanCheck{
+			helpers.IsNotResourceAction(td.ResourceName, plancheck.ResourceActionReplace),
+		},
+	}
+
+	testCase := resource.TestCase{
+		PreCheck: func() { PreCheck(t) },
+		CheckDestroy: func(s *terraform.State) error {
+			client, err := testclient.BuildWithTestName(t.Name())
+			if err != nil {
+				return fmt.Errorf("building client: %+v", err)
+			}
+			return helpers.CheckDestroyedFunc(client, testResource, td.ResourceType, td.ResourceName)(s)
+		},
+		Steps: steps,
+	}
+
+	resource.ParallelTest(t, testCase)
+}
+
+// ResourceRegressionAdditionalStepsTest runs an acceptance test for resource regression scenarios that require multiple steps to set up.
+// It expects multiple steps (3 or more), for regression testing with 1 or 2 steps, use ResourceRegressionTest.
 // All steps except the final step use a specified previous provider version constraint. If an empty string is supplied, the test will use the version in ./version/VERSION from the root of the project
 // For StateMigration testing, this should be the last version that has the previous `SchemaVersion` value.
 // The final step uses the locally built provider code.
-func (td TestData) ResourceRegressionTest(t *testing.T, testResource types.TestResource, steps []TestStep, previousVersion string) {
+func (td TestData) ResourceRegressionAdditionalStepsTest(t *testing.T, testResource types.TestResource, steps []TestStep, previousVersion string) {
 	l := len(steps)
-	if l == 1 {
-		// duplicate step[0] for second stage - this is all that _should_ be required for breaking change testing
-		steps = append(steps, steps[0])
+	if l < 3 {
+		t.Fatalf("expected at least 3 steps, got %d. For tests with less than 3 steps, use `ResourceRegressionTest`", l)
 	}
 
 	os.Setenv("TF_ACC_REFRESH_AFTER_APPLY", "true")

--- a/internal/services/cdn/cdn_frontdoor_origin_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_origin_resource.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cdn/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cdn/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -29,7 +30,7 @@ import (
 )
 
 func resourceCdnFrontDoorOrigin() *pluginsdk.Resource {
-	resource := &pluginsdk.Resource{
+	return &pluginsdk.Resource{
 		Create: resourceCdnFrontDoorOriginCreate,
 		Read:   resourceCdnFrontDoorOriginRead,
 		Update: resourceCdnFrontDoorOriginUpdate,
@@ -45,6 +46,11 @@ func resourceCdnFrontDoorOrigin() *pluginsdk.Resource {
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
 			_, err := afdorigins.ParseOriginGroupOriginID(id)
 			return err
+		}),
+
+		SchemaVersion: 1,
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.CdnFrontDoorOriginV0ToV1{},
 		}),
 
 		Schema: map[string]*pluginsdk.Schema{
@@ -159,8 +165,6 @@ func resourceCdnFrontDoorOrigin() *pluginsdk.Resource {
 			},
 		},
 	}
-
-	return resource
 }
 
 func resourceCdnFrontDoorOriginCreate(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/cdn/cdn_frontdoor_origin_resource_v0_to_v1_test.go
+++ b/internal/services/cdn/cdn_frontdoor_origin_resource_v0_to_v1_test.go
@@ -1,0 +1,104 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package cdn_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+)
+
+// TestAccCdnFrontDoorOrigin_V0ToV1_4810 tests the state migration path from an `id` with lowercased
+// static segments to their canonicalized format. It uses v4.81.0 as the setup version because it is
+// the last release where the `id` could have been stored in state with lowercased static segments via an import using a non-canonical ID.
+func TestAccCdnFrontDoorOrigin_V0ToV1_4810(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_origin", "test")
+	r := CdnFrontDoorOriginResource{}
+
+	importedResourceName := data.ResourceName + "-import"
+
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("id").HasValue(fmt.Sprintf("/subscriptions/%[1]s/resourceGroups/acctestrg-cdn-afdx-%[2]d/providers/Microsoft.Cdn/profiles/acctest-cdnfdprofile-%[2]d/originGroups/acctest-cdnfd-group-%[2]d/origins/acctest-cdnfdorigin-%[2]d", data.Subscriptions.Primary, data.RandomInteger)),
+			),
+		},
+		{
+			Config: r.basicV0(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(importedResourceName).Key("id").HasValue(fmt.Sprintf("/subscriptions/%[1]s/resourcegroups/acctestrg-cdn-afdx-%[2]d/providers/microsoft.cdn/profiles/acctest-cdnfdprofile-%[2]d/originGroups/acctest-cdnfd-group-%[2]d/origins/acctest-cdnfdorigin-%[2]d", data.Subscriptions.Primary, data.RandomInteger)),
+			),
+		},
+		{
+			Config: r.basicImported(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(importedResourceName).ExistsInAzure(r),
+				check.That(importedResourceName).Key("id").HasValue(fmt.Sprintf("/subscriptions/%[1]s/resourceGroups/acctestrg-cdn-afdx-%[2]d/providers/Microsoft.Cdn/profiles/acctest-cdnfdprofile-%[2]d/originGroups/acctest-cdnfd-group-%[2]d/origins/acctest-cdnfdorigin-%[2]d", data.Subscriptions.Primary, data.RandomInteger)),
+			),
+		},
+	}, "4.81.0")
+}
+
+func (r CdnFrontDoorOriginResource) basicV0(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_cdn_frontdoor_origin" "test-import" {
+  name                          = "acctest-cdnfdorigin-%[2]d"
+  cdn_frontdoor_origin_group_id = azurerm_cdn_frontdoor_origin_group.test.id
+  enabled                       = true
+
+  certificate_name_check_enabled = false
+  host_name                      = "contoso.com"
+  http_port                      = 80
+  https_port                     = 443
+  origin_host_header             = "www.contoso.com"
+  priority                       = 1
+  weight                         = 1
+}
+
+removed {
+  from = azurerm_cdn_frontdoor_origin.test
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = azurerm_cdn_frontdoor_origin.test-import
+  id = "/subscriptions/%[3]s/resourcegroups/acctestrg-cdn-afdx-%[2]d/providers/microsoft.cdn/profiles/acctest-cdnfdprofile-%[2]d/originGroups/acctest-cdnfd-group-%[2]d/origins/acctest-cdnfdorigin-%[2]d"
+}
+`, r.template(data, "Standard_AzureFrontDoor", false), data.RandomInteger, data.Subscriptions.Primary)
+}
+
+func (r CdnFrontDoorOriginResource) basicImported(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_cdn_frontdoor_origin" "test-import" {
+  name                          = "acctest-cdnfdorigin-%[2]d"
+  cdn_frontdoor_origin_group_id = azurerm_cdn_frontdoor_origin_group.test.id
+  enabled                       = true
+
+  certificate_name_check_enabled = false
+  host_name                      = "contoso.com"
+  http_port                      = 80
+  https_port                     = 443
+  origin_host_header             = "www.contoso.com"
+  priority                       = 1
+  weight                         = 1
+}
+`, r.template(data, "Standard_AzureFrontDoor", false), data.RandomInteger, data.Subscriptions.Primary)
+}

--- a/internal/services/cdn/cdn_frontdoor_origin_resource_v0_to_v1_test.go
+++ b/internal/services/cdn/cdn_frontdoor_origin_resource_v0_to_v1_test.go
@@ -20,7 +20,7 @@ func TestAccCdnFrontDoorOrigin_V0ToV1_4810(t *testing.T) {
 
 	importedResourceName := data.ResourceName + "-import"
 
-	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+	data.ResourceRegressionAdditionalStepsTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(

--- a/internal/services/cdn/migration/cdn_frontdoor_origin_v0_to_v1.go
+++ b/internal/services/cdn/migration/cdn_frontdoor_origin_v0_to_v1.go
@@ -1,0 +1,115 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package migration
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/afdorigins"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+var _ pluginsdk.StateUpgrade = CdnFrontDoorOriginV0ToV1{}
+
+type CdnFrontDoorOriginV0ToV1 struct{}
+
+func (CdnFrontDoorOriginV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+		},
+
+		"cdn_frontdoor_origin_group_id": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+		},
+
+		"host_name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+		},
+
+		"certificate_name_check_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Required: true,
+		},
+
+		"enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+		},
+
+		"http_port": {
+			Type:     pluginsdk.TypeInt,
+			Optional: true,
+		},
+
+		"https_port": {
+			Type:     pluginsdk.TypeInt,
+			Optional: true,
+		},
+
+		"origin_host_header": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+		},
+
+		"priority": {
+			Type:     pluginsdk.TypeInt,
+			Optional: true,
+		},
+
+		"private_link": {
+			Type:     pluginsdk.TypeList,
+			MaxItems: 1,
+			Optional: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"location": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+					},
+
+					"private_link_target_id": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+					},
+
+					"request_message": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+					},
+
+					"target_type": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+					},
+				},
+			},
+		},
+
+		"weight": {
+			Type:     pluginsdk.TypeInt,
+			Optional: true,
+		},
+	}
+}
+
+func (CdnFrontDoorOriginV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		oldId := rawState["id"].(string)
+		id, err := afdorigins.ParseOriginGroupOriginIDInsensitively(oldId)
+		if err != nil {
+			return rawState, err
+		}
+
+		newId := id.ID()
+		log.Printf("[DEBUG] Updating ID from `%s` to `%s`", oldId, newId)
+		rawState["id"] = newId
+
+		return rawState, nil
+	}
+}


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

While the Create function for `azurerm_cdn_frontdoor_origin` has always set a correclty cased ID into state, imports previously did not normalize the `id` value. Adds a state migration to take care of any casing issues.

Also adds a `ResourceRegressionAdditionalStepsTest` helper to allow more than 2 steps (required to properly test this migration)


## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #33054


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
