### PR TITLE
linters - enable azproviderlint AZG001 - combine err assignment with check

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -86,7 +86,6 @@ linters:
         type: module
         settings:
           disable:
-            - AZG001 # 'err' assignment should be combined many MANY hits, to fix in another pr
             - AZR002 # splite create and udpate: ~350 todo over time
             - AZT002 #tests should not obtain credentials via os.Getenv - investigate in a later pr
             - AZR004 #Resource IDs should not be compared with == or != - to fix in a later commit

--- a/internal/provider/function/parse_resource_id.go
+++ b/internal/provider/function/parse_resource_id.go
@@ -95,8 +95,7 @@ func (p ParseResourceIDFunction) Run(ctx context.Context, request function.RunRe
 		return
 	}
 
-	err = idType.FromParseResult(*parsed)
-	if err != nil {
+	if err = idType.FromParseResult(*parsed); err != nil {
 		response.Error = function.NewFuncError(fmt.Sprintf("Expanding Parsed Resource ID Error: %s", err))
 		return
 	}

--- a/internal/services/apimanagement/api_management_resource.go
+++ b/internal/services/apimanagement/api_management_resource.go
@@ -711,7 +711,7 @@ func resourceApiManagementServiceCreate(d *pluginsdk.ResourceData, meta interfac
 		}
 
 		// retry to restore service since there is an API issue : https://github.com/Azure/azure-rest-api-specs/issues/25262
-		err = pluginsdk.Retry(d.Timeout(pluginsdk.TimeoutCreate), func() *pluginsdk.RetryError {
+		if err = pluginsdk.Retry(d.Timeout(pluginsdk.TimeoutCreate), func() *pluginsdk.RetryError {
 			resp, err := client.CreateOrUpdate(ctx, id, params)
 			if err != nil {
 				if response.WasBadRequest(resp.HttpResponse) {
@@ -723,8 +723,7 @@ func resourceApiManagementServiceCreate(d *pluginsdk.ResourceData, meta interfac
 				return pluginsdk.NonRetryableError(err)
 			}
 			return nil
-		})
-		if err != nil {
+		}); err != nil {
 			return fmt.Errorf("recovering %s: %+v", id, err)
 		}
 	}

--- a/internal/services/apimanagement/api_management_subscription_resource.go
+++ b/internal/services/apimanagement/api_management_subscription_resource.go
@@ -195,7 +195,7 @@ func resourceApiManagementSubscriptionCreateUpdate(d *pluginsdk.ResourceData, me
 		params.Properties.SecondaryKey = pointer.To(v.(string))
 	}
 
-	err := pluginsdk.Retry(d.Timeout(pluginsdk.TimeoutCreate), func() *pluginsdk.RetryError {
+	if err := pluginsdk.Retry(d.Timeout(pluginsdk.TimeoutCreate), func() *pluginsdk.RetryError {
 		if _, err := client.CreateOrUpdate(ctx, id, params, subscription.CreateOrUpdateOperationOptions{AppType: pointer.To(subscription.AppTypeDeveloperPortal), Notify: pointer.To(false)}); err != nil {
 			// APIM admins set limit on number of subscriptions to a product.  In order to be able to correctly enforce that limit service cannot let simultaneous creations
 			// to go through and first one wins/subsequent one gets 412 and that client/user can retry. This ensures that we have proper limits enforces as desired by APIM admin.
@@ -205,8 +205,7 @@ func resourceApiManagementSubscriptionCreateUpdate(d *pluginsdk.ResourceData, me
 			return pluginsdk.NonRetryableError(err)
 		}
 		return nil
-	})
-	if err != nil {
+	}); err != nil {
 		return fmt.Errorf("creating/updating %s: %+v", id, err)
 	}
 

--- a/internal/services/appconfiguration/app_configuration_feature_resource.go
+++ b/internal/services/appconfiguration/app_configuration_feature_resource.go
@@ -419,8 +419,7 @@ func (k FeatureResource) Read() sdk.ResourceFunc {
 			}
 
 			var fv FeatureValue
-			err = json.Unmarshal([]byte(pointer.From(kv.Value)), &fv)
-			if err != nil {
+			if err = json.Unmarshal([]byte(pointer.From(kv.Value)), &fv); err != nil {
 				return fmt.Errorf("while unmarshalling underlying key's value: %+v", err)
 			}
 
@@ -483,8 +482,7 @@ func (k FeatureResource) Update() sdk.ResourceFunc {
 			}
 
 			var fv FeatureValue
-			err = json.Unmarshal([]byte(pointer.From(kv.Value)), &fv)
-			if err != nil {
+			if err = json.Unmarshal([]byte(pointer.From(kv.Value)), &fv); err != nil {
 				return fmt.Errorf("while unmarshalling underlying key's value: %+v", err)
 			}
 

--- a/internal/services/appconfiguration/app_configuration_key_data_source.go
+++ b/internal/services/appconfiguration/app_configuration_key_data_source.go
@@ -131,8 +131,7 @@ func (k KeyDataSource) Read() sdk.ResourceFunc {
 			} else {
 				var ref VaultKeyReference
 				refBytes := []byte(pointer.From(kv.Value))
-				err := json.Unmarshal(refBytes, &ref)
-				if err != nil {
+				if err := json.Unmarshal(refBytes, &ref); err != nil {
 					return fmt.Errorf("while unmarshalling vault reference: %+v", err)
 				}
 

--- a/internal/services/appconfiguration/app_configuration_key_resource.go
+++ b/internal/services/appconfiguration/app_configuration_key_resource.go
@@ -321,8 +321,7 @@ func (k KeyResource) Read() sdk.ResourceFunc {
 			} else {
 				var ref VaultKeyReference
 				refBytes := []byte(pointer.From(kv.Value))
-				err := json.Unmarshal(refBytes, &ref)
-				if err != nil {
+				if err := json.Unmarshal(refBytes, &ref); err != nil {
 					return fmt.Errorf("while unmarshalling vault reference: %+v", err)
 				}
 

--- a/internal/services/appconfiguration/app_configuration_keys_data_source.go
+++ b/internal/services/appconfiguration/app_configuration_keys_data_source.go
@@ -174,8 +174,7 @@ func (k KeysDataSource) Read() sdk.ResourceFunc {
 				} else {
 					var ref VaultKeyReference
 					refBytes := []byte(pointer.From(kv.Value))
-					err := json.Unmarshal(refBytes, &ref)
-					if err != nil {
+					if err := json.Unmarshal(refBytes, &ref); err != nil {
 						return fmt.Errorf("while unmarshalling vault reference: %+v", err)
 					}
 

--- a/internal/services/appconfiguration/feature_structs.go
+++ b/internal/services/appconfiguration/feature_structs.go
@@ -50,8 +50,7 @@ func (p *ClientFilter) UnmarshalJSON(b []byte) error {
 				if err != nil {
 					return err
 				}
-				err = mpd.Decode(filterRaw)
-				if err != nil {
+				if err = mpd.Decode(filterRaw); err != nil {
 					return err
 				}
 				filtersOut = append(filtersOut, out)
@@ -64,8 +63,7 @@ func (p *ClientFilter) UnmarshalJSON(b []byte) error {
 				if err != nil {
 					return err
 				}
-				err = mpd.Decode(filterRaw)
-				if err != nil {
+				if err = mpd.Decode(filterRaw); err != nil {
 					return err
 				}
 				filtersOut = append(filtersOut, out)
@@ -78,8 +76,7 @@ func (p *ClientFilter) UnmarshalJSON(b []byte) error {
 				if err != nil {
 					return err
 				}
-				err = mpd.Decode(filterRaw)
-				if err != nil {
+				if err = mpd.Decode(filterRaw); err != nil {
 					return err
 				}
 				filtersOut = append(filtersOut, out)
@@ -93,8 +90,7 @@ func (p *ClientFilter) UnmarshalJSON(b []byte) error {
 				if err != nil {
 					return err
 				}
-				err = mpd.Decode(filterRaw)
-				if err != nil {
+				if err = mpd.Decode(filterRaw); err != nil {
 					return err
 				}
 				filtersOut = append(filtersOut, out)

--- a/internal/services/applicationinsights/application_insights_resource.go
+++ b/internal/services/applicationinsights/application_insights_resource.go
@@ -296,7 +296,7 @@ func resourceApplicationInsightsCreate(d *pluginsdk.ResourceData, meta interface
 	// Instead, we'll opt to disable them here
 	if meta.(*clients.Client).Features.ApplicationInsights.DisableGeneratedRule {
 		// TODO: replace this with a StateWait func
-		err = pluginsdk.Retry(d.Timeout(pluginsdk.TimeoutCreate), func() *pluginsdk.RetryError {
+		if err = pluginsdk.Retry(d.Timeout(pluginsdk.TimeoutCreate), func() *pluginsdk.RetryError {
 			time.Sleep(30 * time.Second)
 			ruleName := fmt.Sprintf("Failure Anomalies - %s", id.ComponentName)
 			ruleId := smartdetectoralertrules.NewSmartDetectorAlertRuleID(id.SubscriptionId, id.ResourceGroupName, ruleName)
@@ -321,8 +321,7 @@ func resourceApplicationInsightsCreate(d *pluginsdk.ResourceData, meta interface
 			}
 
 			return nil
-		})
-		if err != nil {
+		}); err != nil {
 			return err
 		}
 	}

--- a/internal/services/applicationinsights/application_insights_workbook_template_resource.go
+++ b/internal/services/applicationinsights/application_insights_workbook_template_resource.go
@@ -265,8 +265,7 @@ func (r ApplicationInsightsWorkbookTemplateResource) Update() sdk.ResourceFunc {
 
 			if metadata.ResourceData.HasChange("template_data") {
 				var templateDataValue interface{}
-				err := json.Unmarshal([]byte(model.TemplateData), &templateDataValue)
-				if err != nil {
+				if err := json.Unmarshal([]byte(model.TemplateData), &templateDataValue); err != nil {
 					return err
 				}
 

--- a/internal/services/appservice/function_app_function_resource.go
+++ b/internal/services/appservice/function_app_function_resource.go
@@ -217,8 +217,7 @@ func (r FunctionAppFunctionResource) Create() sdk.ResourceFunc {
 			}
 
 			var confJSON interface{}
-			err = json.Unmarshal([]byte(appFunction.ConfigJSON), &confJSON)
-			if err != nil {
+			if err = json.Unmarshal([]byte(appFunction.ConfigJSON), &confJSON); err != nil {
 				return fmt.Errorf("error preparing config data to send: %+v", err)
 			}
 
@@ -416,8 +415,7 @@ func (r FunctionAppFunctionResource) Update() sdk.ResourceFunc {
 
 			if metadata.ResourceData.HasChange("config_json") {
 				var confJSON interface{}
-				err = json.Unmarshal([]byte(appFunction.ConfigJSON), &confJSON)
-				if err != nil {
+				if err = json.Unmarshal([]byte(appFunction.ConfigJSON), &confJSON); err != nil {
 					return fmt.Errorf("error preparing config data to send: %+v", err)
 				}
 				model.Properties.Config = pointer.To(confJSON)

--- a/internal/services/appservice/helpers/credentials_reader.go
+++ b/internal/services/appservice/helpers/credentials_reader.go
@@ -31,8 +31,7 @@ func ListPublishingCredentials(ctx context.Context, client *webapps.WebAppsClien
 	}
 
 	if siteCredentials.HttpResponse != nil {
-		err = UnmarshalCredentialsResponse(siteCredentials.HttpResponse.Body, userModel)
-		if err != nil {
+		if err = UnmarshalCredentialsResponse(siteCredentials.HttpResponse.Body, userModel); err != nil {
 			return nil, fmt.Errorf("could not decode Publishing Credential information for %s: %+v", id, err)
 		}
 	}
@@ -57,8 +56,7 @@ func ListPublishingCredentialsSlot(ctx context.Context, client *webapps.WebAppsC
 	}
 
 	if siteCredentials.HttpResponse != nil {
-		err = UnmarshalCredentialsResponse(siteCredentials.HttpResponse.Body, userModel)
-		if err != nil {
+		if err = UnmarshalCredentialsResponse(siteCredentials.HttpResponse.Body, userModel); err != nil {
 			return nil, fmt.Errorf("could not decode Publishing Credential information for %s: %+v", id, err)
 		}
 	}

--- a/internal/services/appservice/helpers/publish_app.go
+++ b/internal/services/appservice/helpers/publish_app.go
@@ -187,8 +187,7 @@ func checkZipDeploymentStatusRefresh(r *http.Request) pluginsdk.StateRefreshFunc
 		}
 
 		body := make(map[string]interface{})
-		err = json.Unmarshal(respBody, &body)
-		if err != nil {
+		if err = json.Unmarshal(respBody, &body); err != nil {
 			return nil, "", fmt.Errorf("could not parse status response for Zip Deploy")
 		}
 

--- a/internal/services/appservice/windows_web_app_data_source.go
+++ b/internal/services/appservice/windows_web_app_data_source.go
@@ -393,8 +393,7 @@ func (d WindowsWebAppDataSource) Read() sdk.ResourceFunc {
 				}
 
 				siteConfig := helpers.SiteConfigWindows{}
-				err = siteConfig.Flatten(webAppSiteConfig.Model.Properties, currentStack)
-				if err != nil {
+				if err = siteConfig.Flatten(webAppSiteConfig.Model.Properties, currentStack); err != nil {
 					return err
 				}
 

--- a/internal/services/authorization/role_definition_data_source.go
+++ b/internal/services/authorization/role_definition_data_source.go
@@ -175,7 +175,7 @@ func (a RoleDefinitionDataSource) Read() sdk.ResourceFunc {
 				if !ok {
 					return fmt.Errorf("internal error: context had no deadline")
 				}
-				err := pluginsdk.Retry(time.Until(deadline), func() *pluginsdk.RetryError {
+				if err := pluginsdk.Retry(time.Until(deadline), func() *pluginsdk.RetryError {
 					roleDefinitions, err := client.List(ctx, commonids.NewScopeID(config.Scope), roledefinitions.ListOperationOptions{
 						Filter: pointer.To(fmt.Sprintf("roleName eq '%s'", config.Name)),
 					})
@@ -196,8 +196,7 @@ func (a RoleDefinitionDataSource) Read() sdk.ResourceFunc {
 					id = roledefinitions.NewScopedRoleDefinitionID(config.Scope, defId)
 
 					return nil
-				})
-				if err != nil {
+				}); err != nil {
 					return err
 				}
 			} else {

--- a/internal/services/batch/batch_pool.go
+++ b/internal/services/batch/batch_pool.go
@@ -842,15 +842,13 @@ func expandBatchPoolExtension(ref map[string]interface{}) (*pool.VmExtension, er
 	}
 
 	if settings, ok := ref["settings_json"]; ok {
-		err := json.Unmarshal([]byte(settings.(string)), &result.Settings)
-		if err != nil {
+		if err := json.Unmarshal([]byte(settings.(string)), &result.Settings); err != nil {
 			return nil, fmt.Errorf("unmarshaling `settings_json`: %+v", err)
 		}
 	}
 
 	if protectedSettings, ok := ref["protected_settings"]; ok {
-		err := json.Unmarshal([]byte(protectedSettings.(string)), &result.ProtectedSettings)
-		if err != nil {
+		if err := json.Unmarshal([]byte(protectedSettings.(string)), &result.ProtectedSettings); err != nil {
 			return nil, fmt.Errorf("unmarshaling `protected_settings`: %+v", err)
 		}
 	}

--- a/internal/services/cdn/cdn_frontdoor_firewall_policy_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_firewall_policy_resource.go
@@ -875,8 +875,7 @@ func resourceCdnFrontDoorFirewallPolicyUpdate(d *pluginsdk.ResourceData, meta in
 
 	model.Properties = pointer.To(props)
 
-	err = client.PoliciesCreateOrUpdateThenPoll(ctx, *id, *model)
-	if err != nil {
+	if err = client.PoliciesCreateOrUpdateThenPoll(ctx, *id, *model); err != nil {
 		return fmt.Errorf("updating %s: %+v", *id, err)
 	}
 
@@ -966,8 +965,7 @@ func resourceCdnFrontDoorFirewallPolicyDelete(d *pluginsdk.ResourceData, meta in
 		return err
 	}
 
-	err = client.PoliciesDeleteThenPoll(ctx, *id)
-	if err != nil {
+	if err = client.PoliciesDeleteThenPoll(ctx, *id); err != nil {
 		return fmt.Errorf("deleting %s: %+v", *id, err)
 	}
 

--- a/internal/services/cdn/cdn_frontdoor_profile_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_profile_resource.go
@@ -256,8 +256,7 @@ func resourceCdnFrontDoorProfileUpdate(d *pluginsdk.ResourceData, meta interface
 		props.Identity = i
 	}
 
-	err = client.UpdateThenPoll(ctx, pointer.From(id), props)
-	if err != nil {
+	if err = client.UpdateThenPoll(ctx, pointer.From(id), props); err != nil {
 		return fmt.Errorf("updating %s: %+v", *id, err)
 	}
 

--- a/internal/services/cdn/cdn_frontdoor_rule_set_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_rule_set_resource.go
@@ -146,8 +146,7 @@ func resourceCdnFrontDoorRuleSetDelete(d *pluginsdk.ResourceData, meta interface
 		return err
 	}
 
-	err = client.DeleteThenPoll(ctx, *id)
-	if err != nil {
+	if err = client.DeleteThenPoll(ctx, *id); err != nil {
 		return fmt.Errorf("deleting %s: %+v", *id, err)
 	}
 

--- a/internal/services/cdn/cdn_frontdoor_security_policy_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_security_policy_resource.go
@@ -289,8 +289,7 @@ func resourceCdnFrontdoorSecurityPolicyUpdate(d *pluginsdk.ResourceData, meta in
 	}
 
 	// Using 'Create' for update because it is a PUT operation
-	err = client.CreateThenPoll(ctx, id, props)
-	if err != nil {
+	if err = client.CreateThenPoll(ctx, id, props); err != nil {
 		return fmt.Errorf("updating %s: %+v", id, err)
 	}
 
@@ -307,8 +306,7 @@ func resourceCdnFrontdoorSecurityPolicyDelete(d *pluginsdk.ResourceData, meta in
 		return err
 	}
 
-	err = client.DeleteThenPoll(ctx, pointer.From(id))
-	if err != nil {
+	if err = client.DeleteThenPoll(ctx, pointer.From(id)); err != nil {
 		return fmt.Errorf("deleting %s: %+v", pointer.From(id), err)
 	}
 

--- a/internal/services/cdn/custompollers/cdn_frontdoor_profile_delete_poller.go
+++ b/internal/services/cdn/custompollers/cdn_frontdoor_profile_delete_poller.go
@@ -28,8 +28,7 @@ func NewFrontDoorProfileDeletePoller(client *profiles.ProfilesClient, id profile
 }
 
 func (p frontDoorProfileDeletePoller) Poll(ctx context.Context) (*pollers.PollResult, error) {
-	err := p.client.DeleteThenPoll(ctx, p.id)
-	if err != nil {
+	if err := p.client.DeleteThenPoll(ctx, p.id); err != nil {
 		msg := strings.ToLower(err.Error())
 		if strings.Contains(msg, "another operation is in progress") || strings.Contains(msg, "operation is in progress") {
 			return &pollers.PollResult{

--- a/internal/services/compute/helpers.go
+++ b/internal/services/compute/helpers.go
@@ -195,8 +195,7 @@ func resourceManagedDiskUpdateWithVmShutDown(ctx context.Context, clients *clien
 	}
 
 	// Update Disk
-	err = diskClient.UpdateThenPoll(ctx, *id, diskUpdate)
-	if err != nil {
+	if err = diskClient.UpdateThenPoll(ctx, *id, diskUpdate); err != nil {
 		return fmt.Errorf("updating %s: %+v", id, err)
 	}
 

--- a/internal/services/compute/linux_virtual_machine_resource.go
+++ b/internal/services/compute/linux_virtual_machine_resource.go
@@ -1678,8 +1678,7 @@ func resourceLinuxVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interface
 			},
 		}
 
-		err := disksClient.UpdateThenPoll(ctx, id, update)
-		if err != nil {
+		if err := disksClient.UpdateThenPoll(ctx, id, update); err != nil {
 			return fmt.Errorf("resizing OS Disk %q for Linux Virtual Machine %q (Resource Group %q): %+v", diskName, id.DiskName, id.ResourceGroupName, err)
 		}
 
@@ -1708,8 +1707,7 @@ func resourceLinuxVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interface
 				},
 			}
 
-			err = disksClient.UpdateThenPoll(ctx, id, update)
-			if err != nil {
+			if err = disksClient.UpdateThenPoll(ctx, id, update); err != nil {
 				return fmt.Errorf("updating encryption settings of OS Disk %q for Linux Virtual Machine %q (Resource Group %q): %+v", diskName, id.DiskName, id.ResourceGroupName, err)
 			}
 		} else {

--- a/internal/services/compute/managed_disk_resource.go
+++ b/internal/services/compute/managed_disk_resource.go
@@ -821,13 +821,11 @@ func resourceManagedDiskUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 		locks.ByName(virtualMachineId.VirtualMachineName, VirtualMachineResourceName)
 		defer locks.UnlockByName(virtualMachineId.VirtualMachineName, VirtualMachineResourceName)
 
-		err = resourceManagedDiskUpdateWithVmShutDown(ctx, meta.(*clients.Client), id, virtualMachineId, diskUpdate, shouldDetach)
-		if err != nil {
+		if err = resourceManagedDiskUpdateWithVmShutDown(ctx, meta.(*clients.Client), id, virtualMachineId, diskUpdate, shouldDetach); err != nil {
 			return err
 		}
 	} else { // otherwise, just update it
-		err := client.UpdateThenPoll(ctx, *id, diskUpdate)
-		if err != nil {
+		if err := client.UpdateThenPoll(ctx, *id, diskUpdate); err != nil {
 			return fmt.Errorf("expanding managed disk %q (Resource Group %q): %+v", name, resourceGroup, err)
 		}
 	}
@@ -960,8 +958,7 @@ func resourceManagedDiskDelete(d *pluginsdk.ResourceData, meta interface{}) erro
 		return err
 	}
 
-	err = client.DeleteThenPoll(ctx, *id)
-	if err != nil {
+	if err = client.DeleteThenPoll(ctx, *id); err != nil {
 		return fmt.Errorf("deleting Managed Disk %q (Resource Group %q): %+v", id.DiskName, id.ResourceGroupName, err)
 	}
 

--- a/internal/services/compute/managed_disk_sas_token_resource.go
+++ b/internal/services/compute/managed_disk_sas_token_resource.go
@@ -183,8 +183,7 @@ func resourceManagedDiskSasTokenDelete(d *pluginsdk.ResourceData, meta interface
 		return err
 	}
 
-	err = client.RevokeAccessThenPoll(ctx, *id)
-	if err != nil {
+	if err = client.RevokeAccessThenPoll(ctx, *id); err != nil {
 		return fmt.Errorf("revoking access to %s: %+v", *id, err)
 	}
 

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set.go
@@ -1484,8 +1484,7 @@ func expandOrchestratedVirtualMachineScaleSetExtensions(input []interface{}) (ex
 
 		if val, ok := extensionRaw["settings"]; ok && val.(string) != "" {
 			var result interface{}
-			err := json.Unmarshal([]byte(val.(string)), &result)
-			if err != nil {
+			if err := json.Unmarshal([]byte(val.(string)), &result); err != nil {
 				return nil, false, fmt.Errorf("unmarshaling `settings`: %+v", err)
 			}
 			extensionProps.Settings = pointer.To(result)
@@ -1504,8 +1503,7 @@ func expandOrchestratedVirtualMachineScaleSetExtensions(input []interface{}) (ex
 			}
 
 			var result interface{}
-			err := json.Unmarshal([]byte(val.(string)), &result)
-			if err != nil {
+			if err := json.Unmarshal([]byte(val.(string)), &result); err != nil {
 				return nil, false, fmt.Errorf("unmarshaling `protected_settings`: %+v", err)
 			}
 			extensionProps.ProtectedSettings = pointer.To(result)

--- a/internal/services/compute/shared_image_version_resource.go
+++ b/internal/services/compute/shared_image_version_resource.go
@@ -288,7 +288,7 @@ func resourceSharedImageVersionCreate(d *pluginsdk.ResourceData, meta interface{
 
 	readCtx, cancelCtx := context.WithTimeout(ctx, 5*time.Minute)
 	defer cancelCtx()
-	err = retry.RetryContext(readCtx, 5*time.Second, func() *retry.RetryError {
+	if err = retry.RetryContext(readCtx, 5*time.Second, func() *retry.RetryError {
 		read, err := client.Get(ctx, id, galleryimageversions.DefaultGetOperationOptions())
 		if err != nil {
 			if response.WasNotFound(read.HttpResponse) {
@@ -300,8 +300,7 @@ func resourceSharedImageVersionCreate(d *pluginsdk.ResourceData, meta interface{
 			return retry.RetryableError(fmt.Errorf("waiting for `model` to become available for %s", id))
 		}
 		return nil
-	})
-	if err != nil {
+	}); err != nil {
 		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 

--- a/internal/services/compute/virtual_machine_data_source.go
+++ b/internal/services/compute/virtual_machine_data_source.go
@@ -121,20 +121,16 @@ func dataSourceVirtualMachineRead(d *pluginsdk.ResourceData, meta interface{}) e
 				}
 			}
 			connectionInfo := retrieveConnectionInformation(ctx, networkInterfacesClient, publicIPAddressesClient, props)
-			err = d.Set("private_ip_address", connectionInfo.primaryPrivateAddress)
-			if err != nil {
+			if err = d.Set("private_ip_address", connectionInfo.primaryPrivateAddress); err != nil {
 				return err
 			}
-			err = d.Set("private_ip_addresses", connectionInfo.privateAddresses)
-			if err != nil {
+			if err = d.Set("private_ip_addresses", connectionInfo.privateAddresses); err != nil {
 				return err
 			}
-			err = d.Set("public_ip_address", connectionInfo.primaryPublicAddress)
-			if err != nil {
+			if err = d.Set("public_ip_address", connectionInfo.primaryPublicAddress); err != nil {
 				return err
 			}
-			err = d.Set("public_ip_addresses", connectionInfo.publicAddresses)
-			if err != nil {
+			if err = d.Set("public_ip_addresses", connectionInfo.publicAddresses); err != nil {
 				return err
 			}
 		}

--- a/internal/services/compute/virtual_machine_extension_resource.go
+++ b/internal/services/compute/virtual_machine_extension_resource.go
@@ -194,8 +194,7 @@ func resourceVirtualMachineExtensionsCreateUpdate(d *pluginsdk.ResourceData, met
 
 	if settingsString := d.Get("settings").(string); settingsString != "" {
 		var result interface{}
-		err := json.Unmarshal([]byte(settingsString), &result)
-		if err != nil {
+		if err := json.Unmarshal([]byte(settingsString), &result); err != nil {
 			return fmt.Errorf("unmarshaling `settings`: %+v", err)
 		}
 		extension.Properties.Settings = pointer.To(result)
@@ -203,8 +202,7 @@ func resourceVirtualMachineExtensionsCreateUpdate(d *pluginsdk.ResourceData, met
 
 	if protectedSettingsString := d.Get("protected_settings").(string); protectedSettingsString != "" {
 		var result interface{}
-		err := json.Unmarshal([]byte(protectedSettingsString), &result)
-		if err != nil {
+		if err := json.Unmarshal([]byte(protectedSettingsString), &result); err != nil {
 			return fmt.Errorf("unmarshaling `protected_settings`: %+v", err)
 		}
 		extension.Properties.ProtectedSettings = pointer.To(result)

--- a/internal/services/compute/virtual_machine_implicit_data_disk_from_source_resource.go
+++ b/internal/services/compute/virtual_machine_implicit_data_disk_from_source_resource.go
@@ -213,8 +213,7 @@ func (r VirtualMachineImplicitDataDiskFromSourceResource) Create() sdk.ResourceF
 					model.Resources = nil
 
 					// TODO: implement `CallbackThenPoll`, requires migrating to an ID that implements `resourceids.ResourceId`
-					err = client.CreateOrUpdateThenPoll(ctx, *virtualMachineId, *model, virtualmachines.DefaultCreateOrUpdateOperationOptions())
-					if err != nil {
+					if err = client.CreateOrUpdateThenPoll(ctx, *virtualMachineId, *model, virtualmachines.DefaultCreateOrUpdateOperationOptions()); err != nil {
 						return fmt.Errorf("creating %s: %+v", id, err)
 					}
 				}
@@ -331,8 +330,7 @@ func (r VirtualMachineImplicitDataDiskFromSourceResource) Delete() sdk.ResourceF
 						// fixes #1600
 						model.Resources = nil
 
-						err = client.CreateOrUpdateThenPoll(ctx, virtualMachineId, *model, virtualmachines.DefaultCreateOrUpdateOperationOptions())
-						if err != nil {
+						if err = client.CreateOrUpdateThenPoll(ctx, virtualMachineId, *model, virtualmachines.DefaultCreateOrUpdateOperationOptions()); err != nil {
 							return fmt.Errorf("deleting %s: %+v", id, err)
 						}
 
@@ -345,8 +343,7 @@ func (r VirtualMachineImplicitDataDiskFromSourceResource) Delete() sdk.ResourceF
 								return err
 							}
 
-							err = diskClient.DeleteThenPoll(ctx, *diskId)
-							if err != nil {
+							if err = diskClient.DeleteThenPoll(ctx, *diskId); err != nil {
 								return fmt.Errorf("deleting Managed Disk %s: %+v", *diskId, err)
 							}
 						}
@@ -427,16 +424,14 @@ func (r VirtualMachineImplicitDataDiskFromSourceResource) Update() sdk.ResourceF
 								// fixes #1600
 								model.Resources = nil
 
-								err = client.CreateOrUpdateThenPoll(ctx, virtualMachineId, *model, virtualmachines.DefaultCreateOrUpdateOperationOptions())
-								if err != nil {
+								if err = client.CreateOrUpdateThenPoll(ctx, virtualMachineId, *model, virtualmachines.DefaultCreateOrUpdateOperationOptions()); err != nil {
 									return fmt.Errorf("updating %s: %+v", id, err)
 								}
 							}
 
 							// VirtualMachineClient does not support expanding implicit data disk size, need to use DisksClient
 							if metadata.ResourceData.HasChange("disk_size_gb") {
-								err = resizeImplicitDataDisk(ctx, metadata, id)
-								if err != nil {
+								if err = resizeImplicitDataDisk(ctx, metadata, id); err != nil {
 									return err
 								}
 							}
@@ -542,13 +537,11 @@ func resizeImplicitDataDisk(ctx context.Context, metadata sdk.ResourceMetaData, 
 			return err
 		}
 
-		err = resourceManagedDiskUpdateWithVmShutDown(ctx, metadata.Client, pointer.To(commonids.NewManagedDiskID(id.SubscriptionId, id.ResourceGroup, id.Name)), virtualMachineId, diskUpdate, shouldDetach)
-		if err != nil {
+		if err = resourceManagedDiskUpdateWithVmShutDown(ctx, metadata.Client, pointer.To(commonids.NewManagedDiskID(id.SubscriptionId, id.ResourceGroup, id.Name)), virtualMachineId, diskUpdate, shouldDetach); err != nil {
 			return err
 		}
 	} else { // otherwise, just update it
-		err := diskClient.UpdateThenPoll(ctx, managedDiskId, diskUpdate)
-		if err != nil {
+		if err := diskClient.UpdateThenPoll(ctx, managedDiskId, diskUpdate); err != nil {
 			return fmt.Errorf("updating %s: %+v", managedDiskId, err)
 		}
 	}

--- a/internal/services/compute/virtual_machine_implicit_data_disk_from_source_resource_test.go
+++ b/internal/services/compute/virtual_machine_implicit_data_disk_from_source_resource_test.go
@@ -436,8 +436,7 @@ func (VirtualMachineImplicitDataDiskFromSourceResource) Destroy(ctx context.Cont
 					return nil, err
 				}
 
-				err = diskClient.DeleteThenPoll(ctx, *diskId)
-				if err != nil {
+				if err = diskClient.DeleteThenPoll(ctx, *diskId); err != nil {
 					return nil, fmt.Errorf("deleting Managed Disk %s: %+v", *diskId, err)
 				}
 			}

--- a/internal/services/compute/virtual_machine_scale_set.go
+++ b/internal/services/compute/virtual_machine_scale_set.go
@@ -2012,8 +2012,7 @@ func expandVirtualMachineScaleSetExtensions(input []interface{}) (extensionProfi
 
 		if val, ok := extensionRaw["settings"]; ok && val.(string) != "" {
 			var result interface{}
-			err := json.Unmarshal([]byte(val.(string)), &result)
-			if err != nil {
+			if err := json.Unmarshal([]byte(val.(string)), &result); err != nil {
 				return nil, false, fmt.Errorf("unmarshaling `settings`: %+v", err)
 			}
 			extensionProps.Settings = pointer.To(result)
@@ -2028,8 +2027,7 @@ func expandVirtualMachineScaleSetExtensions(input []interface{}) (extensionProfi
 			}
 
 			var result interface{}
-			err := json.Unmarshal([]byte(val.(string)), &result)
-			if err != nil {
+			if err := json.Unmarshal([]byte(val.(string)), &result); err != nil {
 				return nil, false, fmt.Errorf("unmarshaling `protected_settings`: %+v", err)
 			}
 			extensionProps.ProtectedSettings = pointer.To(result)

--- a/internal/services/compute/virtual_machine_scale_set_extension_resource.go
+++ b/internal/services/compute/virtual_machine_scale_set_extension_resource.go
@@ -159,8 +159,7 @@ func resourceVirtualMachineScaleSetExtensionCreate(d *pluginsdk.ResourceData, me
 	var settings *interface{}
 	if settingsString := d.Get("settings").(string); settingsString != "" {
 		var result interface{}
-		err := json.Unmarshal([]byte(settingsString), &result)
-		if err != nil {
+		if err := json.Unmarshal([]byte(settingsString), &result); err != nil {
 			return fmt.Errorf("unmarshaling `settings`: %+v", err)
 		}
 		settings = pointer.To(result)
@@ -189,8 +188,7 @@ func resourceVirtualMachineScaleSetExtensionCreate(d *pluginsdk.ResourceData, me
 
 	if protectedSettingsString := d.Get("protected_settings").(string); protectedSettingsString != "" {
 		var result interface{}
-		err := json.Unmarshal([]byte(protectedSettingsString), &result)
-		if err != nil {
+		if err := json.Unmarshal([]byte(protectedSettingsString), &result); err != nil {
 			return fmt.Errorf("unmarshaling `protected_settings`: %+v", err)
 		}
 		props.Properties.ProtectedSettings = pointer.To(result)
@@ -233,8 +231,7 @@ func resourceVirtualMachineScaleSetExtensionUpdate(d *pluginsdk.ResourceData, me
 		var protectedSettings interface{}
 		if protectedSettingsString := d.Get("protected_settings").(string); protectedSettingsString != "" {
 			var result interface{}
-			err := json.Unmarshal([]byte(protectedSettingsString), &result)
-			if err != nil {
+			if err := json.Unmarshal([]byte(protectedSettingsString), &result); err != nil {
 				return fmt.Errorf("unmarshaling `protected_settings`: %+v", err)
 			}
 
@@ -260,8 +257,7 @@ func resourceVirtualMachineScaleSetExtensionUpdate(d *pluginsdk.ResourceData, me
 		var settings interface{}
 		if settingsString := d.Get("settings").(string); settingsString != "" {
 			var result interface{}
-			err := json.Unmarshal([]byte(settingsString), &result)
-			if err != nil {
+			if err := json.Unmarshal([]byte(settingsString), &result); err != nil {
 				return fmt.Errorf("unmarshaling `settings`: %+v", err)
 			}
 			settings = result

--- a/internal/services/compute/windows_virtual_machine_resource.go
+++ b/internal/services/compute/windows_virtual_machine_resource.go
@@ -1709,8 +1709,7 @@ func resourceWindowsVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interfa
 			},
 		}
 
-		err := disksClient.UpdateThenPoll(ctx, id, update)
-		if err != nil {
+		if err := disksClient.UpdateThenPoll(ctx, id, update); err != nil {
 			return fmt.Errorf("resizing OS Disk %q for Windows Virtual Machine %q (Resource Group %q): %+v", diskName, id.DiskName, id.ResourceGroupName, err)
 		}
 
@@ -1739,8 +1738,7 @@ func resourceWindowsVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interfa
 				},
 			}
 
-			err = disksClient.UpdateThenPoll(ctx, id, update)
-			if err != nil {
+			if err = disksClient.UpdateThenPoll(ctx, id, update); err != nil {
 				return fmt.Errorf("updating encryption settings of OS Disk %q for Windows Virtual Machine %q (Resource Group %q): %+v", diskName, id.DiskName, id.ResourceGroupName, err)
 			}
 		} else {

--- a/internal/services/containers/container_registry_resource.go
+++ b/internal/services/containers/container_registry_resource.go
@@ -442,8 +442,7 @@ func resourceContainerRegistryCreate(d *pluginsdk.ResourceData, meta interface{}
 	newGeoReplicationLocations = expandReplications(d.Get("georeplications").([]interface{}))
 	// geo replications have been specified
 	if len(newGeoReplicationLocations) > 0 {
-		err = applyGeoReplicationLocations(ctx, meta, id, oldGeoReplicationLocations, newGeoReplicationLocations)
-		if err != nil {
+		if err = applyGeoReplicationLocations(ctx, meta, id, oldGeoReplicationLocations, newGeoReplicationLocations); err != nil {
 			return fmt.Errorf("applying geo replications for %s: %+v", id, err)
 		}
 	}
@@ -605,8 +604,7 @@ func resourceContainerRegistryUpdate(d *pluginsdk.ResourceData, meta interface{}
 	}
 
 	if hasGeoReplicationsChanges {
-		err := applyGeoReplicationLocations(ctx, meta, *id, expandReplications(oldReplications), expandReplications(newReplications))
-		if err != nil {
+		if err := applyGeoReplicationLocations(ctx, meta, *id, expandReplications(oldReplications), expandReplications(newReplications)); err != nil {
 			return fmt.Errorf("applying geo replications for %s: %+v", id, err)
 		}
 	}

--- a/internal/services/containers/container_registry_task_schedule_run_now_resource.go
+++ b/internal/services/containers/container_registry_task_schedule_run_now_resource.go
@@ -98,10 +98,9 @@ func (r ContainerRegistryTaskScheduleResource) Create() sdk.ResourceFunc {
 				// If the SDK didn't parse the response body, try parsing it on our side.
 				if scheduleResp.HttpResponse != nil {
 					scheduleRunModel := registries.Run{}
-					err = json.
+					if err = json.
 						NewDecoder(scheduleResp.HttpResponse.Body).
-						Decode(&scheduleRunModel)
-					if err != nil {
+						Decode(&scheduleRunModel); err != nil {
 						return fmt.Errorf("can't decode ScheduleRun model, err: %w for taskID %s", err, taskId)
 					}
 

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -720,16 +720,14 @@ func resourceKubernetesClusterNodePoolCreate(d *pluginsdk.ResourceData, meta int
 	}
 	if nodeSubnetID != nil {
 		// Wait for vnet and node subnet to come back to Succeeded before releasing any locks
-		err = network.NewSubnetAndVnetPoller(subnetClient, vnetClient, nodeSubnetID, timeout).Poll(ctx)
-		if err != nil {
+		if err = network.NewSubnetAndVnetPoller(subnetClient, vnetClient, nodeSubnetID, timeout).Poll(ctx); err != nil {
 			return fmt.Errorf("waiting for provisioning state of subnet for AKS Node Pool creation %s: %+v", *nodeSubnetID, err)
 		}
 	}
 
 	if podSubnetID != nil {
 		// Wait for vnet and pod subnet to come back to Succeeded before releasing any locks
-		err = network.NewSubnetAndVnetPoller(subnetClient, vnetClient, podSubnetID, timeout).Poll(ctx)
-		if err != nil {
+		if err = network.NewSubnetAndVnetPoller(subnetClient, vnetClient, podSubnetID, timeout).Poll(ctx); err != nil {
 			return fmt.Errorf("waiting for provisioning state of the pod subnet for AKS Node Pool creation %s: %+v", *podSubnetID, err)
 		}
 	}
@@ -1039,8 +1037,7 @@ func resourceKubernetesClusterNodePoolUpdate(d *pluginsdk.ResourceData, meta int
 
 		log.Printf("[DEBUG] Cycled Node Pool..")
 	} else {
-		err = client.CreateOrUpdateThenPoll(ctx, *id, *existing.Model, agentpools.DefaultCreateOrUpdateOperationOptions())
-		if err != nil {
+		if err = client.CreateOrUpdateThenPoll(ctx, *id, *existing.Model, agentpools.DefaultCreateOrUpdateOperationOptions()); err != nil {
 			return fmt.Errorf("updating Node Pool %s: %+v", *id, err)
 		}
 	}
@@ -1243,8 +1240,7 @@ func resourceKubernetesClusterNodePoolDelete(d *pluginsdk.ResourceData, meta int
 		return err
 	}
 
-	err = client.DeleteThenPoll(ctx, *id, agentpools.DefaultDeleteOperationOptions())
-	if err != nil {
+	if err = client.DeleteThenPoll(ctx, *id, agentpools.DefaultDeleteOperationOptions()); err != nil {
 		return fmt.Errorf("deleting %s: %+v", *id, err)
 	}
 

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -1301,8 +1301,7 @@ func (KubernetesClusterNodePoolResource) scaleNodePool(nodeCount int) acceptance
 
 		nodePool.Model.Properties.Count = pointer.To(int64(nodeCount))
 
-		err = clients.Containers.AgentPoolsClient.CreateOrUpdateThenPoll(ctx, parsedAgentPoolId, *nodePool.Model, agentpools.DefaultCreateOrUpdateOperationOptions())
-		if err != nil {
+		if err = clients.Containers.AgentPoolsClient.CreateOrUpdateThenPoll(ctx, parsedAgentPoolId, *nodePool.Model, agentpools.DefaultCreateOrUpdateOperationOptions()); err != nil {
 			return fmt.Errorf("Bad: updating node pool %q: %+v", nodePoolName, err)
 		}
 

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -2037,8 +2037,7 @@ func resourceKubernetesClusterCreate(d *pluginsdk.ResourceData, meta interface{}
 		parameters.Properties.ServiceMeshProfile = serviceMeshProfile
 	}
 
-	err = client.CreateOrUpdateCallbackThenPoll(ctx, id, parameters, managedclusters.DefaultCreateOrUpdateOperationOptions(), sdk.SetIDCallback(meta, &id, d))
-	if err != nil {
+	if err = client.CreateOrUpdateCallbackThenPoll(ctx, id, parameters, managedclusters.DefaultCreateOrUpdateOperationOptions(), sdk.SetIDCallback(meta, &id, d)); err != nil {
 		return fmt.Errorf("creating %s: %+v", id, err)
 	}
 	d.SetId(id.ID())
@@ -2127,8 +2126,7 @@ func resourceKubernetesClusterUpdate(d *pluginsdk.ResourceData, meta interface{}
 			Secret:   pointer.To(clientSecret),
 		}
 
-		err = clusterClient.ResetServicePrincipalProfileThenPoll(ctx, *id, params)
-		if err != nil {
+		if err = clusterClient.ResetServicePrincipalProfileThenPoll(ctx, *id, params); err != nil {
 			return fmt.Errorf("updating Service Principal for %s: %+v", *id, err)
 		}
 
@@ -2168,8 +2166,7 @@ func resourceKubernetesClusterUpdate(d *pluginsdk.ResourceData, meta interface{}
 		props.AadProfile = azureADProfile
 		if props.AadProfile == nil || (props.AadProfile.Managed == nil || !*props.AadProfile.Managed) {
 			props.AadProfile = &managedclusters.ManagedClusterAADProfile{}
-			err = clusterClient.ResetAADProfileThenPoll(ctx, *id, *props.AadProfile)
-			if err != nil {
+			if err = clusterClient.ResetAADProfileThenPoll(ctx, *id, *props.AadProfile); err != nil {
 				return fmt.Errorf("updating Managed Kubernetes Cluster AAD Profile for %s: %+v", *id, err)
 			}
 		}
@@ -2629,8 +2626,7 @@ func resourceKubernetesClusterUpdate(d *pluginsdk.ResourceData, meta interface{}
 			existing.Model.Properties.SecurityProfile.Defender = nil
 		}
 
-		err = clusterClient.CreateOrUpdateThenPoll(ctx, *id, *existing.Model, managedclusters.DefaultCreateOrUpdateOperationOptions())
-		if err != nil {
+		if err = clusterClient.CreateOrUpdateThenPoll(ctx, *id, *existing.Model, managedclusters.DefaultCreateOrUpdateOperationOptions()); err != nil {
 			return fmt.Errorf("updating %s: %+v", *id, err)
 		}
 	}
@@ -2649,8 +2645,7 @@ func resourceKubernetesClusterUpdate(d *pluginsdk.ResourceData, meta interface{}
 		log.Printf("[DEBUG] Upgrading the version of Kubernetes to %q..", kubernetesVersion)
 		existing.Model.Properties.KubernetesVersion = pointer.To(kubernetesVersion)
 
-		err = clusterClient.CreateOrUpdateThenPoll(ctx, *id, *existing.Model, managedclusters.DefaultCreateOrUpdateOperationOptions())
-		if err != nil {
+		if err = clusterClient.CreateOrUpdateThenPoll(ctx, *id, *existing.Model, managedclusters.DefaultCreateOrUpdateOperationOptions()); err != nil {
 			return fmt.Errorf("updating Kubernetes Version for %s: %+v", *id, err)
 		}
 
@@ -3221,8 +3216,7 @@ func resourceKubernetesClusterDelete(d *pluginsdk.ResourceData, meta interface{}
 		}
 	}
 
-	err = client.DeleteThenPoll(ctx, *id, managedclusters.DefaultDeleteOperationOptions())
-	if err != nil {
+	if err = client.DeleteThenPoll(ctx, *id, managedclusters.DefaultDeleteOperationOptions()); err != nil {
 		return fmt.Errorf("deleting %s: %+v", *id, err)
 	}
 

--- a/internal/services/containers/kubernetes_cluster_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_resource_test.go
@@ -374,8 +374,7 @@ func (KubernetesClusterResource) updateDefaultNodePoolAgentCount(nodeCount int) 
 
 		nodePool.Model.Properties.Count = pointer.To(int64(nodeCount))
 
-		err = clients.Containers.AgentPoolsClient.CreateOrUpdateThenPoll(ctx, agentPoolId, *nodePool.Model, agentpools.DefaultCreateOrUpdateOperationOptions())
-		if err != nil {
+		if err = clients.Containers.AgentPoolsClient.CreateOrUpdateThenPoll(ctx, agentPoolId, *nodePool.Model, agentpools.DefaultCreateOrUpdateOperationOptions()); err != nil {
 			return fmt.Errorf("Bad: updating node pool %q: %+v", nodePoolName, err)
 		}
 

--- a/internal/services/cosmos/cosmosdb_account_resource.go
+++ b/internal/services/cosmos/cosmosdb_account_resource.go
@@ -900,8 +900,7 @@ func resourceCosmosDbAccountCreate(d *pluginsdk.ResourceData, meta interface{}) 
 		}
 	}
 
-	err = resourceCosmosDbAccountApiCreateOrUpdate(client, ctx, id, account)
-	if err != nil {
+	if err = resourceCosmosDbAccountApiCreateOrUpdate(client, ctx, id, account); err != nil {
 		return fmt.Errorf("creating %s: %+v", id, err)
 	}
 
@@ -910,8 +909,7 @@ func resourceCosmosDbAccountCreate(d *pluginsdk.ResourceData, meta interface{}) 
 	// NOTE: this is to work around the issue here: https://github.com/Azure/azure-rest-api-specs/issues/27596
 	// Once the above issue is resolved we shouldn't need this check and update anymore
 	if d.Get("create_mode").(string) == string(cosmosdb.CreateModeRestore) {
-		err = resourceCosmosDbAccountApiCreateOrUpdate(client, ctx, id, account)
-		if err != nil {
+		if err = resourceCosmosDbAccountApiCreateOrUpdate(client, ctx, id, account); err != nil {
 			return fmt.Errorf("updating %s: %+v", id, err)
 		}
 	}
@@ -1148,8 +1146,7 @@ func resourceCosmosDbAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 		account.Properties.Locations = configLocations
 
 		// Update the database locations...
-		err = resourceCosmosDbAccountApiCreateOrUpdate(client, ctx, *id, account)
-		if err != nil {
+		if err = resourceCosmosDbAccountApiCreateOrUpdate(client, ctx, *id, account); err != nil {
 			return fmt.Errorf("updating %q `locations`: %+v", id, err)
 		}
 	}
@@ -1171,8 +1168,7 @@ func resourceCosmosDbAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 		}
 
 		// Update the database 'Identity' to 'None'...
-		err = resourceCosmosDbAccountApiUpdate(client, ctx, *id, identityVal)
-		if err != nil {
+		if err = resourceCosmosDbAccountApiUpdate(client, ctx, *id, identityVal); err != nil {
 			return fmt.Errorf("updating 'identity' %q: %+v", id, err)
 		}
 
@@ -1189,8 +1185,7 @@ func resourceCosmosDbAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 			}
 
 			// Update the database...
-			err = resourceCosmosDbAccountApiUpdate(client, ctx, *id, identityVal)
-			if err != nil {
+			if err = resourceCosmosDbAccountApiUpdate(client, ctx, *id, identityVal); err != nil {
 				return fmt.Errorf("updating `identity` for %s: %+v", id, err)
 			}
 		}
@@ -1213,8 +1208,7 @@ func resourceCosmosDbAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 		}
 
 		// Update the database...
-		err = resourceCosmosDbAccountApiUpdate(client, ctx, *id, defaultIdentity)
-		if err != nil {
+		if err = resourceCosmosDbAccountApiUpdate(client, ctx, *id, defaultIdentity); err != nil {
 			return fmt.Errorf("updating `default_identity_type` for %s: %+v", id, err)
 		}
 	}

--- a/internal/services/cosmos/cosmosdb_cassandra_cluster_resource.go
+++ b/internal/services/cosmos/cosmosdb_cassandra_cluster_resource.go
@@ -196,8 +196,7 @@ func resourceCassandraClusterCreate(d *pluginsdk.ResourceData, meta interface{})
 		body.Properties.ExternalSeedNodes = expandCassandraClusterExternalSeedNode(v.([]interface{}))
 	}
 
-	err = client.CassandraClustersCreateUpdateCallbackThenPoll(ctx, id, body, sdk.SetIDCallback(meta, &id, d))
-	if err != nil {
+	if err = client.CassandraClustersCreateUpdateCallbackThenPoll(ctx, id, body, sdk.SetIDCallback(meta, &id, d)); err != nil {
 		return fmt.Errorf("creating %q: %+v", id, err)
 	}
 
@@ -314,8 +313,7 @@ func resourceCassandraClusterUpdate(d *pluginsdk.ResourceData, meta interface{})
 	}
 
 	// Though there is update method but Service API complains it isn't implemented
-	err = client.CassandraClustersCreateUpdateThenPoll(ctx, id, body)
-	if err != nil {
+	if err = client.CassandraClustersCreateUpdateThenPoll(ctx, id, body); err != nil {
 		return fmt.Errorf("updating %q: %+v", id, err)
 	}
 
@@ -349,8 +347,7 @@ func resourceCassandraClusterDelete(d *pluginsdk.ResourceData, meta interface{})
 		return err
 	}
 
-	err = client.CassandraClustersDeleteThenPoll(ctx, *id)
-	if err != nil {
+	if err = client.CassandraClustersDeleteThenPoll(ctx, *id); err != nil {
 		return fmt.Errorf("deleting %q: %+v", id, err)
 	}
 

--- a/internal/services/cosmos/cosmosdb_gremlin_database_resource.go
+++ b/internal/services/cosmos/cosmosdb_gremlin_database_resource.go
@@ -131,8 +131,7 @@ func resourceCosmosGremlinDatabaseUpdate(d *pluginsdk.ResourceData, meta interfa
 		return err
 	}
 
-	err = common.CheckForChangeFromAutoscaleAndManualThroughput(d)
-	if err != nil {
+	if err = common.CheckForChangeFromAutoscaleAndManualThroughput(d); err != nil {
 		return fmt.Errorf("checking `autoscale_settings` and `throughput` for %s: %w", id, err)
 	}
 
@@ -145,8 +144,7 @@ func resourceCosmosGremlinDatabaseUpdate(d *pluginsdk.ResourceData, meta interfa
 		},
 	}
 
-	err = client.GremlinResourcesCreateUpdateGremlinDatabaseThenPoll(ctx, *id, db)
-	if err != nil {
+	if err = client.GremlinResourcesCreateUpdateGremlinDatabaseThenPoll(ctx, *id, db); err != nil {
 		return fmt.Errorf("updating %q: %+v", id, err)
 	}
 
@@ -216,8 +214,7 @@ func resourceCosmosGremlinDatabaseDelete(d *pluginsdk.ResourceData, meta interfa
 		return err
 	}
 
-	err = client.GremlinResourcesDeleteGremlinDatabaseThenPoll(ctx, *id)
-	if err != nil {
+	if err = client.GremlinResourcesDeleteGremlinDatabaseThenPoll(ctx, *id); err != nil {
 		return fmt.Errorf("deleting %s: %+v", id, err)
 	}
 

--- a/internal/services/cosmos/cosmosdb_gremlin_graph_resource.go
+++ b/internal/services/cosmos/cosmosdb_gremlin_graph_resource.go
@@ -283,8 +283,7 @@ func resourceCosmosDbGremlinGraphUpdate(d *pluginsdk.ResourceData, meta interfac
 		return err
 	}
 
-	err = common.CheckForChangeFromAutoscaleAndManualThroughput(d)
-	if err != nil {
+	if err = common.CheckForChangeFromAutoscaleAndManualThroughput(d); err != nil {
 		return fmt.Errorf("checking `autoscale_settings` and `throughput` for %s: %w", id, err)
 	}
 
@@ -326,8 +325,7 @@ func resourceCosmosDbGremlinGraphUpdate(d *pluginsdk.ResourceData, meta interfac
 		db.Properties.Resource.DefaultTtl = pointer.To(int64(defaultTTL.(int)))
 	}
 
-	err = client.GremlinResourcesCreateUpdateGremlinGraphThenPoll(ctx, *id, db)
-	if err != nil {
+	if err = client.GremlinResourcesCreateUpdateGremlinGraphThenPoll(ctx, *id, db); err != nil {
 		return fmt.Errorf("updating %q: %+v", id, err)
 	}
 
@@ -443,8 +441,7 @@ func resourceCosmosDbGremlinGraphDelete(d *pluginsdk.ResourceData, meta interfac
 		return err
 	}
 
-	err = client.GremlinResourcesDeleteGremlinGraphThenPoll(ctx, *id)
-	if err != nil {
+	if err = client.GremlinResourcesDeleteGremlinGraphThenPoll(ctx, *id); err != nil {
 		return fmt.Errorf("deleting %s: %+v", id, err)
 	}
 

--- a/internal/services/cosmos/cosmosdb_sql_container_resource.go
+++ b/internal/services/cosmos/cosmosdb_sql_container_resource.go
@@ -251,8 +251,7 @@ func resourceCosmosDbSQLContainerUpdate(d *pluginsdk.ResourceData, meta interfac
 		return err
 	}
 
-	err = common.CheckForChangeFromAutoscaleAndManualThroughput(d)
-	if err != nil {
+	if err = common.CheckForChangeFromAutoscaleAndManualThroughput(d); err != nil {
 		return fmt.Errorf("checking `autoscale_settings` and `throughput` for %s: %w", id, err)
 	}
 
@@ -297,8 +296,7 @@ func resourceCosmosDbSQLContainerUpdate(d *pluginsdk.ResourceData, meta interfac
 		db.Properties.Resource.DefaultTtl = pointer.To(int64(defaultTTL.(int)))
 	}
 
-	err = client.SqlResourcesCreateUpdateSqlContainerThenPoll(ctx, *id, db)
-	if err != nil {
+	if err = client.SqlResourcesCreateUpdateSqlContainerThenPoll(ctx, *id, db); err != nil {
 		return fmt.Errorf("updating %q: %+v", id, err)
 	}
 
@@ -398,8 +396,7 @@ func resourceCosmosDbSQLContainerDelete(d *pluginsdk.ResourceData, meta interfac
 		return err
 	}
 
-	err = client.SqlResourcesDeleteSqlContainerThenPoll(ctx, *id)
-	if err != nil {
+	if err = client.SqlResourcesDeleteSqlContainerThenPoll(ctx, *id); err != nil {
 		return fmt.Errorf("deleting %s: %+v", id, err)
 	}
 

--- a/internal/services/cosmos/cosmosdb_sql_database_resource.go
+++ b/internal/services/cosmos/cosmosdb_sql_database_resource.go
@@ -129,8 +129,7 @@ func resourceCosmosDbSQLDatabaseUpdate(d *pluginsdk.ResourceData, meta interface
 		return err
 	}
 
-	err = common.CheckForChangeFromAutoscaleAndManualThroughput(d)
-	if err != nil {
+	if err = common.CheckForChangeFromAutoscaleAndManualThroughput(d); err != nil {
 		return fmt.Errorf("checking `autoscale_settings` and `throughput` for %s: %w", id, err)
 	}
 

--- a/internal/services/datafactory/data_factory_integration_runtime_azure_resource.go
+++ b/internal/services/datafactory/data_factory_integration_runtime_azure_resource.go
@@ -213,8 +213,7 @@ func resourceDataFactoryIntegrationRuntimeAzureCreate(d *pluginsdk.ResourceData,
 	if ttl := d.Get("interactive_authoring_time_to_live_in_minutes").(int); ttl != 0 {
 		// Interactive Authoring/Query can only be modified once the integration runtime is online
 		poller := pollers.NewPoller(custompollers.NewDataFactoryIntegrationRuntimeStatusPoller(client, id), time.Second*5, pollers.DefaultNumberOfDroppedConnectionsToAllow)
-		err := poller.PollUntilDone(ctx)
-		if err != nil {
+		if err := poller.PollUntilDone(ctx); err != nil {
 			return fmt.Errorf("waiting for state change of %s: %+v", id, err)
 		}
 

--- a/internal/services/dataprotection/data_protection_backup_instance_blob_storage_resource.go
+++ b/internal/services/dataprotection/data_protection_backup_instance_blob_storage_resource.go
@@ -248,8 +248,7 @@ func resourceDataProtectionBackupInstanceBlobStorageDelete(d *schema.ResourceDat
 		return err
 	}
 
-	err = client.BackupInstancesDeleteThenPoll(ctx, *id, backupinstanceresources.DefaultBackupInstancesDeleteOperationOptions())
-	if err != nil {
+	if err = client.BackupInstancesDeleteThenPoll(ctx, *id, backupinstanceresources.DefaultBackupInstancesDeleteOperationOptions()); err != nil {
 		return fmt.Errorf("deleting %s: %+v", *id, err)
 	}
 

--- a/internal/services/dataprotection/data_protection_backup_instance_data_lake_storage_resource.go
+++ b/internal/services/dataprotection/data_protection_backup_instance_data_lake_storage_resource.go
@@ -347,8 +347,7 @@ func (r DataProtectionBackupInstanceDataLakeStorageResource) Delete() sdk.Resour
 				return err
 			}
 
-			err = client.BackupInstancesDeleteThenPoll(ctx, *id, backupinstanceresources.DefaultBackupInstancesDeleteOperationOptions())
-			if err != nil {
+			if err = client.BackupInstancesDeleteThenPoll(ctx, *id, backupinstanceresources.DefaultBackupInstancesDeleteOperationOptions()); err != nil {
 				return fmt.Errorf("deleting %s: %+v", *id, err)
 			}
 

--- a/internal/services/dataprotection/data_protection_backup_instance_disk_resource.go
+++ b/internal/services/dataprotection/data_protection_backup_instance_disk_resource.go
@@ -268,8 +268,7 @@ func resourceDataProtectionBackupInstanceDiskDelete(d *schema.ResourceData, meta
 		return err
 	}
 
-	err = client.BackupInstancesDeleteThenPoll(ctx, *id, backupinstanceresources.DefaultBackupInstancesDeleteOperationOptions())
-	if err != nil {
+	if err = client.BackupInstancesDeleteThenPoll(ctx, *id, backupinstanceresources.DefaultBackupInstancesDeleteOperationOptions()); err != nil {
 		return fmt.Errorf("deleting DataProtection BackupInstance (%q): %+v", id, err)
 	}
 

--- a/internal/services/dataprotection/data_protection_backup_instance_kubernetes_cluster_resource.go
+++ b/internal/services/dataprotection/data_protection_backup_instance_kubernetes_cluster_resource.go
@@ -342,8 +342,7 @@ func (r DataProtectionBackupInstanceKubernatesClusterResource) Delete() sdk.Reso
 				return err
 			}
 
-			err = client.BackupInstancesDeleteThenPoll(ctx, *id, backupinstanceresources.DefaultBackupInstancesDeleteOperationOptions())
-			if err != nil {
+			if err = client.BackupInstancesDeleteThenPoll(ctx, *id, backupinstanceresources.DefaultBackupInstancesDeleteOperationOptions()); err != nil {
 				return fmt.Errorf("deleting %s: %+v", *id, err)
 			}
 

--- a/internal/services/dataprotection/data_protection_backup_instance_mysql_flexible_server_resource.go
+++ b/internal/services/dataprotection/data_protection_backup_instance_mysql_flexible_server_resource.go
@@ -300,8 +300,7 @@ func (r DataProtectionBackupInstanceMySQLFlexibleServerResource) Delete() sdk.Re
 				return err
 			}
 
-			err = client.BackupInstancesDeleteThenPoll(ctx, *id, backupinstanceresources.DefaultBackupInstancesDeleteOperationOptions())
-			if err != nil {
+			if err = client.BackupInstancesDeleteThenPoll(ctx, *id, backupinstanceresources.DefaultBackupInstancesDeleteOperationOptions()); err != nil {
 				return fmt.Errorf("deleting %s: %+v", *id, err)
 			}
 

--- a/internal/services/dataprotection/data_protection_backup_instance_postgresql_flexible_server_resource.go
+++ b/internal/services/dataprotection/data_protection_backup_instance_postgresql_flexible_server_resource.go
@@ -313,8 +313,7 @@ func (r DataProtectionBackupInstancePostgreSQLFlexibleServerResource) Delete() s
 				return err
 			}
 
-			err = client.BackupInstancesDeleteThenPoll(ctx, *id, backupinstanceresources.DefaultBackupInstancesDeleteOperationOptions())
-			if err != nil {
+			if err = client.BackupInstancesDeleteThenPoll(ctx, *id, backupinstanceresources.DefaultBackupInstancesDeleteOperationOptions()); err != nil {
 				return fmt.Errorf("deleting %s: %+v", *id, err)
 			}
 

--- a/internal/services/dataprotection/data_protection_backup_vault_customer_managed_key_resource.go
+++ b/internal/services/dataprotection/data_protection_backup_vault_customer_managed_key_resource.go
@@ -125,8 +125,7 @@ func (r DataProtectionBackupVaultCustomerManagedKeyResource) Create() sdk.Resour
 				IdentityType: pointer.To(backupvaultresources.IdentityTypeSystemAssigned),
 			}
 
-			err = client.BackupVaultsCreateOrUpdateCallbackThenPoll(ctx, *id, *payload, backupvaultresources.DefaultBackupVaultsCreateOrUpdateOperationOptions(), metadata.SetIDAndIdentityCallback(id))
-			if err != nil {
+			if err = client.BackupVaultsCreateOrUpdateCallbackThenPoll(ctx, *id, *payload, backupvaultresources.DefaultBackupVaultsCreateOrUpdateOperationOptions(), metadata.SetIDAndIdentityCallback(id)); err != nil {
 				return fmt.Errorf("creating Customer Managed Key for %s: %+v", *id, err)
 			}
 
@@ -234,8 +233,7 @@ func (r DataProtectionBackupVaultCustomerManagedKeyResource) Update() sdk.Resour
 				}
 			}
 
-			err = client.BackupVaultsCreateOrUpdateThenPoll(ctx, *id, *payload, backupvaultresources.DefaultBackupVaultsCreateOrUpdateOperationOptions())
-			if err != nil {
+			if err = client.BackupVaultsCreateOrUpdateThenPoll(ctx, *id, *payload, backupvaultresources.DefaultBackupVaultsCreateOrUpdateOperationOptions()); err != nil {
 				return fmt.Errorf("updating Customer Managed Key for %s: %+v", *id, err)
 			}
 

--- a/internal/services/devtestlabs/dev_test_lab_resource.go
+++ b/internal/services/devtestlabs/dev_test_lab_resource.go
@@ -218,8 +218,7 @@ func resourceDevTestLabDelete(d *pluginsdk.ResourceData, meta interface{}) error
 		return fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	err = client.DeleteThenPoll(ctx, *id)
-	if err != nil {
+	if err = client.DeleteThenPoll(ctx, *id); err != nil {
 		return fmt.Errorf("deleting %s: %+v", *id, err)
 	}
 

--- a/internal/services/devtestlabs/dev_test_linux_virtual_machine_resource.go
+++ b/internal/services/devtestlabs/dev_test_linux_virtual_machine_resource.go
@@ -320,8 +320,7 @@ func resourceArmDevTestLinuxVirtualMachineDelete(d *pluginsdk.ResourceData, meta
 		return fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	err = client.DeleteThenPoll(ctx, *id)
-	if err != nil {
+	if err = client.DeleteThenPoll(ctx, *id); err != nil {
 		return fmt.Errorf("deleting %s: %+v", *id, err)
 	}
 

--- a/internal/services/devtestlabs/dev_test_virtual_network_resource.go
+++ b/internal/services/devtestlabs/dev_test_virtual_network_resource.go
@@ -266,8 +266,7 @@ func resourceArmDevTestVirtualNetworkUpdate(d *pluginsdk.ResourceData, meta inte
 		payload.Tags = tags.Expand(d.Get("tags").(map[string]interface{}))
 	}
 
-	err = client.CreateOrUpdateThenPoll(ctx, *id, *payload)
-	if err != nil {
+	if err = client.CreateOrUpdateThenPoll(ctx, *id, *payload); err != nil {
 		return fmt.Errorf("updating %s: %+v", id, err)
 	}
 
@@ -297,8 +296,7 @@ func resourceArmDevTestVirtualNetworkDelete(d *pluginsdk.ResourceData, meta inte
 		return fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	err = client.DeleteThenPoll(ctx, *id)
-	if err != nil {
+	if err = client.DeleteThenPoll(ctx, *id); err != nil {
 		return fmt.Errorf("deleting %s: %+v", *id, err)
 	}
 

--- a/internal/services/devtestlabs/dev_test_windows_virtual_machine_resource.go
+++ b/internal/services/devtestlabs/dev_test_windows_virtual_machine_resource.go
@@ -310,8 +310,7 @@ func resourceArmDevTestWindowsVirtualMachineDelete(d *pluginsdk.ResourceData, me
 		return fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	err = client.DeleteThenPoll(ctx, *id)
-	if err != nil {
+	if err = client.DeleteThenPoll(ctx, *id); err != nil {
 		return fmt.Errorf("deleting %s: %+v", *id, err)
 	}
 

--- a/internal/services/hdinsight/common_hdinsight.go
+++ b/internal/services/hdinsight/common_hdinsight.go
@@ -95,8 +95,7 @@ func hdinsightClusterUpdate(clusterKind string, readFunc pluginsdk.ReadFunc) plu
 				}
 
 				if newEdgeNodeInt != 0 {
-					err = createHDInsightEdgeNodes(ctx, applicationsClient, applicationId, edgeNodeConfig)
-					if err != nil {
+					if err = createHDInsightEdgeNodes(ctx, applicationsClient, applicationId, edgeNodeConfig); err != nil {
 						return err
 					}
 				}

--- a/internal/services/hdinsight/hdinsight_hadoop_cluster_resource.go
+++ b/internal/services/hdinsight/hdinsight_hadoop_cluster_resource.go
@@ -333,8 +333,7 @@ func resourceHDInsightHadoopClusterCreate(d *pluginsdk.ResourceData, meta interf
 		edgeNodeConfig := edgeNodeRaw[0].(map[string]interface{})
 		applicationId := applications.NewApplicationID(id.SubscriptionId, id.ResourceGroupName, id.ClusterName, id.ClusterName) // 2 id.ClusterName's are intentional
 
-		err := createHDInsightEdgeNodes(ctx, applicationsClient, applicationId, edgeNodeConfig)
-		if err != nil {
+		if err := createHDInsightEdgeNodes(ctx, applicationsClient, applicationId, edgeNodeConfig); err != nil {
 			return err
 		}
 

--- a/internal/services/healthcare/healthcare_dicom_service_resource.go
+++ b/internal/services/healthcare/healthcare_dicom_service_resource.go
@@ -281,8 +281,7 @@ func resourceHealthcareApisDicomServiceCreate(d *pluginsdk.ResourceData, meta in
 		parameters.Properties.PublicNetworkAccess = pointer.To(dicomservices.PublicNetworkAccessDisabled)
 	}
 
-	err = client.CreateOrUpdateCallbackThenPoll(ctx, id, parameters, sdk.SetIDCallback(meta, &id, d))
-	if err != nil {
+	if err = client.CreateOrUpdateCallbackThenPoll(ctx, id, parameters, sdk.SetIDCallback(meta, &id, d)); err != nil {
 		return fmt.Errorf("creating %s: %+v", id, err)
 	}
 
@@ -418,8 +417,7 @@ func resourceHealthcareApisDicomServiceUpdate(d *pluginsdk.ResourceData, meta in
 		}
 	}
 
-	err = client.CreateOrUpdateThenPoll(ctx, *id, *payload)
-	if err != nil {
+	if err = client.CreateOrUpdateThenPoll(ctx, *id, *payload); err != nil {
 		return fmt.Errorf("updating %s: %+v", id, err)
 	}
 
@@ -437,8 +435,7 @@ func resourceHealthcareApisDicomServiceDelete(d *pluginsdk.ResourceData, meta in
 		return fmt.Errorf("parsing Dicom service error: %+v", err)
 	}
 
-	err = client.DeleteThenPoll(ctx, *id)
-	if err != nil {
+	if err = client.DeleteThenPoll(ctx, *id); err != nil {
 		return fmt.Errorf("deleting Healthcare Dicom Service %s: %+v", id, err)
 	}
 
@@ -486,8 +483,7 @@ func updateTags(d *pluginsdk.ResourceData, meta interface{}) error {
 		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
 	}
 
-	err = client.UpdateThenPoll(ctx, *id, update)
-	if err != nil {
+	if err = client.UpdateThenPoll(ctx, *id, update); err != nil {
 		return fmt.Errorf("updating %s: %+v", id, err)
 	}
 

--- a/internal/services/healthcare/healthcare_fhir_service_resource.go
+++ b/internal/services/healthcare/healthcare_fhir_service_resource.go
@@ -437,8 +437,7 @@ func resourceHealthcareApisFhirServiceUpdate(d *pluginsdk.ResourceData, meta int
 	}
 	parameters.Properties.AcrConfiguration = &acrConfig
 
-	err = client.CreateOrUpdateThenPoll(ctx, id, parameters)
-	if err != nil {
+	if err = client.CreateOrUpdateThenPoll(ctx, id, parameters); err != nil {
 		return fmt.Errorf("updating %s: %+v", id, err)
 	}
 
@@ -456,8 +455,7 @@ func resourceHealthcareApisFhirServiceDelete(d *pluginsdk.ResourceData, meta int
 		return err
 	}
 
-	err = client.DeleteThenPoll(ctx, *id)
-	if err != nil {
+	if err = client.DeleteThenPoll(ctx, *id); err != nil {
 		return fmt.Errorf("deleting %s: %+v", *id, err)
 	}
 

--- a/internal/services/healthcare/healthcare_medtech_service_fhir_destination_resource.go
+++ b/internal/services/healthcare/healthcare_medtech_service_fhir_destination_resource.go
@@ -222,8 +222,7 @@ func resourceHealthcareApisMedTechServiceFhirDestinationUpdate(d *pluginsdk.Reso
 	}
 	medTechFhirServiceParameters.Properties.FhirMapping = fhirMap
 
-	err = client.IotConnectorFhirDestinationCreateOrUpdateThenPoll(ctx, id, medTechFhirServiceParameters)
-	if err != nil {
+	if err = client.IotConnectorFhirDestinationCreateOrUpdateThenPoll(ctx, id, medTechFhirServiceParameters); err != nil {
 		return fmt.Errorf("updating fhir service %s for the Med Tech Service err: %+v", id, err)
 	}
 
@@ -242,8 +241,7 @@ func resourceHealthcareApisMedTechServiceFhirDestinationDelete(d *pluginsdk.Reso
 		return err
 	}
 
-	err = client.IotConnectorFhirDestinationDeleteThenPoll(ctx, *id)
-	if err != nil {
+	if err = client.IotConnectorFhirDestinationDeleteThenPoll(ctx, *id); err != nil {
 		return fmt.Errorf("deleting %s: %+v", *id, err)
 	}
 	log.Printf("[DEBUG] Waiting for %s to be deleted..", id)

--- a/internal/services/healthcare/healthcare_service_resource.go
+++ b/internal/services/healthcare/healthcare_service_resource.go
@@ -379,8 +379,7 @@ func resourceHealthcareServiceDelete(d *pluginsdk.ResourceData, meta interface{}
 		return err
 	}
 
-	err = client.ServicesDeleteThenPoll(ctx, *id)
-	if err != nil {
+	if err = client.ServicesDeleteThenPoll(ctx, *id); err != nil {
 		return fmt.Errorf("deleting Healthcare Service %q (Resource Group %q): %+v", id.ServiceName, id.ResourceGroupName, err)
 	}
 	return nil

--- a/internal/services/healthcare/healthcare_workspace_resource.go
+++ b/internal/services/healthcare/healthcare_workspace_resource.go
@@ -101,8 +101,7 @@ func resourceHealthcareApisWorkspaceCreate(d *pluginsdk.ResourceData, meta inter
 		Tags:     tags.Expand(t),
 	}
 
-	err := client.CreateOrUpdateCallbackThenPoll(ctx, id, parameters, sdk.SetIDCallback(meta, &id, d))
-	if err != nil {
+	if err := client.CreateOrUpdateCallbackThenPoll(ctx, id, parameters, sdk.SetIDCallback(meta, &id, d)); err != nil {
 		return fmt.Errorf("creating/ updating %s: %+v", id, err)
 	}
 
@@ -163,8 +162,7 @@ func resourceHealthcareApisWorkspaceUpdate(d *pluginsdk.ResourceData, meta inter
 		Tags: tags.Expand(t),
 	}
 
-	err = client.UpdateThenPoll(ctx, *id, parameters)
-	if err != nil {
+	if err = client.UpdateThenPoll(ctx, *id, parameters); err != nil {
 		return fmt.Errorf("updating %s: %+v", id, err)
 	}
 
@@ -181,8 +179,7 @@ func resourceHealthcareApisWorkspaceDelete(d *pluginsdk.ResourceData, meta inter
 		return err
 	}
 
-	err = client.DeleteThenPoll(ctx, *id)
-	if err != nil {
+	if err = client.DeleteThenPoll(ctx, *id); err != nil {
 		return fmt.Errorf("deleting %s: %+v", id, err)
 	}
 

--- a/internal/services/hybridcompute/arc_machine_extension_resource.go
+++ b/internal/services/hybridcompute/arc_machine_extension_resource.go
@@ -180,8 +180,7 @@ func (r ArcMachineExtensionResource) Create() sdk.ResourceFunc {
 
 			if model.ProtectedSettings != "" {
 				protectedSettingsValue := make(map[string]interface{})
-				err = json.Unmarshal([]byte(model.ProtectedSettings), &protectedSettingsValue)
-				if err != nil {
+				if err = json.Unmarshal([]byte(model.ProtectedSettings), &protectedSettingsValue); err != nil {
 					return err
 				}
 				properties.Properties.ProtectedSettings = &protectedSettingsValue
@@ -193,8 +192,7 @@ func (r ArcMachineExtensionResource) Create() sdk.ResourceFunc {
 
 			if model.Settings != "" {
 				settingsValue := make(map[string]interface{})
-				err = json.Unmarshal([]byte(model.Settings), &settingsValue)
-				if err != nil {
+				if err = json.Unmarshal([]byte(model.Settings), &settingsValue); err != nil {
 					return err
 				}
 				properties.Properties.Settings = &settingsValue
@@ -258,8 +256,7 @@ func (r ArcMachineExtensionResource) Update() sdk.ResourceFunc {
 
 			if metadata.ResourceData.HasChange("protected_settings") {
 				protectedSettingsValue := make(map[string]interface{})
-				err := json.Unmarshal([]byte(model.ProtectedSettings), &protectedSettingsValue)
-				if err != nil {
+				if err := json.Unmarshal([]byte(model.ProtectedSettings), &protectedSettingsValue); err != nil {
 					return err
 				}
 
@@ -276,8 +273,7 @@ func (r ArcMachineExtensionResource) Update() sdk.ResourceFunc {
 
 			if metadata.ResourceData.HasChange("settings") {
 				settingsValue := make(map[string]interface{})
-				err := json.Unmarshal([]byte(model.Settings), &settingsValue)
-				if err != nil {
+				if err := json.Unmarshal([]byte(model.Settings), &settingsValue); err != nil {
 					return err
 				}
 
@@ -359,8 +355,7 @@ func (r ArcMachineExtensionResource) Read() sdk.ResourceFunc {
 					}
 
 					var extModel MachineExtensionModel
-					err := metadata.Decode(&extModel)
-					if err != nil {
+					if err := metadata.Decode(&extModel); err != nil {
 						return err
 					}
 

--- a/internal/services/iotcentral/validate/organization_organization_id.go
+++ b/internal/services/iotcentral/validate/organization_organization_id.go
@@ -15,8 +15,7 @@ func OrganizationOrganizationID(i interface{}, k string) (warnings []string, err
 		return warnings, errors
 	}
 
-	err := validateOrganizationId(id)
-	if err != nil {
+	if err := validateOrganizationId(id); err != nil {
 		errors = append(errors, err)
 		return warnings, errors
 	}

--- a/internal/services/keyvault/internal.go
+++ b/internal/services/keyvault/internal.go
@@ -71,7 +71,7 @@ func deleteAndOptionallyPurge(ctx context.Context, description string, shouldPur
 	}
 
 	log.Printf("[DEBUG] Purging %s..", description)
-	err := pluginsdk.Retry(time.Until(timeout), func() *pluginsdk.RetryError {
+	if err := pluginsdk.Retry(time.Until(timeout), func() *pluginsdk.RetryError {
 		_, err := helper.PurgeNestedItem(ctx)
 		if err == nil {
 			return nil
@@ -80,8 +80,7 @@ func deleteAndOptionallyPurge(ctx context.Context, description string, shouldPur
 			return pluginsdk.RetryableError(fmt.Errorf("%s is currently being deleted, retrying", description))
 		}
 		return pluginsdk.NonRetryableError(fmt.Errorf("purging of %s : %+v", description, err))
-	})
-	if err != nil {
+	}); err != nil {
 		return err
 	}
 

--- a/internal/services/keyvault/key_vault_certificate_data_data_source.go
+++ b/internal/services/keyvault/key_vault_certificate_data_data_source.go
@@ -252,8 +252,7 @@ func dataSourceArmKeyVaultCertificateDataRead(d *pluginsdk.ResourceData, meta in
 	}
 
 	var keyPEM bytes.Buffer
-	err = pem.Encode(&keyPEM, keyBlock)
-	if err != nil {
+	if err = pem.Encode(&keyPEM, keyBlock); err != nil {
 		return fmt.Errorf("encoding Key Vault Certificate Key: %+v", err)
 	}
 
@@ -266,8 +265,7 @@ func dataSourceArmKeyVaultCertificateDataRead(d *pluginsdk.ResourceData, meta in
 		}
 
 		var certPEM bytes.Buffer
-		err = pem.Encode(&certPEM, certBlock)
-		if err != nil {
+		if err = pem.Encode(&certPEM, certBlock); err != nil {
 			return fmt.Errorf("encoding Key Vault Certificate PEM: %+v", err)
 		}
 		certs += certPEM.String()

--- a/internal/services/keyvault/key_vault_certificate_ephemeral.go
+++ b/internal/services/keyvault/key_vault_certificate_ephemeral.go
@@ -272,8 +272,7 @@ func (e *KeyVaultCertificateEphemeralResource) Open(ctx context.Context, req eph
 	}
 
 	var keyPEM bytes.Buffer
-	err = pem.Encode(&keyPEM, keyBlock)
-	if err != nil {
+	if err = pem.Encode(&keyPEM, keyBlock); err != nil {
 		sdk.SetResponseErrorDiagnostic(resp, fmt.Sprintf("encoding key for %q", id.Name), err)
 		return
 	}
@@ -287,8 +286,7 @@ func (e *KeyVaultCertificateEphemeralResource) Open(ctx context.Context, req eph
 		}
 
 		var certPEM bytes.Buffer
-		err = pem.Encode(&certPEM, certBlock)
-		if err != nil {
+		if err = pem.Encode(&certPEM, certBlock); err != nil {
 			sdk.SetResponseErrorDiagnostic(resp, fmt.Sprintf("encoding PEM for %q", id.Name), err)
 			return
 		}

--- a/internal/services/keyvault/key_vault_certificates_data_source.go
+++ b/internal/services/keyvault/key_vault_certificates_data_source.go
@@ -109,8 +109,7 @@ func dataSourceKeyVaultCertificatesRead(d *pluginsdk.ResourceData, meta interfac
 
 				names = append(names, nestedItem.Name)
 				certs = append(certs, expandCertificate(nestedItem.Name, v))
-				err = certificateList.NextWithContext(ctx)
-				if err != nil {
+				if err = certificateList.NextWithContext(ctx); err != nil {
 					return fmt.Errorf("retrieving next page of Certificates from %s: %+v", *keyVaultId, err)
 				}
 			}

--- a/internal/services/keyvault/key_vault_key_data_source.go
+++ b/internal/services/keyvault/key_vault_key_data_source.go
@@ -213,8 +213,7 @@ func dataSourceKeyVaultKeyRead(d *pluginsdk.ResourceData, meta interface{}) erro
 					publicKey.Curve = elliptic.P521()
 				}
 				if publicKey.Curve != nil {
-					err = readPublicKey(d, publicKey)
-					if err != nil {
+					if err = readPublicKey(d, publicKey); err != nil {
 						return fmt.Errorf("failed to read public key: %+v", err)
 					}
 				}

--- a/internal/services/keyvault/key_vault_key_resource.go
+++ b/internal/services/keyvault/key_vault_key_resource.go
@@ -685,8 +685,7 @@ func resourceKeyVaultKeyRead(d *pluginsdk.ResourceData, meta interface{}) error 
 					publicKey.Curve = elliptic.P521()
 				}
 				if publicKey.Curve != nil {
-					err = readPublicKey(d, publicKey)
-					if err != nil {
+					if err = readPublicKey(d, publicKey); err != nil {
 						return fmt.Errorf("failed to read public key: %+v", err)
 					}
 				}

--- a/internal/services/keyvault/key_vault_secrets_data_source.go
+++ b/internal/services/keyvault/key_vault_secrets_data_source.go
@@ -102,8 +102,7 @@ func dataSourceKeyVaultSecretsRead(d *pluginsdk.ResourceData, meta interface{}) 
 				}
 				names = append(names, *name)
 				secrets = append(secrets, expandSecrets(*name, v))
-				err = secretList.NextWithContext(ctx)
-				if err != nil {
+				if err = secretList.NextWithContext(ctx); err != nil {
 					return fmt.Errorf("listing secrets on Azure KeyVault %q: %+v", *keyVaultId, err)
 				}
 			}

--- a/internal/services/kusto/kusto_attached_database_configuration_resource.go
+++ b/internal/services/kusto/kusto_attached_database_configuration_resource.go
@@ -299,8 +299,7 @@ func resourceKustoAttachedDatabaseConfigurationDelete(d *pluginsdk.ResourceData,
 	locks.ByName(id.ClusterName, "azurerm_kusto_cluster")
 	defer locks.UnlockByName(id.ClusterName, "azurerm_kusto_cluster")
 
-	err = client.DeleteThenPoll(ctx, *id)
-	if err != nil {
+	if err = client.DeleteThenPoll(ctx, *id); err != nil {
 		return fmt.Errorf("deleting %s: %+v", id, err)
 	}
 

--- a/internal/services/kusto/kusto_cluster_customer_managed_key_resource.go
+++ b/internal/services/kusto/kusto_cluster_customer_managed_key_resource.go
@@ -324,8 +324,7 @@ func resourceKustoClusterCustomerManagedKeyDelete(d *pluginsdk.ResourceData, met
 		},
 	}
 
-	err = client.UpdateThenPoll(ctx, *clusterID, props, clusters.DefaultUpdateOperationOptions())
-	if err != nil {
+	if err = client.UpdateThenPoll(ctx, *clusterID, props, clusters.DefaultUpdateOperationOptions()); err != nil {
 		return fmt.Errorf("removing Customer Managed Key for %s: %+v", clusterID, err)
 	}
 

--- a/internal/services/kusto/kusto_cluster_managed_private_endpoint_resource.go
+++ b/internal/services/kusto/kusto_cluster_managed_private_endpoint_resource.go
@@ -198,8 +198,7 @@ func resourceKustoClusterManagedPrivateEndpointDelete(d *schema.ResourceData, me
 		return err
 	}
 
-	err = client.DeleteThenPoll(ctx, *id)
-	if err != nil {
+	if err = client.DeleteThenPoll(ctx, *id); err != nil {
 		return fmt.Errorf("deleting %s: %+v", *id, err)
 	}
 

--- a/internal/services/kusto/kusto_cluster_principal_assignment_resource.go
+++ b/internal/services/kusto/kusto_cluster_principal_assignment_resource.go
@@ -196,8 +196,7 @@ func resourceKustoClusterPrincipalAssignmentDelete(d *pluginsdk.ResourceData, me
 		return err
 	}
 
-	err = client.DeleteThenPoll(ctx, *id)
-	if err != nil {
+	if err = client.DeleteThenPoll(ctx, *id); err != nil {
 		return fmt.Errorf("deleting %s: %+v", *id, err)
 	}
 

--- a/internal/services/kusto/kusto_cluster_resource.go
+++ b/internal/services/kusto/kusto_cluster_resource.go
@@ -574,8 +574,7 @@ func resourceKustoClusterDelete(d *pluginsdk.ResourceData, meta interface{}) err
 		return err
 	}
 
-	err = client.DeleteThenPoll(ctx, *id)
-	if err != nil {
+	if err = client.DeleteThenPoll(ctx, *id); err != nil {
 		return fmt.Errorf("deleting %s: %+v", *id, err)
 	}
 	return nil

--- a/internal/services/kusto/kusto_database_principal_assignment_resource.go
+++ b/internal/services/kusto/kusto_database_principal_assignment_resource.go
@@ -196,8 +196,7 @@ func resourceKustoDatabasePrincipalAssignmentDelete(d *pluginsdk.ResourceData, m
 		return err
 	}
 
-	err = client.DeleteThenPoll(ctx, *id)
-	if err != nil {
+	if err = client.DeleteThenPoll(ctx, *id); err != nil {
 		return fmt.Errorf("deleting %s: %+v", *id, err)
 	}
 

--- a/internal/services/kusto/kusto_database_resource.go
+++ b/internal/services/kusto/kusto_database_resource.go
@@ -184,8 +184,7 @@ func resourceKustoDatabaseDelete(d *pluginsdk.ResourceData, meta interface{}) er
 		return err
 	}
 
-	err = client.DeleteThenPoll(ctx, *id)
-	if err != nil {
+	if err = client.DeleteThenPoll(ctx, *id); err != nil {
 		return fmt.Errorf("deleting %s: %+v", id, err)
 	}
 

--- a/internal/services/kusto/kusto_eventgrid_data_connection_resource.go
+++ b/internal/services/kusto/kusto_eventgrid_data_connection_resource.go
@@ -305,8 +305,7 @@ func resourceKustoEventGridDataConnectionDelete(d *pluginsdk.ResourceData, meta 
 		return err
 	}
 
-	err = client.DeleteThenPoll(ctx, *id)
-	if err != nil {
+	if err = client.DeleteThenPoll(ctx, *id); err != nil {
 		return fmt.Errorf("deleting %s: %+v", id, err)
 	}
 

--- a/internal/services/kusto/kusto_eventhub_data_connection_resource.go
+++ b/internal/services/kusto/kusto_eventhub_data_connection_resource.go
@@ -304,8 +304,7 @@ func resourceKustoEventHubDataConnectionUpdate(d *pluginsdk.ResourceData, meta i
 		Properties: props,
 	}
 
-	err = client.CreateOrUpdateThenPoll(ctx, *id, dataConnection)
-	if err != nil {
+	if err = client.CreateOrUpdateThenPoll(ctx, *id, dataConnection); err != nil {
 		return fmt.Errorf("updating %s: %+v", id, err)
 	}
 
@@ -322,8 +321,7 @@ func resourceKustoEventHubDataConnectionDelete(d *pluginsdk.ResourceData, meta i
 		return err
 	}
 
-	err = client.DeleteThenPoll(ctx, *id)
-	if err != nil {
+	if err = client.DeleteThenPoll(ctx, *id); err != nil {
 		return fmt.Errorf("deleting Kusto Event Hub Data Connection %q (Resource Group %q, Cluster %q, Database %q): %+v", id.DataConnectionName, id.ResourceGroupName, id.ClusterName, id.DatabaseName, err)
 	}
 

--- a/internal/services/kusto/kusto_iothub_data_connection_resource.go
+++ b/internal/services/kusto/kusto_iothub_data_connection_resource.go
@@ -270,8 +270,7 @@ func resourceKustoIotHubDataConnectionUpdate(d *pluginsdk.ResourceData, meta int
 		Properties: props,
 	}
 
-	err = client.CreateOrUpdateThenPoll(ctx, *id, dataConnection)
-	if err != nil {
+	if err = client.CreateOrUpdateThenPoll(ctx, *id, dataConnection); err != nil {
 		return fmt.Errorf("updating %s: %+v", id, err)
 	}
 
@@ -288,8 +287,7 @@ func resourceKustoIotHubDataConnectionDelete(d *pluginsdk.ResourceData, meta int
 		return err
 	}
 
-	err = client.DeleteThenPoll(ctx, *id)
-	if err != nil {
+	if err = client.DeleteThenPoll(ctx, *id); err != nil {
 		return fmt.Errorf("deleting %s: %+v", id, err)
 	}
 

--- a/internal/services/kusto/kusto_script_resource.go
+++ b/internal/services/kusto/kusto_script_resource.go
@@ -244,8 +244,7 @@ func resourceKustoDatabaseScriptDelete(d *pluginsdk.ResourceData, meta interface
 	locks.ByName(id.ClusterName, "azurerm_kusto_cluster")
 	defer locks.UnlockByName(id.ClusterName, "azurerm_kusto_cluster")
 
-	err = client.DeleteThenPoll(ctx, *id)
-	if err != nil {
+	if err = client.DeleteThenPoll(ctx, *id); err != nil {
 		return fmt.Errorf("deleting %q: %+v", id, err)
 	}
 

--- a/internal/services/legacy/virtual_machine_scale_set_resource.go
+++ b/internal/services/legacy/virtual_machine_scale_set_resource.go
@@ -2229,8 +2229,7 @@ func expandAzureRMVirtualMachineScaleSetExtensions(d *pluginsdk.ResourceData) (*
 
 		if s := config["settings"].(string); s != "" {
 			var result interface{}
-			err := json.Unmarshal([]byte(s), &result)
-			if err != nil {
+			if err := json.Unmarshal([]byte(s), &result); err != nil {
 				return nil, fmt.Errorf("unmarshaling `settings`: %+v", err)
 			}
 			extension.Properties.Settings = pointer.To(result)
@@ -2238,8 +2237,7 @@ func expandAzureRMVirtualMachineScaleSetExtensions(d *pluginsdk.ResourceData) (*
 
 		if s := config["protected_settings"].(string); s != "" {
 			var result interface{}
-			err := json.Unmarshal([]byte(s), &result)
-			if err != nil {
+			if err := json.Unmarshal([]byte(s), &result); err != nil {
 				return nil, fmt.Errorf("unmarshaling `protected_settings`: %+v", err)
 			}
 			extension.Properties.ProtectedSettings = pointer.To(result)

--- a/internal/services/loadbalancer/lb_backend_address_pool_address_resource.go
+++ b/internal/services/loadbalancer/lb_backend_address_pool_address_resource.go
@@ -387,8 +387,7 @@ func (r BackendAddressPoolAddressResource) Delete() sdk.ResourceFunc {
 
 			pool.Model.Properties.LoadBalancerBackendAddresses = &newAddresses
 
-			err = lbClient.LoadBalancerBackendAddressPoolsCreateOrUpdateThenPoll(ctx, poolId, *pool.Model)
-			if err != nil {
+			if err = lbClient.LoadBalancerBackendAddressPoolsCreateOrUpdateThenPoll(ctx, poolId, *pool.Model); err != nil {
 				return fmt.Errorf("removing %s: %+v", *id, err)
 			}
 
@@ -494,8 +493,7 @@ func (r BackendAddressPoolAddressResource) Update() sdk.ResourceFunc {
 				return fmt.Errorf("waiting for parent resource loadbalancer status to be ready error: %+v", err)
 			}
 
-			err = lbClient.LoadBalancerBackendAddressPoolsCreateOrUpdateThenPoll(ctx, poolId, *pool.Model)
-			if err != nil {
+			if err = lbClient.LoadBalancerBackendAddressPoolsCreateOrUpdateThenPoll(ctx, poolId, *pool.Model); err != nil {
 				return fmt.Errorf("updating %s: %+v", *id, err)
 			}
 			return nil

--- a/internal/services/loadbalancer/lb_backend_address_pool_address_resource_test.go
+++ b/internal/services/loadbalancer/lb_backend_address_pool_address_resource_test.go
@@ -192,8 +192,7 @@ func (BackendAddressPoolAddressResourceTests) Destroy(ctx context.Context, clien
 
 	pool.Model.Properties.LoadBalancerBackendAddresses = &newAddresses
 
-	err = client.LoadBalancers.LoadBalancersClient.LoadBalancerBackendAddressPoolsCreateOrUpdateThenPoll(ctx, poolId, *pool.Model)
-	if err != nil {
+	if err = client.LoadBalancers.LoadBalancersClient.LoadBalancerBackendAddressPoolsCreateOrUpdateThenPoll(ctx, poolId, *pool.Model); err != nil {
 		return nil, fmt.Errorf("updating %s: %+v", *id, err)
 	}
 

--- a/internal/services/loadbalancer/lb_backend_address_pool_resource.go
+++ b/internal/services/loadbalancer/lb_backend_address_pool_resource.go
@@ -460,13 +460,11 @@ func resourceArmLoadBalancerBackendAddressPoolDelete(d *pluginsdk.ResourceData, 
 		backEndPools = append(backEndPools[:index], backEndPools[index+1:]...)
 		lb.Model.Properties.BackendAddressPools = &backEndPools
 
-		err := lbClient.CreateOrUpdateThenPoll(ctx, plbId, *lb.Model)
-		if err != nil {
+		if err := lbClient.CreateOrUpdateThenPoll(ctx, plbId, *lb.Model); err != nil {
 			return fmt.Errorf("updating %s: %+v", loadBalancerId, err)
 		}
 	} else {
-		err := lbClient.LoadBalancerBackendAddressPoolsDeleteThenPoll(ctx, *id)
-		if err != nil {
+		if err := lbClient.LoadBalancerBackendAddressPoolsDeleteThenPoll(ctx, *id); err != nil {
 			return fmt.Errorf("deleting %s: %+v", *id, err)
 		}
 	}

--- a/internal/services/loadbalancer/lb_backend_address_pool_resource_test.go
+++ b/internal/services/loadbalancer/lb_backend_address_pool_resource_test.go
@@ -258,8 +258,7 @@ func (r LoadBalancerBackendAddressPool) Destroy(ctx context.Context, client *cli
 	}
 	lb.Model.Properties.BackendAddressPools = &backendAddressPools
 
-	err = client.LoadBalancers.LoadBalancersClient.CreateOrUpdateThenPoll(ctx, plbId, *lb.Model)
-	if err != nil {
+	if err = client.LoadBalancers.LoadBalancersClient.CreateOrUpdateThenPoll(ctx, plbId, *lb.Model); err != nil {
 		return nil, fmt.Errorf("updating Load Balancer %q (Resource Group %q): %+v", id.LoadBalancerName, id.ResourceGroupName, err)
 	}
 

--- a/internal/services/loadbalancer/lb_nat_pool_resource.go
+++ b/internal/services/loadbalancer/lb_nat_pool_resource.go
@@ -286,8 +286,7 @@ func resourceArmLoadBalancerNatPoolDelete(d *pluginsdk.ResourceData, meta interf
 			natPools = append(natPools[:index], natPools[index+1:]...)
 			props.InboundNatPools = &natPools
 
-			err := client.CreateOrUpdateThenPoll(ctx, plbId, *model)
-			if err != nil {
+			if err := client.CreateOrUpdateThenPoll(ctx, plbId, *model); err != nil {
 				return fmt.Errorf("updating Load Balancer %q (Resource Group %q) for Nat Pool %q: %+v", id.LoadBalancerName, id.ResourceGroup, id.InboundNatPoolName, err)
 			}
 		}

--- a/internal/services/loadbalancer/lb_nat_rule_resource.go
+++ b/internal/services/loadbalancer/lb_nat_rule_resource.go
@@ -320,8 +320,7 @@ func resourceArmLoadBalancerNatRuleDelete(d *pluginsdk.ResourceData, meta interf
 			natRules = append(natRules[:index], natRules[index+1:]...)
 			props.InboundNatRules = &natRules
 
-			err := client.CreateOrUpdateThenPoll(ctx, plbId, *model)
-			if err != nil {
+			if err := client.CreateOrUpdateThenPoll(ctx, plbId, *model); err != nil {
 				return fmt.Errorf("Creating/Updating %s: %+v", *id, err)
 			}
 		}

--- a/internal/services/loadbalancer/lb_nat_rule_resource_test.go
+++ b/internal/services/loadbalancer/lb_nat_rule_resource_test.go
@@ -278,8 +278,7 @@ func (r LoadBalancerNatRule) Destroy(ctx context.Context, client *clients.Client
 	}
 	lb.Model.Properties.InboundNatRules = &inboundNatRules
 
-	err = client.LoadBalancers.LoadBalancersClient.CreateOrUpdateThenPoll(ctx, plbId, *lb.Model)
-	if err != nil {
+	if err = client.LoadBalancers.LoadBalancersClient.CreateOrUpdateThenPoll(ctx, plbId, *lb.Model); err != nil {
 		return nil, fmt.Errorf("updating %s: %+v", *id, err)
 	}
 

--- a/internal/services/loadbalancer/lb_outbound_rule_resource.go
+++ b/internal/services/loadbalancer/lb_outbound_rule_resource.go
@@ -301,8 +301,7 @@ func resourceArmLoadBalancerOutboundRuleDelete(d *pluginsdk.ResourceData, meta i
 			outboundRules = append(outboundRules[:index], outboundRules[index+1:]...)
 			props.OutboundRules = &outboundRules
 
-			err := client.CreateOrUpdateThenPoll(ctx, plbId, *model)
-			if err != nil {
+			if err := client.CreateOrUpdateThenPoll(ctx, plbId, *model); err != nil {
 				return fmt.Errorf("updating %s: %+v", *id, err)
 			}
 		}

--- a/internal/services/loadbalancer/lb_outbound_rule_resource_test.go
+++ b/internal/services/loadbalancer/lb_outbound_rule_resource_test.go
@@ -222,8 +222,7 @@ func (r LoadBalancerOutboundRule) Destroy(ctx context.Context, client *clients.C
 	}
 	lb.Model.Properties.OutboundRules = &outboundRules
 
-	err = client.LoadBalancers.LoadBalancersClient.CreateOrUpdateThenPoll(ctx, plbId, *lb.Model)
-	if err != nil {
+	if err = client.LoadBalancers.LoadBalancersClient.CreateOrUpdateThenPoll(ctx, plbId, *lb.Model); err != nil {
 		return nil, fmt.Errorf("updating %s: %+v", *id, err)
 	}
 

--- a/internal/services/loadbalancer/lb_probe_resource.go
+++ b/internal/services/loadbalancer/lb_probe_resource.go
@@ -268,8 +268,7 @@ func resourceArmLoadBalancerProbeDelete(d *pluginsdk.ResourceData, meta interfac
 			probes = append(probes[:index], probes[index+1:]...)
 			props.Probes = &probes
 
-			err := client.CreateOrUpdateThenPoll(ctx, plbId, *model)
-			if err != nil {
+			if err := client.CreateOrUpdateThenPoll(ctx, plbId, *model); err != nil {
 				return fmt.Errorf("updating Load Balancer %q (Resource Group %q) for deletion of Probe %q: %+v", id.LoadBalancerName, id.ResourceGroupName, id.ProbeName, err)
 			}
 		}

--- a/internal/services/loadbalancer/lb_resource.go
+++ b/internal/services/loadbalancer/lb_resource.go
@@ -396,8 +396,7 @@ func resourceArmLoadBalancerUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 		model.Tags = tags.Expand(d.Get("tags").(map[string]interface{}))
 	}
 
-	err = client.CreateOrUpdateThenPoll(ctx, loadbalancers.ProviderLoadBalancerId(*id), model)
-	if err != nil {
+	if err = client.CreateOrUpdateThenPoll(ctx, loadbalancers.ProviderLoadBalancerId(*id), model); err != nil {
 		return fmt.Errorf("updating %s: %+v", id, err)
 	}
 
@@ -416,8 +415,7 @@ func resourceArmLoadBalancerDelete(d *pluginsdk.ResourceData, meta interface{}) 
 
 	plbId := loadbalancers.ProviderLoadBalancerId{SubscriptionId: id.SubscriptionId, ResourceGroupName: id.ResourceGroupName, LoadBalancerName: id.LoadBalancerName}
 
-	err = client.DeleteThenPoll(ctx, plbId)
-	if err != nil {
+	if err = client.DeleteThenPoll(ctx, plbId); err != nil {
 		return fmt.Errorf("deleting %s: %+v", *id, err)
 	}
 

--- a/internal/services/loadbalancer/lb_rule_resource.go
+++ b/internal/services/loadbalancer/lb_rule_resource.go
@@ -254,8 +254,7 @@ func resourceArmLoadBalancerRuleDelete(d *pluginsdk.ResourceData, meta interface
 				lbRules = append(lbRules[:index], lbRules[index+1:]...)
 				props.LoadBalancingRules = &lbRules
 
-				err := client.CreateOrUpdateThenPoll(ctx, plbId, *model)
-				if err != nil {
+				if err := client.CreateOrUpdateThenPoll(ctx, plbId, *model); err != nil {
 					return fmt.Errorf("Creating/Updating %s: %+v", id, err)
 				}
 			}

--- a/internal/services/loadbalancer/lb_rule_resource_test.go
+++ b/internal/services/loadbalancer/lb_rule_resource_test.go
@@ -266,8 +266,7 @@ func (r LoadBalancerRule) Destroy(ctx context.Context, client *clients.Client, s
 	}
 	loadBalancer.Model.Properties.LoadBalancingRules = &rules
 
-	err = client.LoadBalancers.LoadBalancersClient.CreateOrUpdateThenPoll(ctx, plbId, *loadBalancer.Model)
-	if err != nil {
+	if err = client.LoadBalancers.LoadBalancersClient.CreateOrUpdateThenPoll(ctx, plbId, *loadBalancer.Model); err != nil {
 		return nil, fmt.Errorf("updating %s: %+v", *id, err)
 	}
 

--- a/internal/services/loadbalancer/loadbalancer_nat_pool_resource_test.go
+++ b/internal/services/loadbalancer/loadbalancer_nat_pool_resource_test.go
@@ -196,8 +196,7 @@ func (r LoadBalancerNatPool) Destroy(ctx context.Context, client *clients.Client
 	}
 	lb.Model.Properties.InboundNatPools = &inboundNatPools
 
-	err = client.LoadBalancers.LoadBalancersClient.CreateOrUpdateThenPoll(ctx, plbId, *lb.Model)
-	if err != nil {
+	if err = client.LoadBalancers.LoadBalancersClient.CreateOrUpdateThenPoll(ctx, plbId, *lb.Model); err != nil {
 		return nil, fmt.Errorf("updating Load Balancer %q (Resource Group %q): %+v", id.LoadBalancerName, id.ResourceGroup, err)
 	}
 	return pointer.To(true), nil

--- a/internal/services/loadbalancer/loadbalancer_probe_resource_test.go
+++ b/internal/services/loadbalancer/loadbalancer_probe_resource_test.go
@@ -189,8 +189,7 @@ func (r LoadBalancerProbe) Destroy(ctx context.Context, client *clients.Client, 
 	}
 	lb.Model.Properties.Probes = &probes
 
-	err = client.LoadBalancers.LoadBalancersClient.CreateOrUpdateThenPoll(ctx, plbId, *lb.Model)
-	if err != nil {
+	if err = client.LoadBalancers.LoadBalancersClient.CreateOrUpdateThenPoll(ctx, plbId, *lb.Model); err != nil {
 		return nil, fmt.Errorf("updating %s: %+v", *id, err)
 	}
 

--- a/internal/services/loganalytics/log_analytics_cluster_resource.go
+++ b/internal/services/loganalytics/log_analytics_cluster_resource.go
@@ -246,8 +246,7 @@ func (r LogAnalyticsClusterResource) Delete() sdk.ResourceFunc {
 			locks.ByID(id.ID())
 			defer locks.UnlockByID(id.ID())
 
-			err = client.DeleteThenPoll(ctx, *id)
-			if err != nil {
+			if err = client.DeleteThenPoll(ctx, *id); err != nil {
 				return fmt.Errorf("deleting %s: %+v", id, err)
 			}
 

--- a/internal/services/loganalytics/log_analytics_linked_service_resource.go
+++ b/internal/services/loganalytics/log_analytics_linked_service_resource.go
@@ -177,8 +177,7 @@ func resourceLogAnalyticsLinkedServiceDelete(d *pluginsdk.ResourceData, meta int
 		return err
 	}
 
-	err = client.DeleteThenPoll(ctx, *id)
-	if err != nil {
+	if err = client.DeleteThenPoll(ctx, *id); err != nil {
 		return fmt.Errorf("deleting %s: %+v", *id, err)
 	}
 

--- a/internal/services/loganalytics/log_analytics_solution_resource.go
+++ b/internal/services/loganalytics/log_analytics_solution_resource.go
@@ -273,8 +273,7 @@ func (s LogAnalyticsSolutionResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			err = client.DeleteThenPoll(ctx, *id)
-			if err != nil {
+			if err = client.DeleteThenPoll(ctx, *id); err != nil {
 				return fmt.Errorf("deleting %s: %+v", *id, err)
 			}
 

--- a/internal/services/loganalytics/log_analytics_workspace_resource.go
+++ b/internal/services/loganalytics/log_analytics_workspace_resource.go
@@ -629,8 +629,7 @@ func resourceLogAnalyticsWorkspaceDelete(d *pluginsdk.ResourceData, meta interfa
 	sharedKeyId := sharedKeyWorkspaces.NewWorkspaceID(id.SubscriptionId, id.ResourceGroupName, id.WorkspaceName)
 
 	permanentlyDeleteOnDestroy := meta.(*clients.Client).Features.LogAnalyticsWorkspace.PermanentlyDeleteOnDestroy
-	err = client.DeleteThenPoll(ctx, sharedKeyId, sharedKeyWorkspaces.DeleteOperationOptions{Force: pointer.To(permanentlyDeleteOnDestroy)})
-	if err != nil {
+	if err = client.DeleteThenPoll(ctx, sharedKeyId, sharedKeyWorkspaces.DeleteOperationOptions{Force: pointer.To(permanentlyDeleteOnDestroy)}); err != nil {
 		return fmt.Errorf("deleting %s: %+v", *id, err)
 	}
 

--- a/internal/services/logic/logic_app_action_custom_resource.go
+++ b/internal/services/logic/logic_app_action_custom_resource.go
@@ -124,8 +124,7 @@ func resourceLogicAppActionCustomDelete(d *pluginsdk.ResourceData, meta interfac
 
 	workflowId := workflows.NewWorkflowID(id.SubscriptionId, id.ResourceGroup, id.WorkflowName)
 
-	err = resourceLogicAppActionRemove(d, meta, workflowId, id.Name)
-	if err != nil {
+	if err = resourceLogicAppActionRemove(d, meta, workflowId, id.Name); err != nil {
 		return fmt.Errorf("removing Action %s: %+v", id, err)
 	}
 

--- a/internal/services/logic/logic_app_action_http_resource.go
+++ b/internal/services/logic/logic_app_action_http_resource.go
@@ -174,8 +174,7 @@ func resourceLogicAppActionHTTPCreateUpdate(d *pluginsdk.ResourceData, meta inte
 		action["runAfter"] = expandLogicAppActionRunAfter(v.(*pluginsdk.Set).List())
 	}
 
-	err = resourceLogicAppActionUpdate(d, meta, *workflowId, id, action, "azurerm_logic_app_action_http")
-	if err != nil {
+	if err = resourceLogicAppActionUpdate(d, meta, *workflowId, id, action, "azurerm_logic_app_action_http"); err != nil {
 		return err
 	}
 
@@ -277,8 +276,7 @@ func resourceLogicAppActionHTTPDelete(d *pluginsdk.ResourceData, meta interface{
 
 	workflowId := workflows.NewWorkflowID(id.SubscriptionId, id.ResourceGroup, id.WorkflowName)
 
-	err = resourceLogicAppActionRemove(d, meta, workflowId, id.Name)
-	if err != nil {
+	if err = resourceLogicAppActionRemove(d, meta, workflowId, id.Name); err != nil {
 		return fmt.Errorf("removing Action %s: %+v", id, err)
 	}
 

--- a/internal/services/logic/logic_app_trigger_custom_resource.go
+++ b/internal/services/logic/logic_app_trigger_custom_resource.go
@@ -135,8 +135,7 @@ func resourceLogicAppTriggerCustomDelete(d *pluginsdk.ResourceData, meta interfa
 
 	workflowId := workflows.NewWorkflowID(id.SubscriptionId, id.ResourceGroupName, id.WorkflowName)
 
-	err = resourceLogicAppTriggerRemove(d, meta, workflowId, id.TriggerName)
-	if err != nil {
+	if err = resourceLogicAppTriggerRemove(d, meta, workflowId, id.TriggerName); err != nil {
 		return fmt.Errorf("removing Trigger %s: %+v", id, err)
 	}
 

--- a/internal/services/logic/logic_app_trigger_http_request_resource.go
+++ b/internal/services/logic/logic_app_trigger_http_request_resource.go
@@ -196,8 +196,7 @@ func resourceLogicAppTriggerHttpRequestDelete(d *pluginsdk.ResourceData, meta in
 
 	workflowId := workflows.NewWorkflowID(id.SubscriptionId, id.ResourceGroupName, id.WorkflowName)
 
-	err = resourceLogicAppTriggerRemove(d, meta, workflowId, id.TriggerName)
-	if err != nil {
+	if err = resourceLogicAppTriggerRemove(d, meta, workflowId, id.TriggerName); err != nil {
 		return fmt.Errorf("removing Trigger %s: %+v", id, err)
 	}
 

--- a/internal/services/logic/logic_app_trigger_recurrence_resource.go
+++ b/internal/services/logic/logic_app_trigger_recurrence_resource.go
@@ -225,8 +225,7 @@ func resourceLogicAppTriggerRecurrenceDelete(d *pluginsdk.ResourceData, meta int
 
 	workflowId := workflows.NewWorkflowID(id.SubscriptionId, id.ResourceGroupName, id.WorkflowName)
 
-	err = resourceLogicAppTriggerRemove(d, meta, workflowId, id.TriggerName)
-	if err != nil {
+	if err = resourceLogicAppTriggerRemove(d, meta, workflowId, id.TriggerName); err != nil {
 		return fmt.Errorf("removing Trigger %s: %+v", id, err)
 	}
 

--- a/internal/services/maintenance/maintenance_assignment_dedicated_host_resource.go
+++ b/internal/services/maintenance/maintenance_assignment_dedicated_host_resource.go
@@ -117,7 +117,7 @@ func resourceArmMaintenanceAssignmentDedicatedHostCreate(d *pluginsdk.ResourceDa
 
 	// TODO: refactor to using a context-aware poller
 	// It may take a few minutes after starting a VM for it to become available to assign to a configuration
-	err = pluginsdk.Retry(d.Timeout(pluginsdk.TimeoutCreate), func() *pluginsdk.RetryError {
+	if err = pluginsdk.Retry(d.Timeout(pluginsdk.TimeoutCreate), func() *pluginsdk.RetryError {
 		if _, err := client.CreateOrUpdateParent(ctx, id, configurationAssignment); err != nil {
 			if strings.Contains(err.Error(), "It may take a few minutes after starting a VM for it to become available to assign to a configuration") {
 				return pluginsdk.RetryableError(errors.New("expected VM is available to assign to a configuration but was in pending state, retrying"))
@@ -126,8 +126,7 @@ func resourceArmMaintenanceAssignmentDedicatedHostCreate(d *pluginsdk.ResourceDa
 		}
 
 		return nil
-	})
-	if err != nil {
+	}); err != nil {
 		return err
 	}
 

--- a/internal/services/maintenance/maintenance_assignment_virtual_machine_resource.go
+++ b/internal/services/maintenance/maintenance_assignment_virtual_machine_resource.go
@@ -114,7 +114,7 @@ func resourceArmMaintenanceAssignmentVirtualMachineCreate(d *pluginsdk.ResourceD
 	}
 
 	// It may take a few minutes after starting a VM for it to become available to assign to a configuration
-	err = pluginsdk.Retry(d.Timeout(pluginsdk.TimeoutCreate), func() *pluginsdk.RetryError {
+	if err = pluginsdk.Retry(d.Timeout(pluginsdk.TimeoutCreate), func() *pluginsdk.RetryError {
 		if _, err := client.CreateOrUpdate(ctx, id, configurationAssignment); err != nil {
 			if strings.Contains(err.Error(), "It may take a few minutes after starting a VM for it to become available to assign to a configuration") {
 				return pluginsdk.RetryableError(errors.New("expected VM is available to assign to a configuration but was in pending state, retrying"))
@@ -123,8 +123,7 @@ func resourceArmMaintenanceAssignmentVirtualMachineCreate(d *pluginsdk.ResourceD
 		}
 
 		return nil
-	})
-	if err != nil {
+	}); err != nil {
 		return err
 	}
 

--- a/internal/services/managedapplications/managed_application_resource.go
+++ b/internal/services/managedapplications/managed_application_resource.go
@@ -232,8 +232,7 @@ func resourceManagedApplicationUpdate(d *pluginsdk.ResourceData, meta interface{
 	}
 	payload.Properties.Parameters = pointer.To(interface{}(params))
 
-	err = client.CreateOrUpdateThenPoll(ctx, *id, *payload)
-	if err != nil {
+	if err = client.CreateOrUpdateThenPoll(ctx, *id, *payload); err != nil {
 		return fmt.Errorf("updating %s: %+v", id, err)
 	}
 

--- a/internal/services/managedhsm/internal.go
+++ b/internal/services/managedhsm/internal.go
@@ -68,7 +68,7 @@ func deleteAndOptionallyPurge(ctx context.Context, description string, shouldPur
 	}
 
 	log.Printf("[DEBUG] Purging %s..", description)
-	err := pluginsdk.Retry(time.Until(timeout), func() *pluginsdk.RetryError {
+	if err := pluginsdk.Retry(time.Until(timeout), func() *pluginsdk.RetryError {
 		_, err := helper.PurgeNestedItem(ctx)
 		if err == nil {
 			return nil
@@ -77,8 +77,7 @@ func deleteAndOptionallyPurge(ctx context.Context, description string, shouldPur
 			return pluginsdk.RetryableError(fmt.Errorf("%s is currently being deleted, retrying", description))
 		}
 		return pluginsdk.NonRetryableError(fmt.Errorf("purging of %s : %+v", description, err))
-	})
-	if err != nil {
+	}); err != nil {
 		return err
 	}
 

--- a/internal/services/managedhsm/key_vault_managed_hardware_security_module_resource.go
+++ b/internal/services/managedhsm/key_vault_managed_hardware_security_module_resource.go
@@ -524,8 +524,7 @@ func securityDomainDownload(ctx context.Context, sdClient *kv74.HSMSecurityDomai
 		Value string `json:"value"`
 	}
 
-	err = json.Unmarshal(data, &encData)
-	if err != nil {
+	if err = json.Unmarshal(data, &encData); err != nil {
 		return "", fmt.Errorf("unmarshal EncData: %v", err)
 	}
 

--- a/internal/services/managedredis/managed_redis_resource.go
+++ b/internal/services/managedredis/managed_redis_resource.go
@@ -336,8 +336,7 @@ func (r ManagedRedisResource) Create() sdk.ResourceFunc {
 			if len(model.DefaultDatabase) == 1 {
 				dbModel := model.DefaultDatabase[0]
 
-				err := createDb(ctx, dbClient, dbId, dbModel)
-				if err != nil {
+				if err := createDb(ctx, dbClient, dbId, dbModel); err != nil {
 					return fmt.Errorf("creating %s: %+v", dbId, err)
 				}
 			}

--- a/internal/services/managementgroup/management_group_resource.go
+++ b/internal/services/managementgroup/management_group_resource.go
@@ -347,10 +347,9 @@ func resourceManagementGroupDelete(d *pluginsdk.ResourceData, meta interface{}) 
 		}
 	}
 
-	err = client.DeleteThenPoll(ctx, *id, managementgroups.DeleteOperationOptions{
+	if err = client.DeleteThenPoll(ctx, *id, managementgroups.DeleteOperationOptions{
 		CacheControl: &managementGroupCacheControl,
-	})
-	if err != nil {
+	}); err != nil {
 		return fmt.Errorf("unable to delete Management Group %q: %+v", id.GroupId, err)
 	}
 

--- a/internal/services/monitor/monitor_action_group_resource.go
+++ b/internal/services/monitor/monitor_action_group_resource.go
@@ -650,8 +650,7 @@ func expandMonitorActionGroupItsmReceiver(v []interface{}) (*[]actiongroupsapis.
 		// https://github.com/Azure/azure-rest-api-specs/issues/20488 ticket_configuration should have `PayloadRevision` and `WorkItemType` keys
 
 		j := make(map[string]interface{})
-		err := json.Unmarshal([]byte(ticketConfiguration), &j)
-		if err != nil {
+		if err := json.Unmarshal([]byte(ticketConfiguration), &j); err != nil {
 			return nil, fmt.Errorf("`itsm_receiver.ticket_configuration` %s unmarshall json error: %+v", ticketConfiguration, err)
 		}
 

--- a/internal/services/monitor/monitor_private_link_scope_resource.go
+++ b/internal/services/monitor/monitor_private_link_scope_resource.go
@@ -164,8 +164,7 @@ func resourceMonitorPrivateLinkScopeDelete(d *pluginsdk.ResourceData, meta inter
 		return err
 	}
 
-	err = client.PrivateLinkScopesDeleteThenPoll(ctx, *id)
-	if err != nil {
+	if err = client.PrivateLinkScopesDeleteThenPoll(ctx, *id); err != nil {
 		return fmt.Errorf("deleting %s: %+v", *id, err)
 	}
 

--- a/internal/services/monitor/monitor_private_link_scoped_service_resource.go
+++ b/internal/services/monitor/monitor_private_link_scoped_service_resource.go
@@ -151,8 +151,7 @@ func resourceMonitorPrivateLinkScopedServiceDelete(d *pluginsdk.ResourceData, me
 		return err
 	}
 
-	err = client.DeleteThenPoll(ctx, *id)
-	if err != nil {
+	if err = client.DeleteThenPoll(ctx, *id); err != nil {
 		return fmt.Errorf("deleting %s: %+v", *id, err)
 	}
 

--- a/internal/services/mssql/mssql_database_resource.go
+++ b/internal/services/mssql/mssql_database_resource.go
@@ -285,12 +285,11 @@ func resourceMsSqlDatabaseCreate(d *pluginsdk.ResourceData, meta interface{}) er
 
 			// See: https://docs.microsoft.com/en-us/azure/azure-sql/database/active-geo-replication-overview#configuring-secondary-database
 			if partnerDatabase.Sku != nil && partnerDatabase.Sku.Name != "" && helper.CompareDatabaseSkuServiceTiers(skuName, partnerDatabase.Sku.Name) {
-				err := client.UpdateThenPoll(ctx, *partnerDatabaseId, databases.DatabaseUpdate{
+				if err := client.UpdateThenPoll(ctx, *partnerDatabaseId, databases.DatabaseUpdate{
 					Sku: &databases.Sku{
 						Name: skuName,
 					},
-				})
-				if err != nil {
+				}); err != nil {
 					return fmt.Errorf("updating SKU of Replication Partner Database %s: %+v", partnerDatabaseId, err)
 				}
 			}
@@ -889,12 +888,11 @@ func resourceMsSqlDatabaseUpdate(d *pluginsdk.ResourceData, meta interface{}) er
 
 				// See: https://docs.microsoft.com/en-us/azure/azure-sql/database/active-geo-replication-overview#configuring-secondary-database
 				if partnerDatabase.Sku != nil && partnerDatabase.Sku.Name != "" && helper.CompareDatabaseSkuServiceTiers(skuName, partnerDatabase.Sku.Name) {
-					err := client.UpdateThenPoll(ctx, *partnerDatabaseId, databases.DatabaseUpdate{
+					if err := client.UpdateThenPoll(ctx, *partnerDatabaseId, databases.DatabaseUpdate{
 						Sku: &databases.Sku{
 							Name: skuName,
 						},
-					})
-					if err != nil {
+					}); err != nil {
 						return fmt.Errorf("updating SKU of Replication Partner Database %s: %+v", partnerDatabaseId, err)
 					}
 				}
@@ -955,8 +953,7 @@ func resourceMsSqlDatabaseUpdate(d *pluginsdk.ResourceData, meta interface{}) er
 	}
 
 	payload.Properties = pointer.To(props)
-	err = client.UpdateThenPoll(ctx, id, payload)
-	if err != nil {
+	if err = client.UpdateThenPoll(ctx, id, payload); err != nil {
 		return fmt.Errorf("updating %s: %+v", id, err)
 	}
 
@@ -1371,8 +1368,7 @@ func resourceMsSqlDatabaseDelete(d *pluginsdk.ResourceData, meta interface{}) er
 		return err
 	}
 
-	err = client.DeleteThenPoll(ctx, *id)
-	if err != nil {
+	if err = client.DeleteThenPoll(ctx, *id); err != nil {
 		return fmt.Errorf("deleting %s: %+v", id, err)
 	}
 

--- a/internal/services/mssql/mssql_elasticpool_resource.go
+++ b/internal/services/mssql/mssql_elasticpool_resource.go
@@ -401,8 +401,7 @@ func resourceMsSqlElasticPoolDelete(d *pluginsdk.ResourceData, meta interface{})
 		return err
 	}
 
-	err = client.DeleteThenPoll(ctx, *id)
-	if err != nil {
+	if err = client.DeleteThenPoll(ctx, *id); err != nil {
 		return fmt.Errorf("deleting ElasticPool %s: %+v", id, err)
 	}
 

--- a/internal/services/mssql/mssql_failover_group_resource.go
+++ b/internal/services/mssql/mssql_failover_group_resource.go
@@ -281,8 +281,7 @@ func (r MsSqlFailoverGroupResource) Update() sdk.ResourceFunc {
 			}
 
 			// client.Update doesn't support changing the PartnerServers
-			err = client.CreateOrUpdateThenPoll(ctx, *id, properties)
-			if err != nil {
+			if err = client.CreateOrUpdateThenPoll(ctx, *id, properties); err != nil {
 				return fmt.Errorf("updating %s: %+v", *id, err)
 			}
 
@@ -364,8 +363,7 @@ func (r MsSqlFailoverGroupResource) Delete() sdk.ResourceFunc {
 				return fmt.Errorf("retrieving %s: %+v", *id, err)
 			}
 
-			err = client.DeleteThenPoll(ctx, *id)
-			if err != nil {
+			if err = client.DeleteThenPoll(ctx, *id); err != nil {
 				return fmt.Errorf("deleting %s: %+v", *id, err)
 			}
 

--- a/internal/services/mssql/mssql_job_agent_resource.go
+++ b/internal/services/mssql/mssql_job_agent_resource.go
@@ -174,8 +174,7 @@ func resourceMsSqlJobAgentUpdate(d *pluginsdk.ResourceData, meta interface{}) er
 		params.Tags = tags.Expand(d.Get("tags").(map[string]interface{}))
 	}
 
-	err = client.CreateOrUpdateThenPoll(ctx, id, *params)
-	if err != nil {
+	if err = client.CreateOrUpdateThenPoll(ctx, id, *params); err != nil {
 		return fmt.Errorf("updating %s: %+v", id, err)
 	}
 
@@ -240,8 +239,7 @@ func resourceMsSqlJobAgentDelete(d *pluginsdk.ResourceData, meta interface{}) er
 		return err
 	}
 
-	err = client.DeleteThenPoll(ctx, *id)
-	if err != nil {
+	if err = client.DeleteThenPoll(ctx, *id); err != nil {
 		return fmt.Errorf("deleting %s: %+v", *id, err)
 	}
 

--- a/internal/services/mssql/mssql_outbound_firewall_rule_resource.go
+++ b/internal/services/mssql/mssql_outbound_firewall_rule_resource.go
@@ -125,8 +125,7 @@ func resourceMsSqlOutboundFirewallRuleDelete(d *pluginsdk.ResourceData, meta int
 		return fmt.Errorf("parsing ID %q: %+v", d.Id(), err)
 	}
 
-	err = client.DeleteThenPoll(ctx, *id)
-	if err != nil {
+	if err = client.DeleteThenPoll(ctx, *id); err != nil {
 		return fmt.Errorf("deleting MSSQL %s: %+v", id.String(), err)
 	}
 

--- a/internal/services/mssql/mssql_server_dns_alias_resource.go
+++ b/internal/services/mssql/mssql_server_dns_alias_resource.go
@@ -139,8 +139,7 @@ func (m ServerDNSAliasResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 			client := metadata.Client.MSSQL.ServerDNSAliasClient
-			err = client.DeleteThenPoll(ctx, *id)
-			if err != nil {
+			if err = client.DeleteThenPoll(ctx, *id); err != nil {
 				return fmt.Errorf("deleting %s: %v", id, err)
 			}
 			return nil

--- a/internal/services/mssql/mssql_server_extended_auditing_policy_resource.go
+++ b/internal/services/mssql/mssql_server_extended_auditing_policy_resource.go
@@ -171,8 +171,7 @@ func resourceMsSqlServerExtendedAuditingPolicyCreateUpdate(d *pluginsdk.Resource
 		params.Properties.AuditActionsAndGroups = helpers.ExpandStringSlice(v.([]interface{}))
 	}
 
-	err = client.ExtendedServerBlobAuditingPoliciesCreateOrUpdateThenPoll(ctx, *serverId, params)
-	if err != nil {
+	if err = client.ExtendedServerBlobAuditingPoliciesCreateOrUpdateThenPoll(ctx, *serverId, params); err != nil {
 		return fmt.Errorf("creating MsSql Server Extended Auditing Policy %s: %+v", serverId, err)
 	}
 
@@ -243,8 +242,7 @@ func resourceMsSqlServerExtendedAuditingPolicyDelete(d *pluginsdk.ResourceData, 
 		},
 	}
 
-	err = client.ExtendedServerBlobAuditingPoliciesCreateOrUpdateThenPoll(ctx, serverId, params)
-	if err != nil {
+	if err = client.ExtendedServerBlobAuditingPoliciesCreateOrUpdateThenPoll(ctx, serverId, params); err != nil {
 		return fmt.Errorf("deleting %s: %+v", serverId, err)
 	}
 	return nil

--- a/internal/services/mssql/mssql_server_microsoft_support_auditing_policy_resource.go
+++ b/internal/services/mssql/mssql_server_microsoft_support_auditing_policy_resource.go
@@ -201,8 +201,7 @@ func resourceMsSqlServerMicrosoftSupportAuditingPolicyDelete(d *pluginsdk.Resour
 		},
 	}
 
-	err = client.SettingsCreateOrUpdateThenPoll(ctx, serverId, params)
-	if err != nil {
+	if err = client.SettingsCreateOrUpdateThenPoll(ctx, serverId, params); err != nil {
 		return fmt.Errorf("deleting %s: %+v", id, err)
 	}
 

--- a/internal/services/mssql/mssql_server_resource.go
+++ b/internal/services/mssql/mssql_server_resource.go
@@ -372,8 +372,7 @@ func resourceMsSqlServerUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 	if d.HasChange("azuread_administrator") {
 		log.Printf("[INFO] Expanding 'azuread_administrator' to see if we need Create or Delete")
 		if adminProps := expandMsSqlServerAdministrator(d.Get("azuread_administrator").([]interface{})); adminProps != nil {
-			err := adminClient.CreateOrUpdateThenPoll(ctx, *id, pointer.From(adminProps))
-			if err != nil {
+			if err := adminClient.CreateOrUpdateThenPoll(ctx, *id, pointer.From(adminProps)); err != nil {
 				return fmt.Errorf("updating Azure Active Directory Administrator %s: %+v", id, err)
 			}
 		} else {
@@ -381,8 +380,7 @@ func resourceMsSqlServerUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 				return fmt.Errorf("retrieving Azure Active Directory Administrator %s: %+v", id, err)
 			}
 
-			err = adminClient.DeleteThenPoll(ctx, *id)
-			if err != nil {
+			if err = adminClient.DeleteThenPoll(ctx, *id); err != nil {
 				return fmt.Errorf("deleting Azure Active Directory Administrator %s: %+v", id, err)
 			}
 		}
@@ -398,8 +396,7 @@ func resourceMsSqlServerUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 				},
 			}
 
-			err := aadOnlyAuthenticationsClient.CreateOrUpdateThenPoll(ctx, *id, aadOnlyAuthenticationProps)
-			if err != nil {
+			if err := aadOnlyAuthenticationsClient.CreateOrUpdateThenPoll(ctx, *id, aadOnlyAuthenticationProps); err != nil {
 				return fmt.Errorf("updating Azure Active Directory Only Authentication for %s: %+v", id, err)
 			}
 		} else {
@@ -487,8 +484,7 @@ func resourceMsSqlServerUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 			payload.Properties.MinimalTlsVersion = pointer.ToEnum[servers.MinimalTlsVersion](d.Get("minimum_tls_version").(string))
 		}
 
-		err := client.CreateOrUpdateThenPoll(ctx, *id, *payload)
-		if err != nil {
+		if err := client.CreateOrUpdateThenPoll(ctx, *id, *payload); err != nil {
 			return fmt.Errorf("updating %s: %+v", id, err)
 		}
 	}
@@ -646,8 +642,7 @@ func resourceMsSqlServerDelete(d *pluginsdk.ResourceData, meta interface{}) erro
 		return err
 	}
 
-	err = client.DeleteThenPoll(ctx, pointer.From(id))
-	if err != nil {
+	if err = client.DeleteThenPoll(ctx, pointer.From(id)); err != nil {
 		return fmt.Errorf("deleting SQL Server %s: %+v", id, err)
 	}
 

--- a/internal/services/mssql/mssql_server_security_alert_policy_resource.go
+++ b/internal/services/mssql/mssql_server_security_alert_policy_resource.go
@@ -361,8 +361,7 @@ func resourceMsSqlServerSecurityAlertPolicyUpdate(d *pluginsdk.ResourceData, met
 
 	payload.Properties = props
 
-	err = client.CreateOrUpdateThenPoll(ctx, serverId, payload)
-	if err != nil {
+	if err = client.CreateOrUpdateThenPoll(ctx, serverId, payload); err != nil {
 		return fmt.Errorf("updating mssql server security alert policy: %+v", err)
 	}
 
@@ -387,8 +386,7 @@ func resourceMsSqlServerSecurityAlertPolicyDelete(d *pluginsdk.ResourceData, met
 
 	serverId := commonids.NewSqlServerID(id.SubscriptionId, id.ResourceGroup, id.ServerName)
 
-	err = client.CreateOrUpdateThenPoll(ctx, serverId, disabledPolicy)
-	if err != nil {
+	if err = client.CreateOrUpdateThenPoll(ctx, serverId, disabledPolicy); err != nil {
 		return fmt.Errorf("updating mssql server security alert policy: %+v", err)
 	}
 

--- a/internal/services/mssql/mssql_server_transparent_data_encryption_resource.go
+++ b/internal/services/mssql/mssql_server_transparent_data_encryption_resource.go
@@ -219,8 +219,7 @@ func resourceMsSqlTransparentDataEncryptionDelete(d *pluginsdk.ResourceData, met
 		},
 	}
 
-	err = client.CreateOrUpdateThenPoll(ctx, serverId, encryptionProtector)
-	if err != nil {
+	if err = client.CreateOrUpdateThenPoll(ctx, serverId, encryptionProtector); err != nil {
 		return fmt.Errorf("deleting %s: %+v", id, err)
 	}
 

--- a/internal/services/mssql/mssql_virtual_network_rule_resource.go
+++ b/internal/services/mssql/mssql_virtual_network_rule_resource.go
@@ -175,8 +175,7 @@ func resourceMsSqlVirtualNetworkRuleDelete(d *pluginsdk.ResourceData, meta inter
 		return fmt.Errorf("parsing ID %q: %+v", d.Id(), err)
 	}
 
-	err = client.DeleteThenPoll(ctx, *id)
-	if err != nil {
+	if err = client.DeleteThenPoll(ctx, *id); err != nil {
 		return fmt.Errorf("deleting MSSQL %s: %+v", id.String(), err)
 	}
 

--- a/internal/services/mssqlmanagedinstance/mssql_managed_database_resource.go
+++ b/internal/services/mssqlmanagedinstance/mssql_managed_database_resource.go
@@ -294,8 +294,7 @@ func (r MsSqlManagedDatabaseResource) Update() sdk.ResourceFunc {
 					Tags:     pointer.To(model.Tags),
 				}
 
-				err = client.CreateOrUpdateThenPoll(ctx, id, parameters)
-				if err != nil {
+				if err = client.CreateOrUpdateThenPoll(ctx, id, parameters); err != nil {
 					return fmt.Errorf("updating %s: %+v", id, err)
 				}
 			}
@@ -405,8 +404,7 @@ func (r MsSqlManagedDatabaseResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			err = client.DeleteThenPoll(ctx, *id)
-			if err != nil {
+			if err = client.DeleteThenPoll(ctx, *id); err != nil {
 				return fmt.Errorf("deleting %s: %+v", *id, err)
 			}
 

--- a/internal/services/mssqlmanagedinstance/mssql_managed_instance_active_directory_administrator_resource.go
+++ b/internal/services/mssqlmanagedinstance/mssql_managed_instance_active_directory_administrator_resource.go
@@ -138,8 +138,7 @@ func (r MsSqlManagedInstanceActiveDirectoryAdministratorResource) Create() sdk.R
 				},
 			}
 
-			err = aadAuthOnlyClient.CreateOrUpdateThenPoll(ctx, *managedInstanceId, aadAuthOnlyParams)
-			if err != nil {
+			if err = aadAuthOnlyClient.CreateOrUpdateThenPoll(ctx, *managedInstanceId, aadAuthOnlyParams); err != nil {
 				return fmt.Errorf("setting `azuread_authentication_only` for %s: %+v", id, err)
 			}
 
@@ -179,8 +178,7 @@ func (r MsSqlManagedInstanceActiveDirectoryAdministratorResource) Update() sdk.R
 				},
 			}
 
-			err = client.CreateOrUpdateThenPoll(ctx, *managedInstanceId, parameters)
-			if err != nil {
+			if err = client.CreateOrUpdateThenPoll(ctx, *managedInstanceId, parameters); err != nil {
 				return fmt.Errorf("updating %s: %+v", id, err)
 			}
 
@@ -190,8 +188,7 @@ func (r MsSqlManagedInstanceActiveDirectoryAdministratorResource) Update() sdk.R
 				},
 			}
 
-			err = aadAuthOnlyClient.CreateOrUpdateThenPoll(ctx, *managedInstanceId, aadAuthOnlyProperties)
-			if err != nil {
+			if err = aadAuthOnlyClient.CreateOrUpdateThenPoll(ctx, *managedInstanceId, aadAuthOnlyProperties); err != nil {
 				return fmt.Errorf("setting `azuread_authentication_only` for %s: %+v", id, err)
 			}
 
@@ -278,13 +275,11 @@ func (r MsSqlManagedInstanceActiveDirectoryAdministratorResource) Delete() sdk.R
 				},
 			}
 
-			err = aadAuthOnlyClient.CreateOrUpdateThenPoll(ctx, managedInstanceId, aadAuthOnlyParams)
-			if err != nil {
+			if err = aadAuthOnlyClient.CreateOrUpdateThenPoll(ctx, managedInstanceId, aadAuthOnlyParams); err != nil {
 				return fmt.Errorf("disabling `azuread_authentication_only` for %s: %+v", id, err)
 			}
 
-			err = client.DeleteThenPoll(ctx, managedInstanceId)
-			if err != nil {
+			if err = client.DeleteThenPoll(ctx, managedInstanceId); err != nil {
 				return fmt.Errorf("deleting %s: %+v", *id, err)
 			}
 

--- a/internal/services/mssqlmanagedinstance/mssql_managed_instance_failover_group_resource.go
+++ b/internal/services/mssqlmanagedinstance/mssql_managed_instance_failover_group_resource.go
@@ -302,8 +302,7 @@ func (r MsSqlManagedInstanceFailoverGroupResource) Update() sdk.ResourceFunc {
 				}
 			}
 
-			err = client.CreateOrUpdateThenPoll(ctx, *id, parameters)
-			if err != nil {
+			if err = client.CreateOrUpdateThenPoll(ctx, *id, parameters); err != nil {
 				return fmt.Errorf("updating %s: %+v", id, err)
 			}
 
@@ -405,8 +404,7 @@ func (r MsSqlManagedInstanceFailoverGroupResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			err = client.DeleteThenPoll(ctx, *id)
-			if err != nil {
+			if err = client.DeleteThenPoll(ctx, *id); err != nil {
 				return fmt.Errorf("deleting %s: %+v", *id, err)
 			}
 

--- a/internal/services/mssqlmanagedinstance/mssql_managed_instance_resource.go
+++ b/internal/services/mssqlmanagedinstance/mssql_managed_instance_resource.go
@@ -662,8 +662,7 @@ func (r MsSqlManagedInstanceResource) Update() sdk.ResourceFunc {
 							AzureADOnlyAuthentication: false,
 						},
 					}
-					err = azureADAuthenticationOnlyClient.CreateOrUpdateThenPoll(ctx, *id, aadAuthOnlyParams)
-					if err != nil {
+					if err = azureADAuthenticationOnlyClient.CreateOrUpdateThenPoll(ctx, *id, aadAuthOnlyParams); err != nil {
 						return fmt.Errorf("disabling `azuread_authentication_only` for %s: %+v", *id, err)
 					}
 
@@ -686,8 +685,7 @@ func (r MsSqlManagedInstanceResource) Update() sdk.ResourceFunc {
 						},
 					}
 
-					err := azureADAuthenticationOnlyClient.CreateOrUpdateThenPoll(ctx, *id, aadOnlyAuthenticationsProps)
-					if err != nil {
+					if err := azureADAuthenticationOnlyClient.CreateOrUpdateThenPoll(ctx, *id, aadOnlyAuthenticationsProps); err != nil {
 						return fmt.Errorf("setting `azuread_authentication_only_enabled` for %s: %+v", *id, err)
 					}
 				}
@@ -827,8 +825,7 @@ func (r MsSqlManagedInstanceResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			err = client.DeleteThenPoll(ctx, *id)
-			if err != nil {
+			if err = client.DeleteThenPoll(ctx, *id); err != nil {
 				return fmt.Errorf("deleting %s: %+v", *id, err)
 			}
 

--- a/internal/services/mssqlmanagedinstance/mssql_managed_instance_security_alert_policy_resource.go
+++ b/internal/services/mssqlmanagedinstance/mssql_managed_instance_security_alert_policy_resource.go
@@ -227,8 +227,7 @@ func resourceMsSqlManagedInstanceSecurityAlertPolicyUpdate(d *pluginsdk.Resource
 		payload.Properties.StorageEndpoint = nil
 	}
 
-	err = client.CreateOrUpdateThenPoll(ctx, managedInstanceId, *payload)
-	if err != nil {
+	if err = client.CreateOrUpdateThenPoll(ctx, managedInstanceId, *payload); err != nil {
 		return fmt.Errorf("updating managed instance security alert policy: %v", err)
 	}
 
@@ -328,8 +327,7 @@ func resourceMsSqlManagedInstanceSecurityAlertPolicyDelete(d *pluginsdk.Resource
 		},
 	}
 
-	err = client.CreateOrUpdateThenPoll(ctx, managedInstanceId, disabledPolicy)
-	if err != nil {
+	if err = client.CreateOrUpdateThenPoll(ctx, managedInstanceId, disabledPolicy); err != nil {
 		return fmt.Errorf("updating managed instance security alert policy: %v", err)
 	}
 

--- a/internal/services/mssqlmanagedinstance/mssql_managed_instance_transparent_data_encryption_resource.go
+++ b/internal/services/mssqlmanagedinstance/mssql_managed_instance_transparent_data_encryption_resource.go
@@ -221,8 +221,7 @@ func resourceMsSqlManagedInstanceTransparentDataEncryptionDelete(d *pluginsdk.Re
 		},
 	}
 
-	err = client.CreateOrUpdateThenPoll(ctx, managedInstanceId, encryptionProtector)
-	if err != nil {
+	if err = client.CreateOrUpdateThenPoll(ctx, managedInstanceId, encryptionProtector); err != nil {
 		return fmt.Errorf("deleting %s: %+v", id, err)
 	}
 

--- a/internal/services/netapp/netapp_snapshot_policy_resource.go
+++ b/internal/services/netapp/netapp_snapshot_policy_resource.go
@@ -356,8 +356,7 @@ func resourceNetAppSnapshotPolicyDelete(d *pluginsdk.ResourceData, meta interfac
 	}
 
 	// Try to delete the snapshot policy using DeleteThenPoll
-	err = client.DeleteThenPoll(ctx, *id)
-	if err != nil {
+	if err = client.DeleteThenPoll(ctx, *id); err != nil {
 		// Check if error is about snapshot policy being in use
 		if strings.Contains(err.Error(), "SnapshotPolicy is used") {
 			// Get all volumes in the account that might be using this snapshot policy

--- a/internal/services/network/application_gateway_resource.go
+++ b/internal/services/network/application_gateway_resource.go
@@ -5146,8 +5146,7 @@ func applicationGatewayCustomizeDiff(ctx context.Context, d *pluginsdk.ResourceD
 	tier := d.Get("sku.0.tier").(string)
 
 	if tier == string(applicationgateways.ApplicationGatewaySkuNameBasic) {
-		err := checkBasicSkuFeatures(d)
-		if err != nil {
+		if err := checkBasicSkuFeatures(d); err != nil {
 			return err
 		}
 	} else if !hasAutoscaleConfig && !hasCapacity {

--- a/internal/services/network/ip_groups_data_source.go
+++ b/internal/services/network/ip_groups_data_source.go
@@ -81,13 +81,11 @@ func dataSourceIpGroupsRead(d *pluginsdk.ResourceData, meta interface{}) error {
 
 	d.SetId(id.ID())
 
-	err = d.Set("names", names)
-	if err != nil {
+	if err = d.Set("names", names); err != nil {
 		return fmt.Errorf("error setting names: %+v", err)
 	}
 
-	err = d.Set("ids", ids)
-	if err != nil {
+	if err = d.Set("ids", ids); err != nil {
 		return fmt.Errorf("error setting ids: %+v", err)
 	}
 

--- a/internal/services/network/network_interface_application_security_group_association_resource.go
+++ b/internal/services/network/network_interface_application_security_group_association_resource.go
@@ -118,8 +118,7 @@ func resourceNetworkInterfaceApplicationSecurityGroupAssociationCreate(d *plugin
 
 	props.IPConfigurations = mapFieldsToNetworkInterface(props.IPConfigurations, info)
 
-	err = client.CreateOrUpdateCallbackThenPoll(ctx, *networkInterfaceId, *read.Model, sdk.SetIDCallback(meta, &id, d))
-	if err != nil {
+	if err = client.CreateOrUpdateCallbackThenPoll(ctx, *networkInterfaceId, *read.Model, sdk.SetIDCallback(meta, &id, d)); err != nil {
 		return fmt.Errorf("updating Application Security Group Association for %s: %+v", *networkInterfaceId, err)
 	}
 
@@ -222,8 +221,7 @@ func resourceNetworkInterfaceApplicationSecurityGroupAssociationDelete(d *plugin
 	info.applicationSecurityGroupIDs = applicationSecurityGroupIds
 	props.IPConfigurations = mapFieldsToNetworkInterface(props.IPConfigurations, info)
 
-	err = client.CreateOrUpdateThenPoll(ctx, *id.First, *read.Model)
-	if err != nil {
+	if err = client.CreateOrUpdateThenPoll(ctx, *id.First, *read.Model); err != nil {
 		return fmt.Errorf("removing Application Security Group for %s: %+v", id.First, err)
 	}
 

--- a/internal/services/network/network_interface_resource.go
+++ b/internal/services/network/network_interface_resource.go
@@ -299,8 +299,7 @@ func resourceNetworkInterfaceCreate(d *pluginsdk.ResourceData, meta interface{})
 		Tags:             tags.Expand(d.Get("tags").(map[string]interface{})),
 	}
 
-	err = client.CreateOrUpdateCallbackThenPoll(ctx, id, iface, sdk.SetIDAndIdentityCallback(meta, &id, d))
-	if err != nil {
+	if err = client.CreateOrUpdateCallbackThenPoll(ctx, id, iface, sdk.SetIDAndIdentityCallback(meta, &id, d)); err != nil {
 		return fmt.Errorf("creating %s: %+v", id, err)
 	}
 
@@ -418,8 +417,7 @@ func resourceNetworkInterfaceUpdate(d *pluginsdk.ResourceData, meta interface{})
 	}
 
 	if propsOtherThanTagsUpdated || !attachedToPrivateEndpoint {
-		err = client.CreateOrUpdateThenPoll(ctx, *id, *payload)
-		if err != nil {
+		if err = client.CreateOrUpdateThenPoll(ctx, *id, *payload); err != nil {
 			return fmt.Errorf("updating %s: %+v", *id, err)
 		}
 	}
@@ -576,8 +574,7 @@ func resourceNetworkInterfaceDelete(d *pluginsdk.ResourceData, meta interface{})
 	lockingDetails.lock()
 	defer lockingDetails.unlock()
 
-	err = client.DeleteThenPoll(ctx, *id)
-	if err != nil {
+	if err = client.DeleteThenPoll(ctx, *id); err != nil {
 		return fmt.Errorf("deleting %s: %+v", *id, err)
 	}
 

--- a/internal/services/network/network_interface_resource_test.go
+++ b/internal/services/network/network_interface_resource_test.go
@@ -419,8 +419,7 @@ func (NetworkInterfaceResource) Destroy(ctx context.Context, client *clients.Cli
 		return nil, err
 	}
 
-	err = client.Network.NetworkInterfaces.DeleteThenPoll(ctx, *id)
-	if err != nil {
+	if err = client.Network.NetworkInterfaces.DeleteThenPoll(ctx, *id); err != nil {
 		return nil, fmt.Errorf("deleting %s: %+v", *id, err)
 	}
 

--- a/internal/services/network/network_manager_admin_rule_collection_resource.go
+++ b/internal/services/network/network_manager_admin_rule_collection_resource.go
@@ -226,10 +226,9 @@ func (r ManagerAdminRuleCollectionResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			err = client.DeleteThenPoll(ctx, *id, adminrulecollections.DeleteOperationOptions{
+			if err = client.DeleteThenPoll(ctx, *id, adminrulecollections.DeleteOperationOptions{
 				Force: pointer.To(true),
-			})
-			if err != nil {
+			}); err != nil {
 				return fmt.Errorf("deleting %s: %+v", id, err)
 			}
 

--- a/internal/services/network/network_manager_admin_rule_resource.go
+++ b/internal/services/network/network_manager_admin_rule_resource.go
@@ -395,10 +395,9 @@ func (r ManagerAdminRuleResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			err = client.DeleteThenPoll(ctx, *id, adminrules.DeleteOperationOptions{
+			if err = client.DeleteThenPoll(ctx, *id, adminrules.DeleteOperationOptions{
 				Force: pointer.To(true),
-			})
-			if err != nil {
+			}); err != nil {
 				return fmt.Errorf("deleting %s: %+v", id, err)
 			}
 

--- a/internal/services/network/network_manager_connectivity_configuration_resource.go
+++ b/internal/services/network/network_manager_connectivity_configuration_resource.go
@@ -420,10 +420,9 @@ func (r ManagerConnectivityConfigurationResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			err = client.DeleteThenPoll(ctx, *id, connectivityconfigurations.DeleteOperationOptions{
+			if err = client.DeleteThenPoll(ctx, *id, connectivityconfigurations.DeleteOperationOptions{
 				Force: pointer.To(true),
-			})
-			if err != nil {
+			}); err != nil {
 				return fmt.Errorf("deleting %s: %+v", id, err)
 			}
 

--- a/internal/services/network/network_manager_network_group_resource.go
+++ b/internal/services/network/network_manager_network_group_resource.go
@@ -220,10 +220,9 @@ func (r ManagerNetworkGroupResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			err = client.DeleteThenPoll(ctx, *id, networkgroups.DeleteOperationOptions{
+			if err = client.DeleteThenPoll(ctx, *id, networkgroups.DeleteOperationOptions{
 				Force: pointer.To(true),
-			})
-			if err != nil {
+			}); err != nil {
 				return fmt.Errorf("deleting %s: %+v", *id, err)
 			}
 

--- a/internal/services/network/network_manager_resource.go
+++ b/internal/services/network/network_manager_resource.go
@@ -327,10 +327,9 @@ func (r ManagerResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			err = client.DeleteThenPoll(ctx, *id, networkmanagers.DeleteOperationOptions{
+			if err = client.DeleteThenPoll(ctx, *id, networkmanagers.DeleteOperationOptions{
 				Force: pointer.To(true),
-			})
-			if err != nil {
+			}); err != nil {
 				return fmt.Errorf("deleting %s: %+v", *id, err)
 			}
 

--- a/internal/services/network/network_manager_security_admin_configuration_resource.go
+++ b/internal/services/network/network_manager_security_admin_configuration_resource.go
@@ -235,10 +235,9 @@ func (r ManagerSecurityAdminConfigurationResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			err = client.DeleteThenPoll(ctx, *id, securityadminconfigurations.DeleteOperationOptions{
+			if err = client.DeleteThenPoll(ctx, *id, securityadminconfigurations.DeleteOperationOptions{
 				Force: pointer.To(true),
-			})
-			if err != nil {
+			}); err != nil {
 				return fmt.Errorf("deleting %s: %+v", id, err)
 			}
 

--- a/internal/services/network/network_service_tags_data_source.go
+++ b/internal/services/network/network_service_tags_data_source.go
@@ -102,8 +102,7 @@ func dataSourceNetworkServiceTagsRead(d *pluginsdk.ResourceData, meta interface{
 				if props.AddressPrefixes != nil {
 					addressPrefixes = *props.AddressPrefixes
 				}
-				err = d.Set("address_prefixes", addressPrefixes)
-				if err != nil {
+				if err = d.Set("address_prefixes", addressPrefixes); err != nil {
 					return fmt.Errorf("setting `address_prefixes`: %+v", err)
 				}
 
@@ -123,13 +122,11 @@ func dataSourceNetworkServiceTagsRead(d *pluginsdk.ResourceData, meta interface{
 					}
 				}
 
-				err = d.Set("ipv4_cidrs", ipv4Cidrs)
-				if err != nil {
+				if err = d.Set("ipv4_cidrs", ipv4Cidrs); err != nil {
 					return fmt.Errorf("setting `ipv4_cidrs`: %+v", err)
 				}
 
-				err = d.Set("ipv6_cidrs", ipv6Cidrs)
-				if err != nil {
+				if err = d.Set("ipv6_cidrs", ipv6Cidrs); err != nil {
 					return fmt.Errorf("setting `ipv6_cidrs`: %+v", err)
 				}
 

--- a/internal/services/network/private_endpoint_application_security_group_association_resource.go
+++ b/internal/services/network/private_endpoint_application_security_group_association_resource.go
@@ -218,9 +218,7 @@ func (p PrivateEndpointApplicationSecurityGroupAssociationResource) Read() sdk.R
 			}
 			if !ASGInPE {
 				log.Printf("ApplicationSecurityGroup %q does not exist in %q, removing from state.", ASGId, privateEndpointId)
-				if err := metadata.MarkAsGone(resourceId); err != nil {
-					return err
-				}
+				return metadata.MarkAsGone(resourceId)
 			}
 
 			state := PrivateEndpointApplicationSecurityGroupAssociationModel{

--- a/internal/services/network/private_endpoint_application_security_group_association_resource.go
+++ b/internal/services/network/private_endpoint_application_security_group_association_resource.go
@@ -218,8 +218,7 @@ func (p PrivateEndpointApplicationSecurityGroupAssociationResource) Read() sdk.R
 			}
 			if !ASGInPE {
 				log.Printf("ApplicationSecurityGroup %q does not exist in %q, removing from state.", ASGId, privateEndpointId)
-				err := metadata.MarkAsGone(resourceId)
-				if err != nil {
+				if err := metadata.MarkAsGone(resourceId); err != nil {
 					return err
 				}
 			}

--- a/internal/services/network/private_endpoint_resource.go
+++ b/internal/services/network/private_endpoint_resource.go
@@ -374,7 +374,7 @@ func resourcePrivateEndpointCreate(d *pluginsdk.ResourceData, meta interface{}) 
 
 	// TODO: refactor to remove Retry func
 	// TODO: implement callback
-	err := pluginsdk.Retry(d.Timeout(pluginsdk.TimeoutCreate), func() *pluginsdk.RetryError {
+	if err := pluginsdk.Retry(d.Timeout(pluginsdk.TimeoutCreate), func() *pluginsdk.RetryError {
 		result, err := client.CreateOrUpdate(ctx, id, parameters)
 		if err != nil {
 			return &pluginsdk.RetryError{
@@ -416,8 +416,7 @@ func resourcePrivateEndpointCreate(d *pluginsdk.ResourceData, meta interface{}) 
 		}
 
 		return nil
-	})
-	if err != nil {
+	}); err != nil {
 		return err
 	}
 
@@ -537,16 +536,14 @@ func resourcePrivateEndpointUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
 	}
 
-	err = validatePrivateLinkServiceId(*parameters.Properties.PrivateLinkServiceConnections)
-	if err != nil {
+	if err = validatePrivateLinkServiceId(*parameters.Properties.PrivateLinkServiceConnections); err != nil {
 		return err
 	}
-	err = validatePrivateLinkServiceId(*parameters.Properties.ManualPrivateLinkServiceConnections)
-	if err != nil {
+	if err = validatePrivateLinkServiceId(*parameters.Properties.ManualPrivateLinkServiceConnections); err != nil {
 		return err
 	}
 
-	err = pluginsdk.Retry(d.Timeout(pluginsdk.TimeoutCreate), func() *pluginsdk.RetryError {
+	if err = pluginsdk.Retry(d.Timeout(pluginsdk.TimeoutCreate), func() *pluginsdk.RetryError {
 		if err = client.CreateOrUpdateThenPoll(ctx, *id, parameters); err != nil {
 			switch {
 			case strings.EqualFold(err.Error(), "is missing required parameter 'group Id'"):
@@ -571,8 +568,7 @@ func resourcePrivateEndpointUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 		}
 
 		return nil
-	})
-	if err != nil {
+	}); err != nil {
 		return err
 	}
 

--- a/internal/services/network/subnet_resource_list.go
+++ b/internal/services/network/subnet_resource_list.go
@@ -90,8 +90,7 @@ func (r SubnetListResource) List(ctx context.Context, request list.ListRequest, 
 
 			rd.SetId(id.ID())
 
-			err = resourceSubnetFlatten(rd, *id, &subnet)
-			if err != nil {
+			if err = resourceSubnetFlatten(rd, *id, &subnet); err != nil {
 				sdk.SetErrorDiagnosticAndPushListResult(result, push, "encoding resource data", err)
 				return
 			}

--- a/internal/services/network/virtual_network_resource_list.go
+++ b/internal/services/network/virtual_network_resource_list.go
@@ -89,8 +89,7 @@ func (r VirtualNetworkListResource) List(ctx context.Context, request list.ListR
 
 			rd.SetId(id.ID())
 
-			err = resourceVirtualNetworkFlatten(rd, *id, &vnet)
-			if err != nil {
+			if err = resourceVirtualNetworkFlatten(rd, *id, &vnet); err != nil {
 				sdk.SetErrorDiagnosticAndPushListResult(result, push, "encoding Resource data", err)
 				return
 			}

--- a/internal/services/nginx/nginx_certificate_resource.go
+++ b/internal/services/nginx/nginx_certificate_resource.go
@@ -160,8 +160,7 @@ func (m CertificateResource) Update() sdk.ResourceFunc {
 				upd.Properties.KeyVaultSecretId = pointer.To(model.KeyVaultSecretId)
 			}
 
-			err = client.CertificatesCreateOrUpdateThenPoll(ctx, *id, *upd)
-			if err != nil {
+			if err = client.CertificatesCreateOrUpdateThenPoll(ctx, *id, *upd); err != nil {
 				return fmt.Errorf("updating %s: %v", id, err)
 			}
 			return nil

--- a/internal/services/oracle/oracle_autonomous_database_backup_resource.go
+++ b/internal/services/oracle/oracle_autonomous_database_backup_resource.go
@@ -161,8 +161,7 @@ func (r AutonomousDatabaseBackupResource) Read() sdk.ResourceFunc {
 			}
 
 			if backup == nil {
-				err := metadata.MarkAsGone(id)
-				if err != nil {
+				if err := metadata.MarkAsGone(id); err != nil {
 					return err
 				}
 				return nil

--- a/internal/services/oracle/oracle_exadata_infrastructure_resource.go
+++ b/internal/services/oracle/oracle_exadata_infrastructure_resource.go
@@ -300,8 +300,7 @@ func (r ExadataInfraResource) Update() sdk.ResourceFunc {
 				update := &cloudexadatainfrastructures.CloudExadataInfrastructureUpdate{
 					Tags: pointer.To(model.Tags),
 				}
-				err = client.UpdateThenPoll(ctx, *id, *update)
-				if err != nil {
+				if err = client.UpdateThenPoll(ctx, *id, *update); err != nil {
 					return fmt.Errorf("updating %s: %v", id, err)
 				}
 			}

--- a/internal/services/oracle/oracle_exascale_database_storage_vault_resource.go
+++ b/internal/services/oracle/oracle_exascale_database_storage_vault_resource.go
@@ -204,8 +204,7 @@ func (r ExascaleDatabaseStorageVaultResource) Update() sdk.ResourceFunc {
 				Tags: pointer.To(model.Tags),
 			}
 
-			err = client.UpdateThenPoll(ctx, *id, *update)
-			if err != nil {
+			if err = client.UpdateThenPoll(ctx, *id, *update); err != nil {
 				return fmt.Errorf("updating %s: %v", id, err)
 			}
 

--- a/internal/services/purview/purview_account_resource.go
+++ b/internal/services/purview/purview_account_resource.go
@@ -337,8 +337,7 @@ func resourcePurviewAccountDelete(d *pluginsdk.ResourceData, meta interface{}) e
 		return err
 	}
 
-	err = client.DeleteThenPoll(ctx, *id)
-	if err != nil {
+	if err = client.DeleteThenPoll(ctx, *id); err != nil {
 		return fmt.Errorf("deleting %s: %+v", *id, err)
 	}
 

--- a/internal/services/recoveryservices/backup_protected_vm_resource.go
+++ b/internal/services/recoveryservices/backup_protected_vm_resource.go
@@ -110,8 +110,7 @@ func resourceRecoveryServicesBackupProtectedVMCreate(d *pluginsdk.ResourceData, 
 
 		if isSoftDeleted {
 			if meta.(*clients.Client).Features.RecoveryServicesVault.RecoverSoftDeletedBackupProtectedVM {
-				err = resourceRecoveryServicesVaultBackupProtectedVMRecoverSoftDeleted(ctx, client, id)
-				if err != nil {
+				if err = resourceRecoveryServicesVaultBackupProtectedVMRecoverSoftDeleted(ctx, client, id); err != nil {
 					return fmt.Errorf("recovering soft deleted %s: %+v", id, err)
 				}
 			} else {

--- a/internal/services/recoveryservices/recovery_services_vault_resource.go
+++ b/internal/services/recoveryservices/recovery_services_vault_resource.go
@@ -398,8 +398,7 @@ func resourceRecoveryServicesVaultUpdate(d *pluginsdk.ResourceData, meta interfa
 			vault.Sku.Tier = pointer.To("Standard")
 		}
 
-		err = client.CreateOrUpdateThenPoll(ctx, id, vault, vaults.DefaultCreateOrUpdateOperationOptions())
-		if err != nil {
+		if err = client.CreateOrUpdateThenPoll(ctx, id, vault, vaults.DefaultCreateOrUpdateOperationOptions()); err != nil {
 			return fmt.Errorf("updating Recovery Service %s: %+v", id, err)
 		}
 	}
@@ -464,14 +463,12 @@ func resourceRecoveryServicesVaultUpdate(d *pluginsdk.ResourceData, meta interfa
 		}
 	}
 
-	err = client.UpdateThenPoll(ctx, id, vault, vaults.DefaultUpdateOperationOptions())
-	if err != nil {
+	if err = client.UpdateThenPoll(ctx, id, vault, vaults.DefaultUpdateOperationOptions()); err != nil {
 		return fmt.Errorf("updating  %s: %+v", id, err)
 	}
 
 	if requireAdditionalUpdate {
-		err := client.UpdateThenPoll(ctx, id, additionalUpdatePatch, vaults.DefaultUpdateOperationOptions())
-		if err != nil {
+		if err := client.UpdateThenPoll(ctx, id, additionalUpdatePatch, vaults.DefaultUpdateOperationOptions()); err != nil {
 			return fmt.Errorf("updating Recovery Service %s: %+v, but recovery vault was created, a manually import might be required", id, err)
 		}
 	}

--- a/internal/services/recoveryservices/site_recovery_hyperv_network_mapping_resource.go
+++ b/internal/services/recoveryservices/site_recovery_hyperv_network_mapping_resource.go
@@ -208,8 +208,7 @@ func (s HyperVNetworkMappingResource) Delete() sdk.ResourceFunc {
 
 			client := metadata.Client.RecoveryServices.NetworkMappingClient
 
-			err = client.DeleteThenPoll(ctx, *id)
-			if err != nil {
+			if err = client.DeleteThenPoll(ctx, *id); err != nil {
 				return fmt.Errorf("deleting %s: %v", id, err)
 			}
 

--- a/internal/services/recoveryservices/site_recovery_hyperv_replication_policy_resource.go
+++ b/internal/services/recoveryservices/site_recovery_hyperv_replication_policy_resource.go
@@ -194,8 +194,7 @@ func (r ReplicationPolicyHyperVResource) Update() sdk.ResourceFunc {
 				},
 			}
 
-			err = client.UpdateThenPoll(ctx, *id, parameters)
-			if err != nil {
+			if err = client.UpdateThenPoll(ctx, *id, parameters); err != nil {
 				return fmt.Errorf("updating %s: %+v", id, err)
 			}
 
@@ -215,8 +214,7 @@ func (r ReplicationPolicyHyperVResource) Delete() sdk.ResourceFunc {
 
 			client := metadata.Client.RecoveryServices.ReplicationPoliciesClient
 
-			err = client.DeleteThenPoll(ctx, *id)
-			if err != nil {
+			if err = client.DeleteThenPoll(ctx, *id); err != nil {
 				return fmt.Errorf("deleting %s : %+v", id, err)
 			}
 

--- a/internal/services/recoveryservices/site_recovery_network_mapping_resource.go
+++ b/internal/services/recoveryservices/site_recovery_network_mapping_resource.go
@@ -189,8 +189,7 @@ func resourceSiteRecoveryNetworkMappingDelete(d *pluginsdk.ResourceData, meta in
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	err = client.DeleteThenPoll(ctx, *id)
-	if err != nil {
+	if err = client.DeleteThenPoll(ctx, *id); err != nil {
 		return fmt.Errorf("deleting site recovery network mapping %q: %+v", id, err)
 	}
 

--- a/internal/services/recoveryservices/site_recovery_protection_container_mapping_resource.go
+++ b/internal/services/recoveryservices/site_recovery_protection_container_mapping_resource.go
@@ -206,8 +206,7 @@ func resourceSiteRecoveryContainerMappingUpdate(d *pluginsdk.ResourceData, meta 
 		update.Properties.ProviderSpecificInput = updateInput
 	}
 
-	err = client.UpdateThenPoll(ctx, *id, update)
-	if err != nil {
+	if err = client.UpdateThenPoll(ctx, *id, update); err != nil {
 		return fmt.Errorf("update %s: %+v", id, err)
 	}
 
@@ -277,8 +276,7 @@ func resourceSiteRecoveryServicesContainerMappingDelete(d *pluginsdk.ResourceDat
 		},
 	}
 
-	err = client.DeleteThenPoll(ctx, *id, input)
-	if err != nil {
+	if err = client.DeleteThenPoll(ctx, *id, input); err != nil {
 		return fmt.Errorf("deleting site recovery protection container mapping %s : %+v", id.String(), err)
 	}
 

--- a/internal/services/recoveryservices/site_recovery_protection_container_resource.go
+++ b/internal/services/recoveryservices/site_recovery_protection_container_resource.go
@@ -134,8 +134,7 @@ func resourceSiteRecoveryProtectionContainerDelete(d *pluginsdk.ResourceData, me
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	err = client.DeleteThenPoll(ctx, *id)
-	if err != nil {
+	if err = client.DeleteThenPoll(ctx, *id); err != nil {
 		return fmt.Errorf("deleting site recovery protection container %s : %+v", id.String(), err)
 	}
 

--- a/internal/services/recoveryservices/site_recovery_replicated_vm_resource.go
+++ b/internal/services/recoveryservices/site_recovery_replicated_vm_resource.go
@@ -684,8 +684,7 @@ func resourceSiteRecoveryReplicatedItemUpdateInternal(ctx context.Context, d *pl
 		},
 	}
 
-	err = client.UpdateThenPoll(ctx, id, parameters)
-	if err != nil {
+	if err = client.UpdateThenPoll(ctx, id, parameters); err != nil {
 		return fmt.Errorf("updating replicated vm %s (vault %s): %+v", name, vaultName, err)
 	}
 
@@ -977,8 +976,7 @@ func resourceSiteRecoveryReplicatedItemDelete(d *pluginsdk.ResourceData, meta in
 
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-	err = client.DeleteThenPoll(ctx, *id, disableProtectionInput)
-	if err != nil {
+	if err = client.DeleteThenPoll(ctx, *id, disableProtectionInput); err != nil {
 		return fmt.Errorf("deleting site recovery replicated vm %s : %+v", id.String(), err)
 	}
 

--- a/internal/services/recoveryservices/site_recovery_replication_policy_resource.go
+++ b/internal/services/recoveryservices/site_recovery_replication_policy_resource.go
@@ -146,8 +146,7 @@ func resourceSiteRecoveryReplicationPolicyUpdate(d *pluginsdk.ResourceData, meta
 			},
 		},
 	}
-	err := client.UpdateThenPoll(ctx, id, parameters)
-	if err != nil {
+	if err := client.UpdateThenPoll(ctx, id, parameters); err != nil {
 		return fmt.Errorf("updating site recovery replication policy %s (vault %s): %+v", name, vaultName, err)
 	}
 
@@ -196,8 +195,7 @@ func resourceSiteRecoveryReplicationPolicyDelete(d *pluginsdk.ResourceData, meta
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	err = client.DeleteThenPoll(ctx, *id)
-	if err != nil {
+	if err = client.DeleteThenPoll(ctx, *id); err != nil {
 		return fmt.Errorf("deleting site recovery replication policy %s : %+v", id.String(), err)
 	}
 

--- a/internal/services/recoveryservices/site_recovery_replication_recovery_plan_resource.go
+++ b/internal/services/recoveryservices/site_recovery_replication_recovery_plan_resource.go
@@ -486,8 +486,7 @@ func (r SiteRecoveryReplicationRecoveryPlanResource) Update() sdk.ResourceFunc {
 				},
 			}
 
-			err = client.UpdateThenPoll(ctx, *id, parameters)
-			if err != nil {
+			if err = client.UpdateThenPoll(ctx, *id, parameters); err != nil {
 				return fmt.Errorf("updating %s: %+v", *id, err)
 			}
 
@@ -507,8 +506,7 @@ func (r SiteRecoveryReplicationRecoveryPlanResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			err = client.DeleteThenPoll(ctx, *id)
-			if err != nil {
+			if err = client.DeleteThenPoll(ctx, *id); err != nil {
 				return fmt.Errorf("deleting site recovery protection replication plan %q : %+v", id, err)
 			}
 

--- a/internal/services/recoveryservices/site_recovery_services_vault_hyperv_site_resource.go
+++ b/internal/services/recoveryservices/site_recovery_services_vault_hyperv_site_resource.go
@@ -138,8 +138,7 @@ func (r HyperVSiteResource) Delete() sdk.ResourceFunc {
 				return fmt.Errorf("parsing %s: %+v", metadata.ResourceData.Id(), err)
 			}
 
-			err = client.DeleteThenPoll(ctx, *id)
-			if err != nil {
+			if err = client.DeleteThenPoll(ctx, *id); err != nil {
 				return fmt.Errorf("creating %s: %+v", id, err)
 			}
 

--- a/internal/services/recoveryservices/site_recovery_vmware_replicated_vm_resource.go
+++ b/internal/services/recoveryservices/site_recovery_vmware_replicated_vm_resource.go
@@ -699,8 +699,7 @@ func (r VMWareReplicatedVmResource) Update() sdk.ResourceFunc {
 				Properties: &props,
 			}
 
-			err = client.UpdateThenPoll(ctx, *id, parameters)
-			if err != nil {
+			if err = client.UpdateThenPoll(ctx, *id, parameters); err != nil {
 				return fmt.Errorf("updating %q: %+v", id, err)
 			}
 
@@ -853,8 +852,7 @@ func (r VMWareReplicatedVmResource) Delete() sdk.ResourceFunc {
 				},
 			}
 
-			err = client.DeleteThenPoll(ctx, *id, disableProtectionInput)
-			if err != nil {
+			if err = client.DeleteThenPoll(ctx, *id, disableProtectionInput); err != nil {
 				return fmt.Errorf("deleting %s : %+v", id.String(), err)
 			}
 

--- a/internal/services/recoveryservices/site_recovery_vmware_replication_policy_association_resource.go
+++ b/internal/services/recoveryservices/site_recovery_vmware_replication_policy_association_resource.go
@@ -84,8 +84,7 @@ func (s VMWareReplicationPolicyAssociationResource) Create() sdk.ResourceFunc {
 			containerClient := metadata.Client.RecoveryServices.ProtectionContainerClient
 			settingsClient := metadata.Client.RecoveryServices.VaultsSettingsClient
 
-			err = validateReplicationPolicyAssociationVaultConfig(ctx, settingsClient, model.RecoveryVaultId)
-			if err != nil {
+			if err = validateReplicationPolicyAssociationVaultConfig(ctx, settingsClient, model.RecoveryVaultId); err != nil {
 				return fmt.Errorf("validating %s: %+v", model.RecoveryVaultId, err)
 			}
 
@@ -196,8 +195,7 @@ func (s VMWareReplicationPolicyAssociationResource) Delete() sdk.ResourceFunc {
 				},
 			}
 
-			err = client.DeleteThenPoll(ctx, *id, input)
-			if err != nil {
+			if err = client.DeleteThenPoll(ctx, *id, input); err != nil {
 				return fmt.Errorf("deleting %s : %+v", id.String(), err)
 			}
 

--- a/internal/services/recoveryservices/site_recovery_vmware_replication_policy_resource.go
+++ b/internal/services/recoveryservices/site_recovery_vmware_replication_policy_resource.go
@@ -214,8 +214,7 @@ func (r VMWareReplicationPolicyResource) Update() sdk.ResourceFunc {
 					},
 				},
 			}
-			err = client.UpdateThenPoll(ctx, *id, parameters)
-			if err != nil {
+			if err = client.UpdateThenPoll(ctx, *id, parameters); err != nil {
 				return fmt.Errorf("updating %q: %+v", id, err)
 			}
 
@@ -235,8 +234,7 @@ func (r VMWareReplicationPolicyResource) Delete() sdk.ResourceFunc {
 
 			client := metadata.Client.RecoveryServices.ReplicationPoliciesClient
 
-			err = client.DeleteThenPoll(ctx, *id)
-			if err != nil {
+			if err = client.DeleteThenPoll(ctx, *id); err != nil {
 				return fmt.Errorf("deleting %s : %+v", id, err)
 			}
 

--- a/internal/services/resource/resource_provider_registration_resource.go
+++ b/internal/services/resource/resource_provider_registration_resource.go
@@ -132,8 +132,7 @@ func (r ResourceProviderRegistrationResource) Create() sdk.ResourceFunc {
 
 			if metadata.ResourceData.HasChange("feature") {
 				oldFeaturesRaw, newFeaturesRaw := metadata.ResourceData.GetChange("feature")
-				err := r.applyFeatures(ctx, metadata, resourceId, oldFeaturesRaw.(*pluginsdk.Set).List(), newFeaturesRaw.(*pluginsdk.Set).List())
-				if err != nil {
+				if err := r.applyFeatures(ctx, metadata, resourceId, oldFeaturesRaw.(*pluginsdk.Set).List(), newFeaturesRaw.(*pluginsdk.Set).List()); err != nil {
 					return fmt.Errorf("applying features for %q: %+v", resourceId, err)
 				}
 			}
@@ -205,8 +204,7 @@ func (r ResourceProviderRegistrationResource) Update() sdk.ResourceFunc {
 
 			if metadata.ResourceData.HasChange("feature") {
 				oldFeaturesRaw, newFeaturesRaw := metadata.ResourceData.GetChange("feature")
-				err := r.applyFeatures(ctx, metadata, *id, oldFeaturesRaw.(*pluginsdk.Set).List(), newFeaturesRaw.(*pluginsdk.Set).List())
-				if err != nil {
+				if err := r.applyFeatures(ctx, metadata, *id, oldFeaturesRaw.(*pluginsdk.Set).List(), newFeaturesRaw.(*pluginsdk.Set).List()); err != nil {
 					return fmt.Errorf("applying features for %s: %+v", *id, err)
 				}
 			}
@@ -315,8 +313,7 @@ func (r ResourceProviderRegistrationResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			err = r.applyFeatures(ctx, metadata, *id, metadata.ResourceData.Get("feature").(*pluginsdk.Set).List(), make([]interface{}, 0))
-			if err != nil {
+			if err = r.applyFeatures(ctx, metadata, *id, metadata.ResourceData.Get("feature").(*pluginsdk.Set).List(), make([]interface{}, 0)); err != nil {
 				return fmt.Errorf("applying features for %s: %+v", *id, err)
 			}
 

--- a/internal/services/resource/template_deployment_common.go
+++ b/internal/services/resource/template_deployment_common.go
@@ -231,8 +231,7 @@ func deleteItemsProvisionedByTemplate(ctx context.Context, client *client.Client
 				continue
 			}
 
-			err = deleteNestedResource(ctx, resourcesClient, resourceProviderApiVersions, nestedResource)
-			if err != nil {
+			if err = deleteNestedResource(ctx, resourcesClient, resourceProviderApiVersions, nestedResource); err != nil {
 				errorList = append(errorList, err)
 			} else {
 				deletedResources[*nestedResource.ID] = true

--- a/internal/services/search/search_service_resource.go
+++ b/internal/services/search/search_service_resource.go
@@ -352,8 +352,7 @@ func resourceSearchServiceCreate(d *pluginsdk.ResourceData, meta interface{}) er
 		payload.Identity = expandedIdentity
 	}
 
-	err = client.CreateOrUpdateCallbackThenPoll(ctx, id, payload, services.CreateOrUpdateOperationOptions{}, sdk.SetIDCallback(meta, &id, d))
-	if err != nil {
+	if err = client.CreateOrUpdateCallbackThenPoll(ctx, id, payload, services.CreateOrUpdateOperationOptions{}, sdk.SetIDCallback(meta, &id, d)); err != nil {
 		return fmt.Errorf("creating %s: %+v", id, err)
 	}
 	d.SetId(id.ID())

--- a/internal/services/securitycenter/azuresdkhacks/security_center_contact.go
+++ b/internal/services/securitycenter/azuresdkhacks/security_center_contact.go
@@ -53,13 +53,12 @@ func CreateSecurityCenterContact(ctx context.Context, client *security.ContactsC
 }
 
 func createResponder(resp *http.Response) (result security.Contact, err error) {
-	err = autorest.Respond(
+	if err = autorest.Respond(
 		resp,
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing(),
-	)
-	if err != nil {
+	); err != nil {
 		return result, err
 	}
 	result.Response = autorest.Response{Response: resp}

--- a/internal/services/securitycenter/security_center_subscription_pricing_resource.go
+++ b/internal/services/securitycenter/security_center_subscription_pricing_resource.go
@@ -312,8 +312,7 @@ func resourceSecurityCenterSubscriptionPricingRead(d *pluginsdk.ResourceData, me
 		if properties := resp.Model.Properties; properties != nil {
 			d.Set("tier", properties.PricingTier)
 			d.Set("subplan", properties.SubPlan)
-			err = d.Set("extension", flattenExtensions(properties.Extensions))
-			if err != nil {
+			if err = d.Set("extension", flattenExtensions(properties.Extensions)); err != nil {
 				return fmt.Errorf("setting `extension`: %+v", err)
 			}
 		}

--- a/internal/services/sentinel/sentinel_automation_rule_resource.go
+++ b/internal/services/sentinel/sentinel_automation_rule_resource.go
@@ -374,8 +374,7 @@ func expandAutomationRuleConditionsFromJSON(input string) (*[]automationrules.Au
 		return nil, nil
 	}
 	triggerLogic := &automationrules.AutomationRuleTriggeringLogic{}
-	err := triggerLogic.UnmarshalJSON([]byte(fmt.Sprintf(`{ "conditions": %s }`, input)))
-	if err != nil {
+	if err := triggerLogic.UnmarshalJSON([]byte(fmt.Sprintf(`{ "conditions": %s }`, input))); err != nil {
 		return nil, err
 	}
 	return triggerLogic.Conditions, nil

--- a/internal/services/servicefabricmanaged/service_fabric_managed_cluster_resource.go
+++ b/internal/services/servicefabricmanaged/service_fabric_managed_cluster_resource.go
@@ -484,8 +484,7 @@ func (k ClusterResource) Delete() sdk.ResourceFunc {
 			}
 			clusterClient := metadata.Client.ServiceFabricManaged.ManagedClusterClient
 
-			err = clusterClient.DeleteThenPoll(ctx, *resourceId)
-			if err != nil {
+			if err = clusterClient.DeleteThenPoll(ctx, *resourceId); err != nil {
 				return fmt.Errorf("while deleting cluster %q: %+v", resourceId.String(), err)
 			}
 			return nil
@@ -991,8 +990,7 @@ func nodeTypeSchema() *pluginsdk.Schema {
 					ValidateFunc: func(i interface{}, s string) ([]string, []error) {
 						input := i.(string)
 						errors := make([]error, 0)
-						_, _, err := parsePortRange(input)
-						if err != nil {
+						if _, _, err := parsePortRange(input); err != nil {
 							errors = append(errors, err)
 						}
 						return nil, errors

--- a/internal/services/springcloud/spring_cloud_api_portal_resource.go
+++ b/internal/services/springcloud/spring_cloud_api_portal_resource.go
@@ -295,8 +295,7 @@ func (s SpringCloudAPIPortalResource) Update() sdk.ResourceFunc {
 				Properties: properties,
 				Sku:        sku,
 			}
-			err = client.ApiPortalsCreateOrUpdateThenPoll(ctx, *id, apiPortalResource)
-			if err != nil {
+			if err = client.ApiPortalsCreateOrUpdateThenPoll(ctx, *id, apiPortalResource); err != nil {
 				return fmt.Errorf("updating %s: %+v", id, err)
 			}
 
@@ -364,8 +363,7 @@ func (s SpringCloudAPIPortalResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			err = client.ApiPortalsDeleteThenPoll(ctx, *id)
-			if err != nil {
+			if err = client.ApiPortalsDeleteThenPoll(ctx, *id); err != nil {
 				return fmt.Errorf("deleting %s: %+v", *id, err)
 			}
 

--- a/internal/services/springcloud/spring_cloud_app_dynamics_application_performance_monitoring_resource.go
+++ b/internal/services/springcloud/spring_cloud_app_dynamics_application_performance_monitoring_resource.go
@@ -189,8 +189,7 @@ func (s SpringCloudAppDynamicsApplicationPerformanceMonitoringResource) Create()
 				apmReference := appplatform.ApmReference{
 					ResourceId: id.ID(),
 				}
-				err = client.ServicesEnableApmGloballyThenPoll(ctx, *springId, apmReference)
-				if err != nil {
+				if err = client.ServicesEnableApmGloballyThenPoll(ctx, *springId, apmReference); err != nil {
 					return fmt.Errorf("enabling %s globally: %+v", id, err)
 				}
 			}
@@ -272,8 +271,7 @@ func (s SpringCloudAppDynamicsApplicationPerformanceMonitoringResource) Update()
 				Properties: properties,
 			}
 
-			err = client.ApmsCreateOrUpdateThenPoll(ctx, *id, resource)
-			if err != nil {
+			if err = client.ApmsCreateOrUpdateThenPoll(ctx, *id, resource); err != nil {
 				return fmt.Errorf("updating %s: %+v", id, err)
 			}
 
@@ -283,13 +281,11 @@ func (s SpringCloudAppDynamicsApplicationPerformanceMonitoringResource) Update()
 				}
 				springId := commonids.NewSpringCloudServiceID(id.SubscriptionId, id.ResourceGroupName, id.SpringName)
 				if model.GloballyEnabled {
-					err := client.ServicesEnableApmGloballyThenPoll(ctx, springId, apmReference)
-					if err != nil {
+					if err := client.ServicesEnableApmGloballyThenPoll(ctx, springId, apmReference); err != nil {
 						return fmt.Errorf("enabling %s globally: %+v", id, err)
 					}
 				} else {
-					err := client.ServicesDisableApmGloballyThenPoll(ctx, springId, apmReference)
-					if err != nil {
+					if err := client.ServicesDisableApmGloballyThenPoll(ctx, springId, apmReference); err != nil {
 						return fmt.Errorf("disabling %s globally: %+v", id, err)
 					}
 				}
@@ -396,8 +392,7 @@ func (s SpringCloudAppDynamicsApplicationPerformanceMonitoringResource) Delete()
 				return err
 			}
 
-			err = client.ApmsDeleteThenPoll(ctx, *id)
-			if err != nil {
+			if err = client.ApmsDeleteThenPoll(ctx, *id); err != nil {
 				return fmt.Errorf("deleting %s: %+v", *id, err)
 			}
 

--- a/internal/services/springcloud/spring_cloud_app_resource.go
+++ b/internal/services/springcloud/spring_cloud_app_resource.go
@@ -489,8 +489,7 @@ func expandAppCustomPersistentDiskResourceArray(input []interface{}, id parse.Sp
 func expandSpringCloudAppAddon(input string) (map[string]interface{}, error) {
 	var addonConfig map[string]interface{}
 	if len(input) != 0 {
-		err := json.Unmarshal([]byte(input), &addonConfig)
-		if err != nil {
+		if err := json.Unmarshal([]byte(input), &addonConfig); err != nil {
 			return nil, fmt.Errorf("unable to unmarshal `addon_json`: %+v", err)
 		}
 	}

--- a/internal/services/springcloud/spring_cloud_application_insights_application_performance_monitoring_resource.go
+++ b/internal/services/springcloud/spring_cloud_application_insights_application_performance_monitoring_resource.go
@@ -159,8 +159,7 @@ func (s SpringCloudApplicationInsightsApplicationPerformanceMonitoringResource) 
 				apmReference := appplatform.ApmReference{
 					ResourceId: id.ID(),
 				}
-				err = client.ServicesEnableApmGloballyThenPoll(ctx, *springId, apmReference)
-				if err != nil {
+				if err = client.ServicesEnableApmGloballyThenPoll(ctx, *springId, apmReference); err != nil {
 					return fmt.Errorf("enabling %s globally: %+v", id, err)
 				}
 			}
@@ -219,8 +218,7 @@ func (s SpringCloudApplicationInsightsApplicationPerformanceMonitoringResource) 
 				Properties: properties,
 			}
 
-			err = client.ApmsCreateOrUpdateThenPoll(ctx, *id, resource)
-			if err != nil {
+			if err = client.ApmsCreateOrUpdateThenPoll(ctx, *id, resource); err != nil {
 				return fmt.Errorf("updating %s: %+v", id, err)
 			}
 
@@ -230,13 +228,11 @@ func (s SpringCloudApplicationInsightsApplicationPerformanceMonitoringResource) 
 				}
 				springId := commonids.NewSpringCloudServiceID(id.SubscriptionId, id.ResourceGroupName, id.SpringName)
 				if model.GloballyEnabled {
-					err := client.ServicesEnableApmGloballyThenPoll(ctx, springId, apmReference)
-					if err != nil {
+					if err := client.ServicesEnableApmGloballyThenPoll(ctx, springId, apmReference); err != nil {
 						return fmt.Errorf("enabling %s globally: %+v", id, err)
 					}
 				} else {
-					err := client.ServicesDisableApmGloballyThenPoll(ctx, springId, apmReference)
-					if err != nil {
+					if err := client.ServicesDisableApmGloballyThenPoll(ctx, springId, apmReference); err != nil {
 						return fmt.Errorf("disabling %s globally: %+v", id, err)
 					}
 				}
@@ -335,8 +331,7 @@ func (s SpringCloudApplicationInsightsApplicationPerformanceMonitoringResource) 
 				return err
 			}
 
-			err = client.ApmsDeleteThenPoll(ctx, *id)
-			if err != nil {
+			if err = client.ApmsDeleteThenPoll(ctx, *id); err != nil {
 				return fmt.Errorf("deleting %s: %+v", *id, err)
 			}
 

--- a/internal/services/springcloud/spring_cloud_configuration_service_resource.go
+++ b/internal/services/springcloud/spring_cloud_configuration_service_resource.go
@@ -293,8 +293,7 @@ func (s SpringCloudConfigurationServiceResource) Update() sdk.ResourceFunc {
 			configurationServiceResource := appplatform.ConfigurationServiceResource{
 				Properties: properties,
 			}
-			err = client.ConfigurationServicesCreateOrUpdateThenPoll(ctx, id, configurationServiceResource)
-			if err != nil {
+			if err = client.ConfigurationServicesCreateOrUpdateThenPoll(ctx, id, configurationServiceResource); err != nil {
 				return fmt.Errorf("creating/updating %s: %+v", id, err)
 			}
 
@@ -360,8 +359,7 @@ func (s SpringCloudConfigurationServiceResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			err = client.ConfigurationServicesDeleteThenPoll(ctx, *id)
-			if err != nil {
+			if err = client.ConfigurationServicesDeleteThenPoll(ctx, *id); err != nil {
 				return fmt.Errorf("deleting %s: %+v", id, err)
 			}
 

--- a/internal/services/springcloud/spring_cloud_customized_accelerator_resource.go
+++ b/internal/services/springcloud/spring_cloud_customized_accelerator_resource.go
@@ -351,8 +351,7 @@ func (s SpringCloudCustomizedAcceleratorResource) Update() sdk.ResourceFunc {
 			CustomizedAcceleratorResource := appplatform.CustomizedAcceleratorResource{
 				Properties: properties,
 			}
-			err = client.CustomizedAcceleratorsCreateOrUpdateThenPoll(ctx, *id, CustomizedAcceleratorResource)
-			if err != nil {
+			if err = client.CustomizedAcceleratorsCreateOrUpdateThenPoll(ctx, *id, CustomizedAcceleratorResource); err != nil {
 				return fmt.Errorf("updating %s: %+v", id, err)
 			}
 
@@ -426,8 +425,7 @@ func (s SpringCloudCustomizedAcceleratorResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			err = client.CustomizedAcceleratorsDeleteThenPoll(ctx, *id)
-			if err != nil {
+			if err = client.CustomizedAcceleratorsDeleteThenPoll(ctx, *id); err != nil {
 				return fmt.Errorf("deleting %s: %+v", *id, err)
 			}
 

--- a/internal/services/springcloud/spring_cloud_dynatrace_application_performance_monitoring_resource.go
+++ b/internal/services/springcloud/spring_cloud_dynatrace_application_performance_monitoring_resource.go
@@ -167,8 +167,7 @@ func (s SpringCloudDynatraceApplicationPerformanceMonitoringResource) Create() s
 				apmReference := appplatform.ApmReference{
 					ResourceId: id.ID(),
 				}
-				err = client.ServicesEnableApmGloballyThenPoll(ctx, *springId, apmReference)
-				if err != nil {
+				if err = client.ServicesEnableApmGloballyThenPoll(ctx, *springId, apmReference); err != nil {
 					return fmt.Errorf("enabling %s globally: %+v", id, err)
 				}
 			}
@@ -238,8 +237,7 @@ func (s SpringCloudDynatraceApplicationPerformanceMonitoringResource) Update() s
 				Properties: properties,
 			}
 
-			err = client.ApmsCreateOrUpdateThenPoll(ctx, *id, resource)
-			if err != nil {
+			if err = client.ApmsCreateOrUpdateThenPoll(ctx, *id, resource); err != nil {
 				return fmt.Errorf("updating %s: %+v", id, err)
 			}
 
@@ -249,13 +247,11 @@ func (s SpringCloudDynatraceApplicationPerformanceMonitoringResource) Update() s
 				}
 				springId := commonids.NewSpringCloudServiceID(id.SubscriptionId, id.ResourceGroupName, id.SpringName)
 				if model.GloballyEnabled {
-					err := client.ServicesEnableApmGloballyThenPoll(ctx, springId, apmReference)
-					if err != nil {
+					if err := client.ServicesEnableApmGloballyThenPoll(ctx, springId, apmReference); err != nil {
 						return fmt.Errorf("enabling %s globally: %+v", id, err)
 					}
 				} else {
-					err := client.ServicesDisableApmGloballyThenPoll(ctx, springId, apmReference)
-					if err != nil {
+					if err := client.ServicesDisableApmGloballyThenPoll(ctx, springId, apmReference); err != nil {
 						return fmt.Errorf("disabling %s globally: %+v", id, err)
 					}
 				}
@@ -349,8 +345,7 @@ func (s SpringCloudDynatraceApplicationPerformanceMonitoringResource) Delete() s
 				return err
 			}
 
-			err = client.ApmsDeleteThenPoll(ctx, *id)
-			if err != nil {
+			if err = client.ApmsDeleteThenPoll(ctx, *id); err != nil {
 				return fmt.Errorf("deleting %s: %+v", *id, err)
 			}
 

--- a/internal/services/springcloud/spring_cloud_elastic_application_performance_monitoring_resource.go
+++ b/internal/services/springcloud/spring_cloud_elastic_application_performance_monitoring_resource.go
@@ -144,8 +144,7 @@ func (s SpringCloudElasticApplicationPerformanceMonitoringResource) Create() sdk
 				apmReference := appplatform.ApmReference{
 					ResourceId: id.ID(),
 				}
-				err = client.ServicesEnableApmGloballyThenPoll(ctx, *springId, apmReference)
-				if err != nil {
+				if err = client.ServicesEnableApmGloballyThenPoll(ctx, *springId, apmReference); err != nil {
 					return fmt.Errorf("enabling %s globally: %+v", id, err)
 				}
 			}
@@ -203,8 +202,7 @@ func (s SpringCloudElasticApplicationPerformanceMonitoringResource) Update() sdk
 				Properties: properties,
 			}
 
-			err = client.ApmsCreateOrUpdateThenPoll(ctx, *id, resource)
-			if err != nil {
+			if err = client.ApmsCreateOrUpdateThenPoll(ctx, *id, resource); err != nil {
 				return fmt.Errorf("updating %s: %+v", id, err)
 			}
 
@@ -214,13 +212,11 @@ func (s SpringCloudElasticApplicationPerformanceMonitoringResource) Update() sdk
 				}
 				springId := commonids.NewSpringCloudServiceID(id.SubscriptionId, id.ResourceGroupName, id.SpringName)
 				if model.GloballyEnabled {
-					err := client.ServicesEnableApmGloballyThenPoll(ctx, springId, apmReference)
-					if err != nil {
+					if err := client.ServicesEnableApmGloballyThenPoll(ctx, springId, apmReference); err != nil {
 						return fmt.Errorf("enabling %s globally: %+v", id, err)
 					}
 				} else {
-					err := client.ServicesDisableApmGloballyThenPoll(ctx, springId, apmReference)
-					if err != nil {
+					if err := client.ServicesDisableApmGloballyThenPoll(ctx, springId, apmReference); err != nil {
 						return fmt.Errorf("disabling %s globally: %+v", id, err)
 					}
 				}
@@ -311,8 +307,7 @@ func (s SpringCloudElasticApplicationPerformanceMonitoringResource) Delete() sdk
 				return err
 			}
 
-			err = client.ApmsDeleteThenPoll(ctx, *id)
-			if err != nil {
+			if err = client.ApmsDeleteThenPoll(ctx, *id); err != nil {
 				return fmt.Errorf("deleting %s: %+v", *id, err)
 			}
 

--- a/internal/services/springcloud/spring_cloud_gateway_resource.go
+++ b/internal/services/springcloud/spring_cloud_gateway_resource.go
@@ -592,8 +592,7 @@ func (s SpringCloudGatewayResource) Update() sdk.ResourceFunc {
 				Sku:        sku,
 			}
 
-			err = client.GatewaysCreateOrUpdateThenPoll(ctx, *id, resource)
-			if err != nil {
+			if err = client.GatewaysCreateOrUpdateThenPoll(ctx, *id, resource); err != nil {
 				return fmt.Errorf("updating %s: %+v", id, err)
 			}
 
@@ -677,8 +676,7 @@ func (s SpringCloudGatewayResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			err = client.GatewaysDeleteThenPoll(ctx, *id)
-			if err != nil {
+			if err = client.GatewaysDeleteThenPoll(ctx, *id); err != nil {
 				return fmt.Errorf("deleting %s: %+v", *id, err)
 			}
 

--- a/internal/services/springcloud/spring_cloud_new_relic_application_performance_monitoring_resource.go
+++ b/internal/services/springcloud/spring_cloud_new_relic_application_performance_monitoring_resource.go
@@ -191,8 +191,7 @@ func (s SpringCloudNewRelicApplicationPerformanceMonitoringResource) Create() sd
 				apmReference := appplatform.ApmReference{
 					ResourceId: id.ID(),
 				}
-				err = client.ServicesEnableApmGloballyThenPoll(ctx, *springId, apmReference)
-				if err != nil {
+				if err = client.ServicesEnableApmGloballyThenPoll(ctx, *springId, apmReference); err != nil {
 					return fmt.Errorf("enabling %s globally: %+v", id, err)
 				}
 			}
@@ -274,8 +273,7 @@ func (s SpringCloudNewRelicApplicationPerformanceMonitoringResource) Update() sd
 				Properties: properties,
 			}
 
-			err = client.ApmsCreateOrUpdateThenPoll(ctx, *id, resource)
-			if err != nil {
+			if err = client.ApmsCreateOrUpdateThenPoll(ctx, *id, resource); err != nil {
 				return fmt.Errorf("updating %s: %+v", id, err)
 			}
 
@@ -285,13 +283,11 @@ func (s SpringCloudNewRelicApplicationPerformanceMonitoringResource) Update() sd
 				}
 				springId := commonids.NewSpringCloudServiceID(id.SubscriptionId, id.ResourceGroupName, id.SpringName)
 				if model.GloballyEnabled {
-					err := client.ServicesEnableApmGloballyThenPoll(ctx, springId, apmReference)
-					if err != nil {
+					if err := client.ServicesEnableApmGloballyThenPoll(ctx, springId, apmReference); err != nil {
 						return fmt.Errorf("enabling %s globally: %+v", id, err)
 					}
 				} else {
-					err := client.ServicesDisableApmGloballyThenPoll(ctx, springId, apmReference)
-					if err != nil {
+					if err := client.ServicesDisableApmGloballyThenPoll(ctx, springId, apmReference); err != nil {
 						return fmt.Errorf("disabling %s globally: %+v", id, err)
 					}
 				}
@@ -400,8 +396,7 @@ func (s SpringCloudNewRelicApplicationPerformanceMonitoringResource) Delete() sd
 				return err
 			}
 
-			err = client.ApmsDeleteThenPoll(ctx, *id)
-			if err != nil {
+			if err = client.ApmsDeleteThenPoll(ctx, *id); err != nil {
 				return fmt.Errorf("deleting %s: %+v", *id, err)
 			}
 

--- a/internal/services/storage/client/data_plane.go
+++ b/internal/services/storage/client/data_plane.go
@@ -88,8 +88,7 @@ func (c Client) AccountsDataPlaneClient(ctx context.Context, account AccountDeta
 		return nil, fmt.Errorf("building %s client: %+v", clientName, err)
 	}
 
-	err = c.configureDataPlane(ctx, clientName, *baseUri, apiClient.Client, account, operation)
-	if err != nil {
+	if err = c.configureDataPlane(ctx, clientName, *baseUri, apiClient.Client, account, operation); err != nil {
 		return nil, err
 	}
 
@@ -110,8 +109,7 @@ func (c Client) BlobsDataPlaneClient(ctx context.Context, account AccountDetails
 		return nil, fmt.Errorf("building %s client: %+v", clientName, err)
 	}
 
-	err = c.configureDataPlane(ctx, clientName, *baseUri, apiClient.Client, account, operation)
-	if err != nil {
+	if err = c.configureDataPlane(ctx, clientName, *baseUri, apiClient.Client, account, operation); err != nil {
 		return nil, err
 	}
 
@@ -132,8 +130,7 @@ func (c Client) ContainersDataPlaneClient(ctx context.Context, account AccountDe
 		return nil, fmt.Errorf("building %s client: %+v", clientName, err)
 	}
 
-	err = c.configureDataPlane(ctx, clientName, *baseUri, apiClient.Client, account, operation)
-	if err != nil {
+	if err = c.configureDataPlane(ctx, clientName, *baseUri, apiClient.Client, account, operation); err != nil {
 		return nil, err
 	}
 
@@ -154,8 +151,7 @@ func (c Client) DataLakeFilesystemsDataPlaneClient(ctx context.Context, account 
 		return nil, fmt.Errorf("building %s client: %+v", clientName, err)
 	}
 
-	err = c.configureDataPlane(ctx, clientName, *baseUri, apiClient.Client, account, operation)
-	if err != nil {
+	if err = c.configureDataPlane(ctx, clientName, *baseUri, apiClient.Client, account, operation); err != nil {
 		return nil, err
 	}
 
@@ -176,8 +172,7 @@ func (c Client) DataLakePathsDataPlaneClient(ctx context.Context, account Accoun
 		return nil, fmt.Errorf("building %s client: %+v", clientName, err)
 	}
 
-	err = c.configureDataPlane(ctx, clientName, *baseUri, apiClient.Client, account, operation)
-	if err != nil {
+	if err = c.configureDataPlane(ctx, clientName, *baseUri, apiClient.Client, account, operation); err != nil {
 		return nil, err
 	}
 
@@ -198,8 +193,7 @@ func (c Client) FileShareDirectoriesDataPlaneClient(ctx context.Context, account
 		return nil, fmt.Errorf("building %s client: %+v", clientName, err)
 	}
 
-	err = c.configureDataPlane(ctx, clientName, *baseUri, apiClient.Client, account, operation)
-	if err != nil {
+	if err = c.configureDataPlane(ctx, clientName, *baseUri, apiClient.Client, account, operation); err != nil {
 		return nil, err
 	}
 
@@ -220,8 +214,7 @@ func (c Client) FileShareFilesDataPlaneClient(ctx context.Context, account Accou
 		return nil, fmt.Errorf("building %s client: %+v", clientName, err)
 	}
 
-	err = c.configureDataPlane(ctx, clientName, *baseUri, apiClient.Client, account, operation)
-	if err != nil {
+	if err = c.configureDataPlane(ctx, clientName, *baseUri, apiClient.Client, account, operation); err != nil {
 		return nil, err
 	}
 
@@ -242,8 +235,7 @@ func (c Client) FileSharesDataPlaneClient(ctx context.Context, account AccountDe
 		return nil, fmt.Errorf("building %s client: %+v", clientName, err)
 	}
 
-	err = c.configureDataPlane(ctx, clientName, *baseUri, apiClient.Client, account, operation)
-	if err != nil {
+	if err = c.configureDataPlane(ctx, clientName, *baseUri, apiClient.Client, account, operation); err != nil {
 		return nil, err
 	}
 
@@ -264,8 +256,7 @@ func (c Client) QueuesDataPlaneClient(ctx context.Context, account AccountDetail
 		return nil, fmt.Errorf("building %s client: %+v", clientName, err)
 	}
 
-	err = c.configureDataPlane(ctx, clientName, *baseUri, apiClient.Client, account, operation)
-	if err != nil {
+	if err = c.configureDataPlane(ctx, clientName, *baseUri, apiClient.Client, account, operation); err != nil {
 		return nil, err
 	}
 
@@ -286,8 +277,7 @@ func (c Client) TableEntityDataPlaneClient(ctx context.Context, account AccountD
 		return nil, fmt.Errorf("building %s client: %+v", clientName, err)
 	}
 
-	err = c.configureDataPlane(ctx, clientName, *baseUri, apiClient.Client, account, operation)
-	if err != nil {
+	if err = c.configureDataPlane(ctx, clientName, *baseUri, apiClient.Client, account, operation); err != nil {
 		return nil, err
 	}
 
@@ -308,8 +298,7 @@ func (c Client) TablesDataPlaneClient(ctx context.Context, account AccountDetail
 		return nil, fmt.Errorf("building %s client: %+v", clientName, err)
 	}
 
-	err = c.configureDataPlane(ctx, clientName, *baseUri, apiClient.Client, account, operation)
-	if err != nil {
+	if err = c.configureDataPlane(ctx, clientName, *baseUri, apiClient.Client, account, operation); err != nil {
 		return nil, err
 	}
 

--- a/internal/services/synapse/synapse_linked_service_resource.go
+++ b/internal/services/synapse/synapse_linked_service_resource.go
@@ -543,8 +543,7 @@ func checkLinkedServiceResponse(response *http.Response) error {
 	defer response.Body.Close()
 
 	body := make(map[string]interface{})
-	err = json.Unmarshal(respBody, &body)
-	if err != nil {
+	if err = json.Unmarshal(respBody, &body); err != nil {
 		return fmt.Errorf("could not parse status response: %+v", err)
 	}
 

--- a/internal/tf/pluginsdk/customize_diff.go
+++ b/internal/tf/pluginsdk/customize_diff.go
@@ -44,8 +44,7 @@ func CustomDiffWithAll(funcs ...CustomizeDiffFunc) schema.CustomizeDiffFunc {
 func CustomDiffInSequence(funcs ...CustomizeDiffFunc) schema.CustomizeDiffFunc {
 	return func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
 		for _, f := range funcs {
-			err := f(ctx, d, meta)
-			if err != nil {
+			if err := f(ctx, d, meta); err != nil {
 				return err
 			}
 		}

--- a/internal/tf/pluginsdk/resource_identity.go
+++ b/internal/tf/pluginsdk/resource_identity.go
@@ -127,8 +127,7 @@ func ValidateResourceIdentityData(d *schema.ResourceData, id resourceids.Resourc
 				return fmt.Errorf("%q cannot be empty", name)
 			}
 
-			err := identity.Set(name, value)
-			if err != nil {
+			if err := identity.Set(name, value); err != nil {
 				return fmt.Errorf("error setting id: %+v", err)
 			}
 

--- a/internal/tools/changelog-updater/update_changelog.go
+++ b/internal/tools/changelog-updater/update_changelog.go
@@ -28,8 +28,7 @@ func appendUnderHeader(filePath string, newEntry, header string) error {
 		return err
 	}
 	defer func(file *os.File) {
-		err := file.Close()
-		if err != nil {
+		if err := file.Close(); err != nil {
 			println("file open error ", err.Error())
 		}
 	}(file)
@@ -89,8 +88,7 @@ func appendUnderHeader(filePath string, newEntry, header string) error {
 		return err
 	}
 	defer func(file *os.File) {
-		err := file.Close()
-		if err != nil {
+		if err := file.Close(); err != nil {
 			println("file open error ", err.Error())
 		}
 	}(writtenFile)
@@ -98,8 +96,7 @@ func appendUnderHeader(filePath string, newEntry, header string) error {
 	// Write the updated content back to the file
 	writer := bufio.NewWriter(writtenFile)
 	for _, line := range lines {
-		_, err := writer.WriteString(line + "\n")
-		if err != nil {
+		if _, err := writer.WriteString(line + "\n"); err != nil {
 			return err
 		}
 	}

--- a/internal/tools/document-fmt/template/template.go
+++ b/internal/tools/document-fmt/template/template.go
@@ -28,8 +28,7 @@ func Render(data *data.TerraformNodeData, text string) ([]string, error) {
 		return nil, err
 	}
 
-	err = tmpl.Execute(&b, data)
-	if err != nil {
+	if err = tmpl.Execute(&b, data); err != nil {
 		return nil, err
 	}
 

--- a/internal/tools/document-lint/check/document_fixer.go
+++ b/internal/tools/document-lint/check/document_fixer.go
@@ -156,8 +156,7 @@ func (f *Fixer) WriteBack() (err error) {
 		_ = fd.Sync()
 		_ = fd.Close()
 	}()
-	_, err = fd.WriteString(f.FixedContent)
-	if err != nil {
+	if _, err = fd.WriteString(f.FixedContent); err != nil {
 		log.Printf("write %s back: %v", f.MDFile, err)
 		return err
 	}

--- a/internal/tools/generator-tests/generators/resource_identity.go
+++ b/internal/tools/generator-tests/generators/resource_identity.go
@@ -384,8 +384,7 @@ func (d *resourceIdentityData) exec() error {
 		return fmt.Errorf("failed opening output resource file for writing: %+v", err.Error())
 	}
 	defer func(f *os.File) {
-		err := f.Close()
-		if err != nil {
+		if err := f.Close(); err != nil {
 			log.Println("failed closing output resource file for writing:", err.Error())
 			os.Exit(3)
 		}

--- a/internal/tools/pr-guide-suggestions/lint/lint.go
+++ b/internal/tools/pr-guide-suggestions/lint/lint.go
@@ -163,7 +163,7 @@ func gatherFiles(targets []string) ([]string, error) {
 			add(t)
 			continue
 		}
-		err = filepath.WalkDir(t, func(path string, d fs.DirEntry, err error) error {
+		if err = filepath.WalkDir(t, func(path string, d fs.DirEntry, err error) error {
 			if err != nil {
 				return err
 			}
@@ -172,8 +172,7 @@ func gatherFiles(targets []string) ([]string, error) {
 			}
 			add(path)
 			return nil
-		})
-		if err != nil {
+		}); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/tools/scaff/commands/resource.go
+++ b/internal/tools/scaff/commands/resource.go
@@ -178,8 +178,7 @@ func (d *resourceData) exec() error {
 		return fmt.Errorf("failed opening output resource file for writing: %+v", err.Error())
 	}
 	defer func(f *os.File) {
-		err := f.Close()
-		if err != nil {
+		if err := f.Close(); err != nil {
 			log.Println("failed closing output resource file for writing:", err.Error())
 			os.Exit(3)
 		}
@@ -203,8 +202,7 @@ func (d *resourceData) exec() error {
 		return fmt.Errorf("failed opening output models file for writing: %+v", err.Error())
 	}
 	defer func(f *os.File) {
-		err := f.Close()
-		if err != nil {
+		if err := f.Close(); err != nil {
 			log.Println("failed closing output models file for writing:", err.Error())
 			os.Exit(3)
 		}

--- a/internal/tools/schema-api/providerjson/json.go
+++ b/internal/tools/schema-api/providerjson/json.go
@@ -37,8 +37,7 @@ type SchemaJSON struct {
 
 func (b *SchemaJSON) UnmarshalJSON(body []byte) error {
 	var m map[string]interface{}
-	err := json.Unmarshal(body, &m)
-	if err != nil {
+	if err := json.Unmarshal(body, &m); err != nil {
 		return err
 	}
 	b.Type, _ = m["type"].(string)

--- a/main.go
+++ b/main.go
@@ -32,8 +32,7 @@ func main() {
 		serveOpts = append(serveOpts, tf5server.WithManagedDebug())
 	}
 
-	err = tf5server.Serve("registry.terraform.io/hashicorp/azurerm", providerServer, serveOpts...)
-	if err != nil {
+	if err = tf5server.Serve("registry.terraform.io/hashicorp/azurerm", providerServer, serveOpts...); err != nil {
 		log.Fatal(err)
 	}
 }


### PR DESCRIPTION
Enables the `AZG001` azproviderlint check, which flags an `err` assignment immediately followed by `if err != nil` that should be combined into a single `if err := ...; err != nil` statement.

Fixes all ~370 existing findings (211 files) by applying the check's suggested fix, so the changes are purely mechanical with no functional impact. One comment that the rewrite would have dropped (inside a retry closure in `api_management_subscription_resource.go`) was restored by hand.