### PR TITLE
Linters - Enable azproviderlint AZG005 - Services (servicebus - workloads)

### DIFF
--- a/internal/services/servicebus/migration/namespace_auth_rule.go
+++ b/internal/services/servicebus/migration/namespace_auth_rule.go
@@ -15,7 +15,7 @@ var _ pluginsdk.StateUpgrade = ServicebusNamespaceAuthRuleV0ToV1{}
 type ServicebusNamespaceAuthRuleV0ToV1 struct{}
 
 func (ServicebusNamespaceAuthRuleV0ToV1) Schema() map[string]*pluginsdk.Schema {
-	s := map[string]*pluginsdk.Schema{
+	return map[string]*pluginsdk.Schema{
 		"name": {
 			Type:     pluginsdk.TypeString,
 			Required: true,
@@ -82,7 +82,6 @@ func (ServicebusNamespaceAuthRuleV0ToV1) Schema() map[string]*pluginsdk.Schema {
 			Sensitive: true,
 		},
 	}
-	return s
 }
 
 func (ServicebusNamespaceAuthRuleV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {

--- a/internal/services/servicebus/registration.go
+++ b/internal/services/servicebus/registration.go
@@ -51,7 +51,7 @@ func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 
 // SupportedResources returns the supported Resources supported by this Service
 func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
-	resources := map[string]*pluginsdk.Resource{
+	return map[string]*pluginsdk.Resource{
 		"azurerm_servicebus_namespace":                          resourceServiceBusNamespace(),
 		"azurerm_servicebus_namespace_disaster_recovery_config": resourceServiceBusNamespaceDisasterRecoveryConfig(),
 		"azurerm_servicebus_namespace_authorization_rule":       resourceServiceBusNamespaceAuthorizationRule(),
@@ -62,8 +62,6 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 		"azurerm_servicebus_topic_authorization_rule":           resourceServiceBusTopicAuthorizationRule(),
 		"azurerm_servicebus_topic":                              resourceServiceBusTopic(),
 	}
-
-	return resources
 }
 
 // DataSources returns the typed DataSources supported by this service

--- a/internal/services/servicebus/servicebus_namespace_authorization_rule_data_source.go
+++ b/internal/services/servicebus/servicebus_namespace_authorization_rule_data_source.go
@@ -16,7 +16,7 @@ import (
 )
 
 func dataSourceServiceBusNamespaceAuthorizationRule() *pluginsdk.Resource {
-	r := &pluginsdk.Resource{
+	return &pluginsdk.Resource{
 		Read: dataSourceServiceBusNamespaceAuthorizationRuleRead,
 
 		Timeouts: &pluginsdk.ResourceTimeout{
@@ -72,8 +72,6 @@ func dataSourceServiceBusNamespaceAuthorizationRule() *pluginsdk.Resource {
 			},
 		},
 	}
-
-	return r
 }
 
 func dataSourceServiceBusNamespaceAuthorizationRuleRead(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/servicebus/servicebus_namespace_data_source.go
+++ b/internal/services/servicebus/servicebus_namespace_data_source.go
@@ -19,7 +19,7 @@ import (
 )
 
 func dataSourceServiceBusNamespace() *pluginsdk.Resource {
-	resource := &pluginsdk.Resource{
+	return &pluginsdk.Resource{
 		Read: dataSourceServiceBusNamespaceRead,
 
 		Timeouts: &pluginsdk.ResourceTimeout{
@@ -86,8 +86,6 @@ func dataSourceServiceBusNamespace() *pluginsdk.Resource {
 			"tags": commonschema.TagsDataSource(),
 		},
 	}
-
-	return resource
 }
 
 func dataSourceServiceBusNamespaceRead(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/servicebus/servicebus_namespace_disaster_recovery_config_data_source.go
+++ b/internal/services/servicebus/servicebus_namespace_disaster_recovery_config_data_source.go
@@ -18,7 +18,7 @@ import (
 )
 
 func dataSourceServiceBusNamespaceDisasterRecoveryConfig() *pluginsdk.Resource {
-	resource := &pluginsdk.Resource{
+	return &pluginsdk.Resource{
 		Read: dataSourceServiceBusNamespaceDisasterRecoveryConfigRead,
 
 		Timeouts: &pluginsdk.ResourceTimeout{
@@ -73,8 +73,6 @@ func dataSourceServiceBusNamespaceDisasterRecoveryConfig() *pluginsdk.Resource {
 			},
 		},
 	}
-
-	return resource
 }
 
 func dataSourceServiceBusNamespaceDisasterRecoveryConfigRead(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/servicebus/servicebus_queue_data_source.go
+++ b/internal/services/servicebus/servicebus_queue_data_source.go
@@ -18,7 +18,7 @@ import (
 )
 
 func dataSourceServiceBusQueue() *pluginsdk.Resource {
-	resource := &pluginsdk.Resource{
+	return &pluginsdk.Resource{
 		Read: dataSourceServiceBusQueueRead,
 
 		Timeouts: &pluginsdk.ResourceTimeout{
@@ -114,8 +114,6 @@ func dataSourceServiceBusQueue() *pluginsdk.Resource {
 			},
 		},
 	}
-
-	return resource
 }
 
 func dataSourceServiceBusQueueRead(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/servicebus/servicebus_subscription_data_source.go
+++ b/internal/services/servicebus/servicebus_subscription_data_source.go
@@ -16,7 +16,7 @@ import (
 )
 
 func dataSourceServiceBusSubscription() *pluginsdk.Resource {
-	resource := &pluginsdk.Resource{
+	return &pluginsdk.Resource{
 		Read: dataSourceServiceBusSubscriptionRead,
 
 		Timeouts: &pluginsdk.ResourceTimeout{
@@ -86,8 +86,6 @@ func dataSourceServiceBusSubscription() *pluginsdk.Resource {
 			},
 		},
 	}
-
-	return resource
 }
 
 func dataSourceServiceBusSubscriptionRead(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/servicebus/servicebus_subscription_resource.go
+++ b/internal/services/servicebus/servicebus_subscription_resource.go
@@ -51,7 +51,7 @@ func resourceServiceBusSubscription() *pluginsdk.Resource {
 }
 
 func resourceServicebusSubscriptionSchema() map[string]*pluginsdk.Schema {
-	schema := map[string]*pluginsdk.Schema{
+	return map[string]*pluginsdk.Schema{
 		"name": {
 			Type:         pluginsdk.TypeString,
 			Required:     true,
@@ -166,8 +166,6 @@ func resourceServicebusSubscriptionSchema() map[string]*pluginsdk.Schema {
 			},
 		},
 	}
-
-	return schema
 }
 
 func resourceServiceBusSubscriptionCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/servicebus/servicebus_topic_data_source.go
+++ b/internal/services/servicebus/servicebus_topic_data_source.go
@@ -17,7 +17,7 @@ import (
 )
 
 func dataSourceServiceBusTopic() *pluginsdk.Resource {
-	d := &pluginsdk.Resource{
+	return &pluginsdk.Resource{
 		Read: dataSourceServiceBusTopicRead,
 
 		Timeouts: &pluginsdk.ResourceTimeout{
@@ -88,8 +88,6 @@ func dataSourceServiceBusTopic() *pluginsdk.Resource {
 			},
 		},
 	}
-
-	return d
 }
 
 func dataSourceServiceBusTopicRead(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/serviceconnector/app_service_connection_resource.go
+++ b/internal/services/serviceconnector/app_service_connection_resource.go
@@ -148,8 +148,7 @@ func (r AppServiceConnectorResource) Create() sdk.ResourceFunc {
 			}
 
 			if model.SecretStore != nil {
-				secretStore := expandSecretStore(model.SecretStore)
-				serviceConnectorProperties.SecretStore = secretStore
+				serviceConnectorProperties.SecretStore = expandSecretStore(model.SecretStore)
 			}
 
 			if model.ClientType != "" {

--- a/internal/services/serviceconnector/function_app_connection_resource.go
+++ b/internal/services/serviceconnector/function_app_connection_resource.go
@@ -145,8 +145,7 @@ func (r FunctionAppConnectorResource) Create() sdk.ResourceFunc {
 			}
 
 			if model.SecretStore != nil {
-				secretStore := expandSecretStore(model.SecretStore)
-				serviceConnectorProperties.SecretStore = secretStore
+				serviceConnectorProperties.SecretStore = expandSecretStore(model.SecretStore)
 			}
 
 			if model.ClientType != "" {

--- a/internal/services/serviceconnector/spring_cloud_connection_resource.go
+++ b/internal/services/serviceconnector/spring_cloud_connection_resource.go
@@ -145,8 +145,7 @@ func (r SpringCloudConnectorResource) Create() sdk.ResourceFunc {
 			}
 
 			if model.SecretStore != nil {
-				secretStore := expandSecretStore(model.SecretStore)
-				serviceConnectorProperties.SecretStore = secretStore
+				serviceConnectorProperties.SecretStore = expandSecretStore(model.SecretStore)
 			}
 
 			if model.ClientType != "" {

--- a/internal/services/servicefabric/service_fabric_cluster_resource.go
+++ b/internal/services/servicefabric/service_fabric_cluster_resource.go
@@ -642,23 +642,19 @@ func resourceServiceFabricClusterCreateUpdate(d *pluginsdk.ResourceData, meta in
 	}
 
 	if certificateRaw, ok := d.GetOk("certificate"); ok {
-		certificate := expandServiceFabricClusterCertificate(certificateRaw.([]interface{}))
-		clusterModel.Properties.Certificate = certificate
+		clusterModel.Properties.Certificate = expandServiceFabricClusterCertificate(certificateRaw.([]interface{}))
 	}
 
 	if reverseProxyCertificateRaw, ok := d.GetOk("reverse_proxy_certificate"); ok {
-		reverseProxyCertificate := expandServiceFabricClusterReverseProxyCertificate(reverseProxyCertificateRaw.([]interface{}))
-		clusterModel.Properties.ReverseProxyCertificate = reverseProxyCertificate
+		clusterModel.Properties.ReverseProxyCertificate = expandServiceFabricClusterReverseProxyCertificate(reverseProxyCertificateRaw.([]interface{}))
 	}
 
 	if clientCertificateThumbprintRaw, ok := d.GetOk("client_certificate_thumbprint"); ok {
-		clientCertificateThumbprints := expandServiceFabricClusterClientCertificateThumbprints(clientCertificateThumbprintRaw.([]interface{}))
-		clusterModel.Properties.ClientCertificateThumbprints = clientCertificateThumbprints
+		clusterModel.Properties.ClientCertificateThumbprints = expandServiceFabricClusterClientCertificateThumbprints(clientCertificateThumbprintRaw.([]interface{}))
 	}
 
 	if clientCertificateCommonNamesRaw, ok := d.GetOk("client_certificate_common_name"); ok {
-		clientCertificateCommonNames := expandServiceFabricClusterClientCertificateCommonNames(clientCertificateCommonNamesRaw.([]interface{}))
-		clusterModel.Properties.ClientCertificateCommonNames = clientCertificateCommonNames
+		clusterModel.Properties.ClientCertificateCommonNames = expandServiceFabricClusterClientCertificateCommonNames(clientCertificateCommonNamesRaw.([]interface{}))
 	}
 
 	if clusterCodeVersion != "" {

--- a/internal/services/signalr/migration/web_pubsub_hub_v0_to_v1.go
+++ b/internal/services/signalr/migration/web_pubsub_hub_v0_to_v1.go
@@ -15,7 +15,7 @@ var _ pluginsdk.StateUpgrade = WebPubsubHubV0ToV1{}
 type WebPubsubHubV0ToV1 struct{}
 
 func (WebPubsubHubV0ToV1) Schema() map[string]*pluginsdk.Schema {
-	s := map[string]*pluginsdk.Schema{
+	return map[string]*pluginsdk.Schema{
 		"name": {
 			Type:     pluginsdk.TypeString,
 			Required: true,
@@ -75,7 +75,6 @@ func (WebPubsubHubV0ToV1) Schema() map[string]*pluginsdk.Schema {
 			Default:  false,
 		},
 	}
-	return s
 }
 
 func (WebPubsubHubV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {

--- a/internal/services/signalr/migration/web_pubsub_v0_to_v1.go
+++ b/internal/services/signalr/migration/web_pubsub_v0_to_v1.go
@@ -16,7 +16,7 @@ var _ pluginsdk.StateUpgrade = WebPubsubV0ToV1{}
 type WebPubsubV0ToV1 struct{}
 
 func (WebPubsubV0ToV1) Schema() map[string]*pluginsdk.Schema {
-	s := map[string]*pluginsdk.Schema{
+	return map[string]*pluginsdk.Schema{
 		"name": {
 			Type:     pluginsdk.TypeString,
 			Required: true,
@@ -183,7 +183,6 @@ func (WebPubsubV0ToV1) Schema() map[string]*pluginsdk.Schema {
 			},
 		},
 	}
-	return s
 }
 
 func (WebPubsubV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {

--- a/internal/services/storage/migration/blob.go
+++ b/internal/services/storage/migration/blob.go
@@ -96,8 +96,7 @@ func (BlobV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
 		blobName := rawState["name"]
 		containerName := rawState["storage_container_name"]
 		storageAccountName := rawState["storage_account_name"]
-		newID := fmt.Sprintf("https://%s.blob.%s/%s/%s", storageAccountName, *storageDomainSuffix, containerName, blobName)
-		rawState["id"] = newID
+		rawState["id"] = fmt.Sprintf("https://%s.blob.%s/%s/%s", storageAccountName, *storageDomainSuffix, containerName, blobName)
 
 		return rawState, nil
 	}

--- a/internal/services/storage/migration/container.go
+++ b/internal/services/storage/migration/container.go
@@ -60,8 +60,7 @@ func (ContainerV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
 
 		containerName := rawState["name"]
 		storageAccountName := rawState["storage_account_name"]
-		newID := fmt.Sprintf("https://%s.blob.%s/%s", storageAccountName, *storageDomainSuffix, containerName)
-		rawState["id"] = newID
+		rawState["id"] = fmt.Sprintf("https://%s.blob.%s/%s", storageAccountName, *storageDomainSuffix, containerName)
 
 		return rawState, nil
 	}

--- a/internal/services/storage/migration/queue.go
+++ b/internal/services/storage/migration/queue.go
@@ -46,8 +46,7 @@ func (QueueV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
 
 		queueName := rawState["name"]
 		storageAccountName := rawState["storage_account_name"]
-		newID := fmt.Sprintf("https://%s.queue.%s/%s", storageAccountName, *storageDomainSuffix, queueName)
-		rawState["id"] = newID
+		rawState["id"] = fmt.Sprintf("https://%s.queue.%s/%s", storageAccountName, *storageDomainSuffix, queueName)
 
 		return rawState, nil
 	}

--- a/internal/services/storage/storage_account_data_source.go
+++ b/internal/services/storage/storage_account_data_source.go
@@ -24,7 +24,7 @@ import (
 )
 
 func dataSourceStorageAccount() *pluginsdk.Resource {
-	resource := &pluginsdk.Resource{
+	return &pluginsdk.Resource{
 		Read: dataSourceStorageAccountRead,
 
 		Timeouts: &pluginsdk.ResourceTimeout{
@@ -540,8 +540,6 @@ func dataSourceStorageAccount() *pluginsdk.Resource {
 			"tags": commonschema.TagsDataSource(),
 		},
 	}
-
-	return resource
 }
 
 func dataSourceStorageAccountRead(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/storage/storage_filesystem_ace.go
+++ b/internal/services/storage/storage_filesystem_ace.go
@@ -38,13 +38,12 @@ func ExpandDataLakeGen2AceList(input []interface{}) (*accesscontrol.ACL, error) 
 
 		permissions := v["permissions"].(string)
 
-		ace := accesscontrol.ACE{
+		aceList[i] = accesscontrol.ACE{
 			IsDefault:    isDefault,
 			TagType:      tagType,
 			TagQualifier: id,
 			Permissions:  permissions,
 		}
-		aceList[i] = ace
 	}
 
 	return &accesscontrol.ACL{Entries: aceList}, nil

--- a/internal/services/storage/storage_share_directory_resource.go
+++ b/internal/services/storage/storage_share_directory_resource.go
@@ -41,7 +41,7 @@ func resourceStorageShareDirectory() *pluginsdk.Resource {
 
 		"metadata": MetaDataSchema(),
 	}
-	resource := &pluginsdk.Resource{
+	return &pluginsdk.Resource{
 		Create: resourceStorageShareDirectoryCreate,
 		Read:   resourceStorageShareDirectoryRead,
 		Update: resourceStorageShareDirectoryUpdate,
@@ -61,8 +61,6 @@ func resourceStorageShareDirectory() *pluginsdk.Resource {
 
 		Schema: schema,
 	}
-
-	return resource
 }
 
 func resourceStorageShareDirectoryCreate(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/web/migration/app_service_certificate_order.go
+++ b/internal/services/web/migration/app_service_certificate_order.go
@@ -155,9 +155,7 @@ func (AppServiceCertificateOrderResourceV0ToV1) UpgradeFunc() pluginsdk.StateUpg
 		}
 
 		appServiceCertOrderId := appservicecertificateorders.NewCertificateOrderID(oldId.SubscriptionId, oldId.ResourceGroup, oldId.CertificateOrderName)
-		newId := appServiceCertOrderId.ID()
-
-		rawState["id"] = newId
+		rawState["id"] = appServiceCertOrderId.ID()
 		return rawState, nil
 	}
 }

--- a/internal/services/workloads/workloads_sap_single_node_virtual_instance_resource.go
+++ b/internal/services/workloads/workloads_sap_single_node_virtual_instance_resource.go
@@ -672,13 +672,11 @@ func expandSAPSingleNodeVirtualInstanceVirtualMachineConfiguration(input []Singl
 
 	virtualMachineConfiguration := input[0]
 
-	result := &sapvirtualinstances.VirtualMachineConfiguration{
+	return &sapvirtualinstances.VirtualMachineConfiguration{
 		ImageReference: pointer.From(expandSAPSingleNodeVirtualInstanceImageReference(virtualMachineConfiguration.ImageReference)),
 		OsProfile:      pointer.From(expandSAPSingleNodeVirtualInstanceOsProfile(virtualMachineConfiguration.OSProfile)),
 		VMSize:         virtualMachineConfiguration.VmSize,
 	}
-
-	return result
 }
 
 func expandSAPSingleNodeVirtualInstanceImageReference(input []SingleServerImageReference) *sapvirtualinstances.ImageReference {
@@ -688,14 +686,12 @@ func expandSAPSingleNodeVirtualInstanceImageReference(input []SingleServerImageR
 
 	imageReference := input[0]
 
-	result := &sapvirtualinstances.ImageReference{
+	return &sapvirtualinstances.ImageReference{
 		Offer:     pointer.To(imageReference.Offer),
 		Publisher: pointer.To(imageReference.Publisher),
 		Sku:       pointer.To(imageReference.Sku),
 		Version:   pointer.To(imageReference.Version),
 	}
-
-	return result
 }
 
 func expandSAPSingleNodeVirtualInstanceOsProfile(input []SingleServerOSProfile) *sapvirtualinstances.OSProfile {
@@ -705,7 +701,7 @@ func expandSAPSingleNodeVirtualInstanceOsProfile(input []SingleServerOSProfile) 
 
 	osProfile := input[0]
 
-	result := &sapvirtualinstances.OSProfile{
+	return &sapvirtualinstances.OSProfile{
 		AdminUsername: pointer.To(osProfile.AdminUsername),
 		OsConfiguration: &sapvirtualinstances.LinuxConfiguration{
 			DisablePasswordAuthentication: pointer.To(true),
@@ -715,8 +711,6 @@ func expandSAPSingleNodeVirtualInstanceOsProfile(input []SingleServerOSProfile) 
 			},
 		},
 	}
-
-	return result
 }
 
 func expandSAPSingleNodeVirtualInstanceVirtualMachineFullResourceNames(input []SingleServerVirtualMachineResourceNames) *sapvirtualinstances.SingleServerFullResourceNames {

--- a/internal/services/workloads/workloads_sap_single_node_virtual_instance_resource_test.go
+++ b/internal/services/workloads/workloads_sap_single_node_virtual_instance_resource_test.go
@@ -515,7 +515,5 @@ resource "azurerm_workloads_sap_single_node_virtual_instance" "test" {
 
 func SAPSingleNodeVirtualInstanceNameSuffix() int {
 	rand.NewSource(time.Now().UnixNano())
-	num := rand.Intn(90) + 10
-
-	return num
+	return rand.Intn(90) + 10
 }

--- a/internal/services/workloads/workloads_sap_three_tier_virtual_instance_resource.go
+++ b/internal/services/workloads/workloads_sap_three_tier_virtual_instance_resource.go
@@ -1328,13 +1328,11 @@ func expandVirtualMachineConfiguration(input []VirtualMachineConfiguration) *sap
 
 	virtualMachineConfiguration := input[0]
 
-	result := &sapvirtualinstances.VirtualMachineConfiguration{
+	return &sapvirtualinstances.VirtualMachineConfiguration{
 		ImageReference: pointer.From(expandImageReference(virtualMachineConfiguration.ImageReference)),
 		OsProfile:      pointer.From(expandOsProfile(virtualMachineConfiguration.OSProfile)),
 		VMSize:         virtualMachineConfiguration.VmSize,
 	}
-
-	return result
 }
 
 func expandImageReference(input []ImageReference) *sapvirtualinstances.ImageReference {
@@ -1344,14 +1342,12 @@ func expandImageReference(input []ImageReference) *sapvirtualinstances.ImageRefe
 
 	imageReference := input[0]
 
-	result := &sapvirtualinstances.ImageReference{
+	return &sapvirtualinstances.ImageReference{
 		Offer:     pointer.To(imageReference.Offer),
 		Publisher: pointer.To(imageReference.Publisher),
 		Sku:       pointer.To(imageReference.Sku),
 		Version:   pointer.To(imageReference.Version),
 	}
-
-	return result
 }
 
 func expandOsProfile(input []OSProfile) *sapvirtualinstances.OSProfile {
@@ -1361,7 +1357,7 @@ func expandOsProfile(input []OSProfile) *sapvirtualinstances.OSProfile {
 
 	osProfile := input[0]
 
-	result := &sapvirtualinstances.OSProfile{
+	return &sapvirtualinstances.OSProfile{
 		AdminUsername: pointer.To(osProfile.AdminUsername),
 		OsConfiguration: &sapvirtualinstances.LinuxConfiguration{
 			DisablePasswordAuthentication: pointer.To(true),
@@ -1371,8 +1367,6 @@ func expandOsProfile(input []OSProfile) *sapvirtualinstances.OSProfile {
 			},
 		},
 	}
-
-	return result
 }
 
 func expandNetworkInterfaceNames(input []string) *[]sapvirtualinstances.NetworkInterfaceResourceNames {
@@ -1436,13 +1430,11 @@ func expandApplicationServer(input []ApplicationServerConfiguration) *sapvirtual
 
 	applicationServer := input[0]
 
-	result := &sapvirtualinstances.ApplicationServerConfiguration{
+	return &sapvirtualinstances.ApplicationServerConfiguration{
 		InstanceCount:               applicationServer.InstanceCount,
 		SubnetId:                    applicationServer.SubnetId,
 		VirtualMachineConfiguration: pointer.From(expandVirtualMachineConfiguration(applicationServer.VirtualMachineConfiguration)),
 	}
-
-	return result
 }
 
 func expandCentralServer(input []CentralServerConfiguration) *sapvirtualinstances.CentralServerConfiguration {
@@ -1452,13 +1444,11 @@ func expandCentralServer(input []CentralServerConfiguration) *sapvirtualinstance
 
 	centralServer := input[0]
 
-	result := &sapvirtualinstances.CentralServerConfiguration{
+	return &sapvirtualinstances.CentralServerConfiguration{
 		InstanceCount:               centralServer.InstanceCount,
 		SubnetId:                    centralServer.SubnetId,
 		VirtualMachineConfiguration: pointer.From(expandVirtualMachineConfiguration(centralServer.VirtualMachineConfiguration)),
 	}
-
-	return result
 }
 
 func expandDatabaseServer(input []DatabaseServerConfiguration) *sapvirtualinstances.DatabaseConfiguration {
@@ -1534,14 +1524,12 @@ func expandResourceNames(input []ResourceNames) *sapvirtualinstances.ThreeTierFu
 
 	resourceNames := input[0]
 
-	result := &sapvirtualinstances.ThreeTierFullResourceNames{
+	return &sapvirtualinstances.ThreeTierFullResourceNames{
 		ApplicationServer: expandApplicationServerResourceNames(resourceNames.ApplicationServer),
 		CentralServer:     expandCentralServerResourceNames(resourceNames.CentralServer),
 		DatabaseServer:    expandDatabaseServerResourceNames(resourceNames.DatabaseServer),
 		SharedStorage:     expandSharedStorage(resourceNames.SharedStorage),
 	}
-
-	return result
 }
 
 func expandApplicationServerResourceNames(input []ApplicationServerResourceNames) *sapvirtualinstances.ApplicationServerFullResourceNames {

--- a/internal/services/workloads/workloads_sap_three_tier_virtual_instance_resource_test.go
+++ b/internal/services/workloads/workloads_sap_three_tier_virtual_instance_resource_test.go
@@ -885,7 +885,5 @@ resource "azurerm_workloads_sap_three_tier_virtual_instance" "test" {
 
 func RandomInt() int {
 	rand.NewSource(time.Now().UnixNano())
-	num := rand.Intn(90) + 10
-
-	return num
+	return rand.Intn(90) + 10
 }

--- a/internal/tools/document-fmt/data/packages.go
+++ b/internal/tools/document-fmt/data/packages.go
@@ -189,8 +189,7 @@ func findUntypedSSAFunc(pkg pkg, e ast.Expr) *ssa.Function {
 		if !ok {
 			return nil
 		}
-		ssaFn := findResourceFunc(pkg.ssa.Prog, pkg.pkg, pkg.ssa, pkg.ssa.Func(fn.Name))
-		return ssaFn
+		return findResourceFunc(pkg.ssa.Prog, pkg.pkg, pkg.ssa, pkg.ssa.Func(fn.Name))
 	}
 
 	return nil
@@ -281,9 +280,7 @@ func findAPIsForUntypedResources(d packageData, s *Service) map[string][]API {
 		})
 
 		sdkMethods := usedMethods(d.fset, servicePackage.pkg, util.MapKeys2Slice(filenames))
-		apis := methodsToAPIs(sdkMethods)
-
-		result[resourceFileName] = apis
+		result[resourceFileName] = methodsToAPIs(sdkMethods)
 	}
 
 	return result
@@ -345,9 +342,7 @@ func findAPIsForTypedResources(d packageData, s *Service) map[string][]API {
 		}
 
 		sdkMethods := usedMethods(d.fset, servicePackage.pkg, util.MapKeys2Slice(filenames))
-		apis := methodsToAPIs(sdkMethods)
-
-		result[resourceFileName] = apis
+		result[resourceFileName] = methodsToAPIs(sdkMethods)
 	}
 	return result
 }

--- a/internal/tools/document-lint/check/check_required.go
+++ b/internal/tools/document-lint/check/check_required.go
@@ -36,8 +36,7 @@ func (c requireDiff) String() string {
 	if c.RequiredMiss == ShouldBeComputed {
 		return fmt.Sprintf("%s Fields listed under Attributes Reference should not be marked Required/Optional", c.Str())
 	}
-	str := fmt.Sprintf("%s should be %s", c.Str(), util.Blue(c.RequiredMiss))
-	return str
+	return fmt.Sprintf("%s should be %s", c.Str(), util.Blue(c.RequiredMiss))
 }
 
 func (c requireDiff) Fix(line string) (result string, err error) {

--- a/internal/tools/document-lint/check/check_timeout.go
+++ b/internal/tools/document-lint/check/check_timeout.go
@@ -68,8 +68,7 @@ func (t *TimeoutDiffItem) FixLine(line string) string {
 	if end <= start {
 		return line
 	}
-	res := fmt.Sprintf("%s%s%s", line[:start], t.ValueString(), line[end:])
-	return res
+	return fmt.Sprintf("%s%s%s", line[:start], t.ValueString(), line[end:])
 }
 
 func NewTimeoutDiffItem(line int, typ TimeoutType, want int64) TimeoutDiffItem {

--- a/internal/tools/document-lint/check/document_fixer.go
+++ b/internal/tools/document-lint/check/document_fixer.go
@@ -23,13 +23,12 @@ type Fixer struct {
 }
 
 func NewFixer(d *ResourceDiff) *Fixer {
-	f := &Fixer{
+	return &Fixer{
 		MDFile:       d.MDFile,
 		SchemaFile:   d.SchemaFile,
 		ResourceType: d.tf.ResourceType,
 		Diff:         d.Diff,
 	}
-	return f
 }
 
 // param rt: resource type

--- a/internal/tools/document-lint/md/normalize.go
+++ b/internal/tools/document-lint/md/normalize.go
@@ -177,8 +177,7 @@ func FixFileNormalize(file string) {
 			}
 		} else if strings.HasPrefix(line, "*") {
 			// need a dash(-) after property name
-			line2 := tryFixProp(line)
-			line = line2
+			line = tryFixProp(line)
 			for k, v := range orderFixMap {
 				if strings.Contains(line, k) && !strings.Contains(line, v) {
 					line = strings.Replace(line, k, v, 1)

--- a/internal/tools/document-lint/md/parse_md.go
+++ b/internal/tools/document-lint/md/parse_md.go
@@ -53,12 +53,11 @@ func (m *MarkItem) addLine(num int, line string) {
 }
 
 func NewMarkItem(fromLine int, content string, typ ItemType) *MarkItem {
-	m := &MarkItem{
+	return &MarkItem{
 		FromLine: fromLine,
 		lines:    []string{content},
 		Type:     typ,
 	}
-	return m
 }
 
 type Block struct {
@@ -127,8 +126,7 @@ func MustNewMarkFromFile(file string) *Mark {
 	if err != nil {
 		panic(err)
 	}
-	m := newMarkFromString(string(bs), file)
-	return m
+	return newMarkFromString(string(bs), file)
 }
 
 func newMarkFromString(content string, filepath string) *Mark {

--- a/internal/tools/templatehelpers/formatters.go
+++ b/internal/tools/templatehelpers/formatters.go
@@ -103,9 +103,7 @@ func NewIDResourceIdentityFormatter(idType []string, idSegments []string, prefix
 	out := make([]string, 0)
 	out = append(out, idSegments...)
 
-	output := fmt.Sprintf(f, idType[0], IdToID(idType[1]), strings.Join(out, ", "))
-
-	return output
+	return fmt.Sprintf(f, idType[0], IdToID(idType[1]), strings.Join(out, ", "))
 }
 
 func NewIDCreateFormatter(idType []string, idSegments []string, prefix string) string {


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This is part of a series of PRs that enable the `azproviderlint` **AZG005** check and apply the resulting fixes across the provider. To keep each PR reviewable, the changes are split by service in alphabetical order; this PR covers the services from `servicebus` through `workloads` (also include some internal/tools files).

AZG005 flags single-use temporary variables that are assigned and then immediately returned or assigned onward. The fixes here inline those temporaries,

These are mechanical, behavior-preserving refactors with no functional changes. No schema, API, or resource behavior is affected.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->

## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

No new test coverage is included because this PR contains no functional changes — it only inlines single-use temporary variables to satisfy the newly enabled AZG005 lint rule. Existing acceptance tests for the affected resources continue to apply unchanged.


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
