### PR TITLE
Linters - enable azproviderlint AZG004 - Services (Compute, Consumptions)

### DIFF
--- a/internal/services/compute/capacity_reservation_resource.go
+++ b/internal/services/compute/capacity_reservation_resource.go
@@ -243,20 +243,10 @@ func expandCapacityReservationSku(input []interface{}) capacityreservations.Sku 
 }
 
 func flattenCapacityReservationSku(input capacityreservations.Sku) []interface{} {
-	var name string
-	if input.Name != nil {
-		name = *input.Name
-	}
-
-	var capacity int64
-	if input.Capacity != nil {
-		capacity = *input.Capacity
-	}
-
 	return []interface{}{
 		map[string]interface{}{
-			"name":     name,
-			"capacity": capacity,
+			"name":     pointer.From(input.Name),
+			"capacity": pointer.From(input.Capacity),
 		},
 	}
 }

--- a/internal/services/compute/encryption_settings.go
+++ b/internal/services/compute/encryption_settings.go
@@ -123,10 +123,7 @@ func flattenSnapshotDiskEncryptionSettings(encryptionSettings *snapshots.Encrypt
 				secretUrl = key.SecretURL
 			}
 
-			sourceVaultId := ""
-			if key.SourceVault.Id != nil {
-				sourceVaultId = *key.SourceVault.Id
-			}
+			sourceVaultId := pointer.From(key.SourceVault.Id)
 
 			diskEncryptionKeys = append(diskEncryptionKeys, map[string]interface{}{
 				"secret_url":      secretUrl,
@@ -140,10 +137,7 @@ func flattenSnapshotDiskEncryptionSettings(encryptionSettings *snapshots.Encrypt
 				keyUrl = key.KeyURL
 			}
 
-			sourceVaultId := ""
-			if key.SourceVault.Id != nil {
-				sourceVaultId = *key.SourceVault.Id
-			}
+			sourceVaultId := pointer.From(key.SourceVault.Id)
 
 			keyEncryptionKeys = append(keyEncryptionKeys, map[string]interface{}{
 				"key_url":         keyUrl,
@@ -229,10 +223,7 @@ func flattenManagedDiskEncryptionSettings(encryptionSettings *disks.EncryptionSe
 				secretUrl = key.SecretURL
 			}
 
-			sourceVaultId := ""
-			if key.SourceVault.Id != nil {
-				sourceVaultId = *key.SourceVault.Id
-			}
+			sourceVaultId := pointer.From(key.SourceVault.Id)
 
 			diskEncryptionKeys = append(diskEncryptionKeys, map[string]interface{}{
 				"secret_url":      secretUrl,
@@ -246,10 +237,7 @@ func flattenManagedDiskEncryptionSettings(encryptionSettings *disks.EncryptionSe
 				keyUrl = key.KeyURL
 			}
 
-			sourceVaultId := ""
-			if key.SourceVault.Id != nil {
-				sourceVaultId = *key.SourceVault.Id
-			}
+			sourceVaultId := pointer.From(key.SourceVault.Id)
 
 			keyEncryptionKeys = append(keyEncryptionKeys, map[string]interface{}{
 				"key_url":         keyUrl,

--- a/internal/services/compute/gallery_application_version_resource.go
+++ b/internal/services/compute/gallery_application_version_resource.go
@@ -344,11 +344,7 @@ func (r GalleryApplicationVersionResource) Read() sdk.ResourceFunc {
 						state.EndOfLifeDate = d.Format(time.RFC3339)
 					}
 
-					excludeFromLatest := false
-					if props.PublishingProfile.ExcludeFromLatest != nil {
-						excludeFromLatest = *props.PublishingProfile.ExcludeFromLatest
-					}
-					state.ExcludeFromLatest = excludeFromLatest
+					state.ExcludeFromLatest = pointer.From(props.PublishingProfile.ExcludeFromLatest)
 
 					state.ConfigFile = ""
 					state.PackageFile = ""

--- a/internal/services/compute/image_data_source.go
+++ b/internal/services/compute/image_data_source.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
@@ -214,10 +215,7 @@ func flattenImageDataSourceOSDisk(input *images.ImageOSDisk) []interface{} {
 	output := make([]interface{}, 0)
 
 	if input != nil {
-		blobUri := ""
-		if uri := input.BlobUri; uri != nil {
-			blobUri = *uri
-		}
+		blobUri := pointer.From(input.BlobUri)
 		caching := ""
 		if input.Caching != nil {
 			caching = string(*input.Caching)
@@ -248,10 +246,7 @@ func flattenImageDataSourceDataDisks(input *[]images.ImageDataDisk) []interface{
 
 	if input != nil {
 		for _, disk := range *input {
-			blobUri := ""
-			if disk.BlobUri != nil {
-				blobUri = *disk.BlobUri
-			}
+			blobUri := pointer.From(disk.BlobUri)
 			caching := ""
 			if disk.Caching != nil {
 				caching = string(*disk.Caching)

--- a/internal/services/compute/image_resource.go
+++ b/internal/services/compute/image_resource.go
@@ -457,10 +457,7 @@ func flattenImageOSDisk(input *images.ImageStorageProfile) []interface{} {
 
 	if input != nil {
 		if v := input.OsDisk; v != nil {
-			blobUri := ""
-			if uri := v.BlobUri; uri != nil {
-				blobUri = *uri
-			}
+			blobUri := pointer.From(v.BlobUri)
 			caching := ""
 			if v.Caching != nil {
 				caching = string(*v.Caching)
@@ -508,10 +505,7 @@ func flattenImageDataDisks(input *images.ImageStorageProfile) []interface{} {
 	if input != nil {
 		if v := input.DataDisks; v != nil {
 			for _, disk := range *input.DataDisks {
-				blobUri := ""
-				if disk.BlobUri != nil {
-					blobUri = *disk.BlobUri
-				}
+				blobUri := pointer.From(disk.BlobUri)
 				caching := ""
 				if disk.Caching != nil {
 					caching = string(*disk.Caching)

--- a/internal/services/compute/images_data_source.go
+++ b/internal/services/compute/images_data_source.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
@@ -211,10 +212,7 @@ func filterToImagesMatchingTags(input []images.Image, filterTags map[string]stri
 }
 
 func flattenImage(input images.Image) map[string]interface{} {
-	name := ""
-	if input.Name != nil {
-		name = *input.Name
-	}
+	name := pointer.From(input.Name)
 
 	zoneResilient := false
 	osDisk := make([]interface{}, 0)
@@ -243,10 +241,7 @@ func flattenImagesOSDisk(input *images.ImageStorageProfile) []interface{} {
 
 	if input != nil {
 		if v := input.OsDisk; v != nil {
-			blobUri := ""
-			if uri := v.BlobUri; uri != nil {
-				blobUri = *uri
-			}
+			blobUri := pointer.From(v.BlobUri)
 			caching := ""
 			if v.Caching != nil {
 				caching = string(*v.Caching)
@@ -284,10 +279,7 @@ func flattenImagesDataDisks(input *images.ImageStorageProfile) []interface{} {
 	if input != nil {
 		if v := input.DataDisks; v != nil {
 			for _, disk := range *input.DataDisks {
-				blobUri := ""
-				if disk.BlobUri != nil {
-					blobUri = *disk.BlobUri
-				}
+				blobUri := pointer.From(disk.BlobUri)
 				caching := ""
 				if disk.Caching != nil {
 					caching = string(*disk.Caching)

--- a/internal/services/compute/managed_disk_data_source.go
+++ b/internal/services/compute/managed_disk_data_source.go
@@ -204,11 +204,7 @@ func dataSourceManagedDiskRead(d *pluginsdk.ResourceData, meta interface{}) erro
 			d.Set("source_uri", creationData.SourceUri)
 			d.Set("storage_account_id", creationData.StorageAccountId)
 
-			diskAccessId := ""
-			if props.DiskAccessId != nil {
-				diskAccessId = *props.DiskAccessId
-			}
-			d.Set("disk_access_id", diskAccessId)
+			d.Set("disk_access_id", pointer.From(props.DiskAccessId))
 
 			d.Set("network_access_policy", string(*props.NetworkAccessPolicy))
 			d.Set("disk_size_gb", props.DiskSizeGB)

--- a/internal/services/compute/managed_disk_resource.go
+++ b/internal/services/compute/managed_disk_resource.go
@@ -939,11 +939,7 @@ func resourceManagedDiskRead(d *pluginsdk.ResourceData, meta interface{}) error 
 			d.Set("security_type", securityType)
 			d.Set("secure_vm_disk_encryption_set_id", secureVMDiskEncryptionSetId)
 
-			onDemandBurstingEnabled := false
-			if props.BurstingEnabled != nil {
-				onDemandBurstingEnabled = *props.BurstingEnabled
-			}
-			d.Set("on_demand_bursting_enabled", onDemandBurstingEnabled)
+			d.Set("on_demand_bursting_enabled", pointer.From(props.BurstingEnabled))
 		}
 
 		if err := tags.FlattenAndSet(d, model.Tags); err != nil {

--- a/internal/services/compute/managed_disks_data_source.go
+++ b/internal/services/compute/managed_disks_data_source.go
@@ -313,10 +313,7 @@ func flattenManagedDiskEncryptionSettingsTyped(encryptionSettings *disks.Encrypt
 				secretUrl = key.SecretURL
 			}
 
-			sourceVaultId := ""
-			if key.SourceVault.Id != nil {
-				sourceVaultId = *key.SourceVault.Id
-			}
+			sourceVaultId := pointer.From(key.SourceVault.Id)
 
 			diskEncryptionKeys = append(diskEncryptionKeys, DiskEncryptionKey{
 				SecretURL:     secretUrl,
@@ -330,10 +327,7 @@ func flattenManagedDiskEncryptionSettingsTyped(encryptionSettings *disks.Encrypt
 				keyUrl = key.KeyURL
 			}
 
-			sourceVaultId := ""
-			if key.SourceVault.Id != nil {
-				sourceVaultId = *key.SourceVault.Id
-			}
+			sourceVaultId := pointer.From(key.SourceVault.Id)
 
 			keyEncryptionKeys = append(keyEncryptionKeys, KeyEncryptionKey{
 				KeyURL:        keyUrl,

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set.go
@@ -926,15 +926,9 @@ func FlattenOrchestratedVirtualMachineScaleSetAdditionalCapabilities(input *virt
 		return []interface{}{}
 	}
 
-	ultraSsdEnabled := false
-
-	if input.UltraSSDEnabled != nil {
-		ultraSsdEnabled = *input.UltraSSDEnabled
-	}
-
 	return []interface{}{
 		map[string]interface{}{
-			"ultra_ssd_enabled": ultraSsdEnabled,
+			"ultra_ssd_enabled": pointer.From(input.UltraSSDEnabled),
 		},
 	}
 }
@@ -1559,10 +1553,7 @@ func flattenOrchestratedVirtualMachineScaleSetExtensions(input *virtualmachinesc
 	}
 
 	for _, v := range *input.Extensions {
-		name := ""
-		if v.Name != nil {
-			name = *v.Name
-		}
+		name := pointer.From(v.Name)
 
 		autoUpgradeMinorVersion := false
 		suppressFailures := false
@@ -1940,10 +1931,7 @@ func FlattenOrchestratedVirtualMachineScaleSetDataDisk(input *[]virtualmachinesc
 			}
 		}
 
-		writeAcceleratorEnabled := false
-		if v.WriteAcceleratorEnabled != nil {
-			writeAcceleratorEnabled = *v.WriteAcceleratorEnabled
-		}
+		writeAcceleratorEnabled := pointer.From(v.WriteAcceleratorEnabled)
 
 		iops := 0
 		if v.DiskIOPSReadWrite != nil {
@@ -2031,10 +2019,7 @@ func FlattenOrchestratedVirtualMachineScaleSetOSDisk(input *virtualmachinescales
 		}
 	}
 
-	writeAcceleratorEnabled := false
-	if input.WriteAcceleratorEnabled != nil {
-		writeAcceleratorEnabled = *input.WriteAcceleratorEnabled
-	}
+	writeAcceleratorEnabled := pointer.From(input.WriteAcceleratorEnabled)
 
 	return []interface{}{
 		map[string]interface{}{

--- a/internal/services/compute/protected_settings_from_key_vault.go
+++ b/internal/services/compute/protected_settings_from_key_vault.go
@@ -89,10 +89,7 @@ func flattenProtectedSettingsFromKeyVault(input *virtualmachineextensions.KeyVau
 		return []interface{}{}
 	}
 
-	sourceVaultId := ""
-	if input.SourceVault.Id != nil {
-		sourceVaultId = *input.SourceVault.Id
-	}
+	sourceVaultId := pointer.From(input.SourceVault.Id)
 
 	return []interface{}{
 		map[string]interface{}{
@@ -107,10 +104,7 @@ func flattenProtectedSettingsFromKeyVaultVMSS(input *virtualmachinescalesets.Key
 		return []interface{}{}
 	}
 
-	sourceVaultId := ""
-	if input.SourceVault.Id != nil {
-		sourceVaultId = *input.SourceVault.Id
-	}
+	sourceVaultId := pointer.From(input.SourceVault.Id)
 
 	return []interface{}{
 		map[string]interface{}{
@@ -125,10 +119,7 @@ func flattenProtectedSettingsFromKeyVaultOldVMSSExtension(input *virtualmachines
 		return nil
 	}
 
-	sourceVaultId := ""
-	if input.SourceVault.Id != nil {
-		sourceVaultId = *input.SourceVault.Id
-	}
+	sourceVaultId := pointer.From(input.SourceVault.Id)
 
 	return []interface{}{
 		map[string]interface{}{

--- a/internal/services/compute/shared_image_data_source.go
+++ b/internal/services/compute/shared_image_data_source.go
@@ -267,26 +267,11 @@ func flattenGalleryImageDataSourcePurchasePlan(input *galleryimages.ImagePurchas
 		return []interface{}{}
 	}
 
-	name := ""
-	if input.Name != nil {
-		name = *input.Name
-	}
-
-	publisher := ""
-	if input.Publisher != nil {
-		publisher = *input.Publisher
-	}
-
-	product := ""
-	if input.Product != nil {
-		product = *input.Product
-	}
-
 	return []interface{}{
 		map[string]interface{}{
-			"name":      name,
-			"publisher": publisher,
-			"product":   product,
+			"name":      pointer.From(input.Name),
+			"publisher": pointer.From(input.Publisher),
+			"product":   pointer.From(input.Product),
 		},
 	}
 }

--- a/internal/services/compute/shared_image_resource.go
+++ b/internal/services/compute/shared_image_resource.go
@@ -693,26 +693,11 @@ func flattenGalleryImagePurchasePlan(input *galleryimages.ImagePurchasePlan) []i
 		return []interface{}{}
 	}
 
-	name := ""
-	if input.Name != nil {
-		name = *input.Name
-	}
-
-	publisher := ""
-	if input.Publisher != nil {
-		publisher = *input.Publisher
-	}
-
-	product := ""
-	if input.Product != nil {
-		product = *input.Product
-	}
-
 	return []interface{}{
 		map[string]interface{}{
-			"name":      name,
-			"publisher": publisher,
-			"product":   product,
+			"name":      pointer.From(input.Name),
+			"publisher": pointer.From(input.Publisher),
+			"product":   pointer.From(input.Product),
 		},
 	}
 }

--- a/internal/services/compute/shared_image_version_data_source.go
+++ b/internal/services/compute/shared_image_version_data_source.go
@@ -119,10 +119,7 @@ func dataSourceSharedImageVersionRead(d *pluginsdk.ResourceData, meta interface{
 		return err
 	}
 
-	name := ""
-	if image.Name != nil {
-		name = *image.Name
-	}
+	name := pointer.From(image.Name)
 
 	exactId := galleryimageversions.NewImageVersionID(subscriptionId, id.ResourceGroupName, id.GalleryName, id.ImageName, name)
 	d.SetId(exactId.ID())

--- a/internal/services/compute/shared_image_version_resource.go
+++ b/internal/services/compute/shared_image_version_resource.go
@@ -439,10 +439,7 @@ func resourceSharedImageVersionRead(d *pluginsdk.ResourceData, meta interface{})
 			osDiskSnapShotID := ""
 			storageAccountID := ""
 			if props.StorageProfile.OsDiskImage != nil && props.StorageProfile.OsDiskImage.Source != nil {
-				sourceID := ""
-				if props.StorageProfile.OsDiskImage.Source.Id != nil {
-					sourceID = *props.StorageProfile.OsDiskImage.Source.Id
-				}
+				sourceID := pointer.From(props.StorageProfile.OsDiskImage.Source.Id)
 
 				if props.StorageProfile.OsDiskImage.Source.StorageAccountId != nil {
 					sourceID = *props.StorageProfile.OsDiskImage.Source.StorageAccountId

--- a/internal/services/compute/shared_schema.go
+++ b/internal/services/compute/shared_schema.go
@@ -276,10 +276,7 @@ func flattenBootDiagnostics(input *virtualmachines.DiagnosticsProfile) []interfa
 		return []interface{}{}
 	}
 
-	storageAccountUri := ""
-	if input.BootDiagnostics.StorageUri != nil {
-		storageAccountUri = *input.BootDiagnostics.StorageUri
-	}
+	storageAccountUri := pointer.From(input.BootDiagnostics.StorageUri)
 
 	return []interface{}{
 		map[string]interface{}{
@@ -293,10 +290,7 @@ func flattenBootDiagnosticsVMSS(input *virtualmachinescalesets.DiagnosticsProfil
 		return []interface{}{}
 	}
 
-	storageAccountUri := ""
-	if input.BootDiagnostics.StorageUri != nil {
-		storageAccountUri = *input.BootDiagnostics.StorageUri
-	}
+	storageAccountUri := pointer.From(input.BootDiagnostics.StorageUri)
 
 	return []interface{}{
 		map[string]interface{}{
@@ -528,20 +522,11 @@ func flattenPlan(input *virtualmachines.Plan) []interface{} {
 		return []interface{}{}
 	}
 
-	name := ""
-	if input.Name != nil {
-		name = *input.Name
-	}
+	name := pointer.From(input.Name)
 
-	product := ""
-	if input.Product != nil {
-		product = *input.Product
-	}
+	product := pointer.From(input.Product)
 
-	publisher := ""
-	if input.Publisher != nil {
-		publisher = *input.Publisher
-	}
+	publisher := pointer.From(input.Publisher)
 
 	return []interface{}{
 		map[string]interface{}{
@@ -557,20 +542,11 @@ func flattenPlanVMSS(input *virtualmachinescalesets.Plan) []interface{} {
 		return []interface{}{}
 	}
 
-	name := ""
-	if input.Name != nil {
-		name = *input.Name
-	}
+	name := pointer.From(input.Name)
 
-	product := ""
-	if input.Product != nil {
-		product = *input.Product
-	}
+	product := pointer.From(input.Product)
 
-	publisher := ""
-	if input.Publisher != nil {
-		publisher = *input.Publisher
-	}
+	publisher := pointer.From(input.Publisher)
 
 	return []interface{}{
 		map[string]interface{}{
@@ -984,10 +960,7 @@ func flattenWinRMListener(input *virtualmachines.WinRMConfiguration) []interface
 	output := make([]interface{}, 0)
 
 	for _, v := range *input.Listeners {
-		certificateUrl := ""
-		if v.CertificateURL != nil {
-			certificateUrl = *v.CertificateURL
-		}
+		certificateUrl := pointer.From(v.CertificateURL)
 
 		output = append(output, map[string]interface{}{
 			"certificate_url": certificateUrl,
@@ -1006,10 +979,7 @@ func flattenWinRMListenerVMSS(input *virtualmachinescalesets.WinRMConfiguration)
 	output := make([]interface{}, 0)
 
 	for _, v := range *input.Listeners {
-		certificateUrl := ""
-		if v.CertificateURL != nil {
-			certificateUrl = *v.CertificateURL
-		}
+		certificateUrl := pointer.From(v.CertificateURL)
 
 		output = append(output, map[string]interface{}{
 			"certificate_url": certificateUrl,
@@ -1166,15 +1136,9 @@ func flattenWindowsSecrets(input *[]virtualmachines.VaultSecretGroup) []interfac
 
 		if v.VaultCertificates != nil {
 			for _, c := range *v.VaultCertificates {
-				store := ""
-				if c.CertificateStore != nil {
-					store = *c.CertificateStore
-				}
+				store := pointer.From(c.CertificateStore)
 
-				url := ""
-				if c.CertificateURL != nil {
-					url = *c.CertificateURL
-				}
+				url := pointer.From(c.CertificateURL)
 
 				certificates = append(certificates, map[string]interface{}{
 					"store": store,
@@ -1209,15 +1173,9 @@ func flattenWindowsSecretsVMSS(input *[]virtualmachinescalesets.VaultSecretGroup
 
 		if v.VaultCertificates != nil {
 			for _, c := range *v.VaultCertificates {
-				store := ""
-				if c.CertificateStore != nil {
-					store = *c.CertificateStore
-				}
+				store := pointer.From(c.CertificateStore)
 
-				url := ""
-				if c.CertificateURL != nil {
-					url = *c.CertificateURL
-				}
+				url := pointer.From(c.CertificateURL)
 
 				certificates = append(certificates, map[string]interface{}{
 					"store": store,

--- a/internal/services/compute/snapshot_resource.go
+++ b/internal/services/compute/snapshot_resource.go
@@ -283,11 +283,7 @@ func resourceSnapshotRead(d *pluginsdk.ResourceData, meta interface{}) error {
 			}
 			d.Set("public_network_access_enabled", publicNetworkAccessEnabled)
 
-			incrementalEnabled := false
-			if props.Incremental != nil {
-				incrementalEnabled = *props.Incremental
-			}
-			d.Set("incremental_enabled", incrementalEnabled)
+			d.Set("incremental_enabled", pointer.From(props.Incremental))
 
 			trustedLaunchEnabled := false
 			if securityProfile := props.SecurityProfile; securityProfile != nil && securityProfile.SecurityType != nil {

--- a/internal/services/compute/virtual_machine.go
+++ b/internal/services/compute/virtual_machine.go
@@ -68,21 +68,10 @@ func flattenVirtualMachineAdditionalCapabilities(input *virtualmachines.Addition
 		return []interface{}{}
 	}
 
-	ultraSsdEnabled := false
-
-	if input.UltraSSDEnabled != nil {
-		ultraSsdEnabled = *input.UltraSSDEnabled
-	}
-
-	hibernationEnabled := false
-	if input.HibernationEnabled != nil {
-		hibernationEnabled = *input.HibernationEnabled
-	}
-
 	return []interface{}{
 		map[string]interface{}{
-			"ultra_ssd_enabled":   ultraSsdEnabled,
-			"hibernation_enabled": hibernationEnabled,
+			"ultra_ssd_enabled":   pointer.From(input.UltraSSDEnabled),
+			"hibernation_enabled": pointer.From(input.HibernationEnabled),
 		},
 	}
 }
@@ -345,10 +334,7 @@ func flattenVirtualMachineOSDisk(ctx context.Context, disksClient *disks.DisksCl
 		diskSizeGb = int(*input.DiskSizeGB)
 	}
 
-	var name string
-	if input.Name != nil {
-		name = *input.Name
-	}
+	name := pointer.From(input.Name)
 
 	diskEncryptionSetId := ""
 	storageAccountType := ""
@@ -405,10 +391,7 @@ func flattenVirtualMachineOSDisk(ctx context.Context, disksClient *disks.DisksCl
 		}
 	}
 
-	writeAcceleratorEnabled := false
-	if input.WriteAcceleratorEnabled != nil {
-		writeAcceleratorEnabled = *input.WriteAcceleratorEnabled
-	}
+	writeAcceleratorEnabled := pointer.From(input.WriteAcceleratorEnabled)
 	return []interface{}{
 		map[string]interface{}{
 			"caching":                          string(pointer.From(input.Caching)),

--- a/internal/services/compute/virtual_machine_extension_resource.go
+++ b/internal/services/compute/virtual_machine_extension_resource.go
@@ -276,11 +276,7 @@ func resourceVirtualMachineExtensionsRead(d *pluginsdk.ResourceData, meta interf
 			d.Set("protected_settings_from_key_vault", flattenProtectedSettingsFromKeyVault(props.ProtectedSettingsFromKeyVault))
 			d.Set("provision_after_extensions", pointer.From(props.ProvisionAfterExtensions))
 
-			suppressFailure := false
-			if props.SuppressFailures != nil {
-				suppressFailure = *props.SuppressFailures
-			}
-			d.Set("failure_suppression_enabled", suppressFailure)
+			d.Set("failure_suppression_enabled", pointer.From(props.SuppressFailures))
 
 			if props.Settings != nil {
 				settings, err := json.Marshal(props.Settings)

--- a/internal/services/compute/virtual_machine_scale_set.go
+++ b/internal/services/compute/virtual_machine_scale_set.go
@@ -61,14 +61,9 @@ func FlattenVirtualMachineScaleSetAdditionalCapabilities(input *virtualmachinesc
 		return []interface{}{}
 	}
 
-	ultraSsdEnabled := false
-	if input.UltraSSDEnabled != nil {
-		ultraSsdEnabled = *input.UltraSSDEnabled
-	}
-
 	return []interface{}{
 		map[string]interface{}{
-			"ultra_ssd_enabled": ultraSsdEnabled,
+			"ultra_ssd_enabled": pointer.From(input.UltraSSDEnabled),
 		},
 	}
 }
@@ -357,20 +352,10 @@ func FlattenVirtualMachineScaleSetSpotRestorePolicy(input *virtualmachinescalese
 		return nil
 	}
 
-	var enabled bool
-	if input.Enabled != nil {
-		enabled = *input.Enabled
-	}
-
-	var restore string
-	if input.RestoreTimeout != nil {
-		restore = *input.RestoreTimeout
-	}
-
 	return []interface{}{
 		map[string]interface{}{
-			"enabled": enabled,
-			"timeout": restore,
+			"enabled": pointer.From(input.Enabled),
+			"timeout": pointer.From(input.RestoreTimeout),
 		},
 	}
 }
@@ -1285,10 +1270,7 @@ func FlattenVirtualMachineScaleSetDataDisk(input *[]virtualmachinescalesets.Virt
 	output := make([]interface{}, 0)
 
 	for _, v := range *input {
-		var name string
-		if v.Name != nil {
-			name = *v.Name
-		}
+		name := pointer.From(v.Name)
 
 		diskSizeGb := 0
 		if v.DiskSizeGB != nil && *v.DiskSizeGB != 0 {
@@ -1304,10 +1286,7 @@ func FlattenVirtualMachineScaleSetDataDisk(input *[]virtualmachinescalesets.Virt
 			}
 		}
 
-		writeAcceleratorEnabled := false
-		if v.WriteAcceleratorEnabled != nil {
-			writeAcceleratorEnabled = *v.WriteAcceleratorEnabled
-		}
+		writeAcceleratorEnabled := pointer.From(v.WriteAcceleratorEnabled)
 
 		iops := 0
 		if v.DiskIOPSReadWrite != nil {
@@ -1560,10 +1539,7 @@ func FlattenVirtualMachineScaleSetOSDisk(input *virtualmachinescalesets.VirtualM
 		}
 	}
 
-	writeAcceleratorEnabled := false
-	if input.WriteAcceleratorEnabled != nil {
-		writeAcceleratorEnabled = *input.WriteAcceleratorEnabled
-	}
+	writeAcceleratorEnabled := pointer.From(input.WriteAcceleratorEnabled)
 
 	return []interface{}{
 		map[string]interface{}{
@@ -1706,10 +1682,7 @@ func FlattenVirtualMachineScaleSetRollingUpgradePolicy(input *virtualmachinescal
 		return []interface{}{}
 	}
 
-	enableCrossZoneUpgrade := false
-	if input.EnableCrossZoneUpgrade != nil {
-		enableCrossZoneUpgrade = *input.EnableCrossZoneUpgrade
-	}
+	enableCrossZoneUpgrade := pointer.From(input.EnableCrossZoneUpgrade)
 
 	maxBatchInstancePercent := 0
 	if input.MaxBatchInstancePercent != nil {
@@ -1726,20 +1699,11 @@ func FlattenVirtualMachineScaleSetRollingUpgradePolicy(input *virtualmachinescal
 		maxUnhealthyUpgradedInstancePercent = int(*input.MaxUnhealthyUpgradedInstancePercent)
 	}
 
-	pauseTimeBetweenBatches := ""
-	if input.PauseTimeBetweenBatches != nil {
-		pauseTimeBetweenBatches = *input.PauseTimeBetweenBatches
-	}
+	pauseTimeBetweenBatches := pointer.From(input.PauseTimeBetweenBatches)
 
-	prioritizeUnhealthyInstances := false
-	if input.PrioritizeUnhealthyInstances != nil {
-		prioritizeUnhealthyInstances = *input.PrioritizeUnhealthyInstances
-	}
+	prioritizeUnhealthyInstances := pointer.From(input.PrioritizeUnhealthyInstances)
 
-	maxSurge := false
-	if input.MaxSurge != nil {
-		maxSurge = *input.MaxSurge
-	}
+	maxSurge := pointer.From(input.MaxSurge)
 
 	return []interface{}{
 		map[string]interface{}{
@@ -2100,10 +2064,7 @@ func flattenVirtualMachineScaleSetExtensions(input *virtualmachinescalesets.Virt
 	}
 
 	for _, v := range *input.Extensions {
-		name := ""
-		if v.Name != nil {
-			name = *v.Name
-		}
+		name := pointer.From(v.Name)
 
 		autoUpgradeMinorVersion := false
 		enableAutomaticUpgrade := false

--- a/internal/services/compute/virtual_machine_scale_set_extension_resource.go
+++ b/internal/services/compute/virtual_machine_scale_set_extension_resource.go
@@ -338,11 +338,7 @@ func resourceVirtualMachineScaleSetExtensionRead(d *pluginsdk.ResourceData, meta
 			d.Set("type", props.Type)
 			d.Set("type_handler_version", props.TypeHandlerVersion)
 
-			suppressFailure := false
-			if props.SuppressFailures != nil {
-				suppressFailure = *props.SuppressFailures
-			}
-			d.Set("failure_suppression_enabled", suppressFailure)
+			d.Set("failure_suppression_enabled", pointer.From(props.SuppressFailures))
 
 			settings := ""
 			if props.Settings != nil {

--- a/internal/services/compute/windows_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_resource.go
@@ -1028,16 +1028,11 @@ func resourceWindowsVirtualMachineScaleSetRead(d *pluginsdk.ResourceData, meta i
 							return fmt.Errorf("setting `additional_unattend_content`: %+v", err)
 						}
 
-						enableAutomaticUpdates := false
-						if windows.EnableAutomaticUpdates != nil {
-							enableAutomaticUpdates = *windows.EnableAutomaticUpdates
-						}
-
 						// the API requires this is set to 'true' on submission (since it's now required for Windows VMSS's with
 						// an Automatic Upgrade Mode configured) however it actually returns false from the API..
 						// after a bunch of testing the least bad option appears to be not to set this if it's an Automatic Upgrade Mode
 						if upgradeMode != virtualmachinescalesets.UpgradeModeAutomatic {
-							d.Set("automatic_updates_enabled", enableAutomaticUpdates)
+							d.Set("automatic_updates_enabled", pointer.From(windows.EnableAutomaticUpdates))
 						}
 
 						d.Set("provision_vm_agent", windows.ProvisionVMAgent)

--- a/internal/services/confidentialledger/confidential_ledger_resource.go
+++ b/internal/services/confidentialledger/confidential_ledger_resource.go
@@ -344,20 +344,10 @@ func flattenAADBasedSecurityPrincipal(input *[]confidentialledger.AADBasedSecuri
 			ledgerRoleName = string(*item.LedgerRoleName)
 		}
 
-		principalId := ""
-		if item.PrincipalId != nil {
-			principalId = *item.PrincipalId
-		}
-
-		tenantId := ""
-		if item.TenantId != nil {
-			tenantId = *item.TenantId
-		}
-
 		output = append(output, map[string]interface{}{
 			"ledger_role_name": ledgerRoleName,
-			"principal_id":     principalId,
-			"tenant_id":        tenantId,
+			"principal_id":     pointer.From(item.PrincipalId),
+			"tenant_id":        pointer.From(item.TenantId),
 		})
 	}
 
@@ -371,11 +361,6 @@ func flattenCertBasedSecurityPrincipal(input *[]confidentialledger.CertBasedSecu
 	}
 
 	for _, item := range *input {
-		pemPublicKey := ""
-		if item.Cert != nil {
-			pemPublicKey = *item.Cert
-		}
-
 		ledgerRoleName := ""
 		if item.LedgerRoleName != nil {
 			ledgerRoleName = string(*item.LedgerRoleName)
@@ -383,7 +368,7 @@ func flattenCertBasedSecurityPrincipal(input *[]confidentialledger.CertBasedSecu
 
 		output = append(output, map[string]interface{}{
 			"ledger_role_name": ledgerRoleName,
-			"pem_public_key":   pemPublicKey,
+			"pem_public_key":   pointer.From(item.Cert),
 		})
 	}
 

--- a/internal/services/consumption/consumption_budget_data_source_helpers.go
+++ b/internal/services/consumption/consumption_budget_data_source_helpers.go
@@ -4,6 +4,7 @@
 package consumption
 
 import (
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/consumption/2019-10-01/budgets"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers"
 )
@@ -17,14 +18,9 @@ func flattenConsumptionBudgetTimePeriod(input *budgets.BudgetTimePeriod) []inter
 
 	startDate := input.StartDate
 
-	endDate := ""
-	if v := input.EndDate; v != nil {
-		endDate = *v
-	}
-
 	return append(timePeriod, map[string]interface{}{
 		"start_date": startDate,
-		"end_date":   endDate,
+		"end_date":   pointer.From(input.EndDate),
 	})
 }
 


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR is part of a series of changes to enable the azproviderlint AZG004 analyzer, which flags the pattern of declaring a variable with its type's zero value and then conditionally overwriting it from a pointer after a nil check.

As a prerequisite to turning the analyzer on repo-wide, this slice migrates all such occurrences in the following services to the equivalent `pointer.From()` helper

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

No functional behavior changes are introduced, so no new test coverage is added. The refactor is verified by go build, go vet, gofmt, and the existing linter/acceptance test suites for the affected services.

## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
