### PR TITLE
Datadog - fix acceptance tests

### DIFF
--- a/internal/services/datadog/datadog_monitor_resource_test.go
+++ b/internal/services/datadog/datadog_monitor_resource_test.go
@@ -277,7 +277,12 @@ resource "azurerm_datadog_monitor" "import" {
 
 func (r DatadogMonitorResource) complete(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-	%s
+provider "azurerm" {
+  features {}
+}
+
+%s
+
 resource "azurerm_datadog_monitor" "test" {
   name                = "acctest-datadog-%s"
   resource_group_name = azurerm_resource_group.test.name


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

`TestAccDatadogMonitor_complete` fails as `azurerm` provider is not specified. The issue is fixed accordingly in this PR. A few tests can fail intermittently but are confirmed to pass after running for more than 1 time.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] ~I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.~
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] ~I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).~
- [ ] ~I have written new tests for my resource or datasource changes & updated any relevant documentation.~
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] ~(For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.~


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

Local test results are shown below. Tests are not run in TeamCity as `ARM_TEST_DATADOG_API_KEY`, `ARM_TEST_DATADOG_APPLICATION_KEY`, and `ARM_TEST_DATADOG_APPLICATION_KEY` environment variables are not set in TeamCity. Parallelism is set to 1 and location is fixed as `westus2`.

```
PASS: TestAccDatadogMonitor_basic (126.06s)
PASS: TestAccDatadogMonitorSSO_requiresImport (133.45s)
PASS: TestAccDatadogMonitorSSO_update (856.31s)
PASS: TestAccDatadogMonitor_update (356.51s)
PASS: TestAccDatadogMonitorSSO_basic (148.54s)
PASS: TestAccDatadogMonitor_complete (134.57s)
PASS: TestAccDatadogMonitor_requiresImport (113.41s)
PASS: TestAccDatadogMonitorTagRules_basic (135.16s)
PASS: TestAccDatadogMonitorTagRules_update (209.18s)
PASS: TestAccDatadogMonitorTagRules_requiresImport (115.87s)
```


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_datadog_monitor` - fix `TestAccDatadogMonitor_complete`


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
