### PR TITLE
New Resource: `azurerm_container_app_session_pool`

### DIFF
--- a/internal/services/containerapps/client/client.go
+++ b/internal/services/containerapps/client/client.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/certificates"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerapps"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappsrevisions"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/daprcomponents"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/jobs"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/managedenvironments"
@@ -22,6 +23,7 @@ type Client struct {
 	ContainerAppRevisionClient *containerappsrevisions.ContainerAppsRevisionsClient
 	DaprComponentsClient       *daprcomponents.DaprComponentsClient
 	ManagedEnvironmentClient   *managedenvironments.ManagedEnvironmentsClient
+	SessionPoolClient          *containerappssessionpools.ContainerAppsSessionPoolsClient
 	StorageClient              *managedenvironmentsstorages.ManagedEnvironmentsStoragesClient
 	JobClient                  *jobs.JobsClient
 }
@@ -69,12 +71,19 @@ func NewClient(o *common.ClientOptions) (*Client, error) {
 	}
 	o.Configure(jobsClient.Client, o.Authorizers.ResourceManager)
 
+	sessionPoolClient, err := containerappssessionpools.NewContainerAppsSessionPoolsClientWithBaseURI(o.Environment.ResourceManager)
+	if err != nil {
+		return nil, fmt.Errorf("building Session Pools client : %+v", err)
+	}
+	o.Configure(sessionPoolClient.Client, o.Authorizers.ResourceManager)
+
 	return &Client{
 		CertificatesClient:         certificatesClient,
 		ContainerAppClient:         containerAppsClient,
 		ContainerAppRevisionClient: containerAppsRevisionsClient,
 		DaprComponentsClient:       daprComponentClient,
 		ManagedEnvironmentClient:   managedEnvironmentClient,
+		SessionPoolClient:          sessionPoolClient,
 		StorageClient:              managedEnvironmentStoragesClient,
 		JobClient:                  jobsClient,
 	}, nil

--- a/internal/services/containerapps/container_app_session_pool_resource.go
+++ b/internal/services/containerapps/container_app_session_pool_resource.go
@@ -139,8 +139,12 @@ func (r ContainerAppSessionPoolResource) CustomizeDiff() sdk.ResourceFunc {
 					return errors.New("`custom_container_template` must be set when `container_type` is `CustomContainer`")
 				}
 
-				if config.ContainerAppEnvironmentId == "" {
+				if !isConfigured("container_app_environment_id") {
 					return errors.New("`container_app_environment_id` must be set when `container_type` is `CustomContainer`")
+				}
+
+				if !isConfigured("ready_session_instances") {
+					return errors.New("`ready_session_instances` must be set when `container_type` is `CustomContainer`")
 				}
 
 			default:

--- a/internal/services/containerapps/container_app_session_pool_resource.go
+++ b/internal/services/containerapps/container_app_session_pool_resource.go
@@ -44,12 +44,10 @@ type ContainerAppSessionPoolModel struct {
 	ContainerType             string                                     `tfschema:"container_type"`
 	MaxConcurrentSessions     int64                                      `tfschema:"max_concurrent_sessions"`
 	ContainerAppEnvironmentId string                                     `tfschema:"container_app_environment_id"`
-	CooldownPeriodInSeconds   int64                                      `tfschema:"cooldown_period_in_seconds"`
 	CustomContainerTemplate   []CustomContainerTemplateModel             `tfschema:"custom_container_template"`
 	Identity                  []identity.ModelSystemAssignedUserAssigned `tfschema:"identity"`
-	LifecycleType             string                                     `tfschema:"lifecycle_type"`
+	LifecycleConfiguration    []LifecycleConfigurationModel              `tfschema:"lifecycle_configuration"`
 	SessionManagedIdentities  []string                                   `tfschema:"session_managed_identities"`
-	MaxAlivePeriodInSeconds   int64                                      `tfschema:"max_alive_period_in_seconds"`
 	NetworkEgressEnabled      bool                                       `tfschema:"network_egress_enabled"`
 	ReadySessionInstances     int64                                      `tfschema:"ready_session_instances"`
 	Secrets                   []SessionPoolSecretModel                   `tfschema:"secret"`
@@ -57,6 +55,12 @@ type ContainerAppSessionPoolModel struct {
 
 	NodeCount              int64  `tfschema:"node_count"`
 	PoolManagementEndpoint string `tfschema:"pool_management_endpoint"`
+}
+
+type LifecycleConfigurationModel struct {
+	CooldownPeriodInSeconds int64  `tfschema:"cooldown_period_in_seconds"`
+	LifecycleType           string `tfschema:"lifecycle_type"`
+	MaxAlivePeriodInSeconds int64  `tfschema:"max_alive_period_in_seconds"`
 }
 
 type CustomContainerTemplateModel struct {
@@ -148,24 +152,43 @@ func (r ContainerAppSessionPoolResource) CustomizeDiff() sdk.ResourceFunc {
 				}
 			}
 
-			switch config.LifecycleType {
+			if len(config.LifecycleConfiguration) == 0 {
+				return nil
+			}
+
+			rawLifecycleConfiguration := rawConfig.AsValueMap()["lifecycle_configuration"]
+			if rawLifecycleConfiguration.IsNull() || !rawLifecycleConfiguration.IsKnown() || len(rawLifecycleConfiguration.AsValueSlice()) == 0 {
+				return nil
+			}
+
+			rawLifecycle := rawLifecycleConfiguration.AsValueSlice()[0]
+			if rawLifecycle.IsNull() || !rawLifecycle.IsKnown() {
+				return nil
+			}
+
+			rawLifecycleProperties := rawLifecycle.AsValueMap()
+			cooldownPeriodInSecondsConfigured := !rawLifecycleProperties["cooldown_period_in_seconds"].IsNull()
+			maxAlivePeriodInSecondsConfigured := !rawLifecycleProperties["max_alive_period_in_seconds"].IsNull()
+
+			lifecycle := config.LifecycleConfiguration[0]
+			switch lifecycle.LifecycleType {
 			case string(containerappssessionpools.LifecycleTypeTimed):
-				if !isConfigured("cooldown_period_in_seconds") {
-					return errors.New("`cooldown_period_in_seconds` must be set when `lifecycle_type` is `Timed`")
+				if !cooldownPeriodInSecondsConfigured {
+					return errors.New("`lifecycle_configuration.0.cooldown_period_in_seconds` must be set when `lifecycle_configuration.0.lifecycle_type` is `Timed`")
 				}
-				if isConfigured("max_alive_period_in_seconds") {
-					return errors.New("`max_alive_period_in_seconds` cannot be set when `lifecycle_type` is `Timed`, use `cooldown_period_in_seconds` instead")
+				if maxAlivePeriodInSecondsConfigured {
+					return errors.New("`lifecycle_configuration.0.max_alive_period_in_seconds` cannot be set when `lifecycle_configuration.0.lifecycle_type` is `Timed`, use `lifecycle_configuration.0.cooldown_period_in_seconds` instead")
 				}
 
 			case string(containerappssessionpools.LifecycleTypeOnContainerExit):
 				if config.ContainerType != string(containerappssessionpools.ContainerTypeCustomContainer) {
-					return errors.New("`lifecycle_type` can only be set to `OnContainerExit` when `container_type` is `CustomContainer`")
+					return errors.New("`lifecycle_configuration.0.lifecycle_type` can only be set to `OnContainerExit` when `container_type` is `CustomContainer`")
 				}
-				if isConfigured("cooldown_period_in_seconds") {
-					return errors.New("`cooldown_period_in_seconds` cannot be set when `lifecycle_type` is `OnContainerExit`, use `max_alive_period_in_seconds` instead")
+				if cooldownPeriodInSecondsConfigured {
+					return errors.New("`lifecycle_configuration.0.cooldown_period_in_seconds` cannot be set when `lifecycle_configuration.0.lifecycle_type` is `OnContainerExit`, use `lifecycle_configuration.0.max_alive_period_in_seconds` instead")
 				}
-				if !isConfigured("max_alive_period_in_seconds") {
-					return errors.New("`max_alive_period_in_seconds` must be set when `lifecycle_type` is `OnContainerExit`")
+				if !maxAlivePeriodInSecondsConfigured {
+					return errors.New("`lifecycle_configuration.0.max_alive_period_in_seconds` must be set when `lifecycle_configuration.0.lifecycle_type` is `OnContainerExit`")
 				}
 			}
 
@@ -210,13 +233,6 @@ func (r ContainerAppSessionPoolResource) Arguments() map[string]*pluginsdk.Schem
 			Optional:     true,
 			ForceNew:     true,
 			ValidateFunc: managedenvironments.ValidateManagedEnvironmentID,
-		},
-
-		"cooldown_period_in_seconds": {
-			Type:          pluginsdk.TypeInt,
-			Optional:      true,
-			ValidateFunc:  validation.IntBetween(300, 3600),
-			ConflictsWith: []string{"max_alive_period_in_seconds"},
 		},
 
 		"custom_container_template": {
@@ -323,18 +339,34 @@ func (r ContainerAppSessionPoolResource) Arguments() map[string]*pluginsdk.Schem
 
 		"identity": commonschema.SystemAssignedUserAssignedIdentityOptional(),
 
-		"lifecycle_type": {
-			Type:         pluginsdk.TypeString,
-			Optional:     true,
-			Default:      string(containerappssessionpools.LifecycleTypeTimed),
-			ValidateFunc: validation.StringInSlice(containerappssessionpools.PossibleValuesForLifecycleType(), false),
-		},
+		"lifecycle_configuration": {
+			Type:     pluginsdk.TypeList,
+			Required: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"lifecycle_type": {
+						Type:         pluginsdk.TypeString,
+						Optional:     true,
+						Default:      string(containerappssessionpools.LifecycleTypeTimed),
+						ValidateFunc: validation.StringInSlice(containerappssessionpools.PossibleValuesForLifecycleType(), false),
+					},
 
-		"max_alive_period_in_seconds": {
-			Type:          pluginsdk.TypeInt,
-			Optional:      true,
-			ValidateFunc:  validation.IntAtLeast(1),
-			ConflictsWith: []string{"cooldown_period_in_seconds"},
+					"cooldown_period_in_seconds": {
+						Type:          pluginsdk.TypeInt,
+						Optional:      true,
+						ValidateFunc:  validation.IntBetween(300, 3600),
+						ConflictsWith: []string{"lifecycle_configuration.0.max_alive_period_in_seconds"},
+					},
+
+					"max_alive_period_in_seconds": {
+						Type:          pluginsdk.TypeInt,
+						Optional:      true,
+						ValidateFunc:  validation.IntAtLeast(1),
+						ConflictsWith: []string{"lifecycle_configuration.0.cooldown_period_in_seconds"},
+					},
+				},
+			},
 		},
 
 		"network_egress_enabled": {
@@ -446,9 +478,9 @@ func (r ContainerAppSessionPoolResource) Create() sdk.ResourceFunc {
 				Identity: expandedIdentity,
 				Location: location.Normalize(config.Location),
 				Properties: &containerappssessionpools.SessionPoolProperties{
-					ContainerType:            pointer.To(containerappssessionpools.ContainerType(config.ContainerType)),
+					ContainerType:            pointer.ToEnum[containerappssessionpools.ContainerType](config.ContainerType),
 					CustomContainerTemplate:  customContainerTemplate,
-					DynamicPoolConfiguration: expandContainerAppSessionPoolDynamicPoolConfiguration(config),
+					DynamicPoolConfiguration: expandContainerAppSessionPoolDynamicPoolConfiguration(config.LifecycleConfiguration),
 					ManagedIdentitySettings:  expandContainerAppSessionPoolManagedIdentitySettings(config.SessionManagedIdentities),
 					PoolManagementType:       pointer.To(containerappssessionpools.PoolManagementTypeDynamic),
 					ScaleConfiguration:       expandContainerAppSessionPoolScaleConfiguration(config),
@@ -513,8 +545,8 @@ func (r ContainerAppSessionPoolResource) Update() sdk.ResourceFunc {
 				props.CustomContainerTemplate = customContainerTemplate
 			}
 
-			if metadata.ResourceData.HasChanges("cooldown_period_in_seconds", "lifecycle_type", "max_alive_period_in_seconds") {
-				props.DynamicPoolConfiguration = expandContainerAppSessionPoolDynamicPoolConfiguration(config)
+			if metadata.ResourceData.HasChange("lifecycle_configuration") {
+				props.DynamicPoolConfiguration = expandContainerAppSessionPoolDynamicPoolConfiguration(config.LifecycleConfiguration)
 			}
 
 			if metadata.ResourceData.HasChanges("max_concurrent_sessions", "ready_session_instances") {
@@ -623,10 +655,7 @@ func (r ContainerAppSessionPoolResource) flatten(metadata sdk.ResourceMetaData, 
 			state.Secrets = flattenContainerAppSessionPoolSecrets(props.Secrets, existing.Secrets)
 
 			if dynamicPool := props.DynamicPoolConfiguration; dynamicPool != nil && dynamicPool.LifecycleConfiguration != nil {
-				lifecycle := dynamicPool.LifecycleConfiguration
-				state.CooldownPeriodInSeconds = pointer.From(lifecycle.CooldownPeriodInSeconds)
-				state.LifecycleType = string(pointer.From(lifecycle.LifecycleType))
-				state.MaxAlivePeriodInSeconds = pointer.From(lifecycle.MaxAlivePeriodInSeconds)
+				state.LifecycleConfiguration = flattenContainerAppSessionPoolLifecycleConfiguration(dynamicPool.LifecycleConfiguration)
 			}
 
 			if scale := props.ScaleConfiguration; scale != nil {
@@ -765,21 +794,22 @@ func expandContainerAppSessionPoolEnvironmentVars(input []helpers.ContainerEnvVa
 	return &result
 }
 
-func expandContainerAppSessionPoolDynamicPoolConfiguration(input ContainerAppSessionPoolModel) *containerappssessionpools.DynamicPoolConfiguration {
+func expandContainerAppSessionPoolDynamicPoolConfiguration(input []LifecycleConfigurationModel) *containerappssessionpools.DynamicPoolConfiguration {
 	// The API rejects a null `dynamicPoolConfiguration` when `poolManagementType` is `Dynamic`.
+	config := input[0]
 	lifecycle := &containerappssessionpools.LifecycleConfiguration{
-		LifecycleType: pointer.To(containerappssessionpools.LifecycleType(input.LifecycleType)),
+		LifecycleType: pointer.ToEnum[containerappssessionpools.LifecycleType](config.LifecycleType),
 	}
 
-	switch containerappssessionpools.LifecycleType(input.LifecycleType) {
+	switch containerappssessionpools.LifecycleType(config.LifecycleType) {
 	case containerappssessionpools.LifecycleTypeTimed:
-		if input.CooldownPeriodInSeconds != 0 {
-			lifecycle.CooldownPeriodInSeconds = pointer.To(input.CooldownPeriodInSeconds)
+		if config.CooldownPeriodInSeconds != 0 {
+			lifecycle.CooldownPeriodInSeconds = pointer.To(config.CooldownPeriodInSeconds)
 		}
 
 	case containerappssessionpools.LifecycleTypeOnContainerExit:
-		if input.MaxAlivePeriodInSeconds != 0 {
-			lifecycle.MaxAlivePeriodInSeconds = pointer.To(input.MaxAlivePeriodInSeconds)
+		if config.MaxAlivePeriodInSeconds != 0 {
+			lifecycle.MaxAlivePeriodInSeconds = pointer.To(config.MaxAlivePeriodInSeconds)
 		}
 	}
 
@@ -900,6 +930,20 @@ func flattenContainerAppSessionPoolEnvironmentVars(input *[]containerappssession
 	}
 
 	return result
+}
+
+func flattenContainerAppSessionPoolLifecycleConfiguration(input *containerappssessionpools.LifecycleConfiguration) []LifecycleConfigurationModel {
+	if input == nil {
+		return []LifecycleConfigurationModel{}
+	}
+
+	return []LifecycleConfigurationModel{
+		{
+			CooldownPeriodInSeconds: pointer.From(input.CooldownPeriodInSeconds),
+			LifecycleType:           string(pointer.From(input.LifecycleType)),
+			MaxAlivePeriodInSeconds: pointer.From(input.MaxAlivePeriodInSeconds),
+		},
+	}
 }
 
 func flattenContainerAppSessionPoolManagedIdentitySettings(input *[]containerappssessionpools.ManagedIdentitySetting) []string {

--- a/internal/services/containerapps/container_app_session_pool_resource.go
+++ b/internal/services/containerapps/container_app_session_pool_resource.go
@@ -48,7 +48,7 @@ type ContainerAppSessionPoolModel struct {
 	CustomContainerTemplate   []CustomContainerTemplateModel             `tfschema:"custom_container_template"`
 	Identity                  []identity.ModelSystemAssignedUserAssigned `tfschema:"identity"`
 	LifecycleType             string                                     `tfschema:"lifecycle_type"`
-	ManagedIdentitySettings   []ManagedIdentitySettingModel              `tfschema:"managed_identity_setting"`
+	SessionManagedIdentities  []string                                   `tfschema:"session_managed_identities"`
 	MaxAlivePeriodInSeconds   int64                                      `tfschema:"max_alive_period_in_seconds"`
 	NetworkEgressEnabled      bool                                       `tfschema:"network_egress_enabled"`
 	ReadySessionInstances     int64                                      `tfschema:"ready_session_instances"`
@@ -73,11 +73,6 @@ type SessionContainerModel struct {
 	Cpu     float64                   `tfschema:"cpu"`
 	Env     []helpers.ContainerEnvVar `tfschema:"env"`
 	Memory  string                    `tfschema:"memory"`
-}
-
-type ManagedIdentitySettingModel struct {
-	Identity  string `tfschema:"identity"`
-	Lifecycle string `tfschema:"lifecycle"`
 }
 
 type SessionPoolSecretModel struct {
@@ -335,36 +330,6 @@ func (r ContainerAppSessionPoolResource) Arguments() map[string]*pluginsdk.Schem
 			ValidateFunc: validation.StringInSlice(containerappssessionpools.PossibleValuesForLifecycleType(), false),
 		},
 
-		"managed_identity_setting": {
-			Type:     pluginsdk.TypeList,
-			Optional: true,
-			ForceNew: true,
-			Elem: &pluginsdk.Resource{
-				Schema: map[string]*pluginsdk.Schema{
-					"identity": {
-						Type:     pluginsdk.TypeString,
-						Required: true,
-						ForceNew: true,
-						ValidateFunc: validation.Any(
-							commonids.ValidateUserAssignedIdentityID,
-							validation.StringInSlice([]string{"System"}, false),
-						),
-					},
-
-					// Note: the `None` value is represented by omitting this block, so it isn't exposed here.
-					"lifecycle": {
-						Type:     pluginsdk.TypeString,
-						Optional: true,
-						ForceNew: true,
-						Default:  string(containerappssessionpools.IdentitySettingsLifeCycleMain),
-						ValidateFunc: validation.StringInSlice([]string{
-							string(containerappssessionpools.IdentitySettingsLifeCycleMain),
-						}, false),
-					},
-				},
-			},
-		},
-
 		"max_alive_period_in_seconds": {
 			Type:          pluginsdk.TypeInt,
 			Optional:      true,
@@ -403,6 +368,20 @@ func (r ContainerAppSessionPoolResource) Arguments() map[string]*pluginsdk.Schem
 						ValidateFunc: validation.StringIsNotEmpty,
 					},
 				},
+			},
+		},
+
+		// these must already be assigned via `identity`; listing one here exposes it to the code
+		// running inside the sessions, which the API otherwise denies by default
+		"session_managed_identities": {
+			Type:     pluginsdk.TypeSet,
+			Optional: true,
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+				ValidateFunc: validation.Any(
+					commonids.ValidateUserAssignedIdentityID,
+					validation.StringInSlice([]string{"System"}, false),
+				),
 			},
 		},
 
@@ -470,7 +449,7 @@ func (r ContainerAppSessionPoolResource) Create() sdk.ResourceFunc {
 					ContainerType:            pointer.To(containerappssessionpools.ContainerType(config.ContainerType)),
 					CustomContainerTemplate:  customContainerTemplate,
 					DynamicPoolConfiguration: expandContainerAppSessionPoolDynamicPoolConfiguration(config),
-					ManagedIdentitySettings:  expandContainerAppSessionPoolManagedIdentitySettings(config.ManagedIdentitySettings),
+					ManagedIdentitySettings:  expandContainerAppSessionPoolManagedIdentitySettings(config.SessionManagedIdentities),
 					PoolManagementType:       pointer.To(containerappssessionpools.PoolManagementTypeDynamic),
 					ScaleConfiguration:       expandContainerAppSessionPoolScaleConfiguration(config),
 					Secrets:                  expandContainerAppSessionPoolSecrets(config.Secrets),
@@ -540,6 +519,11 @@ func (r ContainerAppSessionPoolResource) Update() sdk.ResourceFunc {
 
 			if metadata.ResourceData.HasChanges("max_concurrent_sessions", "ready_session_instances") {
 				props.ScaleConfiguration = expandContainerAppSessionPoolScaleConfiguration(config)
+			}
+
+			// clearing this sends a null, which the API resets to the `None` lifecycle stage
+			if metadata.ResourceData.HasChange("session_managed_identities") {
+				props.ManagedIdentitySettings = expandContainerAppSessionPoolManagedIdentitySettings(config.SessionManagedIdentities)
 			}
 
 			if metadata.ResourceData.HasChange("network_egress_enabled") {
@@ -633,7 +617,7 @@ func (r ContainerAppSessionPoolResource) flatten(metadata sdk.ResourceMetaData, 
 			}
 			state.ContainerType = string(pointer.From(props.ContainerType))
 			state.CustomContainerTemplate = flattenContainerAppSessionPoolCustomContainerTemplate(props.CustomContainerTemplate)
-			state.ManagedIdentitySettings = flattenContainerAppSessionPoolManagedIdentitySettings(props.ManagedIdentitySettings)
+			state.SessionManagedIdentities = flattenContainerAppSessionPoolManagedIdentitySettings(props.ManagedIdentitySettings)
 			state.NodeCount = pointer.From(props.NodeCount)
 			state.PoolManagementEndpoint = pointer.From(props.PoolManagementEndpoint)
 			state.Secrets = flattenContainerAppSessionPoolSecrets(props.Secrets, existing.Secrets)
@@ -816,7 +800,7 @@ func expandContainerAppSessionPoolScaleConfiguration(input ContainerAppSessionPo
 	return result
 }
 
-func expandContainerAppSessionPoolManagedIdentitySettings(input []ManagedIdentitySettingModel) *[]containerappssessionpools.ManagedIdentitySetting {
+func expandContainerAppSessionPoolManagedIdentitySettings(input []string) *[]containerappssessionpools.ManagedIdentitySetting {
 	if len(input) == 0 {
 		return nil
 	}
@@ -824,8 +808,8 @@ func expandContainerAppSessionPoolManagedIdentitySettings(input []ManagedIdentit
 	result := make([]containerappssessionpools.ManagedIdentitySetting, 0, len(input))
 	for _, v := range input {
 		result = append(result, containerappssessionpools.ManagedIdentitySetting{
-			Identity:  v.Identity,
-			Lifecycle: pointer.To(containerappssessionpools.IdentitySettingsLifeCycle(v.Lifecycle)),
+			Identity:  v,
+			Lifecycle: pointer.To(containerappssessionpools.IdentitySettingsLifeCycleMain),
 		})
 	}
 
@@ -918,22 +902,19 @@ func flattenContainerAppSessionPoolEnvironmentVars(input *[]containerappssession
 	return result
 }
 
-func flattenContainerAppSessionPoolManagedIdentitySettings(input *[]containerappssessionpools.ManagedIdentitySetting) []ManagedIdentitySettingModel {
+func flattenContainerAppSessionPoolManagedIdentitySettings(input *[]containerappssessionpools.ManagedIdentitySetting) []string {
 	if input == nil {
-		return []ManagedIdentitySettingModel{}
+		return []string{}
 	}
 
-	result := make([]ManagedIdentitySettingModel, 0, len(*input))
+	result := make([]string, 0, len(*input))
 	for _, v := range *input {
-		// `None` means the identity isn't in use, which is represented by omitting the block.
+		// the API adds a `None` entry for every assigned identity that isn't exposed to the sessions
 		if pointer.From(v.Lifecycle) == containerappssessionpools.IdentitySettingsLifeCycleNone {
 			continue
 		}
 
-		result = append(result, ManagedIdentitySettingModel{
-			Identity:  normaliseContainerAppSessionPoolIdentity(v.Identity),
-			Lifecycle: string(pointer.From(v.Lifecycle)),
-		})
+		result = append(result, normaliseContainerAppSessionPoolIdentity(v.Identity))
 	}
 
 	return result

--- a/internal/services/containerapps/container_app_session_pool_resource.go
+++ b/internal/services/containerapps/container_app_session_pool_resource.go
@@ -51,7 +51,6 @@ type ContainerAppSessionPoolModel struct {
 	ManagedIdentitySettings   []ManagedIdentitySettingModel              `tfschema:"managed_identity_setting"`
 	MaxAlivePeriodInSeconds   int64                                      `tfschema:"max_alive_period_in_seconds"`
 	NetworkEgressEnabled      bool                                       `tfschema:"network_egress_enabled"`
-	PoolManagementType        string                                     `tfschema:"pool_management_type"`
 	ReadySessionInstances     int64                                      `tfschema:"ready_session_instances"`
 	Secrets                   []SessionPoolSecretModel                   `tfschema:"secret"`
 	Tags                      map[string]string                          `tfschema:"tags"`
@@ -115,9 +114,14 @@ func (r ContainerAppSessionPoolResource) CustomizeDiff() sdk.ResourceFunc {
 				return err
 			}
 
-			rawConfig := metadata.ResourceDiff.GetRawConfig().AsValueMap()
+			rawConfig := metadata.ResourceDiff.GetRawConfig()
 			isConfigured := func(name string) bool {
-				value, ok := rawConfig[name]
+				// `AsValueMap` panics on a null raw config, which Terraform can send during a destroy plan
+				if rawConfig.IsNull() {
+					return false
+				}
+
+				value, ok := rawConfig.AsValueMap()[name]
 				return ok && !value.IsNull()
 			}
 
@@ -135,36 +139,34 @@ func (r ContainerAppSessionPoolResource) CustomizeDiff() sdk.ResourceFunc {
 					return errors.New("`custom_container_template` must be set when `container_type` is `CustomContainer`")
 				}
 
+				if config.ContainerAppEnvironmentId == "" {
+					return errors.New("`container_app_environment_id` must be set when `container_type` is `CustomContainer`")
+				}
+
 			default:
 				if len(config.CustomContainerTemplate) > 0 {
 					return errors.New("`custom_container_template` can only be set when `container_type` is `CustomContainer`")
 				}
 			}
 
-			if config.PoolManagementType == string(containerappssessionpools.PoolManagementTypeDynamic) {
-				if !isConfigured("lifecycle_type") {
-					return errors.New("`lifecycle_type` must be set when `pool_management_type` is `Dynamic`")
+			switch config.LifecycleType {
+			case string(containerappssessionpools.LifecycleTypeTimed):
+				if !isConfigured("cooldown_period_in_seconds") {
+					return errors.New("`cooldown_period_in_seconds` must be set when `lifecycle_type` is `Timed`")
+				}
+				if isConfigured("max_alive_period_in_seconds") {
+					return errors.New("`max_alive_period_in_seconds` cannot be set when `lifecycle_type` is `Timed`, use `cooldown_period_in_seconds` instead")
 				}
 
-				switch config.LifecycleType {
-				case string(containerappssessionpools.LifecycleTypeTimed):
-					if !isConfigured("cooldown_period_in_seconds") {
-						return errors.New("`cooldown_period_in_seconds` must be set when `lifecycle_type` is `Timed`")
-					}
-					if isConfigured("max_alive_period_in_seconds") {
-						return errors.New("`max_alive_period_in_seconds` cannot be set when `lifecycle_type` is `Timed`, use `cooldown_period_in_seconds` instead")
-					}
-
-				case string(containerappssessionpools.LifecycleTypeOnContainerExit):
-					if config.ContainerType != string(containerappssessionpools.ContainerTypeCustomContainer) {
-						return errors.New("`lifecycle_type` can only be set to `OnContainerExit` when `container_type` is `CustomContainer`")
-					}
-					if isConfigured("cooldown_period_in_seconds") {
-						return errors.New("`cooldown_period_in_seconds` cannot be set when `lifecycle_type` is `OnContainerExit`, use `max_alive_period_in_seconds` instead")
-					}
-					if !isConfigured("max_alive_period_in_seconds") {
-						return errors.New("`max_alive_period_in_seconds` must be set when `lifecycle_type` is `OnContainerExit`")
-					}
+			case string(containerappssessionpools.LifecycleTypeOnContainerExit):
+				if config.ContainerType != string(containerappssessionpools.ContainerTypeCustomContainer) {
+					return errors.New("`lifecycle_type` can only be set to `OnContainerExit` when `container_type` is `CustomContainer`")
+				}
+				if isConfigured("cooldown_period_in_seconds") {
+					return errors.New("`cooldown_period_in_seconds` cannot be set when `lifecycle_type` is `OnContainerExit`, use `max_alive_period_in_seconds` instead")
+				}
+				if !isConfigured("max_alive_period_in_seconds") {
+					return errors.New("`max_alive_period_in_seconds` must be set when `lifecycle_type` is `OnContainerExit`")
 				}
 			}
 
@@ -191,14 +193,16 @@ func (r ContainerAppSessionPoolResource) Arguments() map[string]*pluginsdk.Schem
 
 		"container_type": {
 			Type:         pluginsdk.TypeString,
-			Required:     true,
+			Optional:     true,
 			ForceNew:     true,
+			Default:      string(containerappssessionpools.ContainerTypePythonLTS),
 			ValidateFunc: validation.StringInSlice(containerappssessionpools.PossibleValuesForContainerType(), false),
 		},
 
 		"max_concurrent_sessions": {
 			Type:         pluginsdk.TypeInt,
-			Required:     true,
+			Optional:     true,
+			Default:      5,
 			ValidateFunc: validation.IntAtLeast(1),
 		},
 
@@ -323,6 +327,7 @@ func (r ContainerAppSessionPoolResource) Arguments() map[string]*pluginsdk.Schem
 		"lifecycle_type": {
 			Type:         pluginsdk.TypeString,
 			Optional:     true,
+			Default:      string(containerappssessionpools.LifecycleTypeTimed),
 			ValidateFunc: validation.StringInSlice(containerappssessionpools.PossibleValuesForLifecycleType(), false),
 		},
 
@@ -367,16 +372,6 @@ func (r ContainerAppSessionPoolResource) Arguments() map[string]*pluginsdk.Schem
 			Type:     pluginsdk.TypeBool,
 			Optional: true,
 			Default:  false,
-		},
-
-		"pool_management_type": {
-			Type:     pluginsdk.TypeString,
-			Required: true,
-			ForceNew: true,
-			// The API enum includes `Manual`, but the service currently rejects creating Manual session pools.
-			ValidateFunc: validation.StringInSlice([]string{
-				string(containerappssessionpools.PoolManagementTypeDynamic),
-			}, false),
 		},
 
 		"ready_session_instances": {
@@ -472,7 +467,7 @@ func (r ContainerAppSessionPoolResource) Create() sdk.ResourceFunc {
 					CustomContainerTemplate:  customContainerTemplate,
 					DynamicPoolConfiguration: expandContainerAppSessionPoolDynamicPoolConfiguration(config),
 					ManagedIdentitySettings:  expandContainerAppSessionPoolManagedIdentitySettings(config.ManagedIdentitySettings),
-					PoolManagementType:       pointer.To(containerappssessionpools.PoolManagementType(config.PoolManagementType)),
+					PoolManagementType:       pointer.To(containerappssessionpools.PoolManagementTypeDynamic),
 					ScaleConfiguration:       expandContainerAppSessionPoolScaleConfiguration(config),
 					Secrets:                  expandContainerAppSessionPoolSecrets(config.Secrets),
 					SessionNetworkConfiguration: &containerappssessionpools.SessionNetworkConfiguration{
@@ -637,7 +632,6 @@ func (r ContainerAppSessionPoolResource) flatten(metadata sdk.ResourceMetaData, 
 			state.ManagedIdentitySettings = flattenContainerAppSessionPoolManagedIdentitySettings(props.ManagedIdentitySettings)
 			state.NodeCount = pointer.From(props.NodeCount)
 			state.PoolManagementEndpoint = pointer.From(props.PoolManagementEndpoint)
-			state.PoolManagementType = string(pointer.From(props.PoolManagementType))
 			state.Secrets = flattenContainerAppSessionPoolSecrets(props.Secrets, existing.Secrets)
 
 			if dynamicPool := props.DynamicPoolConfiguration; dynamicPool != nil && dynamicPool.LifecycleConfiguration != nil {
@@ -785,10 +779,6 @@ func expandContainerAppSessionPoolEnvironmentVars(input []helpers.ContainerEnvVa
 
 func expandContainerAppSessionPoolDynamicPoolConfiguration(input ContainerAppSessionPoolModel) *containerappssessionpools.DynamicPoolConfiguration {
 	// The API rejects a null `dynamicPoolConfiguration` when `poolManagementType` is `Dynamic`.
-	if input.PoolManagementType != string(containerappssessionpools.PoolManagementTypeDynamic) {
-		return nil
-	}
-
 	lifecycle := &containerappssessionpools.LifecycleConfiguration{
 		LifecycleType: pointer.To(containerappssessionpools.LifecycleType(input.LifecycleType)),
 	}

--- a/internal/services/containerapps/container_app_session_pool_resource.go
+++ b/internal/services/containerapps/container_app_session_pool_resource.go
@@ -1,0 +1,982 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package containerapps
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/managedenvironments"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/containerapps/helpers"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/containerapps/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+//go:generate go run ../../tools/generator-tests resourceidentity
+
+type ContainerAppSessionPoolResource struct{}
+
+var (
+	_ sdk.ResourceWithCustomizeDiff = ContainerAppSessionPoolResource{}
+	_ sdk.ResourceWithIdentity      = ContainerAppSessionPoolResource{}
+	_ sdk.ResourceWithUpdate        = ContainerAppSessionPoolResource{}
+)
+
+type ContainerAppSessionPoolModel struct {
+	Name                      string                                     `tfschema:"name"`
+	ResourceGroupName         string                                     `tfschema:"resource_group_name"`
+	Location                  string                                     `tfschema:"location"`
+	ContainerType             string                                     `tfschema:"container_type"`
+	MaxConcurrentSessions     int64                                      `tfschema:"max_concurrent_sessions"`
+	ContainerAppEnvironmentId string                                     `tfschema:"container_app_environment_id"`
+	CooldownPeriodInSeconds   int64                                      `tfschema:"cooldown_period_in_seconds"`
+	CustomContainerTemplate   []CustomContainerTemplateModel             `tfschema:"custom_container_template"`
+	Identity                  []identity.ModelSystemAssignedUserAssigned `tfschema:"identity"`
+	LifecycleType             string                                     `tfschema:"lifecycle_type"`
+	ManagedIdentitySettings   []ManagedIdentitySettingModel              `tfschema:"managed_identity_setting"`
+	MaxAlivePeriodInSeconds   int64                                      `tfschema:"max_alive_period_in_seconds"`
+	NetworkEgressEnabled      bool                                       `tfschema:"network_egress_enabled"`
+	PoolManagementType        string                                     `tfschema:"pool_management_type"`
+	ReadySessionInstances     int64                                      `tfschema:"ready_session_instances"`
+	Secrets                   []SessionPoolSecretModel                   `tfschema:"secret"`
+	Tags                      map[string]string                          `tfschema:"tags"`
+
+	NodeCount              int64  `tfschema:"node_count"`
+	PoolManagementEndpoint string `tfschema:"pool_management_endpoint"`
+}
+
+type CustomContainerTemplateModel struct {
+	Containers        []SessionContainerModel `tfschema:"container"`
+	IngressTargetPort int64                   `tfschema:"ingress_target_port"`
+	Registry          []helpers.Registry      `tfschema:"registry"`
+}
+
+type SessionContainerModel struct {
+	Name    string                    `tfschema:"name"`
+	Image   string                    `tfschema:"image"`
+	Args    []string                  `tfschema:"args"`
+	Command []string                  `tfschema:"command"`
+	Cpu     float64                   `tfschema:"cpu"`
+	Env     []helpers.ContainerEnvVar `tfschema:"env"`
+	Memory  string                    `tfschema:"memory"`
+}
+
+type ManagedIdentitySettingModel struct {
+	Identity  string `tfschema:"identity"`
+	Lifecycle string `tfschema:"lifecycle"`
+}
+
+type SessionPoolSecretModel struct {
+	Name  string `tfschema:"name"`
+	Value string `tfschema:"value"`
+}
+
+func (r ContainerAppSessionPoolResource) ResourceType() string {
+	return "azurerm_container_app_session_pool"
+}
+
+func (r ContainerAppSessionPoolResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return containerappssessionpools.ValidateSessionPoolID
+}
+
+func (r ContainerAppSessionPoolResource) Identity() resourceids.ResourceId {
+	return &containerappssessionpools.SessionPoolId{}
+}
+
+func (r ContainerAppSessionPoolResource) ModelObject() interface{} {
+	return &ContainerAppSessionPoolModel{}
+}
+
+func (r ContainerAppSessionPoolResource) CustomizeDiff() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			if metadata.ResourceDiff == nil {
+				return nil
+			}
+
+			var config ContainerAppSessionPoolModel
+			if err := metadata.DecodeDiff(&config); err != nil {
+				return err
+			}
+
+			rawConfig := metadata.ResourceDiff.GetRawConfig().AsValueMap()
+			isConfigured := func(name string) bool {
+				value, ok := rawConfig[name]
+				return ok && !value.IsNull()
+			}
+
+			if config.ContainerType != string(containerappssessionpools.ContainerTypeCustomContainer) && len(config.Identity) > 0 {
+				return errors.New("`identity` can only be set when `container_type` is `CustomContainer`")
+			}
+
+			if config.ReadySessionInstances != 0 && config.ReadySessionInstances >= config.MaxConcurrentSessions {
+				return errors.New("`ready_session_instances` must be less than `max_concurrent_sessions`")
+			}
+
+			switch config.ContainerType {
+			case string(containerappssessionpools.ContainerTypeCustomContainer):
+				if len(config.CustomContainerTemplate) == 0 {
+					return errors.New("`custom_container_template` must be set when `container_type` is `CustomContainer`")
+				}
+
+			default:
+				if len(config.CustomContainerTemplate) > 0 {
+					return errors.New("`custom_container_template` can only be set when `container_type` is `CustomContainer`")
+				}
+			}
+
+			if config.PoolManagementType == string(containerappssessionpools.PoolManagementTypeDynamic) {
+				if !isConfigured("lifecycle_type") {
+					return errors.New("`lifecycle_type` must be set when `pool_management_type` is `Dynamic`")
+				}
+
+				switch config.LifecycleType {
+				case string(containerappssessionpools.LifecycleTypeTimed):
+					if !isConfigured("cooldown_period_in_seconds") {
+						return errors.New("`cooldown_period_in_seconds` must be set when `lifecycle_type` is `Timed`")
+					}
+					if isConfigured("max_alive_period_in_seconds") {
+						return errors.New("`max_alive_period_in_seconds` cannot be set when `lifecycle_type` is `Timed`, use `cooldown_period_in_seconds` instead")
+					}
+
+				case string(containerappssessionpools.LifecycleTypeOnContainerExit):
+					if config.ContainerType != string(containerappssessionpools.ContainerTypeCustomContainer) {
+						return errors.New("`lifecycle_type` can only be set to `OnContainerExit` when `container_type` is `CustomContainer`")
+					}
+					if isConfigured("cooldown_period_in_seconds") {
+						return errors.New("`cooldown_period_in_seconds` cannot be set when `lifecycle_type` is `OnContainerExit`, use `max_alive_period_in_seconds` instead")
+					}
+					if !isConfigured("max_alive_period_in_seconds") {
+						return errors.New("`max_alive_period_in_seconds` must be set when `lifecycle_type` is `OnContainerExit`")
+					}
+				}
+			}
+
+			return nil
+		},
+	}
+}
+
+func (r ContainerAppSessionPoolResource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+			ValidateFunc: validation.StringMatch(
+				regexp.MustCompile(`^[a-z][a-z0-9]{2,62}$`),
+				"The `name` must be between 3 and 63 characters long, begin with a lowercase letter and contain only lowercase letters and numbers.",
+			),
+		},
+
+		"resource_group_name": commonschema.ResourceGroupName(),
+
+		"location": commonschema.Location(),
+
+		"container_type": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringInSlice(containerappssessionpools.PossibleValuesForContainerType(), false),
+		},
+
+		"max_concurrent_sessions": {
+			Type:         pluginsdk.TypeInt,
+			Required:     true,
+			ValidateFunc: validation.IntAtLeast(1),
+		},
+
+		"container_app_environment_id": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ForceNew:     true,
+			ValidateFunc: managedenvironments.ValidateManagedEnvironmentID,
+		},
+
+		"cooldown_period_in_seconds": {
+			Type:          pluginsdk.TypeInt,
+			Optional:      true,
+			ValidateFunc:  validation.IntBetween(300, 3600),
+			ConflictsWith: []string{"max_alive_period_in_seconds"},
+		},
+
+		"custom_container_template": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"container": {
+						Type:     pluginsdk.TypeList,
+						Required: true,
+						MinItems: 1,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"name": {
+									Type:         pluginsdk.TypeString,
+									Required:     true,
+									ValidateFunc: validate.ContainerAppContainerName,
+								},
+
+								"image": {
+									Type:         pluginsdk.TypeString,
+									Required:     true,
+									ValidateFunc: validation.StringIsNotEmpty,
+								},
+
+								"args": {
+									Type:     pluginsdk.TypeList,
+									Optional: true,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+
+								"command": {
+									Type:     pluginsdk.TypeList,
+									Optional: true,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+
+								"cpu": {
+									Type:         pluginsdk.TypeFloat,
+									Optional:     true,
+									ValidateFunc: validation.FloatAtLeast(0.1),
+								},
+
+								"env": helpers.ContainerEnvVarSchema(),
+
+								"memory": {
+									Type:         pluginsdk.TypeString,
+									Optional:     true,
+									ValidateFunc: validation.StringIsNotEmpty,
+								},
+							},
+						},
+					},
+
+					"ingress_target_port": {
+						Type:         pluginsdk.TypeInt,
+						Required:     true,
+						ValidateFunc: validation.IntBetween(1, 65535),
+					},
+
+					"registry": {
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						MaxItems: 1,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"server": {
+									Type:         pluginsdk.TypeString,
+									Required:     true,
+									ValidateFunc: validation.StringIsNotEmpty,
+								},
+
+								"identity": {
+									Type:     pluginsdk.TypeString,
+									Optional: true,
+									ValidateFunc: validation.Any(
+										commonids.ValidateUserAssignedIdentityID,
+										validation.StringInSlice([]string{"System"}, false),
+									),
+								},
+
+								"password_secret_name": {
+									Type:         pluginsdk.TypeString,
+									Optional:     true,
+									ValidateFunc: validate.SecretName,
+								},
+
+								"username": {
+									Type:         pluginsdk.TypeString,
+									Optional:     true,
+									ValidateFunc: validation.StringIsNotEmpty,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+
+		"identity": commonschema.SystemAssignedUserAssignedIdentityOptional(),
+
+		"lifecycle_type": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.StringInSlice(containerappssessionpools.PossibleValuesForLifecycleType(), false),
+		},
+
+		"managed_identity_setting": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			ForceNew: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"identity": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+						ForceNew: true,
+						ValidateFunc: validation.Any(
+							commonids.ValidateUserAssignedIdentityID,
+							validation.StringInSlice([]string{"System"}, false),
+						),
+					},
+
+					// Note: the `None` value is represented by omitting this block, so it isn't exposed here.
+					"lifecycle": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						ForceNew: true,
+						Default:  string(containerappssessionpools.IdentitySettingsLifeCycleMain),
+						ValidateFunc: validation.StringInSlice([]string{
+							string(containerappssessionpools.IdentitySettingsLifeCycleMain),
+						}, false),
+					},
+				},
+			},
+		},
+
+		"max_alive_period_in_seconds": {
+			Type:          pluginsdk.TypeInt,
+			Optional:      true,
+			ValidateFunc:  validation.IntAtLeast(1),
+			ConflictsWith: []string{"cooldown_period_in_seconds"},
+		},
+
+		"network_egress_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Default:  false,
+		},
+
+		"pool_management_type": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+			// The API enum includes `Manual`, but the service currently rejects creating Manual session pools.
+			ValidateFunc: validation.StringInSlice([]string{
+				string(containerappssessionpools.PoolManagementTypeDynamic),
+			}, false),
+		},
+
+		"ready_session_instances": {
+			Type:         pluginsdk.TypeInt,
+			Optional:     true,
+			ValidateFunc: validation.IntAtLeast(1),
+		},
+
+		"secret": {
+			Type:      pluginsdk.TypeSet,
+			Optional:  true,
+			Sensitive: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"name": {
+						Type:         pluginsdk.TypeString,
+						Required:     true,
+						ValidateFunc: validate.SecretName,
+					},
+
+					"value": {
+						Type:         pluginsdk.TypeString,
+						Required:     true,
+						Sensitive:    true,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+				},
+			},
+		},
+
+		"tags": commonschema.Tags(),
+	}
+}
+
+func (r ContainerAppSessionPoolResource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"node_count": {
+			Type:     pluginsdk.TypeInt,
+			Computed: true,
+		},
+
+		"pool_management_endpoint": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+	}
+}
+
+func (r ContainerAppSessionPoolResource) Create() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.ContainerApps.SessionPoolClient
+			subscriptionId := metadata.Client.Account.SubscriptionId
+
+			var config ContainerAppSessionPoolModel
+			if err := metadata.Decode(&config); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			id := containerappssessionpools.NewSessionPoolID(subscriptionId, config.ResourceGroupName, config.Name)
+
+			if !metadata.Client.Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+				existing, err := client.Get(ctx, id)
+				if err != nil && !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+				}
+				if !response.WasNotFound(existing.HttpResponse) {
+					return metadata.ResourceRequiresImport(r.ResourceType(), id)
+				}
+			}
+
+			expandedIdentity, err := identity.ExpandLegacySystemAndUserAssignedMapFromModel(config.Identity)
+			if err != nil {
+				return fmt.Errorf("expanding `identity`: %+v", err)
+			}
+
+			customContainerTemplate, err := expandContainerAppSessionPoolCustomContainerTemplate(config.CustomContainerTemplate)
+			if err != nil {
+				return fmt.Errorf("expanding `custom_container_template`: %+v", err)
+			}
+
+			networkStatus := containerappssessionpools.SessionNetworkStatusEgressDisabled
+			if config.NetworkEgressEnabled {
+				networkStatus = containerappssessionpools.SessionNetworkStatusEgressEnabled
+			}
+
+			payload := containerappssessionpools.SessionPool{
+				Identity: expandedIdentity,
+				Location: location.Normalize(config.Location),
+				Properties: &containerappssessionpools.SessionPoolProperties{
+					ContainerType:            pointer.To(containerappssessionpools.ContainerType(config.ContainerType)),
+					CustomContainerTemplate:  customContainerTemplate,
+					DynamicPoolConfiguration: expandContainerAppSessionPoolDynamicPoolConfiguration(config),
+					ManagedIdentitySettings:  expandContainerAppSessionPoolManagedIdentitySettings(config.ManagedIdentitySettings),
+					PoolManagementType:       pointer.To(containerappssessionpools.PoolManagementType(config.PoolManagementType)),
+					ScaleConfiguration:       expandContainerAppSessionPoolScaleConfiguration(config),
+					Secrets:                  expandContainerAppSessionPoolSecrets(config.Secrets),
+					SessionNetworkConfiguration: &containerappssessionpools.SessionNetworkConfiguration{
+						Status: pointer.To(networkStatus),
+					},
+				},
+				Tags: pointer.To(config.Tags),
+			}
+
+			if config.ContainerAppEnvironmentId != "" {
+				payload.Properties.EnvironmentId = pointer.To(config.ContainerAppEnvironmentId)
+			}
+
+			if err := client.CreateOrUpdateCallbackThenPoll(ctx, id, payload, metadata.SetIDAndIdentityCallback(&id)); err != nil {
+				return fmt.Errorf("creating %s: %+v", id, err)
+			}
+
+			metadata.SetID(id)
+
+			return pluginsdk.SetResourceIdentityData(metadata.ResourceData, &id)
+		},
+	}
+}
+
+func (r ContainerAppSessionPoolResource) Update() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.ContainerApps.SessionPoolClient
+
+			id, err := containerappssessionpools.ParseSessionPoolID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			var config ContainerAppSessionPoolModel
+			if err := metadata.Decode(&config); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			existing, err := client.Get(ctx, *id)
+			if err != nil {
+				return fmt.Errorf("retrieving %s: %+v", *id, err)
+			}
+			if existing.Model == nil {
+				return fmt.Errorf("retrieving %s: `model` was nil", *id)
+			}
+			if existing.Model.Properties == nil {
+				return fmt.Errorf("retrieving %s: `properties` was nil", *id)
+			}
+
+			payload := *existing.Model
+			props := payload.Properties
+
+			if metadata.ResourceData.HasChange("custom_container_template") {
+				customContainerTemplate, err := expandContainerAppSessionPoolCustomContainerTemplate(config.CustomContainerTemplate)
+				if err != nil {
+					return fmt.Errorf("expanding `custom_container_template`: %+v", err)
+				}
+				props.CustomContainerTemplate = customContainerTemplate
+			}
+
+			if metadata.ResourceData.HasChanges("cooldown_period_in_seconds", "lifecycle_type", "max_alive_period_in_seconds") {
+				props.DynamicPoolConfiguration = expandContainerAppSessionPoolDynamicPoolConfiguration(config)
+			}
+
+			if metadata.ResourceData.HasChanges("max_concurrent_sessions", "ready_session_instances") {
+				props.ScaleConfiguration = expandContainerAppSessionPoolScaleConfiguration(config)
+			}
+
+			if metadata.ResourceData.HasChange("network_egress_enabled") {
+				networkStatus := containerappssessionpools.SessionNetworkStatusEgressDisabled
+				if config.NetworkEgressEnabled {
+					networkStatus = containerappssessionpools.SessionNetworkStatusEgressEnabled
+				}
+
+				props.SessionNetworkConfiguration = &containerappssessionpools.SessionNetworkConfiguration{
+					Status: pointer.To(networkStatus),
+				}
+			}
+
+			// The API doesn't return secret values, so these are always sent from the config to avoid clearing them.
+			props.Secrets = expandContainerAppSessionPoolSecrets(config.Secrets)
+
+			if metadata.ResourceData.HasChange("identity") {
+				expandedIdentity, err := identity.ExpandLegacySystemAndUserAssignedMapFromModel(config.Identity)
+				if err != nil {
+					return fmt.Errorf("expanding `identity`: %+v", err)
+				}
+				payload.Identity = expandedIdentity
+			}
+
+			if metadata.ResourceData.HasChange("tags") {
+				payload.Tags = pointer.To(config.Tags)
+			}
+
+			if err := client.CreateOrUpdateThenPoll(ctx, *id, payload); err != nil {
+				return fmt.Errorf("updating %s: %+v", *id, err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func (r ContainerAppSessionPoolResource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.ContainerApps.SessionPoolClient
+
+			id, err := containerappssessionpools.ParseSessionPoolID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.Get(ctx, *id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return metadata.MarkAsGone(id)
+				}
+
+				return fmt.Errorf("retrieving %s: %+v", *id, err)
+			}
+
+			return r.flatten(metadata, id, resp.Model)
+		},
+	}
+}
+
+func (r ContainerAppSessionPoolResource) flatten(metadata sdk.ResourceMetaData, id *containerappssessionpools.SessionPoolId, model *containerappssessionpools.SessionPool) error {
+	var existing ContainerAppSessionPoolModel
+	if err := metadata.Decode(&existing); err != nil {
+		return fmt.Errorf("decoding: %+v", err)
+	}
+
+	state := ContainerAppSessionPoolModel{
+		Name:              id.SessionPoolName,
+		ResourceGroupName: id.ResourceGroupName,
+	}
+
+	if model != nil {
+		state.Location = location.Normalize(model.Location)
+		state.Tags = pointer.From(model.Tags)
+
+		flattenedIdentity, err := identity.FlattenLegacySystemAndUserAssignedMapToModel(model.Identity)
+		if err != nil {
+			return fmt.Errorf("flattening `identity`: %+v", err)
+		}
+		state.Identity = flattenedIdentity
+
+		if props := model.Properties; props != nil {
+			if props.EnvironmentId != nil {
+				environmentId, err := managedenvironments.ParseManagedEnvironmentIDInsensitively(pointer.From(props.EnvironmentId))
+				if err != nil {
+					return fmt.Errorf("parsing `container_app_environment_id`: %+v", err)
+				}
+				state.ContainerAppEnvironmentId = environmentId.ID()
+			}
+			state.ContainerType = string(pointer.From(props.ContainerType))
+			state.CustomContainerTemplate = flattenContainerAppSessionPoolCustomContainerTemplate(props.CustomContainerTemplate)
+			state.ManagedIdentitySettings = flattenContainerAppSessionPoolManagedIdentitySettings(props.ManagedIdentitySettings)
+			state.NodeCount = pointer.From(props.NodeCount)
+			state.PoolManagementEndpoint = pointer.From(props.PoolManagementEndpoint)
+			state.PoolManagementType = string(pointer.From(props.PoolManagementType))
+			state.Secrets = flattenContainerAppSessionPoolSecrets(props.Secrets, existing.Secrets)
+
+			if dynamicPool := props.DynamicPoolConfiguration; dynamicPool != nil && dynamicPool.LifecycleConfiguration != nil {
+				lifecycle := dynamicPool.LifecycleConfiguration
+				state.CooldownPeriodInSeconds = pointer.From(lifecycle.CooldownPeriodInSeconds)
+				state.LifecycleType = string(pointer.From(lifecycle.LifecycleType))
+				state.MaxAlivePeriodInSeconds = pointer.From(lifecycle.MaxAlivePeriodInSeconds)
+			}
+
+			if scale := props.ScaleConfiguration; scale != nil {
+				state.MaxConcurrentSessions = pointer.From(scale.MaxConcurrentSessions)
+				state.ReadySessionInstances = pointer.From(scale.ReadySessionInstances)
+			}
+
+			if network := props.SessionNetworkConfiguration; network != nil {
+				state.NetworkEgressEnabled = pointer.From(network.Status) == containerappssessionpools.SessionNetworkStatusEgressEnabled
+			}
+		}
+	}
+
+	if err := pluginsdk.SetResourceIdentityData(metadata.ResourceData, id); err != nil {
+		return err
+	}
+
+	return metadata.Encode(&state)
+}
+
+func (r ContainerAppSessionPoolResource) Delete() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.ContainerApps.SessionPoolClient
+
+			id, err := containerappssessionpools.ParseSessionPoolID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			if err := client.DeleteThenPoll(ctx, *id); err != nil {
+				return fmt.Errorf("deleting %s: %+v", *id, err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func expandContainerAppSessionPoolCustomContainerTemplate(input []CustomContainerTemplateModel) (*containerappssessionpools.CustomContainerTemplate, error) {
+	if len(input) == 0 {
+		return nil, nil
+	}
+
+	v := input[0]
+	result := &containerappssessionpools.CustomContainerTemplate{
+		Containers: expandContainerAppSessionPoolContainers(v.Containers),
+	}
+
+	if v.IngressTargetPort != 0 {
+		result.Ingress = &containerappssessionpools.SessionIngress{
+			TargetPort: pointer.To(v.IngressTargetPort),
+		}
+	}
+
+	if len(v.Registry) > 0 {
+		registry := v.Registry[0]
+		if err := helpers.ValidateContainerAppRegistry(registry); err != nil {
+			return nil, err
+		}
+
+		result.RegistryCredentials = &containerappssessionpools.SessionRegistryCredentials{
+			Server: pointer.To(registry.Server),
+		}
+
+		if registry.Identity != "" {
+			result.RegistryCredentials.Identity = pointer.To(registry.Identity)
+		}
+		if registry.PasswordSecretRef != "" {
+			result.RegistryCredentials.PasswordSecretRef = pointer.To(registry.PasswordSecretRef)
+		}
+		if registry.UserName != "" {
+			result.RegistryCredentials.Username = pointer.To(registry.UserName)
+		}
+	}
+
+	return result, nil
+}
+
+func expandContainerAppSessionPoolContainers(input []SessionContainerModel) *[]containerappssessionpools.SessionContainer {
+	if len(input) == 0 {
+		return nil
+	}
+
+	result := make([]containerappssessionpools.SessionContainer, 0, len(input))
+	for _, v := range input {
+		container := containerappssessionpools.SessionContainer{
+			Env:   expandContainerAppSessionPoolEnvironmentVars(v.Env),
+			Image: pointer.To(v.Image),
+			Name:  pointer.To(v.Name),
+		}
+
+		if len(v.Args) > 0 {
+			container.Args = pointer.To(v.Args)
+		}
+		if len(v.Command) > 0 {
+			container.Command = pointer.To(v.Command)
+		}
+		if v.Cpu != 0 || v.Memory != "" {
+			container.Resources = &containerappssessionpools.SessionContainerResources{}
+			if v.Cpu != 0 {
+				container.Resources.Cpu = pointer.To(v.Cpu)
+			}
+			if v.Memory != "" {
+				container.Resources.Memory = pointer.To(v.Memory)
+			}
+		}
+
+		result = append(result, container)
+	}
+
+	return &result
+}
+
+func expandContainerAppSessionPoolEnvironmentVars(input []helpers.ContainerEnvVar) *[]containerappssessionpools.EnvironmentVar {
+	if len(input) == 0 {
+		return nil
+	}
+
+	result := make([]containerappssessionpools.EnvironmentVar, 0, len(input))
+	for _, v := range input {
+		env := containerappssessionpools.EnvironmentVar{
+			Name: pointer.To(v.Name),
+		}
+
+		if v.SecretReference != "" {
+			env.SecretRef = pointer.To(v.SecretReference)
+		} else {
+			env.Value = pointer.To(v.Value)
+		}
+
+		result = append(result, env)
+	}
+
+	return &result
+}
+
+func expandContainerAppSessionPoolDynamicPoolConfiguration(input ContainerAppSessionPoolModel) *containerappssessionpools.DynamicPoolConfiguration {
+	// The API rejects a null `dynamicPoolConfiguration` when `poolManagementType` is `Dynamic`.
+	if input.PoolManagementType != string(containerappssessionpools.PoolManagementTypeDynamic) {
+		return nil
+	}
+
+	lifecycle := &containerappssessionpools.LifecycleConfiguration{
+		LifecycleType: pointer.To(containerappssessionpools.LifecycleType(input.LifecycleType)),
+	}
+
+	switch containerappssessionpools.LifecycleType(input.LifecycleType) {
+	case containerappssessionpools.LifecycleTypeTimed:
+		if input.CooldownPeriodInSeconds != 0 {
+			lifecycle.CooldownPeriodInSeconds = pointer.To(input.CooldownPeriodInSeconds)
+		}
+
+	case containerappssessionpools.LifecycleTypeOnContainerExit:
+		if input.MaxAlivePeriodInSeconds != 0 {
+			lifecycle.MaxAlivePeriodInSeconds = pointer.To(input.MaxAlivePeriodInSeconds)
+		}
+	}
+
+	return &containerappssessionpools.DynamicPoolConfiguration{
+		LifecycleConfiguration: lifecycle,
+	}
+}
+
+func expandContainerAppSessionPoolScaleConfiguration(input ContainerAppSessionPoolModel) *containerappssessionpools.ScaleConfiguration {
+	result := &containerappssessionpools.ScaleConfiguration{
+		MaxConcurrentSessions: pointer.To(input.MaxConcurrentSessions),
+	}
+
+	if input.ReadySessionInstances != 0 {
+		result.ReadySessionInstances = pointer.To(input.ReadySessionInstances)
+	}
+
+	return result
+}
+
+func expandContainerAppSessionPoolManagedIdentitySettings(input []ManagedIdentitySettingModel) *[]containerappssessionpools.ManagedIdentitySetting {
+	if len(input) == 0 {
+		return nil
+	}
+
+	result := make([]containerappssessionpools.ManagedIdentitySetting, 0, len(input))
+	for _, v := range input {
+		result = append(result, containerappssessionpools.ManagedIdentitySetting{
+			Identity:  v.Identity,
+			Lifecycle: pointer.To(containerappssessionpools.IdentitySettingsLifeCycle(v.Lifecycle)),
+		})
+	}
+
+	return &result
+}
+
+func expandContainerAppSessionPoolSecrets(input []SessionPoolSecretModel) *[]containerappssessionpools.SessionPoolSecret {
+	if len(input) == 0 {
+		return nil
+	}
+
+	result := make([]containerappssessionpools.SessionPoolSecret, 0, len(input))
+	for _, v := range input {
+		result = append(result, containerappssessionpools.SessionPoolSecret{
+			Name:  pointer.To(v.Name),
+			Value: pointer.To(v.Value),
+		})
+	}
+
+	return &result
+}
+
+func flattenContainerAppSessionPoolCustomContainerTemplate(input *containerappssessionpools.CustomContainerTemplate) []CustomContainerTemplateModel {
+	if input == nil {
+		return []CustomContainerTemplateModel{}
+	}
+
+	result := CustomContainerTemplateModel{
+		Containers: flattenContainerAppSessionPoolContainers(input.Containers),
+	}
+
+	if ingress := input.Ingress; ingress != nil {
+		result.IngressTargetPort = pointer.From(ingress.TargetPort)
+	}
+
+	if credentials := input.RegistryCredentials; credentials != nil {
+		result.Registry = []helpers.Registry{
+			{
+				Identity:          normaliseContainerAppSessionPoolIdentity(pointer.From(credentials.Identity)),
+				PasswordSecretRef: pointer.From(credentials.PasswordSecretRef),
+				Server:            pointer.From(credentials.Server),
+				UserName:          pointer.From(credentials.Username),
+			},
+		}
+	}
+
+	return []CustomContainerTemplateModel{result}
+}
+
+func flattenContainerAppSessionPoolContainers(input *[]containerappssessionpools.SessionContainer) []SessionContainerModel {
+	if input == nil {
+		return []SessionContainerModel{}
+	}
+
+	result := make([]SessionContainerModel, 0, len(*input))
+	for _, v := range *input {
+		container := SessionContainerModel{
+			Args:    pointer.From(v.Args),
+			Command: pointer.From(v.Command),
+			Env:     flattenContainerAppSessionPoolEnvironmentVars(v.Env),
+			Image:   pointer.From(v.Image),
+			Name:    pointer.From(v.Name),
+		}
+
+		if resources := v.Resources; resources != nil {
+			container.Cpu = pointer.From(resources.Cpu)
+			container.Memory = pointer.From(resources.Memory)
+		}
+
+		result = append(result, container)
+	}
+
+	return result
+}
+
+func flattenContainerAppSessionPoolEnvironmentVars(input *[]containerappssessionpools.EnvironmentVar) []helpers.ContainerEnvVar {
+	if input == nil {
+		return []helpers.ContainerEnvVar{}
+	}
+
+	result := make([]helpers.ContainerEnvVar, 0, len(*input))
+	for _, v := range *input {
+		result = append(result, helpers.ContainerEnvVar{
+			Name:            pointer.From(v.Name),
+			SecretReference: pointer.From(v.SecretRef),
+			Value:           pointer.From(v.Value),
+		})
+	}
+
+	return result
+}
+
+func flattenContainerAppSessionPoolManagedIdentitySettings(input *[]containerappssessionpools.ManagedIdentitySetting) []ManagedIdentitySettingModel {
+	if input == nil {
+		return []ManagedIdentitySettingModel{}
+	}
+
+	result := make([]ManagedIdentitySettingModel, 0, len(*input))
+	for _, v := range *input {
+		// `None` means the identity isn't in use, which is represented by omitting the block.
+		if pointer.From(v.Lifecycle) == containerappssessionpools.IdentitySettingsLifeCycleNone {
+			continue
+		}
+
+		result = append(result, ManagedIdentitySettingModel{
+			Identity:  normaliseContainerAppSessionPoolIdentity(v.Identity),
+			Lifecycle: string(pointer.From(v.Lifecycle)),
+		})
+	}
+
+	return result
+}
+
+// The API returns `System` as `system`, and can return User Assigned Identity IDs with inconsistent segment casing.
+func normaliseContainerAppSessionPoolIdentity(input string) string {
+	if strings.EqualFold(input, "System") {
+		return "System"
+	}
+
+	if id, err := commonids.ParseUserAssignedIdentityIDInsensitively(input); err == nil {
+		return id.ID()
+	}
+
+	return input
+}
+
+func flattenContainerAppSessionPoolSecrets(input *[]containerappssessionpools.SessionPoolSecret, existing []SessionPoolSecretModel) []SessionPoolSecretModel {
+	if input == nil {
+		return []SessionPoolSecretModel{}
+	}
+
+	// `value` is flagged `x-ms-secret` in the API definition so it's never returned and has to be carried over from state.
+	valuesFromState := make(map[string]string, len(existing))
+	for _, v := range existing {
+		valuesFromState[v.Name] = v.Value
+	}
+
+	result := make([]SessionPoolSecretModel, 0, len(*input))
+	for _, v := range *input {
+		name := pointer.From(v.Name)
+		result = append(result, SessionPoolSecretModel{
+			Name:  name,
+			Value: valuesFromState[name],
+		})
+	}
+
+	return result
+}

--- a/internal/services/containerapps/container_app_session_pool_resource_identity_gen_test.go
+++ b/internal/services/containerapps/container_app_session_pool_resource_identity_gen_test.go
@@ -1,0 +1,39 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package containerapps_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
+)
+
+func TestAccContainerAppSessionPool_resourceIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_app_session_pool", "test")
+	r := ContainerAppSessionPoolResource{}
+
+	checkedFields := map[string]struct{}{
+		"subscription_id":     {},
+		"name":                {},
+		"resource_group_name": {},
+	}
+
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				customstatecheck.ExpectAllIdentityFieldsAreChecked("azurerm_container_app_session_pool.test", checkedFields),
+				statecheck.ExpectIdentityValue("azurerm_container_app_session_pool.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_container_app_session_pool.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_container_app_session_pool.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
+			},
+		},
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
+}

--- a/internal/services/containerapps/container_app_session_pool_resource_list.go
+++ b/internal/services/containerapps/container_app_session_pool_resource_list.go
@@ -1,0 +1,98 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package containerapps
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type ContainerAppSessionPoolListResource struct{}
+
+var _ sdk.FrameworkListWrappedResource = new(ContainerAppSessionPoolListResource)
+
+func (ContainerAppSessionPoolListResource) Metadata(_ context.Context, _ resource.MetadataRequest, response *resource.MetadataResponse) {
+	response.TypeName = ContainerAppSessionPoolResource{}.ResourceType()
+}
+
+func (ContainerAppSessionPoolListResource) ResourceFunc() *pluginsdk.Resource {
+	return sdk.WrappedResource(ContainerAppSessionPoolResource{})
+}
+
+func (ContainerAppSessionPoolListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream, metadata sdk.ResourceMetadata) {
+	client := metadata.Client.ContainerApps.SessionPoolClient
+
+	var data sdk.DefaultListModel
+	diags := request.Config.Get(ctx, &data)
+	if diags.HasError() {
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+
+	var results []containerappssessionpools.SessionPool
+	subscriptionID := metadata.SubscriptionId
+	if !data.SubscriptionId.IsNull() {
+		subscriptionID = data.SubscriptionId.ValueString()
+	}
+
+	sessionPool := ContainerAppSessionPoolResource{}
+
+	switch {
+	case !data.ResourceGroupName.IsNull():
+		resp, err := client.ListByResourceGroupComplete(ctx, commonids.NewResourceGroupID(subscriptionID, data.ResourceGroupName.ValueString()))
+		if err != nil {
+			sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("listing `%s`", sessionPool.ResourceType()), err)
+			return
+		}
+
+		results = resp.Items
+	default:
+		resp, err := client.ListBySubscriptionComplete(ctx, commonids.NewSubscriptionID(subscriptionID))
+		if err != nil {
+			sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("listing `%s`", sessionPool.ResourceType()), err)
+			return
+		}
+
+		results = resp.Items
+	}
+
+	stream.Results = func(push func(list.ListResult) bool) {
+		for _, item := range results {
+			result := request.NewListResult(ctx)
+			result.DisplayName = pointer.From(item.Name)
+
+			id, err := containerappssessionpools.ParseSessionPoolIDInsensitively(pointer.From(item.Id))
+			if err != nil {
+				sdk.SetErrorDiagnosticAndPushListResult(result, push, "parsing Session Pool ID", err)
+				return
+			}
+
+			meta := sdk.NewResourceMetaData(metadata.Client, sessionPool)
+			meta.SetID(id)
+
+			if err := sessionPool.flatten(meta, id, &item); err != nil {
+				sdk.SetErrorDiagnosticAndPushListResult(result, push, fmt.Sprintf("encoding `%s` resource data", sessionPool.ResourceType()), err)
+				return
+			}
+
+			sdk.EncodeListResult(ctx, meta.ResourceData, &result)
+			if result.Diagnostics.HasError() {
+				push(result)
+				return
+			}
+
+			if !push(result) {
+				return
+			}
+		}
+	}
+}

--- a/internal/services/containerapps/container_app_session_pool_resource_list_test.go
+++ b/internal/services/containerapps/container_app_session_pool_resource_list_test.go
@@ -1,0 +1,101 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package containerapps_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
+)
+
+func TestAccContainerAppSessionPool_list(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_app_session_pool", "testlist")
+	r := ContainerAppSessionPoolResource{}
+	resourceName := fmt.Sprintf("acctestcasp0%d", data.RandomInteger)
+	resourceGroupName := fmt.Sprintf("acctestRG-CASP-%d", data.RandomInteger)
+
+	expectedIdentity := map[string]knownvalue.Check{
+		"name":                knownvalue.StringExact(resourceName),
+		"resource_group_name": knownvalue.StringExact(resourceGroupName),
+		"subscription_id":     knownvalue.StringExact(data.Subscriptions.Primary),
+	}
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []resource.TestStep{
+			{
+				Config: r.basicList(data),
+			},
+			{
+				Query:  true,
+				Config: r.subscriptionListQuery(),
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectLengthAtLeast("azurerm_container_app_session_pool.list", 2),
+					querycheck.ExpectIdentity("azurerm_container_app_session_pool.list", expectedIdentity),
+				},
+			},
+			{
+				Query:  true,
+				Config: r.resourceGroupListQuery(data),
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectLength("azurerm_container_app_session_pool.list", 2),
+					querycheck.ExpectIdentity("azurerm_container_app_session_pool.list", expectedIdentity),
+				},
+			},
+		},
+	})
+}
+
+func (r ContainerAppSessionPoolResource) basicList(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_container_app_session_pool" "test" {
+  count = 2
+
+  name                    = "acctestcasp${count.index}%[2]d"
+  resource_group_name     = azurerm_resource_group.test.name
+  location                = azurerm_resource_group.test.location
+  container_type          = "PythonLTS"
+  max_concurrent_sessions = 5
+
+  pool_management_type       = "Dynamic"
+  lifecycle_type             = "Timed"
+  cooldown_period_in_seconds = 300
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r ContainerAppSessionPoolResource) subscriptionListQuery() string {
+	return `
+list "azurerm_container_app_session_pool" "list" {
+  provider = azurerm
+}
+`
+}
+
+func (r ContainerAppSessionPoolResource) resourceGroupListQuery(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+list "azurerm_container_app_session_pool" "list" {
+  provider = azurerm
+  config {
+    resource_group_name = "acctestRG-CASP-%[1]d"
+  }
+}
+`, data.RandomInteger)
+}

--- a/internal/services/containerapps/container_app_session_pool_resource_list_test.go
+++ b/internal/services/containerapps/container_app_session_pool_resource_list_test.go
@@ -57,14 +57,9 @@ provider "azurerm" {
 resource "azurerm_container_app_session_pool" "test" {
   count = 2
 
-  name                    = "acctestcasp${count.index}%[2]d"
-  resource_group_name     = azurerm_resource_group.test.name
-  location                = azurerm_resource_group.test.location
-  container_type          = "PythonLTS"
-  max_concurrent_sessions = 5
-
-  pool_management_type       = "Dynamic"
-  lifecycle_type             = "Timed"
+  name                       = "acctestcasp${count.index}%[2]d"
+  resource_group_name        = azurerm_resource_group.test.name
+  location                   = azurerm_resource_group.test.location
   cooldown_period_in_seconds = 300
 }
 `, r.template(data), data.RandomInteger)

--- a/internal/services/containerapps/container_app_session_pool_resource_list_test.go
+++ b/internal/services/containerapps/container_app_session_pool_resource_list_test.go
@@ -57,10 +57,13 @@ provider "azurerm" {
 resource "azurerm_container_app_session_pool" "test" {
   count = 2
 
-  name                       = "acctestcasp${count.index}%[2]d"
-  resource_group_name        = azurerm_resource_group.test.name
-  location                   = azurerm_resource_group.test.location
-  cooldown_period_in_seconds = 300
+  name                = "acctestcasp${count.index}%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  lifecycle_configuration {
+    cooldown_period_in_seconds = 300
+  }
 }
 `, r.template(data), data.RandomInteger)
 }

--- a/internal/services/containerapps/container_app_session_pool_resource_list_test.go
+++ b/internal/services/containerapps/container_app_session_pool_resource_list_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/querycheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
@@ -19,14 +18,6 @@ import (
 func TestAccContainerAppSessionPool_list(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_container_app_session_pool", "testlist")
 	r := ContainerAppSessionPoolResource{}
-	resourceName := fmt.Sprintf("acctestcasp0%d", data.RandomInteger)
-	resourceGroupName := fmt.Sprintf("acctestRG-CASP-%d", data.RandomInteger)
-
-	expectedIdentity := map[string]knownvalue.Check{
-		"name":                knownvalue.StringExact(resourceName),
-		"resource_group_name": knownvalue.StringExact(resourceGroupName),
-		"subscription_id":     knownvalue.StringExact(data.Subscriptions.Primary),
-	}
 
 	resource.Test(t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -42,7 +33,6 @@ func TestAccContainerAppSessionPool_list(t *testing.T) {
 				Config: r.subscriptionListQuery(),
 				QueryResultChecks: []querycheck.QueryResultCheck{
 					querycheck.ExpectLengthAtLeast("azurerm_container_app_session_pool.list", 2),
-					querycheck.ExpectIdentity("azurerm_container_app_session_pool.list", expectedIdentity),
 				},
 			},
 			{
@@ -50,7 +40,6 @@ func TestAccContainerAppSessionPool_list(t *testing.T) {
 				Config: r.resourceGroupListQuery(data),
 				QueryResultChecks: []querycheck.QueryResultCheck{
 					querycheck.ExpectLength("azurerm_container_app_session_pool.list", 2),
-					querycheck.ExpectIdentity("azurerm_container_app_session_pool.list", expectedIdentity),
 				},
 			},
 		},

--- a/internal/services/containerapps/container_app_session_pool_resource_test.go
+++ b/internal/services/containerapps/container_app_session_pool_resource_test.go
@@ -223,10 +223,7 @@ resource "azurerm_container_app_session_pool" "test" {
     type = "SystemAssigned"
   }
 
-  managed_identity_setting {
-    identity  = "System"
-    lifecycle = "Main"
-  }
+  session_managed_identities = ["System"]
 
   custom_container_template {
     ingress_target_port = 80

--- a/internal/services/containerapps/container_app_session_pool_resource_test.go
+++ b/internal/services/containerapps/container_app_session_pool_resource_test.go
@@ -28,6 +28,9 @@ func TestAccContainerAppSessionPool_basic(t *testing.T) {
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("container_type").HasValue("PythonLTS"),
+				check.That(data.ResourceName).Key("max_concurrent_sessions").HasValue("5"),
+				check.That(data.ResourceName).Key("lifecycle_type").HasValue("Timed"),
 			),
 		},
 		data.ImportStep(),
@@ -149,14 +152,9 @@ provider "azurerm" {
 %[1]s
 
 resource "azurerm_container_app_session_pool" "test" {
-  name                    = "acctestcasp%[2]d"
-  resource_group_name     = azurerm_resource_group.test.name
-  location                = azurerm_resource_group.test.location
-  container_type          = "PythonLTS"
-  max_concurrent_sessions = 5
-
-  pool_management_type       = "Dynamic"
-  lifecycle_type             = "Timed"
+  name                       = "acctestcasp%[2]d"
+  resource_group_name        = azurerm_resource_group.test.name
+  location                   = azurerm_resource_group.test.location
   cooldown_period_in_seconds = 300
 }
 `, r.template(data), data.RandomInteger)
@@ -167,14 +165,9 @@ func (r ContainerAppSessionPoolResource) requiresImport(data acceptance.TestData
 %[1]s
 
 resource "azurerm_container_app_session_pool" "import" {
-  name                    = azurerm_container_app_session_pool.test.name
-  resource_group_name     = azurerm_container_app_session_pool.test.resource_group_name
-  location                = azurerm_container_app_session_pool.test.location
-  container_type          = azurerm_container_app_session_pool.test.container_type
-  max_concurrent_sessions = azurerm_container_app_session_pool.test.max_concurrent_sessions
-
-  pool_management_type       = azurerm_container_app_session_pool.test.pool_management_type
-  lifecycle_type             = azurerm_container_app_session_pool.test.lifecycle_type
+  name                       = azurerm_container_app_session_pool.test.name
+  resource_group_name        = azurerm_container_app_session_pool.test.resource_group_name
+  location                   = azurerm_container_app_session_pool.test.location
   cooldown_period_in_seconds = azurerm_container_app_session_pool.test.cooldown_period_in_seconds
 }
 `, r.basic(data))
@@ -195,7 +188,6 @@ resource "azurerm_container_app_session_pool" "test" {
   container_type          = "PythonLTS"
   max_concurrent_sessions = 10
 
-  pool_management_type       = "Dynamic"
   lifecycle_type             = "Timed"
   cooldown_period_in_seconds = 600
   network_egress_enabled     = true
@@ -223,7 +215,6 @@ resource "azurerm_container_app_session_pool" "test" {
   container_type               = "CustomContainer"
   max_concurrent_sessions      = 10
 
-  pool_management_type       = "Dynamic"
   lifecycle_type             = "Timed"
   cooldown_period_in_seconds = 600
   ready_session_instances    = 2
@@ -296,7 +287,6 @@ resource "azurerm_container_app_session_pool" "test" {
   container_type               = "CustomContainer"
   max_concurrent_sessions      = 5
 
-  pool_management_type        = "Dynamic"
   lifecycle_type              = "OnContainerExit"
   max_alive_period_in_seconds = 600
   ready_session_instances     = 1

--- a/internal/services/containerapps/container_app_session_pool_resource_test.go
+++ b/internal/services/containerapps/container_app_session_pool_resource_test.go
@@ -30,7 +30,8 @@ func TestAccContainerAppSessionPool_basic(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("container_type").HasValue("PythonLTS"),
 				check.That(data.ResourceName).Key("max_concurrent_sessions").HasValue("5"),
-				check.That(data.ResourceName).Key("lifecycle_type").HasValue("Timed"),
+				check.That(data.ResourceName).Key("lifecycle_configuration.0.lifecycle_type").HasValue("Timed"),
+				check.That(data.ResourceName).Key("lifecycle_configuration.0.cooldown_period_in_seconds").HasValue("300"),
 			),
 		},
 		data.ImportStep(),
@@ -120,6 +121,8 @@ func TestAccContainerAppSessionPool_onContainerExit(t *testing.T) {
 			Config: r.onContainerExit(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("lifecycle_configuration.0.lifecycle_type").HasValue("OnContainerExit"),
+				check.That(data.ResourceName).Key("lifecycle_configuration.0.max_alive_period_in_seconds").HasValue("600"),
 			),
 		},
 		data.ImportStep(),
@@ -152,10 +155,13 @@ provider "azurerm" {
 %[1]s
 
 resource "azurerm_container_app_session_pool" "test" {
-  name                       = "acctestcasp%[2]d"
-  resource_group_name        = azurerm_resource_group.test.name
-  location                   = azurerm_resource_group.test.location
-  cooldown_period_in_seconds = 300
+  name                = "acctestcasp%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  lifecycle_configuration {
+    cooldown_period_in_seconds = 300
+  }
 }
 `, r.template(data), data.RandomInteger)
 }
@@ -165,10 +171,14 @@ func (r ContainerAppSessionPoolResource) requiresImport(data acceptance.TestData
 %[1]s
 
 resource "azurerm_container_app_session_pool" "import" {
-  name                       = azurerm_container_app_session_pool.test.name
-  resource_group_name        = azurerm_container_app_session_pool.test.resource_group_name
-  location                   = azurerm_container_app_session_pool.test.location
-  cooldown_period_in_seconds = azurerm_container_app_session_pool.test.cooldown_period_in_seconds
+  name                = azurerm_container_app_session_pool.test.name
+  resource_group_name = azurerm_container_app_session_pool.test.resource_group_name
+  location            = azurerm_container_app_session_pool.test.location
+
+  lifecycle_configuration {
+    lifecycle_type             = azurerm_container_app_session_pool.test.lifecycle_configuration[0].lifecycle_type
+    cooldown_period_in_seconds = azurerm_container_app_session_pool.test.lifecycle_configuration[0].cooldown_period_in_seconds
+  }
 }
 `, r.basic(data))
 }
@@ -188,9 +198,12 @@ resource "azurerm_container_app_session_pool" "test" {
   container_type          = "PythonLTS"
   max_concurrent_sessions = 10
 
-  lifecycle_type             = "Timed"
-  cooldown_period_in_seconds = 600
-  network_egress_enabled     = true
+  lifecycle_configuration {
+    lifecycle_type             = "Timed"
+    cooldown_period_in_seconds = 600
+  }
+
+  network_egress_enabled = true
 
   tags = {
     environment = "acctest"
@@ -215,9 +228,12 @@ resource "azurerm_container_app_session_pool" "test" {
   container_type               = "CustomContainer"
   max_concurrent_sessions      = 10
 
-  lifecycle_type             = "Timed"
-  cooldown_period_in_seconds = 600
-  ready_session_instances    = 2
+  lifecycle_configuration {
+    lifecycle_type             = "Timed"
+    cooldown_period_in_seconds = 600
+  }
+
+  ready_session_instances = 2
 
   identity {
     type = "SystemAssigned"
@@ -284,9 +300,12 @@ resource "azurerm_container_app_session_pool" "test" {
   container_type               = "CustomContainer"
   max_concurrent_sessions      = 5
 
-  lifecycle_type              = "OnContainerExit"
-  max_alive_period_in_seconds = 600
-  ready_session_instances     = 1
+  lifecycle_configuration {
+    lifecycle_type              = "OnContainerExit"
+    max_alive_period_in_seconds = 600
+  }
+
+  ready_session_instances = 1
 
   custom_container_template {
     ingress_target_port = 80

--- a/internal/services/containerapps/container_app_session_pool_resource_test.go
+++ b/internal/services/containerapps/container_app_session_pool_resource_test.go
@@ -1,0 +1,351 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package containerapps_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type ContainerAppSessionPoolResource struct{}
+
+func TestAccContainerAppSessionPool_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_app_session_pool", "test")
+	r := ContainerAppSessionPoolResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccContainerAppSessionPool_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_app_session_pool", "test")
+	r := ContainerAppSessionPoolResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func TestAccContainerAppSessionPool_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_app_session_pool", "test")
+	r := ContainerAppSessionPoolResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccContainerAppSessionPool_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_app_session_pool", "test")
+	r := ContainerAppSessionPoolResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccContainerAppSessionPool_customContainer(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_app_session_pool", "test")
+	r := ContainerAppSessionPoolResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.customContainer(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("secret"),
+	})
+}
+
+func TestAccContainerAppSessionPool_onContainerExit(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_app_session_pool", "test")
+	r := ContainerAppSessionPoolResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.onContainerExit(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (r ContainerAppSessionPoolResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := containerappssessionpools.ParseSessionPoolID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.ContainerApps.SessionPoolClient.Get(ctx, *id)
+	if err != nil {
+		if response.WasNotFound(resp.HttpResponse) {
+			return pointer.To(false), nil
+		}
+		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
+	}
+
+	return pointer.To(resp.Model != nil), nil
+}
+
+func (r ContainerAppSessionPoolResource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_container_app_session_pool" "test" {
+  name                    = "acctestcasp%[2]d"
+  resource_group_name     = azurerm_resource_group.test.name
+  location                = azurerm_resource_group.test.location
+  container_type          = "PythonLTS"
+  max_concurrent_sessions = 5
+
+  pool_management_type       = "Dynamic"
+  lifecycle_type             = "Timed"
+  cooldown_period_in_seconds = 300
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r ContainerAppSessionPoolResource) requiresImport(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_container_app_session_pool" "import" {
+  name                    = azurerm_container_app_session_pool.test.name
+  resource_group_name     = azurerm_container_app_session_pool.test.resource_group_name
+  location                = azurerm_container_app_session_pool.test.location
+  container_type          = azurerm_container_app_session_pool.test.container_type
+  max_concurrent_sessions = azurerm_container_app_session_pool.test.max_concurrent_sessions
+
+  pool_management_type       = azurerm_container_app_session_pool.test.pool_management_type
+  lifecycle_type             = azurerm_container_app_session_pool.test.lifecycle_type
+  cooldown_period_in_seconds = azurerm_container_app_session_pool.test.cooldown_period_in_seconds
+}
+`, r.basic(data))
+}
+
+func (r ContainerAppSessionPoolResource) complete(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_container_app_session_pool" "test" {
+  name                    = "acctestcasp%[2]d"
+  resource_group_name     = azurerm_resource_group.test.name
+  location                = azurerm_resource_group.test.location
+  container_type          = "PythonLTS"
+  max_concurrent_sessions = 10
+
+  pool_management_type       = "Dynamic"
+  lifecycle_type             = "Timed"
+  cooldown_period_in_seconds = 600
+  network_egress_enabled     = true
+
+  tags = {
+    environment = "acctest"
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r ContainerAppSessionPoolResource) customContainer(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_container_app_session_pool" "test" {
+  name                         = "acctestcasp%[2]d"
+  resource_group_name          = azurerm_resource_group.test.name
+  location                     = azurerm_resource_group.test.location
+  container_app_environment_id = azurerm_container_app_environment.test.id
+  container_type               = "CustomContainer"
+  max_concurrent_sessions      = 10
+
+  pool_management_type       = "Dynamic"
+  lifecycle_type             = "Timed"
+  cooldown_period_in_seconds = 600
+  ready_session_instances    = 2
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  managed_identity_setting {
+    identity  = "System"
+    lifecycle = "Main"
+  }
+
+  custom_container_template {
+    ingress_target_port = 80
+
+    registry {
+      server               = azurerm_container_registry.test.login_server
+      username             = azurerm_container_registry.test.admin_username
+      password_secret_name = "registry-password"
+    }
+
+    container {
+      name   = "acctestcontainer"
+      image  = "mcr.microsoft.com/k8se/quickstart:latest"
+      cpu    = 0.25
+      memory = "0.5Gi"
+
+      args    = ["-c", "while true; do echo hello; sleep 10;done"]
+      command = ["/bin/sh"]
+
+      env {
+        name  = "ACC_TEST"
+        value = "acctestvalue"
+      }
+
+      env {
+        name        = "ACC_TEST_SECRET"
+        secret_name = "acctestsecret"
+      }
+    }
+  }
+
+  secret {
+    name  = "acctestsecret"
+    value = "acctestsecretvalue"
+  }
+
+  secret {
+    name  = "registry-password"
+    value = azurerm_container_registry.test.admin_password
+  }
+}
+`, r.templateWithEnvironment(data), data.RandomInteger)
+}
+
+func (r ContainerAppSessionPoolResource) onContainerExit(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_container_app_session_pool" "test" {
+  name                         = "acctestcasp%[2]d"
+  resource_group_name          = azurerm_resource_group.test.name
+  location                     = azurerm_resource_group.test.location
+  container_app_environment_id = azurerm_container_app_environment.test.id
+  container_type               = "CustomContainer"
+  max_concurrent_sessions      = 5
+
+  pool_management_type        = "Dynamic"
+  lifecycle_type              = "OnContainerExit"
+  max_alive_period_in_seconds = 600
+  ready_session_instances     = 1
+
+  custom_container_template {
+    ingress_target_port = 80
+
+    container {
+      name   = "acctestcontainer"
+      image  = "mcr.microsoft.com/k8se/quickstart:latest"
+      cpu    = 0.25
+      memory = "0.5Gi"
+    }
+  }
+}
+`, r.templateWithEnvironment(data), data.RandomInteger)
+}
+
+func (r ContainerAppSessionPoolResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-CASP-%[1]d"
+  location = "%[2]s"
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (r ContainerAppSessionPoolResource) templateWithEnvironment(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_container_app_environment" "test" {
+  name                = "acctest-CAEnv%[2]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  # Session Pools are only supported on Workload profile environments.
+  workload_profile {
+    name                  = "Consumption"
+    workload_profile_type = "Consumption"
+  }
+}
+
+resource "azurerm_container_registry" "test" {
+  name                = "acctestcr%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  sku                 = "Basic"
+  admin_enabled       = true
+}
+`, r.template(data), data.RandomInteger)
+}

--- a/internal/services/containerapps/registration.go
+++ b/internal/services/containerapps/registration.go
@@ -50,6 +50,7 @@ func (r Registration) Resources() []sdk.Resource {
 		ContainerAppResource{},
 		ContainerAppCustomDomainResource{},
 		ContainerAppJobResource{},
+		ContainerAppSessionPoolResource{},
 	}
 }
 
@@ -70,5 +71,7 @@ func (r Registration) EphemeralResources() []func() ephemeral.EphemeralResource 
 }
 
 func (r Registration) ListResources() []sdk.FrameworkListWrappedResource {
-	return []sdk.FrameworkListWrappedResource{}
+	return []sdk.FrameworkListWrappedResource{
+		ContainerAppSessionPoolListResource{},
+	}
 }

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools/README.md
@@ -1,0 +1,117 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools` Documentation
+
+The `containerappssessionpools` SDK allows for interaction with Azure Resource Manager `containerapps` (API Version `2025-07-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+import "github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools"
+```
+
+
+### Client Initialization
+
+```go
+client := containerappssessionpools.NewContainerAppsSessionPoolsClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `ContainerAppsSessionPoolsClient.CreateOrUpdate`
+
+```go
+ctx := context.TODO()
+id := containerappssessionpools.NewSessionPoolID("12345678-1234-9876-4563-123456789012", "example-resource-group", "sessionPoolName")
+
+payload := containerappssessionpools.SessionPool{
+	// ...
+}
+
+
+if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `ContainerAppsSessionPoolsClient.Delete`
+
+```go
+ctx := context.TODO()
+id := containerappssessionpools.NewSessionPoolID("12345678-1234-9876-4563-123456789012", "example-resource-group", "sessionPoolName")
+
+if err := client.DeleteThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `ContainerAppsSessionPoolsClient.Get`
+
+```go
+ctx := context.TODO()
+id := containerappssessionpools.NewSessionPoolID("12345678-1234-9876-4563-123456789012", "example-resource-group", "sessionPoolName")
+
+read, err := client.Get(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `ContainerAppsSessionPoolsClient.ListByResourceGroup`
+
+```go
+ctx := context.TODO()
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+
+// alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
+items, err := client.ListByResourceGroupComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `ContainerAppsSessionPoolsClient.ListBySubscription`
+
+```go
+ctx := context.TODO()
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+
+// alternatively `client.ListBySubscription(ctx, id)` can be used to do batched pagination
+items, err := client.ListBySubscriptionComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `ContainerAppsSessionPoolsClient.Update`
+
+```go
+ctx := context.TODO()
+id := containerappssessionpools.NewSessionPoolID("12345678-1234-9876-4563-123456789012", "example-resource-group", "sessionPoolName")
+
+payload := containerappssessionpools.SessionPoolUpdatableProperties{
+	// ...
+}
+
+
+if err := client.UpdateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools/client.go
@@ -1,0 +1,26 @@
+package containerappssessionpools
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ContainerAppsSessionPoolsClient struct {
+	Client *resourcemanager.Client
+}
+
+func NewContainerAppsSessionPoolsClientWithBaseURI(sdkApi sdkEnv.Api) (*ContainerAppsSessionPoolsClient, error) {
+	client, err := resourcemanager.NewClient(sdkApi, "containerappssessionpools", defaultApiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating ContainerAppsSessionPoolsClient: %+v", err)
+	}
+
+	return &ContainerAppsSessionPoolsClient{
+		Client: client,
+	}, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools/constants.go
@@ -1,0 +1,265 @@
+package containerappssessionpools
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ContainerType string
+
+const (
+	ContainerTypeCustomContainer ContainerType = "CustomContainer"
+	ContainerTypePythonLTS       ContainerType = "PythonLTS"
+)
+
+func PossibleValuesForContainerType() []string {
+	return []string{
+		string(ContainerTypeCustomContainer),
+		string(ContainerTypePythonLTS),
+	}
+}
+
+func (s *ContainerType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseContainerType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseContainerType(input string) (*ContainerType, error) {
+	vals := map[string]ContainerType{
+		"customcontainer": ContainerTypeCustomContainer,
+		"pythonlts":       ContainerTypePythonLTS,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ContainerType(input)
+	return &out, nil
+}
+
+type IdentitySettingsLifeCycle string
+
+const (
+	IdentitySettingsLifeCycleMain IdentitySettingsLifeCycle = "Main"
+	IdentitySettingsLifeCycleNone IdentitySettingsLifeCycle = "None"
+)
+
+func PossibleValuesForIdentitySettingsLifeCycle() []string {
+	return []string{
+		string(IdentitySettingsLifeCycleMain),
+		string(IdentitySettingsLifeCycleNone),
+	}
+}
+
+func (s *IdentitySettingsLifeCycle) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseIdentitySettingsLifeCycle(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseIdentitySettingsLifeCycle(input string) (*IdentitySettingsLifeCycle, error) {
+	vals := map[string]IdentitySettingsLifeCycle{
+		"main": IdentitySettingsLifeCycleMain,
+		"none": IdentitySettingsLifeCycleNone,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := IdentitySettingsLifeCycle(input)
+	return &out, nil
+}
+
+type LifecycleType string
+
+const (
+	LifecycleTypeOnContainerExit LifecycleType = "OnContainerExit"
+	LifecycleTypeTimed           LifecycleType = "Timed"
+)
+
+func PossibleValuesForLifecycleType() []string {
+	return []string{
+		string(LifecycleTypeOnContainerExit),
+		string(LifecycleTypeTimed),
+	}
+}
+
+func (s *LifecycleType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseLifecycleType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseLifecycleType(input string) (*LifecycleType, error) {
+	vals := map[string]LifecycleType{
+		"oncontainerexit": LifecycleTypeOnContainerExit,
+		"timed":           LifecycleTypeTimed,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := LifecycleType(input)
+	return &out, nil
+}
+
+type PoolManagementType string
+
+const (
+	PoolManagementTypeDynamic PoolManagementType = "Dynamic"
+	PoolManagementTypeManual  PoolManagementType = "Manual"
+)
+
+func PossibleValuesForPoolManagementType() []string {
+	return []string{
+		string(PoolManagementTypeDynamic),
+		string(PoolManagementTypeManual),
+	}
+}
+
+func (s *PoolManagementType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parsePoolManagementType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parsePoolManagementType(input string) (*PoolManagementType, error) {
+	vals := map[string]PoolManagementType{
+		"dynamic": PoolManagementTypeDynamic,
+		"manual":  PoolManagementTypeManual,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := PoolManagementType(input)
+	return &out, nil
+}
+
+type SessionNetworkStatus string
+
+const (
+	SessionNetworkStatusEgressDisabled SessionNetworkStatus = "EgressDisabled"
+	SessionNetworkStatusEgressEnabled  SessionNetworkStatus = "EgressEnabled"
+)
+
+func PossibleValuesForSessionNetworkStatus() []string {
+	return []string{
+		string(SessionNetworkStatusEgressDisabled),
+		string(SessionNetworkStatusEgressEnabled),
+	}
+}
+
+func (s *SessionNetworkStatus) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseSessionNetworkStatus(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseSessionNetworkStatus(input string) (*SessionNetworkStatus, error) {
+	vals := map[string]SessionNetworkStatus{
+		"egressdisabled": SessionNetworkStatusEgressDisabled,
+		"egressenabled":  SessionNetworkStatusEgressEnabled,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := SessionNetworkStatus(input)
+	return &out, nil
+}
+
+type SessionPoolProvisioningState string
+
+const (
+	SessionPoolProvisioningStateCanceled   SessionPoolProvisioningState = "Canceled"
+	SessionPoolProvisioningStateDeleting   SessionPoolProvisioningState = "Deleting"
+	SessionPoolProvisioningStateFailed     SessionPoolProvisioningState = "Failed"
+	SessionPoolProvisioningStateInProgress SessionPoolProvisioningState = "InProgress"
+	SessionPoolProvisioningStateSucceeded  SessionPoolProvisioningState = "Succeeded"
+)
+
+func PossibleValuesForSessionPoolProvisioningState() []string {
+	return []string{
+		string(SessionPoolProvisioningStateCanceled),
+		string(SessionPoolProvisioningStateDeleting),
+		string(SessionPoolProvisioningStateFailed),
+		string(SessionPoolProvisioningStateInProgress),
+		string(SessionPoolProvisioningStateSucceeded),
+	}
+}
+
+func (s *SessionPoolProvisioningState) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseSessionPoolProvisioningState(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseSessionPoolProvisioningState(input string) (*SessionPoolProvisioningState, error) {
+	vals := map[string]SessionPoolProvisioningState{
+		"canceled":   SessionPoolProvisioningStateCanceled,
+		"deleting":   SessionPoolProvisioningStateDeleting,
+		"failed":     SessionPoolProvisioningStateFailed,
+		"inprogress": SessionPoolProvisioningStateInProgress,
+		"succeeded":  SessionPoolProvisioningStateSucceeded,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := SessionPoolProvisioningState(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools/id_sessionpool.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools/id_sessionpool.go
@@ -1,0 +1,130 @@
+package containerappssessionpools
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&SessionPoolId{})
+}
+
+var _ resourceids.ResourceId = &SessionPoolId{}
+
+// SessionPoolId is a struct representing the Resource ID for a Session Pool
+type SessionPoolId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	SessionPoolName   string
+}
+
+// NewSessionPoolID returns a new SessionPoolId struct
+func NewSessionPoolID(subscriptionId string, resourceGroupName string, sessionPoolName string) SessionPoolId {
+	return SessionPoolId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		SessionPoolName:   sessionPoolName,
+	}
+}
+
+// ParseSessionPoolID parses 'input' into a SessionPoolId
+func ParseSessionPoolID(input string) (*SessionPoolId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&SessionPoolId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := SessionPoolId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseSessionPoolIDInsensitively parses 'input' case-insensitively into a SessionPoolId
+// note: this method should only be used for API response data and not user input
+func ParseSessionPoolIDInsensitively(input string) (*SessionPoolId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&SessionPoolId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := SessionPoolId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *SessionPoolId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.SessionPoolName, ok = input.Parsed["sessionPoolName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "sessionPoolName", input)
+	}
+
+	return nil
+}
+
+// ValidateSessionPoolID checks that 'input' can be parsed as a Session Pool ID
+func ValidateSessionPoolID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseSessionPoolID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Session Pool ID
+func (id SessionPoolId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.App/sessionPools/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.SessionPoolName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Session Pool ID
+func (id SessionPoolId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftApp", "Microsoft.App", "Microsoft.App"),
+		resourceids.StaticSegment("staticSessionPools", "sessionPools", "sessionPools"),
+		resourceids.UserSpecifiedSegment("sessionPoolName", "sessionPoolName"),
+	}
+}
+
+// String returns a human-readable description of this Session Pool ID
+func (id SessionPoolId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Session Pool Name: %q", id.SessionPoolName),
+	}
+	return fmt.Sprintf("Session Pool (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools/method_createorupdate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools/method_createorupdate.go
@@ -1,0 +1,86 @@
+package containerappssessionpools
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateOrUpdateOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *SessionPool
+}
+
+// CreateOrUpdate ...
+func (c ContainerAppsSessionPoolsClient) CreateOrUpdate(ctx context.Context, id SessionPoolId, input SessionPool) (result CreateOrUpdateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPut,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// CreateOrUpdateThenPoll performs CreateOrUpdate then polls until it's completed
+func (c ContainerAppsSessionPoolsClient) CreateOrUpdateThenPoll(ctx context.Context, id SessionPoolId, input SessionPool) error {
+	return c.CreateOrUpdateCallbackThenPoll(ctx, id, input, nil)
+}
+
+// CreateOrUpdateCallbackThenPoll performs CreateOrUpdate, runs the optional callback function, then polls until it's completed
+func (c ContainerAppsSessionPoolsClient) CreateOrUpdateCallbackThenPoll(ctx context.Context, id SessionPoolId, input SessionPool, callback func() error) error {
+	result, err := c.CreateOrUpdate(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing CreateOrUpdate: %+v", err)
+	}
+
+	if callback != nil {
+		if err := callback(); err != nil {
+			return fmt.Errorf("executing callback function: %+v", err)
+		}
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after CreateOrUpdate: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools/method_delete.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools/method_delete.go
@@ -1,0 +1,70 @@
+package containerappssessionpools
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeleteOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// Delete ...
+func (c ContainerAppsSessionPoolsClient) Delete(ctx context.Context, id SessionPoolId) (result DeleteOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusNoContent,
+		},
+		HttpMethod: http.MethodDelete,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// DeleteThenPoll performs Delete then polls until it's completed
+func (c ContainerAppsSessionPoolsClient) DeleteThenPoll(ctx context.Context, id SessionPoolId) error {
+	result, err := c.Delete(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing Delete: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Delete: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools/method_get.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools/method_get.go
@@ -1,0 +1,53 @@
+package containerappssessionpools
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *SessionPool
+}
+
+// Get ...
+func (c ContainerAppsSessionPoolsClient) Get(ctx context.Context, id SessionPoolId) (result GetOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model SessionPool
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools/method_listbyresourcegroup.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools/method_listbyresourcegroup.go
@@ -1,0 +1,106 @@
+package containerappssessionpools
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListByResourceGroupOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]SessionPool
+}
+
+type ListByResourceGroupCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []SessionPool
+}
+
+type ListByResourceGroupCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *ListByResourceGroupCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// ListByResourceGroup ...
+func (c ContainerAppsSessionPoolsClient) ListByResourceGroup(ctx context.Context, id commonids.ResourceGroupId) (result ListByResourceGroupOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Pager:      &ListByResourceGroupCustomPager{},
+		Path:       fmt.Sprintf("%s/providers/Microsoft.App/sessionPools", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]SessionPool `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListByResourceGroupComplete retrieves all the results into a single object
+func (c ContainerAppsSessionPoolsClient) ListByResourceGroupComplete(ctx context.Context, id commonids.ResourceGroupId) (ListByResourceGroupCompleteResult, error) {
+	return c.ListByResourceGroupCompleteMatchingPredicate(ctx, id, SessionPoolOperationPredicate{})
+}
+
+// ListByResourceGroupCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c ContainerAppsSessionPoolsClient) ListByResourceGroupCompleteMatchingPredicate(ctx context.Context, id commonids.ResourceGroupId, predicate SessionPoolOperationPredicate) (result ListByResourceGroupCompleteResult, err error) {
+	items := make([]SessionPool, 0)
+
+	resp, err := c.ListByResourceGroup(ctx, id)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListByResourceGroupCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools/method_listbysubscription.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools/method_listbysubscription.go
@@ -1,0 +1,106 @@
+package containerappssessionpools
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListBySubscriptionOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]SessionPool
+}
+
+type ListBySubscriptionCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []SessionPool
+}
+
+type ListBySubscriptionCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *ListBySubscriptionCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// ListBySubscription ...
+func (c ContainerAppsSessionPoolsClient) ListBySubscription(ctx context.Context, id commonids.SubscriptionId) (result ListBySubscriptionOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Pager:      &ListBySubscriptionCustomPager{},
+		Path:       fmt.Sprintf("%s/providers/Microsoft.App/sessionPools", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]SessionPool `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListBySubscriptionComplete retrieves all the results into a single object
+func (c ContainerAppsSessionPoolsClient) ListBySubscriptionComplete(ctx context.Context, id commonids.SubscriptionId) (ListBySubscriptionCompleteResult, error) {
+	return c.ListBySubscriptionCompleteMatchingPredicate(ctx, id, SessionPoolOperationPredicate{})
+}
+
+// ListBySubscriptionCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c ContainerAppsSessionPoolsClient) ListBySubscriptionCompleteMatchingPredicate(ctx context.Context, id commonids.SubscriptionId, predicate SessionPoolOperationPredicate) (result ListBySubscriptionCompleteResult, err error) {
+	items := make([]SessionPool, 0)
+
+	resp, err := c.ListBySubscription(ctx, id)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListBySubscriptionCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools/method_update.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools/method_update.go
@@ -1,0 +1,86 @@
+package containerappssessionpools
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpdateOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *SessionPool
+}
+
+// Update ...
+func (c ContainerAppsSessionPoolsClient) Update(ctx context.Context, id SessionPoolId, input SessionPoolUpdatableProperties) (result UpdateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPatch,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// UpdateThenPoll performs Update then polls until it's completed
+func (c ContainerAppsSessionPoolsClient) UpdateThenPoll(ctx context.Context, id SessionPoolId, input SessionPoolUpdatableProperties) error {
+	return c.UpdateCallbackThenPoll(ctx, id, input, nil)
+}
+
+// UpdateCallbackThenPoll performs Update, runs the optional callback function, then polls until it's completed
+func (c ContainerAppsSessionPoolsClient) UpdateCallbackThenPoll(ctx context.Context, id SessionPoolId, input SessionPoolUpdatableProperties, callback func() error) error {
+	result, err := c.Update(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing Update: %+v", err)
+	}
+
+	if callback != nil {
+		if err := callback(); err != nil {
+			return fmt.Errorf("executing callback function: %+v", err)
+		}
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Update: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools/model_customcontainertemplate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools/model_customcontainertemplate.go
@@ -1,0 +1,10 @@
+package containerappssessionpools
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CustomContainerTemplate struct {
+	Containers          *[]SessionContainer         `json:"containers,omitempty"`
+	Ingress             *SessionIngress             `json:"ingress,omitempty"`
+	RegistryCredentials *SessionRegistryCredentials `json:"registryCredentials,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools/model_dynamicpoolconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools/model_dynamicpoolconfiguration.go
@@ -1,0 +1,8 @@
+package containerappssessionpools
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DynamicPoolConfiguration struct {
+	LifecycleConfiguration *LifecycleConfiguration `json:"lifecycleConfiguration,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools/model_environmentvar.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools/model_environmentvar.go
@@ -1,0 +1,10 @@
+package containerappssessionpools
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type EnvironmentVar struct {
+	Name      *string `json:"name,omitempty"`
+	SecretRef *string `json:"secretRef,omitempty"`
+	Value     *string `json:"value,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools/model_lifecycleconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools/model_lifecycleconfiguration.go
@@ -1,0 +1,10 @@
+package containerappssessionpools
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type LifecycleConfiguration struct {
+	CooldownPeriodInSeconds *int64         `json:"cooldownPeriodInSeconds,omitempty"`
+	LifecycleType           *LifecycleType `json:"lifecycleType,omitempty"`
+	MaxAlivePeriodInSeconds *int64         `json:"maxAlivePeriodInSeconds,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools/model_managedidentitysetting.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools/model_managedidentitysetting.go
@@ -1,0 +1,9 @@
+package containerappssessionpools
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ManagedIdentitySetting struct {
+	Identity  string                     `json:"identity"`
+	Lifecycle *IdentitySettingsLifeCycle `json:"lifecycle,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools/model_scaleconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools/model_scaleconfiguration.go
@@ -1,0 +1,9 @@
+package containerappssessionpools
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ScaleConfiguration struct {
+	MaxConcurrentSessions *int64 `json:"maxConcurrentSessions,omitempty"`
+	ReadySessionInstances *int64 `json:"readySessionInstances,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools/model_sessioncontainer.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools/model_sessioncontainer.go
@@ -1,0 +1,13 @@
+package containerappssessionpools
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SessionContainer struct {
+	Args      *[]string                  `json:"args,omitempty"`
+	Command   *[]string                  `json:"command,omitempty"`
+	Env       *[]EnvironmentVar          `json:"env,omitempty"`
+	Image     *string                    `json:"image,omitempty"`
+	Name      *string                    `json:"name,omitempty"`
+	Resources *SessionContainerResources `json:"resources,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools/model_sessioncontainerresources.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools/model_sessioncontainerresources.go
@@ -1,0 +1,9 @@
+package containerappssessionpools
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SessionContainerResources struct {
+	Cpu    *float64 `json:"cpu,omitempty"`
+	Memory *string  `json:"memory,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools/model_sessioningress.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools/model_sessioningress.go
@@ -1,0 +1,8 @@
+package containerappssessionpools
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SessionIngress struct {
+	TargetPort *int64 `json:"targetPort,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools/model_sessionnetworkconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools/model_sessionnetworkconfiguration.go
@@ -1,0 +1,8 @@
+package containerappssessionpools
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SessionNetworkConfiguration struct {
+	Status *SessionNetworkStatus `json:"status,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools/model_sessionpool.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools/model_sessionpool.go
@@ -1,0 +1,20 @@
+package containerappssessionpools
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/systemdata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SessionPool struct {
+	Id         *string                                  `json:"id,omitempty"`
+	Identity   *identity.LegacySystemAndUserAssignedMap `json:"identity,omitempty"`
+	Location   string                                   `json:"location"`
+	Name       *string                                  `json:"name,omitempty"`
+	Properties *SessionPoolProperties                   `json:"properties,omitempty"`
+	SystemData *systemdata.SystemData                   `json:"systemData,omitempty"`
+	Tags       *map[string]string                       `json:"tags,omitempty"`
+	Type       *string                                  `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools/model_sessionpoolproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools/model_sessionpoolproperties.go
@@ -1,0 +1,19 @@
+package containerappssessionpools
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SessionPoolProperties struct {
+	ContainerType               *ContainerType                `json:"containerType,omitempty"`
+	CustomContainerTemplate     *CustomContainerTemplate      `json:"customContainerTemplate,omitempty"`
+	DynamicPoolConfiguration    *DynamicPoolConfiguration     `json:"dynamicPoolConfiguration,omitempty"`
+	EnvironmentId               *string                       `json:"environmentId,omitempty"`
+	ManagedIdentitySettings     *[]ManagedIdentitySetting     `json:"managedIdentitySettings,omitempty"`
+	NodeCount                   *int64                        `json:"nodeCount,omitempty"`
+	PoolManagementEndpoint      *string                       `json:"poolManagementEndpoint,omitempty"`
+	PoolManagementType          *PoolManagementType           `json:"poolManagementType,omitempty"`
+	ProvisioningState           *SessionPoolProvisioningState `json:"provisioningState,omitempty"`
+	ScaleConfiguration          *ScaleConfiguration           `json:"scaleConfiguration,omitempty"`
+	Secrets                     *[]SessionPoolSecret          `json:"secrets,omitempty"`
+	SessionNetworkConfiguration *SessionNetworkConfiguration  `json:"sessionNetworkConfiguration,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools/model_sessionpoolsecret.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools/model_sessionpoolsecret.go
@@ -1,0 +1,9 @@
+package containerappssessionpools
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SessionPoolSecret struct {
+	Name  *string `json:"name,omitempty"`
+	Value *string `json:"value,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools/model_sessionpoolupdatableproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools/model_sessionpoolupdatableproperties.go
@@ -1,0 +1,14 @@
+package containerappssessionpools
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SessionPoolUpdatableProperties struct {
+	Identity   *identity.LegacySystemAndUserAssignedMap  `json:"identity,omitempty"`
+	Properties *SessionPoolUpdatablePropertiesProperties `json:"properties,omitempty"`
+	Tags       *map[string]string                        `json:"tags,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools/model_sessionpoolupdatablepropertiesproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools/model_sessionpoolupdatablepropertiesproperties.go
@@ -1,0 +1,12 @@
+package containerappssessionpools
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SessionPoolUpdatablePropertiesProperties struct {
+	CustomContainerTemplate     *CustomContainerTemplate     `json:"customContainerTemplate,omitempty"`
+	DynamicPoolConfiguration    *DynamicPoolConfiguration    `json:"dynamicPoolConfiguration,omitempty"`
+	ScaleConfiguration          *ScaleConfiguration          `json:"scaleConfiguration,omitempty"`
+	Secrets                     *[]SessionPoolSecret         `json:"secrets,omitempty"`
+	SessionNetworkConfiguration *SessionNetworkConfiguration `json:"sessionNetworkConfiguration,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools/model_sessionregistrycredentials.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools/model_sessionregistrycredentials.go
@@ -1,0 +1,11 @@
+package containerappssessionpools
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SessionRegistryCredentials struct {
+	Identity          *string `json:"identity,omitempty"`
+	PasswordSecretRef *string `json:"passwordSecretRef,omitempty"`
+	Server            *string `json:"server,omitempty"`
+	Username          *string `json:"username,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools/predicates.go
@@ -1,0 +1,32 @@
+package containerappssessionpools
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SessionPoolOperationPredicate struct {
+	Id       *string
+	Location *string
+	Name     *string
+	Type     *string
+}
+
+func (p SessionPoolOperationPredicate) Matches(input SessionPool) bool {
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Location != nil && *p.Location != input.Location {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools/version.go
@@ -1,0 +1,14 @@
+package containerappssessionpools
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2025-07-01"
+
+func userAgent() string {
+	return "hashicorp/go-azure-sdk/containerappssessionpools/2025-07-01"
+}
+
+func AzureAPIVersion() string {
+	return defaultApiVersion
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -437,6 +437,7 @@ github.com/hashicorp/go-azure-sdk/resource-manager/consumption/2019-10-01/budget
 github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/certificates
 github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerapps
 github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappsrevisions
+github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappssessionpools
 github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/daprcomponents
 github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/jobs
 github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/managedenvironments

--- a/website/docs/list-resources/container_app_session_pool.html.markdown
+++ b/website/docs/list-resources/container_app_session_pool.html.markdown
@@ -1,0 +1,42 @@
+---
+subcategory: "Container Apps"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_container_app_session_pool"
+description: |-
+  Lists Container App Session Pool resources.
+---
+
+# List resource: azurerm_container_app_session_pool
+
+Lists Container App Session Pool resources.
+
+## Example Usage
+
+### List all Container App Session Pools in the subscription
+
+```hcl
+list "azurerm_container_app_session_pool" "example" {
+  provider = azurerm
+}
+```
+
+### List all Container App Session Pools in a specific resource group
+
+```hcl
+list "azurerm_container_app_session_pool" "example" {
+  provider = azurerm
+  config {
+    resource_group_name = "example-resources"
+  }
+}
+```
+
+## Argument Reference
+
+This list resource supports the following arguments:
+
+* `resource_group_name` - (Optional) The name of the resource group to query.
+
+* `subscription_id` - (Optional) The Subscription ID to query. Defaults to the value specified in the Provider Configuration.
+
+~> **Note:** The `value` of each `secret` block is not returned by the Azure API, so listed Container App Session Pools do not include secret values.

--- a/website/docs/list-resources/container_app_session_pool.html.markdown
+++ b/website/docs/list-resources/container_app_session_pool.html.markdown
@@ -20,7 +20,7 @@ list "azurerm_container_app_session_pool" "example" {
 }
 ```
 
-### List all Container App Session Pools in a specific resource group
+### List all Container App Session Pools in a specific Resource Group
 
 ```hcl
 list "azurerm_container_app_session_pool" "example" {
@@ -35,8 +35,6 @@ list "azurerm_container_app_session_pool" "example" {
 
 This list resource supports the following arguments:
 
-* `resource_group_name` - (Optional) The name of the resource group to query.
+* `resource_group_name` - (Optional) The name of the Resource Group to query.
 
 * `subscription_id` - (Optional) The Subscription ID to query. Defaults to the value specified in the Provider Configuration.
-
-~> **Note:** The `value` of each `secret` block is not returned by the Azure API, so listed Container App Session Pools do not include secret values.

--- a/website/docs/r/container_app_session_pool.html.markdown
+++ b/website/docs/r/container_app_session_pool.html.markdown
@@ -35,7 +35,9 @@ resource "azurerm_container_app_session_pool" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name which should be used for this Container App Session Pool. Must be between 3 and 63 characters long, begin with a lowercase letter and contain only lowercase letters and numbers. Changing this forces a new resource to be created.
+* `name` - (Required) The name which should be used for this Container App Session Pool. Changing this forces a new resource to be created.
+
+~> **Note:** `name` must be between 3 and 63 characters long, begin with a lowercase letter and contain only lowercase letters and numbers.
 
 * `resource_group_name` - (Required) The name of the Resource Group where the Container App Session Pool should exist. Changing this forces a new resource to be created.
 
@@ -47,7 +49,9 @@ The following arguments are supported:
 
 * `pool_management_type` - (Required) The management type of this Container App Session Pool. The Azure REST API defines `Dynamic` and `Manual`; however, Azure Container Apps currently supports creating session pools only with `Dynamic`, so `Manual` cannot be configured at this time. Changing this forces a new resource to be created.
 
-* `container_app_environment_id` - (Optional) The ID of the Container App Environment in which this Container App Session Pool should exist. Changing this forces a new resource to be created.
+* `container_app_environment_id` - (Optional) The ID of the Container App Environment used to host the sessions in this Container App Session Pool. Changing this forces a new resource to be created.
+
+~> **Note:** `container_app_environment_id` is required when `container_type` is set to `CustomContainer`.
 
 ~> **Note:** The Container App Environment must be of type `Workload profile`. `Consumption only` environments are not supported.
 

--- a/website/docs/r/container_app_session_pool.html.markdown
+++ b/website/docs/r/container_app_session_pool.html.markdown
@@ -154,7 +154,7 @@ A `secret` block supports the following:
 
 * `value` - (Required) The value for this secret.
 
-~> **Note:** `value` is not returned by the Azure API, so it is populated from the Terraform configuration. Changes made to a secret value outside of Terraform are not detected, and the value is not populated when importing this resource. For the same reason the configured value is always sent on update, meaning `ignore_changes` has no effect on `secret`.
+~> **Note:** `value` is not returned by the Azure API, so it is stored from the Terraform configuration. Changes made to a secret value outside of Terraform cannot be detected.
 
 ## Attributes Reference
 

--- a/website/docs/r/container_app_session_pool.html.markdown
+++ b/website/docs/r/container_app_session_pool.html.markdown
@@ -64,10 +64,6 @@ The following arguments are supported:
 
 ~> **Note:** `OnContainerExit` can only be used when `container_type` is set to `CustomContainer`.
 
-* `managed_identity_setting` - (Optional) One or more `managed_identity_setting` blocks as defined below. Changing this forces a new resource to be created.
-
-~> **Note:** Omitting `managed_identity_setting` is equivalent to the `None` lifecycle stage in the Azure API.
-
 * `max_alive_period_in_seconds` - (Optional) The maximum number of seconds a session remains alive.
 
 ~> **Note:** `max_alive_period_in_seconds` must be specified when `lifecycle_type` is set to `OnContainerExit`, cannot be specified otherwise, and conflicts with `cooldown_period_in_seconds`.
@@ -79,6 +75,10 @@ The following arguments are supported:
 ~> **Note:** `ready_session_instances` must be specified when `container_type` is set to `CustomContainer`.
 
 * `secret` - (Optional) One or more `secret` blocks as defined below.
+
+* `session_managed_identities` - (Optional) A list of Managed Identities which are made available to the code running inside the sessions. Each value should be the ID of a User Assigned Managed Identity, or `System` to use the System Assigned Identity.
+
+~> **Note:** Each Managed Identity listed here must also be assigned to this Container App Session Pool via the `identity` block. Listing it here grants the code running in a session access to that Managed Identity.
 
 * `tags` - (Optional) A mapping of tags which should be assigned to the Container App Session Pool.
 
@@ -131,14 +131,6 @@ An `identity` block supports the following:
 * `identity_ids` - (Optional) A list of User Assigned Managed Identity IDs to be assigned to this Container App Session Pool.
 
 ~> **Note:** `identity_ids` is required when `type` is set to `UserAssigned` or `SystemAssigned, UserAssigned`.
-
----
-
-A `managed_identity_setting` block supports the following:
-
-* `identity` - (Required) The ID of a User Assigned Managed Identity, or `System` to use the System Assigned Identity. Changing this forces a new resource to be created.
-
-* `lifecycle` - (Optional) The lifecycle stage during which the Managed Identity is available. The only possible value is `Main`. Defaults to `Main`. Changing this forces a new resource to be created.
 
 ---
 

--- a/website/docs/r/container_app_session_pool.html.markdown
+++ b/website/docs/r/container_app_session_pool.html.markdown
@@ -76,6 +76,8 @@ The following arguments are supported:
 
 * `ready_session_instances` - (Optional) The minimum number of sessions which are kept ready in this Container App Session Pool. This must be greater than `0` and less than `max_concurrent_sessions`.
 
+~> **Note:** `ready_session_instances` must be specified when `container_type` is set to `CustomContainer`.
+
 * `secret` - (Optional) One or more `secret` blocks as defined below.
 
 * `tags` - (Optional) A mapping of tags which should be assigned to the Container App Session Pool.

--- a/website/docs/r/container_app_session_pool.html.markdown
+++ b/website/docs/r/container_app_session_pool.html.markdown
@@ -1,0 +1,207 @@
+---
+subcategory: "Container Apps"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_container_app_session_pool"
+description: |-
+  Manages a Container App Session Pool.
+---
+
+# azurerm_container_app_session_pool
+
+Manages a Container App Session Pool.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_container_app_session_pool" "example" {
+  name                    = "examplesessionpool"
+  resource_group_name     = azurerm_resource_group.example.name
+  location                = azurerm_resource_group.example.location
+  container_type          = "PythonLTS"
+  max_concurrent_sessions = 5
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name which should be used for this Container App Session Pool. Must be between 3 and 63 characters long, begin with a lowercase letter and contain only lowercase letters and numbers. Changing this forces a new resource to be created.
+
+* `resource_group_name` - (Required) The name of the Resource Group where the Container App Session Pool should exist. Changing this forces a new resource to be created.
+
+* `location` - (Required) The Azure Region where the Container App Session Pool should exist. Changing this forces a new resource to be created.
+
+* `container_type` - (Required) The type of container used for the sessions in this Container App Session Pool. Possible values are `CustomContainer` and `PythonLTS`. Changing this forces a new resource to be created.
+
+* `max_concurrent_sessions` - (Required) The maximum number of sessions which can run concurrently in this Container App Session Pool.
+
+---
+
+* `container_app_environment_id` - (Optional) The ID of the Container App Environment in which this Container App Session Pool should exist. Changing this forces a new resource to be created.
+
+~> **Note:** The Container App Environment must be of type `Workload profile`. `Consumption only` environments are not supported.
+
+* `cooldown_period_in_seconds` - (Optional) The number of seconds a session remains alive once it becomes idle. Possible values range between `300` and `3600`. Defaults to `300`.
+
+~> **Note:** `cooldown_period_in_seconds` only applies when `lifecycle_type` is set to `Timed`, and conflicts with `max_alive_period_in_seconds`.
+
+* `custom_container_template` - (Optional) A `custom_container_template` block as defined below.
+
+~> **Note:** `custom_container_template` must be specified when `container_type` is set to `CustomContainer`, and may not be specified otherwise.
+
+* `identity` - (Optional) An `identity` block as defined below.
+
+~> **Note:** `identity` may only be specified when `container_type` is set to `CustomContainer`.
+
+* `lifecycle_type` - (Optional) The lifecycle type of the sessions in this Container App Session Pool. Possible values are `OnContainerExit` and `Timed`. Defaults to `Timed`.
+
+~> **Note:** `lifecycle_type`, `cooldown_period_in_seconds` and `max_alive_period_in_seconds` are only used when `pool_management_type` is set to `Dynamic`.
+
+* `managed_identity_setting` - (Optional) One or more `managed_identity_setting` blocks as defined below. Changing this forces a new resource to be created.
+
+~> **Note:** Omitting `managed_identity_setting` is equivalent to the `None` lifecycle stage in the Azure API.
+
+* `max_alive_period_in_seconds` - (Optional) The maximum number of seconds a session remains alive.
+
+~> **Note:** `max_alive_period_in_seconds` only applies when `lifecycle_type` is set to `OnContainerExit`, and conflicts with `cooldown_period_in_seconds`.
+
+* `network_egress_enabled` - (Optional) Should sessions in this Container App Session Pool be able to make outbound network requests? Defaults to `false`.
+
+* `pool_management_type` - (Optional) The management type of this Container App Session Pool. Possible values are `Dynamic` and `Manual`. Defaults to `Dynamic`. Changing this forces a new resource to be created.
+
+* `ready_session_instances` - (Optional) The minimum number of sessions which are kept ready in this Container App Session Pool.
+
+* `secret` - (Optional) One or more `secret` blocks as defined below.
+
+* `tags` - (Optional) A mapping of tags which should be assigned to the Container App Session Pool.
+
+---
+
+A `container` block supports the following:
+
+* `image` - (Required) The image used to create the container.
+
+* `name` - (Required) The name which should be used for this container.
+
+* `args` - (Optional) A list of arguments to pass to the container.
+
+* `command` - (Optional) A command to pass to the container to override the default. This is provided as a list of command line elements without spaces.
+
+* `cpu` - (Optional) The amount of vCPU to allocate to the container, e.g. `0.25`.
+
+* `env` - (Optional) One or more `env` blocks as defined below.
+
+* `memory` - (Optional) The amount of memory to allocate to the container, e.g. `0.5Gi`.
+
+---
+
+A `custom_container_template` block supports the following:
+
+* `container` - (Required) One or more `container` blocks as defined below.
+
+* `ingress_target_port` - (Optional) The target port in the container which receives traffic from the ingress. Possible values range between `1` and `65535`.
+
+* `registry` - (Optional) A `registry` block as defined below.
+
+---
+
+An `env` block supports the following:
+
+* `name` - (Required) The name of the environment variable.
+
+* `secret_name` - (Optional) The name of the `secret` which contains the value for this environment variable.
+
+* `value` - (Optional) The value for this environment variable.
+
+~> **Note:** `value` is ignored when `secret_name` is specified.
+
+---
+
+An `identity` block supports the following:
+
+* `type` - (Required) The type of Managed Identity assigned to this Container App Session Pool. Possible values are `SystemAssigned`, `UserAssigned` and `SystemAssigned, UserAssigned`.
+
+* `identity_ids` - (Optional) A list of User Assigned Managed Identity IDs to be assigned to this Container App Session Pool.
+
+~> **Note:** `identity_ids` is required when `type` is set to `UserAssigned` or `SystemAssigned, UserAssigned`.
+
+---
+
+A `managed_identity_setting` block supports the following:
+
+* `identity` - (Required) The ID of a User Assigned Managed Identity, or `System` to use the System Assigned Identity. Changing this forces a new resource to be created.
+
+* `lifecycle` - (Optional) The lifecycle stage during which the Managed Identity is available. The only possible value is `Main`. Defaults to `Main`. Changing this forces a new resource to be created.
+
+---
+
+A `registry` block supports the following:
+
+* `server` - (Required) The hostname of the Container Registry.
+
+* `identity` - (Optional) The ID of a User Assigned Managed Identity, or `System` to use the System Assigned Identity, used to pull images from the Container Registry.
+
+* `password_secret_name` - (Optional) The name of the `secret` which contains the login password for the Container Registry.
+
+* `username` - (Optional) The username to use for the Container Registry.
+
+~> **Note:** `identity` conflicts with `username` and `password_secret_name`.
+
+---
+
+A `secret` block supports the following:
+
+* `name` - (Required) The name of the secret.
+
+* `value` - (Required) The value for this secret.
+
+~> **Note:** `value` is not returned by the Azure API, so it is populated from the Terraform configuration. Changes made to a secret value outside of Terraform are not detected, and the value is not populated when importing this resource. For the same reason the configured value is always sent on update, meaning `ignore_changes` has no effect on `secret`.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the Container App Session Pool.
+
+* `identity` - An `identity` block as defined below.
+
+* `node_count` - The number of nodes in use by this Container App Session Pool.
+
+* `pool_management_endpoint` - The endpoint used to manage the sessions in this Container App Session Pool.
+
+---
+
+An `identity` block exports the following:
+
+* `principal_id` - The Principal ID of the System Assigned Managed Identity assigned to this Container App Session Pool.
+
+* `tenant_id` - The Tenant ID of the System Assigned Managed Identity assigned to this Container App Session Pool.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/configure#define-operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Container App Session Pool.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Container App Session Pool.
+* `update` - (Defaults to 30 minutes) Used when updating the Container App Session Pool.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Container App Session Pool.
+
+## Import
+
+Container App Session Pools can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_container_app_session_pool.example /subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resources/providers/Microsoft.App/sessionPools/examplesessionpool
+```
+
+## API Providers
+<!-- This section is generated, changes will be overwritten -->
+This resource uses the following Azure API Providers:
+
+* `Microsoft.App` - 2025-07-01

--- a/website/docs/r/container_app_session_pool.html.markdown
+++ b/website/docs/r/container_app_session_pool.html.markdown
@@ -19,10 +19,13 @@ resource "azurerm_resource_group" "example" {
 }
 
 resource "azurerm_container_app_session_pool" "example" {
-  name                       = "examplesessionpool"
-  resource_group_name        = azurerm_resource_group.example.name
-  location                   = azurerm_resource_group.example.location
-  cooldown_period_in_seconds = 300
+  name                = "examplesessionpool"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+
+  lifecycle_configuration {
+    cooldown_period_in_seconds = 300
+  }
 }
 ```
 
@@ -48,10 +51,6 @@ The following arguments are supported:
 
 ~> **Note:** The Container App Environment must be of type `Workload profile`. `Consumption only` environments are not supported.
 
-* `cooldown_period_in_seconds` - (Optional) The number of seconds a session remains alive once it becomes idle. Possible values range between `300` and `3600`.
-
-~> **Note:** `cooldown_period_in_seconds` must be specified when `lifecycle_type` is set to `Timed`, cannot be specified otherwise, and conflicts with `max_alive_period_in_seconds`.
-
 * `custom_container_template` - (Optional) A `custom_container_template` block as defined below.
 
 ~> **Note:** `custom_container_template` must be specified when `container_type` is set to `CustomContainer`, and may not be specified otherwise.
@@ -60,13 +59,7 @@ The following arguments are supported:
 
 ~> **Note:** `identity` may only be specified when `container_type` is set to `CustomContainer`.
 
-* `lifecycle_type` - (Optional) The lifecycle type of the sessions in this Container App Session Pool. Possible values are `OnContainerExit` and `Timed`. Defaults to `Timed`.
-
-~> **Note:** `OnContainerExit` can only be used when `container_type` is set to `CustomContainer`.
-
-* `max_alive_period_in_seconds` - (Optional) The maximum number of seconds a session remains alive.
-
-~> **Note:** `max_alive_period_in_seconds` must be specified when `lifecycle_type` is set to `OnContainerExit`, cannot be specified otherwise, and conflicts with `cooldown_period_in_seconds`.
+* `lifecycle_configuration` - (Required) A `lifecycle_configuration` block as defined below.
 
 * `network_egress_enabled` - (Optional) Should sessions in this Container App Session Pool be able to make outbound network requests? Defaults to `false`.
 
@@ -131,6 +124,22 @@ An `identity` block supports the following:
 * `identity_ids` - (Optional) A list of User Assigned Managed Identity IDs to be assigned to this Container App Session Pool.
 
 ~> **Note:** `identity_ids` is required when `type` is set to `UserAssigned` or `SystemAssigned, UserAssigned`.
+
+---
+
+A `lifecycle_configuration` block supports the following:
+
+* `lifecycle_type` - (Optional) The lifecycle type of the sessions in this Container App Session Pool. Possible values are `OnContainerExit` and `Timed`. Defaults to `Timed`.
+
+~> **Note:** `OnContainerExit` can only be used when `container_type` is set to `CustomContainer`.
+
+* `cooldown_period_in_seconds` - (Optional) The number of seconds a session remains alive once it becomes idle. Possible values range between `300` and `3600`.
+
+~> **Note:** `cooldown_period_in_seconds` must be specified when `lifecycle_type` is set to `Timed`, cannot be specified otherwise, and conflicts with `max_alive_period_in_seconds`.
+
+* `max_alive_period_in_seconds` - (Optional) The maximum number of seconds a session remains alive.
+
+~> **Note:** `max_alive_period_in_seconds` must be specified when `lifecycle_type` is set to `OnContainerExit`, cannot be specified otherwise, and conflicts with `cooldown_period_in_seconds`.
 
 ---
 

--- a/website/docs/r/container_app_session_pool.html.markdown
+++ b/website/docs/r/container_app_session_pool.html.markdown
@@ -19,14 +19,9 @@ resource "azurerm_resource_group" "example" {
 }
 
 resource "azurerm_container_app_session_pool" "example" {
-  name                    = "examplesessionpool"
-  resource_group_name     = azurerm_resource_group.example.name
-  location                = azurerm_resource_group.example.location
-  container_type          = "PythonLTS"
-  max_concurrent_sessions = 5
-
-  pool_management_type       = "Dynamic"
-  lifecycle_type             = "Timed"
+  name                       = "examplesessionpool"
+  resource_group_name        = azurerm_resource_group.example.name
+  location                   = azurerm_resource_group.example.location
   cooldown_period_in_seconds = 300
 }
 ```
@@ -43,11 +38,9 @@ The following arguments are supported:
 
 * `location` - (Required) The Azure Region where the Container App Session Pool should exist. Changing this forces a new resource to be created.
 
-* `container_type` - (Required) The type of container used for the sessions in this Container App Session Pool. Possible values are `CustomContainer` and `PythonLTS`. Changing this forces a new resource to be created.
+* `container_type` - (Optional) The type of container used for the sessions in this Container App Session Pool. Possible values are `CustomContainer` and `PythonLTS`. Defaults to `PythonLTS`. Changing this forces a new resource to be created.
 
-* `max_concurrent_sessions` - (Required) The maximum number of sessions which can run concurrently in this Container App Session Pool.
-
-* `pool_management_type` - (Required) The management type of this Container App Session Pool. The Azure REST API defines `Dynamic` and `Manual`; however, Azure Container Apps currently supports creating session pools only with `Dynamic`, so `Manual` cannot be configured at this time. Changing this forces a new resource to be created.
+* `max_concurrent_sessions` - (Optional) The maximum number of sessions which can run concurrently in this Container App Session Pool. Defaults to `5`.
 
 * `container_app_environment_id` - (Optional) The ID of the Container App Environment used to host the sessions in this Container App Session Pool. Changing this forces a new resource to be created.
 
@@ -67,9 +60,7 @@ The following arguments are supported:
 
 ~> **Note:** `identity` may only be specified when `container_type` is set to `CustomContainer`.
 
-* `lifecycle_type` - (Optional) The lifecycle type of the sessions in this Container App Session Pool. Possible values are `OnContainerExit` and `Timed`.
-
-~> **Note:** `lifecycle_type` must be specified when `pool_management_type` is set to `Dynamic`.
+* `lifecycle_type` - (Optional) The lifecycle type of the sessions in this Container App Session Pool. Possible values are `OnContainerExit` and `Timed`. Defaults to `Timed`.
 
 ~> **Note:** `OnContainerExit` can only be used when `container_type` is set to `CustomContainer`.
 

--- a/website/docs/r/container_app_session_pool.html.markdown
+++ b/website/docs/r/container_app_session_pool.html.markdown
@@ -24,6 +24,10 @@ resource "azurerm_container_app_session_pool" "example" {
   location                = azurerm_resource_group.example.location
   container_type          = "PythonLTS"
   max_concurrent_sessions = 5
+
+  pool_management_type       = "Dynamic"
+  lifecycle_type             = "Timed"
+  cooldown_period_in_seconds = 300
 }
 ```
 
@@ -41,15 +45,15 @@ The following arguments are supported:
 
 * `max_concurrent_sessions` - (Required) The maximum number of sessions which can run concurrently in this Container App Session Pool.
 
----
+* `pool_management_type` - (Required) The management type of this Container App Session Pool. The Azure REST API defines `Dynamic` and `Manual`; however, Azure Container Apps currently supports creating session pools only with `Dynamic`, so `Manual` cannot be configured at this time. Changing this forces a new resource to be created.
 
 * `container_app_environment_id` - (Optional) The ID of the Container App Environment in which this Container App Session Pool should exist. Changing this forces a new resource to be created.
 
 ~> **Note:** The Container App Environment must be of type `Workload profile`. `Consumption only` environments are not supported.
 
-* `cooldown_period_in_seconds` - (Optional) The number of seconds a session remains alive once it becomes idle. Possible values range between `300` and `3600`. Defaults to `300`.
+* `cooldown_period_in_seconds` - (Optional) The number of seconds a session remains alive once it becomes idle. Possible values range between `300` and `3600`.
 
-~> **Note:** `cooldown_period_in_seconds` only applies when `lifecycle_type` is set to `Timed`, and conflicts with `max_alive_period_in_seconds`.
+~> **Note:** `cooldown_period_in_seconds` must be specified when `lifecycle_type` is set to `Timed`, cannot be specified otherwise, and conflicts with `max_alive_period_in_seconds`.
 
 * `custom_container_template` - (Optional) A `custom_container_template` block as defined below.
 
@@ -59,9 +63,11 @@ The following arguments are supported:
 
 ~> **Note:** `identity` may only be specified when `container_type` is set to `CustomContainer`.
 
-* `lifecycle_type` - (Optional) The lifecycle type of the sessions in this Container App Session Pool. Possible values are `OnContainerExit` and `Timed`. Defaults to `Timed`.
+* `lifecycle_type` - (Optional) The lifecycle type of the sessions in this Container App Session Pool. Possible values are `OnContainerExit` and `Timed`.
 
-~> **Note:** `lifecycle_type`, `cooldown_period_in_seconds` and `max_alive_period_in_seconds` are only used when `pool_management_type` is set to `Dynamic`.
+~> **Note:** `lifecycle_type` must be specified when `pool_management_type` is set to `Dynamic`.
+
+~> **Note:** `OnContainerExit` can only be used when `container_type` is set to `CustomContainer`.
 
 * `managed_identity_setting` - (Optional) One or more `managed_identity_setting` blocks as defined below. Changing this forces a new resource to be created.
 
@@ -69,13 +75,11 @@ The following arguments are supported:
 
 * `max_alive_period_in_seconds` - (Optional) The maximum number of seconds a session remains alive.
 
-~> **Note:** `max_alive_period_in_seconds` only applies when `lifecycle_type` is set to `OnContainerExit`, and conflicts with `cooldown_period_in_seconds`.
+~> **Note:** `max_alive_period_in_seconds` must be specified when `lifecycle_type` is set to `OnContainerExit`, cannot be specified otherwise, and conflicts with `cooldown_period_in_seconds`.
 
 * `network_egress_enabled` - (Optional) Should sessions in this Container App Session Pool be able to make outbound network requests? Defaults to `false`.
 
-* `pool_management_type` - (Optional) The management type of this Container App Session Pool. Possible values are `Dynamic` and `Manual`. Defaults to `Dynamic`. Changing this forces a new resource to be created.
-
-* `ready_session_instances` - (Optional) The minimum number of sessions which are kept ready in this Container App Session Pool.
+* `ready_session_instances` - (Optional) The minimum number of sessions which are kept ready in this Container App Session Pool. This must be greater than `0` and less than `max_concurrent_sessions`.
 
 * `secret` - (Optional) One or more `secret` blocks as defined below.
 
@@ -105,7 +109,7 @@ A `custom_container_template` block supports the following:
 
 * `container` - (Required) One or more `container` blocks as defined below.
 
-* `ingress_target_port` - (Optional) The target port in the container which receives traffic from the ingress. Possible values range between `1` and `65535`.
+* `ingress_target_port` - (Required) The target port in the container which receives traffic from the ingress. Possible values range between `1` and `65535`.
 
 * `registry` - (Optional) A `registry` block as defined below.
 
@@ -125,7 +129,7 @@ An `env` block supports the following:
 
 An `identity` block supports the following:
 
-* `type` - (Required) The type of Managed Identity assigned to this Container App Session Pool. Possible values are `SystemAssigned`, `UserAssigned` and `SystemAssigned, UserAssigned`.
+* `type` - (Required) The type of Managed Identity assigned to this Container App Session Pool. Possible values are `SystemAssigned`, `UserAssigned`, and `SystemAssigned, UserAssigned`.
 
 * `identity_ids` - (Optional) A list of User Assigned Managed Identity IDs to be assigned to this Container App Session Pool.
 
@@ -194,10 +198,10 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Container App Session Pools can be imported using the `resource id`, e.g.
+A Container App Session Pool can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_container_app_session_pool.example /subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resources/providers/Microsoft.App/sessionPools/examplesessionpool
+terraform import azurerm_container_app_session_pool.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1/providers/Microsoft.App/sessionPools/sessionPool1
 ```
 
 ## API Providers


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Adds a new resource `azurerm_container_app_session_pool` for managing [Azure Container Apps Session Pools](https://learn.microsoft.com/en-us/azure/container-apps/sessions), using the `2025-07-01` API version. Docs and acceptance tests (including a List Resource) are included.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 

## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass.
```
=== RUN   TestAccContainerAppSessionPool_basic
=== PAUSE TestAccContainerAppSessionPool_basic
=== CONT  TestAccContainerAppSessionPool_basic
--- PASS: TestAccContainerAppSessionPool_basic (101.27s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/containerapps	101.307s
=== RUN   TestAccContainerAppSessionPool_complete
=== PAUSE TestAccContainerAppSessionPool_complete
=== CONT  TestAccContainerAppSessionPool_complete
--- PASS: TestAccContainerAppSessionPool_complete (101.25s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/containerapps	101.276s
=== RUN   TestAccContainerAppSessionPool_update
=== PAUSE TestAccContainerAppSessionPool_update
=== CONT  TestAccContainerAppSessionPool_update
--- PASS: TestAccContainerAppSessionPool_update (217.75s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/containerapps	217.785s
=== RUN   TestAccContainerAppSessionPool_requiresImport
=== PAUSE TestAccContainerAppSessionPool_requiresImport
=== CONT  TestAccContainerAppSessionPool_requiresImport
--- PASS: TestAccContainerAppSessionPool_requiresImport (103.34s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/containerapps	103.372s
=== RUN   TestAccContainerAppSessionPool_customContainer
=== PAUSE TestAccContainerAppSessionPool_customContainer
=== CONT  TestAccContainerAppSessionPool_customContainer
--- PASS: TestAccContainerAppSessionPool_customContainer (2248.28s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/containerapps	2248.307s
=== RUN   TestAccContainerAppSessionPool_onContainerExit
=== PAUSE TestAccContainerAppSessionPool_onContainerExit
=== CONT  TestAccContainerAppSessionPool_onContainerExit
--- PASS: TestAccContainerAppSessionPool_onContainerExit (2310.55s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/containerapps	2310.589s
```

## Change Log

* **New Resource**: `azurerm_container_app_session_pool` [GH-33083]

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [x] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #32921 


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

NA

## Changes to Security Controls

NA