### PR TITLE
Linters - enable azproviderlint AZG004 - Services (trafficmanager- Web)

### DIFF
--- a/internal/services/trafficmanager/endpoint.go
+++ b/internal/services/trafficmanager/endpoint.go
@@ -28,15 +28,9 @@ func flattenEndpointCustomHeaderConfig(input *[]trafficmanagers.EndpointProperti
 		return result
 	}
 	for _, header := range *input {
-		name := ""
-		if header.Name != nil {
-			name = *header.Name
-		}
+		name := pointer.From(header.Name)
 
-		value := ""
-		if header.Value != nil {
-			value = *header.Value
-		}
+		value := pointer.From(header.Value)
 		result = append(result, map[string]interface{}{
 			"name":  name,
 			"value": value,
@@ -72,15 +66,9 @@ func flattenEndpointSubnetConfig(input *[]trafficmanagers.EndpointPropertiesSubn
 		return result
 	}
 	for _, subnet := range *input {
-		first := ""
-		if subnet.First != nil {
-			first = *subnet.First
-		}
+		first := pointer.From(subnet.First)
 
-		last := ""
-		if subnet.Last != nil {
-			last = *subnet.Last
-		}
+		last := pointer.From(subnet.Last)
 		scope := 0
 		if subnet.Scope != nil {
 			scope = int(*subnet.Scope)

--- a/internal/services/vmware/vmware_private_cloud.go
+++ b/internal/services/vmware/vmware_private_cloud.go
@@ -4,6 +4,7 @@
 package vmware
 
 import (
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/vmware/2022-05-01/privateclouds"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers"
 )
@@ -27,22 +28,10 @@ func flattenPrivateCloudCircuit(input *privateclouds.Circuit) []interface{} {
 		return make([]interface{}, 0)
 	}
 
-	var expressRouteId string
-	if input.ExpressRouteID != nil {
-		expressRouteId = *input.ExpressRouteID
-	}
-	var expressRoutePrivatePeeringId string
-	if input.ExpressRoutePrivatePeeringID != nil {
-		expressRoutePrivatePeeringId = *input.ExpressRoutePrivatePeeringID
-	}
-	var primarySubnet string
-	if input.PrimarySubnet != nil {
-		primarySubnet = *input.PrimarySubnet
-	}
-	var secondarySubnet string
-	if input.SecondarySubnet != nil {
-		secondarySubnet = *input.SecondarySubnet
-	}
+	expressRouteId := pointer.From(input.ExpressRouteID)
+	expressRoutePrivatePeeringId := pointer.From(input.ExpressRoutePrivatePeeringID)
+	primarySubnet := pointer.From(input.PrimarySubnet)
+	secondarySubnet := pointer.From(input.SecondarySubnet)
 	return []interface{}{
 		map[string]interface{}{
 			"express_route_id":                 expressRouteId,

--- a/internal/services/web/app_service.go
+++ b/internal/services/web/app_service.go
@@ -1880,11 +1880,7 @@ func flattenAppServiceSiteConfig(input *web.SiteConfig) []interface{} {
 		result["acr_user_managed_identity_client_id"] = *input.AcrUserManagedIdentityID
 	}
 
-	vnetRouteAllEnabled := false
-	if input.VnetRouteAllEnabled != nil {
-		vnetRouteAllEnabled = *input.VnetRouteAllEnabled
-	}
-	result["vnet_route_all_enabled"] = vnetRouteAllEnabled
+	result["vnet_route_all_enabled"] = pointer.From(input.VnetRouteAllEnabled)
 
 	return append(results, result)
 }
@@ -1911,17 +1907,9 @@ func flattenAppServiceIpRestriction(input *[]web.IPSecurityRestriction) []interf
 			}
 		}
 
-		subnetId := ""
-		if subnetIdRaw := v.VnetSubnetResourceID; subnetIdRaw != nil {
-			subnetId = *subnetIdRaw
-		}
-		restriction["virtual_network_subnet_id"] = subnetId
+		restriction["virtual_network_subnet_id"] = pointer.From(v.VnetSubnetResourceID)
 
-		name := ""
-		if nameRaw := v.Name; nameRaw != nil {
-			name = *nameRaw
-		}
-		restriction["name"] = name
+		restriction["name"] = pointer.From(v.Name)
 
 		priority := 0
 		if priorityRaw := v.Priority; priorityRaw != nil {
@@ -1929,11 +1917,7 @@ func flattenAppServiceIpRestriction(input *[]web.IPSecurityRestriction) []interf
 		}
 		restriction["priority"] = priority
 
-		action := ""
-		if actionRaw := v.Action; actionRaw != nil {
-			action = *actionRaw
-		}
-		restriction["action"] = action
+		restriction["action"] = pointer.From(v.Action)
 
 		if headers := v.Headers; headers != nil {
 			restriction["headers"] = flattenHeaders(headers)

--- a/internal/services/web/function_app.go
+++ b/internal/services/web/function_app.go
@@ -578,11 +578,7 @@ func flattenFunctionAppSiteConfig(input *web.SiteConfig) []interface{} {
 		result["dotnet_framework_version"] = *input.NetFrameworkVersion
 	}
 
-	vnetRouteAllEnabled := false
-	if input.VnetRouteAllEnabled != nil {
-		vnetRouteAllEnabled = *input.VnetRouteAllEnabled
-	}
-	result["vnet_route_all_enabled"] = vnetRouteAllEnabled
+	result["vnet_route_all_enabled"] = pointer.From(input.VnetRouteAllEnabled)
 
 	results = append(results, result)
 	return results

--- a/internal/services/web/static_site_resource.go
+++ b/internal/services/web/static_site_resource.go
@@ -207,11 +207,7 @@ func resourceStaticSiteRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	d.Set("location", location.NormalizeNilable(resp.Location))
 
 	if prop := resp.StaticSite; prop != nil {
-		defaultHostname := ""
-		if prop.DefaultHostname != nil {
-			defaultHostname = *prop.DefaultHostname
-		}
-		d.Set("default_host_name", defaultHostname)
+		d.Set("default_host_name", pointer.From(prop.DefaultHostname))
 	}
 
 	skuName := ""
@@ -233,11 +229,7 @@ func resourceStaticSiteRead(d *pluginsdk.ResourceData, meta interface{}) error {
 		return fmt.Errorf("listing secretes for %s: %v", id, err)
 	}
 
-	apiKey := ""
-	if pkey := secretResp.Properties["apiKey"]; pkey != nil {
-		apiKey = *pkey
-	}
-	d.Set("api_key", apiKey)
+	d.Set("api_key", pointer.From(secretResp.Properties["apiKey"]))
 
 	appSettingsResp, err := client.ListStaticSiteAppSettings(ctx, id.ResourceGroup, id.Name)
 	if err != nil {


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR is part of a series of changes to enable the azproviderlint AZG004 analyzer, which flags the pattern of declaring a variable with its type's zero value and then conditionally overwriting it from a pointer after a nil check.

As a prerequisite to turning the analyzer on repo-wide, this slice migrates all such occurrences in the following services to the equivalent `pointer.From()` helper

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

No functional behavior changes are introduced, so no new test coverage is added. The refactor is verified by go build, go vet, gofmt, and the existing linter/acceptance test suites for the affected services.

## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
