### PR TITLE
`azurerm_network_interface(_application_security_group_association)` - apply the ASG to IPv6 IP and match associations by IP configuration name

### DIFF
--- a/internal/services/network/network_interface.go
+++ b/internal/services/network/network_interface.go
@@ -112,7 +112,7 @@ func mapFieldsToNetworkInterface(input *[]networkinterfaces.NetworkInterfaceIPCo
 	}
 
 	for _, config := range *output {
-		if config.Properties == nil || config.Properties.PrivateIPAddressVersion == nil || *config.Properties.PrivateIPAddressVersion != networkinterfaces.IPVersionIPvFour {
+		if config.Properties == nil {
 			continue
 		}
 

--- a/internal/services/network/network_interface.go
+++ b/internal/services/network/network_interface.go
@@ -106,6 +106,7 @@ func mapFieldsToNetworkInterface(input *[]networkinterfaces.NetworkInterfaceIPCo
 			continue
 		}
 
+		// ASG associations apply to the network interface, so propagate them to every IP configuration.
 		config.Properties.ApplicationSecurityGroups = &applicationSecurityGroups
 
 		loadBalancerBackendAddressPools := make([]networkinterfaces.BackendAddressPool, 0)

--- a/internal/services/network/network_interface.go
+++ b/internal/services/network/network_interface.go
@@ -9,10 +9,10 @@ import (
 )
 
 type networkInterfaceUpdateInformation struct {
-	applicationGatewayBackendAddressPoolIDs []string
+	applicationGatewayBackendAddressPoolIDs map[string]string
 	applicationSecurityGroupIDs             []string
 	loadBalancerBackendAddressPoolIDs       map[string]string
-	loadBalancerInboundNatRuleIDs           []string
+	loadBalancerInboundNatRuleIDs           map[string]string
 	networkSecurityGroupID                  string
 }
 
@@ -33,9 +33,9 @@ func parseFieldsFromNetworkInterface(input networkinterfaces.NetworkInterfacePro
 	}
 
 	applicationSecurityGroupIds := make(map[string]struct{})
-	applicationGatewayBackendAddressPoolIds := make(map[string]struct{})
+	applicationGatewayBackendAddressPoolIds := make(map[string]string)
 	loadBalancerBackendAddressPoolIds := make(map[string]string)
-	loadBalancerInboundNatRuleIds := make(map[string]struct{})
+	loadBalancerInboundNatRuleIds := make(map[string]string)
 
 	if input.IPConfigurations != nil {
 		for _, v := range *input.IPConfigurations {
@@ -52,17 +52,21 @@ func parseFieldsFromNetworkInterface(input networkinterfaces.NetworkInterfacePro
 				}
 			}
 
+			if v.Name == nil {
+				continue
+			}
+
 			if props.ApplicationGatewayBackendAddressPools != nil {
 				for _, pool := range *props.ApplicationGatewayBackendAddressPools {
 					if pool.Id != nil {
-						applicationGatewayBackendAddressPoolIds[*pool.Id] = struct{}{}
+						applicationGatewayBackendAddressPoolIds[*pool.Id] = *v.Name
 					}
 				}
 			}
 
 			if props.LoadBalancerBackendAddressPools != nil {
 				for _, pool := range *props.LoadBalancerBackendAddressPools {
-					if v.Name != nil && pool.Id != nil {
+					if pool.Id != nil {
 						loadBalancerBackendAddressPoolIds[*pool.Id] = *v.Name
 					}
 				}
@@ -71,7 +75,7 @@ func parseFieldsFromNetworkInterface(input networkinterfaces.NetworkInterfacePro
 			if props.LoadBalancerInboundNatRules != nil {
 				for _, rule := range *props.LoadBalancerInboundNatRules {
 					if rule.Id != nil {
-						loadBalancerInboundNatRuleIds[*rule.Id] = struct{}{}
+						loadBalancerInboundNatRuleIds[*rule.Id] = *v.Name
 					}
 				}
 			}
@@ -79,10 +83,10 @@ func parseFieldsFromNetworkInterface(input networkinterfaces.NetworkInterfacePro
 	}
 
 	return networkInterfaceUpdateInformation{
-		applicationGatewayBackendAddressPoolIDs: mapToSlice(applicationGatewayBackendAddressPoolIds),
+		applicationGatewayBackendAddressPoolIDs: applicationGatewayBackendAddressPoolIds,
 		applicationSecurityGroupIDs:             mapToSlice(applicationSecurityGroupIds),
 		loadBalancerBackendAddressPoolIDs:       loadBalancerBackendAddressPoolIds,
-		loadBalancerInboundNatRuleIDs:           mapToSlice(loadBalancerInboundNatRuleIds),
+		loadBalancerInboundNatRuleIDs:           loadBalancerInboundNatRuleIds,
 		networkSecurityGroupID:                  networkSecurityGroupId,
 	}
 }
@@ -97,30 +101,12 @@ func mapFieldsToNetworkInterface(input *[]networkinterfaces.NetworkInterfaceIPCo
 		})
 	}
 
-	applicationGatewayBackendAddressPools := make([]networkinterfaces.ApplicationGatewayBackendAddressPool, 0)
-	for _, id := range info.applicationGatewayBackendAddressPoolIDs {
-		applicationGatewayBackendAddressPools = append(applicationGatewayBackendAddressPools, networkinterfaces.ApplicationGatewayBackendAddressPool{
-			Id: pointer.To(id),
-		})
-	}
-
-	loadBalancerInboundNatRules := make([]networkinterfaces.InboundNatRule, 0)
-	for _, id := range info.loadBalancerInboundNatRuleIDs {
-		loadBalancerInboundNatRules = append(loadBalancerInboundNatRules, networkinterfaces.InboundNatRule{
-			Id: pointer.To(id),
-		})
-	}
-
 	for _, config := range *output {
 		if config.Properties == nil {
 			continue
 		}
 
 		config.Properties.ApplicationSecurityGroups = &applicationSecurityGroups
-
-		if config.Properties.PrivateIPAddressVersion == nil || *config.Properties.PrivateIPAddressVersion != networkinterfaces.IPVersionIPvFour {
-			continue
-		}
 
 		loadBalancerBackendAddressPools := make([]networkinterfaces.BackendAddressPool, 0)
 		for id, name := range info.loadBalancerBackendAddressPoolIDs {
@@ -129,12 +115,28 @@ func mapFieldsToNetworkInterface(input *[]networkinterfaces.NetworkInterfaceIPCo
 					Id: pointer.To(id),
 				})
 			}
-
-			config.Properties.LoadBalancerBackendAddressPools = &loadBalancerBackendAddressPools
 		}
+		config.Properties.LoadBalancerBackendAddressPools = &loadBalancerBackendAddressPools
 
-		config.Properties.ApplicationGatewayBackendAddressPools = &applicationGatewayBackendAddressPools
+		loadBalancerInboundNatRules := make([]networkinterfaces.InboundNatRule, 0)
+		for id, name := range info.loadBalancerInboundNatRuleIDs {
+			if config.Name != nil && *config.Name == name {
+				loadBalancerInboundNatRules = append(loadBalancerInboundNatRules, networkinterfaces.InboundNatRule{
+					Id: pointer.To(id),
+				})
+			}
+		}
 		config.Properties.LoadBalancerInboundNatRules = &loadBalancerInboundNatRules
+
+		applicationGatewayBackendAddressPools := make([]networkinterfaces.ApplicationGatewayBackendAddressPool, 0)
+		for id, name := range info.applicationGatewayBackendAddressPoolIDs {
+			if config.Name != nil && *config.Name == name {
+				applicationGatewayBackendAddressPools = append(applicationGatewayBackendAddressPools, networkinterfaces.ApplicationGatewayBackendAddressPool{
+					Id: pointer.To(id),
+				})
+			}
+		}
+		config.Properties.ApplicationGatewayBackendAddressPools = &applicationGatewayBackendAddressPools
 	}
 
 	return output

--- a/internal/services/network/network_interface.go
+++ b/internal/services/network/network_interface.go
@@ -116,6 +116,12 @@ func mapFieldsToNetworkInterface(input *[]networkinterfaces.NetworkInterfaceIPCo
 			continue
 		}
 
+		config.Properties.ApplicationSecurityGroups = &applicationSecurityGroups
+
+		if config.Properties.PrivateIPAddressVersion == nil || *config.Properties.PrivateIPAddressVersion != networkinterfaces.IPVersionIPvFour {
+			continue
+		}
+
 		loadBalancerBackendAddressPools := make([]networkinterfaces.BackendAddressPool, 0)
 		for id, name := range info.loadBalancerBackendAddressPoolIDs {
 			if config.Name != nil && *config.Name == name {
@@ -127,7 +133,6 @@ func mapFieldsToNetworkInterface(input *[]networkinterfaces.NetworkInterfaceIPCo
 			config.Properties.LoadBalancerBackendAddressPools = &loadBalancerBackendAddressPools
 		}
 
-		config.Properties.ApplicationSecurityGroups = &applicationSecurityGroups
 		config.Properties.ApplicationGatewayBackendAddressPools = &applicationGatewayBackendAddressPools
 		config.Properties.LoadBalancerInboundNatRules = &loadBalancerInboundNatRules
 	}

--- a/internal/services/network/network_interface_application_gateway_backend_address_pool_association_resource_test.go
+++ b/internal/services/network/network_interface_application_gateway_backend_address_pool_association_resource_test.go
@@ -88,6 +88,7 @@ func TestAccNetworkInterfaceApplicationGatewayBackendAddressPoolAssociation_upda
 			Config: r.updateNIC(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				data.CheckWithClient(r.associationOnlyOnNamedIPConfiguration),
 			),
 		},
 		data.ImportStep(),
@@ -139,6 +140,53 @@ func (NetworkInterfaceApplicationGatewayBackendAddressPoolAssociationResource) E
 	}
 
 	return pointer.To(found), nil
+}
+
+func (NetworkInterfaceApplicationGatewayBackendAddressPoolAssociationResource) associationOnlyOnNamedIPConfiguration(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) error {
+	id, err := commonids.ParseCompositeResourceID(state.ID, &commonids.NetworkInterfaceIPConfigurationId{}, &parse.ApplicationGatewayBackendAddressPoolId{})
+	if err != nil {
+		return err
+	}
+
+	networkInterfaceId := commonids.NewNetworkInterfaceID(id.First.SubscriptionId, id.First.ResourceGroupName, id.First.NetworkInterfaceName)
+
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+
+	read, err := client.Network.NetworkInterfaces.Get(ctx, networkInterfaceId, networkinterfaces.DefaultGetOperationOptions())
+	if err != nil {
+		return fmt.Errorf("retrieving %s: %+v", networkInterfaceId, err)
+	}
+	if read.Model == nil || read.Model.Properties == nil || read.Model.Properties.IPConfigurations == nil {
+		return fmt.Errorf("retrieving %s: `properties.ipConfigurations` was nil", networkInterfaceId)
+	}
+
+	for _, config := range *read.Model.Properties.IPConfigurations {
+		props := config.Properties
+		if props == nil {
+			return fmt.Errorf("retrieving %s: `properties` was nil for IP configuration %q", networkInterfaceId, pointer.From(config.Name))
+		}
+
+		associated := false
+		if props.ApplicationGatewayBackendAddressPools != nil {
+			for _, pool := range *props.ApplicationGatewayBackendAddressPools {
+				if pool.Id != nil && *pool.Id == id.Second.ID() {
+					associated = true
+					break
+				}
+			}
+		}
+
+		isTarget := pointer.From(config.Name) == id.First.IpConfigurationName
+		if isTarget && !associated {
+			return fmt.Errorf("expected Application Gateway Backend Address Pool %q to be associated with IP configuration %q but it was not", id.Second.ID(), id.First.IpConfigurationName)
+		}
+		if !isTarget && associated {
+			return fmt.Errorf("expected Application Gateway Backend Address Pool %q not to be associated with IP configuration %q but it was", id.Second.ID(), pointer.From(config.Name))
+		}
+	}
+
+	return nil
 }
 
 func (NetworkInterfaceApplicationGatewayBackendAddressPoolAssociationResource) destroy(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) error {

--- a/internal/services/network/network_interface_application_security_group_association_resource_test.go
+++ b/internal/services/network/network_interface_application_security_group_association_resource_test.go
@@ -97,6 +97,7 @@ func TestAccNetworkInterfaceApplicationSecurityGroupAssociation_updateNIC(t *tes
 			Config: r.updateNIC(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				data.CheckWithClient(r.associationExistsOnIPv6Config),
 			),
 		},
 		data.ImportStep(),
@@ -135,6 +136,54 @@ func (t NetworkInterfaceApplicationSecurityGroupAssociationResource) Exists(ctx 
 	}
 
 	return pointer.To(found), nil
+}
+
+func (NetworkInterfaceApplicationSecurityGroupAssociationResource) associationExistsOnIPv6Config(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) error {
+	id, err := commonids.ParseCompositeResourceID(state.ID, &commonids.NetworkInterfaceId{}, &applicationsecuritygroups.ApplicationSecurityGroupId{})
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+
+	read, err := client.Network.NetworkInterfaces.Get(ctx, *id.First, networkinterfaces.DefaultGetOperationOptions())
+	if err != nil {
+		return fmt.Errorf("retrieving %s: %+v", id.First, err)
+	}
+	if read.Model == nil || read.Model.Properties == nil || read.Model.Properties.IPConfigurations == nil {
+		return fmt.Errorf("retrieving %s: `properties.ipConfigurations` was nil", id.First)
+	}
+
+	foundIPv6Config := false
+	for _, config := range *read.Model.Properties.IPConfigurations {
+		props := config.Properties
+		if props == nil || props.PrivateIPAddressVersion == nil || *props.PrivateIPAddressVersion != networkinterfaces.IPVersionIPvSix {
+			continue
+		}
+
+		foundIPv6Config = true
+
+		associated := false
+		if props.ApplicationSecurityGroups != nil {
+			for _, group := range *props.ApplicationSecurityGroups {
+				if group.Id != nil && *group.Id == id.Second.ID() {
+					associated = true
+					break
+				}
+			}
+		}
+
+		if !associated {
+			return fmt.Errorf("expected Application Security Group %q to be associated with the IPv6 IP configuration %q but it was not", id.Second.ID(), pointer.From(config.Name))
+		}
+	}
+
+	if !foundIPv6Config {
+		return fmt.Errorf("expected an IPv6 IP configuration on %s but none was found", id.First)
+	}
+
+	return nil
 }
 
 func (NetworkInterfaceApplicationSecurityGroupAssociationResource) destroy(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) error {
@@ -263,6 +312,7 @@ resource "azurerm_network_interface" "test" {
 
   ip_configuration {
     name                          = "testconfiguration2"
+    subnet_id                     = azurerm_subnet.test.id
     private_ip_address_version    = "IPv6"
     private_ip_address_allocation = "Dynamic"
   }
@@ -288,7 +338,7 @@ resource "azurerm_resource_group" "test" {
 
 resource "azurerm_virtual_network" "test" {
   name                = "acctestvn-%d"
-  address_space       = ["10.0.0.0/16"]
+  address_space       = ["10.0.0.0/16", "ace:cab:deca::/48"]
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
 }
@@ -297,7 +347,7 @@ resource "azurerm_subnet" "test" {
   name                 = "internal"
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes     = ["10.0.1.0/24"]
+  address_prefixes     = ["10.0.1.0/24", "ace:cab:deca:deed::/64"]
 }
 
 resource "azurerm_application_security_group" "test" {

--- a/internal/services/network/network_interface_application_security_group_association_resource_test.go
+++ b/internal/services/network/network_interface_application_security_group_association_resource_test.go
@@ -97,7 +97,7 @@ func TestAccNetworkInterfaceApplicationSecurityGroupAssociation_updateNIC(t *tes
 			Config: r.updateNIC(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				data.CheckWithClient(r.associationExistsOnIPv6Config),
+				data.CheckWithClient(r.asgAppliedToAllIPConfigurations),
 			),
 		},
 		data.ImportStep(),
@@ -138,7 +138,7 @@ func (t NetworkInterfaceApplicationSecurityGroupAssociationResource) Exists(ctx 
 	return pointer.To(found), nil
 }
 
-func (NetworkInterfaceApplicationSecurityGroupAssociationResource) associationExistsOnIPv6Config(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) error {
+func (NetworkInterfaceApplicationSecurityGroupAssociationResource) asgAppliedToAllIPConfigurations(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) error {
 	id, err := commonids.ParseCompositeResourceID(state.ID, &commonids.NetworkInterfaceId{}, &applicationsecuritygroups.ApplicationSecurityGroupId{})
 	if err != nil {
 		return err
@@ -155,14 +155,11 @@ func (NetworkInterfaceApplicationSecurityGroupAssociationResource) associationEx
 		return fmt.Errorf("retrieving %s: `properties.ipConfigurations` was nil", id.First)
 	}
 
-	foundIPv6Config := false
 	for _, config := range *read.Model.Properties.IPConfigurations {
 		props := config.Properties
-		if props == nil || props.PrivateIPAddressVersion == nil || *props.PrivateIPAddressVersion != networkinterfaces.IPVersionIPvSix {
-			continue
+		if props == nil {
+			return fmt.Errorf("retrieving %s: `properties` was nil for IP configuration %q", id.First, pointer.From(config.Name))
 		}
-
-		foundIPv6Config = true
 
 		associated := false
 		if props.ApplicationSecurityGroups != nil {
@@ -175,12 +172,10 @@ func (NetworkInterfaceApplicationSecurityGroupAssociationResource) associationEx
 		}
 
 		if !associated {
-			return fmt.Errorf("expected Application Security Group %q to be associated with the IPv6 IP configuration %q but it was not", id.Second.ID(), pointer.From(config.Name))
+			return fmt.Errorf(
+				"expected Application Security Group %q to be associated with IP configuration %q but it was not", id.Second.ID(), pointer.From(config.Name),
+			)
 		}
-	}
-
-	if !foundIPv6Config {
-		return fmt.Errorf("expected an IPv6 IP configuration on %s but none was found", id.First)
 	}
 
 	return nil

--- a/internal/services/network/network_interface_backend_address_pool_association_resource_test.go
+++ b/internal/services/network/network_interface_backend_address_pool_association_resource_test.go
@@ -88,6 +88,7 @@ func TestAccNetworkInterfaceBackendAddressPoolAssociation_updateNIC(t *testing.T
 			Config: r.updateNIC(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				data.CheckWithClient(r.associationOnlyOnNamedIPConfiguration),
 			),
 		},
 		data.ImportStep(),
@@ -133,6 +134,53 @@ func (t NetworkInterfaceBackendAddressPoolResource) Exists(ctx context.Context, 
 	}
 
 	return pointer.To(found), nil
+}
+
+func (NetworkInterfaceBackendAddressPoolResource) associationOnlyOnNamedIPConfiguration(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) error {
+	id, err := commonids.ParseCompositeResourceID(state.ID, &commonids.NetworkInterfaceIPConfigurationId{}, &loadbalancers.BackendAddressPoolId{})
+	if err != nil {
+		return err
+	}
+
+	networkInterfaceId := commonids.NewNetworkInterfaceID(id.First.SubscriptionId, id.First.ResourceGroupName, id.First.NetworkInterfaceName)
+
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+
+	read, err := client.Network.NetworkInterfaces.Get(ctx, networkInterfaceId, networkinterfaces.DefaultGetOperationOptions())
+	if err != nil {
+		return fmt.Errorf("retrieving %s: %+v", networkInterfaceId, err)
+	}
+	if read.Model == nil || read.Model.Properties == nil || read.Model.Properties.IPConfigurations == nil {
+		return fmt.Errorf("retrieving %s: `properties.ipConfigurations` was nil", networkInterfaceId)
+	}
+
+	for _, config := range *read.Model.Properties.IPConfigurations {
+		props := config.Properties
+		if props == nil {
+			return fmt.Errorf("retrieving %s: `properties` was nil for IP configuration %q", networkInterfaceId, pointer.From(config.Name))
+		}
+
+		associated := false
+		if props.LoadBalancerBackendAddressPools != nil {
+			for _, pool := range *props.LoadBalancerBackendAddressPools {
+				if pool.Id != nil && *pool.Id == id.Second.ID() {
+					associated = true
+					break
+				}
+			}
+		}
+
+		isTarget := pointer.From(config.Name) == id.First.IpConfigurationName
+		if isTarget && !associated {
+			return fmt.Errorf("expected Backend Address Pool %q to be associated with IP configuration %q but it was not", id.Second.ID(), id.First.IpConfigurationName)
+		}
+		if !isTarget && associated {
+			return fmt.Errorf("expected Backend Address Pool %q not to be associated with IP configuration %q but it was", id.Second.ID(), pointer.From(config.Name))
+		}
+	}
+
+	return nil
 }
 
 func (NetworkInterfaceBackendAddressPoolResource) destroy(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) error {

--- a/internal/services/network/network_interface_nat_rule_association_resource_test.go
+++ b/internal/services/network/network_interface_nat_rule_association_resource_test.go
@@ -88,6 +88,7 @@ func TestAccNetworkInterfaceNATRuleAssociation_updateNIC(t *testing.T) {
 			Config: r.updateNIC(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				data.CheckWithClient(r.associationOnlyOnNamedIPConfiguration),
 			),
 		},
 		data.ImportStep(),
@@ -135,6 +136,53 @@ func (t NetworkInterfaceNATRuleAssociationResource) Exists(ctx context.Context, 
 	}
 
 	return pointer.To(found), nil
+}
+
+func (NetworkInterfaceNATRuleAssociationResource) associationOnlyOnNamedIPConfiguration(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) error {
+	id, err := commonids.ParseCompositeResourceID(state.ID, &commonids.NetworkInterfaceIPConfigurationId{}, &loadbalancers.InboundNatRuleId{})
+	if err != nil {
+		return err
+	}
+
+	networkInterfaceId := commonids.NewNetworkInterfaceID(id.First.SubscriptionId, id.First.ResourceGroupName, id.First.NetworkInterfaceName)
+
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+
+	read, err := client.Network.NetworkInterfaces.Get(ctx, networkInterfaceId, networkinterfaces.DefaultGetOperationOptions())
+	if err != nil {
+		return fmt.Errorf("retrieving %s: %+v", networkInterfaceId, err)
+	}
+	if read.Model == nil || read.Model.Properties == nil || read.Model.Properties.IPConfigurations == nil {
+		return fmt.Errorf("retrieving %s: `properties.ipConfigurations` was nil", networkInterfaceId)
+	}
+
+	for _, config := range *read.Model.Properties.IPConfigurations {
+		props := config.Properties
+		if props == nil {
+			return fmt.Errorf("retrieving %s: `properties` was nil for IP configuration %q", networkInterfaceId, pointer.From(config.Name))
+		}
+
+		associated := false
+		if props.LoadBalancerInboundNatRules != nil {
+			for _, rule := range *props.LoadBalancerInboundNatRules {
+				if rule.Id != nil && *rule.Id == id.Second.ID() {
+					associated = true
+					break
+				}
+			}
+		}
+
+		isTarget := pointer.From(config.Name) == id.First.IpConfigurationName
+		if isTarget && !associated {
+			return fmt.Errorf("expected NAT Rule %q to be associated with IP configuration %q but it was not", id.Second.ID(), id.First.IpConfigurationName)
+		}
+		if !isTarget && associated {
+			return fmt.Errorf("expected NAT Rule %q not to be associated with IP configuration %q but it was", id.Second.ID(), pointer.From(config.Name))
+		}
+	}
+
+	return nil
 }
 
 func (NetworkInterfaceNATRuleAssociationResource) destroy(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) error {

--- a/website/docs/r/network_interface_application_gateway_backend_address_pool_association.html.markdown
+++ b/website/docs/r/network_interface_application_gateway_backend_address_pool_association.html.markdown
@@ -139,6 +139,8 @@ The following arguments are supported:
 
 * `ip_configuration_name` - (Required) The Name of the IP Configuration within the Network Interface which should be connected to the Backend Address Pool. Changing this forces a new resource to be created.
 
+~> **Note:** The referenced IP Configuration must use IPv4 addressing. Application Gateway Backend Address Pools cannot be associated with an IP Configuration that uses IPv6 addressing.
+
 * `backend_address_pool_id` - (Required) The ID of the Application Gateway's Backend Address Pool which this Network Interface which should be connected to. Changing this forces a new resource to be created.
 
 ## Attributes Reference


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR fixes the association-mapping logic in `mapFieldsToNetworkInterface`, which reapplies associations onto a network interface's IP configurations during updates and during create/delete of `azurerm_network_interface_application_security_group_association`.

1. Fix IP configuration targeting. Inbound NAT rule and Application Gateway backend address pool association resources include an `ip_configuration_name` field and should only be associated with the matching IP configuration. Previously, these associations were applied to all IP configurations on the NIC. They are now correctly matched by IP configuration name.

2. Remove the IPv4-only restriction. Previously, the helper skipped non-IPv4 IP configurations, preventing ASGs from being restored on IPv6 configurations during updates. Now that ASGs support IPv6 and associations are scoped by IP configuration name, this check is no longer needed as any unsupported association will be rejected during creation.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.

## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_NETWORK/728800?buildTab=tests

<img width="802" height="190" alt="image" src="https://github.com/user-attachments/assets/fafb6983-09e4-446a-a890-ece125c9f13f" />

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #32633


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

Use AI for writing the test. 

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
