### PR TITLE
Test Fix: `TestAccKubernetesFleetManager_update `

### DIFF
--- a/internal/services/containers/kubernetes_fleet_manager_resource_test.go
+++ b/internal/services/containers/kubernetes_fleet_manager_resource_test.go
@@ -150,9 +150,6 @@ resource "azurerm_kubernetes_fleet_manager" "test" {
     environment = "terraform-acctests"
     some_key    = "some-value"
   }
-  hub_profile {
-    dns_prefix = "val-${var.random_string}"
-  }
 }
 `, r.template(data))
 }


### PR DESCRIPTION
```
--- PASS: TestAccKubernetesFleetManager_update (174.24s)
------- Stdout: -------
=== RUN   TestAccKubernetesFleetManager_update
=== PAUSE TestAccKubernetesFleetManager_update
=== CONT  TestAccKubernetesFleetManager_update
    testcase.go:225: Step 3/6 error: Pre-apply plan check(s) failed:
        'azurerm_kubernetes_fleet_manager.test' - expected action to not be Replace, path: [[hub_profile]] tried to update a value that is ForceNew
--- FAIL: TestAccKubernetesFleetManager_update (105.47s)
FAIL
```