### PR TITLE
`azurerm_container_app_job` - clarify `rules` and `authentication` support one or more blocks

### DIFF
--- a/website/docs/r/container_app_job.html.markdown
+++ b/website/docs/r/container_app_job.html.markdown
@@ -382,7 +382,7 @@ A `scale` block supports the following:
 
 * `polling_interval_in_seconds` - (Optional) Interval to check each event source in seconds.
 
-* `rules` - (Optional) A `rules` block as defined below.
+* `rules` - (Optional) One or more `rules` blocks as defined below.
 
 ---
 
@@ -394,7 +394,7 @@ A `rules` block supports the following:
 
 * `metadata` - (Required) Metadata properties to describe the scale rule.
 
-* `authentication` - (Optional) A `authentication` block as defined below.
+* `authentication` - (Optional) One or more `authentication` blocks as defined below.
 
 * `identity_id` - (Optional) The ID of the identity used to authenticate with the scale rule backend. This can either be the Resource ID of a User Assigned Identity, or `System` for the System Assigned Identity.
 


### PR DESCRIPTION
### Description

The `rules` and `authentication` argument documentation under the `scale` block used singular wording ("A `rules` block", "A `authentication` block"), implying only one is allowed. Both are backed by list-typed fields (`Rules []ScaleRule`, `Auth []ScaleRuleAuth`) with no `MaxItems` restriction, so multiple blocks are supported. This updates the wording to reflect that.

Closes #31028