### PR TITLE
linters - Enable azproviderlint AZG005 checks for single-use temporaries - Services a-c

### DIFF
--- a/internal/provider/services.go
+++ b/internal/provider/services.go
@@ -242,7 +242,7 @@ func SupportedTypedServices() []sdk.TypedServiceRegistration {
 
 func SupportedUntypedServices() []sdk.UntypedServiceRegistration {
 	return func() []sdk.UntypedServiceRegistration {
-		out := []sdk.UntypedServiceRegistration{
+		return []sdk.UntypedServiceRegistration{
 			advisor.Registration{},
 			analysisservices.Registration{},
 			apimanagement.Registration{},
@@ -336,12 +336,11 @@ func SupportedUntypedServices() []sdk.UntypedServiceRegistration {
 			vmware.Registration{},
 			web.Registration{},
 		}
-		return out
 	}()
 }
 
 func SupportedFrameworkServices() []sdk.FrameworkServiceRegistration {
-	services := []sdk.FrameworkServiceRegistration{
+	return []sdk.FrameworkServiceRegistration{
 		// Services with Framework Resources, Data Sources, or Ephemeral Resources to be listed here
 		// e.g.
 		// resource.Registration{}
@@ -473,6 +472,4 @@ func SupportedFrameworkServices() []sdk.FrameworkServiceRegistration {
 		web.Registration{},
 		workloads.Registration{},
 	}
-
-	return services
 }

--- a/internal/sdk/wrapper_helpers.go
+++ b/internal/sdk/wrapper_helpers.go
@@ -49,12 +49,10 @@ func combineSchema(arguments map[string]*schema.Schema, attributes map[string]*s
 
 func runArgs(d *schema.ResourceData, meta interface{}, logger Logger) ResourceMetaData {
 	client := meta.(*clients.Client)
-	metaData := ResourceMetaData{
+	return ResourceMetaData{
 		Client:                   client,
 		Logger:                   logger,
 		ResourceData:             d,
 		serializationDebugLogger: NullLogger{},
 	}
-
-	return metaData
 }

--- a/internal/services/analysisservices/analysis_services_server_resource.go
+++ b/internal/services/analysisservices/analysis_services_server_resource.go
@@ -29,7 +29,7 @@ import (
 //go:generate go run ../../tools/generator-tests resourceidentity
 
 func resourceAnalysisServicesServer() *pluginsdk.Resource {
-	resource := &pluginsdk.Resource{
+	return &pluginsdk.Resource{
 		Create: resourceAnalysisServicesServerCreate,
 		Read:   resourceAnalysisServicesServerRead,
 		Update: resourceAnalysisServicesServerUpdate,
@@ -141,8 +141,6 @@ func resourceAnalysisServicesServer() *pluginsdk.Resource {
 			"tags": commonschema.Tags(),
 		},
 	}
-
-	return resource
 }
 
 func resourceAnalysisServicesServerCreate(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/apimanagement/api_management_api_resource.go
+++ b/internal/services/apimanagement/api_management_api_resource.go
@@ -28,7 +28,7 @@ import (
 )
 
 func resourceApiManagementApi() *pluginsdk.Resource {
-	resource := &pluginsdk.Resource{
+	return &pluginsdk.Resource{
 		Create: resourceApiManagementApiCreate,
 		Read:   resourceApiManagementApiRead,
 		Update: resourceApiManagementApiUpdate,
@@ -359,8 +359,6 @@ func resourceApiManagementApi() *pluginsdk.Resource {
 			}),
 		),
 	}
-
-	return resource
 }
 
 func resourceApiManagementApiCreate(d *pluginsdk.ResourceData, meta interface{}) error {
@@ -426,12 +424,10 @@ func resourceApiManagementApiCreate(d *pluginsdk.ResourceData, meta interface{})
 	authenticationSettings := &api.AuthenticationSettingsContract{}
 
 	oAuth2AuthorizationSettingsRaw := d.Get("oauth2_authorization").([]interface{})
-	oAuth2AuthorizationSettings := expandApiManagementOAuth2AuthenticationSettingsContract(oAuth2AuthorizationSettingsRaw)
-	authenticationSettings.OAuth2 = oAuth2AuthorizationSettings
+	authenticationSettings.OAuth2 = expandApiManagementOAuth2AuthenticationSettingsContract(oAuth2AuthorizationSettingsRaw)
 
 	openIDAuthorizationSettingsRaw := d.Get("openid_authentication").([]interface{})
-	openIDAuthorizationSettings := expandApiManagementOpenIDAuthenticationSettingsContract(openIDAuthorizationSettingsRaw)
-	authenticationSettings.Openid = openIDAuthorizationSettings
+	authenticationSettings.Openid = expandApiManagementOpenIDAuthenticationSettingsContract(openIDAuthorizationSettingsRaw)
 
 	contactInfoRaw := d.Get("contact").([]interface{})
 	contactInfo := expandApiManagementApiContact(contactInfoRaw)
@@ -639,16 +635,14 @@ func resourceApiManagementApiUpdate(d *pluginsdk.ResourceData, meta interface{})
 	if d.HasChange("oauth2_authorization") {
 		authenticationSettings := &api.AuthenticationSettingsContract{}
 		oAuth2AuthorizationSettingsRaw := d.Get("oauth2_authorization").([]interface{})
-		oAuth2AuthorizationSettings := expandApiManagementOAuth2AuthenticationSettingsContract(oAuth2AuthorizationSettingsRaw)
-		authenticationSettings.OAuth2 = oAuth2AuthorizationSettings
+		authenticationSettings.OAuth2 = expandApiManagementOAuth2AuthenticationSettingsContract(oAuth2AuthorizationSettingsRaw)
 		prop.AuthenticationSettings = authenticationSettings
 	}
 
 	if d.HasChange("openid_authentication") {
 		authenticationSettings := &api.AuthenticationSettingsContract{}
 		openIDAuthorizationSettingsRaw := d.Get("openid_authentication").([]interface{})
-		openIDAuthorizationSettings := expandApiManagementOpenIDAuthenticationSettingsContract(openIDAuthorizationSettingsRaw)
-		authenticationSettings.Openid = openIDAuthorizationSettings
+		authenticationSettings.Openid = expandApiManagementOpenIDAuthenticationSettingsContract(openIDAuthorizationSettingsRaw)
 		prop.AuthenticationSettings = authenticationSettings
 	}
 

--- a/internal/services/apimanagement/api_management_authorization_server_resource.go
+++ b/internal/services/apimanagement/api_management_authorization_server_resource.go
@@ -253,14 +253,12 @@ func resourceApiManagementAuthorizationServerCreateUpdate(d *pluginsdk.ResourceD
 
 	authorizationMethodsRaw := d.Get("authorization_methods").(*pluginsdk.Set).List()
 	if len(authorizationMethodsRaw) > 0 {
-		authorizationMethods := expandApiManagementAuthorizationServerAuthorizationMethods(authorizationMethodsRaw)
-		params.Properties.AuthorizationMethods = authorizationMethods
+		params.Properties.AuthorizationMethods = expandApiManagementAuthorizationServerAuthorizationMethods(authorizationMethodsRaw)
 	}
 
 	bearerTokenSendingMethodsRaw := d.Get("bearer_token_sending_methods").(*pluginsdk.Set).List()
 	if len(bearerTokenSendingMethodsRaw) > 0 {
-		bearerTokenSendingMethods := expandApiManagementAuthorizationServerBearerTokenSendingMethods(bearerTokenSendingMethodsRaw)
-		params.Properties.BearerTokenSendingMethods = bearerTokenSendingMethods
+		params.Properties.BearerTokenSendingMethods = expandApiManagementAuthorizationServerBearerTokenSendingMethods(bearerTokenSendingMethodsRaw)
 	}
 
 	if tokenEndpoint := d.Get("token_endpoint").(string); tokenEndpoint != "" {

--- a/internal/services/apimanagement/api_management_backend_resource.go
+++ b/internal/services/apimanagement/api_management_backend_resource.go
@@ -497,8 +497,7 @@ func expandApiManagementBackendCredentials(input []interface{}) *backend.Backend
 	v := input[0].(map[string]interface{})
 	contract := backend.BackendCredentialsContract{}
 	if authorizationRaw := v["authorization"]; authorizationRaw != nil {
-		authorization := expandApiManagementBackendCredentialsAuthorization(authorizationRaw.([]interface{}))
-		contract.Authorization = authorization
+		contract.Authorization = expandApiManagementBackendCredentialsAuthorization(authorizationRaw.([]interface{}))
 	}
 	if certificate := v["certificate"]; certificate != nil {
 		certificates := helpers.ExpandStringSlice(certificate.([]interface{}))
@@ -507,12 +506,10 @@ func expandApiManagementBackendCredentials(input []interface{}) *backend.Backend
 		}
 	}
 	if headerRaw := v["header"]; headerRaw != nil {
-		header := expandApiManagementBackendCredentialsObject(headerRaw.(map[string]interface{}))
-		contract.Header = header
+		contract.Header = expandApiManagementBackendCredentialsObject(headerRaw.(map[string]interface{}))
 	}
 	if queryRaw := v["query"]; queryRaw != nil {
-		query := expandApiManagementBackendCredentialsObject(queryRaw.(map[string]interface{}))
-		contract.Query = query
+		contract.Query = expandApiManagementBackendCredentialsObject(queryRaw.(map[string]interface{}))
 	}
 	return &contract
 }

--- a/internal/services/apimanagement/api_management_logger_resource.go
+++ b/internal/services/apimanagement/api_management_logger_resource.go
@@ -212,8 +212,7 @@ func resourceApiManagementLoggerCreate(d *pluginsdk.ResourceData, meta interface
 
 	if len(eventHubRaw) > 0 {
 		parameters.Properties.LoggerType = logger.LoggerTypeAzureEventHub
-		credentials := expandApiManagementLoggerEventHub(eventHubRaw)
-		parameters.Properties.Credentials = credentials
+		parameters.Properties.Credentials = expandApiManagementLoggerEventHub(eventHubRaw)
 	} else if len(appInsightsRaw) > 0 {
 		parameters.Properties.LoggerType = logger.LoggerTypeApplicationInsights
 		parameters.Properties.Credentials = expandApiManagementLoggerApplicationInsights(appInsightsRaw)
@@ -290,8 +289,7 @@ func resourceApiManagementLoggerUpdate(d *pluginsdk.ResourceData, meta interface
 
 	if hasEventHub {
 		parameters.Properties.LoggerType = pointer.To(logger.LoggerTypeAzureEventHub)
-		credentials := expandApiManagementLoggerEventHub(eventHubRaw.([]interface{}))
-		parameters.Properties.Credentials = credentials
+		parameters.Properties.Credentials = expandApiManagementLoggerEventHub(eventHubRaw.([]interface{}))
 	} else if hasAppInsights {
 		parameters.Properties.LoggerType = pointer.To(logger.LoggerTypeApplicationInsights)
 		parameters.Properties.Credentials = expandApiManagementLoggerApplicationInsights(appInsightsRaw.([]interface{}))

--- a/internal/services/apimanagement/migration/api_v0_to_v1.go
+++ b/internal/services/apimanagement/migration/api_v0_to_v1.go
@@ -19,7 +19,7 @@ var _ pluginsdk.StateUpgrade = ApiV0ToV1{}
 type ApiV0ToV1 struct{}
 
 func (ApiV0ToV1) Schema() map[string]*pluginsdk.Schema {
-	schema := map[string]*pluginsdk.Schema{
+	return map[string]*pluginsdk.Schema{
 		"name": schemaz.SchemaApiManagementApiName(),
 
 		"api_management_name": schemaz.SchemaApiManagementName(),
@@ -263,8 +263,6 @@ func (ApiV0ToV1) Schema() map[string]*pluginsdk.Schema {
 			Optional: true,
 		},
 	}
-
-	return schema
 }
 
 func (ApiV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {

--- a/internal/services/appconfiguration/app_configuration_feature_resource.go
+++ b/internal/services/appconfiguration/app_configuration_feature_resource.go
@@ -537,8 +537,7 @@ func (k FeatureResource) Update() sdk.ResourceFunc {
 						tfp := f
 						targetingFilters = append(targetingFilters, tfp)
 					case PercentageFeatureFilter:
-						pfp := f
-						percentageFilter = pfp
+						percentageFilter = f
 					case CustomFilter:
 						cf := f
 						customFilters = append(customFilters, cf)

--- a/internal/services/appservice/helpers/auth_v2_schema.go
+++ b/internal/services/appservice/helpers/auth_v2_schema.go
@@ -1654,7 +1654,7 @@ func GithubAuthV2SettingsSchemaComputed() *pluginsdk.Schema {
 func expandGitHubAuthV2Settings(input []GithubAuthV2Settings) *webapps.GitHub {
 	if len(input) == 1 {
 		github := input[0]
-		result := &webapps.GitHub{
+		return &webapps.GitHub{
 			Enabled: pointer.To(true),
 			Registration: &webapps.ClientRegistration{
 				ClientId:                pointer.To(github.ClientId),
@@ -1664,8 +1664,6 @@ func expandGitHubAuthV2Settings(input []GithubAuthV2Settings) *webapps.GitHub {
 				Scopes: pointer.To(github.LoginScopes),
 			},
 		}
-
-		return result
 	}
 
 	return &webapps.GitHub{
@@ -2048,15 +2046,13 @@ func TwitterAuthV2SettingsSchemaComputed() *pluginsdk.Schema {
 func expandTwitterAuthV2Settings(input []TwitterAuthV2Settings) *webapps.Twitter {
 	if len(input) == 1 {
 		twitter := input[0]
-		result := &webapps.Twitter{
+		return &webapps.Twitter{
 			Enabled: pointer.To(true),
 			Registration: &webapps.TwitterRegistration{
 				ConsumerKey:               pointer.To(twitter.ConsumerKey),
 				ConsumerSecretSettingName: pointer.To(twitter.ConsumerSecretSettingName),
 			},
 		}
-
-		return result
 	}
 
 	return &webapps.Twitter{

--- a/internal/services/appservice/helpers/function_app_schema.go
+++ b/internal/services/appservice/helpers/function_app_schema.go
@@ -2047,8 +2047,7 @@ func ExpandSiteConfigLinuxFunctionApp(siteConfig []SiteConfigLinuxFunctionApp, e
 	}
 
 	if metadata.ResourceData.HasChange("site_config.0.cors") {
-		cors := ExpandCorsSettings(linuxSiteConfig.Cors)
-		expanded.Cors = cors
+		expanded.Cors = ExpandCorsSettings(linuxSiteConfig.Cors)
 	}
 
 	// the value 0 cannot be detected as a valid change during the creation.
@@ -2214,8 +2213,7 @@ func ExpandSiteConfigFunctionFlexConsumptionApp(siteConfigFlexConsumption []Site
 	}
 
 	if metadata.ResourceData.HasChange("site_config.0.cors") {
-		cors := ExpandCorsSettings(FlexConsumptionSiteConfig.Cors)
-		expanded.Cors = cors
+		expanded.Cors = ExpandCorsSettings(FlexConsumptionSiteConfig.Cors)
 	}
 
 	if metadata.ResourceData.HasChange("site_config.0.elastic_instance_minimum") {
@@ -2450,8 +2448,7 @@ func ExpandSiteConfigWindowsFunctionApp(siteConfig []SiteConfigWindowsFunctionAp
 	}
 
 	if metadata.ResourceData.HasChange("site_config.0.cors") {
-		cors := ExpandCorsSettings(windowsSiteConfig.Cors)
-		expanded.Cors = cors
+		expanded.Cors = ExpandCorsSettings(windowsSiteConfig.Cors)
 	}
 
 	if metadata.ResourceData.HasChange("site_config.0.pre_warmed_instance_count") || existing == nil {

--- a/internal/services/appservice/helpers/function_app_slot_schema.go
+++ b/internal/services/appservice/helpers/function_app_slot_schema.go
@@ -867,8 +867,7 @@ func ExpandSiteConfigWindowsFunctionAppSlot(siteConfig []SiteConfigWindowsFuncti
 	}
 
 	if metadata.ResourceData.HasChange("site_config.0.cors") {
-		cors := ExpandCorsSettings(windowsSlotSiteConfig.Cors)
-		expanded.Cors = cors
+		expanded.Cors = ExpandCorsSettings(windowsSlotSiteConfig.Cors)
 	}
 
 	if metadata.ResourceData.HasChange("site_config.0.pre_warmed_instance_count") {
@@ -1217,8 +1216,7 @@ func ExpandSiteConfigLinuxFunctionAppSlot(siteConfig []SiteConfigLinuxFunctionAp
 	}
 
 	if metadata.ResourceData.HasChange("site_config.0.cors") {
-		cors := ExpandCorsSettings(linuxSlotSiteConfig.Cors)
-		expanded.Cors = cors
+		expanded.Cors = ExpandCorsSettings(linuxSlotSiteConfig.Cors)
 	}
 
 	if metadata.ResourceData.HasChange("site_config.0.pre_warmed_instance_count") {

--- a/internal/services/appservice/linux_function_app_data_source.go
+++ b/internal/services/appservice/linux_function_app_data_source.go
@@ -497,8 +497,7 @@ func (m *LinuxFunctionAppDataSourceModel) unpackLinuxFunctionAppSettings(input *
 
 		case "AzureWebJobsStorage":
 			if strings.HasPrefix(v, "@Microsoft.KeyVault") {
-				trimmed := strings.TrimPrefix(strings.TrimSuffix(v, ")"), "@Microsoft.KeyVault(")
-				m.StorageKeyVaultSecretID = trimmed
+				m.StorageKeyVaultSecretID = strings.TrimPrefix(strings.TrimSuffix(v, ")"), "@Microsoft.KeyVault(")
 			} else {
 				m.StorageAccountName, m.StorageAccountKey = helpers.ParseWebJobsStorageString(v)
 			}

--- a/internal/services/appservice/linux_function_app_resource.go
+++ b/internal/services/appservice/linux_function_app_resource.go
@@ -1390,8 +1390,7 @@ func (m *LinuxFunctionAppModel) unpackLinuxFunctionAppSettings(input webapps.Str
 
 		case "AzureWebJobsStorage":
 			if strings.HasPrefix(v, "@Microsoft.KeyVault") {
-				trimmed := strings.TrimPrefix(strings.TrimSuffix(v, ")"), "@Microsoft.KeyVault(SecretUri=")
-				m.StorageKeyVaultSecretID = trimmed
+				m.StorageKeyVaultSecretID = strings.TrimPrefix(strings.TrimSuffix(v, ")"), "@Microsoft.KeyVault(SecretUri=")
 			} else {
 				m.StorageAccountName, m.StorageAccountKey = helpers.ParseWebJobsStorageString(v)
 			}

--- a/internal/services/appservice/linux_function_app_slot_resource.go
+++ b/internal/services/appservice/linux_function_app_slot_resource.go
@@ -1163,8 +1163,7 @@ func (m *LinuxFunctionAppSlotModel) unpackLinuxFunctionAppSettings(input webapps
 
 		case "AzureWebJobsStorage":
 			if strings.HasPrefix(v, "@Microsoft.KeyVault") {
-				trimmed := strings.TrimPrefix(strings.TrimSuffix(v, ")"), "@Microsoft.KeyVault(SecretUri=")
-				m.StorageKeyVaultSecretID = trimmed
+				m.StorageKeyVaultSecretID = strings.TrimPrefix(strings.TrimSuffix(v, ")"), "@Microsoft.KeyVault(SecretUri=")
 			} else {
 				m.StorageAccountName, m.StorageAccountKey = helpers.ParseWebJobsStorageString(v)
 			}

--- a/internal/services/appservice/migration/linux_function_app.go
+++ b/internal/services/appservice/migration/linux_function_app.go
@@ -1613,8 +1613,7 @@ func (l LinuxFunctionAppV0toV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
 		if err != nil {
 			return nil, err
 		}
-		newId := parsedId.ID()
-		rawState["service_plan_id"] = newId
+		rawState["service_plan_id"] = parsedId.ID()
 		return rawState, nil
 	}
 }

--- a/internal/services/appservice/migration/linux_function_app_slot.go
+++ b/internal/services/appservice/migration/linux_function_app_slot.go
@@ -1584,8 +1584,7 @@ func (l LinuxFunctionAppSlotV0toV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
 		if err != nil {
 			return nil, err
 		}
-		newId := parsedId.ID()
-		rawState["service_plan_id"] = newId
+		rawState["service_plan_id"] = parsedId.ID()
 		return rawState, nil
 	}
 }

--- a/internal/services/appservice/migration/linux_web_app.go
+++ b/internal/services/appservice/migration/linux_web_app.go
@@ -1766,8 +1766,7 @@ func (l LinuxWebAppV0toV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
 		if err != nil {
 			return nil, err
 		}
-		newId := parsedId.ID()
-		rawState["service_plan_id"] = newId
+		rawState["service_plan_id"] = parsedId.ID()
 		return rawState, nil
 	}
 }

--- a/internal/services/appservice/migration/linux_web_app_slot.go
+++ b/internal/services/appservice/migration/linux_web_app_slot.go
@@ -1747,8 +1747,7 @@ func (l LinuxWebAppSlotV0toV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
 		if err != nil {
 			return nil, err
 		}
-		newId := parsedId.ID()
-		rawState["service_plan_id"] = newId
+		rawState["service_plan_id"] = parsedId.ID()
 		return rawState, nil
 	}
 }

--- a/internal/services/appservice/migration/service_plan.go
+++ b/internal/services/appservice/migration/service_plan.go
@@ -92,8 +92,7 @@ func (s ServicePlanV0toV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
 		if err != nil {
 			return nil, err
 		}
-		newId := parsedId.ID()
-		rawState["id"] = newId
+		rawState["id"] = parsedId.ID()
 		return rawState, nil
 	}
 }

--- a/internal/services/appservice/migration/windows_function_app.go
+++ b/internal/services/appservice/migration/windows_function_app.go
@@ -1564,8 +1564,7 @@ func (w WindowsFunctionAppV0toV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
 		if err != nil {
 			return nil, err
 		}
-		newId := parsedId.ID()
-		rawState["service_plan_id"] = newId
+		rawState["service_plan_id"] = parsedId.ID()
 		return rawState, nil
 	}
 }

--- a/internal/services/appservice/migration/windows_function_app_slot.go
+++ b/internal/services/appservice/migration/windows_function_app_slot.go
@@ -1536,8 +1536,7 @@ func (w WindowsFunctionAppSlotV0toV1) UpgradeFunc() pluginsdk.StateUpgraderFunc 
 		if err != nil {
 			return nil, err
 		}
-		newId := parsedId.ID()
-		rawState["service_plan_id"] = newId
+		rawState["service_plan_id"] = parsedId.ID()
 		return rawState, nil
 	}
 }

--- a/internal/services/appservice/migration/windows_web_app.go
+++ b/internal/services/appservice/migration/windows_web_app.go
@@ -1856,8 +1856,7 @@ func (w WindowsWebAppV0toV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
 		if err != nil {
 			return nil, err
 		}
-		newId := parsedId.ID()
-		rawState["service_plan_id"] = newId
+		rawState["service_plan_id"] = parsedId.ID()
 		return rawState, nil
 	}
 }

--- a/internal/services/appservice/migration/windows_web_app_slot.go
+++ b/internal/services/appservice/migration/windows_web_app_slot.go
@@ -1817,8 +1817,7 @@ func (w WindowsWebAppSlotV0toV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
 		if err != nil {
 			return nil, err
 		}
-		newId := parsedId.ID()
-		rawState["service_plan_id"] = newId
+		rawState["service_plan_id"] = parsedId.ID()
 		return rawState, nil
 	}
 }

--- a/internal/services/appservice/source_control_schema.go
+++ b/internal/services/appservice/source_control_schema.go
@@ -181,21 +181,19 @@ func flattenGitHubActionConfiguration(input *webapps.GitHubActionConfiguration) 
 	}
 
 	if codeConfig := input.CodeConfiguration; codeConfig != nil {
-		ghCodeConfig := []GitHubActionCodeConfig{{
+		ghConfig.CodeConfig = []GitHubActionCodeConfig{{
 			RuntimeStack:   pointer.From(codeConfig.RuntimeStack),
 			RuntimeVersion: pointer.From(codeConfig.RuntimeVersion),
 		}}
-		ghConfig.CodeConfig = ghCodeConfig
 	}
 
 	if containerConfig := input.ContainerConfiguration; containerConfig != nil {
-		ghContainerConfig := []GitHubActionContainerConfig{{
+		ghConfig.ContainerConfig = []GitHubActionContainerConfig{{
 			RegistryPassword: pointer.From(containerConfig.Password),
 			RegistryUsername: pointer.From(containerConfig.Username),
 			RegistryURL:      pointer.From(containerConfig.ServerURL),
 			ImageName:        pointer.From(containerConfig.ImageName),
 		}}
-		ghConfig.ContainerConfig = ghContainerConfig
 	}
 
 	output = append(output, ghConfig)

--- a/internal/services/appservice/windows_function_app_data_source.go
+++ b/internal/services/appservice/windows_function_app_data_source.go
@@ -490,8 +490,7 @@ func (m *WindowsFunctionAppDataSourceModel) unpackWindowsFunctionAppSettings(inp
 
 		case "AzureWebJobsStorage":
 			if strings.HasPrefix(v, "@Microsoft.KeyVault") {
-				trimmed := strings.TrimPrefix(strings.TrimSuffix(v, ")"), "@Microsoft.KeyVault(")
-				m.StorageKeyVaultSecretID = trimmed
+				m.StorageKeyVaultSecretID = strings.TrimPrefix(strings.TrimSuffix(v, ")"), "@Microsoft.KeyVault(")
 			} else {
 				m.StorageAccountName, m.StorageAccountKey = helpers.ParseWebJobsStorageString(v)
 			}

--- a/internal/services/appservice/windows_function_app_resource.go
+++ b/internal/services/appservice/windows_function_app_resource.go
@@ -1404,8 +1404,7 @@ func (m *WindowsFunctionAppModel) unpackWindowsFunctionAppSettings(input *webapp
 
 		case "AzureWebJobsStorage":
 			if strings.HasPrefix(v, "@Microsoft.KeyVault") {
-				trimmed := strings.TrimPrefix(strings.TrimSuffix(v, ")"), "@Microsoft.KeyVault(SecretUri=")
-				m.StorageKeyVaultSecretID = trimmed
+				m.StorageKeyVaultSecretID = strings.TrimPrefix(strings.TrimSuffix(v, ")"), "@Microsoft.KeyVault(SecretUri=")
 			} else {
 				m.StorageAccountName, m.StorageAccountKey = helpers.ParseWebJobsStorageString(v)
 			}

--- a/internal/services/appservice/windows_function_app_slot_resource.go
+++ b/internal/services/appservice/windows_function_app_slot_resource.go
@@ -1182,8 +1182,7 @@ func (m *WindowsFunctionAppSlotModel) unpackWindowsFunctionAppSettings(input *we
 
 		case "AzureWebJobsStorage":
 			if strings.HasPrefix(v, "@Microsoft.KeyVault") {
-				trimmed := strings.TrimPrefix(strings.TrimSuffix(v, ")"), "@Microsoft.KeyVault(SecretUri=")
-				m.StorageKeyVaultSecretID = trimmed
+				m.StorageKeyVaultSecretID = strings.TrimPrefix(strings.TrimSuffix(v, ")"), "@Microsoft.KeyVault(SecretUri=")
 			} else {
 				m.StorageAccountName, m.StorageAccountKey = helpers.ParseWebJobsStorageString(v)
 			}

--- a/internal/services/attestation/attestation_provider_resource.go
+++ b/internal/services/attestation/attestation_provider_resource.go
@@ -72,7 +72,7 @@ func resourceAttestationProvider() *pluginsdk.Resource {
 		},
 
 		Schema: func() map[string]*pluginsdk.Schema {
-			s := map[string]*pluginsdk.Schema{
+			return map[string]*pluginsdk.Schema{
 				"name": {
 					Type:         pluginsdk.TypeString,
 					Required:     true,
@@ -127,8 +127,6 @@ func resourceAttestationProvider() *pluginsdk.Resource {
 					ValidateFunc: validate.ContainsABase64UriEncodedJWTOfAStoredAttestationPolicy,
 				},
 			}
-
-			return s
 		}(),
 	}
 }

--- a/internal/services/authorization/migration/role_definition_migration.go
+++ b/internal/services/authorization/migration/role_definition_migration.go
@@ -104,9 +104,7 @@ func (RoleDefinitionV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
 			return nil, fmt.Errorf("failed to migrate state: scope missing")
 		}
 
-		newID := fmt.Sprintf("%s|%s", oldID, scope)
-
-		rawState["id"] = newID
+		rawState["id"] = fmt.Sprintf("%s|%s", oldID, scope)
 
 		return rawState, nil
 	}

--- a/internal/services/authorization/parse/role_assignment.go
+++ b/internal/services/authorization/parse/role_assignment.go
@@ -171,8 +171,7 @@ func RoleAssignmentID(input string) (*RoleAssignmentId, error) {
 		if strings.Contains(input, "/aliases/") {
 			roleAssignmentId.IsSubscriptionAliasLevel = true
 			aliasParts := strings.Split(idParts[0], "/")
-			alias := aliasParts[len(aliasParts)-1]
-			roleAssignmentId.SubscriptionAlias = alias
+			roleAssignmentId.SubscriptionAlias = aliasParts[len(aliasParts)-1]
 		} else {
 			roleAssignmentId.IsSubscriptionLevel = true
 		}

--- a/internal/services/authorization/registration.go
+++ b/internal/services/authorization/registration.go
@@ -57,14 +57,13 @@ func (r Registration) DataSources() []sdk.DataSource {
 }
 
 func (r Registration) Resources() []sdk.Resource {
-	resources := []sdk.Resource{
+	return []sdk.Resource{
 		PimActiveRoleAssignmentResource{},
 		PimEligibleRoleAssignmentResource{},
 		RoleAssignmentMarketplaceResource{},
 		RoleDefinitionResource{},
 		RoleManagementPolicyResource{},
 	}
-	return resources
 }
 
 func (r Registration) Actions() []func() action.Action {

--- a/internal/services/automation/automation_account_resource.go
+++ b/internal/services/automation/automation_account_resource.go
@@ -434,14 +434,12 @@ func flattenEncryption(encryption *automationaccount.EncryptionProperties) []int
 			}
 		}
 	}
-	flattened := []interface{}{
+	return []interface{}{
 		map[string]interface{}{
 			"key_vault_key_id":          keyVaultKeyId,
 			"user_assigned_identity_id": userAssignedIdentityId,
 		},
 	}
-
-	return flattened
 }
 
 func flattenPrivateEndpointConnections(input *[]automationaccount.PrivateEndpointConnection) []interface{} {

--- a/internal/services/automation/automation_certificate_resource.go
+++ b/internal/services/automation/automation_certificate_resource.go
@@ -19,7 +19,7 @@ import (
 )
 
 func resourceAutomationCertificate() *pluginsdk.Resource {
-	resource := &pluginsdk.Resource{
+	return &pluginsdk.Resource{
 		Create: resourceAutomationCertificateCreate,
 		Read:   resourceAutomationCertificateRead,
 		Update: resourceAutomationCertificateUpdate,
@@ -79,8 +79,6 @@ func resourceAutomationCertificate() *pluginsdk.Resource {
 			},
 		},
 	}
-
-	return resource
 }
 
 func resourceAutomationCertificateCreate(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/automation/automation_job_schedule_resource.go
+++ b/internal/services/automation/automation_job_schedule_resource.go
@@ -159,8 +159,7 @@ func resourceAutomationJobScheduleCreate(d *pluginsdk.ResourceData, meta interfa
 	if v, ok := d.GetOk("parameters"); ok {
 		jsParameters := make(map[string]string)
 		for k, v := range v.(map[string]interface{}) {
-			value := v.(string)
-			jsParameters[k] = value
+			jsParameters[k] = v.(string)
 		}
 		parameters.Properties.Parameters = &jsParameters
 	}

--- a/internal/services/automation/helper/automation_job_schedule.go
+++ b/internal/services/automation/helper/automation_job_schedule.go
@@ -41,8 +41,7 @@ func ExpandAutomationJobSchedule(input []interface{}, runBookName string) (*map[
 		if v, ok := js["parameters"]; ok {
 			jsParameters := make(map[string]string)
 			for k, v := range v.(map[string]interface{}) {
-				value := v.(string)
-				jsParameters[k] = value
+				jsParameters[k] = v.(string)
 			}
 			jobScheduleCreateParameters.Properties.Parameters = &jsParameters
 		}

--- a/internal/services/batch/batch_pool_data_source.go
+++ b/internal/services/batch/batch_pool_data_source.go
@@ -553,7 +553,7 @@ func dataSourceBatchPool() *pluginsdk.Resource {
 }
 
 func startTaskDSSchema() map[string]*pluginsdk.Schema {
-	s := map[string]*pluginsdk.Schema{
+	return map[string]*pluginsdk.Schema{
 		"command_line": {
 			Type:     pluginsdk.TypeString,
 			Computed: true,
@@ -672,7 +672,6 @@ func startTaskDSSchema() map[string]*pluginsdk.Schema {
 			},
 		},
 	}
-	return s
 }
 
 func batchPoolDataContainerRegistry() map[string]*schema.Schema {

--- a/internal/services/bot/bot_channel_web_chat_resource.go
+++ b/internal/services/bot/bot_channel_web_chat_resource.go
@@ -23,7 +23,7 @@ import (
 )
 
 func resourceBotChannelWebChat() *pluginsdk.Resource {
-	resource := &pluginsdk.Resource{
+	return &pluginsdk.Resource{
 		Create: resourceBotChannelWebChatCreate,
 		Read:   resourceBotChannelWebChatRead,
 		Delete: resourceBotChannelWebChatDelete,
@@ -85,8 +85,6 @@ func resourceBotChannelWebChat() *pluginsdk.Resource {
 			},
 		},
 	}
-
-	return resource
 }
 
 func resourceBotChannelWebChatCreate(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/bot/bot_connection_resource.go
+++ b/internal/services/bot/bot_connection_resource.go
@@ -25,7 +25,7 @@ import (
 )
 
 func resourceArmBotConnection() *pluginsdk.Resource {
-	resource := &pluginsdk.Resource{
+	return &pluginsdk.Resource{
 		Create: resourceArmBotConnectionCreate,
 		Read:   resourceArmBotConnectionRead,
 		Update: resourceArmBotConnectionUpdate,
@@ -96,8 +96,6 @@ func resourceArmBotConnection() *pluginsdk.Resource {
 			},
 		},
 	}
-
-	return resource
 }
 
 func resourceArmBotConnectionCreate(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/cdn/cdn_endpoint_custom_domain_resource.go
+++ b/internal/services/cdn/cdn_endpoint_custom_domain_resource.go
@@ -417,7 +417,7 @@ func expandArmCdnEndpointCustomDomainCdnManagedHttpsSettings(input []interface{}
 	}
 
 	raw := input[0].(map[string]interface{})
-	output := &cdn.ManagedHTTPSParameters{
+	return &cdn.ManagedHTTPSParameters{
 		CertificateSourceParameters: &cdn.CertificateSourceParameters{
 			OdataType:       pointer.To("#Microsoft.Azure.Cdn.Models.CdnCertificateSourceParameters"),
 			CertificateType: cdn.CertificateType(raw["certificate_type"].(string)),
@@ -426,8 +426,6 @@ func expandArmCdnEndpointCustomDomainCdnManagedHttpsSettings(input []interface{}
 		ProtocolType:      cdn.ProtocolType(raw["protocol_type"].(string)),
 		MinimumTLSVersion: cdn.MinimumTLSVersion(raw["tls_version"].(string)),
 	}
-
-	return output
 }
 
 func expandArmCdnEndpointCustomDomainUserManagedHttpsSettings(ctx context.Context, input []interface{}, clients *clients.Client) (cdn.BasicCustomDomainHTTPSParameters, error) {

--- a/internal/services/cdn/cdn_endpoint_resource.go
+++ b/internal/services/cdn/cdn_endpoint_resource.go
@@ -270,8 +270,7 @@ func resourceCdnEndpointCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 	}
 
 	if _, ok := d.GetOk("geo_filter"); ok {
-		geoFilters := expandCdnEndpointGeoFilters(d)
-		endpoint.GeoFilters = geoFilters
+		endpoint.GeoFilters = expandCdnEndpointGeoFilters(d)
 	}
 
 	if v, ok := d.GetOk("is_compression_enabled"); ok {
@@ -400,8 +399,7 @@ func resourceCdnEndpointUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 		}
 
 		if _, ok := d.GetOk("geo_filter"); ok {
-			geoFilters := expandCdnEndpointGeoFilters(d)
-			endpoint.GeoFilters = geoFilters
+			endpoint.GeoFilters = expandCdnEndpointGeoFilters(d)
 		}
 
 		if v, ok := d.GetOk("is_compression_enabled"); ok {

--- a/internal/services/compute/image_resource.go
+++ b/internal/services/compute/image_resource.go
@@ -382,10 +382,9 @@ func expandImageOSDisk(input []interface{}) *images.ImageOSDisk {
 		}
 		managedDiskID := config["managed_disk_id"].(string)
 		if managedDiskID != "" {
-			managedDisk := &images.SubResource{
+			out.ManagedDisk = &images.SubResource{
 				Id: &managedDiskID,
 			}
-			out.ManagedDisk = managedDisk
 		}
 
 		blobURI := config["blob_uri"].(string)
@@ -432,10 +431,9 @@ func expandImageDataDisks(disks []interface{}) *[]images.ImageDataDisk {
 		}
 
 		if managedDiskID := config["managed_disk_id"].(string); managedDiskID != "" {
-			managedDisk := &images.SubResource{
+			item.ManagedDisk = &images.SubResource{
 				Id: &managedDiskID,
 			}
-			item.ManagedDisk = managedDisk
 		}
 
 		if id := config["disk_encryption_set_id"].(string); id != "" {

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set.go
@@ -1137,8 +1137,7 @@ func expandOrchestratedVirtualMachineScaleSetIPConfiguration(raw map[string]inte
 	publicIPConfigsRaw := raw["public_ip_address"].([]interface{})
 	if len(publicIPConfigsRaw) > 0 && publicIPConfigsRaw[0] != nil {
 		publicIPConfigRaw := publicIPConfigsRaw[0].(map[string]interface{})
-		publicIPAddressConfig := expandOrchestratedVirtualMachineScaleSetPublicIPAddress(publicIPConfigRaw)
-		ipConfiguration.Properties.PublicIPAddressConfiguration = publicIPAddressConfig
+		ipConfiguration.Properties.PublicIPAddressConfiguration = expandOrchestratedVirtualMachineScaleSetPublicIPAddress(publicIPConfigRaw)
 	}
 
 	return &ipConfiguration, nil
@@ -1163,10 +1162,9 @@ func expandOrchestratedVirtualMachineScaleSetPublicIPAddress(raw map[string]inte
 	}
 
 	if domainNameLabel := raw["domain_name_label"].(string); domainNameLabel != "" {
-		dns := &virtualmachinescalesets.VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings{
+		publicIPAddressConfig.Properties.DnsSettings = &virtualmachinescalesets.VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings{
 			DomainNameLabel: domainNameLabel,
 		}
-		publicIPAddressConfig.Properties.DnsSettings = dns
 	}
 
 	if idleTimeout := raw["idle_timeout_in_minutes"].(int); idleTimeout > 0 {
@@ -1180,8 +1178,7 @@ func expandOrchestratedVirtualMachineScaleSetPublicIPAddress(raw map[string]inte
 	}
 
 	if sku := raw["sku_name"].(string); sku != "" {
-		v := expandOrchestratedVirtualMachineScaleSetPublicIPSku(sku)
-		publicIPAddressConfig.Sku = v
+		publicIPAddressConfig.Sku = expandOrchestratedVirtualMachineScaleSetPublicIPSku(sku)
 	}
 
 	if version := raw["version"].(string); version != "" {
@@ -1284,8 +1281,7 @@ func expandOrchestratedVirtualMachineScaleSetIPConfigurationUpdate(raw map[strin
 	publicIPConfigsRaw := raw["public_ip_address"].([]interface{})
 	if len(publicIPConfigsRaw) > 0 && publicIPConfigsRaw[0] != nil {
 		publicIPConfigRaw := publicIPConfigsRaw[0].(map[string]interface{})
-		publicIPAddressConfig := expandOrchestratedVirtualMachineScaleSetPublicIPAddressUpdate(publicIPConfigRaw)
-		ipConfiguration.Properties.PublicIPAddressConfiguration = publicIPAddressConfig
+		ipConfiguration.Properties.PublicIPAddressConfiguration = expandOrchestratedVirtualMachineScaleSetPublicIPAddressUpdate(publicIPConfigRaw)
 	}
 
 	return &ipConfiguration, nil
@@ -1298,10 +1294,9 @@ func expandOrchestratedVirtualMachineScaleSetPublicIPAddressUpdate(raw map[strin
 	}
 
 	if domainNameLabel := raw["domain_name_label"].(string); domainNameLabel != "" {
-		dns := &virtualmachinescalesets.VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings{
+		publicIPAddressConfig.Properties.DnsSettings = &virtualmachinescalesets.VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings{
 			DomainNameLabel: domainNameLabel,
 		}
-		publicIPAddressConfig.Properties.DnsSettings = dns
 	}
 
 	if idleTimeout := raw["idle_timeout_in_minutes"].(int); idleTimeout > 0 {

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
@@ -598,8 +598,7 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 	sourceImageReferenceRaw := d.Get("source_image_reference").([]interface{})
 	sourceImageId := d.Get("source_image_id").(string)
 	if len(sourceImageReferenceRaw) != 0 || sourceImageId != "" {
-		sourceImageReference := expandSourceImageReferenceVMSS(sourceImageReferenceRaw, sourceImageId)
-		virtualMachineProfile.StorageProfile.ImageReference = sourceImageReference
+		virtualMachineProfile.StorageProfile.ImageReference = expandSourceImageReferenceVMSS(sourceImageReferenceRaw, sourceImageId)
 	}
 
 	if userData, ok := d.GetOk("user_data_base64"); ok {
@@ -753,8 +752,7 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 	}
 
 	additionalCapabilitiesRaw := d.Get("additional_capabilities").([]interface{})
-	additionalCapabilities := ExpandOrchestratedVirtualMachineScaleSetAdditionalCapabilities(additionalCapabilitiesRaw)
-	props.Properties.AdditionalCapabilities = additionalCapabilities
+	props.Properties.AdditionalCapabilities = ExpandOrchestratedVirtualMachineScaleSetAdditionalCapabilities(additionalCapabilitiesRaw)
 
 	if v, ok := d.GetOk("data_disk"); ok {
 		ultraSSDEnabled := d.Get("additional_capabilities.0.ultra_ssd_enabled").(bool)
@@ -1137,8 +1135,7 @@ func resourceOrchestratedVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData,
 				sourceImageId := d.Get("source_image_id").(string)
 
 				if len(sourceImageReferenceRaw) != 0 || sourceImageId != "" {
-					sourceImageReference := expandSourceImageReferenceVMSS(sourceImageReferenceRaw, sourceImageId)
-					updateProps.VirtualMachineProfile.StorageProfile.ImageReference = sourceImageReference
+					updateProps.VirtualMachineProfile.StorageProfile.ImageReference = expandSourceImageReferenceVMSS(sourceImageReferenceRaw, sourceImageId)
 				}
 
 				// Must include all storage profile properties when updating disk image.  See: https://github.com/hashicorp/terraform-provider-azurerm/issues/8273

--- a/internal/services/compute/registration.go
+++ b/internal/services/compute/registration.go
@@ -55,7 +55,7 @@ func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 
 // SupportedResources returns the supported Resources supported by this Service
 func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
-	resources := map[string]*pluginsdk.Resource{
+	return map[string]*pluginsdk.Resource{
 		"azurerm_availability_set":                       resourceAvailabilitySet(),
 		"azurerm_capacity_reservation":                   resourceCapacityReservation(),
 		"azurerm_capacity_reservation_group":             resourceCapacityReservationGroup(),
@@ -82,8 +82,6 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 		"azurerm_ssh_public_key":                         resourceSshPublicKey(),
 		"azurerm_managed_disk_sas_token":                 resourceManagedDiskSasToken(),
 	}
-
-	return resources
 }
 
 func (r Registration) DataSources() []sdk.DataSource {

--- a/internal/services/compute/virtual_machine_scale_set.go
+++ b/internal/services/compute/virtual_machine_scale_set.go
@@ -810,8 +810,7 @@ func expandVirtualMachineScaleSetIPConfiguration(raw map[string]interface{}) (*v
 	publicIPConfigsRaw := raw["public_ip_address"].([]interface{})
 	if len(publicIPConfigsRaw) > 0 {
 		publicIPConfigRaw := publicIPConfigsRaw[0].(map[string]interface{})
-		publicIPAddressConfig := expandVirtualMachineScaleSetPublicIPAddress(publicIPConfigRaw)
-		ipConfiguration.Properties.PublicIPAddressConfiguration = publicIPAddressConfig
+		ipConfiguration.Properties.PublicIPAddressConfiguration = expandVirtualMachineScaleSetPublicIPAddress(publicIPConfigRaw)
 	}
 
 	return &ipConfiguration, nil
@@ -837,10 +836,9 @@ func expandVirtualMachineScaleSetPublicIPAddress(raw map[string]interface{}) *vi
 	}
 
 	if domainNameLabel := raw["domain_name_label"].(string); domainNameLabel != "" {
-		dns := &virtualmachinescalesets.VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings{
+		publicIPAddressConfig.Properties.DnsSettings = &virtualmachinescalesets.VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings{
 			DomainNameLabel: domainNameLabel,
 		}
-		publicIPAddressConfig.Properties.DnsSettings = dns
 	}
 
 	if idleTimeout := raw["idle_timeout_in_minutes"].(int); idleTimeout > 0 {
@@ -950,8 +948,7 @@ func expandVirtualMachineScaleSetIPConfigurationUpdate(raw map[string]interface{
 	publicIPConfigsRaw := raw["public_ip_address"].([]interface{})
 	if len(publicIPConfigsRaw) > 0 {
 		publicIPConfigRaw := publicIPConfigsRaw[0].(map[string]interface{})
-		publicIPAddressConfig := expandVirtualMachineScaleSetPublicIPAddressUpdate(publicIPConfigRaw)
-		ipConfiguration.Properties.PublicIPAddressConfiguration = publicIPAddressConfig
+		ipConfiguration.Properties.PublicIPAddressConfiguration = expandVirtualMachineScaleSetPublicIPAddressUpdate(publicIPConfigRaw)
 	}
 
 	return &ipConfiguration, nil
@@ -964,10 +961,9 @@ func expandVirtualMachineScaleSetPublicIPAddressUpdate(raw map[string]interface{
 	}
 
 	if domainNameLabel := raw["domain_name_label"].(string); domainNameLabel != "" {
-		dns := &virtualmachinescalesets.VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings{
+		publicIPAddressConfig.Properties.DnsSettings = &virtualmachinescalesets.VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings{
 			DomainNameLabel: domainNameLabel,
 		}
-		publicIPAddressConfig.Properties.DnsSettings = dns
 	}
 
 	if idleTimeout := raw["idle_timeout_in_minutes"].(int); idleTimeout > 0 {
@@ -1881,7 +1877,7 @@ func FlattenVirtualMachineScaleSetAutomaticRepairsPolicy(input *virtualmachinesc
 }
 
 func VirtualMachineScaleSetExtensionsSchema() *pluginsdk.Schema {
-	schema := &pluginsdk.Schema{
+	return &pluginsdk.Schema{
 		Type:     pluginsdk.TypeSet,
 		Optional: true,
 		Computed: true,
@@ -1956,8 +1952,6 @@ func VirtualMachineScaleSetExtensionsSchema() *pluginsdk.Schema {
 		},
 		Set: virtualMachineScaleSetExtensionHash,
 	}
-
-	return schema
 }
 
 func virtualMachineScaleSetExtensionHash(v interface{}) int {

--- a/internal/services/confidentialledger/confidential_ledger_resource.go
+++ b/internal/services/confidentialledger/confidential_ledger_resource.go
@@ -258,13 +258,11 @@ func resourceConfidentialLedgerUpdate(d *pluginsdk.ResourceData, meta interface{
 	}
 
 	if d.HasChange("azuread_based_service_principal") {
-		aadBasedUsers := expandAADBasedSecurityPrincipal(d.Get("azuread_based_service_principal").([]interface{}))
-		ledger.Properties.AadBasedSecurityPrincipals = aadBasedUsers
+		ledger.Properties.AadBasedSecurityPrincipals = expandAADBasedSecurityPrincipal(d.Get("azuread_based_service_principal").([]interface{}))
 	}
 
 	if d.HasChange("certificate_based_security_principal") {
-		certBasedUsers := expandCertBasedSecurityPrincipal(d.Get("certificate_based_security_principal").([]interface{}))
-		ledger.Properties.CertBasedSecurityPrincipals = certBasedUsers
+		ledger.Properties.CertBasedSecurityPrincipals = expandCertBasedSecurityPrincipal(d.Get("certificate_based_security_principal").([]interface{}))
 	}
 
 	if d.HasChange("tags") {

--- a/internal/services/connections/api_connection_resource.go
+++ b/internal/services/connections/api_connection_resource.go
@@ -24,7 +24,7 @@ import (
 )
 
 func resourceApiConnection() *pluginsdk.Resource {
-	resource := &pluginsdk.Resource{
+	return &pluginsdk.Resource{
 		Create: resourceApiConnectionCreate,
 		Read:   resourceApiConnectionRead,
 		Update: resourceApiConnectionUpdate,
@@ -81,8 +81,6 @@ func resourceApiConnection() *pluginsdk.Resource {
 			"tags": commonschema.Tags(),
 		},
 	}
-
-	return resource
 }
 
 func resourceApiConnectionCreate(d *schema.ResourceData, meta interface{}) error {

--- a/internal/services/consumption/consumption_budget_subscription_resource_test.go
+++ b/internal/services/consumption/consumption_budget_subscription_resource_test.go
@@ -19,9 +19,7 @@ import (
 
 func consumptionBudgetTestStartDate() time.Time {
 	utcNow := time.Now().UTC()
-	startDate := time.Date(utcNow.Year(), utcNow.Month(), 1, 0, 0, 0, 0, utcNow.Location())
-
-	return startDate
+	return time.Date(utcNow.Year(), utcNow.Month(), 1, 0, 0, 0, 0, utcNow.Location())
 }
 
 type ConsumptionBudgetSubscriptionResource struct{}

--- a/internal/services/consumption/migration/consumption_budget_subscription.go
+++ b/internal/services/consumption/migration/consumption_budget_subscription.go
@@ -248,8 +248,7 @@ func (SubscriptionConsumptionBudgetV1ToV2) UpgradeFunc() pluginsdk.StateUpgrader
 			return nil, fmt.Errorf("parsing %q: %+v", idRaw, err)
 		}
 
-		newSubscriptionId := commonids.NewSubscriptionID(id.Scope).ID()
-		rawState["subscription_id"] = newSubscriptionId
+		rawState["subscription_id"] = commonids.NewSubscriptionID(id.Scope).ID()
 
 		return rawState, nil
 	}

--- a/internal/services/containerapps/container_app_environment_storage_resource.go
+++ b/internal/services/containerapps/container_app_environment_storage_resource.go
@@ -148,16 +148,15 @@ func (r ContainerAppEnvironmentStorageResource) Create() sdk.ResourceFunc {
 			managedEnvironmentStorage := managedenvironmentsstorages.ManagedEnvironmentStorage{}
 
 			if storage.NfsServer != "" {
-				props := &managedenvironmentsstorages.ManagedEnvironmentStorageProperties{
+				managedEnvironmentStorage.Properties = &managedenvironmentsstorages.ManagedEnvironmentStorageProperties{
 					NfsAzureFile: &managedenvironmentsstorages.NfsAzureFileProperties{
 						AccessMode: &accessMode,
 						Server:     pointer.To(storage.NfsServer),
 						ShareName:  pointer.To(storage.ShareName),
 					},
 				}
-				managedEnvironmentStorage.Properties = props
 			} else {
-				props := &managedenvironmentsstorages.ManagedEnvironmentStorageProperties{
+				managedEnvironmentStorage.Properties = &managedenvironmentsstorages.ManagedEnvironmentStorageProperties{
 					AzureFile: &managedenvironmentsstorages.AzureFileProperties{
 						AccessMode:  &accessMode,
 						AccountKey:  pointer.To(storage.AccessKey),
@@ -165,7 +164,6 @@ func (r ContainerAppEnvironmentStorageResource) Create() sdk.ResourceFunc {
 						ShareName:   pointer.To(storage.ShareName),
 					},
 				}
-				managedEnvironmentStorage.Properties = props
 			}
 
 			if _, err := client.CreateOrUpdate(ctx, id, managedEnvironmentStorage); err != nil {

--- a/internal/services/containerapps/helpers/container_app_job.go
+++ b/internal/services/containerapps/helpers/container_app_job.go
@@ -290,13 +290,11 @@ func ExpandContainerAppJobTemplate(input []JobTemplateModel) *jobs.JobTemplate {
 		return nil
 	}
 	v := input[0]
-	template := &jobs.JobTemplate{
+	return &jobs.JobTemplate{
 		Containers:     expandContainerAppJobContainers(v.Containers),
 		InitContainers: expandInitContainerAppJobContainers(v.InitContainers),
 		Volumes:        expandContainerAppJobVolumes(v.Volumes),
 	}
-
-	return template
 }
 
 func FlattenContainerAppJobTemplate(input *jobs.JobTemplate) []JobTemplateModel {
@@ -895,8 +893,7 @@ func FlattenContainerAppJobConfigurationEventTriggerConfig(input *jobs.JobConfig
 	}
 
 	if input.Scale != nil {
-		scale := flattenContainerAppJobScale(input.Scale)
-		eventTriggerConfig.Scale = scale
+		eventTriggerConfig.Scale = flattenContainerAppJobScale(input.Scale)
 	}
 
 	result = append(result, eventTriggerConfig)
@@ -956,8 +953,7 @@ func flattenContainerAppJobScale(input *jobs.JobScale) []ScaleModel {
 	}
 
 	if input.Rules != nil {
-		rules := flattenContainerAppJobScaleRules(input.Rules)
-		scale.Rules = rules
+		scale.Rules = flattenContainerAppJobScaleRules(input.Rules)
 	}
 
 	result = append(result, scale)
@@ -987,8 +983,7 @@ func flattenContainerAppJobScaleRules(input *[]jobs.JobScaleRule) []ScaleRule {
 		}
 
 		if v.Auth != nil {
-			auth := flattenContainerAppJobScaleRulesAuth(v.Auth)
-			rule.Auth = auth
+			rule.Auth = flattenContainerAppJobScaleRulesAuth(v.Auth)
 		}
 
 		result = append(result, rule)

--- a/internal/services/containers/container_group_resource.go
+++ b/internal/services/containers/container_group_resource.go
@@ -33,7 +33,7 @@ import (
 )
 
 func resourceContainerGroup() *pluginsdk.Resource {
-	resource := &pluginsdk.Resource{
+	return &pluginsdk.Resource{
 		Create: resourceContainerGroupCreate,
 		Read:   resourceContainerGroupRead,
 		Delete: resourceContainerGroupDelete,
@@ -519,8 +519,6 @@ func resourceContainerGroup() *pluginsdk.Resource {
 			return nil
 		},
 	}
-
-	return resource
 }
 
 func containerVolumeSchema() *pluginsdk.Schema {
@@ -1124,11 +1122,9 @@ func expandContainerSecurityContext(input []interface{}) *containerinstance.Secu
 
 	raw := input[0].(map[string]interface{})
 
-	output := &containerinstance.SecurityContextDefinition{
+	return &containerinstance.SecurityContextDefinition{
 		Privileged: pointer.To(raw["privilege_enabled"].(bool)),
 	}
-
-	return output
 }
 
 func flattenContainerSecurityContext(input *containerinstance.SecurityContextDefinition) []interface{} {
@@ -1283,8 +1279,7 @@ func expandContainerGroupContainers(d *pluginsdk.ResourceData, addedEmptyDirs ma
 				val[protocol] = true
 				cgpMap[p.Port] = val
 			} else {
-				protoMap := map[containerinstance.ContainerGroupNetworkProtocol]bool{protocol: true}
-				cgpMap[p.Port] = protoMap
+				cgpMap[p.Port] = map[containerinstance.ContainerGroupNetworkProtocol]bool{protocol: true}
 			}
 		}
 
@@ -1803,8 +1798,7 @@ func flattenContainerVolume(containerConfig map[string]interface{}, containersCo
 				cv := cvr.(map[string]interface{})
 				rawName := cv["name"].(string)
 				if vm.Name == rawName {
-					storageAccountKey := cv["storage_account_key"].(string)
-					volumeConfig["storage_account_key"] = storageAccountKey
+					volumeConfig["storage_account_key"] = cv["storage_account_key"].(string)
 					volumeConfig["secret"] = cv["secret"]
 				}
 			}
@@ -1825,8 +1819,7 @@ func flattenContainerSecureEnvironmentVariables(input *[]containerinstance.Envir
 
 	for _, envVar := range *input {
 		if envVar.Value == nil {
-			envVarValue := d.Get(fmt.Sprintf("%s.%d.secure_environment_variables.%s", rootPropName, oldContainerIndex, envVar.Name))
-			output[envVar.Name] = envVarValue
+			output[envVar.Name] = d.Get(fmt.Sprintf("%s.%d.secure_environment_variables.%s", rootPropName, oldContainerIndex, envVar.Name))
 		}
 	}
 
@@ -1945,8 +1938,7 @@ func expandContainerGroupDiagnostics(input []interface{}) *containerinstance.Con
 		metadataMap := analyticsV["metadata"].(map[string]interface{})
 		metadata := make(map[string]string)
 		for k, v := range metadataMap {
-			strValue := v.(string)
-			metadata[k] = strValue
+			metadata[k] = v.(string)
 		}
 
 		logAnalytics.Metadata = &metadata

--- a/internal/services/containers/container_registry_resource.go
+++ b/internal/services/containers/container_registry_resource.go
@@ -891,8 +891,7 @@ func resourceContainerRegistryRead(d *pluginsdk.ResourceData, meta interface{}) 
 				replication["location"] = valueLocation
 				replication["tags"] = tags.Flatten(value.Tags)
 				replication["zone_redundancy_enabled"] = *value.Properties.ZoneRedundancy == replications.ZoneRedundancyEnabled
-				regionEndpointEnabled := value.Properties.RegionEndpointEnabled != nil && *value.Properties.RegionEndpointEnabled
-				replication["global_endpoint_routing_enabled"] = regionEndpointEnabled
+				replication["global_endpoint_routing_enabled"] = value.Properties.RegionEndpointEnabled != nil && *value.Properties.RegionEndpointEnabled
 				geoReplications = append(geoReplications, replication)
 			}
 		}

--- a/internal/services/containers/kubernetes_addons.go
+++ b/internal/services/containers/kubernetes_addons.go
@@ -47,7 +47,7 @@ var unsupportedAddonsForEnvironment = map[string][]string{
 }
 
 func schemaKubernetesAddOns() map[string]*pluginsdk.Schema {
-	out := map[string]*pluginsdk.Schema{
+	return map[string]*pluginsdk.Schema{
 		"aci_connector_linux": {
 			Type:     pluginsdk.TypeList,
 			MaxItems: 1,
@@ -278,8 +278,6 @@ func schemaKubernetesAddOns() map[string]*pluginsdk.Schema {
 			},
 		},
 	}
-
-	return out
 }
 
 func expandKubernetesAddOns(d *pluginsdk.ResourceData, input map[string]interface{}, env environments.Environment) (*map[string]managedclusters.ManagedClusterAddonProfile, error) {
@@ -356,13 +354,12 @@ func expandKubernetesAddOns(d *pluginsdk.ResourceData, input map[string]interfac
 
 	// Always set the azure_policy addon profile to ensure it's synchronized with Azure on every update
 	azurePolicyEnabled := input["azure_policy_enabled"].(bool)
-	props := managedclusters.ManagedClusterAddonProfile{
+	addonProfiles[azurePolicyKey] = managedclusters.ManagedClusterAddonProfile{
 		Enabled: azurePolicyEnabled,
 		Config: pointer.To(map[string]string{
 			"version": "v2",
 		}),
 	}
-	addonProfiles[azurePolicyKey] = props
 
 	ingressApplicationGateway := input["ingress_application_gateway"].([]interface{})
 	if len(ingressApplicationGateway) > 0 && ingressApplicationGateway[0] != nil {
@@ -405,8 +402,7 @@ func expandKubernetesAddOns(d *pluginsdk.ResourceData, input map[string]interfac
 		value := azureKeyVaultSecretsProvider[0].(map[string]interface{})
 		config := make(map[string]string)
 
-		enableSecretRotation := fmt.Sprintf("%t", value["secret_rotation_enabled"].(bool))
-		config["enableSecretRotation"] = enableSecretRotation
+		config["enableSecretRotation"] = fmt.Sprintf("%t", value["secret_rotation_enabled"].(bool))
 		config["rotationPollInterval"] = value["secret_rotation_interval"].(string)
 
 		addonProfiles[azureKeyvaultSecretsProviderKey] = managedclusters.ManagedClusterAddonProfile{

--- a/internal/services/containers/kubernetes_cluster_data_source.go
+++ b/internal/services/containers/kubernetes_cluster_data_source.go
@@ -27,7 +27,7 @@ import (
 )
 
 func dataSourceKubernetesCluster() *pluginsdk.Resource {
-	resource := &pluginsdk.Resource{
+	return &pluginsdk.Resource{
 		Read: dataSourceKubernetesClusterRead,
 
 		Timeouts: &pluginsdk.ResourceTimeout{
@@ -739,8 +739,6 @@ func dataSourceKubernetesCluster() *pluginsdk.Resource {
 			"tags": commonschema.TagsDataSource(),
 		},
 	}
-
-	return resource
 }
 
 func dataSourceKubernetesClusterRead(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/containers/kubernetes_cluster_node_pool_data_source.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_data_source.go
@@ -23,7 +23,7 @@ import (
 )
 
 func dataSourceKubernetesClusterNodePool() *pluginsdk.Resource {
-	dataSource := &pluginsdk.Resource{
+	return &pluginsdk.Resource{
 		Read: dataSourceKubernetesClusterNodePoolRead,
 
 		Timeouts: &pluginsdk.ResourceTimeout{
@@ -168,8 +168,6 @@ func dataSourceKubernetesClusterNodePool() *pluginsdk.Resource {
 			"zones": commonschema.ZonesMultipleComputed(),
 		},
 	}
-
-	return dataSource
 }
 
 func dataSourceKubernetesClusterNodePoolRead(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -118,7 +118,7 @@ func resourceKubernetesClusterNodePool() *pluginsdk.Resource {
 }
 
 func resourceKubernetesClusterNodePoolSchema() map[string]*pluginsdk.Schema {
-	s := map[string]*pluginsdk.Schema{
+	return map[string]*pluginsdk.Schema{
 		"name": {
 			Type:         pluginsdk.TypeString,
 			Required:     true,
@@ -438,8 +438,6 @@ func resourceKubernetesClusterNodePoolSchema() map[string]*pluginsdk.Schema {
 			Optional: true,
 		},
 	}
-
-	return s
 }
 
 func resourceKubernetesClusterNodePoolCreate(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -2203,31 +2203,27 @@ func resourceKubernetesClusterUpdate(d *pluginsdk.ResourceData, meta interface{}
 	if d.HasChanges("run_command_enabled", "private_cluster_public_fqdn_enabled", "api_server_access_profile") {
 		updateCluster = true
 
-		apiServerProfile := expandKubernetesClusterAPIAccessProfile(d)
-		existing.Model.Properties.ApiServerAccessProfile = apiServerProfile
+		existing.Model.Properties.ApiServerAccessProfile = expandKubernetesClusterAPIAccessProfile(d)
 	}
 
 	if d.HasChange("auto_scaler_profile") {
 		updateCluster = true
 		autoScalerProfileRaw := d.Get("auto_scaler_profile").([]interface{})
 
-		autoScalerProfile := expandKubernetesClusterAutoScalerProfile(autoScalerProfileRaw)
-		existing.Model.Properties.AutoScalerProfile = autoScalerProfile
+		existing.Model.Properties.AutoScalerProfile = expandKubernetesClusterAutoScalerProfile(autoScalerProfileRaw)
 	}
 
 	if d.HasChange("monitor_metrics") {
 		updateCluster = true
 		azureMonitorKubernetesMetricsRaw := d.Get("monitor_metrics").([]interface{})
 
-		azureMonitorProfile := expandKubernetesClusterAzureMonitorProfile(azureMonitorKubernetesMetricsRaw)
-		existing.Model.Properties.AzureMonitorProfile = azureMonitorProfile
+		existing.Model.Properties.AzureMonitorProfile = expandKubernetesClusterAzureMonitorProfile(azureMonitorKubernetesMetricsRaw)
 	}
 
 	if d.HasChange("linux_profile") {
 		updateCluster = true
 		linuxProfileRaw := d.Get("linux_profile").([]interface{})
-		linuxProfile := expandKubernetesClusterLinuxProfile(linuxProfileRaw)
-		existing.Model.Properties.LinuxProfile = linuxProfile
+		existing.Model.Properties.LinuxProfile = expandKubernetesClusterLinuxProfile(linuxProfileRaw)
 	}
 
 	if d.HasChange("local_account_disabled") {
@@ -2262,8 +2258,7 @@ func resourceKubernetesClusterUpdate(d *pluginsdk.ResourceData, meta interface{}
 			}
 
 			if key := "network_profile.0.load_balancer_profile.0.effective_outbound_ips"; d.HasChange(key) {
-				effectiveOutboundIPs := idsToResourceReferences(d.Get(key))
-				loadBalancerProfile.EffectiveOutboundIPs = effectiveOutboundIPs
+				loadBalancerProfile.EffectiveOutboundIPs = idsToResourceReferences(d.Get(key))
 			}
 
 			if key := "network_profile.0.load_balancer_profile.0.idle_timeout_in_minutes"; d.HasChange(key) {
@@ -2425,8 +2420,7 @@ func resourceKubernetesClusterUpdate(d *pluginsdk.ResourceData, meta interface{}
 	if d.HasChange("windows_profile") {
 		updateCluster = true
 		windowsProfileRaw := d.Get("windows_profile").([]interface{})
-		windowsProfile := expandKubernetesClusterWindowsProfile(windowsProfileRaw)
-		existing.Model.Properties.WindowsProfile = windowsProfile
+		existing.Model.Properties.WindowsProfile = expandKubernetesClusterWindowsProfile(windowsProfileRaw)
 	}
 
 	if d.HasChange("identity") {
@@ -2484,15 +2478,13 @@ func resourceKubernetesClusterUpdate(d *pluginsdk.ResourceData, meta interface{}
 	if d.HasChange("http_proxy_config") {
 		updateCluster = true
 		httpProxyConfigRaw := d.Get("http_proxy_config").([]interface{})
-		httpProxyConfig := expandKubernetesClusterHttpProxyConfig(httpProxyConfigRaw)
-		existing.Model.Properties.HTTPProxyConfig = httpProxyConfig
+		existing.Model.Properties.HTTPProxyConfig = expandKubernetesClusterHttpProxyConfig(httpProxyConfigRaw)
 	}
 
 	if d.HasChange("oidc_issuer_enabled") {
 		updateCluster = true
 		oidcIssuerEnabled := d.Get("oidc_issuer_enabled").(bool)
-		oidcIssuerProfile := expandKubernetesClusterOidcIssuerProfile(oidcIssuerEnabled)
-		existing.Model.Properties.OidcIssuerProfile = oidcIssuerProfile
+		existing.Model.Properties.OidcIssuerProfile = expandKubernetesClusterOidcIssuerProfile(oidcIssuerEnabled)
 	}
 
 	if d.HasChanges("key_management_service") {
@@ -2527,8 +2519,7 @@ func resourceKubernetesClusterUpdate(d *pluginsdk.ResourceData, meta interface{}
 	if d.HasChanges("storage_profile") {
 		updateCluster = true
 		storageProfileRaw := d.Get("storage_profile").([]interface{})
-		clusterStorageProfile := expandStorageProfile(storageProfileRaw)
-		existing.Model.Properties.StorageProfile = clusterStorageProfile
+		existing.Model.Properties.StorageProfile = expandStorageProfile(storageProfileRaw)
 	}
 
 	if d.HasChange("workload_autoscaler_profile") {
@@ -2556,8 +2547,7 @@ func resourceKubernetesClusterUpdate(d *pluginsdk.ResourceData, meta interface{}
 	if d.HasChange("node_provisioning_profile") {
 		updateCluster = true
 		nodeProvisioningProfileRaw := d.Get("node_provisioning_profile").([]interface{})
-		nodeProvisioningProfile := expandKubernetesClusterNodeProvisioningProfile(nodeProvisioningProfileRaw)
-		existing.Model.Properties.NodeProvisioningProfile = nodeProvisioningProfile
+		existing.Model.Properties.NodeProvisioningProfile = expandKubernetesClusterNodeProvisioningProfile(nodeProvisioningProfileRaw)
 	}
 
 	if d.HasChanges("workload_identity_enabled") {
@@ -2605,8 +2595,7 @@ func resourceKubernetesClusterUpdate(d *pluginsdk.ResourceData, meta interface{}
 		}
 
 		updateCluster = true
-		upgradeOverrideSetting := expandKubernetesClusterUpgradeOverrideSetting(upgradeOverrideSettingRaw)
-		existing.Model.Properties.UpgradeSettings = upgradeOverrideSetting
+		existing.Model.Properties.UpgradeSettings = expandKubernetesClusterUpgradeOverrideSetting(upgradeOverrideSettingRaw)
 	}
 
 	if d.HasChange("web_app_routing") {
@@ -4874,8 +4863,7 @@ func expandKubernetesClusterServiceMeshProfile(input []interface{}, existing *ma
 		profile.Istio.Components.IngressGateways = &istioIngressGatewaysList
 
 		if raw["certificate_authority"] != nil {
-			certificateAuthority := expandKubernetesClusterServiceMeshProfileCertificateAuthority(raw["certificate_authority"].([]interface{}))
-			profile.Istio.CertificateAuthority = certificateAuthority
+			profile.Istio.CertificateAuthority = expandKubernetesClusterServiceMeshProfileCertificateAuthority(raw["certificate_authority"].([]interface{}))
 		}
 
 		if raw["revisions"] != nil {

--- a/internal/services/containers/kubernetes_cluster_trusted_access_role_binding_resource.go
+++ b/internal/services/containers/kubernetes_cluster_trusted_access_role_binding_resource.go
@@ -215,15 +215,13 @@ func (r KubernetesClusterTrustedAccessRoleBindingResource) mapTrustedAccessRoleB
 }
 
 func (r KubernetesClusterTrustedAccessRoleBindingResource) mapKubernetesClusterTrustedAccessRoleBindingResourceSchemaToTrustedAccessRoleBindingProperties(input KubernetesClusterTrustedAccessRoleBindingResourceSchema, output *trustedaccess.TrustedAccessRoleBindingProperties) {
-	roles := append([]string{}, input.Roles...)
-	output.Roles = roles
+	output.Roles = append([]string{}, input.Roles...)
 
 	output.SourceResourceId = input.SourceResourceId
 }
 
 func (r KubernetesClusterTrustedAccessRoleBindingResource) mapTrustedAccessRoleBindingPropertiesToKubernetesClusterTrustedAccessRoleBindingResourceSchema(input trustedaccess.TrustedAccessRoleBindingProperties, output *KubernetesClusterTrustedAccessRoleBindingResourceSchema) {
-	roles := append([]string{}, input.Roles...)
-	output.Roles = roles
+	output.Roles = append([]string{}, input.Roles...)
 
 	output.SourceResourceId = input.SourceResourceId
 }

--- a/internal/services/containers/kubernetes_nodepool.go
+++ b/internal/services/containers/kubernetes_nodepool.go
@@ -287,7 +287,7 @@ func SchemaDefaultNodePool() *pluginsdk.Schema {
 }
 
 func schemaNodePoolKubeletConfig() *pluginsdk.Schema {
-	s := &pluginsdk.Schema{
+	return &pluginsdk.Schema{
 		Type:     pluginsdk.TypeList,
 		Optional: true,
 		MaxItems: 1,
@@ -362,8 +362,6 @@ func schemaNodePoolKubeletConfig() *pluginsdk.Schema {
 			},
 		},
 	}
-
-	return s
 }
 
 func schemaNodePoolLinuxOSConfig() *pluginsdk.Schema {
@@ -1478,7 +1476,7 @@ func flattenClusterNodePoolKubeletConfig(input *managedclusters.KubeletConfig) [
 		podMaxPids = int(*input.PodMaxPids)
 	}
 
-	result := []interface{}{
+	return []interface{}{
 		map[string]interface{}{
 			"cpu_manager_policy":        cpuManagerPolicy,
 			"cpu_cfs_quota_enabled":     cpuCfsQuotaEnabled,
@@ -1492,8 +1490,6 @@ func flattenClusterNodePoolKubeletConfig(input *managedclusters.KubeletConfig) [
 			"pod_max_pid":               podMaxPids,
 		},
 	}
-
-	return result
 }
 
 func flattenAgentPoolKubeletConfig(input *agentpools.KubeletConfig) []interface{} {
@@ -1533,7 +1529,7 @@ func flattenAgentPoolKubeletConfig(input *agentpools.KubeletConfig) []interface{
 		podMaxPids = int(*input.PodMaxPids)
 	}
 
-	result := []interface{}{
+	return []interface{}{
 		map[string]interface{}{
 			"cpu_manager_policy":        cpuManagerPolicy,
 			"cpu_cfs_quota_enabled":     cpuCfsQuotaEnabled,
@@ -1547,8 +1543,6 @@ func flattenAgentPoolKubeletConfig(input *agentpools.KubeletConfig) []interface{
 			"pod_max_pid":               podMaxPids,
 		},
 	}
-
-	return result
 }
 
 func flattenClusterNodePoolLinuxOSConfig(input *managedclusters.LinuxOSConfig) ([]interface{}, error) {

--- a/internal/services/cosmos/cosmosdb_account_data_source.go
+++ b/internal/services/cosmos/cosmosdb_account_data_source.go
@@ -22,7 +22,7 @@ import (
 )
 
 func dataSourceCosmosDbAccount() *pluginsdk.Resource {
-	dataSource := &pluginsdk.Resource{
+	return &pluginsdk.Resource{
 		Read: dataSourceCosmosDbAccountRead,
 
 		Timeouts: &pluginsdk.ResourceTimeout{
@@ -250,8 +250,6 @@ func dataSourceCosmosDbAccount() *pluginsdk.Resource {
 			},
 		},
 	}
-
-	return dataSource
 }
 
 func dataSourceCosmosDbAccountRead(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/cosmos/cosmosdb_cassandra_datacenter_resource.go
+++ b/internal/services/cosmos/cosmosdb_cassandra_datacenter_resource.go
@@ -25,7 +25,7 @@ import (
 )
 
 func resourceCassandraDatacenter() *pluginsdk.Resource {
-	resource := &pluginsdk.Resource{
+	return &pluginsdk.Resource{
 		Create: resourceCassandraDatacenterCreate,
 		Read:   resourceCassandraDatacenterRead,
 		Update: resourceCassandraDatacenterUpdate,
@@ -127,8 +127,6 @@ func resourceCassandraDatacenter() *pluginsdk.Resource {
 			},
 		},
 	}
-
-	return resource
 }
 
 func resourceCassandraDatacenterCreate(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/cosmos/cosmosdb_gremlin_graph_resource.go
+++ b/internal/services/cosmos/cosmosdb_gremlin_graph_resource.go
@@ -483,10 +483,9 @@ func expandAzureRmCosmosDbGremlinGraphIncludedPath(input map[string]interface{})
 
 	for i, pathConfig := range includedPath {
 		attrs := pathConfig.(string)
-		path := cosmosdb.IncludedPath{
+		paths[i] = cosmosdb.IncludedPath{
 			Path: pointer.To(attrs),
 		}
-		paths[i] = path
 	}
 
 	return &paths
@@ -498,10 +497,9 @@ func expandAzureRmCosmosDbGremlinGraphExcludedPath(input map[string]interface{})
 
 	for i, pathConfig := range excludedPath {
 		attrs := pathConfig.(string)
-		path := cosmosdb.ExcludedPath{
+		paths[i] = cosmosdb.ExcludedPath{
 			Path: pointer.To(attrs),
 		}
-		paths[i] = path
 	}
 
 	return &paths

--- a/internal/services/cosmos/cosmosdb_sql_container_resource.go
+++ b/internal/services/cosmos/cosmosdb_sql_container_resource.go
@@ -25,7 +25,7 @@ import (
 )
 
 func resourceCosmosDbSQLContainer() *pluginsdk.Resource {
-	resource := &pluginsdk.Resource{
+	return &pluginsdk.Resource{
 		Create: resourceCosmosDbSQLContainerCreate,
 		Read:   resourceCosmosDbSQLContainerRead,
 		Update: resourceCosmosDbSQLContainerUpdate,
@@ -156,8 +156,6 @@ func resourceCosmosDbSQLContainer() *pluginsdk.Resource {
 			}),
 		),
 	}
-
-	return resource
 }
 
 func resourceCosmosDbSQLContainerCreate(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/cosmos/registration.go
+++ b/internal/services/cosmos/registration.go
@@ -64,7 +64,7 @@ func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 
 // SupportedResources returns the supported Resources supported by this Service
 func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
-	resources := map[string]*pluginsdk.Resource{
+	return map[string]*pluginsdk.Resource{
 		"azurerm_cosmosdb_account":              resourceCosmosDbAccount(),
 		"azurerm_cosmosdb_cassandra_cluster":    resourceCassandraCluster(),
 		"azurerm_cosmosdb_cassandra_datacenter": resourceCassandraDatacenter(),
@@ -83,8 +83,6 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 		"azurerm_cosmosdb_sql_trigger":          resourceCosmosDbSQLTrigger(),
 		"azurerm_cosmosdb_table":                resourceCosmosDbTable(),
 	}
-
-	return resources
 }
 
 func (r Registration) Actions() []func() action.Action {

--- a/internal/services/databasemigration/registration.go
+++ b/internal/services/databasemigration/registration.go
@@ -43,12 +43,10 @@ func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 
 // SupportedResources returns the supported Resources supported by this Service
 func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
-	resources := map[string]*pluginsdk.Resource{
+	return map[string]*pluginsdk.Resource{
 		"azurerm_database_migration_service": resourceDatabaseMigrationService(),
 		"azurerm_database_migration_project": resourceDatabaseMigrationProject(),
 	}
-
-	return resources
 }
 
 func (r Registration) Actions() []func() action.Action {

--- a/internal/services/databoxedge/databox_edge_device_resource.go
+++ b/internal/services/databoxedge/databox_edge_device_resource.go
@@ -420,7 +420,5 @@ func flattenDeviceSku(input *devices.Sku) string {
 		tier = devices.SkuTierStandard
 	}
 
-	skuName := fmt.Sprintf("%s-%s", name, tier)
-
-	return skuName
+	return fmt.Sprintf("%s-%s", name, tier)
 }

--- a/internal/services/databricks/databricks_workspace_resource.go
+++ b/internal/services/databricks/databricks_workspace_resource.go
@@ -39,7 +39,7 @@ import (
 //go:generate go run ../../tools/generator-tests resourceidentity -test-name basicForResourceIdentity
 
 func resourceDatabricksWorkspace() *pluginsdk.Resource {
-	resource := &pluginsdk.Resource{
+	return &pluginsdk.Resource{
 		Create: resourceDatabricksWorkspaceCreate,
 		Read:   resourceDatabricksWorkspaceRead,
 		Update: resourceDatabricksWorkspaceUpdate,
@@ -453,8 +453,6 @@ func resourceDatabricksWorkspace() *pluginsdk.Resource {
 			}),
 		),
 	}
-
-	return resource
 }
 
 func resourceDatabricksWorkspaceCreate(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/datadog/datadog_monitor_tag_rule_resource.go
+++ b/internal/services/datadog/datadog_monitor_tag_rule_resource.go
@@ -381,11 +381,9 @@ func isDefaultSettings(input *rules.MonitoringTagRules) bool {
 
 	logRules := input.Properties.LogRules
 	metricRules := input.Properties.MetricRules
-	result := (logRules.SendAadLogs != nil && !*logRules.SendAadLogs) &&
+	return (logRules.SendAadLogs != nil && !*logRules.SendAadLogs) &&
 		(logRules.SendSubscriptionLogs != nil && !*logRules.SendSubscriptionLogs) &&
 		(logRules.SendResourceLogs != nil && !*logRules.SendResourceLogs) &&
 		(logRules.FilteringTags != nil && len(*logRules.FilteringTags) == 0) &&
 		(metricRules.FilteringTags != nil && len(*metricRules.FilteringTags) == 0)
-
-	return result
 }

--- a/internal/services/datafactory/data_factory.go
+++ b/internal/services/datafactory/data_factory.go
@@ -311,11 +311,10 @@ func expandDataFactoryDatasetSFTPServerLocation(d *pluginsdk.ResourceData) dataf
 
 	props := sftpServerLocations[0].(map[string]interface{})
 
-	sftpServerLocation := datafactory.SftpLocation{
+	return datafactory.SftpLocation{
 		FolderPath: expandDataFactoryExpressionResultType(props["path"].(string), props["dynamic_path_enabled"].(bool)),
 		FileName:   expandDataFactoryExpressionResultType(props["filename"].(string), props["dynamic_filename_enabled"].(bool)),
 	}
-	return sftpServerLocation
 }
 
 func expandDataFactoryDatasetHttpServerLocation(d *pluginsdk.ResourceData) datafactory.BasicDatasetLocation {
@@ -326,12 +325,11 @@ func expandDataFactoryDatasetHttpServerLocation(d *pluginsdk.ResourceData) dataf
 
 	props := httpServerLocations[0].(map[string]interface{})
 
-	httpServerLocation := datafactory.HTTPServerLocation{
+	return datafactory.HTTPServerLocation{
 		RelativeURL: props["relative_url"].(string),
 		FolderPath:  expandDataFactoryExpressionResultType(props["path"].(string), props["dynamic_path_enabled"].(bool)),
 		FileName:    expandDataFactoryExpressionResultType(props["filename"].(string), props["dynamic_filename_enabled"].(bool)),
 	}
-	return httpServerLocation
 }
 
 func expandDataFactoryDatasetAzureBlobStorageLocation(d *pluginsdk.ResourceData) datafactory.BasicDatasetLocation {
@@ -342,13 +340,11 @@ func expandDataFactoryDatasetAzureBlobStorageLocation(d *pluginsdk.ResourceData)
 
 	props := azureBlobStorageLocations[0].(map[string]interface{})
 
-	blobStorageLocation := datafactory.AzureBlobStorageLocation{
+	return datafactory.AzureBlobStorageLocation{
 		Container:  expandDataFactoryExpressionResultType(props["container"].(string), props["dynamic_container_enabled"].(bool)),
 		FolderPath: expandDataFactoryExpressionResultType(props["path"].(string), props["dynamic_path_enabled"].(bool)),
 		FileName:   expandDataFactoryExpressionResultType(props["filename"].(string), props["dynamic_filename_enabled"].(bool)),
 	}
-
-	return blobStorageLocation
 }
 
 func expandDataFactoryDatasetAzureBlobFSLocation(d *pluginsdk.ResourceData) datafactory.BasicDatasetLocation {
@@ -359,14 +355,12 @@ func expandDataFactoryDatasetAzureBlobFSLocation(d *pluginsdk.ResourceData) data
 
 	props := azureBlobFsLocations[0].(map[string]interface{})
 
-	blobFSLocation := datafactory.AzureBlobFSLocation{
+	return datafactory.AzureBlobFSLocation{
 		Type:       datafactory.TypeBasicDatasetLocationTypeAzureBlobFSLocation,
 		FileSystem: expandDataFactoryExpressionResultType(props["file_system"].(string), props["dynamic_file_system_enabled"].(bool)),
 		FolderPath: expandDataFactoryExpressionResultType(props["path"].(string), props["dynamic_path_enabled"].(bool)),
 		FileName:   expandDataFactoryExpressionResultType(props["filename"].(string), props["dynamic_filename_enabled"].(bool)),
 	}
-
-	return blobFSLocation
 }
 
 func flattenDataFactoryDatasetHTTPServerLocation(input *datafactory.HTTPServerLocation) []interface{} {

--- a/internal/services/datafactory/data_factory_linked_service_cosmosdb_mongoapi_resource.go
+++ b/internal/services/datafactory/data_factory_linked_service_cosmosdb_mongoapi_resource.go
@@ -143,11 +143,10 @@ func resourceDataFactoryLinkedServiceCosmosDbMongoAPICreateUpdate(d *pluginsdk.R
 
 	cosmosdbProperties := &datafactory.CosmosDbMongoDbAPILinkedServiceTypeProperties{}
 
-	connectionStringSecureString := datafactory.SecureString{
+	cosmosdbProperties.ConnectionString = datafactory.SecureString{
 		Value: pointer.To(d.Get("connection_string").(string)),
 		Type:  datafactory.TypeSecureString,
 	}
-	cosmosdbProperties.ConnectionString = connectionStringSecureString
 	cosmosdbProperties.Database = d.Get("database").(string)
 	cosmosdbProperties.IsServerVersionAbove32 = d.Get("server_version_is_32_or_higher").(bool)
 

--- a/internal/services/datafactory/data_factory_linked_service_cosmosdb_resource.go
+++ b/internal/services/datafactory/data_factory_linked_service_cosmosdb_resource.go
@@ -168,11 +168,10 @@ func resourceDataFactoryLinkedServiceCosmosDbCreateUpdate(d *pluginsdk.ResourceD
 		cosmosdbProperties.Database = databaseName
 	} else {
 		connectionString := d.Get("connection_string").(string)
-		connectionStringSecureString := datafactory.SecureString{
+		cosmosdbProperties.ConnectionString = datafactory.SecureString{
 			Value: &connectionString,
 			Type:  datafactory.TypeSecureString,
 		}
-		cosmosdbProperties.ConnectionString = connectionStringSecureString
 		cosmosdbProperties.Database = databaseName
 	}
 

--- a/internal/services/datafactory/data_factory_linked_service_web_resource.go
+++ b/internal/services/datafactory/data_factory_linked_service_web_resource.go
@@ -157,11 +157,10 @@ func resourceDataFactoryLinkedServiceWebCreateUpdate(d *pluginsdk.ResourceData, 
 	authenticationType := d.Get("authentication_type").(string)
 
 	if authenticationType == "Anonymous" {
-		anonAuthProperties := &datafactory.WebAnonymousAuthentication{
+		webLinkedService.TypeProperties = &datafactory.WebAnonymousAuthentication{
 			AuthenticationType: datafactory.AuthenticationType(authenticationType),
 			URL:                pointer.To(url),
 		}
-		webLinkedService.TypeProperties = anonAuthProperties
 	}
 
 	if authenticationType == "Basic" {
@@ -171,13 +170,12 @@ func resourceDataFactoryLinkedServiceWebCreateUpdate(d *pluginsdk.ResourceData, 
 			Value: &password,
 			Type:  datafactory.TypeSecureString,
 		}
-		basicAuthProperties := &datafactory.WebBasicAuthentication{
+		webLinkedService.TypeProperties = &datafactory.WebBasicAuthentication{
 			AuthenticationType: datafactory.AuthenticationType(authenticationType),
 			URL:                pointer.To(url),
 			Username:           username,
 			Password:           passwordSecureString,
 		}
-		webLinkedService.TypeProperties = basicAuthProperties
 	}
 
 	if v, ok := d.GetOk("parameters"); ok {

--- a/internal/services/datafactory/data_factory_pipeline_resource.go
+++ b/internal/services/datafactory/data_factory_pipeline_resource.go
@@ -23,7 +23,7 @@ import (
 )
 
 func resourceDataFactoryPipeline() *pluginsdk.Resource {
-	resource := &pluginsdk.Resource{
+	return &pluginsdk.Resource{
 		Create: resourceDataFactoryPipelineCreateUpdate,
 		Read:   resourceDataFactoryPipelineRead,
 		Update: resourceDataFactoryPipelineCreateUpdate,
@@ -111,8 +111,6 @@ func resourceDataFactoryPipeline() *pluginsdk.Resource {
 			},
 		},
 	}
-
-	return resource
 }
 
 func resourceDataFactoryPipelineCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/datafactory/registration.go
+++ b/internal/services/datafactory/registration.go
@@ -60,7 +60,7 @@ func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 
 // SupportedResources returns the supported Resources supported by this Service
 func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
-	resources := map[string]*pluginsdk.Resource{
+	return map[string]*pluginsdk.Resource{
 		"azurerm_data_factory":                                       resourceDataFactory(),
 		"azurerm_data_factory_data_flow":                             resourceDataFactoryDataFlow(),
 		"azurerm_data_factory_flowlet_data_flow":                     resourceDataFactoryFlowletDataFlow(),
@@ -108,8 +108,6 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 		"azurerm_data_factory_trigger_schedule":                      resourceDataFactoryTriggerSchedule(),
 		"azurerm_data_factory_trigger_tumbling_window":               resourceDataFactoryTriggerTumblingWindow(),
 	}
-
-	return resources
 }
 
 func (r Registration) Actions() []func() action.Action {

--- a/internal/services/dataprotection/data_protection_backup_policy_blob_storage_resource.go
+++ b/internal/services/dataprotection/data_protection_backup_policy_blob_storage_resource.go
@@ -26,7 +26,7 @@ import (
 //go:generate go run ../../tools/generator-tests resourceidentity -resource-name data_protection_backup_policy_blob_storage -service-package-name dataprotection -properties "name" -compare-values "subscription_id:vault_id,resource_group_name:vault_id,backup_vault_name:vault_id"
 
 func resourceDataProtectionBackupPolicyBlobStorage() *schema.Resource {
-	resource := &schema.Resource{
+	return &schema.Resource{
 		Create: resourceDataProtectionBackupPolicyBlobStorageCreate,
 		Read:   resourceDataProtectionBackupPolicyBlobStorageRead,
 		Delete: resourceDataProtectionBackupPolicyBlobStorageDelete,
@@ -221,8 +221,6 @@ func resourceDataProtectionBackupPolicyBlobStorage() *schema.Resource {
 			},
 		},
 	}
-
-	return resource
 }
 
 func resourceDataProtectionBackupPolicyBlobStorageCreate(d *schema.ResourceData, meta interface{}) error {

--- a/internal/services/dataprotection/data_protection_backup_policy_kubernetes_cluster_resource.go
+++ b/internal/services/dataprotection/data_protection_backup_policy_kubernetes_cluster_resource.go
@@ -81,7 +81,7 @@ func (r DataProtectionBackupPolicyKubernatesClusterResource) IDValidationFunc() 
 }
 
 func (r DataProtectionBackupPolicyKubernatesClusterResource) Arguments() map[string]*pluginsdk.Schema {
-	arguments := map[string]*pluginsdk.Schema{
+	return map[string]*pluginsdk.Schema{
 		"name": {
 			Type:     pluginsdk.TypeString,
 			Required: true,
@@ -265,7 +265,6 @@ func (r DataProtectionBackupPolicyKubernatesClusterResource) Arguments() map[str
 			ValidateFunc: validation.StringIsNotEmpty,
 		},
 	}
-	return arguments
 }
 
 func (r DataProtectionBackupPolicyKubernatesClusterResource) Attributes() map[string]*pluginsdk.Schema {

--- a/internal/services/dataprotection/data_protection_backup_policy_mysql_flexible_server_resource.go
+++ b/internal/services/dataprotection/data_protection_backup_policy_mysql_flexible_server_resource.go
@@ -80,7 +80,7 @@ func (r DataProtectionBackupPolicyMySQLFlexibleServerResource) IDValidationFunc(
 }
 
 func (r DataProtectionBackupPolicyMySQLFlexibleServerResource) Arguments() map[string]*pluginsdk.Schema {
-	arguments := map[string]*pluginsdk.Schema{
+	return map[string]*pluginsdk.Schema{
 		"name": {
 			Type:         pluginsdk.TypeString,
 			Required:     true,
@@ -255,7 +255,6 @@ func (r DataProtectionBackupPolicyMySQLFlexibleServerResource) Arguments() map[s
 			ValidateFunc: validate.BackupPolicyMySQLFlexibleServerTimeZone(),
 		},
 	}
-	return arguments
 }
 
 func (r DataProtectionBackupPolicyMySQLFlexibleServerResource) Attributes() map[string]*pluginsdk.Schema {

--- a/internal/services/dataprotection/data_protection_backup_policy_postgresql_flexible_server_resource.go
+++ b/internal/services/dataprotection/data_protection_backup_policy_postgresql_flexible_server_resource.go
@@ -80,7 +80,7 @@ func (r DataProtectionBackupPolicyPostgreSQLFlexibleServerResource) IDValidation
 }
 
 func (r DataProtectionBackupPolicyPostgreSQLFlexibleServerResource) Arguments() map[string]*pluginsdk.Schema {
-	arguments := map[string]*pluginsdk.Schema{
+	return map[string]*pluginsdk.Schema{
 		"name": {
 			Type:         pluginsdk.TypeString,
 			Required:     true,
@@ -255,7 +255,6 @@ func (r DataProtectionBackupPolicyPostgreSQLFlexibleServerResource) Arguments() 
 			ValidateFunc: validation.StringIsNotEmpty,
 		},
 	}
-	return arguments
 }
 
 func (r DataProtectionBackupPolicyPostgreSQLFlexibleServerResource) Attributes() map[string]*pluginsdk.Schema {

--- a/internal/services/desktopvirtualization/virtual_desktop_host_pool_resource.go
+++ b/internal/services/desktopvirtualization/virtual_desktop_host_pool_resource.go
@@ -509,8 +509,7 @@ func expandAgentUpdatePatch(input []interface{}) *hostpool.AgentUpdatePatchPrope
 	updatesDefault := hostpool.SessionHostComponentUpdateTypeDefault
 
 	useSessionHostLocalTime := *pointer.To(raw["use_session_host_timezone"].(bool))
-	updateScheduleTimeZone := pointer.To(raw["timezone"].(string))
-	props.MaintenanceWindowTimeZone = updateScheduleTimeZone
+	props.MaintenanceWindowTimeZone = pointer.To(raw["timezone"].(string))
 	props.UseSessionHostLocalTime = &useSessionHostLocalTime
 
 	if raw["enabled"].(bool) {

--- a/internal/services/devcenter/dev_center_dev_box_definition_resource.go
+++ b/internal/services/devcenter/dev_center_dev_box_definition_resource.go
@@ -265,11 +265,9 @@ func expandDevCenterDevBoxDefinitionSku(input string) *devboxdefinitions.Sku {
 		return nil
 	}
 
-	result := &devboxdefinitions.Sku{
+	return &devboxdefinitions.Sku{
 		Name: input,
 	}
-
-	return result
 }
 
 func flattenDevCenterDevBoxDefinition(input *devboxdefinitions.Sku) string {

--- a/internal/tools/document-fmt/data/packages.go
+++ b/internal/tools/document-fmt/data/packages.go
@@ -189,8 +189,7 @@ func findUntypedSSAFunc(pkg pkg, e ast.Expr) *ssa.Function {
 		if !ok {
 			return nil
 		}
-		ssaFn := findResourceFunc(pkg.ssa.Prog, pkg.pkg, pkg.ssa, pkg.ssa.Func(fn.Name))
-		return ssaFn
+		return findResourceFunc(pkg.ssa.Prog, pkg.pkg, pkg.ssa, pkg.ssa.Func(fn.Name))
 	}
 
 	return nil
@@ -281,9 +280,7 @@ func findAPIsForUntypedResources(d packageData, s *Service) map[string][]API {
 		})
 
 		sdkMethods := usedMethods(d.fset, servicePackage.pkg, util.MapKeys2Slice(filenames))
-		apis := methodsToAPIs(sdkMethods)
-
-		result[resourceFileName] = apis
+		result[resourceFileName] = methodsToAPIs(sdkMethods)
 	}
 
 	return result
@@ -345,9 +342,7 @@ func findAPIsForTypedResources(d packageData, s *Service) map[string][]API {
 		}
 
 		sdkMethods := usedMethods(d.fset, servicePackage.pkg, util.MapKeys2Slice(filenames))
-		apis := methodsToAPIs(sdkMethods)
-
-		result[resourceFileName] = apis
+		result[resourceFileName] = methodsToAPIs(sdkMethods)
 	}
 	return result
 }

--- a/internal/tools/document-lint/check/check_required.go
+++ b/internal/tools/document-lint/check/check_required.go
@@ -36,8 +36,7 @@ func (c requireDiff) String() string {
 	if c.RequiredMiss == ShouldBeComputed {
 		return fmt.Sprintf("%s Fields listed under Attributes Reference should not be marked Required/Optional", c.Str())
 	}
-	str := fmt.Sprintf("%s should be %s", c.Str(), util.Blue(c.RequiredMiss))
-	return str
+	return fmt.Sprintf("%s should be %s", c.Str(), util.Blue(c.RequiredMiss))
 }
 
 func (c requireDiff) Fix(line string) (result string, err error) {

--- a/internal/tools/document-lint/check/check_timeout.go
+++ b/internal/tools/document-lint/check/check_timeout.go
@@ -68,8 +68,7 @@ func (t *TimeoutDiffItem) FixLine(line string) string {
 	if end <= start {
 		return line
 	}
-	res := fmt.Sprintf("%s%s%s", line[:start], t.ValueString(), line[end:])
-	return res
+	return fmt.Sprintf("%s%s%s", line[:start], t.ValueString(), line[end:])
 }
 
 func NewTimeoutDiffItem(line int, typ TimeoutType, want int64) TimeoutDiffItem {

--- a/internal/tools/document-lint/check/document_fixer.go
+++ b/internal/tools/document-lint/check/document_fixer.go
@@ -23,13 +23,12 @@ type Fixer struct {
 }
 
 func NewFixer(d *ResourceDiff) *Fixer {
-	f := &Fixer{
+	return &Fixer{
 		MDFile:       d.MDFile,
 		SchemaFile:   d.SchemaFile,
 		ResourceType: d.tf.ResourceType,
 		Diff:         d.Diff,
 	}
-	return f
 }
 
 // param rt: resource type

--- a/internal/tools/document-lint/md/normalize.go
+++ b/internal/tools/document-lint/md/normalize.go
@@ -177,8 +177,7 @@ func FixFileNormalize(file string) {
 			}
 		} else if strings.HasPrefix(line, "*") {
 			// need a dash(-) after property name
-			line2 := tryFixProp(line)
-			line = line2
+			line = tryFixProp(line)
 			for k, v := range orderFixMap {
 				if strings.Contains(line, k) && !strings.Contains(line, v) {
 					line = strings.Replace(line, k, v, 1)

--- a/internal/tools/document-lint/md/parse_md.go
+++ b/internal/tools/document-lint/md/parse_md.go
@@ -53,12 +53,11 @@ func (m *MarkItem) addLine(num int, line string) {
 }
 
 func NewMarkItem(fromLine int, content string, typ ItemType) *MarkItem {
-	m := &MarkItem{
+	return &MarkItem{
 		FromLine: fromLine,
 		lines:    []string{content},
 		Type:     typ,
 	}
-	return m
 }
 
 type Block struct {
@@ -127,8 +126,7 @@ func MustNewMarkFromFile(file string) *Mark {
 	if err != nil {
 		panic(err)
 	}
-	m := newMarkFromString(string(bs), file)
-	return m
+	return newMarkFromString(string(bs), file)
 }
 
 func newMarkFromString(content string, filepath string) *Mark {

--- a/internal/tools/templatehelpers/formatters.go
+++ b/internal/tools/templatehelpers/formatters.go
@@ -103,9 +103,7 @@ func NewIDResourceIdentityFormatter(idType []string, idSegments []string, prefix
 	out := make([]string, 0)
 	out = append(out, idSegments...)
 
-	output := fmt.Sprintf(f, idType[0], IdToID(idType[1]), strings.Join(out, ", "))
-
-	return output
+	return fmt.Sprintf(f, idType[0], IdToID(idType[1]), strings.Join(out, ", "))
 }
 
 func NewIDCreateFormatter(idType []string, idSegments []string, prefix string) string {


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR enables `AZG005` linter compliance for single-use temporary variables across core/tooling code and services from `analysisservices` through `devcenter`.

The changes simplify code by inlining temporary variables that are immediately returned or assigned, without changing provider behavior. This is a mechanical cleanup intended to reduce unnecessary local variables and satisfy the new linter rule.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

Existing test coverage is unchanged because this PR only removes single-use temporary variables and does not alter behavior.

Locally run:

```text
go build -o "C:/Users/qixialu/go/bin/terraform-provider-azurerm.exe"
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
