### PR TITLE
 `data.attestation` - add support for `open_enclave_policy_base64`

### DIFF
--- a/internal/services/attestation/attestation_provider_data_source.go
+++ b/internal/services/attestation/attestation_provider_data_source.go
@@ -48,7 +48,21 @@ func dataSourceAttestationProvider() *pluginsdk.Resource {
 				Computed: true,
 			},
 
+			"sev_snp_policy_base64": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
 			"open_enclave_policy_base64": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+			"sgx_enclave_policy_base64": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
+			"tpm_policy_base64": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
 			},
@@ -96,13 +110,42 @@ func dataSourceArmAttestationProviderRead(d *pluginsdk.ResourceData, meta interf
 	if err != nil && !utils.ResponseWasBadRequest(openEnclavePolicy.Response) {
 		return fmt.Errorf("retrieving OpenEnclave Policy for %s: %+v", id, err)
 	}
+	sgxEnclavePolicy, err := dataPlaneClient.Get(ctx, *dataPlaneUri, attestation.TypeSgxEnclave)
+	if err != nil && !utils.ResponseWasBadRequest(sgxEnclavePolicy.Response) {
+		return fmt.Errorf("retrieving SgxEnclave Policy for %s: %+v", id, err)
+	}
+	tpmPolicy, err := dataPlaneClient.Get(ctx, *dataPlaneUri, attestation.TypeTpm)
+	if err != nil && !utils.ResponseWasBadRequest(tpmPolicy.Response) {
+		return fmt.Errorf("retrieving Tpm Policy for %s: %+v", id, err)
+	}
+	sevSnpPolicy, err := dataPlaneClient.Get(ctx, *dataPlaneUri, attestation.TypeSevSnpVM)
+	if err != nil && !utils.ResponseWasBadRequest(sevSnpPolicy.Response) {
+		return fmt.Errorf("retrieving SEV-SNP Policy for %s: %+v", id, err)
+	}
 
 	openEnclavePolicyData, err := base64DataFromAttestationJWT(openEnclavePolicy.Token)
 	if err != nil {
 		return fmt.Errorf("parsing OpenEnclave Policy for %s: %+v", id, err)
 	}
-
 	d.Set("open_enclave_policy_base64", pointer.From(openEnclavePolicyData))
+
+	sgxEnclavePolicyData, err := base64DataFromAttestationJWT(sgxEnclavePolicy.Token)
+	if err != nil {
+		return fmt.Errorf("parsing SgxEnclave Policy for %s: %+v", id, err)
+	}
+	d.Set("sgx_enclave_policy_base64", pointer.From(sgxEnclavePolicyData))
+
+	tpmPolicyData, err := base64DataFromAttestationJWT(tpmPolicy.Token)
+	if err != nil {
+		return fmt.Errorf("parsing Tpm Policy for %s: %+v", id, err)
+	}
+	d.Set("tpm_policy_base64", pointer.From(tpmPolicyData))
+
+	sevSnpPolicyData, err := base64DataFromAttestationJWT(sevSnpPolicy.Token)
+	if err != nil {
+		return fmt.Errorf("parsing SEV-SNP policy for %s: %+v", id, err)
+	}
+	d.Set("sev_snp_policy_base64", pointer.From(sevSnpPolicyData))
 
 	if resp.Model != nil {
 		d.Set("location", location.Normalize(resp.Model.Location))

--- a/internal/services/attestation/attestation_provider_data_source.go
+++ b/internal/services/attestation/attestation_provider_data_source.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
@@ -15,6 +16,8 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+	"github.com/jackofallops/kermit/sdk/attestation/2022-08-01/attestation"
 )
 
 func dataSourceAttestationProvider() *pluginsdk.Resource {
@@ -45,13 +48,18 @@ func dataSourceAttestationProvider() *pluginsdk.Resource {
 				Computed: true,
 			},
 
+			"open_enclave_policy_base64": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
 			"tags": commonschema.TagsDataSource(),
 		},
 	}
 }
 
 func dataSourceArmAttestationProviderRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Attestation.ProviderClient
+	attestationClients := meta.(*clients.Client).Attestation
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -60,7 +68,7 @@ func dataSourceArmAttestationProviderRead(d *pluginsdk.ResourceData, meta interf
 	resourceGroup := d.Get("resource_group_name").(string)
 	id := attestationproviders.NewAttestationProvidersID(subscriptionId, resourceGroup, name)
 
-	resp, err := client.Get(ctx, id)
+	resp, err := attestationClients.ProviderClient.Get(ctx, id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
 			return fmt.Errorf("%s was not found", id)
@@ -72,6 +80,29 @@ func dataSourceArmAttestationProviderRead(d *pluginsdk.ResourceData, meta interf
 
 	d.Set("name", name)
 	d.Set("resource_group_name", resourceGroup)
+
+	dataPlaneUri, err := attestationClients.DataPlaneEndpointForProvider(ctx, id)
+	if err != nil {
+		return fmt.Errorf("determining Data Plane URI for %s: %+v", id, err)
+	}
+
+	dataPlaneClient, err := attestationClients.DataPlaneClientWithEndpoint(*dataPlaneUri)
+	if err != nil {
+		return fmt.Errorf("building Data Plane Client for %s: %+v", id, err)
+	}
+
+	// Status=400 Code="Bad request" Message="Tpm attestation is not supported in the 'UKSouth' region"
+	openEnclavePolicy, err := dataPlaneClient.Get(ctx, *dataPlaneUri, attestation.TypeOpenEnclave)
+	if err != nil && !utils.ResponseWasBadRequest(openEnclavePolicy.Response) {
+		return fmt.Errorf("retrieving OpenEnclave Policy for %s: %+v", id, err)
+	}
+
+	openEnclavePolicyData, err := base64DataFromAttestationJWT(openEnclavePolicy.Token)
+	if err != nil {
+		return fmt.Errorf("parsing OpenEnclave Policy for %s: %+v", id, err)
+	}
+
+	d.Set("open_enclave_policy_base64", pointer.From(openEnclavePolicyData))
 
 	if resp.Model != nil {
 		d.Set("location", location.Normalize(resp.Model.Location))

--- a/internal/services/attestation/attestation_provider_data_source_test.go
+++ b/internal/services/attestation/attestation_provider_data_source_test.go
@@ -25,6 +25,10 @@ func TestAccAttestationProviderDataSource_basic(t *testing.T) {
 				check.That(data.ResourceName).Key("resource_group_name").MatchesOtherKey(check.That(resource.ResourceName).Key("resource_group_name")),
 				check.That(data.ResourceName).Key("location").MatchesOtherKey(check.That(resource.ResourceName).Key("location")),
 				check.That(data.ResourceName).Key("attestation_uri").Exists(),
+				check.That(data.ResourceName).Key("open_enclave_policy_base64").MatchesOtherKey(check.That(resource.ResourceName).Key("open_enclave_policy_base64")),
+				check.That(data.ResourceName).Key("sgx_enclave_policy_base64").MatchesOtherKey(check.That(resource.ResourceName).Key("sgx_enclave_policy_base64")),
+				check.That(data.ResourceName).Key("tpm_policy_base64").MatchesOtherKey(check.That(resource.ResourceName).Key("tpm_policy_base64")),
+				check.That(data.ResourceName).Key("sev_snp_policy_base64").MatchesOtherKey(check.That(resource.ResourceName).Key("sev_snp_policy_base64")),
 			),
 		},
 	})

--- a/website/docs/d/attestation_provider.html.markdown
+++ b/website/docs/d/attestation_provider.html.markdown
@@ -41,9 +41,18 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `attestation_uri` - The (Endpoint|URI) of the Attestation Service.
 
-* `trust_model` - Trust model used for the Attestation Service.
+* `open_enclave_policy_base64` - (Optional) Specifies the base64 URI Encoded RFC 7519 JWT that should be used for the Attestation Policy.
+
+* `sev_snp_policy_base64` - (Optional) Specifies the base64 URI Encoded RFC 7519 JWT that should be used for the Attestation Policy.
+
+* `sgx_enclave_policy_base64` - (Optional) Specifies the base64 URI Encoded RFC 7519 JWT that should be used for the Attestation Policy.
 
 * `tags` - A mapping of tags assigned to the Attestation Provider.
+
+* `tpm_policy_base64` - (Optional) Specifies the base64 URI Encoded RFC 7519 JWT that should be used for the Attestation Policy.
+
+* `trust_model` - Trust model used for the Attestation Service.
+
 
 ## Timeouts
 

--- a/website/docs/d/attestation_provider.html.markdown
+++ b/website/docs/d/attestation_provider.html.markdown
@@ -41,15 +41,15 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `attestation_uri` - The (Endpoint|URI) of the Attestation Service.
 
-* `open_enclave_policy_base64` - (Optional) Specifies the base64 URI Encoded RFC 7519 JWT that should be used for the Attestation Policy.
+* `open_enclave_policy_base64` - Specifies the base64 URI Encoded RFC 7519 JWT that should be used for the Attestation Policy.
 
-* `sev_snp_policy_base64` - (Optional) Specifies the base64 URI Encoded RFC 7519 JWT that should be used for the Attestation Policy.
+* `sev_snp_policy_base64` - Specifies the base64 URI Encoded RFC 7519 JWT that should be used for the Attestation Policy.
 
-* `sgx_enclave_policy_base64` - (Optional) Specifies the base64 URI Encoded RFC 7519 JWT that should be used for the Attestation Policy.
+* `sgx_enclave_policy_base64` - Specifies the base64 URI Encoded RFC 7519 JWT that should be used for the Attestation Policy.
 
 * `tags` - A mapping of tags assigned to the Attestation Provider.
 
-* `tpm_policy_base64` - (Optional) Specifies the base64 URI Encoded RFC 7519 JWT that should be used for the Attestation Policy.
+* `tpm_policy_base64` - Specifies the base64 URI Encoded RFC 7519 JWT that should be used for the Attestation Policy.
 
 * `trust_model` - Trust model used for the Attestation Service.
 


### PR DESCRIPTION
data.attestation - added support for "open_enclave_policy_base64", "sev_snp_policy_base64", "sgx_enclave_policy_base64", "tpm_policy_base64"

--- PASS: TestAccAttestationProviderDataSource_basic (84.72s)