### PR TITLE
Linters - enable azproviderlint AZG004 - Services (appconfiguration - cognitive)

### DIFF
--- a/internal/services/appconfiguration/app_configuration_data_source.go
+++ b/internal/services/appconfiguration/app_configuration_data_source.go
@@ -274,11 +274,7 @@ func dataSourceAppConfigurationRead(d *pluginsdk.ResourceData, meta interface{})
 			}
 
 			d.Set("local_auth_enabled", localAuthEnabled)
-			purgeProtectionEnabled := false
-			if props.EnablePurgeProtection != nil {
-				purgeProtectionEnabled = *props.EnablePurgeProtection
-			}
-			d.Set("purge_protection_enabled", purgeProtectionEnabled)
+			d.Set("purge_protection_enabled", pointer.From(props.EnablePurgeProtection))
 		}
 
 		accessKeys := flattenAppConfigurationAccessKeys(resultPage.Items)

--- a/internal/services/appconfiguration/app_configuration_resource.go
+++ b/internal/services/appconfiguration/app_configuration_resource.go
@@ -513,10 +513,7 @@ func resourceAppConfigurationUpdate(d *pluginsdk.ResourceData, meta interface{})
 		}
 
 		newValue := d.Get("purge_protection_enabled").(bool)
-		oldValue := false
-		if existing.Model.Properties.EnablePurgeProtection != nil {
-			oldValue = *existing.Model.Properties.EnablePurgeProtection
-		}
+		oldValue := pointer.From(existing.Model.Properties.EnablePurgeProtection)
 
 		if oldValue && !newValue {
 			return fmt.Errorf("updating %s: once Purge Protection has been Enabled it's not possible to disable it", *id)
@@ -641,11 +638,7 @@ func resourceAppConfigurationRead(d *pluginsdk.ResourceData, meta interface{}) e
 
 			d.Set("local_auth_enabled", localAuthEnabled)
 
-			purgeProtectionEnabled := false
-			if props.EnablePurgeProtection != nil {
-				purgeProtectionEnabled = *props.EnablePurgeProtection
-			}
-			d.Set("purge_protection_enabled", purgeProtectionEnabled)
+			d.Set("purge_protection_enabled", pointer.From(props.EnablePurgeProtection))
 
 			softDeleteRetentionDays := 0
 			if props.SoftDeleteRetentionInDays != nil {
@@ -715,10 +708,7 @@ func resourceAppConfigurationDelete(d *pluginsdk.ResourceData, meta interface{})
 		return fmt.Errorf("retrieving %q: `properties` was nil", *id)
 	}
 
-	purgeProtectionEnabled := false
-	if ppe := existing.Model.Properties.EnablePurgeProtection; ppe != nil {
-		purgeProtectionEnabled = *ppe
-	}
+	purgeProtectionEnabled := pointer.From(existing.Model.Properties.EnablePurgeProtection)
 	softDeleteEnabled := false
 	if sde := existing.Model.Properties.SoftDeleteRetentionInDays; sde != nil && *sde > 0 {
 		softDeleteEnabled = true
@@ -918,27 +908,11 @@ func flattenAppConfigurationAccessKeys(values []configurationstores.ApiKey) flat
 }
 
 func flattenAppConfigurationAccessKey(input configurationstores.ApiKey) []interface{} {
-	connectionString := ""
-
-	if input.ConnectionString != nil {
-		connectionString = *input.ConnectionString
-	}
-
-	id := ""
-	if input.Id != nil {
-		id = *input.Id
-	}
-
-	secret := ""
-	if input.Value != nil {
-		secret = *input.Value
-	}
-
 	return []interface{}{
 		map[string]interface{}{
-			"connection_string": connectionString,
-			"id":                id,
-			"secret":            secret,
+			"connection_string": pointer.From(input.ConnectionString),
+			"id":                pointer.From(input.Id),
+			"secret":            pointer.From(input.Value),
 		},
 	}
 }

--- a/internal/services/applicationinsights/application_insights_data_source.go
+++ b/internal/services/applicationinsights/application_insights_data_source.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
@@ -115,12 +116,7 @@ func dataSourceArmApplicationInsightsRead(d *pluginsdk.ResourceData, meta interf
 				retentionInDays = int(*props.RetentionInDays)
 			}
 			d.Set("retention_in_days", retentionInDays)
-
-			workspaceId := ""
-			if props.WorkspaceResourceId != nil {
-				workspaceId = *props.WorkspaceResourceId
-			}
-			d.Set("workspace_id", workspaceId)
+			d.Set("workspace_id", pointer.From(props.WorkspaceResourceId))
 		}
 	}
 	return nil

--- a/internal/services/appservice/helpers/shared_schema.go
+++ b/internal/services/appservice/helpers/shared_schema.go
@@ -1409,11 +1409,7 @@ func FlattenAuthSettings(auth *webapps.SiteAuthSettings) []AuthSettings {
 		result.AdditionalLoginParameters = params
 	}
 
-	var allowedRedirectUrls []string
-	if props.AllowedExternalRedirectURLs != nil {
-		allowedRedirectUrls = *props.AllowedExternalRedirectURLs
-	}
-	result.AllowedExternalRedirectURLs = allowedRedirectUrls
+	result.AllowedExternalRedirectURLs = pointer.From(props.AllowedExternalRedirectURLs)
 
 	if props.Issuer != nil {
 		result.Issuer = *props.Issuer

--- a/internal/services/appservice/source_control_schema.go
+++ b/internal/services/appservice/source_control_schema.go
@@ -167,17 +167,9 @@ func flattenGitHubActionConfiguration(input *webapps.GitHubActionConfiguration) 
 		return output
 	}
 
-	isLinux := false
-	if v := input.IsLinux; v != nil {
-		isLinux = *v
-	}
-	genWorkflow := false
-	if v := input.GenerateWorkflowFile; v != nil {
-		genWorkflow = *v
-	}
 	ghConfig := GithubActionConfiguration{
-		UsesLinux:            isLinux,
-		GenerateWorkflowFile: genWorkflow,
+		UsesLinux:            pointer.From(input.IsLinux),
+		GenerateWorkflowFile: pointer.From(input.GenerateWorkflowFile),
 	}
 
 	if codeConfig := input.CodeConfiguration; codeConfig != nil {

--- a/internal/services/automation/automation_connection_service_principal_resource.go
+++ b/internal/services/automation/automation_connection_service_principal_resource.go
@@ -217,11 +217,7 @@ func resourceAutomationConnectionServicePrincipalRead(d *pluginsdk.ResourceData,
 
 	if model := resp.Model; model != nil {
 		if props := model.Properties; props != nil {
-			description := ""
-			if props.Description != nil {
-				description = *props.Description
-			}
-			d.Set("description", description)
+			d.Set("description", pointer.From(props.Description))
 
 			if props.FieldDefinitionValues != nil {
 				fieldDefinitionValues := *props.FieldDefinitionValues

--- a/internal/services/batch/batch_pool.go
+++ b/internal/services/batch/batch_pool.go
@@ -105,11 +105,7 @@ func flattenBatchPoolStartTask(oldConfig *pluginsdk.ResourceData, startTask *poo
 	}
 
 	result := make(map[string]interface{})
-	commandLine := ""
-	if startTask.CommandLine != nil {
-		commandLine = *startTask.CommandLine
-	}
-	result["command_line"] = commandLine
+	result["command_line"] = pointer.From(startTask.CommandLine)
 
 	if startTask.ContainerSettings != nil {
 		containerSettings := make(map[string]interface{})
@@ -132,18 +128,9 @@ func flattenBatchPoolStartTask(oldConfig *pluginsdk.ResourceData, startTask *poo
 		}
 	}
 
-	waitForSuccess := false
-	if startTask.WaitForSuccess != nil {
-		waitForSuccess = *startTask.WaitForSuccess
-	}
-	result["wait_for_success"] = waitForSuccess
+	result["wait_for_success"] = pointer.From(startTask.WaitForSuccess)
 
-	maxTaskRetryCount := int64(0)
-	if startTask.MaxTaskRetryCount != nil {
-		maxTaskRetryCount = *startTask.MaxTaskRetryCount
-	}
-
-	result["task_retry_maximum"] = maxTaskRetryCount
+	result["task_retry_maximum"] = pointer.From(startTask.MaxTaskRetryCount)
 
 	if startTask.UserIdentity != nil {
 		userIdentity := make(map[string]interface{})
@@ -1245,11 +1232,6 @@ func flattenBatchPoolNetworkConfiguration(input *pool.NetworkConfiguration) []in
 		return []interface{}{}
 	}
 
-	subnetId := ""
-	if input.SubnetId != nil {
-		subnetId = *input.SubnetId
-	}
-
 	publicIPAddressIds := make([]interface{}, 0)
 	publicAddressProvisioningType := ""
 	if config := input.PublicIPAddressConfiguration; config != nil {
@@ -1312,7 +1294,7 @@ func flattenBatchPoolNetworkConfiguration(input *pool.NetworkConfiguration) []in
 			"endpoint_configuration":           endpointConfigs,
 			"public_address_provisioning_type": publicAddressProvisioningType,
 			"public_ips":                       pluginsdk.NewSet(pluginsdk.HashString, publicIPAddressIds),
-			"subnet_id":                        subnetId,
+			"subnet_id":                        pointer.From(input.SubnetId),
 		},
 	}
 }

--- a/internal/services/bot/bot_channel_directline_resource.go
+++ b/internal/services/bot/bot_channel_directline_resource.go
@@ -366,11 +366,7 @@ func flattenDirectlineSites(input []botservice.DirectLineSite) []interface{} {
 		}
 		site["user_upload_enabled"] = userUploadEnabled
 
-		var endpointParametersEnabled bool
-		if v := element.IsEndpointParametersEnabled; v != nil {
-			endpointParametersEnabled = *v
-		}
-		site["endpoint_parameters_enabled"] = endpointParametersEnabled
+		site["endpoint_parameters_enabled"] = pointer.From(element.IsEndpointParametersEnabled)
 
 		storageEnabled := true
 		if v := element.IsNoStorageEnabled; v != nil {

--- a/internal/services/bot/bot_channel_facebook_resource.go
+++ b/internal/services/bot/bot_channel_facebook_resource.go
@@ -253,19 +253,9 @@ func flattenFacebookPage(input *[]botservice.FacebookPage) []interface{} {
 	}
 
 	for _, item := range *input {
-		var id string
-		if item.ID != nil {
-			id = *item.ID
-		}
-
-		var accessToken string
-		if item.AccessToken != nil {
-			accessToken = *item.AccessToken
-		}
-
 		results = append(results, map[string]interface{}{
-			"id":           id,
-			"access_token": accessToken,
+			"id":           pointer.From(item.ID),
+			"access_token": pointer.From(item.AccessToken),
 		})
 	}
 

--- a/internal/services/bot/bot_channel_line_resource.go
+++ b/internal/services/bot/bot_channel_line_resource.go
@@ -230,19 +230,9 @@ func flattenLineChannel(input *[]botservice.LineRegistration) []interface{} {
 	}
 
 	for _, item := range *input {
-		var channelAccessToken string
-		if item.ChannelAccessToken != nil {
-			channelAccessToken = *item.ChannelAccessToken
-		}
-
-		var channelSecret string
-		if item.ChannelSecret != nil {
-			channelSecret = *item.ChannelSecret
-		}
-
 		results = append(results, map[string]interface{}{
-			"access_token": channelAccessToken,
-			"secret":       channelSecret,
+			"access_token": pointer.From(item.ChannelAccessToken),
+			"secret":       pointer.From(item.ChannelSecret),
 		})
 	}
 

--- a/internal/services/bot/bot_channel_web_chat_resource.go
+++ b/internal/services/bot/bot_channel_web_chat_resource.go
@@ -293,11 +293,7 @@ func flattenSites(input *[]botservice.WebChatSite) []interface{} {
 	for _, item := range *input {
 		result := make(map[string]interface{})
 
-		var name string
-		if v := item.SiteName; v != nil {
-			name = *v
-		}
-		result["name"] = name
+		result["name"] = pointer.From(item.SiteName)
 
 		userUploadEnabled := true
 		if v := item.IsBlockUserUploadEnabled; v != nil {
@@ -305,11 +301,7 @@ func flattenSites(input *[]botservice.WebChatSite) []interface{} {
 		}
 		result["user_upload_enabled"] = userUploadEnabled
 
-		var endpointParametersEnabled bool
-		if v := item.IsEndpointParametersEnabled; v != nil {
-			endpointParametersEnabled = *v
-		}
-		result["endpoint_parameters_enabled"] = endpointParametersEnabled
+		result["endpoint_parameters_enabled"] = pointer.From(item.IsEndpointParametersEnabled)
 
 		storageEnabled := true
 		if v := item.IsNoStorageEnabled; v != nil {

--- a/internal/services/bot/bot_service_azure_bot_resource.go
+++ b/internal/services/bot/bot_service_azure_bot_resource.go
@@ -360,11 +360,7 @@ func (r AzureBotServiceResource) Read() sdk.ResourceFunc {
 					state.LuisAppIds = *v
 				}
 
-				streamingEndpointEnabled := false
-				if v := props.IsStreamingSupported; v != nil {
-					streamingEndpointEnabled = *v
-				}
-				state.StreamingEndpointEnabled = streamingEndpointEnabled
+				state.StreamingEndpointEnabled = pointer.From(props.IsStreamingSupported)
 			}
 
 			return metadata.Encode(&state)

--- a/internal/services/cdn/cdn_endpoint_custom_domain_resource.go
+++ b/internal/services/cdn/cdn_endpoint_custom_domain_resource.go
@@ -523,10 +523,7 @@ func flattenArmCdnEndpointCustomDomainUserManagedHttpsSettings(ctx context.Conte
 	}
 	secretName := *params.SecretName
 
-	var secretVersion string
-	if params.SecretVersion != nil {
-		secretVersion = *params.SecretVersion
-	}
+	secretVersion := pointer.From(params.SecretVersion)
 
 	keyVaultId := commonids.NewKeyVaultID(subscriptionId, resourceGroupName, vaultName)
 	keyVaultBaseUrl, err := keyVaultsClient.BaseUriForKeyVault(ctx, keyVaultId)

--- a/internal/services/cdn/cdn_endpoint_resource.go
+++ b/internal/services/cdn/cdn_endpoint_resource.go
@@ -495,11 +495,7 @@ func resourceCdnEndpointRead(d *pluginsdk.ResourceData, meta interface{}) error 
 		d.Set("probe_path", props.ProbePath)
 		d.Set("optimization_type", string(props.OptimizationType))
 
-		compressionEnabled := false
-		if v := props.IsCompressionEnabled; v != nil {
-			compressionEnabled = *v
-		}
-		d.Set("is_compression_enabled", compressionEnabled)
+		d.Set("is_compression_enabled", pointer.From(props.IsCompressionEnabled))
 
 		contentTypes := flattenAzureRMCdnEndpointContentTypes(props.ContentTypesToCompress)
 		if err := d.Set("content_types_to_compress", contentTypes); err != nil {
@@ -588,11 +584,6 @@ func flattenCdnEndpointGeoFilters(input *[]cdn.GeoFilter) []interface{} {
 
 	if filters := input; filters != nil {
 		for _, filter := range *filters {
-			relativePath := ""
-			if filter.RelativePath != nil {
-				relativePath = *filter.RelativePath
-			}
-
 			outputCodes := make([]interface{}, 0)
 			if codes := filter.CountryCodes; codes != nil {
 				for _, code := range *codes {
@@ -603,7 +594,7 @@ func flattenCdnEndpointGeoFilters(input *[]cdn.GeoFilter) []interface{} {
 			results = append(results, map[string]interface{}{
 				"action":        string(filter.Action),
 				"country_codes": outputCodes,
-				"relative_path": relativePath,
+				"relative_path": pointer.From(filter.RelativePath),
 			})
 		}
 	}
@@ -673,11 +664,6 @@ func flattenAzureRMCdnEndpointOrigin(input *[]cdn.DeepCreatedOrigin) []interface
 
 	if list := input; list != nil {
 		for _, i := range *list {
-			name := ""
-			if i.Name != nil {
-				name = *i.Name
-			}
-
 			hostName := ""
 			httpPort := 80
 			httpsPort := 443
@@ -694,7 +680,7 @@ func flattenAzureRMCdnEndpointOrigin(input *[]cdn.DeepCreatedOrigin) []interface
 			}
 
 			results = append(results, map[string]interface{}{
-				"name":       name,
+				"name":       pointer.From(i.Name),
 				"host_name":  hostName,
 				"http_port":  httpPort,
 				"https_port": httpsPort,

--- a/internal/services/cdn/cdn_frontdoor_firewall_policy_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_firewall_policy_resource.go
@@ -1298,11 +1298,6 @@ func flattenCdnFrontDoorFirewallCustomRules(input *waf.CustomRuleList) []interfa
 			enabled = pointer.From(v.EnabledState) == waf.CustomRuleEnabledStateEnabled
 		}
 
-		name := ""
-		if v.Name != nil {
-			name = *v.Name
-		}
-
 		rateLimitDurationInMinutes := 0
 		if v.RateLimitDurationInMinutes != nil {
 			rateLimitDurationInMinutes = int(*v.RateLimitDurationInMinutes)
@@ -1320,7 +1315,7 @@ func flattenCdnFrontDoorFirewallCustomRules(input *waf.CustomRuleList) []interfa
 			"rate_limit_duration_in_minutes": rateLimitDurationInMinutes,
 			"rate_limit_threshold":           rateLimitThreshold,
 			"priority":                       priority,
-			"name":                           name,
+			"name":                           pointer.From(v.Name),
 			"type":                           ruleType,
 		})
 	}
@@ -1335,22 +1330,12 @@ func flattenCdnFrontDoorFirewallMatchConditions(input []waf.MatchCondition) []in
 
 	results := make([]interface{}, 0)
 	for _, v := range input {
-		selector := ""
-		if v.Selector != nil {
-			selector = *v.Selector
-		}
-
-		negateCondition := false
-		if v.NegateCondition != nil {
-			negateCondition = *v.NegateCondition
-		}
-
 		results = append(results, map[string]interface{}{
 			"match_variable":     string(v.MatchVariable),
 			"match_values":       v.MatchValue,
-			"negation_condition": negateCondition,
+			"negation_condition": pointer.From(v.NegateCondition),
 			"operator":           string(v.Operator),
-			"selector":           selector,
+			"selector":           pointer.From(v.Selector),
 			"transforms":         flattenTransformSlice(v.Transforms),
 		})
 	}

--- a/internal/services/cdn/endpoint_delivery_rule.go
+++ b/internal/services/cdn/endpoint_delivery_rule.go
@@ -237,18 +237,13 @@ func expandDeliveryRuleActions(input map[string]interface{}) ([]cdn.BasicDeliver
 }
 
 func flattenArmCdnEndpointDeliveryRule(deliveryRule cdn.DeliveryRule) (*map[string]interface{}, error) {
-	name := ""
-	if deliveryRule.Name != nil {
-		name = *deliveryRule.Name
-	}
-
 	order := -1
 	if deliveryRule.Order != nil {
 		order = int(*deliveryRule.Order)
 	}
 
 	output := map[string]interface{}{
-		"name":  name,
+		"name":  pointer.From(deliveryRule.Name),
 		"order": order,
 	}
 

--- a/internal/services/cognitive/cognitive_account_resource.go
+++ b/internal/services/cognitive/cognitive_account_resource.go
@@ -688,12 +688,8 @@ func resourceCognitiveAccountFlatten(ctx context.Context, client *cognitiveservi
 			if err := d.Set("storage", flattenCognitiveAccountStorage(props.UserOwnedStorage)); err != nil {
 				return fmt.Errorf("setting `storages` for Cognitive Account %q: %+v", id, err)
 			}
-			outboundNetworkAccessRestricted := false
-			if props.RestrictOutboundNetworkAccess != nil {
-				outboundNetworkAccessRestricted = *props.RestrictOutboundNetworkAccess
-			}
 			// lintignore:R001
-			d.Set("outbound_network_access_restricted", outboundNetworkAccessRestricted)
+			d.Set("outbound_network_access_restricted", pointer.From(props.RestrictOutboundNetworkAccess))
 
 			localAuthEnabled := !pointer.From(props.DisableLocalAuth)
 			d.Set("local_auth_enabled", localAuthEnabled)

--- a/internal/services/cognitive/cognitive_deployment_resource.go
+++ b/internal/services/cognitive/cognitive_deployment_resource.go
@@ -432,23 +432,9 @@ func flattenDeploymentModelModel(input *deployments.DeploymentModel) []Deploymen
 	}
 
 	output := DeploymentModelModel{}
-	format := ""
-	if input.Format != nil {
-		format = *input.Format
-	}
-	output.Format = format
-
-	name := ""
-	if input.Name != nil {
-		name = *input.Name
-	}
-	output.Name = name
-
-	version := ""
-	if input.Version != nil {
-		version = *input.Version
-	}
-	output.Version = version
+	output.Format = pointer.From(input.Format)
+	output.Name = pointer.From(input.Name)
+	output.Version = pointer.From(input.Version)
 
 	return append(outputList, output)
 }


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR is part of a series of changes to enable the azproviderlint AZG004 analyzer, which flags the pattern of declaring a variable with its type's zero value and then conditionally overwriting it from a pointer after a nil check.

As a prerequisite to turning the analyzer on repo-wide, this slice migrates all such occurrences in the following services to the equivalent `pointer.From()` helper

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

No functional behavior changes are introduced, so no new test coverage is added. The refactor is verified by go build, go vet, gofmt, and the existing linter/acceptance test suites for the affected services.

## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
