### PR TITLE
Linters - enable azproviderlint AZG004 - Services (Streamanalytics - Synapse)

### DIFF
--- a/internal/services/streamanalytics/stream_analytics_cluster_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_cluster_resource.go
@@ -149,11 +149,7 @@ func (r ClusterResource) Read() sdk.ResourceFunc {
 				state.Location = *model.Location
 				state.Tags = tags.Flatten(model.Tags)
 
-				var capacity int64
-				if v := model.Sku.Capacity; v != nil {
-					capacity = *v
-				}
-				state.StreamingCapacity = capacity
+				state.StreamingCapacity = pointer.From(model.Sku.Capacity)
 			}
 
 			return metadata.Encode(&state)

--- a/internal/services/streamanalytics/stream_analytics_function_javascript_uda_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_function_javascript_uda_resource.go
@@ -206,11 +206,7 @@ func resourceStreamAnalyticsFunctionUDARead(d *pluginsdk.ResourceData, meta inte
 
 			binding := function.Properties.Binding.(functions.JavaScriptFunctionBinding)
 
-			script := ""
-			if v := binding.Properties.Script; v != nil {
-				script = *v
-			}
-			d.Set("script", script)
+			d.Set("script", pointer.From(binding.Properties.Script))
 
 			if err := d.Set("input", flattenStreamAnalyticsFunctionUDAInputs(function.Properties.Inputs)); err != nil {
 				return fmt.Errorf("flattening `input`: %+v", err)
@@ -298,15 +294,9 @@ func flattenStreamAnalyticsFunctionUDAInputs(input *[]functions.FunctionInput) [
 	outputs := make([]interface{}, 0)
 
 	for _, v := range *input {
-		var variableType string
-		if v.DataType != nil {
-			variableType = *v.DataType
-		}
+		variableType := pointer.From(v.DataType)
 
-		var isConfigurationParameter bool
-		if v.IsConfigurationParameter != nil {
-			isConfigurationParameter = *v.IsConfigurationParameter
-		}
+		isConfigurationParameter := pointer.From(v.IsConfigurationParameter)
 
 		outputs = append(outputs, map[string]interface{}{
 			"type":                    variableType,
@@ -331,10 +321,7 @@ func flattenStreamAnalyticsFunctionUDAOutput(input *functions.FunctionOutput) []
 		return []interface{}{}
 	}
 
-	var variableType string
-	if input.DataType != nil {
-		variableType = *input.DataType
-	}
+	variableType := pointer.From(input.DataType)
 
 	return []interface{}{
 		map[string]interface{}{

--- a/internal/services/streamanalytics/stream_analytics_function_javascript_udf_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_function_javascript_udf_resource.go
@@ -214,11 +214,7 @@ func resourceStreamAnalyticsFunctionUDFRead(d *pluginsdk.ResourceData, meta inte
 				return fmt.Errorf("converting to Binding")
 			}
 
-			script := ""
-			if v := binding.Properties.Script; v != nil {
-				script = *v
-			}
-			d.Set("script", script)
+			d.Set("script", pointer.From(binding.Properties.Script))
 
 			if err := d.Set("input", flattenStreamAnalyticsFunctionInputs(function.Properties.Inputs)); err != nil {
 				return fmt.Errorf("flattening `input`: %+v", err)
@@ -274,15 +270,9 @@ func flattenStreamAnalyticsFunctionInputs(input *[]functions.FunctionInput) []in
 	outputs := make([]interface{}, 0)
 
 	for _, v := range *input {
-		var variableType string
-		if v.DataType != nil {
-			variableType = *v.DataType
-		}
+		variableType := pointer.From(v.DataType)
 
-		var isConfigurationParameter bool
-		if v.IsConfigurationParameter != nil {
-			isConfigurationParameter = *v.IsConfigurationParameter
-		}
+		isConfigurationParameter := pointer.From(v.IsConfigurationParameter)
 
 		outputs = append(outputs, map[string]interface{}{
 			"type":                    variableType,
@@ -307,10 +297,7 @@ func flattenStreamAnalyticsFunctionOutput(input *functions.FunctionOutput) []int
 		return []interface{}{}
 	}
 
-	var variableType string
-	if input.DataType != nil {
-		variableType = *input.DataType
-	}
+	variableType := pointer.From(input.DataType)
 
 	return []interface{}{
 		map[string]interface{}{

--- a/internal/services/streamanalytics/stream_analytics_job_data_source.go
+++ b/internal/services/streamanalytics/stream_analytics_job_data_source.go
@@ -147,23 +147,11 @@ func dataSourceStreamAnalyticsJobRead(d *pluginsdk.ResourceData, meta interface{
 			}
 			d.Set("compatibility_level", compatibilityLevel)
 
-			dataLocale := ""
-			if v := props.DataLocale; v != nil {
-				dataLocale = *v
-			}
-			d.Set("data_locale", dataLocale)
+			d.Set("data_locale", pointer.From(props.DataLocale))
 
-			var lateArrival int64
-			if v := props.EventsLateArrivalMaxDelayInSeconds; v != nil {
-				lateArrival = *v
-			}
-			d.Set("events_late_arrival_max_delay_in_seconds", lateArrival)
+			d.Set("events_late_arrival_max_delay_in_seconds", pointer.From(props.EventsLateArrivalMaxDelayInSeconds))
 
-			var maxDelay int64
-			if v := props.EventsLateArrivalMaxDelayInSeconds; v != nil {
-				maxDelay = *v
-			}
-			d.Set("events_out_of_order_max_delay_in_seconds", maxDelay)
+			d.Set("events_out_of_order_max_delay_in_seconds", pointer.From(props.EventsLateArrivalMaxDelayInSeconds))
 
 			orderPolicy := ""
 			if v := props.EventsOutOfOrderPolicy; v != nil {
@@ -177,17 +165,9 @@ func dataSourceStreamAnalyticsJobRead(d *pluginsdk.ResourceData, meta interface{
 			}
 			d.Set("output_error_policy", outputPolicy)
 
-			lastOutputTime := ""
-			if v := props.LastOutputEventTime; v != nil {
-				lastOutputTime = *v
-			}
-			d.Set("last_output_time", lastOutputTime)
+			d.Set("last_output_time", pointer.From(props.LastOutputEventTime))
 
-			startTime := ""
-			if v := props.OutputStartTime; v != nil {
-				startTime = *v
-			}
-			d.Set("start_time", startTime)
+			d.Set("start_time", pointer.From(props.OutputStartTime))
 
 			startMode := ""
 			if v := props.OutputStartMode; v != nil {
@@ -195,11 +175,7 @@ func dataSourceStreamAnalyticsJobRead(d *pluginsdk.ResourceData, meta interface{
 			}
 			d.Set("start_mode", startMode)
 
-			jobId := ""
-			if v := props.JobId; v != nil {
-				jobId = *v
-			}
-			d.Set("job_id", jobId)
+			d.Set("job_id", pointer.From(props.JobId))
 
 			sku := ""
 			if props.Sku != nil && props.Sku.Name != nil {
@@ -208,17 +184,9 @@ func dataSourceStreamAnalyticsJobRead(d *pluginsdk.ResourceData, meta interface{
 			d.Set("sku_name", sku)
 
 			if props.Transformation != nil && props.Transformation.Properties != nil {
-				var streamingUnits int64
-				if v := props.Transformation.Properties.StreamingUnits; v != nil {
-					streamingUnits = *v
-				}
-				d.Set("streaming_units", streamingUnits)
+				d.Set("streaming_units", pointer.From(props.Transformation.Properties.StreamingUnits))
 
-				query := ""
-				if v := props.Transformation.Properties.Query; v != nil {
-					query = *v
-				}
-				d.Set("transformation_query", query)
+				d.Set("transformation_query", pointer.From(props.Transformation.Properties.Query))
 			}
 		}
 	}

--- a/internal/services/streamanalytics/stream_analytics_job_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_job_resource.go
@@ -593,10 +593,7 @@ func flattenJobStorageAccount(d *pluginsdk.ResourceData, input *streamingjobs.Jo
 		return []interface{}{}
 	}
 
-	accountName := ""
-	if v := input.AccountName; v != nil {
-		accountName = *v
-	}
+	accountName := pointer.From(input.AccountName)
 
 	return []interface{}{
 		map[string]interface{}{

--- a/internal/services/streamanalytics/stream_analytics_job_schedule_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_job_schedule_resource.go
@@ -168,15 +168,9 @@ func (r JobScheduleResource) Read() sdk.ResourceFunc {
 
 			if model := resp.Model; model != nil {
 				if props := model.Properties; props != nil {
-					startTime := ""
-					if v := props.OutputStartTime; v != nil {
-						startTime = *v
-					}
+					startTime := pointer.From(props.OutputStartTime)
 
-					lastOutputTime := ""
-					if v := props.LastOutputEventTime; v != nil {
-						lastOutputTime = *v
-					}
+					lastOutputTime := pointer.From(props.LastOutputEventTime)
 
 					startMode := ""
 					if v := props.OutputStartMode; v != nil {

--- a/internal/services/streamanalytics/stream_analytics_output_blob_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_output_blob_resource.go
@@ -250,29 +250,13 @@ func resourceStreamAnalyticsOutputBlobRead(d *pluginsdk.ResourceData, meta inter
 				return fmt.Errorf("converting %s to a Blob Output", *id)
 			}
 
-			dateFormat := ""
-			if v := output.Properties.DateFormat; v != nil {
-				dateFormat = *v
-			}
-			d.Set("date_format", dateFormat)
+			d.Set("date_format", pointer.From(output.Properties.DateFormat))
 
-			pathPattern := ""
-			if v := output.Properties.PathPattern; v != nil {
-				pathPattern = *v
-			}
-			d.Set("path_pattern", pathPattern)
+			d.Set("path_pattern", pointer.From(output.Properties.PathPattern))
 
-			containerName := ""
-			if v := output.Properties.Container; v != nil {
-				containerName = *v
-			}
-			d.Set("storage_container_name", containerName)
+			d.Set("storage_container_name", pointer.From(output.Properties.Container))
 
-			timeFormat := ""
-			if v := output.Properties.TimeFormat; v != nil {
-				timeFormat = *v
-			}
-			d.Set("time_format", timeFormat)
+			d.Set("time_format", pointer.From(output.Properties.TimeFormat))
 
 			authenticationMode := ""
 			if v := output.Properties.AuthenticationMode; v != nil {

--- a/internal/services/streamanalytics/stream_analytics_output_cosmosdb_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_output_cosmosdb_resource.go
@@ -210,23 +210,11 @@ func (r OutputCosmosDBResource) Read() sdk.ResourceFunc {
 					databaseId := cosmosdb.NewSqlDatabaseID(id.SubscriptionId, id.ResourceGroupName, *output.Properties.AccountId, *output.Properties.Database)
 					state.Database = databaseId.ID()
 
-					collectionName := ""
-					if v := output.Properties.CollectionNamePattern; v != nil {
-						collectionName = *v
-					}
-					state.ContainerName = collectionName
+					state.ContainerName = pointer.From(output.Properties.CollectionNamePattern)
 
-					document := ""
-					if v := output.Properties.DocumentId; v != nil {
-						document = *v
-					}
-					state.DocumentID = document
+					state.DocumentID = pointer.From(output.Properties.DocumentId)
 
-					partitionKey := ""
-					if v := output.Properties.PartitionKey; v != nil {
-						partitionKey = *v
-					}
-					state.PartitionKey = partitionKey
+					state.PartitionKey = pointer.From(output.Properties.PartitionKey)
 
 					state.AuthenticationMode = string(pointer.From(output.Properties.AuthenticationMode))
 

--- a/internal/services/streamanalytics/stream_analytics_output_eventhub_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_output_eventhub_resource.go
@@ -224,29 +224,13 @@ func resourceStreamAnalyticsOutputEventHubRead(d *pluginsdk.ResourceData, meta i
 				return fmt.Errorf("converting %s to a EventHub Output", *id)
 			}
 
-			eventHubName := ""
-			if v := output.Properties.EventHubName; v != nil {
-				eventHubName = *v
-			}
-			d.Set("eventhub_name", eventHubName)
+			d.Set("eventhub_name", pointer.From(output.Properties.EventHubName))
 
-			serviceBusNamespace := ""
-			if v := output.Properties.ServiceBusNamespace; v != nil {
-				serviceBusNamespace = *v
-			}
-			d.Set("servicebus_namespace", serviceBusNamespace)
+			d.Set("servicebus_namespace", pointer.From(output.Properties.ServiceBusNamespace))
 
-			sharedAccessPolicyName := ""
-			if v := output.Properties.SharedAccessPolicyName; v != nil {
-				sharedAccessPolicyName = *v
-			}
-			d.Set("shared_access_policy_name", sharedAccessPolicyName)
+			d.Set("shared_access_policy_name", pointer.From(output.Properties.SharedAccessPolicyName))
 
-			partitionKey := ""
-			if v := output.Properties.PartitionKey; v != nil {
-				partitionKey = *v
-			}
-			d.Set("partition_key", partitionKey)
+			d.Set("partition_key", pointer.From(output.Properties.PartitionKey))
 
 			authMode := ""
 			if v := output.Properties.AuthenticationMode; v != nil {
@@ -254,11 +238,7 @@ func resourceStreamAnalyticsOutputEventHubRead(d *pluginsdk.ResourceData, meta i
 			}
 			d.Set("authentication_mode", authMode)
 
-			var propertyColumns []string
-			if v := output.Properties.PropertyColumns; v != nil {
-				propertyColumns = *v
-			}
-			d.Set("property_columns", propertyColumns)
+			d.Set("property_columns", pointer.From(output.Properties.PropertyColumns))
 
 			if err := d.Set("serialization", flattenStreamAnalyticsOutputSerialization(props.Serialization)); err != nil {
 				return fmt.Errorf("setting `serialization`: %+v", err)

--- a/internal/services/streamanalytics/stream_analytics_output_mssql_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_output_mssql_resource.go
@@ -218,29 +218,13 @@ func resourceStreamAnalyticsOutputSqlRead(d *pluginsdk.ResourceData, meta interf
 				return fmt.Errorf("converting %s to a SQL Output", *id)
 			}
 
-			server := ""
-			if v := output.Properties.Server; v != nil {
-				server = *v
-			}
-			d.Set("server", server)
+			d.Set("server", pointer.From(output.Properties.Server))
 
-			database := ""
-			if v := output.Properties.Database; v != nil {
-				database = *v
-			}
-			d.Set("database", database)
+			d.Set("database", pointer.From(output.Properties.Database))
 
-			table := ""
-			if v := output.Properties.Table; v != nil {
-				table = *v
-			}
-			d.Set("table", table)
+			d.Set("table", pointer.From(output.Properties.Table))
 
-			user := ""
-			if v := output.Properties.User; v != nil {
-				user = *v
-			}
-			d.Set("user", user)
+			d.Set("user", pointer.From(output.Properties.User))
 
 			authMode := ""
 			if v := output.Properties.AuthenticationMode; v != nil {

--- a/internal/services/streamanalytics/stream_analytics_output_powerbi_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_output_powerbi_resource.go
@@ -275,29 +275,13 @@ func (r OutputPowerBIResource) Read() sdk.ResourceFunc {
 						StreamAnalyticsJob: streamingJobId.ID(),
 					}
 
-					dataset := ""
-					if v := output.Properties.Dataset; v != nil {
-						dataset = *v
-					}
-					state.DataSet = dataset
+					state.DataSet = pointer.From(output.Properties.Dataset)
 
-					table := ""
-					if v := output.Properties.Table; v != nil {
-						table = *v
-					}
-					state.Table = table
+					state.Table = pointer.From(output.Properties.Table)
 
-					groupId := ""
-					if v := output.Properties.GroupId; v != nil {
-						groupId = *v
-					}
-					state.GroupID = groupId
+					state.GroupID = pointer.From(output.Properties.GroupId)
 
-					groupName := ""
-					if v := output.Properties.GroupName; v != nil {
-						groupName = *v
-					}
-					state.GroupName = groupName
+					state.GroupName = pointer.From(output.Properties.GroupName)
 
 					state.TokenUserDisplayName = metadata.ResourceData.Get("token_user_display_name").(string)
 					state.TokenUserPrincipalName = metadata.ResourceData.Get("token_user_principal_name").(string)

--- a/internal/services/streamanalytics/stream_analytics_output_servicebus_queue_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_output_servicebus_queue_resource.go
@@ -227,35 +227,15 @@ func resourceStreamAnalyticsOutputServiceBusQueueRead(d *pluginsdk.ResourceData,
 				return fmt.Errorf("converting %s to a ServiceBus Queue Output", *id)
 			}
 
-			queue := ""
-			if v := output.Properties.QueueName; v != nil {
-				queue = *v
-			}
-			d.Set("queue_name", queue)
+			d.Set("queue_name", pointer.From(output.Properties.QueueName))
 
-			namespace := ""
-			if v := output.Properties.ServiceBusNamespace; v != nil {
-				namespace = *v
-			}
-			d.Set("servicebus_namespace", namespace)
+			d.Set("servicebus_namespace", pointer.From(output.Properties.ServiceBusNamespace))
 
-			policyName := ""
-			if v := output.Properties.SharedAccessPolicyName; v != nil {
-				policyName = *v
-			}
-			d.Set("shared_access_policy_name", policyName)
+			d.Set("shared_access_policy_name", pointer.From(output.Properties.SharedAccessPolicyName))
 
-			var columns []string
-			if v := output.Properties.PropertyColumns; v != nil {
-				columns = *v
-			}
-			d.Set("property_columns", columns)
+			d.Set("property_columns", pointer.From(output.Properties.PropertyColumns))
 
-			var systemColumns interface{}
-			if v := output.Properties.SystemPropertyColumns; v != nil {
-				systemColumns = *v
-			}
-			d.Set("system_property_columns", systemColumns)
+			d.Set("system_property_columns", pointer.From(output.Properties.SystemPropertyColumns))
 
 			authMode := ""
 			if v := output.Properties.AuthenticationMode; v != nil {

--- a/internal/services/streamanalytics/stream_analytics_output_servicebus_topic_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_output_servicebus_topic_resource.go
@@ -221,29 +221,13 @@ func resourceStreamAnalyticsOutputServiceBusTopicRead(d *pluginsdk.ResourceData,
 				return fmt.Errorf("converting %s to a ServiceBus Topic Output", *id)
 			}
 
-			topicName := ""
-			if v := output.Properties.TopicName; v != nil {
-				topicName = *v
-			}
-			d.Set("topic_name", topicName)
+			d.Set("topic_name", pointer.From(output.Properties.TopicName))
 
-			namespace := ""
-			if v := output.Properties.ServiceBusNamespace; v != nil {
-				namespace = *v
-			}
-			d.Set("servicebus_namespace", namespace)
+			d.Set("servicebus_namespace", pointer.From(output.Properties.ServiceBusNamespace))
 
-			accessPolicy := ""
-			if v := output.Properties.SharedAccessPolicyName; v != nil {
-				accessPolicy = *v
-			}
-			d.Set("shared_access_policy_name", accessPolicy)
+			d.Set("shared_access_policy_name", pointer.From(output.Properties.SharedAccessPolicyName))
 
-			var propertyColumns []string
-			if v := output.Properties.PropertyColumns; v != nil {
-				propertyColumns = *v
-			}
-			d.Set("property_columns", propertyColumns)
+			d.Set("property_columns", pointer.From(output.Properties.PropertyColumns))
 
 			authMode := ""
 			if v := output.Properties.AuthenticationMode; v != nil {

--- a/internal/services/streamanalytics/stream_analytics_output_synapse_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_output_synapse_resource.go
@@ -187,29 +187,13 @@ func resourceStreamAnalyticsOutputSynapseRead(d *pluginsdk.ResourceData, meta in
 				return fmt.Errorf("converting %s to a Synapse Output", *id)
 			}
 
-			server := ""
-			if v := output.Properties.Server; v != nil {
-				server = *v
-			}
-			d.Set("server", server)
+			d.Set("server", pointer.From(output.Properties.Server))
 
-			database := ""
-			if v := output.Properties.Database; v != nil {
-				database = *v
-			}
-			d.Set("database", database)
+			d.Set("database", pointer.From(output.Properties.Database))
 
-			table := ""
-			if v := output.Properties.Table; v != nil {
-				table = *v
-			}
-			d.Set("table", table)
+			d.Set("table", pointer.From(output.Properties.Table))
 
-			user := ""
-			if v := output.Properties.User; v != nil {
-				user = *v
-			}
-			d.Set("user", user)
+			d.Set("user", pointer.From(output.Properties.User))
 		}
 	}
 	return nil

--- a/internal/services/streamanalytics/stream_analytics_output_table_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_output_table_resource.go
@@ -216,35 +216,15 @@ func (r OutputTableResource) Read() sdk.ResourceFunc {
 							StorageAccountKey:  metadata.ResourceData.Get("storage_account_key").(string),
 						}
 
-						accountName := ""
-						if v := output.Properties.AccountName; v != nil {
-							accountName = *v
-						}
-						state.StorageAccount = accountName
+						state.StorageAccount = pointer.From(output.Properties.AccountName)
 
-						table := ""
-						if v := output.Properties.Table; v != nil {
-							table = *v
-						}
-						state.Table = table
+						state.Table = pointer.From(output.Properties.Table)
 
-						partitonKey := ""
-						if v := output.Properties.PartitionKey; v != nil {
-							partitonKey = *v
-						}
-						state.PartitionKey = partitonKey
+						state.PartitionKey = pointer.From(output.Properties.PartitionKey)
 
-						rowKey := ""
-						if v := output.Properties.RowKey; v != nil {
-							rowKey = *v
-						}
-						state.RowKey = rowKey
+						state.RowKey = pointer.From(output.Properties.RowKey)
 
-						var batchSize int64
-						if v := output.Properties.BatchSize; v != nil {
-							batchSize = *v
-						}
-						state.BatchSize = batchSize
+						state.BatchSize = pointer.From(output.Properties.BatchSize)
 
 						var columnsToRemove []string
 						if columns := output.Properties.ColumnsToRemove; columns != nil && len(*columns) > 0 {

--- a/internal/services/streamanalytics/stream_analytics_reference_input_blob_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_reference_input_blob_resource.go
@@ -256,29 +256,13 @@ func resourceStreamAnalyticsReferenceInputBlobRead(d *pluginsdk.ResourceData, me
 			}
 
 			if referenceInputBlob.Properties != nil {
-				dateFormat := ""
-				if v := referenceInputBlob.Properties.DateFormat; v != nil {
-					dateFormat = *v
-				}
-				d.Set("date_format", dateFormat)
+				d.Set("date_format", pointer.From(referenceInputBlob.Properties.DateFormat))
 
-				pathPattern := ""
-				if v := referenceInputBlob.Properties.PathPattern; v != nil {
-					pathPattern = *v
-				}
-				d.Set("path_pattern", pathPattern)
+				d.Set("path_pattern", pointer.From(referenceInputBlob.Properties.PathPattern))
 
-				containerName := ""
-				if v := referenceInputBlob.Properties.Container; v != nil {
-					containerName = *v
-				}
-				d.Set("storage_container_name", containerName)
+				d.Set("storage_container_name", pointer.From(referenceInputBlob.Properties.Container))
 
-				timeFormat := ""
-				if v := referenceInputBlob.Properties.TimeFormat; v != nil {
-					timeFormat = *v
-				}
-				d.Set("time_format", timeFormat)
+				d.Set("time_format", pointer.From(referenceInputBlob.Properties.TimeFormat))
 
 				authMode := ""
 				if v := referenceInputBlob.Properties.AuthenticationMode; v != nil {

--- a/internal/services/streamanalytics/stream_analytics_reference_input_mssql_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_reference_input_mssql_resource.go
@@ -235,23 +235,11 @@ func resourceStreamAnalyticsReferenceInputMsSqlRead(d *pluginsdk.ResourceData, m
 			}
 
 			if referenceInputAzureSql.Properties != nil {
-				server := ""
-				if v := referenceInputAzureSql.Properties.Server; v != nil {
-					server = *v
-				}
-				d.Set("server", server)
+				d.Set("server", pointer.From(referenceInputAzureSql.Properties.Server))
 
-				database := ""
-				if v := referenceInputAzureSql.Properties.Database; v != nil {
-					database = *v
-				}
-				d.Set("database", database)
+				d.Set("database", pointer.From(referenceInputAzureSql.Properties.Database))
 
-				username := ""
-				if v := referenceInputAzureSql.Properties.User; v != nil {
-					username = *v
-				}
-				d.Set("username", username)
+				d.Set("username", pointer.From(referenceInputAzureSql.Properties.User))
 
 				refreshType := ""
 				if v := referenceInputAzureSql.Properties.RefreshType; v != nil {
@@ -259,29 +247,13 @@ func resourceStreamAnalyticsReferenceInputMsSqlRead(d *pluginsdk.ResourceData, m
 				}
 				d.Set("refresh_type", refreshType)
 
-				intervalDuration := ""
-				if v := referenceInputAzureSql.Properties.RefreshRate; v != nil {
-					intervalDuration = *v
-				}
-				d.Set("refresh_interval_duration", intervalDuration)
+				d.Set("refresh_interval_duration", pointer.From(referenceInputAzureSql.Properties.RefreshRate))
 
-				fullSnapshotQuery := ""
-				if v := referenceInputAzureSql.Properties.FullSnapshotQuery; v != nil {
-					fullSnapshotQuery = *v
-				}
-				d.Set("full_snapshot_query", fullSnapshotQuery)
+				d.Set("full_snapshot_query", pointer.From(referenceInputAzureSql.Properties.FullSnapshotQuery))
 
-				deltaSnapshotQuery := ""
-				if v := referenceInputAzureSql.Properties.DeltaSnapshotQuery; v != nil {
-					deltaSnapshotQuery = *v
-				}
-				d.Set("delta_snapshot_query", deltaSnapshotQuery)
+				d.Set("delta_snapshot_query", pointer.From(referenceInputAzureSql.Properties.DeltaSnapshotQuery))
 
-				table := ""
-				if v := referenceInputAzureSql.Properties.Table; v != nil {
-					table = *v
-				}
-				d.Set("table", table)
+				d.Set("table", pointer.From(referenceInputAzureSql.Properties.Table))
 			}
 		}
 	}

--- a/internal/services/streamanalytics/stream_analytics_stream_input_blob_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_stream_input_blob_resource.go
@@ -225,29 +225,13 @@ func resourceStreamAnalyticsStreamInputBlobRead(d *pluginsdk.ResourceData, meta 
 			}
 
 			if streamBlobInputProps := streamBlobInput.Properties; streamBlobInputProps != nil {
-				dateFormat := ""
-				if v := streamBlobInput.Properties.DateFormat; v != nil {
-					dateFormat = *v
-				}
-				d.Set("date_format", dateFormat)
+				d.Set("date_format", pointer.From(streamBlobInput.Properties.DateFormat))
 
-				pathPattern := ""
-				if v := streamBlobInputProps.PathPattern; v != nil {
-					pathPattern = *v
-				}
-				d.Set("path_pattern", pathPattern)
+				d.Set("path_pattern", pointer.From(streamBlobInputProps.PathPattern))
 
-				containerName := ""
-				if v := streamBlobInputProps.Container; v != nil {
-					containerName = *v
-				}
-				d.Set("storage_container_name", containerName)
+				d.Set("storage_container_name", pointer.From(streamBlobInputProps.Container))
 
-				timeFormat := ""
-				if v := streamBlobInputProps.TimeFormat; v != nil {
-					timeFormat = *v
-				}
-				d.Set("time_format", timeFormat)
+				d.Set("time_format", pointer.From(streamBlobInputProps.TimeFormat))
 
 				authMode := ""
 				if v := streamBlobInputProps.AuthenticationMode; v != nil {

--- a/internal/services/streamanalytics/stream_analytics_stream_input_eventhub_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_stream_input_eventhub_resource.go
@@ -220,17 +220,9 @@ func resourceStreamAnalyticsStreamInputEventHubRead(d *pluginsdk.ResourceData, m
 			}
 
 			if streamEventHubInputProps := streamEventHubInput.Properties; streamEventHubInputProps != nil {
-				eventHubName := ""
-				if v := streamEventHubInputProps.EventHubName; v != nil {
-					eventHubName = *v
-				}
-				d.Set("eventhub_name", eventHubName)
+				d.Set("eventhub_name", pointer.From(streamEventHubInputProps.EventHubName))
 
-				serviceBusNameSpace := ""
-				if v := streamEventHubInputProps.ServiceBusNamespace; v != nil {
-					serviceBusNameSpace = *v
-				}
-				d.Set("servicebus_namespace", serviceBusNameSpace)
+				d.Set("servicebus_namespace", pointer.From(streamEventHubInputProps.ServiceBusNamespace))
 
 				authMode := ""
 				if v := streamEventHubInputProps.AuthenticationMode; v != nil {
@@ -238,23 +230,11 @@ func resourceStreamAnalyticsStreamInputEventHubRead(d *pluginsdk.ResourceData, m
 				}
 				d.Set("authentication_mode", authMode)
 
-				consumerGroupName := ""
-				if v := streamEventHubInputProps.ConsumerGroupName; v != nil {
-					consumerGroupName = *v
-				}
-				d.Set("eventhub_consumer_group_name", consumerGroupName)
+				d.Set("eventhub_consumer_group_name", pointer.From(streamEventHubInputProps.ConsumerGroupName))
 
-				sharedAccessPolicyName := ""
-				if v := streamEventHubInputProps.SharedAccessPolicyName; v != nil {
-					sharedAccessPolicyName = *v
-				}
-				d.Set("shared_access_policy_name", sharedAccessPolicyName)
+				d.Set("shared_access_policy_name", pointer.From(streamEventHubInputProps.SharedAccessPolicyName))
 
-				partitionKey := ""
-				if v := streamInput.PartitionKey; v != nil {
-					partitionKey = *v
-				}
-				d.Set("partition_key", partitionKey)
+				d.Set("partition_key", pointer.From(streamInput.PartitionKey))
 
 				if err := d.Set("serialization", flattenStreamAnalyticsStreamInputSerialization(streamInput.Serialization)); err != nil {
 					return fmt.Errorf("setting `serialization`: %+v", err)

--- a/internal/services/streamanalytics/stream_analytics_stream_input_eventhub_v2_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_stream_input_eventhub_v2_resource.go
@@ -287,37 +287,22 @@ func (r StreamInputEventHubV2Resource) Read() sdk.ResourceFunc {
 					}
 
 					if eventHubV2InputProps := eventHubV2Input.Properties; eventHubV2InputProps != nil {
-						servicebusNamespace := ""
-						if v := eventHubV2InputProps.ServiceBusNamespace; v != nil {
-							servicebusNamespace = *v
-						}
+						servicebusNamespace := pointer.From(eventHubV2InputProps.ServiceBusNamespace)
 
-						eventHubName := ""
-						if v := eventHubV2InputProps.EventHubName; v != nil {
-							eventHubName = *v
-						}
+						eventHubName := pointer.From(eventHubV2InputProps.EventHubName)
 
-						eventHubConsumerGroup := ""
-						if v := eventHubV2InputProps.ConsumerGroupName; v != nil {
-							eventHubConsumerGroup = *v
-						}
+						eventHubConsumerGroup := pointer.From(eventHubV2InputProps.ConsumerGroupName)
 
 						authenticationMode := ""
 						if v := eventHubV2InputProps.AuthenticationMode; v != nil {
 							authenticationMode = string(*v)
 						}
 
-						sharedAccessPolicyName := ""
-						if v := eventHubV2InputProps.SharedAccessPolicyName; v != nil {
-							sharedAccessPolicyName = *v
-						}
+						sharedAccessPolicyName := pointer.From(eventHubV2InputProps.SharedAccessPolicyName)
 
 						serialization := flattenStreamAnalyticsStreamInputSerializationTyped(streamInput.Serialization)
 
-						partitionKey := ""
-						if v := streamInput.PartitionKey; v != nil {
-							partitionKey = *v
-						}
+						partitionKey := pointer.From(streamInput.PartitionKey)
 
 						state.ServiceBusNamespace = servicebusNamespace
 						state.EventHubName = eventHubName

--- a/internal/services/streamanalytics/stream_analytics_stream_input_iothub_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_stream_input_iothub_resource.go
@@ -201,29 +201,13 @@ func resourceStreamAnalyticsStreamInputIoTHubRead(d *pluginsdk.ResourceData, met
 			}
 
 			if streamIotHubInputProps := streamIotHubInput.Properties; streamIotHubInputProps != nil {
-				eventHubConsumerGroupName := ""
-				if v := streamIotHubInputProps.ConsumerGroupName; v != nil {
-					eventHubConsumerGroupName = *v
-				}
-				d.Set("eventhub_consumer_group_name", eventHubConsumerGroupName)
+				d.Set("eventhub_consumer_group_name", pointer.From(streamIotHubInputProps.ConsumerGroupName))
 
-				endpoint := ""
-				if v := streamIotHubInputProps.Endpoint; v != nil {
-					endpoint = *v
-				}
-				d.Set("endpoint", endpoint)
+				d.Set("endpoint", pointer.From(streamIotHubInputProps.Endpoint))
 
-				iothubNamespace := ""
-				if v := streamIotHubInputProps.IotHubNamespace; v != nil {
-					iothubNamespace = *v
-				}
-				d.Set("iothub_namespace", iothubNamespace)
+				d.Set("iothub_namespace", pointer.From(streamIotHubInputProps.IotHubNamespace))
 
-				sharedAccessPolicyName := ""
-				if v := streamIotHubInputProps.SharedAccessPolicyName; v != nil {
-					sharedAccessPolicyName = *v
-				}
-				d.Set("shared_access_policy_name", sharedAccessPolicyName)
+				d.Set("shared_access_policy_name", pointer.From(streamIotHubInputProps.SharedAccessPolicyName))
 
 				if err := d.Set("serialization", flattenStreamAnalyticsStreamInputSerialization(streamInput.Serialization)); err != nil {
 					return fmt.Errorf("setting `serialization`: %+v", err)

--- a/internal/services/subscription/subscription_resource.go
+++ b/internal/services/subscription/subscription_resource.go
@@ -384,10 +384,7 @@ func resourceSubscriptionDelete(d *pluginsdk.ResourceData, meta interface{}) err
 	if err != nil || alias.Model == nil || alias.Model.Properties == nil {
 		return fmt.Errorf("could not read Alias %q for Subscription: %+v", id.AliasName, err)
 	}
-	subscriptionId := ""
-	if subscriptionIdRaw := alias.Model.Properties.SubscriptionId; subscriptionIdRaw != nil {
-		subscriptionId = *subscriptionIdRaw
-	}
+	subscriptionId := pointer.From(alias.Model.Properties.SubscriptionId)
 	locks.ByID(subscriptionId)
 	defer locks.UnlockByID(subscriptionId)
 

--- a/internal/services/synapse/synapse_linked_service_resource.go
+++ b/internal/services/synapse/synapse_linked_service_resource.go
@@ -521,10 +521,7 @@ func flattenSynapseLinkedServiceIntegrationRuntimeV2(input *artifacts.Integratio
 		return []interface{}{}
 	}
 
-	name := ""
-	if input.ReferenceName != nil {
-		name = *input.ReferenceName
-	}
+	name := pointer.From(input.ReferenceName)
 
 	return []interface{}{
 		map[string]interface{}{

--- a/internal/services/synapse/synapse_role_assignment_resource.go
+++ b/internal/services/synapse/synapse_role_assignment_resource.go
@@ -245,11 +245,7 @@ func resourceSynapseRoleAssignmentRead(d *pluginsdk.ResourceData, meta interface
 	}
 	d.Set("principal_id", principalID)
 
-	principalType := ""
-	if resp.PrincipalType != nil {
-		principalType = *resp.PrincipalType
-	}
-	d.Set("principal_type", principalType)
+	d.Set("principal_type", pointer.From(resp.PrincipalType))
 
 	synapseWorkspaceId := ""
 	synapseSparkPoolId := ""

--- a/internal/services/synapse/synapse_spark_pool_resource.go
+++ b/internal/services/synapse/synapse_spark_pool_resource.go
@@ -495,14 +495,8 @@ func flattenArmSparkPoolAutoPauseProperties(input *synapse.AutoPauseProperties) 
 		return make([]interface{}, 0)
 	}
 
-	var delayInMinutes int32
-	if input.DelayInMinutes != nil {
-		delayInMinutes = *input.DelayInMinutes
-	}
-	var enabled bool
-	if input.Enabled != nil {
-		enabled = *input.Enabled
-	}
+	delayInMinutes := pointer.From(input.DelayInMinutes)
+	enabled := pointer.From(input.Enabled)
 
 	if !enabled {
 		return make([]interface{}, 0)
@@ -520,23 +514,14 @@ func flattenArmSparkPoolAutoScaleProperties(input *synapse.AutoScaleProperties) 
 		return make([]interface{}, 0)
 	}
 
-	var enabled bool
-	if input.Enabled != nil {
-		enabled = *input.Enabled
-	}
+	enabled := pointer.From(input.Enabled)
 
 	if !enabled {
 		return make([]interface{}, 0)
 	}
 
-	var maxNodeCount int32
-	if input.MaxNodeCount != nil {
-		maxNodeCount = *input.MaxNodeCount
-	}
-	var minNodeCount int32
-	if input.MinNodeCount != nil {
-		minNodeCount = *input.MinNodeCount
-	}
+	maxNodeCount := pointer.From(input.MaxNodeCount)
+	minNodeCount := pointer.From(input.MinNodeCount)
 	return []interface{}{
 		map[string]interface{}{
 			"max_node_count": maxNodeCount,
@@ -550,14 +535,8 @@ func flattenArmSparkPoolLibraryRequirements(input *synapse.LibraryRequirements) 
 		return make([]interface{}, 0)
 	}
 
-	var content string
-	if input.Content != nil {
-		content = *input.Content
-	}
-	var filename string
-	if input.Filename != nil {
-		filename = *input.Filename
-	}
+	content := pointer.From(input.Content)
+	filename := pointer.From(input.Filename)
 	return []interface{}{
 		map[string]interface{}{
 			"content":  content,
@@ -571,14 +550,8 @@ func flattenSparkPoolSparkConfig(input *synapse.SparkConfigProperties) []interfa
 		return make([]interface{}, 0)
 	}
 
-	var content string
-	if input.Content != nil {
-		content = *input.Content
-	}
-	var filename string
-	if input.Filename != nil {
-		filename = *input.Filename
-	}
+	content := pointer.From(input.Content)
+	filename := pointer.From(input.Filename)
 	return []interface{}{
 		map[string]interface{}{
 			"content":  content,


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR is part of a series of changes to enable the azproviderlint AZG004 analyzer, which flags the pattern of declaring a variable with its type's zero value and then conditionally overwriting it from a pointer after a nil check.

As a prerequisite to turning the analyzer on repo-wide, this slice migrates all such occurrences in the following services to the equivalent `pointer.From()` helper

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

No functional behavior changes are introduced, so no new test coverage is added. The refactor is verified by go build, go vet, gofmt, and the existing linter/acceptance test suites for the affected services.

## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
