### PR TITLE
Linters - Enable azproviderlint AZG005 - Services (dns- sentinel)

### DIFF
--- a/internal/services/dns/dns_ns_record_resource.go
+++ b/internal/services/dns/dns_ns_record_resource.go
@@ -157,8 +157,7 @@ func resourceDnsNsRecordUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 
 	if d.HasChange("records") {
 		recordsRaw := d.Get("records").([]interface{})
-		records := expandAzureRmDnsNsRecords(recordsRaw)
-		existing.Model.Properties.NSRecords = records
+		existing.Model.Properties.NSRecords = expandAzureRmDnsNsRecords(recordsRaw)
 	}
 
 	if d.HasChange("tags") {

--- a/internal/services/dns/dns_zone_resource.go
+++ b/internal/services/dns/dns_zone_resource.go
@@ -407,7 +407,7 @@ func (r DnsZoneResource) Delete() sdk.ResourceFunc {
 }
 
 func expandDNSZoneSOARecord(input DnsZoneSoaRecordResourceRecord) *recordsets.SoaRecord {
-	result := &recordsets.SoaRecord{
+	return &recordsets.SoaRecord{
 		Email:        pointer.To(input.Email),
 		ExpireTime:   pointer.To(input.ExpireTime),
 		MinimumTTL:   pointer.To(input.MinimumTtl),
@@ -415,8 +415,6 @@ func expandDNSZoneSOARecord(input DnsZoneSoaRecordResourceRecord) *recordsets.So
 		RetryTime:    pointer.To(input.RetryTime),
 		SerialNumber: pointer.To(input.SerialNumber),
 	}
-
-	return result
 }
 
 func flattenDNSZoneSOARecord(input *recordsets.RecordSet) []DnsZoneSoaRecordResourceRecord {

--- a/internal/services/dynatrace/helper.go
+++ b/internal/services/dynatrace/helper.go
@@ -142,8 +142,7 @@ func FlattenLogRules(input *tagrules.LogRules) []LogRule {
 	var sendSubscriptionLogs bool
 
 	if input.FilteringTags != nil {
-		filteringTags := FlattenFilteringTags(input.FilteringTags)
-		logRule.FilteringTags = filteringTags
+		logRule.FilteringTags = FlattenFilteringTags(input.FilteringTags)
 	}
 
 	if input.SendActivityLogs != nil {
@@ -200,8 +199,7 @@ func FlattenMetricRules(input *tagrules.MetricRules) []MetricRule {
 	var metricRule MetricRule
 
 	if input.FilteringTags != nil {
-		filteringTags := FlattenFilteringTags(input.FilteringTags)
-		metricRule.FilteringTags = filteringTags
+		metricRule.FilteringTags = FlattenFilteringTags(input.FilteringTags)
 	}
 
 	if input.SendingMetrics != nil {

--- a/internal/services/eventhub/eventhub_namespace_data_source.go
+++ b/internal/services/eventhub/eventhub_namespace_data_source.go
@@ -20,7 +20,7 @@ import (
 )
 
 func EventHubNamespaceDataSource() *pluginsdk.Resource {
-	resource := &pluginsdk.Resource{
+	return &pluginsdk.Resource{
 		Read: EventHubNamespaceDataSourceRead,
 
 		Timeouts: &pluginsdk.ResourceTimeout{
@@ -106,8 +106,6 @@ func EventHubNamespaceDataSource() *pluginsdk.Resource {
 			"tags": commonschema.TagsDataSource(),
 		},
 	}
-
-	return resource
 }
 
 func EventHubNamespaceDataSourceRead(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/eventhub/migration/eventhub_authorization_rule.go
+++ b/internal/services/eventhub/migration/eventhub_authorization_rule.go
@@ -16,7 +16,7 @@ var _ pluginsdk.StateUpgrade = EventHubAuthorizationRuleV0ToV1{}
 type EventHubAuthorizationRuleV0ToV1 struct{}
 
 func (EventHubAuthorizationRuleV0ToV1) Schema() map[string]*pluginsdk.Schema {
-	s := map[string]*pluginsdk.Schema{
+	return map[string]*pluginsdk.Schema{
 		"name": {
 			Type:     pluginsdk.TypeString,
 			Required: true,
@@ -41,7 +41,6 @@ func (EventHubAuthorizationRuleV0ToV1) Schema() map[string]*pluginsdk.Schema {
 			ForceNew: true,
 		},
 	}
-	return s
 }
 
 func (EventHubAuthorizationRuleV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {

--- a/internal/services/firewall/firewall_policy_resource.go
+++ b/internal/services/firewall/firewall_policy_resource.go
@@ -298,12 +298,10 @@ func expandFirewallPolicyThreatIntelWhitelist(input []interface{}) *firewallpoli
 	}
 
 	raw := input[0].(map[string]interface{})
-	output := &firewallpolicies.FirewallPolicyThreatIntelWhitelist{
+	return &firewallpolicies.FirewallPolicyThreatIntelWhitelist{
 		IPAddresses: helpers.ExpandStringSlice(raw["ip_addresses"].(*pluginsdk.Set).List()),
 		Fqdns:       helpers.ExpandStringSlice(raw["fqdns"].(*pluginsdk.Set).List()),
 	}
-
-	return output
 }
 
 func expandFirewallPolicyDNSSetting(input []interface{}) *firewallpolicies.DnsSettings {
@@ -312,12 +310,10 @@ func expandFirewallPolicyDNSSetting(input []interface{}) *firewallpolicies.DnsSe
 	}
 
 	raw := input[0].(map[string]interface{})
-	output := &firewallpolicies.DnsSettings{
+	return &firewallpolicies.DnsSettings{
 		Servers:     helpers.ExpandStringSlice(raw["servers"].([]interface{})),
 		EnableProxy: pointer.To(raw["proxy_enabled"].(bool)),
 	}
-
-	return output
 }
 
 func expandFirewallPolicyIntrusionDetection(input []interface{}) *firewallpolicies.FirewallPolicyIntrusionDetection {
@@ -390,13 +386,11 @@ func expandFirewallPolicyInsights(input []interface{}) *firewallpolicies.Firewal
 	}
 
 	raw := input[0].(map[string]interface{})
-	output := &firewallpolicies.FirewallPolicyInsights{
+	return &firewallpolicies.FirewallPolicyInsights{
 		IsEnabled:             pointer.To(raw["enabled"].(bool)),
 		RetentionDays:         pointer.To(int64(raw["retention_in_days"].(int))),
 		LogAnalyticsResources: expandFirewallPolicyLogAnalyticsResources(raw["default_log_analytics_workspace_id"].(string), raw["log_analytics_workspace"].([]interface{})),
 	}
-
-	return output
 }
 
 func expandFirewallPolicyExplicitProxy(input []interface{}) *firewallpolicies.ExplicitProxy {
@@ -622,7 +616,7 @@ func flattenFirewallPolicyLogAnalyticsResources(input *firewallpolicies.Firewall
 }
 
 func resourceFirewallPolicySchema() map[string]*pluginsdk.Schema {
-	resource := map[string]*pluginsdk.Schema{
+	return map[string]*pluginsdk.Schema{
 		"name": {
 			Type:         pluginsdk.TypeString,
 			Required:     true,
@@ -972,6 +966,4 @@ func resourceFirewallPolicySchema() map[string]*pluginsdk.Schema {
 
 		"tags": commonschema.Tags(),
 	}
-
-	return resource
 }

--- a/internal/services/fluidrelay/fluid_relay_server_resource.go
+++ b/internal/services/fluidrelay/fluid_relay_server_resource.go
@@ -364,7 +364,7 @@ func expandFluidRelayServerCustomerManagedKey(input []CustomerManagedKey) *fluid
 	}
 
 	v := input[0]
-	encryption := &fluidrelayservers.EncryptionProperties{
+	return &fluidrelayservers.EncryptionProperties{
 		CustomerManagedKeyEncryption: &fluidrelayservers.CustomerManagedKeyEncryptionProperties{
 			KeyEncryptionKeyURL: pointer.To(v.KeyVaultKeyID),
 			KeyEncryptionKeyIdentity: &fluidrelayservers.CustomerManagedKeyEncryptionPropertiesKeyEncryptionKeyIdentity{
@@ -373,8 +373,6 @@ func expandFluidRelayServerCustomerManagedKey(input []CustomerManagedKey) *fluid
 			},
 		},
 	}
-
-	return encryption
 }
 
 func flattenFluidRelayServerCustomerManagedKey(input *fluidrelayservers.EncryptionProperties) ([]CustomerManagedKey, error) {

--- a/internal/services/frontdoor/frontdoor_resource.go
+++ b/internal/services/frontdoor/frontdoor_resource.go
@@ -1324,7 +1324,7 @@ func flattenSingleFrontDoorHealthProbeSettingsModel(input *frontdoors.HealthProb
 		}
 	}
 
-	output := map[string]interface{}{
+	return map[string]interface{}{
 		"enabled":             enabled,
 		"id":                  id,
 		"name":                name,
@@ -1333,8 +1333,6 @@ func flattenSingleFrontDoorHealthProbeSettingsModel(input *frontdoors.HealthProb
 		"path":                path,
 		"probe_method":        probeMethod,
 	}
-
-	return output
 }
 
 func combineLoadBalancingSettingsModel(allLoadBalancingSettings []frontdoors.LoadBalancingSettingsModel, orderedIds []interface{}, frontDoorId frontdoors.FrontDoorId) []interface{} {
@@ -1419,15 +1417,13 @@ func flattenSingleFrontDoorLoadBalancingSettingsModel(input *frontdoors.LoadBala
 		}
 	}
 
-	output := map[string]interface{}{
+	return map[string]interface{}{
 		"additional_latency_milliseconds": additionalLatencyMilliseconds,
 		"id":                              id,
 		"name":                            name,
 		"sample_size":                     sampleSize,
 		"successful_samples_required":     successfulSamplesRequired,
 	}
-
-	return output
 }
 
 func combineRoutingRules(allRoutingRules []frontdoors.RoutingRule, oldBlocks interface{}, orderedIds []interface{}, frontDoorId frontdoors.FrontDoorId) ([]interface{}, error) {

--- a/internal/services/frontdoor/frontdoor_rules_engine_resource.go
+++ b/internal/services/frontdoor/frontdoor_rules_engine_resource.go
@@ -304,12 +304,10 @@ func expandFrontDoorRulesEngineAction(input []interface{}) frontdoors.RulesEngin
 	requestHeaderActions := ruleAction["request_header"].([]interface{})
 	responseHeaderActions := ruleAction["response_header"].([]interface{})
 
-	frontdoorRulesEngineRuleAction := frontdoors.RulesEngineAction{
+	return frontdoors.RulesEngineAction{
 		RequestHeaderActions:  expandHeaderAction(requestHeaderActions),
 		ResponseHeaderActions: expandHeaderAction(responseHeaderActions),
 	}
-
-	return frontdoorRulesEngineRuleAction
 }
 
 func expandHeaderAction(input []interface{}) *[]frontdoors.HeaderAction {

--- a/internal/services/graphservices/registration.go
+++ b/internal/services/graphservices/registration.go
@@ -39,11 +39,9 @@ func (r Registration) DataSources() []sdk.DataSource {
 
 // Resources returns a list of Resources supported by this Service
 func (r Registration) Resources() []sdk.Resource {
-	resources := []sdk.Resource{
+	return []sdk.Resource{
 		AccountResource{},
 	}
-
-	return resources
 }
 
 func (r Registration) Actions() []func() action.Action {

--- a/internal/services/hdinsight/common_hdinsight.go
+++ b/internal/services/hdinsight/common_hdinsight.go
@@ -269,14 +269,12 @@ func flattenHDInsightRoles(d *pluginsdk.ResourceData, input *clusters.ComputePro
 
 	if definition.EdgeNodeDef != nil {
 		edgeNode := FindHDInsightRole(input.Roles, "edgenode")
-		edgeNodes := FlattenHDInsightNodeDefinition(edgeNode, existingEdgeNodes, *definition.EdgeNodeDef)
-		result["edge_node"] = edgeNodes
+		result["edge_node"] = FlattenHDInsightNodeDefinition(edgeNode, existingEdgeNodes, *definition.EdgeNodeDef)
 	}
 
 	if definition.KafkaManagementNodeDef != nil {
 		kafkaManagementNode := FindHDInsightRole(input.Roles, "kafkamanagementnode")
-		kafkaManagementNodes := FlattenHDInsightNodeDefinition(kafkaManagementNode, existingKafkaManagementNodes, *definition.KafkaManagementNodeDef)
-		result["kafka_management_node"] = kafkaManagementNodes
+		result["kafka_management_node"] = FlattenHDInsightNodeDefinition(kafkaManagementNode, existingKafkaManagementNodes, *definition.KafkaManagementNodeDef)
 	}
 
 	return []interface{}{
@@ -304,13 +302,11 @@ func createHDInsightEdgeNodes(ctx context.Context, client *applications.Applicat
 	}
 
 	if v, ok := input["https_endpoints"]; ok {
-		httpsEndpoints := expandHDInsightApplicationEdgeNodeHttpsEndpoints(v.([]interface{}))
-		payload.Properties.HTTPSEndpoints = httpsEndpoints
+		payload.Properties.HTTPSEndpoints = expandHDInsightApplicationEdgeNodeHttpsEndpoints(v.([]interface{}))
 	}
 
 	if v, ok := input["uninstall_script_actions"]; ok {
-		uninstallScriptActions := expandHDInsightApplicationEdgeNodeUninstallScriptActions(v.([]interface{}))
-		payload.Properties.UninstallScriptActions = uninstallScriptActions
+		payload.Properties.UninstallScriptActions = expandHDInsightApplicationEdgeNodeUninstallScriptActions(v.([]interface{}))
 	}
 
 	if err := client.CreateThenPoll(ctx, applicationId, payload); err != nil {

--- a/internal/services/hdinsight/hdinsight_kafka_cluster_resource.go
+++ b/internal/services/hdinsight/hdinsight_kafka_cluster_resource.go
@@ -57,7 +57,7 @@ var hdInsightKafkaClusterKafkaManagementNodeDefinition = HDInsightNodeDefinition
 }
 
 func resourceHDInsightKafkaCluster() *pluginsdk.Resource {
-	resource := &pluginsdk.Resource{
+	return &pluginsdk.Resource{
 		Create: resourceHDInsightKafkaClusterCreate,
 		Read:   resourceHDInsightKafkaClusterRead,
 		Update: hdinsightClusterUpdate("Kafka", resourceHDInsightKafkaClusterRead),
@@ -190,8 +190,6 @@ func resourceHDInsightKafkaCluster() *pluginsdk.Resource {
 			"extension": SchemaHDInsightsExtension(),
 		},
 	}
-
-	return resource
 }
 
 func resourceHDInsightKafkaClusterCreate(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/hdinsight/schema.go
+++ b/internal/services/hdinsight/schema.go
@@ -1333,7 +1333,7 @@ func SchemaHDInsightNodeDefinition(schemaLocation string, definition HDInsightNo
 		}
 	}
 
-	s := &pluginsdk.Schema{
+	return &pluginsdk.Schema{
 		Type:     pluginsdk.TypeList,
 		MaxItems: 1,
 		Required: required,
@@ -1342,8 +1342,6 @@ func SchemaHDInsightNodeDefinition(schemaLocation string, definition HDInsightNo
 			Schema: result,
 		},
 	}
-
-	return s
 }
 
 func SchemaHDInsightNodeDefinitionKafka(schemaLocation string, definition HDInsightNodeDefinition, required bool) *pluginsdk.Schema {
@@ -1520,7 +1518,7 @@ func SchemaHDInsightNodeDefinitionKafka(schemaLocation string, definition HDInsi
 		}
 	}
 
-	s := &pluginsdk.Schema{
+	return &pluginsdk.Schema{
 		Type:     pluginsdk.TypeList,
 		MaxItems: 1,
 		Required: required,
@@ -1529,8 +1527,6 @@ func SchemaHDInsightNodeDefinitionKafka(schemaLocation string, definition HDInsi
 			Schema: result,
 		},
 	}
-
-	return s
 }
 
 func ExpandHDInsightNodeDefinition(name string, input []interface{}, definition HDInsightNodeDefinition) (*clusters.Role, error) {
@@ -1695,12 +1691,10 @@ func ExpandHDInsightAutoscaleRecurrenceDefinition(input []interface{}) *clusters
 		})
 	}
 
-	result := &clusters.AutoscaleRecurrence{
+	return &clusters.AutoscaleRecurrence{
 		TimeZone: pointer.To(vs["timezone"].(string)),
 		Schedule: &schedules,
 	}
-
-	return result
 }
 
 func ExpandHDInsightSecurityProfile(input []interface{}) *clusters.SecurityProfile {
@@ -1763,11 +1757,9 @@ func FlattenHDInsightNodeDefinition(input *clusters.Role, existing []interface{}
 		// after extensive experimentation it appears multiple instance sizes fit `extralarge`, as such
 		// unfortunately we can't transform these; since it can't be changed
 		// we should be "safe" to try and pull it from the state instead, but clearly this isn't ideal
-		vmSize := existingV["vm_size"].(string)
-		output["vm_size"] = vmSize
+		output["vm_size"] = existingV["vm_size"].(string)
 
-		scriptActions := existingV["script_actions"].([]interface{})
-		output["script_actions"] = scriptActions
+		output["script_actions"] = existingV["script_actions"].([]interface{})
 	}
 
 	if profile := input.VirtualNetworkProfile; profile != nil {

--- a/internal/services/healthcare/healthcare_fhir_service_resource.go
+++ b/internal/services/healthcare/healthcare_fhir_service_resource.go
@@ -285,13 +285,11 @@ func resourceHealthcareApisFhirServiceCreate(d *pluginsdk.ResourceData, meta int
 	acrConfig := fhirservices.FhirServiceAcrConfiguration{}
 	ociArtifactsRaw, hasValues := d.GetOk("oci_artifact")
 	if hasValues {
-		ociArtifacts := expandOciArtifacts(ociArtifactsRaw.([]interface{}))
-		acrConfig.OciArtifacts = ociArtifacts
+		acrConfig.OciArtifacts = expandOciArtifacts(ociArtifactsRaw.([]interface{}))
 	}
 	loginServersRaw, hasValues := d.GetOk("container_registry_login_server_url")
 	if hasValues {
-		loginServers := expandFhirAcrLoginServer(loginServersRaw.(*pluginsdk.Set).List())
-		acrConfig.LoginServers = loginServers
+		acrConfig.LoginServers = expandFhirAcrLoginServer(loginServersRaw.(*pluginsdk.Set).List())
 	}
 	parameters.Properties.AcrConfiguration = &acrConfig
 
@@ -427,13 +425,11 @@ func resourceHealthcareApisFhirServiceUpdate(d *pluginsdk.ResourceData, meta int
 	acrConfig := fhirservices.FhirServiceAcrConfiguration{}
 	ociArtifactsRaw, hasValues := d.GetOk("oci_artifact")
 	if hasValues {
-		ociArtifacts := expandOciArtifacts(ociArtifactsRaw.([]interface{}))
-		acrConfig.OciArtifacts = ociArtifacts
+		acrConfig.OciArtifacts = expandOciArtifacts(ociArtifactsRaw.([]interface{}))
 	}
 	loginServersRaw, hasValues := d.GetOk("container_registry_login_server_url")
 	if hasValues {
-		loginServers := expandFhirAcrLoginServer(loginServersRaw.(*pluginsdk.Set).List())
-		acrConfig.LoginServers = loginServers
+		acrConfig.LoginServers = expandFhirAcrLoginServer(loginServersRaw.(*pluginsdk.Set).List())
 	}
 	parameters.Properties.AcrConfiguration = &acrConfig
 
@@ -495,13 +491,11 @@ func expandFhirAuthentication(input []interface{}) *fhirservices.FhirServiceAuth
 	audience := authConfig["audience"].(string)
 	smartProxyEnabled := authConfig["smart_proxy_enabled"].(bool)
 
-	auth := &fhirservices.FhirServiceAuthenticationConfiguration{
+	return &fhirservices.FhirServiceAuthenticationConfiguration{
 		Authority:         pointer.To(authority),
 		Audience:          pointer.To(audience),
 		SmartProxyEnabled: pointer.To(smartProxyEnabled),
 	}
-
-	return auth
 }
 
 func expandAccessPolicy(input []interface{}) *[]fhirservices.FhirServiceAccessPolicyEntry {

--- a/internal/services/healthcare/healthcare_service_resource.go
+++ b/internal/services/healthcare/healthcare_service_resource.go
@@ -412,14 +412,13 @@ func expandCorsConfiguration(d *pluginsdk.ResourceData) *service.ServiceCorsConf
 	maxAgeInSeconds := int64(corsConfigAttr["max_age_in_seconds"].(int))
 	allowCredentials := corsConfigAttr["allow_credentials"].(bool)
 
-	cors := &service.ServiceCorsConfigurationInfo{
+	return &service.ServiceCorsConfigurationInfo{
 		Origins:          &allowedOrigins,
 		Headers:          &allowedHeaders,
 		Methods:          &allowedMethods,
 		MaxAge:           &maxAgeInSeconds,
 		AllowCredentials: &allowCredentials,
 	}
-	return cors
 }
 
 func expandAuthentication(d *pluginsdk.ResourceData) *service.ServiceAuthenticationConfigurationInfo {
@@ -434,12 +433,11 @@ func expandAuthentication(d *pluginsdk.ResourceData) *service.ServiceAuthenticat
 	audience := authConfigAttr["audience"].(string)
 	smartProxyEnabled := authConfigAttr["smart_proxy_enabled"].(bool)
 
-	auth := &service.ServiceAuthenticationConfigurationInfo{
+	return &service.ServiceAuthenticationConfigurationInfo{
 		Authority:         &authority,
 		Audience:          &audience,
 		SmartProxyEnabled: &smartProxyEnabled,
 	}
-	return auth
 }
 
 func expandsCosmosDBConfiguration(d *pluginsdk.ResourceData) (*service.ServiceCosmosDbConfigurationInfo, error) {

--- a/internal/services/hybridcompute/arc_machine_data_source.go
+++ b/internal/services/hybridcompute/arc_machine_data_source.go
@@ -534,9 +534,7 @@ func (a ArcMachineDataSource) Read() sdk.ResourceFunc {
 					state.ClientPublicKey = *properties.ClientPublicKey
 				}
 
-				cloudMetadataValue := flattenCloudMetadataModel(properties.CloudMetadata)
-
-				state.CloudMetadata = cloudMetadataValue
+				state.CloudMetadata = flattenCloudMetadataModel(properties.CloudMetadata)
 
 				if properties.DetectedProperties != nil {
 					state.DetectedProperties = *properties.DetectedProperties
@@ -564,9 +562,7 @@ func (a ArcMachineDataSource) Read() sdk.ResourceFunc {
 					state.LastStatusChange = *properties.LastStatusChange
 				}
 
-				locationDataValue := flattenLocationDataModel(properties.LocationData)
-
-				state.LocationData = locationDataValue
+				state.LocationData = flattenLocationDataModel(properties.LocationData)
 
 				if properties.MachineFqdn != nil {
 					state.MachineFqdn = *properties.MachineFqdn
@@ -583,9 +579,7 @@ func (a ArcMachineDataSource) Read() sdk.ResourceFunc {
 					state.OsName = *properties.OsName
 				}
 
-				osProfileValue := flattenOSProfileModel(properties.OsProfile)
-
-				state.OsProfile = osProfileValue
+				state.OsProfile = flattenOSProfileModel(properties.OsProfile)
 
 				if properties.OsSku != nil {
 					state.OsSku = *properties.OsSku
@@ -607,9 +601,7 @@ func (a ArcMachineDataSource) Read() sdk.ResourceFunc {
 					state.PrivateLinkScopeResourceId = *properties.PrivateLinkScopeResourceId
 				}
 
-				serviceStatusesValue := flattenServiceStatusesModel(properties.ServiceStatuses)
-
-				state.ServiceStatuses = serviceStatusesValue
+				state.ServiceStatuses = flattenServiceStatusesModel(properties.ServiceStatuses)
 
 				if properties.Status != nil {
 					state.Status = *properties.Status
@@ -641,13 +633,9 @@ func flattenAgentConfigurationModel(input *machines.AgentConfiguration) ([]Agent
 
 	output := AgentConfigurationModel{}
 
-	extensionsAllowListValue := flattenConfigurationExtensionModel(input.ExtensionsAllowList)
+	output.ExtensionsAllowList = flattenConfigurationExtensionModel(input.ExtensionsAllowList)
 
-	output.ExtensionsAllowList = extensionsAllowListValue
-
-	extensionsBlockListValue := flattenConfigurationExtensionModel(input.ExtensionsBlockList)
-
-	output.ExtensionsBlockList = extensionsBlockListValue
+	output.ExtensionsBlockList = flattenConfigurationExtensionModel(input.ExtensionsBlockList)
 
 	if input.ExtensionsEnabled != nil {
 		parsedBool, err := strconv.ParseBool(*input.ExtensionsEnabled)
@@ -755,12 +743,9 @@ func flattenOSProfileModel(input *machines.OSProfile) []OSProfileModel {
 		output.ComputerName = *input.ComputerName
 	}
 
-	linuxConfigurationValue := flattenOSProfileLinuxConfigurationModel(input.LinuxConfiguration)
+	output.LinuxConfiguration = flattenOSProfileLinuxConfigurationModel(input.LinuxConfiguration)
 
-	output.LinuxConfiguration = linuxConfigurationValue
-
-	windowsConfigurationValue := flattenOSProfileWindowsConfigurationModel(input.WindowsConfiguration)
-	output.WindowsConfiguration = windowsConfigurationValue
+	output.WindowsConfiguration = flattenOSProfileWindowsConfigurationModel(input.WindowsConfiguration)
 
 	return append(outputList, output)
 }
@@ -773,9 +758,7 @@ func flattenOSProfileLinuxConfigurationModel(input *machines.OSProfileLinuxConfi
 
 	output := OSProfileLinuxConfigurationModel{}
 
-	patchSettingsValue := flattenPatchSettingsModel(input.PatchSettings)
-
-	output.PatchSettings = patchSettingsValue
+	output.PatchSettings = flattenPatchSettingsModel(input.PatchSettings)
 
 	return append(outputList, output)
 }
@@ -806,8 +789,7 @@ func flattenOSProfileWindowsConfigurationModel(input *machines.OSProfileWindowsC
 	}
 
 	output := OSProfileWindowsConfigurationModel{}
-	patchSettingsValue := flattenPatchSettingsModel(input.PatchSettings)
-	output.PatchSettings = patchSettingsValue
+	output.PatchSettings = flattenPatchSettingsModel(input.PatchSettings)
 
 	return append(outputList, output)
 }
@@ -820,11 +802,9 @@ func flattenServiceStatusesModel(input *machines.ServiceStatuses) []ServiceStatu
 
 	output := ServiceStatusesModel{}
 
-	extensionServiceValue := flattenServiceStatusModel(input.ExtensionService)
-	output.ExtensionService = extensionServiceValue
+	output.ExtensionService = flattenServiceStatusModel(input.ExtensionService)
 
-	guestConfigurationServiceValue := flattenServiceStatusModel(input.GuestConfigurationService)
-	output.GuestConfigurationService = guestConfigurationServiceValue
+	output.GuestConfigurationService = flattenServiceStatusModel(input.GuestConfigurationService)
 
 	return append(outputList, output)
 }

--- a/internal/services/iotcentral/iotcentral_application_resource.go
+++ b/internal/services/iotcentral/iotcentral_application_resource.go
@@ -26,7 +26,7 @@ import (
 )
 
 func resourceIotCentralApplication() *pluginsdk.Resource {
-	resource := &pluginsdk.Resource{
+	return &pluginsdk.Resource{
 		Create: resourceIotCentralAppCreate,
 		Read:   resourceIotCentralAppRead,
 		Update: resourceIotCentralAppUpdate,
@@ -104,8 +104,6 @@ func resourceIotCentralApplication() *pluginsdk.Resource {
 			"tags": commonschema.Tags(),
 		},
 	}
-
-	return resource
 }
 
 func resourceIotCentralAppCreate(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/iothub/iothub_endpoint_servicebus_queue_resource.go
+++ b/internal/services/iothub/iothub_endpoint_servicebus_queue_resource.go
@@ -55,7 +55,7 @@ func resourceIotHubEndpointServiceBusQueue() *pluginsdk.Resource {
 }
 
 func resourceIothubEndpointServicebusQueue() map[string]*pluginsdk.Schema {
-	out := map[string]*pluginsdk.Schema{
+	return map[string]*pluginsdk.Schema{
 		"name": {
 			Type:         pluginsdk.TypeString,
 			Required:     true,
@@ -129,8 +129,6 @@ func resourceIothubEndpointServicebusQueue() map[string]*pluginsdk.Schema {
 			ValidateFunc: validation.IsUUID,
 		},
 	}
-
-	return out
 }
 
 func resourceIotHubEndpointServiceBusQueueCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/iothub/iothub_shared_access_policy_resource.go
+++ b/internal/services/iothub/iothub_shared_access_policy_resource.go
@@ -338,8 +338,7 @@ func expandAccessRights(d *pluginsdk.ResourceData) string {
 			actualRights = append(actualRights, possibleRight.right)
 		}
 	}
-	strRights := strings.Join(actualRights, ", ")
-	return strRights
+	return strings.Join(actualRights, ", ")
 }
 
 func flattenAccessRights(r devices.AccessRights) accessRights {

--- a/internal/services/keyvault/key_vault_resource.go
+++ b/internal/services/keyvault/key_vault_resource.go
@@ -442,8 +442,7 @@ func resourceKeyVaultUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 
 	if d.HasChange("access_policy") {
 		policiesRaw := d.Get("access_policy").([]interface{})
-		accessPolicies := expandAccessPolicies(policiesRaw)
-		update.Properties.AccessPolicies = accessPolicies
+		update.Properties.AccessPolicies = expandAccessPolicies(policiesRaw)
 	}
 
 	if d.HasChange("enabled_for_deployment") {

--- a/internal/services/kusto/kusto_cluster_resource.go
+++ b/internal/services/kusto/kusto_cluster_resource.go
@@ -586,14 +586,12 @@ func expandOptimizedAutoScale(input []interface{}) *clusters.OptimizedAutoscale 
 	}
 
 	config := input[0].(map[string]interface{})
-	optimizedAutoScale := &clusters.OptimizedAutoscale{
+	return &clusters.OptimizedAutoscale{
 		Version:   1,
 		IsEnabled: true,
 		Minimum:   int64(config["minimum_instances"].(int)),
 		Maximum:   int64(config["maximum_instances"].(int)),
 	}
-
-	return optimizedAutoScale
 }
 
 func flattenOptimizedAutoScale(optimizedAutoScale *clusters.OptimizedAutoscale) []interface{} {

--- a/internal/services/legacy/registration.go
+++ b/internal/services/legacy/registration.go
@@ -33,12 +33,10 @@ func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 
 // SupportedResources returns the supported Resources supported by this Service
 func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
-	resources := map[string]*pluginsdk.Resource{
+	return map[string]*pluginsdk.Resource{
 		"azurerm_virtual_machine":           resourceVirtualMachine(),
 		"azurerm_virtual_machine_scale_set": resourceVirtualMachineScaleSet(),
 	}
-
-	return resources
 }
 
 func (r Registration) Actions() []func() action.Action {

--- a/internal/services/legacy/virtual_machine_resource.go
+++ b/internal/services/legacy/virtual_machine_resource.go
@@ -1653,12 +1653,10 @@ func expandAzureRmVirtualMachineDiagnosticsProfile(d *pluginsdk.ResourceData) *v
 	if len(bootDiagnostics) > 0 {
 		bootDiagnostic := bootDiagnostics[0].(map[string]interface{})
 
-		diagnostic := &virtualmachines.BootDiagnostics{
+		diagnosticsProfile.BootDiagnostics = &virtualmachines.BootDiagnostics{
 			Enabled:    pointer.To(bootDiagnostic["enabled"].(bool)),
 			StorageUri: pointer.To(bootDiagnostic["storage_uri"].(string)),
 		}
-
-		diagnosticsProfile.BootDiagnostics = diagnostic
 
 		return diagnosticsProfile
 	}
@@ -1673,11 +1671,9 @@ func expandAzureRmVirtualMachineAdditionalCapabilities(d *pluginsdk.ResourceData
 	}
 
 	additionalCapability := additionalCapabilities[0].(map[string]interface{})
-	capability := &virtualmachines.AdditionalCapabilities{
+	return &virtualmachines.AdditionalCapabilities{
 		UltraSSDEnabled: pointer.To(additionalCapability["ultra_ssd_enabled"].(bool)),
 	}
-
-	return capability
 }
 
 func expandAzureRmVirtualMachineImageReference(d *pluginsdk.ResourceData) (*virtualmachines.ImageReference, error) {

--- a/internal/services/legacy/virtual_machine_scale_set_resource.go
+++ b/internal/services/legacy/virtual_machine_scale_set_resource.go
@@ -1366,8 +1366,7 @@ func flattenAzureRMVirtualMachineScaleSetOsProfile(d *pluginsdk.ResourceData, pr
 
 	// admin password isn't returned, so let's look it up
 	if v, ok := d.GetOk("os_profile.0.admin_password"); ok {
-		password := v.(string)
-		result["admin_password"] = password
+		result["admin_password"] = v.(string)
 	}
 
 	if profile.CustomData != nil {
@@ -1912,11 +1911,9 @@ func expandAzureRMVirtualMachineScaleSetsDiagnosticProfile(d *pluginsdk.Resource
 		StorageUri: &storageUri,
 	}
 
-	diagnosticsProfile := virtualmachinescalesets.DiagnosticsProfile{
+	return virtualmachinescalesets.DiagnosticsProfile{
 		BootDiagnostics: bootDiagnostic,
 	}
-
-	return diagnosticsProfile
 }
 
 func expandAzureRMVirtualMachineScaleSetsStorageProfileOsDisk(d *pluginsdk.ResourceData) (*virtualmachinescalesets.VirtualMachineScaleSetOSDisk, error) {
@@ -2072,14 +2069,12 @@ func expandAzureRmVirtualMachineScaleSetOsProfileLinuxConfig(d *pluginsdk.Resour
 		sshPublicKeys = append(sshPublicKeys, sshPublicKey)
 	}
 
-	config := &virtualmachinescalesets.LinuxConfiguration{
+	return &virtualmachinescalesets.LinuxConfiguration{
 		DisablePasswordAuthentication: &disablePasswordAuth,
 		Ssh: &virtualmachinescalesets.SshConfiguration{
 			PublicKeys: &sshPublicKeys,
 		},
 	}
-
-	return config
 }
 
 func expandAzureRmVirtualMachineScaleSetOsProfileWindowsConfig(d *pluginsdk.ResourceData) *virtualmachinescalesets.WindowsConfiguration {

--- a/internal/services/loganalytics/log_analytics_solution_resource.go
+++ b/internal/services/loganalytics/log_analytics_solution_resource.go
@@ -324,14 +324,12 @@ func expandAzureRmLogAnalyticsSolutionPlan(plans []SolutionPlanModel) solution.S
 	promotionCode := plan.PromotionCode
 	product := plan.Product
 
-	expandedPlan := solution.SolutionPlan{
+	return solution.SolutionPlan{
 		Name:          pointer.To(name),
 		PromotionCode: pointer.To(promotionCode),
 		Publisher:     pointer.To(publisher),
 		Product:       pointer.To(product),
 	}
-
-	return expandedPlan
 }
 
 func flattenAzureRmLogAnalyticsSolutionPlan(input *solution.SolutionPlan) []SolutionPlanModel {

--- a/internal/services/loganalytics/log_analytics_workspace_resource.go
+++ b/internal/services/loganalytics/log_analytics_workspace_resource.go
@@ -33,7 +33,7 @@ import (
 )
 
 func resourceLogAnalyticsWorkspace() *pluginsdk.Resource {
-	resource := &pluginsdk.Resource{
+	return &pluginsdk.Resource{
 		Create: resourceLogAnalyticsWorkspaceCreate,
 		Read:   resourceLogAnalyticsWorkspaceRead,
 		Update: resourceLogAnalyticsWorkspaceUpdate,
@@ -193,8 +193,6 @@ func resourceLogAnalyticsWorkspace() *pluginsdk.Resource {
 			"tags": commonschema.Tags(),
 		},
 	}
-
-	return resource
 }
 
 func resourceLogAnalyticsWorkspaceCustomDiff(_ context.Context, d *pluginsdk.ResourceDiff, _ interface{}) error {

--- a/internal/services/logic/logic_app_standard_resource.go
+++ b/internal/services/logic/logic_app_standard_resource.go
@@ -81,7 +81,7 @@ var (
 )
 
 func (r LogicAppResource) Arguments() map[string]*pluginsdk.Schema {
-	s := map[string]*pluginsdk.Schema{
+	return map[string]*pluginsdk.Schema{
 		"name": {
 			Type:         pluginsdk.TypeString,
 			Required:     true,
@@ -278,8 +278,6 @@ func (r LogicAppResource) Arguments() map[string]*pluginsdk.Schema {
 
 		"tags": commonschema.Tags(),
 	}
-
-	return s
 }
 
 func (r LogicAppResource) Attributes() map[string]*pluginsdk.Schema {

--- a/internal/services/logic/registration.go
+++ b/internal/services/logic/registration.go
@@ -55,7 +55,7 @@ func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 
 // SupportedResources returns the supported Resources supported by this Service
 func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
-	resources := map[string]*pluginsdk.Resource{
+	return map[string]*pluginsdk.Resource{
 		"azurerm_logic_app_action_custom":                           resourceLogicAppActionCustom(),
 		"azurerm_logic_app_action_http":                             resourceLogicAppActionHTTP(),
 		"azurerm_logic_app_integration_account":                     resourceLogicAppIntegrationAccount(),
@@ -72,8 +72,6 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 		"azurerm_logic_app_trigger_recurrence":                      resourceLogicAppTriggerRecurrence(),
 		"azurerm_logic_app_workflow":                                resourceLogicAppWorkflow(),
 	}
-
-	return resources
 }
 
 func (r Registration) Actions() []func() action.Action {

--- a/internal/services/machinelearning/ai_foundry_resource.go
+++ b/internal/services/machinelearning/ai_foundry_resource.go
@@ -322,8 +322,7 @@ func (r AIFoundry) Create() sdk.ResourceFunc {
 			}
 
 			if len(model.Encryption) > 0 {
-				encryption := expandEncryption(model.Encryption)
-				payload.Properties.Encryption = encryption
+				payload.Properties.Encryption = expandEncryption(model.Encryption)
 			}
 
 			if len(model.ManagedNetwork) > 0 {

--- a/internal/services/machinelearning/machine_learning_workspace_network_outbound_rule_fqdn_resource.go
+++ b/internal/services/machinelearning/machine_learning_workspace_network_outbound_rule_fqdn_resource.go
@@ -43,7 +43,7 @@ func (r WorkspaceNetworkOutboundRuleFqdn) IDValidationFunc() pluginsdk.SchemaVal
 }
 
 func (r WorkspaceNetworkOutboundRuleFqdn) Arguments() map[string]*pluginsdk.Schema {
-	arguments := map[string]*pluginsdk.Schema{
+	return map[string]*pluginsdk.Schema{
 		"name": {
 			Type:         pluginsdk.TypeString,
 			Required:     true,
@@ -64,7 +64,6 @@ func (r WorkspaceNetworkOutboundRuleFqdn) Arguments() map[string]*pluginsdk.Sche
 			ValidateFunc: validation.StringIsNotEmpty,
 		},
 	}
-	return arguments
 }
 
 func (r WorkspaceNetworkOutboundRuleFqdn) Attributes() map[string]*pluginsdk.Schema {

--- a/internal/services/machinelearning/machine_learning_workspace_network_outbound_rule_private_endpoint_resource.go
+++ b/internal/services/machinelearning/machine_learning_workspace_network_outbound_rule_private_endpoint_resource.go
@@ -51,7 +51,7 @@ func (r WorkspaceNetworkOutboundRulePrivateEndpoint) IDValidationFunc() pluginsd
 }
 
 func (r WorkspaceNetworkOutboundRulePrivateEndpoint) Arguments() map[string]*pluginsdk.Schema {
-	arguments := map[string]*pluginsdk.Schema{
+	return map[string]*pluginsdk.Schema{
 		"name": {
 			Type:         pluginsdk.TypeString,
 			Required:     true,
@@ -97,7 +97,6 @@ func (r WorkspaceNetworkOutboundRulePrivateEndpoint) Arguments() map[string]*plu
 			ForceNew: true,
 		},
 	}
-	return arguments
 }
 
 func (r WorkspaceNetworkOutboundRulePrivateEndpoint) Attributes() map[string]*pluginsdk.Schema {

--- a/internal/services/machinelearning/machine_learning_workspace_network_outbound_rule_service_tag_resource.go
+++ b/internal/services/machinelearning/machine_learning_workspace_network_outbound_rule_service_tag_resource.go
@@ -44,7 +44,7 @@ func (r WorkspaceNetworkOutboundRuleServiceTag) IDValidationFunc() pluginsdk.Sch
 }
 
 func (r WorkspaceNetworkOutboundRuleServiceTag) Arguments() map[string]*pluginsdk.Schema {
-	arguments := map[string]*pluginsdk.Schema{
+	return map[string]*pluginsdk.Schema{
 		"name": {
 			Type:         pluginsdk.TypeString,
 			Required:     true,
@@ -154,7 +154,6 @@ func (r WorkspaceNetworkOutboundRuleServiceTag) Arguments() map[string]*pluginsd
 			ValidateFunc: validation.StringIsNotEmpty,
 		},
 	}
-	return arguments
 }
 
 func (r WorkspaceNetworkOutboundRuleServiceTag) Attributes() map[string]*pluginsdk.Schema {

--- a/internal/services/machinelearning/migration/machine_learning_datastore_fileshare_v0_to_v1.go
+++ b/internal/services/machinelearning/migration/machine_learning_datastore_fileshare_v0_to_v1.go
@@ -19,8 +19,7 @@ func (MachineLearningDataStoreFileShareV0ToV1) UpgradeFunc() pluginsdk.StateUpgr
 	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
 		if v, ok := rawState["storage_fileshare_id"].(string); ok && v != "" {
 			if id, err := storageparse.StorageShareResourceManagerID(v); err == nil {
-				newID := fileshares.NewShareID(id.SubscriptionId, id.ResourceGroup, id.StorageAccountName, id.FileshareName).ID()
-				rawState["storage_fileshare_id"] = newID
+				rawState["storage_fileshare_id"] = fileshares.NewShareID(id.SubscriptionId, id.ResourceGroup, id.StorageAccountName, id.FileshareName).ID()
 			}
 		}
 

--- a/internal/services/maintenance/maintenance_assignment_dynamic_scope_resource.go
+++ b/internal/services/maintenance/maintenance_assignment_dynamic_scope_resource.go
@@ -220,11 +220,10 @@ func (r MaintenanceDynamicScopeResource) Create() sdk.ResourceFunc {
 						tags[tag.Tag] = tag.Values
 					}
 
-					tagProperties := &configurationassignments.TagSettingsProperties{
+					filterProperties.TagSettings = &configurationassignments.TagSettingsProperties{
 						FilterOperator: pointer.ToEnum[configurationassignments.TagOperators](filter.TagFilter),
 						Tags:           pointer.To(tags),
 					}
-					filterProperties.TagSettings = tagProperties
 				}
 				configurationAssignment.Properties.Filter = pointer.To(filterProperties)
 			}
@@ -351,11 +350,10 @@ func (MaintenanceDynamicScopeResource) Update() sdk.ResourceFunc {
 							tags[tag.Tag] = tag.Values
 						}
 
-						tagProperties := &configurationassignments.TagSettingsProperties{
+						filterProperties.TagSettings = &configurationassignments.TagSettingsProperties{
 							FilterOperator: pointer.ToEnum[configurationassignments.TagOperators](filter.TagFilter),
 							Tags:           pointer.To(tags),
 						}
-						filterProperties.TagSettings = tagProperties
 					}
 
 					if pointer.To(filterProperties) != nil {

--- a/internal/services/managedapplications/managed_application_resource.go
+++ b/internal/services/managedapplications/managed_application_resource.go
@@ -53,7 +53,7 @@ func resourceManagedApplication() *pluginsdk.Resource {
 }
 
 func resourceManagedApplicationSchema() map[string]*pluginsdk.Schema {
-	schema := map[string]*pluginsdk.Schema{
+	return map[string]*pluginsdk.Schema{
 		"name": {
 			Type:         pluginsdk.TypeString,
 			Required:     true,
@@ -142,8 +142,6 @@ func resourceManagedApplicationSchema() map[string]*pluginsdk.Schema {
 			},
 		},
 	}
-
-	return schema
 }
 
 func resourceManagedApplicationCreate(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/manageddevopspools/helpers.go
+++ b/internal/services/manageddevopspools/helpers.go
@@ -213,10 +213,9 @@ func expandStatefulAgentModel(input []StatefulAgentModel) pools.AgentProfile {
 			stateful.ResourcePredictions = pointer.To(interface{}(*resourcePredictions))
 		}
 
-		manualPredictionProfile := &pools.ManualResourcePredictionsProfile{
+		stateful.ResourcePredictionsProfile = &pools.ManualResourcePredictionsProfile{
 			Kind: pools.ResourcePredictionsProfileTypeManual,
 		}
-		stateful.ResourcePredictionsProfile = manualPredictionProfile
 	} else if len(agentProfile.AutomaticResourcePrediction) > 0 {
 		automaticResourcePrediction := agentProfile.AutomaticResourcePrediction[0]
 
@@ -254,10 +253,9 @@ func expandStatelessAgentModel(input []StatelessAgentModel) pools.AgentProfile {
 			stateless.ResourcePredictions = pointer.To(interface{}(*resourcePredictions))
 		}
 
-		manualPredictionProfile := &pools.ManualResourcePredictionsProfile{
+		stateless.ResourcePredictionsProfile = &pools.ManualResourcePredictionsProfile{
 			Kind: pools.ResourcePredictionsProfileTypeManual,
 		}
-		stateless.ResourcePredictionsProfile = manualPredictionProfile
 	} else if len(agentProfile.AutomaticResourcePrediction) > 0 {
 		automaticPredictionProfile := &pools.AutomaticResourcePredictionsProfile{
 			Kind: pools.ResourcePredictionsProfileTypeAutomatic,

--- a/internal/services/managedhsm/key_vault_managed_hardware_security_module_resource.go
+++ b/internal/services/managedhsm/key_vault_managed_hardware_security_module_resource.go
@@ -437,12 +437,10 @@ func expandMHSMNetworkAcls(input []interface{}) *managedhsms.MHSMNetworkRuleSet 
 		return nil
 	}
 	v := input[0].(map[string]interface{})
-	res := &managedhsms.MHSMNetworkRuleSet{
+	return &managedhsms.MHSMNetworkRuleSet{
 		Bypass:        pointer.ToEnum[managedhsms.NetworkRuleBypassOptions](v["bypass"].(string)),
 		DefaultAction: pointer.ToEnum[managedhsms.NetworkRuleAction](v["default_action"].(string)),
 	}
-
-	return res
 }
 
 func flattenMHSMNetworkAcls(acl *managedhsms.MHSMNetworkRuleSet) []interface{} {

--- a/internal/services/managedhsm/key_vault_managed_hardware_security_module_role_assignment_resource.go
+++ b/internal/services/managedhsm/key_vault_managed_hardware_security_module_role_assignment_resource.go
@@ -40,7 +40,7 @@ var _ sdk.ResourceWithStateMigration = KeyVaultManagedHSMRoleAssignmentResource{
 type KeyVaultManagedHSMRoleAssignmentResource struct{}
 
 func (r KeyVaultManagedHSMRoleAssignmentResource) Arguments() map[string]*pluginsdk.Schema {
-	s := map[string]*pluginsdk.Schema{
+	return map[string]*pluginsdk.Schema{
 		"managed_hsm_id": {
 			Type:         pluginsdk.TypeString,
 			ForceNew:     true,
@@ -76,8 +76,6 @@ func (r KeyVaultManagedHSMRoleAssignmentResource) Arguments() map[string]*plugin
 			ValidateFunc: validation.StringIsNotEmpty,
 		},
 	}
-
-	return s
 }
 
 func (r KeyVaultManagedHSMRoleAssignmentResource) Attributes() map[string]*pluginsdk.Schema {

--- a/internal/services/managedhsm/key_vault_managed_hardware_security_module_role_definition_resource.go
+++ b/internal/services/managedhsm/key_vault_managed_hardware_security_module_role_definition_resource.go
@@ -51,7 +51,7 @@ var (
 // Arguments ...
 // skip `assignable_scopes` field support as https://github.com/Azure/azure-rest-api-specs/issues/23045
 func (r KeyVaultMHSMRoleDefinitionResource) Arguments() map[string]*pluginsdk.Schema {
-	s := map[string]*pluginsdk.Schema{
+	return map[string]*pluginsdk.Schema{
 		"name": {
 			Type:         pluginsdk.TypeString,
 			Required:     true,
@@ -134,8 +134,6 @@ func (r KeyVaultMHSMRoleDefinitionResource) Arguments() map[string]*pluginsdk.Sc
 			ValidateFunc: validation.StringIsNotEmpty,
 		},
 	}
-
-	return s
 }
 
 func (r KeyVaultMHSMRoleDefinitionResource) Attributes() map[string]*pluginsdk.Schema {

--- a/internal/services/managedidentity/registration.go
+++ b/internal/services/managedidentity/registration.go
@@ -28,16 +28,14 @@ func (r Registration) Name() string {
 }
 
 func (r Registration) DataSources() []sdk.DataSource {
-	dataSources := []sdk.DataSource{}
-	return dataSources
+	return []sdk.DataSource{}
 }
 
 func (r Registration) Resources() []sdk.Resource {
-	resources := []sdk.Resource{
+	return []sdk.Resource{
 		FederatedIdentityCredentialResource{},
 		UserAssignedIdentityResource{},
 	}
-	return resources
 }
 
 // WebsiteCategories returns a list of categories which can be used for the sidebar

--- a/internal/services/monitor/monitor_action_group_data_source.go
+++ b/internal/services/monitor/monitor_action_group_data_source.go
@@ -17,7 +17,7 @@ import (
 )
 
 func dataSourceMonitorActionGroup() *pluginsdk.Resource {
-	resource := &pluginsdk.Resource{
+	return &pluginsdk.Resource{
 		Read: dataSourceMonitorActionGroupRead,
 
 		Timeouts: &pluginsdk.ResourceTimeout{
@@ -348,8 +348,6 @@ func dataSourceMonitorActionGroup() *pluginsdk.Resource {
 			},
 		},
 	}
-
-	return resource
 }
 
 func dataSourceMonitorActionGroupRead(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/monitor/monitor_action_group_resource.go
+++ b/internal/services/monitor/monitor_action_group_resource.go
@@ -29,7 +29,7 @@ import (
 //go:generate go run ../../tools/generator-tests resourceidentity
 
 func resourceMonitorActionGroup() *pluginsdk.Resource {
-	resource := &pluginsdk.Resource{
+	return &pluginsdk.Resource{
 		Create: resourceMonitorActionGroupCreateUpdate,
 		Read:   resourceMonitorActionGroupRead,
 		Update: resourceMonitorActionGroupCreateUpdate,
@@ -439,8 +439,6 @@ func resourceMonitorActionGroup() *pluginsdk.Resource {
 			"tags": commonschema.Tags(),
 		},
 	}
-
-	return resource
 }
 
 func resourceMonitorActionGroupCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/monitor/monitor_alert_processing_rule_suppression_resource.go
+++ b/internal/services/monitor/monitor_alert_processing_rule_suppression_resource.go
@@ -43,8 +43,7 @@ func (r AlertProcessingRuleSuppressionResource) IDValidationFunc() pluginsdk.Sch
 }
 
 func (r AlertProcessingRuleSuppressionResource) Arguments() map[string]*pluginsdk.Schema {
-	arguments := schemaAlertProcessingRule()
-	return arguments
+	return schemaAlertProcessingRule()
 }
 
 func (r AlertProcessingRuleSuppressionResource) Attributes() map[string]*pluginsdk.Schema {

--- a/internal/services/monitor/monitor_alert_prometheus_rule_group_resource.go
+++ b/internal/services/monitor/monitor_alert_prometheus_rule_group_resource.go
@@ -495,16 +495,14 @@ func flattenPrometheusRuleModel(inputList *[]prometheusrulegroups.PrometheusRule
 			Expression: input.Expression,
 		}
 
-		actionsValue := flattenPrometheusRuleGroupActionModel(input.Actions)
-		output.Action = actionsValue
+		output.Action = flattenPrometheusRuleGroupActionModel(input.Actions)
 		output.Alert = pointer.From(input.Alert)
 		output.Annotations = pointer.From(input.Annotations)
 		output.Enabled = pointer.From(input.Enabled)
 		output.For = pointer.From(input.For)
 		output.Labels = pointer.From(input.Labels)
 		output.Record = pointer.From(input.Record)
-		resolveConfigurationValue := flattenPrometheusRuleAlertResolutionModel(input.ResolveConfiguration)
-		output.AlertResolution = resolveConfigurationValue
+		output.AlertResolution = flattenPrometheusRuleAlertResolutionModel(input.ResolveConfiguration)
 		output.Severity = pointer.From(input.Severity)
 		outputList = append(outputList, output)
 	}

--- a/internal/services/monitor/monitor_diagnostic_categories_data_source.go
+++ b/internal/services/monitor/monitor_diagnostic_categories_data_source.go
@@ -17,7 +17,7 @@ import (
 )
 
 func dataSourceMonitorDiagnosticCategories() *pluginsdk.Resource {
-	resource := &pluginsdk.Resource{
+	return &pluginsdk.Resource{
 		Read: dataSourceMonitorDiagnosticCategoriesRead,
 
 		Timeouts: &pluginsdk.ResourceTimeout{
@@ -53,8 +53,6 @@ func dataSourceMonitorDiagnosticCategories() *pluginsdk.Resource {
 			},
 		},
 	}
-
-	return resource
 }
 
 func dataSourceMonitorDiagnosticCategoriesRead(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/monitor/monitor_diagnostic_setting_resource.go
+++ b/internal/services/monitor/monitor_diagnostic_setting_resource.go
@@ -316,8 +316,7 @@ func resourceMonitorDiagnosticSettingUpdate(d *pluginsdk.ResourceData, meta inte
 	if d.HasChange("enabled_metric") {
 		enabledMetrics := d.Get("enabled_metric").(*pluginsdk.Set).List()
 		if len(enabledMetrics) > 0 {
-			expandEnabledMetrics := expandMonitorDiagnosticsSettingsEnabledMetrics(enabledMetrics)
-			metrics = expandEnabledMetrics
+			metrics = expandMonitorDiagnosticsSettingsEnabledMetrics(enabledMetrics)
 			hasEnabledMetrics = true
 		} else if existing.Model != nil && existing.Model.Properties != nil && existing.Model.Properties.Metrics != nil {
 			// if the enabled_metric is updated to empty, we disable the metric explicitly

--- a/internal/services/monitor/registration.go
+++ b/internal/services/monitor/registration.go
@@ -57,19 +57,17 @@ func (r Registration) WebsiteCategories() []string {
 
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
-	dataSources := map[string]*pluginsdk.Resource{
+	return map[string]*pluginsdk.Resource{
 		"azurerm_monitor_action_group":                dataSourceMonitorActionGroup(),
 		"azurerm_monitor_diagnostic_categories":       dataSourceMonitorDiagnosticCategories(),
 		"azurerm_monitor_scheduled_query_rules_alert": dataSourceMonitorScheduledQueryRulesAlert(),
 		"azurerm_monitor_scheduled_query_rules_log":   dataSourceMonitorScheduledQueryRulesLog(),
 	}
-
-	return dataSources
 }
 
 // SupportedResources returns the supported Resources supported by this Service
 func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
-	resources := map[string]*pluginsdk.Resource{
+	return map[string]*pluginsdk.Resource{
 		"azurerm_monitor_aad_diagnostic_setting":      resourceMonitorAADDiagnosticSetting(),
 		"azurerm_monitor_autoscale_setting":           resourceMonitorAutoScaleSetting(),
 		"azurerm_monitor_action_group":                resourceMonitorActionGroup(),
@@ -82,8 +80,6 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 		"azurerm_monitor_scheduled_query_rules_log":   resourceMonitorScheduledQueryRulesLog(),
 		"azurerm_monitor_smart_detector_alert_rule":   resourceMonitorSmartDetectorAlertRule(),
 	}
-
-	return resources
 }
 
 func (r Registration) Actions() []func() action.Action {

--- a/internal/services/mssqlmanagedinstance/mssql_managed_database_resource.go
+++ b/internal/services/mssqlmanagedinstance/mssql_managed_database_resource.go
@@ -424,14 +424,12 @@ func expandLongTermRetentionPolicy(ltrPolicy []LongTermRetentionPolicy) *managed
 		weekOfYear = ltrPolicy[0].WeekOfYear
 	}
 
-	result := &managedinstancelongtermretentionpolicies.ManagedInstanceLongTermRetentionPolicyProperties{
+	return &managedinstancelongtermretentionpolicies.ManagedInstanceLongTermRetentionPolicyProperties{
 		WeeklyRetention:  &ltrPolicy[0].WeeklyRetention,
 		MonthlyRetention: &ltrPolicy[0].MonthlyRetention,
 		YearlyRetention:  &ltrPolicy[0].YearlyRetention,
 		WeekOfYear:       &weekOfYear,
 	}
-
-	return result
 }
 
 func flattenLongTermRetentionPolicy(ltrPolicy managedinstancelongtermretentionpolicies.ManagedInstanceLongTermRetentionPolicyProperties) []LongTermRetentionPolicy {

--- a/internal/services/mysql/registration.go
+++ b/internal/services/mysql/registration.go
@@ -46,23 +46,19 @@ func (r Registration) WebsiteCategories() []string {
 
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
-	dataSources := map[string]*pluginsdk.Resource{
+	return map[string]*pluginsdk.Resource{
 		"azurerm_mysql_flexible_server": dataSourceMysqlFlexibleServer(),
 	}
-
-	return dataSources
 }
 
 // SupportedResources returns the supported Resources supported by this Service
 func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
-	resources := map[string]*pluginsdk.Resource{
+	return map[string]*pluginsdk.Resource{
 		"azurerm_mysql_flexible_server":               resourceMysqlFlexibleServer(),
 		"azurerm_mysql_flexible_database":             resourceMySqlFlexibleDatabase(),
 		"azurerm_mysql_flexible_server_configuration": resourceMySQLFlexibleServerConfiguration(),
 		"azurerm_mysql_flexible_server_firewall_rule": resourceMySqlFlexibleServerFirewallRule(),
 	}
-
-	return resources
 }
 
 // Actions implements [sdk.FrameworkServiceRegistration].

--- a/internal/services/netapp/netapp_pool_resource.go
+++ b/internal/services/netapp/netapp_pool_resource.go
@@ -26,7 +26,7 @@ import (
 )
 
 func resourceNetAppPool() *pluginsdk.Resource {
-	resource := &pluginsdk.Resource{
+	return &pluginsdk.Resource{
 		Create: resourceNetAppPoolCreate,
 		Read:   resourceNetAppPoolRead,
 		Update: resourceNetAppPoolUpdate,
@@ -143,8 +143,6 @@ func resourceNetAppPool() *pluginsdk.Resource {
 			},
 		),
 	}
-
-	return resource
 }
 
 func resourceNetAppPoolCreate(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/netapp/netapp_volume_group_oracle_resource.go
+++ b/internal/services/netapp/netapp_volume_group_oracle_resource.go
@@ -515,8 +515,7 @@ func (r NetAppVolumeGroupOracleResource) Update() sdk.ResourceFunc {
 								}
 							}
 
-							exportPolicyRule := expandNetAppVolumeGroupVolumeExportPolicyRulePatchWithProtocolConversion(exportPolicyRuleRaw, protocolOverride)
-							update.Properties.ExportPolicy = exportPolicyRule
+							update.Properties.ExportPolicy = expandNetAppVolumeGroupVolumeExportPolicyRulePatchWithProtocolConversion(exportPolicyRuleRaw, protocolOverride)
 						}
 
 						if metadata.ResourceData.HasChange(fmt.Sprintf("%v.protocols", volumeItem)) {

--- a/internal/services/netapp/netapp_volume_group_sap_hana_resource.go
+++ b/internal/services/netapp/netapp_volume_group_sap_hana_resource.go
@@ -530,8 +530,7 @@ func (r NetAppVolumeGroupSAPHanaResource) Update() sdk.ResourceFunc {
 								}
 							}
 
-							exportPolicyRule := expandNetAppVolumeGroupVolumeExportPolicyRulePatchWithProtocolConversion(exportPolicyRuleRaw, protocolOverride)
-							update.Properties.ExportPolicy = exportPolicyRule
+							update.Properties.ExportPolicy = expandNetAppVolumeGroupVolumeExportPolicyRulePatchWithProtocolConversion(exportPolicyRuleRaw, protocolOverride)
 						}
 
 						if metadata.ResourceData.HasChange(fmt.Sprintf("%v.protocols", volumeItem)) {

--- a/internal/services/netapp/netapp_volume_helper.go
+++ b/internal/services/netapp/netapp_volume_helper.go
@@ -507,8 +507,7 @@ func flattenNetAppVolumeGroupSAPHanaVolumes(ctx context.Context, input *[]volume
 		volumeGroupVolume.VolumeSpecName = pointer.From(props.VolumeSpecName)
 
 		if props.UsageThreshold > 0 {
-			usageThreshold := props.UsageThreshold / 1073741824
-			volumeGroupVolume.StorageQuotaInGB = usageThreshold
+			volumeGroupVolume.StorageQuotaInGB = props.UsageThreshold / 1073741824
 		}
 
 		if props.ExportPolicy != nil && props.ExportPolicy.Rules != nil && len(pointer.From(props.ExportPolicy.Rules)) > 0 {
@@ -590,8 +589,7 @@ func flattenNetAppVolumeGroupOracleVolumes(ctx context.Context, input *[]volumeg
 		volumeGroupVolume.VolumeSpecName = pointer.From(props.VolumeSpecName)
 
 		if props.UsageThreshold > 0 {
-			usageThreshold := props.UsageThreshold / 1073741824
-			volumeGroupVolume.StorageQuotaInGB = usageThreshold
+			volumeGroupVolume.StorageQuotaInGB = props.UsageThreshold / 1073741824
 		}
 
 		if props.ExportPolicy != nil && props.ExportPolicy.Rules != nil && len(pointer.From(props.ExportPolicy.Rules)) > 0 {

--- a/internal/services/netapp/netapp_volume_resource.go
+++ b/internal/services/netapp/netapp_volume_resource.go
@@ -37,7 +37,7 @@ const (
 )
 
 func resourceNetAppVolume() *pluginsdk.Resource {
-	resource := &pluginsdk.Resource{
+	return &pluginsdk.Resource{
 		Create: resourceNetAppVolumeCreate,
 		Read:   resourceNetAppVolumeRead,
 		Update: resourceNetAppVolumeUpdate,
@@ -574,8 +574,6 @@ func resourceNetAppVolume() *pluginsdk.Resource {
 			return nil
 		},
 	}
-
-	return resource
 }
 
 func resourceNetAppVolumeCreate(d *pluginsdk.ResourceData, meta interface{}) error {
@@ -889,8 +887,7 @@ func resourceNetAppVolumeUpdate(d *pluginsdk.ResourceData, meta interface{}) err
 			protocols := d.Get("protocols").(*pluginsdk.Set).List()
 			protocolOverride = *helpers.ExpandStringSlice(protocols)
 		}
-		exportPolicyRule := expandNetAppVolumeExportPolicyRulePatch(exportPolicyRuleRaw, protocolOverride)
-		update.Properties.ExportPolicy = exportPolicyRule
+		update.Properties.ExportPolicy = expandNetAppVolumeExportPolicyRulePatch(exportPolicyRuleRaw, protocolOverride)
 	}
 
 	if d.HasChange("protocols") {

--- a/internal/services/network/application_gateway_resource.go
+++ b/internal/services/network/application_gateway_resource.go
@@ -2013,8 +2013,7 @@ func resourceApplicationGatewayUpdate(d *pluginsdk.ResourceData, meta interface{
 	}
 
 	if d.HasChange("global") {
-		globalConfiguration := expandApplicationGatewayGlobalConfiguration(d.Get("global").([]interface{}))
-		payload.Properties.GlobalConfiguration = globalConfiguration
+		payload.Properties.GlobalConfiguration = expandApplicationGatewayGlobalConfiguration(d.Get("global").([]interface{}))
 	}
 
 	if d.HasChange("http_listener") {
@@ -2072,9 +2071,7 @@ func resourceApplicationGatewayUpdate(d *pluginsdk.ResourceData, meta interface{
 	}
 
 	if d.HasChange("probe") {
-		probes := expandApplicationGatewayProbes(d.Get("probe").(*schema.Set).List())
-
-		payload.Properties.Probes = probes
+		payload.Properties.Probes = expandApplicationGatewayProbes(d.Get("probe").(*schema.Set).List())
 	}
 
 	if d.HasChange("sku") {
@@ -4446,8 +4443,7 @@ func flattenApplicationGatewaySslCertificates(input *[]applicationgateways.Appli
 
 				if name == existingName {
 					if data := existingCerts["data"]; data != nil {
-						v := helpers.Base64EncodeIfNot(data.(string))
-						output["data"] = v
+						output["data"] = helpers.Base64EncodeIfNot(data.(string))
 					}
 
 					if password := existingCerts["password"]; password != nil {

--- a/internal/services/network/application_gateway_resource_test.go
+++ b/internal/services/network/application_gateway_resource_test.go
@@ -2475,7 +2475,7 @@ resource "azurerm_application_gateway" "import" {
 
 // nolint unused - mistakenly marked as unused
 func (r ApplicationGatewayResource) trustedRootCertificate_keyvault(data acceptance.TestData) string {
-	out := fmt.Sprintf(`
+	return fmt.Sprintf(`
 %[1]s
 
 # since these variables are re-used - a locals block makes this more maintainable
@@ -2640,11 +2640,10 @@ resource "azurerm_application_gateway" "test" {
   }
 }
 `, r.template(data), data.RandomInteger)
-	return out
 }
 
 func (r ApplicationGatewayResource) update_trustedRootCertificate_keyvault(data acceptance.TestData) string {
-	out := fmt.Sprintf(`
+	return fmt.Sprintf(`
 %[1]s
 
 # since these variables are re-used - a locals block makes this more maintainable
@@ -2835,7 +2834,6 @@ resource "azurerm_application_gateway" "test" {
   }
 }
 `, r.template(data), data.RandomInteger)
-	return out
 }
 
 func (r ApplicationGatewayResource) updateForceFirewallPolicyAssociation(data acceptance.TestData, forceFirewallPolicyAssociation bool) string {

--- a/internal/services/network/express_route_circuit_peering_resource.go
+++ b/internal/services/network/express_route_circuit_peering_resource.go
@@ -316,8 +316,7 @@ func resourceExpressRouteCircuitPeeringCreate(d *pluginsdk.ResourceData, meta in
 			return fmt.Errorf("`primary_peer_address_prefix, secondary_peer_address_prefix` must be specified when config for Ipv4")
 		}
 
-		peeringConfig := expandExpressRouteCircuitPeeringMicrosoftConfig(peerings)
-		parameters.Properties.MicrosoftPeeringConfig = peeringConfig
+		parameters.Properties.MicrosoftPeeringConfig = expandExpressRouteCircuitPeeringMicrosoftConfig(peerings)
 
 		if routeFilterId != "" {
 			parameters.Properties.RouteFilter = &expressroutecircuitpeerings.SubResource{
@@ -442,8 +441,7 @@ func resourceExpressRouteCircuitPeeringUpdate(d *pluginsdk.ResourceData, meta in
 				return fmt.Errorf("`primary_peer_address_prefix, secondary_peer_address_prefix` must be specified when config for Ipv4")
 			}
 
-			peeringConfig := expandExpressRouteCircuitPeeringMicrosoftConfig(peerings)
-			payload.Properties.MicrosoftPeeringConfig = peeringConfig
+			payload.Properties.MicrosoftPeeringConfig = expandExpressRouteCircuitPeeringMicrosoftConfig(peerings)
 
 			if d.HasChange("route_filter_id") && routeFilterId != "" {
 				payload.Properties.RouteFilter = &expressroutecircuitpeerings.SubResource{

--- a/internal/services/network/network_security_group_resource.go
+++ b/internal/services/network/network_security_group_resource.go
@@ -34,7 +34,7 @@ import (
 var networkSecurityGroupResourceName = "azurerm_network_security_group"
 
 func resourceNetworkSecurityGroup() *pluginsdk.Resource {
-	resource := &pluginsdk.Resource{
+	return &pluginsdk.Resource{
 		Create: resourceNetworkSecurityGroupCreate,
 		Read:   resourceNetworkSecurityGroupRead,
 		Update: resourceNetworkSecurityGroupUpdate,
@@ -194,8 +194,6 @@ func resourceNetworkSecurityGroup() *pluginsdk.Resource {
 			"tags": commonschema.Tags(),
 		},
 	}
-
-	return resource
 }
 
 func resourceNetworkSecurityGroupCreate(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/network/network_watcher_flow_log_resource.go
+++ b/internal/services/network/network_watcher_flow_log_resource.go
@@ -255,11 +255,9 @@ func resourceNetworkWatcherFlowLogCreate(d *pluginsdk.ResourceData, meta interfa
 	}
 
 	if version, ok := d.GetOk("version"); ok {
-		format := &flowlogs.FlowLogFormatParameters{
+		parameters.Properties.Format = &flowlogs.FlowLogFormatParameters{
 			Version: pointer.To(int64(version.(int))),
 		}
-
-		parameters.Properties.Format = format
 	}
 
 	if err := client.CreateOrUpdateThenPoll(ctx, id, parameters); err != nil {

--- a/internal/services/network/private_link_service_resource.go
+++ b/internal/services/network/private_link_service_resource.go
@@ -32,7 +32,7 @@ import (
 //go:generate go run ../../tools/generator-tests resourceidentity
 
 func resourcePrivateLinkService() *pluginsdk.Resource {
-	resource := &pluginsdk.Resource{
+	return &pluginsdk.Resource{
 		Create:   resourcePrivateLinkServiceCreate,
 		Read:     resourcePrivateLinkServiceRead,
 		Update:   resourcePrivateLinkServiceUpdate,
@@ -174,8 +174,6 @@ func resourcePrivateLinkService() *pluginsdk.Resource {
 			return nil
 		}),
 	}
-
-	return resource
 }
 
 func resourcePrivateLinkServiceCreate(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/notificationhub/notification_hub_data_source.go
+++ b/internal/services/notificationhub/notification_hub_data_source.go
@@ -155,8 +155,7 @@ func flattenNotificationHubsDataSourceAPNSCredentials(input *hubs.ApnsCredential
 		"https://api.push.apple.com:443/3/device":             "Production",
 		"https://api.development.push.apple.com:443/3/device": "Sandbox",
 	}
-	applicationMode := applicationEndpoints[input.Properties.Endpoint]
-	output["application_mode"] = applicationMode
+	output["application_mode"] = applicationEndpoints[input.Properties.Endpoint]
 
 	if keyId := input.Properties.KeyId; keyId != nil {
 		output["key_id"] = *keyId

--- a/internal/services/notificationhub/notification_hub_resource.go
+++ b/internal/services/notificationhub/notification_hub_resource.go
@@ -397,8 +397,7 @@ func flattenNotificationHubsAPNSCredentials(input *hubs.ApnsCredential) []interf
 		apnsProductionEndpoint: apnsProductionName,
 		apnsSandboxEndpoint:    apnsSandboxName,
 	}
-	applicationMode := applicationEndpoints[input.Properties.Endpoint]
-	output["application_mode"] = applicationMode
+	output["application_mode"] = applicationEndpoints[input.Properties.Endpoint]
 
 	if keyId := input.Properties.KeyId; keyId != nil {
 		output["key_id"] = *keyId

--- a/internal/services/paloalto/palo_alto_local_rulestack_rule_resource.go
+++ b/internal/services/paloalto/palo_alto_local_rulestack_rule_resource.go
@@ -62,7 +62,7 @@ func (r LocalRuleStackRule) ResourceType() string {
 }
 
 func (r LocalRuleStackRule) Arguments() map[string]*pluginsdk.Schema {
-	schema := map[string]*pluginsdk.Schema{
+	return map[string]*pluginsdk.Schema{
 		"name": {
 			Type:         pluginsdk.TypeString,
 			Required:     true,
@@ -177,8 +177,6 @@ func (r LocalRuleStackRule) Arguments() map[string]*pluginsdk.Schema {
 
 		"tags": commonschema.Tags(),
 	}
-
-	return schema
 }
 
 func (r LocalRuleStackRule) Attributes() map[string]*pluginsdk.Schema {

--- a/internal/services/paloalto/palo_alto_next_generation_firewall_virtual_hub_local_rulestack_resource.go
+++ b/internal/services/paloalto/palo_alto_next_generation_firewall_virtual_hub_local_rulestack_resource.go
@@ -279,12 +279,10 @@ func (r NextGenerationFirewallVHubLocalRuleStackResource) Update() sdk.ResourceF
 					return err
 				}
 
-				ruleStack := &firewalls.RulestackDetails{
+				props.AssociatedRulestack = &firewalls.RulestackDetails{
 					Location:   props.AssociatedRulestack.Location,
 					ResourceId: pointer.To(ruleStackID.ID()),
 				}
-
-				props.AssociatedRulestack = ruleStack
 				locks.ByID(ruleStackID.ID())
 				defer locks.UnlockByID(ruleStackID.ID())
 			}

--- a/internal/services/paloalto/palo_alto_next_generation_firewall_virtual_network_local_rulestack_resource.go
+++ b/internal/services/paloalto/palo_alto_next_generation_firewall_virtual_network_local_rulestack_resource.go
@@ -274,13 +274,11 @@ func (r NextGenerationFirewallVNetLocalRulestackResource) Update() sdk.ResourceF
 					return err
 				}
 
-				ruleStack := &firewalls.RulestackDetails{
+				props.AssociatedRulestack = &firewalls.RulestackDetails{
 					Location:    props.AssociatedRulestack.Location,
 					ResourceId:  nil,
 					RulestackId: pointer.To(ruleStackID.ID()),
 				}
-
-				props.AssociatedRulestack = ruleStack
 				locks.ByID(ruleStackID.ID())
 				defer locks.UnlockByID(ruleStackID.ID())
 			}

--- a/internal/services/policy/management_group_policy_remediation_resource.go
+++ b/internal/services/policy/management_group_policy_remediation_resource.go
@@ -27,7 +27,7 @@ import (
 )
 
 func resourceArmManagementGroupPolicyRemediation() *pluginsdk.Resource {
-	resource := &pluginsdk.Resource{
+	return &pluginsdk.Resource{
 		Create: resourceArmManagementGroupPolicyRemediationCreateUpdate,
 		Read:   resourceArmManagementGroupPolicyRemediationRead,
 		Update: resourceArmManagementGroupPolicyRemediationCreateUpdate,
@@ -106,8 +106,6 @@ func resourceArmManagementGroupPolicyRemediation() *pluginsdk.Resource {
 			},
 		},
 	}
-
-	return resource
 }
 
 func resourceArmManagementGroupPolicyRemediationCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/policy/resource_group_policy_remediation_resource.go
+++ b/internal/services/policy/resource_group_policy_remediation_resource.go
@@ -24,7 +24,7 @@ import (
 )
 
 func resourceArmResourceGroupPolicyRemediation() *pluginsdk.Resource {
-	resource := &pluginsdk.Resource{
+	return &pluginsdk.Resource{
 		Create: resourceArmResourceGroupPolicyRemediationCreateUpdate,
 		Read:   resourceArmResourceGroupPolicyRemediationRead,
 		Update: resourceArmResourceGroupPolicyRemediationCreateUpdate,
@@ -112,8 +112,6 @@ func resourceArmResourceGroupPolicyRemediation() *pluginsdk.Resource {
 			},
 		},
 	}
-
-	return resource
 }
 
 func resourceArmResourceGroupPolicyRemediationCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/policy/resource_policy_remediation_resource.go
+++ b/internal/services/policy/resource_policy_remediation_resource.go
@@ -26,7 +26,7 @@ import (
 )
 
 func resourceArmResourcePolicyRemediation() *pluginsdk.Resource {
-	resource := &pluginsdk.Resource{
+	return &pluginsdk.Resource{
 		Create: resourceArmResourcePolicyRemediationCreateUpdate,
 		Read:   resourceArmResourcePolicyRemediationRead,
 		Update: resourceArmResourcePolicyRemediationCreateUpdate,
@@ -114,8 +114,6 @@ func resourceArmResourcePolicyRemediation() *pluginsdk.Resource {
 			},
 		},
 	}
-
-	return resource
 }
 
 func resourceArmResourcePolicyRemediationCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/policy/subscription_policy_remediation_resource.go
+++ b/internal/services/policy/subscription_policy_remediation_resource.go
@@ -23,7 +23,7 @@ import (
 )
 
 func resourceArmSubscriptionPolicyRemediation() *pluginsdk.Resource {
-	resource := &pluginsdk.Resource{
+	return &pluginsdk.Resource{
 		Create: resourceArmSubscriptionPolicyRemediationCreateUpdate,
 		Read:   resourceArmSubscriptionPolicyRemediationRead,
 		Update: resourceArmSubscriptionPolicyRemediationCreateUpdate,
@@ -111,8 +111,6 @@ func resourceArmSubscriptionPolicyRemediation() *pluginsdk.Resource {
 			},
 		},
 	}
-
-	return resource
 }
 
 func resourceArmSubscriptionPolicyRemediationCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/portal/registration.go
+++ b/internal/services/portal/registration.go
@@ -42,12 +42,10 @@ func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 
 // SupportedResources returns the supported Resources supported by this Service
 func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
-	resources := map[string]*pluginsdk.Resource{
+	return map[string]*pluginsdk.Resource{
 		"azurerm_portal_dashboard":            resourcePortalDashboard(),
 		"azurerm_portal_tenant_configuration": resourcePortalTenantConfiguration(),
 	}
-
-	return resources
 }
 
 func (r Registration) Actions() []func() action.Action {

--- a/internal/services/postgres/postgresql_flexible_server_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_resource.go
@@ -713,8 +713,7 @@ func resourcePostgresqlFlexibleServerCreate(d *pluginsdk.ResourceData, meta inte
 	}
 
 	if authRaw, ok := d.GetOk("authentication"); ok {
-		authConfig := expandFlexibleServerAuthConfig(authRaw.([]interface{}))
-		parameters.Properties.AuthConfig = authConfig
+		parameters.Properties.AuthConfig = expandFlexibleServerAuthConfig(authRaw.([]interface{}))
 	}
 
 	identity, err := identity.ExpandLegacySystemAndUserAssignedMap(d.Get("identity").([]interface{}))

--- a/internal/services/postgres/validate/flexible_server_storage_tier.go
+++ b/internal/services/postgres/validate/flexible_server_storage_tier.go
@@ -15,7 +15,7 @@ type StorageTiers struct {
 
 // Creates a map of valid StorageTiers based on the storage_mb for the PostgreSQL Flexible Server
 func InitializeFlexibleServerStorageTierDefaults() map[int]StorageTiers {
-	storageTiersMappings := map[int]StorageTiers{
+	return map[int]StorageTiers{
 		32768: {servers.AzureManagedDiskPerformanceTierPFour, &[]string{
 			string(servers.AzureManagedDiskPerformanceTierPFour),
 			string(servers.AzureManagedDiskPerformanceTierPSix),
@@ -84,6 +84,4 @@ func InitializeFlexibleServerStorageTierDefaults() map[int]StorageTiers {
 			string(servers.AzureManagedDiskPerformanceTierPEightZero),
 		}, &[]int{80}},
 	}
-
-	return storageTiersMappings
 }

--- a/internal/services/privatedns/private_dns_mx_record_resource.go
+++ b/internal/services/privatedns/private_dns_mx_record_resource.go
@@ -240,12 +240,10 @@ func expandAzureRmPrivateDnsMxRecords(d *pluginsdk.ResourceData) *[]privatedns.M
 			continue
 		}
 		record := v.(map[string]interface{})
-		mxRecord := privatedns.MxRecord{
+		records[i] = privatedns.MxRecord{
 			Preference: pointer.To(int64(record["preference"].(int))),
 			Exchange:   pointer.To(record["exchange"].(string)),
 		}
-
-		records[i] = mxRecord
 	}
 
 	return &records

--- a/internal/services/privatedns/private_dns_srv_record_resource.go
+++ b/internal/services/privatedns/private_dns_srv_record_resource.go
@@ -250,14 +250,12 @@ func expandAzureRmPrivateDnsSrvRecords(d *pluginsdk.ResourceData) *[]privatedns.
 	for i, v := range recordStrings {
 		record := v.(map[string]interface{})
 
-		srvRecord := privatedns.SrvRecord{
+		records[i] = privatedns.SrvRecord{
 			Priority: pointer.To(int64(record["priority"].(int))),
 			Weight:   pointer.To(int64(record["weight"].(int))),
 			Port:     pointer.To(int64(record["port"].(int))),
 			Target:   pointer.To(record["target"].(string)),
 		}
-
-		records[i] = srvRecord
 	}
 
 	return &records

--- a/internal/services/privatedns/private_dns_txt_record_resource.go
+++ b/internal/services/privatedns/private_dns_txt_record_resource.go
@@ -210,8 +210,7 @@ func flattenAzureRmPrivateDnsTxtRecords(records *[]privatedns.TxtRecord) []map[s
 			txtRecord := make(map[string]interface{})
 
 			if v := record.Value; v != nil {
-				value := strings.Join(*v, "")
-				txtRecord["value"] = value
+				txtRecord["value"] = strings.Join(*v, "")
 			}
 
 			results = append(results, txtRecord)
@@ -241,11 +240,9 @@ func expandAzureRmPrivateDnsTxtRecords(d *pluginsdk.ResourceData) *[]privatedns.
 		}
 		value = append(value, v)
 
-		txtRecord := privatedns.TxtRecord{
+		records[i] = privatedns.TxtRecord{
 			Value: &value,
 		}
-
-		records[i] = txtRecord
 	}
 
 	return &records

--- a/internal/services/recoveryservices/backup_policy_vm_resource.go
+++ b/internal/services/recoveryservices/backup_policy_vm_resource.go
@@ -765,11 +765,9 @@ func flattenBackupProtectionPolicyVMResourceGroup(rpDetail protectionpolicies.In
 
 	block := map[string]interface{}{}
 
-	prefix := pointer.From(rpDetail.AzureBackupRGNamePrefix)
-	block["prefix"] = prefix
+	block["prefix"] = pointer.From(rpDetail.AzureBackupRGNamePrefix)
 
-	suffix := pointer.From(rpDetail.AzureBackupRGNameSuffix)
-	block["suffix"] = suffix
+	block["suffix"] = pointer.From(rpDetail.AzureBackupRGNameSuffix)
 
 	return []interface{}{block}
 }

--- a/internal/services/recoveryservices/recovery_services_vault_resource_guard_association_resource.go
+++ b/internal/services/recoveryservices/recovery_services_vault_resource_guard_association_resource.go
@@ -48,13 +48,11 @@ func (r VaultGuardProxyResource) ResourceType() string {
 }
 
 func (r VaultGuardProxyResource) Arguments() map[string]*schema.Schema {
-	args := map[string]*schema.Schema{
+	return map[string]*schema.Schema{
 		"vault_id": commonschema.ResourceIDReferenceRequiredForceNew(&vaults.VaultId{}),
 
 		"resource_guard_id": commonschema.ResourceIDReferenceRequiredForceNew(&resourceguardresources.ResourceGuardId{}),
 	}
-
-	return args
 }
 
 func (r VaultGuardProxyResource) Attributes() map[string]*schema.Schema {

--- a/internal/services/recoveryservices/site_recovery_protection_container_mapping_resource.go
+++ b/internal/services/recoveryservices/site_recovery_protection_container_mapping_resource.go
@@ -198,12 +198,11 @@ func resourceSiteRecoveryContainerMappingUpdate(d *pluginsdk.ResourceData, meta 
 
 	if d.HasChange("automatic_update") {
 		autoUpdateEnabledValue, automationAccountArmId, authType := expandAutoUpdateSettings(d.Get("automatic_update").([]interface{}))
-		updateInput := replicationprotectioncontainermappings.A2AUpdateContainerMappingInput{
+		update.Properties.ProviderSpecificInput = replicationprotectioncontainermappings.A2AUpdateContainerMappingInput{
 			AgentAutoUpdateStatus:               &autoUpdateEnabledValue,
 			AutomationAccountArmId:              automationAccountArmId,
 			AutomationAccountAuthenticationType: authType,
 		}
-		update.Properties.ProviderSpecificInput = updateInput
 	}
 
 	if err = client.UpdateThenPoll(ctx, *id, update); err != nil {

--- a/internal/services/recoveryservices/site_recovery_replicated_vm_resource.go
+++ b/internal/services/recoveryservices/site_recovery_replicated_vm_resource.go
@@ -908,11 +908,9 @@ func resourceSiteRecoveryReplicatedItemRead(d *pluginsdk.ResourceData, meta inte
 					}
 					diskOutput["target_resource_group_id"] = recoveryResourceGroupID
 
-					recoveryReplicaDiskAccountType := pointer.From(disk.RecoveryReplicaDiskAccountType)
-					diskOutput["target_replica_disk_type"] = recoveryReplicaDiskAccountType
+					diskOutput["target_replica_disk_type"] = pointer.From(disk.RecoveryReplicaDiskAccountType)
 
-					recoveryTargetDiskAccountType := pointer.From(disk.RecoveryTargetDiskAccountType)
-					diskOutput["target_disk_type"] = recoveryTargetDiskAccountType
+					diskOutput["target_disk_type"] = pointer.From(disk.RecoveryTargetDiskAccountType)
 
 					recoveryEncryptionSetId := ""
 					if respDESId := pointer.From(disk.RecoveryDiskEncryptionSetId); respDESId != "" {

--- a/internal/services/redis/redis_cache_data_source.go
+++ b/internal/services/redis/redis_cache_data_source.go
@@ -23,7 +23,7 @@ import (
 )
 
 func dataSourceRedisCache() *pluginsdk.Resource {
-	resource := &pluginsdk.Resource{
+	return &pluginsdk.Resource{
 		Read: dataSourceRedisCacheRead,
 
 		Timeouts: &pluginsdk.ResourceTimeout{
@@ -244,8 +244,6 @@ func dataSourceRedisCache() *pluginsdk.Resource {
 			"tags": commonschema.TagsDataSource(),
 		},
 	}
-
-	return resource
 }
 
 func dataSourceRedisCacheRead(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/resource/registration.go
+++ b/internal/services/resource/registration.go
@@ -51,7 +51,7 @@ func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 
 // SupportedResources returns the supported Resources supported by this Service
 func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
-	resources := map[string]*pluginsdk.Resource{
+	return map[string]*pluginsdk.Resource{
 		"azurerm_management_lock":                      resourceManagementLock(),
 		"azurerm_management_group_template_deployment": managementGroupTemplateDeploymentResource(),
 		"azurerm_resource_group":                       resourceResourceGroup(),
@@ -59,8 +59,6 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 		"azurerm_subscription_template_deployment":     subscriptionTemplateDeploymentResource(),
 		"azurerm_tenant_template_deployment":           tenantTemplateDeploymentResource(),
 	}
-
-	return resources
 }
 
 // DataSources returns a list of Data Sources supported by this Service

--- a/internal/services/securitycenter/security_center_subscription_pricing_resource.go
+++ b/internal/services/securitycenter/security_center_subscription_pricing_resource.go
@@ -172,8 +172,7 @@ func resourceSecurityCenterSubscriptionPricingCreate(d *pluginsdk.ResourceData, 
 
 	// can not set any extension for free tier in the same request.
 	if pricing.Properties.PricingTier == pricings.PricingTierStandard {
-		extensions := expandSecurityCenterSubscriptionPricingExtensions(realCfgExtensions, &extensionsStatusFromBackend)
-		pricing.Properties.Extensions = extensions
+		pricing.Properties.Extensions = expandSecurityCenterSubscriptionPricingExtensions(realCfgExtensions, &extensionsStatusFromBackend)
 	}
 
 	if len(realCfgExtensions) > 0 && pricing.Properties.PricingTier == pricings.PricingTierFree {
@@ -190,8 +189,7 @@ func resourceSecurityCenterSubscriptionPricingCreate(d *pluginsdk.ResourceData, 
 		extensionsStatusFromBackend = *updateResponse.Model.Properties.Extensions
 	}
 
-	extensions := expandSecurityCenterSubscriptionPricingExtensions(realCfgExtensions, &extensionsStatusFromBackend)
-	pricing.Properties.Extensions = extensions
+	pricing.Properties.Extensions = expandSecurityCenterSubscriptionPricingExtensions(realCfgExtensions, &extensionsStatusFromBackend)
 
 	_, updateErr = client.Update(ctx, id, pricing)
 	if updateErr != nil {
@@ -257,8 +255,7 @@ func resourceSecurityCenterSubscriptionPricingUpdate(d *pluginsdk.ResourceData, 
 	// Then do an additional update for the `extensions`
 	requiredAdditionalUpdate := false
 	if d.HasChange("extension") && update.Properties.PricingTier == pricings.PricingTierStandard {
-		extensions := expandSecurityCenterSubscriptionPricingExtensions(realCfgExtensions, &extensionsStatusFromBackend)
-		update.Properties.Extensions = extensions
+		update.Properties.Extensions = expandSecurityCenterSubscriptionPricingExtensions(realCfgExtensions, &extensionsStatusFromBackend)
 		requiredAdditionalUpdate = currentlyFreeTier
 	}
 
@@ -275,8 +272,7 @@ func resourceSecurityCenterSubscriptionPricingUpdate(d *pluginsdk.ResourceData, 
 	}
 
 	if requiredAdditionalUpdate {
-		extensions := expandSecurityCenterSubscriptionPricingExtensions(realCfgExtensions, &extensionsStatusFromBackend)
-		update.Properties.Extensions = extensions
+		update.Properties.Extensions = expandSecurityCenterSubscriptionPricingExtensions(realCfgExtensions, &extensionsStatusFromBackend)
 		if _, err := client.Update(ctx, *id, update); err != nil {
 			return fmt.Errorf("updating %s: %+v", id, err)
 		}

--- a/internal/services/sentinel/sentinel_alert_rule.go
+++ b/internal/services/sentinel/sentinel_alert_rule.go
@@ -122,12 +122,10 @@ func expandAlertRuleIncidentConfiguration(input []interface{}, createIncidentKey
 
 	raw := input[0].(map[string]interface{})
 
-	output := &alertrules.IncidentConfiguration{
+	return &alertrules.IncidentConfiguration{
 		CreateIncident:        raw[createIncidentKey].(bool),
 		GroupingConfiguration: expandAlertRuleGrouping(raw["grouping"].([]interface{}), withGroupByPrefix),
 	}
-
-	return output
 }
 
 func flattenAlertRuleIncidentConfiguration(input *alertrules.IncidentConfiguration, createIncidentKey string, withGroupByPrefix bool) []interface{} {

--- a/internal/services/sentinel/sentinel_alert_rule_scheduled_resource.go
+++ b/internal/services/sentinel/sentinel_alert_rule_scheduled_resource.go
@@ -24,7 +24,7 @@ import (
 )
 
 func resourceSentinelAlertRuleScheduled() *pluginsdk.Resource {
-	resource := &pluginsdk.Resource{
+	return &pluginsdk.Resource{
 		Create: resourceSentinelAlertRuleScheduledCreateUpdate,
 		Read:   resourceSentinelAlertRuleScheduledRead,
 		Update: resourceSentinelAlertRuleScheduledCreateUpdate,
@@ -347,8 +347,6 @@ func resourceSentinelAlertRuleScheduled() *pluginsdk.Resource {
 			},
 		},
 	}
-
-	return resource
 }
 
 func resourceSentinelAlertRuleScheduledCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This is part of a series of PRs that enable the `azproviderlint` **AZG005** check and apply the resulting fixes across the provider. To keep each PR reviewable, the changes are split by service in alphabetical order; this PR covers the services from `dns` through `sentinel`.

AZG005 flags single-use temporary variables that are assigned and then immediately returned or assigned onward. The fixes here inline those temporaries,

These are mechanical, behavior-preserving refactors with no functional changes. No schema, API, or resource behavior is affected.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->

## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

No new test coverage is included because this PR contains no functional changes — it only inlines single-use temporary variables to satisfy the newly enabled AZG005 lint rule. Existing acceptance tests for the affected resources continue to apply unchanged.


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
