### PR TITLE
`azurerm_storage_share` - add a state migration for the `id` field

### DIFF
--- a/internal/services/storage/migration/storage_share_v2_to_v3.go
+++ b/internal/services/storage/migration/storage_share_v2_to_v3.go
@@ -1,0 +1,139 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package migration
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2025-08-01/fileshares"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+var _ pluginsdk.StateUpgrade = StorageShareV2ToV3{}
+
+type StorageShareV2ToV3 struct{}
+
+func (StorageShareV2ToV3) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+		},
+
+		"storage_account_id": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+		},
+
+		"quota": {
+			Type:     pluginsdk.TypeInt,
+			Required: true,
+		},
+
+		"metadata": {
+			Type:     pluginsdk.TypeMap,
+			Optional: true,
+			Computed: true,
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+			},
+		},
+
+		"enabled_protocol": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+		},
+
+		"acl": {
+			Type:     pluginsdk.TypeSet,
+			Optional: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"id": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+					},
+					"access_policy": {
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"start": {
+									Type:     pluginsdk.TypeString,
+									Optional: true,
+								},
+								"expiry": {
+									Type:     pluginsdk.TypeString,
+									Optional: true,
+								},
+								"permissions": {
+									Type:     pluginsdk.TypeString,
+									Required: true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+
+		"url": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"access_tier": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Computed: true,
+		},
+
+		"rbac_scope_id": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+	}
+}
+
+func (StorageShareV2ToV3) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		oldID, ok := rawState["id"].(string)
+		if !ok {
+			return rawState, fmt.Errorf("expected `id` to be of type string, got %T", rawState["id"])
+		}
+
+		// Some instances of this resource may already be using the resource manager ID, in which case this is a no-op
+		if _, err := fileshares.ParseShareID(oldID); err == nil {
+			return rawState, nil
+		}
+
+		storageAccountID, err := resolveStorageAccountIDForStateUpgrade(ctx, meta, rawState, func(idStr string) (*commonids.StorageAccountId, error) {
+			id, err := fileshares.ParseShareIDInsensitively(idStr)
+			if err != nil {
+				return nil, err
+			}
+			return new(commonids.NewStorageAccountID(id.SubscriptionId, id.ResourceGroupName, id.StorageAccountName)), nil
+		})
+		if err != nil {
+			return rawState, err
+		}
+
+		nameRaw, ok := rawState["name"]
+		if !ok {
+			return rawState, errors.New("expected a `name` attribute to be present in state")
+		}
+
+		name, ok := nameRaw.(string)
+		if !ok {
+			return rawState, fmt.Errorf("expected `name` to be of type string, got %T", nameRaw)
+		}
+
+		rawState["id"] = fileshares.NewShareID(storageAccountID.SubscriptionId, storageAccountID.ResourceGroupName, storageAccountID.StorageAccountName, name).ID()
+
+		return rawState, nil
+	}
+}

--- a/internal/services/storage/storage_share_resource.go
+++ b/internal/services/storage/storage_share_resource.go
@@ -40,10 +40,11 @@ func resourceStorageShare() *pluginsdk.Resource {
 			return err
 		}),
 
-		SchemaVersion: 2,
+		SchemaVersion: 3,
 		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
 			0: migration.ShareV0ToV1{},
 			1: migration.ShareV1ToV2{},
+			2: migration.StorageShareV2ToV3{},
 		}),
 
 		Timeouts: &pluginsdk.ResourceTimeout{

--- a/internal/services/storage/storage_share_resource_test.go
+++ b/internal/services/storage/storage_share_resource_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/jackofallops/giovanni/storage/2023-11-03/file/shares"
 )
 
 type StorageShareResource struct{}
@@ -268,32 +267,6 @@ func (r StorageShareResource) Exists(ctx context.Context, client *clients.Client
 	}
 
 	return pointer.To(existing.Model != nil), nil
-}
-
-// Destroy is deprecated for this resource. From 5.0 this will no longer use the Data Plane client.
-func (r StorageShareResource) Destroy(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
-	id, err := shares.ParseShareID(state.ID, client.Storage.StorageDomainSuffix)
-	if err != nil {
-		return nil, err
-	}
-
-	account, err := client.Storage.FindAccount(ctx, client.Account.SubscriptionId, id.AccountId.AccountName)
-	if err != nil {
-		return nil, fmt.Errorf("retrieving Account %q for Share %q: %+v", id.AccountId.AccountName, id.ShareName, err)
-	}
-	if account == nil {
-		return nil, fmt.Errorf("unable to determine Account %q for Storage Share %q", id.AccountId.AccountName, id.ShareName)
-	}
-
-	sharesClient, err := client.Storage.FileSharesDataPlaneClient(ctx, *account, client.Storage.DataPlaneOperationSupportingAnyAuthMethod())
-	if err != nil {
-		return nil, fmt.Errorf("building File Share Client for %s: %+v", account.StorageAccountId, err)
-	}
-	if err := sharesClient.Delete(ctx, id.ShareName); err != nil {
-		return nil, fmt.Errorf("deleting File Share %q in %s: %+v", id.ShareName, account.StorageAccountId, err)
-	}
-
-	return pointer.To(true), nil
 }
 
 func (r StorageShareResource) basic(data acceptance.TestData) string {

--- a/internal/services/storage/storage_share_resource_v2_to_v3_test.go
+++ b/internal/services/storage/storage_share_resource_v2_to_v3_test.go
@@ -1,0 +1,47 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package storage_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+)
+
+// TestAccStorageShare_V2ToV3_4810 tests the regular migration path that uses `resource_manager_id`
+// It uses v4.81.0 as the setup version because it is the last release where the resource was fully functional.
+func TestAccStorageShare_V2ToV3_4810(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_share", "test")
+	r := StorageShareResource{}
+
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicV2(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("id").HasValue(fmt.Sprintf("https://acctestacc%s.file.core.windows.net/testshare%s", data.RandomString, data.RandomString)),
+			),
+		},
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("id").HasValue(fmt.Sprintf("/subscriptions/%[1]s/resourceGroups/acctestRG-%[2]d/providers/Microsoft.Storage/storageAccounts/acctestacc%[3]s/fileServices/default/shares/testshare%[3]s", data.Subscriptions.Primary, data.RandomInteger, data.RandomString)),
+			),
+		},
+	}, "4.81.0")
+}
+
+func (r StorageShareResource) basicV2(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_storage_share" "test" {
+  name                 = "testshare%s"
+  storage_account_name = azurerm_storage_account.test.name
+  quota                = 5
+}
+`, r.template(data), data.RandomString)
+}


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #33057


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
