### PR TITLE
Linters - enable azproviderlint AZG004 - Services (Network- Redis)

### DIFF
--- a/internal/services/network/application_gateway_resource.go
+++ b/internal/services/network/application_gateway_resource.go
@@ -4157,15 +4157,9 @@ func flattenApplicationGatewayRewriteRuleSets(input *[]applicationgateways.Appli
 							config := *actionSet.UrlConfiguration
 							components := ""
 
-							path := ""
-							if config.ModifiedPath != nil {
-								path = *config.ModifiedPath
-							}
+							path := pointer.From(config.ModifiedPath)
 
-							queryString := ""
-							if config.ModifiedQueryString != nil {
-								queryString = *config.ModifiedQueryString
-							}
+							queryString := pointer.From(config.ModifiedQueryString)
 
 							// `components` doesn't exist in the API - it appears to be purely a UI state in the Portal
 							// as such we should consider removing this field in the future.
@@ -4180,16 +4174,11 @@ func flattenApplicationGatewayRewriteRuleSets(input *[]applicationgateways.Appli
 								components = "path_only"
 							}
 
-							reroute := false
-							if config.Reroute != nil {
-								reroute = *config.Reroute
-							}
-
 							urlConfigs = append(urlConfigs, map[string]interface{}{
 								"components":   components,
 								"query_string": queryString,
 								"path":         path,
-								"reroute":      reroute,
+								"reroute":      pointer.From(config.Reroute),
 							})
 						}
 					}

--- a/internal/services/network/express_route_circuit_peering_resource.go
+++ b/internal/services/network/express_route_circuit_peering_resource.go
@@ -642,14 +642,6 @@ func flattenExpressRouteCircuitIpv6PeeringConfig(input *expressroutecircuitpeeri
 		return make([]interface{}, 0)
 	}
 
-	var primaryPeerAddressPrefix string
-	if input.PrimaryPeerAddressPrefix != nil {
-		primaryPeerAddressPrefix = *input.PrimaryPeerAddressPrefix
-	}
-	var secondaryPeerAddressPrefix string
-	if input.SecondaryPeerAddressPrefix != nil {
-		secondaryPeerAddressPrefix = *input.SecondaryPeerAddressPrefix
-	}
 	routeFilterId := ""
 	if input.RouteFilter != nil && input.RouteFilter.Id != nil {
 		routeFilterId = *input.RouteFilter.Id
@@ -657,8 +649,8 @@ func flattenExpressRouteCircuitIpv6PeeringConfig(input *expressroutecircuitpeeri
 	return []interface{}{
 		map[string]interface{}{
 			"microsoft_peering":             flattenExpressRouteCircuitPeeringMicrosoftConfig(input.MicrosoftPeeringConfig),
-			"primary_peer_address_prefix":   primaryPeerAddressPrefix,
-			"secondary_peer_address_prefix": secondaryPeerAddressPrefix,
+			"primary_peer_address_prefix":   pointer.From(input.PrimaryPeerAddressPrefix),
+			"secondary_peer_address_prefix": pointer.From(input.SecondaryPeerAddressPrefix),
 			"route_filter_id":               routeFilterId,
 			"enabled":                       pointer.From(input.State) == expressroutecircuitpeerings.ExpressRouteCircuitPeeringStateEnabled,
 		},

--- a/internal/services/network/express_route_connection_resource.go
+++ b/internal/services/network/express_route_connection_resource.go
@@ -273,10 +273,7 @@ func resourceExpressRouteConnectionRead(d *pluginsdk.ResourceData, meta interfac
 				d.Set("express_route_gateway_bypass_enabled", props.ExpressRouteGatewayBypass)
 			}
 
-			circuitPeeringID := ""
-			if v := props.ExpressRouteCircuitPeering.Id; v != nil {
-				circuitPeeringID = *v
-			}
+			circuitPeeringID := pointer.From(props.ExpressRouteCircuitPeering.Id)
 			peeringId, err := commonids.ParseExpressRouteCircuitPeeringIDInsensitively(circuitPeeringID)
 			if err != nil {
 				return err

--- a/internal/services/network/express_route_port_resource.go
+++ b/internal/services/network/express_route_port_resource.go
@@ -467,11 +467,6 @@ func flattenExpressRoutePortLinks(links *[]expressrouteports.ExpressRouteLink) (
 }
 
 func flattenExpressRoutePortLink(link expressrouteports.ExpressRouteLink) []interface{} {
-	var id string
-	if link.Id != nil {
-		id = *link.Id
-	}
-
 	var (
 		routerName    string
 		interfaceName string
@@ -514,7 +509,7 @@ func flattenExpressRoutePortLink(link expressrouteports.ExpressRouteLink) []inte
 
 	return []interface{}{
 		map[string]interface{}{
-			"id":                            id,
+			"id":                            pointer.From(link.Id),
 			"router_name":                   routerName,
 			"interface_name":                interfaceName,
 			"patch_panel_id":                patchPanelId,

--- a/internal/services/network/network_connection_monitor_resource.go
+++ b/internal/services/network/network_connection_monitor_resource.go
@@ -892,11 +892,6 @@ func flattenNetworkConnectionMonitorEndpoint(input *[]connectionmonitors.Connect
 	}
 
 	for _, item := range *input {
-		var address string
-		if item.Address != nil {
-			address = *item.Address
-		}
-
 		var coverageLevel string
 		if item.CoverageLevel != nil && string(*item.CoverageLevel) != "" {
 			coverageLevel = string(*item.CoverageLevel)
@@ -907,16 +902,11 @@ func flattenNetworkConnectionMonitorEndpoint(input *[]connectionmonitors.Connect
 			endpointType = string(*item.Type)
 		}
 
-		var resourceId string
-		if item.ResourceId != nil {
-			resourceId = *item.ResourceId
-		}
-
 		v := map[string]interface{}{
 			"name":                 item.Name,
-			"address":              address,
+			"address":              pointer.From(item.Address),
 			"coverage_level":       coverageLevel,
-			"target_resource_id":   resourceId,
+			"target_resource_id":   pointer.From(item.ResourceId),
 			"target_resource_type": endpointType,
 			"filter":               flattenNetworkConnectionMonitorEndpointFilter(item.Filter),
 		}
@@ -976,18 +966,13 @@ func flattenNetworkConnectionMonitorEndpointFilterItem(input *[]connectionmonito
 	}
 
 	for _, item := range *input {
-		var address string
-		if item.Address != nil {
-			address = *item.Address
-		}
-
 		var t connectionmonitors.ConnectionMonitorEndpointFilterItemType
 		if item.Type != nil && string(*item.Type) != "" {
 			t = *item.Type
 		}
 
 		v := map[string]interface{}{
-			"address": address,
+			"address": pointer.From(item.Address),
 			"type":    t,
 		}
 
@@ -1014,11 +999,6 @@ func flattenNetworkConnectionMonitorTestConfiguration(input *[]connectionmonitor
 			preferredIpVersion = *item.PreferredIPVersion
 		}
 
-		var testFrequencySec int64
-		if item.TestFrequencySec != nil {
-			testFrequencySec = *item.TestFrequencySec
-		}
-
 		v := map[string]interface{}{
 			"name":                      item.Name,
 			"protocol":                  protocol,
@@ -1027,7 +1007,7 @@ func flattenNetworkConnectionMonitorTestConfiguration(input *[]connectionmonitor
 			"preferred_ip_version":      preferredIpVersion,
 			"success_threshold":         flattenNetworkConnectionMonitorSuccessThreshold(item.SuccessThreshold),
 			"tcp_configuration":         flattenNetworkConnectionMonitorTCPConfiguration(item.TcpConfiguration),
-			"test_frequency_in_seconds": testFrequencySec,
+			"test_frequency_in_seconds": pointer.From(item.TestFrequencySec),
 		}
 
 		results = append(results, v)
@@ -1046,27 +1026,12 @@ func flattenNetworkConnectionMonitorHTTPConfiguration(input *connectionmonitors.
 		method = *input.Method
 	}
 
-	var p string
-	if input.Path != nil {
-		p = *input.Path
-	}
-
-	var port int64
-	if input.Port != nil {
-		port = *input.Port
-	}
-
-	var preferHttps bool
-	if input.PreferHTTPS != nil {
-		preferHttps = *input.PreferHTTPS
-	}
-
 	return []interface{}{
 		map[string]interface{}{
 			"method":                   method,
-			"path":                     p,
-			"port":                     port,
-			"prefer_https":             preferHttps,
+			"path":                     pointer.From(input.Path),
+			"port":                     pointer.From(input.Port),
+			"prefer_https":             pointer.From(input.PreferHTTPS),
 			"request_header":           flattenNetworkConnectionMonitorHTTPHeader(input.RequestHeaders),
 			"valid_status_code_ranges": helpers.FlattenStringSlice(input.ValidStatusCodeRanges),
 		},
@@ -1095,20 +1060,10 @@ func flattenNetworkConnectionMonitorSuccessThreshold(input *connectionmonitors.C
 		return make([]interface{}, 0)
 	}
 
-	var checksFailedPercent int64
-	if input.ChecksFailedPercent != nil {
-		checksFailedPercent = *input.ChecksFailedPercent
-	}
-
-	var roundTripTimeMs float64
-	if input.RoundTripTimeMs != nil {
-		roundTripTimeMs = *input.RoundTripTimeMs
-	}
-
 	return []interface{}{
 		map[string]interface{}{
-			"checks_failed_percent": checksFailedPercent,
-			"round_trip_time_ms":    roundTripTimeMs,
+			"checks_failed_percent": pointer.From(input.ChecksFailedPercent),
+			"round_trip_time_ms":    pointer.From(input.RoundTripTimeMs),
 		},
 	}
 }
@@ -1123,11 +1078,6 @@ func flattenNetworkConnectionMonitorTCPConfiguration(input *connectionmonitors.C
 		enableTraceRoute = !*input.DisableTraceRoute
 	}
 
-	var port int64
-	if input.Port != nil {
-		port = *input.Port
-	}
-
 	var destinationPortBehavior connectionmonitors.DestinationPortBehavior
 	if input.DestinationPortBehavior != nil && string(*input.DestinationPortBehavior) != "" {
 		destinationPortBehavior = *input.DestinationPortBehavior
@@ -1136,7 +1086,7 @@ func flattenNetworkConnectionMonitorTCPConfiguration(input *connectionmonitors.C
 	return []interface{}{
 		map[string]interface{}{
 			"trace_route_enabled":       enableTraceRoute,
-			"port":                      port,
+			"port":                      pointer.From(input.Port),
 			"destination_port_behavior": string(destinationPortBehavior),
 		},
 	}
@@ -1149,19 +1099,9 @@ func flattenNetworkConnectionMonitorHTTPHeader(input *[]connectionmonitors.HTTPH
 	}
 
 	for _, item := range *input {
-		var name string
-		if item.Name != nil {
-			name = *item.Name
-		}
-
-		var value string
-		if item.Value != nil {
-			value = *item.Value
-		}
-
 		v := map[string]interface{}{
-			"name":  name,
-			"value": value,
+			"name":  pointer.From(item.Name),
+			"value": pointer.From(item.Value),
 		}
 
 		results = append(results, v)
@@ -1177,17 +1117,12 @@ func flattenNetworkConnectionMonitorTestGroup(input *[]connectionmonitors.Connec
 	}
 
 	for _, item := range *input {
-		var disable bool
-		if item.Disable != nil {
-			disable = *item.Disable
-		}
-
 		v := map[string]interface{}{
 			"name":                     item.Name,
 			"destination_endpoints":    item.Destinations,
 			"source_endpoints":         item.Sources,
 			"test_configuration_names": item.TestConfigurations,
-			"enabled":                  !disable,
+			"enabled":                  !pointer.From(item.Disable),
 		}
 
 		results = append(results, v)

--- a/internal/services/network/network_interface_resource.go
+++ b/internal/services/network/network_interface_resource.go
@@ -662,19 +662,9 @@ func flattenNetworkInterfaceIPConfigurations(input *[]networkinterfaces.NetworkI
 	for _, ipConfig := range *input {
 		props := ipConfig.Properties
 
-		name := ""
-		if ipConfig.Name != nil {
-			name = *ipConfig.Name
-		}
-
 		subnetId := ""
 		if props.Subnet != nil && props.Subnet.Id != nil {
 			subnetId = *props.Subnet.Id
-		}
-
-		privateIPAddress := ""
-		if props.PrivateIPAddress != nil {
-			privateIPAddress = *props.PrivateIPAddress
 		}
 
 		privateIPAllocationMethod := ""
@@ -692,20 +682,15 @@ func flattenNetworkInterfaceIPConfigurations(input *[]networkinterfaces.NetworkI
 			publicIPAddressId = *props.PublicIPAddress.Id
 		}
 
-		primary := false
-		if props.Primary != nil {
-			primary = *props.Primary
-		}
-
 		gatewayLBFrontendIPConfigId := ""
 		if props.GatewayLoadBalancer != nil && props.GatewayLoadBalancer.Id != nil {
 			gatewayLBFrontendIPConfigId = *props.GatewayLoadBalancer.Id
 		}
 
 		result = append(result, map[string]interface{}{
-			"name":                          name,
-			"primary":                       primary,
-			"private_ip_address":            privateIPAddress,
+			"name":                          pointer.From(ipConfig.Name),
+			"primary":                       pointer.From(props.Primary),
+			"private_ip_address":            pointer.From(props.PrivateIPAddress),
 			"private_ip_address_allocation": privateIPAllocationMethod,
 			"private_ip_address_version":    privateIPAddressVersion,
 			"public_ip_address_id":          publicIPAddressId,

--- a/internal/services/network/network_watcher_flow_log_resource.go
+++ b/internal/services/network/network_watcher_flow_log_resource.go
@@ -512,17 +512,13 @@ func flattenNetworkWatcherFlowLogRetentionPolicy(input *flowlogs.RetentionPolicy
 	output := make([]interface{}, 0)
 
 	if input != nil {
-		enabled := false
-		if input.Enabled != nil {
-			enabled = *input.Enabled
-		}
 		days := 0
 		if input.Days != nil {
 			days = int(*input.Days)
 		}
 		output = append(output, map[string]interface{}{
 			"days":    days,
-			"enabled": enabled,
+			"enabled": pointer.From(input.Enabled),
 		})
 	}
 
@@ -533,33 +529,16 @@ func flattenNetworkWatcherFlowLogTrafficAnalytics(input *flowlogs.TrafficAnalyti
 	output := make([]interface{}, 0)
 	if input != nil {
 		if cfg := input.NetworkWatcherFlowAnalyticsConfiguration; cfg != nil {
-			enabled := false
-			if cfg.Enabled != nil {
-				enabled = *cfg.Enabled
-			}
-			workspaceId := ""
-			if cfg.WorkspaceId != nil {
-				workspaceId = *cfg.WorkspaceId
-			}
-			workspaceRegion := ""
-			if cfg.WorkspaceRegion != nil {
-				workspaceRegion = *cfg.WorkspaceRegion
-			}
-			workspaceResourceId := ""
-			if cfg.WorkspaceResourceId != nil {
-				workspaceResourceId = *cfg.WorkspaceResourceId
-			}
-
 			intervalInMinutes := 0
 			if cfg.TrafficAnalyticsInterval != nil {
 				intervalInMinutes = int(*cfg.TrafficAnalyticsInterval)
 			}
 			output = append(output, map[string]interface{}{
-				"enabled":               enabled,
+				"enabled":               pointer.From(cfg.Enabled),
 				"interval_in_minutes":   intervalInMinutes,
-				"workspace_id":          workspaceId,
-				"workspace_region":      workspaceRegion,
-				"workspace_resource_id": workspaceResourceId,
+				"workspace_id":          pointer.From(cfg.WorkspaceId),
+				"workspace_region":      pointer.From(cfg.WorkspaceRegion),
+				"workspace_resource_id": pointer.From(cfg.WorkspaceResourceId),
 			})
 		}
 	}

--- a/internal/services/network/point_to_site_vpn_gateway_resource.go
+++ b/internal/services/network/point_to_site_vpn_gateway_resource.go
@@ -342,11 +342,7 @@ func resourcePointToSiteVPNGatewayRead(d *pluginsdk.ResourceData, meta interface
 			}
 			d.Set("vpn_server_configuration_id", vpnServerConfigurationId)
 
-			routingPreferenceInternetEnabled := false
-			if props.IsRoutingPreferenceInternet != nil {
-				routingPreferenceInternetEnabled = *props.IsRoutingPreferenceInternet
-			}
-			d.Set("routing_preference_internet_enabled", routingPreferenceInternetEnabled)
+			d.Set("routing_preference_internet_enabled", pointer.From(props.IsRoutingPreferenceInternet))
 		}
 		if err := tags.FlattenAndSet(d, model.Tags); err != nil {
 			return err
@@ -461,11 +457,6 @@ func flattenPointToSiteVPNGatewayConnectionConfiguration(input *[]virtualwans.P2
 	output := make([]interface{}, 0)
 
 	for _, v := range *input {
-		name := ""
-		if v.Name != nil {
-			name = *v.Name
-		}
-
 		route := make([]interface{}, 0)
 		addressPrefixes := make([]interface{}, 0)
 		enableInternetSecurity := false
@@ -490,7 +481,7 @@ func flattenPointToSiteVPNGatewayConnectionConfiguration(input *[]virtualwans.P2
 		}
 
 		output = append(output, map[string]interface{}{
-			"name": name,
+			"name": pointer.From(v.Name),
 			"vpn_client_address_pool": []interface{}{
 				map[string]interface{}{
 					"address_prefixes": addressPrefixes,

--- a/internal/services/network/private_endpoint_resource.go
+++ b/internal/services/network/private_endpoint_resource.go
@@ -699,11 +699,7 @@ func resourcePrivateEndpointFlatten(ctx context.Context, metaClient *clients.Cli
 				subnetId = *props.Subnet.Id
 			}
 			d.Set("subnet_id", subnetId)
-			customNicName := ""
-			if props.CustomNetworkInterfaceName != nil {
-				customNicName = *props.CustomNetworkInterfaceName
-			}
-			d.Set("custom_network_interface_name", customNicName)
+			d.Set("custom_network_interface_name", pointer.From(props.CustomNetworkInterfaceName))
 
 			if fetchCompleteData {
 				privateDnsZoneIds, err := retrievePrivateDnsZoneGroupsForPrivateEndpoint(ctx, dnsClient, *id)
@@ -898,11 +894,6 @@ func flattenPrivateLinkEndpointServiceConnection(serviceConnections *[]privateen
 
 	if serviceConnections != nil {
 		for _, item := range *serviceConnections {
-			name := ""
-			if item.Name != nil {
-				name = *item.Name
-			}
-
 			privateConnectionId := ""
 			subResourceNames := make([]interface{}, 0)
 
@@ -915,7 +906,7 @@ func flattenPrivateLinkEndpointServiceConnection(serviceConnections *[]privateen
 				}
 			}
 			attrs := map[string]interface{}{
-				"name":                 name,
+				"name":                 pointer.From(item.Name),
 				"is_manual_connection": false,
 				"private_ip_address":   privateIPAddress,
 				"subresource_names":    subResourceNames,
@@ -933,11 +924,6 @@ func flattenPrivateLinkEndpointServiceConnection(serviceConnections *[]privateen
 
 	if manualServiceConnections != nil {
 		for _, item := range *manualServiceConnections {
-			name := ""
-			if item.Name != nil {
-				name = *item.Name
-			}
-
 			privateConnectionId := ""
 			requestMessage := ""
 			subResourceNames := make([]interface{}, 0)
@@ -955,7 +941,7 @@ func flattenPrivateLinkEndpointServiceConnection(serviceConnections *[]privateen
 			}
 
 			attrs := map[string]interface{}{
-				"name":                 name,
+				"name":                 pointer.From(item.Name),
 				"is_manual_connection": true,
 				"private_ip_address":   privateIPAddress,
 				"request_message":      requestMessage,
@@ -1117,21 +1103,6 @@ func flattenPrivateDnsZoneGroupRecordSets(input *[]privatednszonegroups.RecordSe
 	}
 
 	for _, v := range *input {
-		fqdn := ""
-		if v.Fqdn != nil {
-			fqdn = *v.Fqdn
-		}
-
-		name := ""
-		if v.RecordSetName != nil {
-			name = *v.RecordSetName
-		}
-
-		recordType := ""
-		if v.RecordType != nil {
-			recordType = *v.RecordType
-		}
-
 		ttl := 0
 		if v.Ttl != nil {
 			ttl = int(*v.Ttl)
@@ -1143,11 +1114,11 @@ func flattenPrivateDnsZoneGroupRecordSets(input *[]privatednszonegroups.RecordSe
 		}
 
 		output = append(output, map[string]interface{}{
-			"fqdn":         fqdn,
+			"fqdn":         pointer.From(v.Fqdn),
 			"ip_addresses": ipAddresses,
-			"name":         name,
+			"name":         pointer.From(v.RecordSetName),
 			"ttl":          ttl,
-			"type":         recordType,
+			"type":         pointer.From(v.RecordType),
 		})
 	}
 

--- a/internal/services/network/private_link_service_resource.go
+++ b/internal/services/network/private_link_service_resource.go
@@ -513,11 +513,6 @@ func flattenPrivateLinkServiceIPConfiguration(input *[]privatelinkservices.Priva
 	}
 
 	for _, item := range *input {
-		name := ""
-		if item.Name != nil {
-			name = *item.Name
-		}
-
 		privateIpAddress := ""
 		privateIpVersion := ""
 		subnetId := ""
@@ -540,7 +535,7 @@ func flattenPrivateLinkServiceIPConfiguration(input *[]privatelinkservices.Priva
 		}
 
 		results = append(results, map[string]interface{}{
-			"name":                       name,
+			"name":                       pointer.From(item.Name),
 			"primary":                    primary,
 			"private_ip_address":         privateIpAddress,
 			"private_ip_address_version": privateIpVersion,

--- a/internal/services/network/public_ips_data_source.go
+++ b/internal/services/network/public_ips_data_source.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/publicipaddresses"
@@ -160,16 +161,6 @@ func flattenDataSourcePublicIPs(input []publicipaddresses.PublicIPAddress) []int
 }
 
 func flattenDataSourcePublicIP(input publicipaddresses.PublicIPAddress) map[string]string {
-	id := ""
-	if input.Id != nil {
-		id = *input.Id
-	}
-
-	name := ""
-	if input.Name != nil {
-		name = *input.Name
-	}
-
 	domainNameLabel := ""
 	fqdn := ""
 	ipAddress := ""
@@ -190,8 +181,8 @@ func flattenDataSourcePublicIP(input publicipaddresses.PublicIPAddress) map[stri
 	}
 
 	return map[string]string{
-		"id":                id,
-		"name":              name,
+		"id":                pointer.From(input.Id),
+		"name":              pointer.From(input.Name),
 		"domain_name_label": domainNameLabel,
 		"fqdn":              fqdn,
 		"ip_address":        ipAddress,

--- a/internal/services/network/subnet_resource.go
+++ b/internal/services/network/subnet_resource.go
@@ -970,10 +970,7 @@ func flattenSubnetServiceEndpointPolicies(input *[]subnets.ServiceEndpointPolicy
 
 	output := make([]interface{}, 0, len(*input))
 	for _, policy := range *input {
-		id := ""
-		if policy.Id != nil {
-			id = *policy.Id
-		}
+		id := pointer.From(policy.Id)
 		output = append(output, id)
 	}
 	return output

--- a/internal/services/network/subnet_service_endpoint_storage_policy_resource.go
+++ b/internal/services/network/subnet_service_endpoint_storage_policy_resource.go
@@ -286,11 +286,6 @@ func flattenServiceEndpointPolicyDefinitions(input *[]serviceendpointpolicies.Se
 
 	output := make([]interface{}, 0)
 	for _, e := range *input {
-		name := ""
-		if e.Name != nil {
-			name = *e.Name
-		}
-
 		var (
 			description     = ""
 			service         = ""
@@ -307,7 +302,7 @@ func flattenServiceEndpointPolicyDefinitions(input *[]serviceendpointpolicies.Se
 		}
 
 		output = append(output, map[string]interface{}{
-			"name":              name,
+			"name":              pointer.From(e.Name),
 			"description":       description,
 			"service_resources": serviceResource,
 			"service":           service,

--- a/internal/services/network/virtual_hub_connection_resource.go
+++ b/internal/services/network/virtual_hub_connection_resource.go
@@ -510,25 +510,15 @@ func flattenVirtualHubConnectionVnetStaticRoute(input *virtualwans.VnetRoute) []
 	}
 
 	for _, item := range *input.StaticRoutes {
-		var name string
-		if item.Name != nil {
-			name = *item.Name
-		}
-
-		var nextHopIpAddress string
-		if item.NextHopIPAddress != nil {
-			nextHopIpAddress = *item.NextHopIPAddress
-		}
-
 		addressPrefixes := make([]interface{}, 0)
 		if item.AddressPrefixes != nil {
 			addressPrefixes = helpers.FlattenStringSlice(item.AddressPrefixes)
 		}
 
 		v := map[string]interface{}{
-			"name":                name,
+			"name":                pointer.From(item.Name),
 			"address_prefixes":    addressPrefixes,
-			"next_hop_ip_address": nextHopIpAddress,
+			"next_hop_ip_address": pointer.From(item.NextHopIPAddress),
 		}
 
 		results = append(results, v)

--- a/internal/services/network/virtual_hub_resource.go
+++ b/internal/services/network/virtual_hub_resource.go
@@ -447,15 +447,10 @@ func flattenVirtualHubRoute(input *virtualwans.VirtualHubRouteTable) []interface
 
 	for _, item := range *input.Routes {
 		addressPrefixes := helpers.FlattenStringSlice(item.AddressPrefixes)
-		nextHopIpAddress := ""
-
-		if item.NextHopIPAddress != nil {
-			nextHopIpAddress = *item.NextHopIPAddress
-		}
 
 		results = append(results, map[string]interface{}{
 			"address_prefixes":    addressPrefixes,
-			"next_hop_ip_address": nextHopIpAddress,
+			"next_hop_ip_address": pointer.From(item.NextHopIPAddress),
 		})
 	}
 

--- a/internal/services/network/virtual_network_gateway_connection_resource.go
+++ b/internal/services/network/virtual_network_gateway_connection_resource.go
@@ -1118,10 +1118,7 @@ func flattenVirtualNetworkGatewayConnectionNatRuleIds(input *[]virtualnetworkgat
 	}
 
 	for _, item := range *input {
-		var id string
-		if item.Id != nil {
-			id = *item.Id
-		}
+		id := pointer.From(item.Id)
 
 		results = append(results, id)
 	}

--- a/internal/services/network/virtual_network_gateway_nat_rule_resource.go
+++ b/internal/services/network/virtual_network_gateway_nat_rule_resource.go
@@ -294,19 +294,9 @@ func flattenVirtualNetworkGatewayNatRuleMappings(input *[]virtualnetworkgateways
 	}
 
 	for _, item := range *input {
-		var addressSpace string
-		if item.AddressSpace != nil {
-			addressSpace = *item.AddressSpace
-		}
-
-		var portRange string
-		if item.PortRange != nil {
-			portRange = *item.PortRange
-		}
-
 		results = append(results, map[string]interface{}{
-			"address_space": addressSpace,
-			"port_range":    portRange,
+			"address_space": pointer.From(item.AddressSpace),
+			"port_range":    pointer.From(item.PortRange),
 		})
 	}
 

--- a/internal/services/network/virtual_network_resource.go
+++ b/internal/services/network/virtual_network_resource.go
@@ -1220,10 +1220,7 @@ func flattenVirtualNetworkSubnetServiceEndpointPolicies(input *[]virtualnetworks
 	}
 
 	for _, policy := range *input {
-		id := ""
-		if policy.Id != nil {
-			id = *policy.Id
-		}
+		id := pointer.From(policy.Id)
 		output = append(output, id)
 	}
 	return output

--- a/internal/services/network/vpn_gateway_connection_resource.go
+++ b/internal/services/network/vpn_gateway_connection_resource.go
@@ -426,11 +426,7 @@ func resourceVpnGatewayConnectionResourceRead(d *pluginsdk.ResourceData, meta in
 			}
 			d.Set("remote_vpn_site_id", vpnSiteId)
 
-			enableInternetSecurity := false
-			if props.EnableInternetSecurity != nil {
-				enableInternetSecurity = *props.EnableInternetSecurity
-			}
-			d.Set("internet_security_enabled", enableInternetSecurity)
+			d.Set("internet_security_enabled", pointer.From(props.EnableInternetSecurity))
 
 			if err := d.Set("routing", flattenVpnGatewayConnectionRoutingConfiguration(props.RoutingConfiguration)); err != nil {
 				return fmt.Errorf(`setting "routing": %v`, err)
@@ -831,10 +827,7 @@ func flattenVpnGatewayConnectionNatRuleIds(input *[]virtualwans.SubResource) []i
 	}
 
 	for _, item := range *input {
-		var id string
-		if item.Id != nil {
-			id = *item.Id
-		}
+		id := pointer.From(item.Id)
 
 		results = append(results, id)
 	}

--- a/internal/services/network/vpn_gateway_data_source.go
+++ b/internal/services/network/vpn_gateway_data_source.go
@@ -236,11 +236,6 @@ func dataSourceFlattenVPNGatewayBGPSettings(input *virtualwans.BgpSettings) []in
 		asn = int(*input.Asn)
 	}
 
-	bgpPeeringAddress := ""
-	if input.BgpPeeringAddress != nil {
-		bgpPeeringAddress = *input.BgpPeeringAddress
-	}
-
 	peerWeight := 0
 	if input.PeerWeight != nil {
 		peerWeight = int(*input.PeerWeight)
@@ -257,7 +252,7 @@ func dataSourceFlattenVPNGatewayBGPSettings(input *virtualwans.BgpSettings) []in
 	return []interface{}{
 		map[string]interface{}{
 			"asn":                            asn,
-			"bgp_peering_address":            bgpPeeringAddress,
+			"bgp_peering_address":            pointer.From(input.BgpPeeringAddress),
 			"instance_0_bgp_peering_address": instance0BgpPeeringAddress,
 			"instance_1_bgp_peering_address": instance1BgpPeeringAddress,
 			"peer_weight":                    peerWeight,
@@ -266,14 +261,9 @@ func dataSourceFlattenVPNGatewayBGPSettings(input *virtualwans.BgpSettings) []in
 }
 
 func dataSourceFlattenVPNGatewayIPConfigurationBgpPeeringAddress(input virtualwans.IPConfigurationBgpPeeringAddress) []interface{} {
-	ipConfigurationID := ""
-	if input.IPconfigurationId != nil {
-		ipConfigurationID = *input.IPconfigurationId
-	}
-
 	return []interface{}{
 		map[string]interface{}{
-			"ip_configuration_id": ipConfigurationID,
+			"ip_configuration_id": pointer.From(input.IPconfigurationId),
 			"custom_ips":          helpers.FlattenStringSlice(input.CustomBgpIPAddresses),
 			"default_ips":         helpers.FlattenStringSlice(input.DefaultBgpIPAddresses),
 			"tunnel_ips":          helpers.FlattenStringSlice(input.TunnelIPAddresses),

--- a/internal/services/network/vpn_gateway_nat_rule_resource.go
+++ b/internal/services/network/vpn_gateway_nat_rule_resource.go
@@ -320,19 +320,9 @@ func flattenVpnGatewayNatRuleMappings(input *[]virtualwans.VpnNatRuleMapping) []
 	}
 
 	for _, item := range *input {
-		var addressSpace string
-		if item.AddressSpace != nil {
-			addressSpace = *item.AddressSpace
-		}
-
-		var portRange string
-		if item.PortRange != nil {
-			portRange = *item.PortRange
-		}
-
 		results = append(results, map[string]interface{}{
-			"address_space": addressSpace,
-			"port_range":    portRange,
+			"address_space": pointer.From(item.AddressSpace),
+			"port_range":    pointer.From(item.PortRange),
 		})
 	}
 

--- a/internal/services/network/vpn_gateway_resource.go
+++ b/internal/services/network/vpn_gateway_resource.go
@@ -393,12 +393,7 @@ func resourceVPNGatewayRead(d *pluginsdk.ResourceData, meta interface{}) error {
 				return fmt.Errorf("setting `bgp_settings`: %+v", err)
 			}
 
-			bgpRouteTranslationForNatEnabled := false
-			if props.EnableBgpRouteTranslationForNat != nil {
-				bgpRouteTranslationForNatEnabled = *props.EnableBgpRouteTranslationForNat
-			}
-			d.Set("bgp_route_translation_for_nat_enabled", bgpRouteTranslationForNatEnabled)
-
+			d.Set("bgp_route_translation_for_nat_enabled", pointer.From(props.EnableBgpRouteTranslationForNat))
 			scaleUnit := 0
 			if props.VpnGatewayScaleUnit != nil {
 				scaleUnit = int(*props.VpnGatewayScaleUnit)
@@ -469,11 +464,6 @@ func flattenVPNGatewayBGPSettings(input *virtualwans.BgpSettings) []interface{} 
 		asn = int(*input.Asn)
 	}
 
-	bgpPeeringAddress := ""
-	if input.BgpPeeringAddress != nil {
-		bgpPeeringAddress = *input.BgpPeeringAddress
-	}
-
 	peerWeight := 0
 	if input.PeerWeight != nil {
 		peerWeight = int(*input.PeerWeight)
@@ -490,7 +480,7 @@ func flattenVPNGatewayBGPSettings(input *virtualwans.BgpSettings) []interface{} 
 	return []interface{}{
 		map[string]interface{}{
 			"asn":                            asn,
-			"bgp_peering_address":            bgpPeeringAddress,
+			"bgp_peering_address":            pointer.From(input.BgpPeeringAddress),
 			"instance_0_bgp_peering_address": instance0BgpPeeringAddress,
 			"instance_1_bgp_peering_address": instance1BgpPeeringAddress,
 			"peer_weight":                    peerWeight,
@@ -499,14 +489,9 @@ func flattenVPNGatewayBGPSettings(input *virtualwans.BgpSettings) []interface{} 
 }
 
 func flattenVPNGatewayIPConfigurationBgpPeeringAddress(input virtualwans.IPConfigurationBgpPeeringAddress) []interface{} {
-	ipConfigurationID := ""
-	if input.IPconfigurationId != nil {
-		ipConfigurationID = *input.IPconfigurationId
-	}
-
 	return []interface{}{
 		map[string]interface{}{
-			"ip_configuration_id": ipConfigurationID,
+			"ip_configuration_id": pointer.From(input.IPconfigurationId),
 			"custom_ips":          helpers.FlattenStringSlice(input.CustomBgpIPAddresses),
 			"default_ips":         helpers.FlattenStringSlice(input.DefaultBgpIPAddresses),
 			"tunnel_ips":          helpers.FlattenStringSlice(input.TunnelIPAddresses),

--- a/internal/services/network/vpn_server_configuration_resource.go
+++ b/internal/services/network/vpn_server_configuration_resource.go
@@ -618,26 +618,11 @@ func flattenVpnServerConfigurationAADAuthentication(input *virtualwans.AadAuthen
 		return []interface{}{}
 	}
 
-	audience := ""
-	if input.AadAudience != nil {
-		audience = *input.AadAudience
-	}
-
-	issuer := ""
-	if input.AadIssuer != nil {
-		issuer = *input.AadIssuer
-	}
-
-	tenant := ""
-	if input.AadTenant != nil {
-		tenant = *input.AadTenant
-	}
-
 	return []interface{}{
 		map[string]interface{}{
-			"audience": audience,
-			"issuer":   issuer,
-			"tenant":   tenant,
+			"audience": pointer.From(input.AadAudience),
+			"issuer":   pointer.From(input.AadIssuer),
+			"tenant":   pointer.From(input.AadTenant),
 		},
 	}
 }
@@ -664,19 +649,9 @@ func flattenVpnServerConfigurationClientRootCertificates(input *[]virtualwans.Vp
 	output := make([]interface{}, 0)
 
 	for _, v := range *input {
-		name := ""
-		if v.Name != nil {
-			name = *v.Name
-		}
-
-		publicCertData := ""
-		if v.PublicCertData != nil {
-			publicCertData = *v.PublicCertData
-		}
-
 		output = append(output, map[string]interface{}{
-			"name":             name,
-			"public_cert_data": publicCertData,
+			"name":             pointer.From(v.Name),
+			"public_cert_data": pointer.From(v.PublicCertData),
 		})
 	}
 
@@ -704,19 +679,9 @@ func flattenVpnServerConfigurationClientRevokedCertificates(input *[]virtualwans
 
 	output := make([]interface{}, 0)
 	for _, v := range *input {
-		name := ""
-		if v.Name != nil {
-			name = *v.Name
-		}
-
-		thumbprint := ""
-		if v.Thumbprint != nil {
-			thumbprint = *v.Thumbprint
-		}
-
 		output = append(output, map[string]interface{}{
-			"name":       name,
-			"thumbprint": thumbprint,
+			"name":       pointer.From(v.Name),
+			"thumbprint": pointer.From(v.Thumbprint),
 		})
 	}
 	return output
@@ -831,19 +796,9 @@ func flattenVpnServerConfigurationRadius(input *virtualwans.VpnServerConfigurati
 	clientRootCertificates := make([]interface{}, 0)
 	if input.RadiusClientRootCertificates != nil {
 		for _, v := range *input.RadiusClientRootCertificates {
-			name := ""
-			if v.Name != nil {
-				name = *v.Name
-			}
-
-			thumbprint := ""
-			if v.Thumbprint != nil {
-				thumbprint = *v.Thumbprint
-			}
-
 			clientRootCertificates = append(clientRootCertificates, map[string]interface{}{
-				"name":       name,
-				"thumbprint": thumbprint,
+				"name":       pointer.From(v.Name),
+				"thumbprint": pointer.From(v.Thumbprint),
 			})
 		}
 	}
@@ -851,19 +806,9 @@ func flattenVpnServerConfigurationRadius(input *virtualwans.VpnServerConfigurati
 	serverRootCertificates := make([]interface{}, 0)
 	if input.RadiusServerRootCertificates != nil {
 		for _, v := range *input.RadiusServerRootCertificates {
-			name := ""
-			if v.Name != nil {
-				name = *v.Name
-			}
-
-			publicCertData := ""
-			if v.PublicCertData != nil {
-				publicCertData = *v.PublicCertData
-			}
-
 			serverRootCertificates = append(serverRootCertificates, map[string]interface{}{
-				"name":             name,
-				"public_cert_data": publicCertData,
+				"name":             pointer.From(v.Name),
+				"public_cert_data": pointer.From(v.PublicCertData),
 			})
 		}
 	}

--- a/internal/services/network/vpn_site_resource.go
+++ b/internal/services/network/vpn_site_resource.go
@@ -445,16 +445,6 @@ func flattenVpnSiteLinks(input *[]virtualwans.VpnSiteLink) []interface{} {
 	output := make([]interface{}, 0)
 
 	for _, e := range *input {
-		var name string
-		if e.Name != nil {
-			name = *e.Name
-		}
-
-		id := ""
-		if e.Id != nil {
-			id = *e.Id
-		}
-
 		var (
 			ipAddress        string
 			fqdn             string
@@ -485,8 +475,8 @@ func flattenVpnSiteLinks(input *[]virtualwans.VpnSiteLink) []interface{} {
 		}
 
 		link := map[string]interface{}{
-			"name":          name,
-			"id":            id,
+			"name":          pointer.From(e.Name),
+			"id":            pointer.From(e.Id),
 			"provider_name": linkProviderName,
 			"speed_in_mbps": linkSpeed,
 			"ip_address":    ipAddress,
@@ -523,15 +513,10 @@ func flattenVpnSiteVpnSiteBgpSettings(input *virtualwans.VpnLinkBgpSettings) []i
 		asn = int(*input.Asn)
 	}
 
-	var peerAddress string
-	if input.BgpPeeringAddress != nil {
-		peerAddress = *input.BgpPeeringAddress
-	}
-
 	return []interface{}{
 		map[string]interface{}{
 			"asn":             asn,
-			"peering_address": peerAddress,
+			"peering_address": pointer.From(input.BgpPeeringAddress),
 		},
 	}
 }
@@ -584,26 +569,11 @@ func flattenVpnSiteO365TrafficCategoryPolicy(input *virtualwans.O365BreakOutCate
 		return make([]interface{}, 0)
 	}
 
-	isAllowed := false
-	if input.Allow != nil {
-		isAllowed = *input.Allow
-	}
-
-	isDefault := false
-	if input.Default != nil {
-		isDefault = *input.Default
-	}
-
-	isOptimized := false
-	if input.Optimize != nil {
-		isOptimized = *input.Optimize
-	}
-
 	return []interface{}{
 		map[string]interface{}{
-			"allow_endpoint_enabled":    isAllowed,
-			"default_endpoint_enabled":  isDefault,
-			"optimize_endpoint_enabled": isOptimized,
+			"allow_endpoint_enabled":    pointer.From(input.Allow),
+			"default_endpoint_enabled":  pointer.From(input.Default),
+			"optimize_endpoint_enabled": pointer.From(input.Optimize),
 		},
 	}
 }

--- a/internal/services/policy/policy_set_definition_data_source.go
+++ b/internal/services/policy/policy_set_definition_data_source.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/resources/mgmt/2021-06-01-preview/policy" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/policy/parse"
@@ -223,10 +224,7 @@ func flattenAzureRMPolicySetDefinitionPolicyDefinitionsTrack1(input *[]policy.De
 	}
 
 	for _, definition := range *input {
-		policyDefinitionID := ""
-		if definition.PolicyDefinitionID != nil {
-			policyDefinitionID = *definition.PolicyDefinitionID
-		}
+		policyDefinitionID := pointer.From(definition.PolicyDefinitionID)
 
 		parametersMap := make(map[string]interface{})
 		for k, v := range definition.Parameters {
@@ -241,10 +239,7 @@ func flattenAzureRMPolicySetDefinitionPolicyDefinitionsTrack1(input *[]policy.De
 			return nil, fmt.Errorf("serializing JSON from `parameter_values`: %+v", err)
 		}
 
-		policyDefinitionReference := ""
-		if definition.PolicyDefinitionReferenceID != nil {
-			policyDefinitionReference = *definition.PolicyDefinitionReferenceID
-		}
+		policyDefinitionReference := pointer.From(definition.PolicyDefinitionReferenceID)
 
 		result = append(result, map[string]interface{}{
 			"policy_definition_id": policyDefinitionID,
@@ -263,26 +258,11 @@ func flattenAzureRMPolicySetDefinitionPolicyGroupsTrack1(input *[]policy.Definit
 	}
 
 	for _, group := range *input {
-		name := ""
-		if group.Name != nil {
-			name = *group.Name
-		}
-		displayName := ""
-		if group.DisplayName != nil {
-			displayName = *group.DisplayName
-		}
-		category := ""
-		if group.Category != nil {
-			category = *group.Category
-		}
-		description := ""
-		if group.Description != nil {
-			description = *group.Description
-		}
-		metadataID := ""
-		if group.AdditionalMetadataID != nil {
-			metadataID = *group.AdditionalMetadataID
-		}
+		name := pointer.From(group.Name)
+		displayName := pointer.From(group.DisplayName)
+		category := pointer.From(group.Category)
+		description := pointer.From(group.Description)
+		metadataID := pointer.From(group.AdditionalMetadataID)
 
 		result = append(result, map[string]interface{}{
 			"name":                            name,

--- a/internal/services/policy/policy_virtual_machine_configuration_assignment_resource.go
+++ b/internal/services/policy/policy_virtual_machine_configuration_assignment_resource.go
@@ -279,22 +279,10 @@ func flattenGuestConfigurationAssignment(input *guestconfigurationassignments.Gu
 		return make([]interface{}, 0)
 	}
 
-	var version string
-	if input.Version != nil {
-		version = *input.Version
-	}
-	var assignmentType guestconfigurationassignments.AssignmentType
-	if input.AssignmentType != nil {
-		assignmentType = *input.AssignmentType
-	}
-	var contentHash string
-	if input.ContentHash != nil {
-		contentHash = *input.ContentHash
-	}
-	var contentUri string
-	if input.ContentUri != nil {
-		contentUri = *input.ContentUri
-	}
+	version := pointer.From(input.Version)
+	assignmentType := pointer.From(input.AssignmentType)
+	contentHash := pointer.From(input.ContentHash)
+	contentUri := pointer.From(input.ContentUri)
 	return []interface{}{
 		map[string]interface{}{
 			"assignment_type": string(assignmentType),
@@ -313,14 +301,8 @@ func flattenGuestConfigurationAssignmentConfigurationParameters(input *[]guestco
 	}
 
 	for _, item := range *input {
-		var name string
-		if item.Name != nil {
-			name = *item.Name
-		}
-		var value string
-		if item.Value != nil {
-			value = *item.Value
-		}
+		name := pointer.From(item.Name)
+		value := pointer.From(item.Value)
 		results = append(results, map[string]interface{}{
 			"name":  name,
 			"value": value,

--- a/internal/services/postgres/postgresql_flexible_server_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_resource.go
@@ -1296,18 +1296,9 @@ func flattenArmServerMaintenanceWindow(input *servers.MaintenanceWindow) []inter
 		return make([]interface{}, 0)
 	}
 
-	var dayOfWeek int64
-	if input.DayOfWeek != nil {
-		dayOfWeek = *input.DayOfWeek
-	}
-	var startHour int64
-	if input.StartHour != nil {
-		startHour = *input.StartHour
-	}
-	var startMinute int64
-	if input.StartMinute != nil {
-		startMinute = *input.StartMinute
-	}
+	dayOfWeek := pointer.From(input.DayOfWeek)
+	startHour := pointer.From(input.StartHour)
+	startMinute := pointer.From(input.StartMinute)
 	return []interface{}{
 		map[string]interface{}{
 			"day_of_week":  dayOfWeek,
@@ -1372,10 +1363,7 @@ func flattenFlexibleServerHighAvailability(ha *servers.HighAvailability) []inter
 		return []interface{}{}
 	}
 
-	var zone string
-	if ha.StandbyAvailabilityZone != nil {
-		zone = *ha.StandbyAvailabilityZone
-	}
+	zone := pointer.From(ha.StandbyAvailabilityZone)
 
 	return []interface{}{
 		map[string]interface{}{

--- a/internal/services/privatedns/private_dns_zone_resource.go
+++ b/internal/services/privatedns/private_dns_zone_resource.go
@@ -338,10 +338,7 @@ func flattenPrivateDNSZoneSOARecord(input *privatedns.RecordSet) []interface{} {
 		metaData = tags.Flatten(input.Properties.Metadata)
 	}
 
-	fqdn := ""
-	if input.Properties.Fqdn != nil {
-		fqdn = *input.Properties.Fqdn
-	}
+	fqdn := pointer.From(input.Properties.Fqdn)
 
 	email := ""
 	hostName := ""

--- a/internal/services/recoveryservices/backup_policy_vm_resource.go
+++ b/internal/services/recoveryservices/backup_policy_vm_resource.go
@@ -765,16 +765,10 @@ func flattenBackupProtectionPolicyVMResourceGroup(rpDetail protectionpolicies.In
 
 	block := map[string]interface{}{}
 
-	prefix := ""
-	if rpDetail.AzureBackupRGNamePrefix != nil {
-		prefix = *rpDetail.AzureBackupRGNamePrefix
-	}
+	prefix := pointer.From(rpDetail.AzureBackupRGNamePrefix)
 	block["prefix"] = prefix
 
-	suffix := ""
-	if rpDetail.AzureBackupRGNameSuffix != nil {
-		suffix = *rpDetail.AzureBackupRGNameSuffix
-	}
+	suffix := pointer.From(rpDetail.AzureBackupRGNameSuffix)
 	block["suffix"] = suffix
 
 	return []interface{}{block}

--- a/internal/services/recoveryservices/site_recovery_replicated_vm_resource.go
+++ b/internal/services/recoveryservices/site_recovery_replicated_vm_resource.go
@@ -909,16 +909,10 @@ func resourceSiteRecoveryReplicatedItemRead(d *pluginsdk.ResourceData, meta inte
 					}
 					diskOutput["target_resource_group_id"] = recoveryResourceGroupID
 
-					recoveryReplicaDiskAccountType := ""
-					if disk.RecoveryReplicaDiskAccountType != nil {
-						recoveryReplicaDiskAccountType = *disk.RecoveryReplicaDiskAccountType
-					}
+					recoveryReplicaDiskAccountType := pointer.From(disk.RecoveryReplicaDiskAccountType)
 					diskOutput["target_replica_disk_type"] = recoveryReplicaDiskAccountType
 
-					recoveryTargetDiskAccountType := ""
-					if disk.RecoveryTargetDiskAccountType != nil {
-						recoveryTargetDiskAccountType = *disk.RecoveryTargetDiskAccountType
-					}
+					recoveryTargetDiskAccountType := pointer.From(disk.RecoveryTargetDiskAccountType)
 					diskOutput["target_disk_type"] = recoveryTargetDiskAccountType
 
 					recoveryEncryptionSetId := ""

--- a/internal/services/redis/redis_cache_resource.go
+++ b/internal/services/redis/redis_cache_resource.go
@@ -1159,10 +1159,7 @@ func flattenRedisPatchSchedules(schedule redispatchschedules.RedisPatchSchedule)
 	outputs := make([]interface{}, 0)
 
 	for _, entry := range schedule.Properties.ScheduleEntries {
-		maintenanceWindow := ""
-		if entry.MaintenanceWindow != nil {
-			maintenanceWindow = *entry.MaintenanceWindow
-		}
+		maintenanceWindow := pointer.From(entry.MaintenanceWindow)
 
 		outputs = append(outputs, map[string]interface{}{
 			"day_of_week":        string(entry.DayOfWeek),


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR is part of a series of changes to enable the azproviderlint AZG004 analyzer, which flags the pattern of declaring a variable with its type's zero value and then conditionally overwriting it from a pointer after a nil check.

As a prerequisite to turning the analyzer on repo-wide, this slice migrates all such occurrences in the following services to the equivalent `pointer.From()` helper

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

No functional behavior changes are introduced, so no new test coverage is added. The refactor is verified by go build, go vet, gofmt, and the existing linter/acceptance test suites for the affected services.

## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
