### PR TITLE
Linters - enable azproviderlint AZG004 - Services (Resource - StorageMover)

### DIFF
--- a/internal/services/resource/resources_data_source.go
+++ b/internal/services/resource/resources_data_source.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2020-06-01/resources" // nolint: staticcheck
 	"github.com/google/uuid"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
@@ -162,15 +163,9 @@ func filterResource(inputs []resources.GenericResourceExpanded, requiredTags map
 		}
 
 		if tagMatches == len(requiredTags) {
-			resName := ""
-			if res.Name != nil {
-				resName = *res.Name
-			}
+			resName := pointer.From(res.Name)
 
-			resID := ""
-			if res.ID != nil {
-				resID = *res.ID
-			}
+			resID := pointer.From(res.ID)
 
 			resResourceGroupName := ""
 			if res.ID != nil {
@@ -180,10 +175,7 @@ func filterResource(inputs []resources.GenericResourceExpanded, requiredTags map
 				}
 			}
 
-			resType := ""
-			if res.Type != nil {
-				resType = *res.Type
-			}
+			resType := pointer.From(res.Type)
 
 			resLocation := ""
 			if res.Location != nil {

--- a/internal/services/securitycenter/iot_security_solution_resource.go
+++ b/internal/services/securitycenter/iot_security_solution_resource.go
@@ -524,14 +524,9 @@ func flattenIotSecuritySolutionAdditionalWorkspace(input *[]security.AdditionalW
 		}
 		dataTypes := helpers.FlattenStringSlice(&rawDataTypes)
 
-		var workspaceId string
-		if item.Workspace != nil {
-			workspaceId = *item.Workspace
-		}
-
 		results = append(results, map[string]interface{}{
 			"data_types":   dataTypes,
-			"workspace_id": workspaceId,
+			"workspace_id": pointer.From(item.Workspace),
 		})
 	}
 

--- a/internal/services/sentinel/sentinel_alert_rule.go
+++ b/internal/services/sentinel/sentinel_alert_rule.go
@@ -303,26 +303,6 @@ func flattenAlertRuleAlertDetailsOverride(input *alertrules.AlertDetailsOverride
 		return []interface{}{}
 	}
 
-	var descriptionFormat string
-	if input.AlertDescriptionFormat != nil {
-		descriptionFormat = *input.AlertDescriptionFormat
-	}
-
-	var displayNameFormat string
-	if input.AlertDisplayNameFormat != nil {
-		displayNameFormat = *input.AlertDisplayNameFormat
-	}
-
-	var severityColumnName string
-	if input.AlertSeverityColumnName != nil {
-		severityColumnName = *input.AlertSeverityColumnName
-	}
-
-	var tacticsColumnName string
-	if input.AlertTacticsColumnName != nil {
-		tacticsColumnName = *input.AlertTacticsColumnName
-	}
-
 	var dynamicProperties []interface{}
 	if input.AlertDynamicProperties != nil {
 		dynamicProperties = flattenAlertRuleAlertDynamicProperties(input.AlertDynamicProperties)
@@ -330,10 +310,10 @@ func flattenAlertRuleAlertDetailsOverride(input *alertrules.AlertDetailsOverride
 
 	return []interface{}{
 		map[string]interface{}{
-			"description_format":   descriptionFormat,
-			"display_name_format":  displayNameFormat,
-			"severity_column_name": severityColumnName,
-			"tactics_column_name":  tacticsColumnName,
+			"description_format":   pointer.From(input.AlertDescriptionFormat),
+			"display_name_format":  pointer.From(input.AlertDisplayNameFormat),
+			"severity_column_name": pointer.From(input.AlertSeverityColumnName),
+			"tactics_column_name":  pointer.From(input.AlertTacticsColumnName),
 			"dynamic_property":     dynamicProperties,
 		},
 	}
@@ -439,19 +419,9 @@ func flattenAlertRuleFieldMapping(input *[]alertrules.FieldMapping) []interface{
 
 	output := make([]interface{}, 0, len(*input))
 	for _, e := range *input {
-		var identifier string
-		if e.Identifier != nil {
-			identifier = *e.Identifier
-		}
-
-		var columnName string
-		if e.ColumnName != nil {
-			columnName = *e.ColumnName
-		}
-
 		output = append(output, map[string]interface{}{
-			"identifier":  identifier,
-			"column_name": columnName,
+			"identifier":  pointer.From(e.Identifier),
+			"column_name": pointer.From(e.ColumnName),
 		})
 	}
 
@@ -481,13 +451,8 @@ func flattenAlertRuleSentinelEntityMapping(input *[]alertrules.SentinelEntityMap
 
 	output := make([]interface{}, 0, len(*input))
 	for _, e := range *input {
-		var columnName string
-		if e.ColumnName != nil {
-			columnName = *e.ColumnName
-		}
-
 		output = append(output, map[string]interface{}{
-			"column_name": columnName,
+			"column_name": pointer.From(e.ColumnName),
 		})
 	}
 

--- a/internal/services/servicebus/servicebus_namespace_resource.go
+++ b/internal/services/servicebus/servicebus_namespace_resource.go
@@ -764,17 +764,12 @@ func flattenServiceBusNamespaceNetworkRuleSet(networkRuleSet namespaces.NetworkR
 		publicNetworkAccess = *v
 	}
 
-	trustedServiceEnabled := false
-	if networkRuleSet.TrustedServiceAccessEnabled != nil {
-		trustedServiceEnabled = *networkRuleSet.TrustedServiceAccessEnabled
-	}
-
 	networkRules := flattenServiceBusNamespaceVirtualNetworkRules(networkRuleSet.VirtualNetworkRules)
 	ipRules := flattenServiceBusNamespaceIPRules(networkRuleSet.IPRules)
 
 	return []interface{}{map[string]interface{}{
 		"default_action":                defaultAction,
-		"trusted_services_allowed":      trustedServiceEnabled,
+		"trusted_services_allowed":      pointer.From(networkRuleSet.TrustedServiceAccessEnabled),
 		"public_network_access_enabled": publicNetworkAccess == namespaces.PublicNetworkAccessFlagEnabled,
 		"network_rules":                 pluginsdk.NewSet(networkRuleHash, networkRules),
 		"ip_rules":                      ipRules,
@@ -820,14 +815,9 @@ func flattenServiceBusNamespaceVirtualNetworkRules(input *[]namespaces.NWRuleSet
 			subnetId = v.Subnet.Id
 		}
 
-		ignore := false
-		if v.IgnoreMissingVnetServiceEndpoint != nil {
-			ignore = *v.IgnoreMissingVnetServiceEndpoint
-		}
-
 		result = append(result, map[string]interface{}{
 			"subnet_id":                            subnetId,
-			"ignore_missing_vnet_service_endpoint": ignore,
+			"ignore_missing_vnet_service_endpoint": pointer.From(v.IgnoreMissingVnetServiceEndpoint),
 		})
 	}
 

--- a/internal/services/serviceconnector/helper.go
+++ b/internal/services/serviceconnector/helper.go
@@ -383,14 +383,9 @@ func flattenTargetService(input servicelinker.TargetServiceBase) string {
 }
 
 func flattenSecretStore(input servicelinker.SecretStore) []SecretStoreModel {
-	var keyVaultId string
-	if input.KeyVaultId != nil {
-		keyVaultId = *input.KeyVaultId
-	}
-
 	return []SecretStoreModel{
 		{
-			KeyVaultId: keyVaultId,
+			KeyVaultId: pointer.From(input.KeyVaultId),
 		},
 	}
 }

--- a/internal/services/signalr/signalr_service_resource.go
+++ b/internal/services/signalr/signalr_service_resource.go
@@ -285,15 +285,9 @@ func resourceArmSignalRServiceFlatten(d *pluginsdk.ResourceData, id *signalr.Sig
 
 			if props.ResourceLogConfiguration != nil && props.ResourceLogConfiguration.Categories != nil {
 				for _, item := range *props.ResourceLogConfiguration.Categories {
-					name := ""
-					if item.Name != nil {
-						name = *item.Name
-					}
+					name := pointer.From(item.Name)
 
-					var cateEnabled string
-					if item.Enabled != nil {
-						cateEnabled = *item.Enabled
-					}
+					cateEnabled := pointer.From(item.Enabled)
 
 					switch name {
 					case "MessagingLogs":
@@ -762,15 +756,9 @@ func flattenSignalRLiveTraceConfig(input *signalr.LiveTraceConfiguration) []inte
 
 	if input.Categories != nil {
 		for _, item := range *input.Categories {
-			name := ""
-			if item.Name != nil {
-				name = *item.Name
-			}
+			name := pointer.From(item.Name)
 
-			var cateEnabled string
-			if item.Enabled != nil {
-				cateEnabled = *item.Enabled
-			}
+			cateEnabled := pointer.From(item.Enabled)
 
 			switch name {
 			case "MessagingLogs":

--- a/internal/services/signalr/web_pubsub_hub_resource.go
+++ b/internal/services/signalr/web_pubsub_hub_resource.go
@@ -313,11 +313,6 @@ func flattenEventHandler(input *[]webpubsub.EventHandler) []interface{} {
 	}
 
 	for _, item := range *input {
-		userEventPatten := ""
-		if item.UserEventPattern != nil {
-			userEventPatten = *item.UserEventPattern
-		}
-
 		sysEvents := make([]interface{}, 0)
 		if item.SystemEvents != nil {
 			sysEvents = helpers.FlattenStringSlice(item.SystemEvents)
@@ -330,7 +325,7 @@ func flattenEventHandler(input *[]webpubsub.EventHandler) []interface{} {
 
 		eventHandlerBlock = append(eventHandlerBlock, map[string]interface{}{
 			"url_template":       item.UrlTemplate,
-			"user_event_pattern": userEventPatten,
+			"user_event_pattern": pointer.From(item.UserEventPattern),
 			"system_events":      sysEvents,
 			"auth":               authBlock,
 		})

--- a/internal/services/signalr/web_pubsub_resource.go
+++ b/internal/services/signalr/web_pubsub_resource.go
@@ -389,15 +389,9 @@ func flattenLiveTraceConfig(input *webpubsub.LiveTraceConfiguration) []interface
 
 	if input.Categories != nil {
 		for _, item := range *input.Categories {
-			name := ""
-			if item.Name != nil {
-				name = *item.Name
-			}
+			name := pointer.From(item.Name)
 
-			var cateEnabled string
-			if item.Enabled != nil {
-				cateEnabled = *item.Enabled
-			}
+			cateEnabled := pointer.From(item.Enabled)
 
 			switch name {
 			case "MessagingLogs":

--- a/internal/services/springcloud/spring_cloud_app_resource.go
+++ b/internal/services/springcloud/spring_cloud_app_resource.go
@@ -546,15 +546,10 @@ func flattenSpringCloudAppPersistentDisk(input *appplatform.PersistentDisk) []in
 		sizeInGB = int(*input.SizeInGB)
 	}
 
-	mountPath := ""
-	if input.MountPath != nil {
-		mountPath = *input.MountPath
-	}
-
 	return []interface{}{
 		map[string]interface{}{
 			"size_in_gb": sizeInGB,
-			"mount_path": mountPath,
+			"mount_path": pointer.From(input.MountPath),
 		},
 	}
 }

--- a/internal/services/springcloud/spring_cloud_builder_resource.go
+++ b/internal/services/springcloud/spring_cloud_builder_resource.go
@@ -250,12 +250,8 @@ func flattenBuildServiceBuilderBuildPacksGroupPropertiesArray(input *[]appplatfo
 	}
 
 	for _, item := range *input {
-		var name string
-		if item.Name != nil {
-			name = *item.Name
-		}
 		results = append(results, map[string]interface{}{
-			"name":           name,
+			"name":           pointer.From(item.Name),
 			"build_pack_ids": flattenBuildServiceBuilderBuildPackPropertiesArray(item.Buildpacks),
 		})
 	}
@@ -267,18 +263,10 @@ func flattenBuildServiceBuilderStackProperties(input *appplatform.StackPropertie
 		return make([]interface{}, 0)
 	}
 
-	var id string
-	if input.ID != nil {
-		id = *input.ID
-	}
-	var version string
-	if input.Version != nil {
-		version = *input.Version
-	}
 	return []interface{}{
 		map[string]interface{}{
-			"id":      id,
-			"version": version,
+			"id":      pointer.From(input.ID),
+			"version": pointer.From(input.Version),
 		},
 	}
 }
@@ -290,11 +278,7 @@ func flattenBuildServiceBuilderBuildPackPropertiesArray(input *[]appplatform.Bui
 	}
 
 	for _, item := range *input {
-		var id string
-		if item.ID != nil {
-			id = *item.ID
-		}
-		results = append(results, id)
+		results = append(results, pointer.From(item.ID))
 	}
 	return results
 }

--- a/internal/services/springcloud/spring_cloud_configuration_service_resource.go
+++ b/internal/services/springcloud/spring_cloud_configuration_service_resource.go
@@ -409,10 +409,7 @@ func flattenConfigurationServiceConfigurationServiceGitRepositoryArray(input *[]
 	}
 
 	for _, item := range *input {
-		var strictHostKeyChecking bool
-		if item.StrictHostKeyChecking != nil {
-			strictHostKeyChecking = *item.StrictHostKeyChecking
-		}
+		strictHostKeyChecking := pointer.From(item.StrictHostKeyChecking)
 
 		var hostKey string
 		var hostKeyAlgorithm string

--- a/internal/services/springcloud/spring_cloud_customized_accelerator_resource.go
+++ b/internal/services/springcloud/spring_cloud_customized_accelerator_resource.go
@@ -515,44 +515,19 @@ func flattenSpringCloudCustomizedAcceleratorGitRepository(state []GitRepositoryM
 		sshAuth = append(sshAuth, sshAuthState)
 	}
 
-	branch := ""
-	if input.Branch != nil {
-		branch = *input.Branch
-	}
-
-	commit := ""
-	if input.Commit != nil {
-		commit = *input.Commit
-	}
-
-	gitTag := ""
-	if input.GitTag != nil {
-		gitTag = *input.GitTag
-	}
-
-	var intervalInSeconds int64
-	if input.IntervalInSeconds != nil {
-		intervalInSeconds = *input.IntervalInSeconds
-	}
-
-	subPath := ""
-	if input.SubPath != nil {
-		subPath = *input.SubPath
-	}
-
 	url := input.Url
 
 	return []GitRepositoryModel{
 		{
 			BasicAuth:         basicAuth,
 			SshAuth:           sshAuth,
-			Branch:            branch,
+			Branch:            pointer.From(input.Branch),
 			CaCertificateId:   caCertificateId,
-			Commit:            commit,
-			GitTag:            gitTag,
-			IntervalInSeconds: intervalInSeconds,
+			Commit:            pointer.From(input.Commit),
+			GitTag:            pointer.From(input.GitTag),
+			IntervalInSeconds: pointer.From(input.IntervalInSeconds),
 			Url:               url,
-			Path:              subPath,
+			Path:              pointer.From(input.SubPath),
 		},
 	}
 }

--- a/internal/services/springcloud/spring_cloud_dev_tool_portal_resource.go
+++ b/internal/services/springcloud/spring_cloud_dev_tool_portal_resource.go
@@ -341,19 +341,9 @@ func flattenSpringCloudDevToolPortalSsoProperties(properties *appplatform.DevToo
 		return []SsoModel{}
 	}
 
-	clientId := ""
-	if properties.ClientID != nil {
-		clientId = *properties.ClientID
-	}
-
 	clientSecret := ""
 	if len(model.Sso) != 0 {
 		clientSecret = model.Sso[0].ClientSecret
-	}
-
-	metadataUrl := ""
-	if properties.MetadataURL != nil {
-		metadataUrl = *properties.MetadataURL
 	}
 
 	scopes := make([]string, 0)
@@ -363,9 +353,9 @@ func flattenSpringCloudDevToolPortalSsoProperties(properties *appplatform.DevToo
 
 	return []SsoModel{
 		{
-			ClientId:     clientId,
+			ClientId:     pointer.From(properties.ClientID),
 			ClientSecret: clientSecret,
-			MetadataUrl:  metadataUrl,
+			MetadataUrl:  pointer.From(properties.MetadataURL),
 			Scope:        scopes,
 		},
 	}

--- a/internal/services/springcloud/spring_cloud_gateway_resource.go
+++ b/internal/services/springcloud/spring_cloud_gateway_resource.go
@@ -863,10 +863,7 @@ func flattenGatewaySsoProperties(input *appplatform.SsoProperties, old []Gateway
 		oldItems[item.IssuerUri] = item
 	}
 
-	var issuerUri string
-	if input.IssuerUri != nil {
-		issuerUri = *input.IssuerUri
-	}
+	issuerUri := pointer.From(input.IssuerUri)
 	var clientId string
 	var clientSecret string
 	if oldItem, ok := oldItems[issuerUri]; ok {

--- a/internal/services/springcloud/spring_cloud_gateway_route_config_resource.go
+++ b/internal/services/springcloud/spring_cloud_gateway_route_config_resource.go
@@ -347,39 +347,15 @@ func flattenGatewayRouteConfigGatewayAPIRouteArray(input *[]appplatform.GatewayA
 	}
 
 	for _, item := range *input {
-		var description string
-		if item.Description != nil {
-			description = *item.Description
-		}
-		var order int32
-		if item.Order != nil {
-			order = *item.Order
-		}
-		var ssoEnabled bool
-		if item.SsoEnabled != nil {
-			ssoEnabled = *item.SsoEnabled
-		}
-		var title string
-		if item.Title != nil {
-			title = *item.Title
-		}
-		var tokenRelay bool
-		if item.TokenRelay != nil {
-			tokenRelay = *item.TokenRelay
-		}
-		var uri string
-		if item.URI != nil {
-			uri = *item.URI
-		}
 		results = append(results, map[string]interface{}{
-			"description":            description,
+			"description":            pointer.From(item.Description),
 			"filters":                helpers.FlattenStringSlice(item.Filters),
-			"order":                  order,
+			"order":                  pointer.From(item.Order),
 			"predicates":             helpers.FlattenStringSlice(item.Predicates),
-			"sso_validation_enabled": ssoEnabled,
-			"title":                  title,
-			"token_relay":            tokenRelay,
-			"uri":                    uri,
+			"sso_validation_enabled": pointer.From(item.SsoEnabled),
+			"title":                  pointer.From(item.Title),
+			"token_relay":            pointer.From(item.TokenRelay),
+			"uri":                    pointer.From(item.URI),
 			"classification_tags":    helpers.FlattenStringSlice(item.Tags),
 		})
 	}
@@ -402,14 +378,9 @@ func flattenGatewayRouteConfigOpenApi(input *appplatform.GatewayRouteConfigOpenA
 		return []interface{}{}
 	}
 
-	uri := ""
-	if input.URI != nil {
-		uri = *input.URI
-	}
-
 	return []interface{}{
 		map[string]interface{}{
-			"uri": uri,
+			"uri": pointer.From(input.URI),
 		},
 	}
 }

--- a/internal/services/springcloud/spring_cloud_java_deployment_resource.go
+++ b/internal/services/springcloud/spring_cloud_java_deployment_resource.go
@@ -305,20 +305,10 @@ func flattenSpringCloudDeploymentResourceRequests(input *appplatform.ResourceReq
 		return []interface{}{}
 	}
 
-	cpu := ""
-	if input.CPU != nil {
-		cpu = *input.CPU
-	}
-
-	memory := ""
-	if input.Memory != nil {
-		memory = *input.Memory
-	}
-
 	return []interface{}{
 		map[string]interface{}{
-			"cpu":    cpu,
-			"memory": memory,
+			"cpu":    pointer.From(input.CPU),
+			"memory": pointer.From(input.Memory),
 		},
 	}
 }

--- a/internal/services/springcloud/spring_cloud_service_resource.go
+++ b/internal/services/springcloud/spring_cloud_service_resource.go
@@ -1125,15 +1125,9 @@ func flattenSpringCloudConfigServerGitProperty(input *appplatform.ConfigServerPr
 		oldGitSetting = oldGitSettings[0].(map[string]interface{})
 	}
 
-	uri := ""
-	if gitProperty.URI != nil {
-		uri = *gitProperty.URI
-	}
+	uri := pointer.From(gitProperty.URI)
 
-	label := ""
-	if gitProperty.Label != nil {
-		label = *gitProperty.Label
-	}
+	label := pointer.From(gitProperty.Label)
 
 	searchPaths := helpers.FlattenStringSlice(gitProperty.SearchPaths)
 
@@ -1177,10 +1171,7 @@ func flattenSpringCloudConfigServerGitProperty(input *appplatform.ConfigServerPr
 			}
 		}
 
-		strictHostKeyChecking := false
-		if gitProperty.StrictHostKeyChecking != nil {
-			strictHostKeyChecking = *gitProperty.StrictHostKeyChecking
-		}
+		strictHostKeyChecking := pointer.From(gitProperty.StrictHostKeyChecking)
 
 		sshAuth = []interface{}{
 			map[string]interface{}{
@@ -1223,20 +1214,11 @@ func flattenSpringCloudGitPatternRepository(input *[]appplatform.GitPatternRepos
 	}
 
 	for _, item := range *input {
-		name := ""
-		if item.Name != nil {
-			name = *item.Name
-		}
+		name := pointer.From(item.Name)
 
-		uri := ""
-		if item.URI != nil {
-			uri = *item.URI
-		}
+		uri := pointer.From(item.URI)
 
-		label := ""
-		if item.Label != nil {
-			label = *item.Label
-		}
+		label := pointer.From(item.Label)
 
 		// prepare old state to find sensitive props not returned by API.
 		oldGitPatternRepository := make(map[string]interface{})
@@ -1287,10 +1269,7 @@ func flattenSpringCloudGitPatternRepository(input *[]appplatform.GitPatternRepos
 				}
 			}
 
-			strictHostKeyChecking := false
-			if item.StrictHostKeyChecking != nil {
-				strictHostKeyChecking = *item.StrictHostKeyChecking
-			}
+			strictHostKeyChecking := pointer.From(item.StrictHostKeyChecking)
 
 			sshAuth = []interface{}{
 				map[string]interface{}{
@@ -1414,10 +1393,7 @@ func flattenRequiredTraffic(input *appplatform.NetworkProfile) []interface{} {
 
 	result := make([]interface{}, 0)
 	for _, v := range *input.RequiredTraffics {
-		protocol := ""
-		if v.Protocol != nil {
-			protocol = *v.Protocol
-		}
+		protocol := pointer.From(v.Protocol)
 
 		port := 0
 		if v.Port != nil {

--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -1879,17 +1879,9 @@ func resourceStorageAccountFlatten(ctx context.Context, d *pluginsdk.ResourceDat
 
 		// NOTE: The Storage API returns `null` rather than the default value in the API response for existing
 		// resources when a new field gets added - meaning we need to default the values below.
-		allowBlobPublicAccess := false
-		if props.AllowBlobPublicAccess != nil {
-			allowBlobPublicAccess = *props.AllowBlobPublicAccess
-		}
-		d.Set("allow_nested_items_to_be_public", allowBlobPublicAccess)
+		d.Set("allow_nested_items_to_be_public", pointer.From(props.AllowBlobPublicAccess))
 
-		defaultToOAuthAuthentication := false
-		if props.DefaultToOAuthAuthentication != nil {
-			defaultToOAuthAuthentication = *props.DefaultToOAuthAuthentication
-		}
-		d.Set("default_to_oauth_authentication", defaultToOAuthAuthentication)
+		d.Set("default_to_oauth_authentication", pointer.From(props.DefaultToOAuthAuthentication))
 
 		dnsEndpointType := storageaccounts.DnsEndpointTypeStandard
 		if props.DnsEndpointType != nil {
@@ -2540,10 +2532,7 @@ func flattenAccountBlobServiceProperties(input *blobservices.BlobServiceProperti
 		}
 	}
 
-	var defaultServiceVersion string
-	if input.Properties.DefaultServiceVersion != nil {
-		defaultServiceVersion = *input.Properties.DefaultServiceVersion
-	}
+	defaultServiceVersion := pointer.From(input.Properties.DefaultServiceVersion)
 
 	var LastAccessTimeTrackingPolicy bool
 	if v := input.Properties.LastAccessTimeTrackingPolicy; v != nil {
@@ -2595,14 +2584,9 @@ func flattenAccountBlobDeleteRetentionPolicy(input *blobservices.DeleteRetention
 			days = int(*input.Days)
 		}
 
-		var permanentDeleteEnabled bool
-		if input.AllowPermanentDelete != nil {
-			permanentDeleteEnabled = *input.AllowPermanentDelete
-		}
-
 		deleteRetentionPolicy = append(deleteRetentionPolicy, map[string]interface{}{
 			"days":                     days,
-			"permanent_delete_enabled": permanentDeleteEnabled,
+			"permanent_delete_enabled": pointer.From(input.AllowPermanentDelete),
 		})
 	}
 

--- a/internal/services/storage/storage_blob_inventory_policy_resource.go
+++ b/internal/services/storage/storage_blob_inventory_policy_resource.go
@@ -361,24 +361,12 @@ func flattenBlobInventoryPolicyFilter(input *blobinventorypolicies.BlobInventory
 		return make([]interface{}, 0)
 	}
 
-	var includeBlobVersions bool
-	if input.IncludeBlobVersions != nil {
-		includeBlobVersions = *input.IncludeBlobVersions
-	}
-	var includeDeleted bool
-	if input.IncludeDeleted != nil {
-		includeDeleted = *input.IncludeDeleted
-	}
-	var includeSnapshots bool
-	if input.IncludeSnapshots != nil {
-		includeSnapshots = *input.IncludeSnapshots
-	}
 	return []interface{}{
 		map[string]interface{}{
 			"blob_types":            helpers.FlattenStringSlice(input.BlobTypes),
-			"include_blob_versions": includeBlobVersions,
-			"include_deleted":       includeDeleted,
-			"include_snapshots":     includeSnapshots,
+			"include_blob_versions": pointer.From(input.IncludeBlobVersions),
+			"include_deleted":       pointer.From(input.IncludeDeleted),
+			"include_snapshots":     pointer.From(input.IncludeSnapshots),
 			"prefix_match":          helpers.FlattenStringSlice(input.PrefixMatch),
 			"exclude_prefixes":      helpers.FlattenStringSlice(input.ExcludePrefix),
 		},

--- a/internal/services/storage/storage_containers_data_source.go
+++ b/internal/services/storage/storage_containers_data_source.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2025-08-01/blobservices"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
@@ -141,23 +142,15 @@ func (r storageContainersDataSource) Read() sdk.ResourceFunc {
 func flattenStorageContainersContainers(l []blobservices.ListContainerItem, accountId accounts.AccountId, prefix string) []containerModel {
 	output := make([]containerModel, 0, len(l))
 	for _, item := range l {
-		var name string
-		if item.Name != nil {
-			name = *item.Name
-		}
+		name := pointer.From(item.Name)
 
 		if prefix != "" && !strings.HasPrefix(name, prefix) {
 			continue
 		}
 
-		var mgmtId string
-		if item.Id != nil {
-			mgmtId = *item.Id
-		}
-
 		output = append(output, containerModel{
 			Name:              name,
-			ResourceManagerId: mgmtId,
+			ResourceManagerId: pointer.From(item.Id),
 			DataPlaneId:       containers.NewContainerID(accountId, name).ID(),
 		})
 	}

--- a/internal/services/storage/storage_object_replication_resource.go
+++ b/internal/services/storage/storage_object_replication_resource.go
@@ -368,10 +368,7 @@ func flattenObjectReplicationRules(input *[]objectreplicationpolicyoperationgrou
 		destinationContainer := item.DestinationContainer
 		sourceContainer := item.SourceContainer
 
-		var ruleId string
-		if item.RuleId != nil {
-			ruleId = *item.RuleId
-		}
+		ruleId := pointer.From(item.RuleId)
 
 		var minCreationTime string
 		if item.Filters != nil && item.Filters.MinCreationTime != nil {

--- a/internal/services/storagemover/storage_mover_source_endpoint_resource.go
+++ b/internal/services/storagemover/storage_mover_source_endpoint_resource.go
@@ -248,11 +248,7 @@ func (r StorageMoverSourceEndpointResource) flatten(metadata sdk.ResourceMetaDat
 				state.NfsVersion = *v
 			}
 
-			description := ""
-			if v.Description != nil {
-				description = *v.Description
-			}
-			state.Description = description
+			state.Description = pointer.From(v.Description)
 		}
 	}
 


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR is part of a series of changes to enable the azproviderlint AZG004 analyzer, which flags the pattern of declaring a variable with its type's zero value and then conditionally overwriting it from a pointer after a nil check.

As a prerequisite to turning the analyzer on repo-wide, this slice migrates all such occurrences in the following services to the equivalent `pointer.From()` helper

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

No functional behavior changes are introduced, so no new test coverage is added. The refactor is verified by go build, go vet, gofmt, and the existing linter/acceptance test suites for the affected services.

## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
