### PR TITLE
Test Fix: `TestAccDataSourceSiteRecoveryReplicationRecoveryPlan_basic`

### DIFF
--- a/internal/services/healthcare/healthcare_service_resource_test.go
+++ b/internal/services/healthcare/healthcare_service_resource_test.go
@@ -222,7 +222,7 @@ resource "azurerm_key_vault" "test" {
 
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = data.azuread_service_principal.cosmosdb.id
+    object_id = data.azuread_service_principal.cosmosdb.object_id
 
     key_permissions = [
       "Get",

--- a/internal/services/recoveryservices/site_recovery_replication_recovery_plan_resource_test.go
+++ b/internal/services/recoveryservices/site_recovery_replication_recovery_plan_resource_test.go
@@ -386,7 +386,9 @@ resource "azurerm_site_recovery_replicated_vm" "test" {
 
   network_interface {
     source_network_interface_id = azurerm_network_interface.test.id
-    target_subnet_name          = "snet-%[2]d_2"
+    ip_configuration {
+      target_subnet_name          = "snet-%[2]d_2"
+    }
   }
 
   depends_on = [

--- a/internal/services/recoveryservices/site_recovery_replication_recovery_plan_resource_test.go
+++ b/internal/services/recoveryservices/site_recovery_replication_recovery_plan_resource_test.go
@@ -387,7 +387,7 @@ resource "azurerm_site_recovery_replicated_vm" "test" {
   network_interface {
     source_network_interface_id = azurerm_network_interface.test.id
     ip_configuration {
-      target_subnet_name          = "snet-%[2]d_2"
+      target_subnet_name = "snet-%[2]d_2"
     }
   }
 


### PR DESCRIPTION
```
--- PASS: TestAccDataSourceSiteRecoveryReplicationRecoveryPlan_basic (2049.55s)

------- Stdout: -------
=== RUN   TestAccDataSourceSiteRecoveryReplicationRecoveryPlan_basic
=== PAUSE TestAccDataSourceSiteRecoveryReplicationRecoveryPlan_basic
=== CONT  TestAccDataSourceSiteRecoveryReplicationRecoveryPlan_basic
    testcase.go:225: Step 1/1 error: Error running pre-apply plan: exit status 1
        
        Error: Unsupported argument
        
          on terraform_plugin_test.tf line 236, in resource "azurerm_site_recovery_replicated_vm" "test":
         236:     target_subnet_name          = "snet-260812025647549449_2"
        
        An argument named "target_subnet_name" is not expected here.
--- FAIL: TestAccDataSourceSiteRecoveryReplicationRecoveryPlan_basic (5.55s)
FAIL


Within the healthcare test file, fixed a deprecated block for error:
=== RUN   TestAccHealthCareServiceDataSource_complete
=== PAUSE TestAccHealthCareServiceDataSource_complete
=== CONT  TestAccHealthCareServiceDataSource_complete
    testcase.go:225: Step 1/1 error: Error running pre-apply plan: exit status 1
        
        Error: expected "access_policy.1.object_id" to be a valid UUID, got /servicePrincipals/44e9050a-1c96-4b10-9c80-4f344280b5cc
        
          with azurerm_key_vault.test,
          on terraform_plugin_test.tf line 95, in resource "azurerm_key_vault" "test":
          95:     object_id = data.azuread_service_principal.cosmosdb.id
        
--- FAIL: TestAccHealthCareServiceDataSource_complete (36.31s)
FAIL
```