### PR TITLE
Attributes added `data.automation` - add support for `dsc_primary_access_key  + 8 attributes`

### DIFF
--- a/internal/services/automation/automation_account_data_source.go
+++ b/internal/services/automation/automation_account_data_source.go
@@ -33,10 +33,7 @@ func dataSourceAutomationAccount() *pluginsdk.Resource {
 				Required: true,
 			},
 
-			"dsc_server_endpoint": {
-				Type:     pluginsdk.TypeString,
-				Computed: true,
-			},
+			"resource_group_name": commonschema.ResourceGroupNameForDataSource(),
 
 			"dsc_primary_access_key": {
 				Type:      pluginsdk.TypeString,
@@ -44,15 +41,15 @@ func dataSourceAutomationAccount() *pluginsdk.Resource {
 				Sensitive: true,
 			},
 
+			"dsc_server_endpoint": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
 			"dsc_secondary_access_key": {
 				Type:      pluginsdk.TypeString,
 				Computed:  true,
 				Sensitive: true,
-			},
-
-			"endpoint": {
-				Type:     pluginsdk.TypeString,
-				Computed: true,
 			},
 
 			"encryption": {
@@ -73,13 +70,6 @@ func dataSourceAutomationAccount() *pluginsdk.Resource {
 				},
 			},
 
-			"hybrid_service_url": {
-				Type:     pluginsdk.TypeString,
-				Computed: true,
-			},
-
-			"identity": commonschema.SystemAssignedUserAssignedIdentityComputed(),
-
 			"location": commonschema.LocationComputed(),
 
 			"local_authentication_enabled": {
@@ -88,6 +78,23 @@ func dataSourceAutomationAccount() *pluginsdk.Resource {
 			},
 
 			"primary_key": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
+			"public_network_access_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Computed: true,
+			},
+
+			"secondary_key": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
+			"identity": commonschema.SystemAssignedUserAssignedIdentityComputed(),
+
+			"endpoint": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
 			},
@@ -109,14 +116,7 @@ func dataSourceAutomationAccount() *pluginsdk.Resource {
 				},
 			},
 
-			"public_network_access_enabled": {
-				Type:     pluginsdk.TypeBool,
-				Computed: true,
-			},
-
-			"resource_group_name": commonschema.ResourceGroupNameForDataSource(),
-
-			"secondary_key": {
+			"hybrid_service_url": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
 			},
@@ -169,7 +169,12 @@ func dataSourceAutomationAccountRead(d *pluginsdk.ResourceData, meta interface{}
 			d.Set("hybrid_service_url", props.AutomationHybridServiceURL)
 			d.Set("local_authentication_enabled", !pointer.From(props.DisableLocalAuth))
 			d.Set("public_network_access_enabled", pointer.From(props.PublicNetworkAccess))
-			d.Set("sku_name", pointer.From(props.Sku))
+
+			skuName := ""
+			if sku := props.Sku; sku != nil {
+				skuName = string(sku.Name)
+			}
+			d.Set("sku_name", skuName)
 
 			if err := d.Set("encryption", flattenEncryption(props.Encryption)); err != nil {
 				return fmt.Errorf("setting `encryption`: %+v", err)

--- a/internal/services/automation/automation_account_data_source.go
+++ b/internal/services/automation/automation_account_data_source.go
@@ -73,11 +73,13 @@ func dataSourceAutomationAccount() *pluginsdk.Resource {
 					Schema: map[string]*pluginsdk.Schema{
 						"user_assigned_identity_id": {
 							Type:     pluginsdk.TypeString,
-							Computed: true},
+							Computed: true,
+						},
 
 						"key_vault_key_id": {
 							Type:     pluginsdk.TypeString,
-							Computed: true},
+							Computed: true,
+						},
 					},
 				},
 			},
@@ -165,28 +167,14 @@ func dataSourceAutomationAccountRead(d *pluginsdk.ResourceData, meta interface{}
 		if props := model.Properties; props != nil {
 			d.Set("private_endpoint_connection", flattenPrivateEndpointConnectionsDataSource(props.PrivateEndpointConnections))
 			d.Set("hybrid_service_url", props.AutomationHybridServiceURL)
-
-			localAuthEnabled := true
-			if val := props.DisableLocalAuth; val != nil && *val {
-				localAuthEnabled = false
-			}
-			d.Set("local_authentication_enabled", localAuthEnabled)
+			d.Set("local_authentication_enabled", !pointer.From(props.DisableLocalAuth))
+			d.Set("public_network_access_enabled", pointer.From(props.PublicNetworkAccess))
+			d.Set("sku_name", pointer.From(props.Sku))
 
 			if err := d.Set("encryption", flattenEncryption(props.Encryption)); err != nil {
 				return fmt.Errorf("setting `encryption`: %+v", err)
 			}
 
-			publicNetworkAccessEnabled := true
-			if props.PublicNetworkAccess != nil {
-				publicNetworkAccessEnabled = *props.PublicNetworkAccess
-			}
-			d.Set("public_network_access_enabled", publicNetworkAccessEnabled)
-
-			skuName := ""
-			if sku := props.Sku; sku != nil {
-				skuName = string(sku.Name)
-			}
-			d.Set("sku_name", skuName)
 		}
 		if err := tags.FlattenAndSet(d, model.Tags); err != nil {
 			return err

--- a/internal/services/automation/automation_account_data_source.go
+++ b/internal/services/automation/automation_account_data_source.go
@@ -33,36 +33,25 @@ func dataSourceAutomationAccount() *pluginsdk.Resource {
 				Required: true,
 			},
 
-			"resource_group_name": commonschema.ResourceGroupNameForDataSource(),
-
-			"primary_key": {
+			"dsc_server_endpoint": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
 			},
 
-			"secondary_key": {
-				Type:     pluginsdk.TypeString,
-				Computed: true,
+			"dsc_primary_access_key": {
+				Type:      pluginsdk.TypeString,
+				Computed:  true,
+				Sensitive: true,
 			},
 
-			"identity": commonschema.SystemAssignedUserAssignedIdentityComputed(),
+			"dsc_secondary_access_key": {
+				Type:      pluginsdk.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
 
 			"endpoint": {
 				Type:     pluginsdk.TypeString,
-				Computed: true,
-			},
-
-			"location": commonschema.LocationComputed(),
-
-			"sku_name": {
-				Type:     pluginsdk.TypeString,
-				Computed: true,
-			},
-
-			"tags": commonschema.TagsDataSource(),
-
-			"public_network_access_enabled": {
-				Type:     pluginsdk.TypeBool,
 				Computed: true,
 			},
 
@@ -84,26 +73,23 @@ func dataSourceAutomationAccount() *pluginsdk.Resource {
 				},
 			},
 
+			"hybrid_service_url": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
+			"identity": commonschema.SystemAssignedUserAssignedIdentityComputed(),
+
+			"location": commonschema.LocationComputed(),
+
 			"local_authentication_enabled": {
 				Type:     pluginsdk.TypeBool,
 				Computed: true,
 			},
 
-			"dsc_server_endpoint": {
+			"primary_key": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
-			},
-
-			"dsc_primary_access_key": {
-				Type:      pluginsdk.TypeString,
-				Computed:  true,
-				Sensitive: true,
-			},
-
-			"dsc_secondary_access_key": {
-				Type:      pluginsdk.TypeString,
-				Computed:  true,
-				Sensitive: true,
 			},
 
 			"private_endpoint_connection": {
@@ -123,10 +109,24 @@ func dataSourceAutomationAccount() *pluginsdk.Resource {
 				},
 			},
 
-			"hybrid_service_url": {
+			"public_network_access_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Computed: true,
+			},
+
+			"resource_group_name": commonschema.ResourceGroupNameForDataSource(),
+
+			"secondary_key": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
 			},
+
+			"sku_name": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
+			"tags": commonschema.TagsDataSource(),
 		},
 	}
 }
@@ -174,7 +174,6 @@ func dataSourceAutomationAccountRead(d *pluginsdk.ResourceData, meta interface{}
 			if err := d.Set("encryption", flattenEncryption(props.Encryption)); err != nil {
 				return fmt.Errorf("setting `encryption`: %+v", err)
 			}
-
 		}
 		if err := tags.FlattenAndSet(d, model.Tags); err != nil {
 			return err

--- a/internal/services/automation/automation_account_data_source.go
+++ b/internal/services/automation/automation_account_data_source.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/automation/2019-06-01/agentregistrationinformation"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/automation/2024-10-23/automationaccount"
@@ -156,6 +157,7 @@ func dataSourceAutomationAccountRead(d *pluginsdk.ResourceData, meta interface{}
 	}
 
 	if model := resp.Model; model != nil {
+		d.Set("location", location.Normalize(model.Location))
 		flattenedIdentity, err := identity.FlattenSystemAndUserAssignedMap(model.Identity)
 		if err != nil {
 			return fmt.Errorf("flattening `identity`: %+v", err)

--- a/internal/services/automation/automation_account_data_source.go
+++ b/internal/services/automation/automation_account_data_source.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/automation/2019-06-01/agentregistrationinformation"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/automation/2024-10-23/automationaccount"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -49,6 +50,58 @@ func dataSourceAutomationAccount() *pluginsdk.Resource {
 			"endpoint": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
+			},
+
+			"location": commonschema.LocationComputed(),
+
+			"sku_name": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
+			"tags": commonschema.TagsDataSource(),
+
+			"public_network_access_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Computed: true,
+			},
+
+			"encryption": {
+				Type:     pluginsdk.TypeList,
+				Computed: true,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"user_assigned_identity_id": {
+							Type:     pluginsdk.TypeString,
+							Computed: true},
+
+						"key_vault_key_id": {
+							Type:     pluginsdk.TypeString,
+							Computed: true},
+					},
+				},
+			},
+
+			"local_authentication_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Computed: true,
+			},
+
+			"dsc_server_endpoint": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
+			"dsc_primary_access_key": {
+				Type:      pluginsdk.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+
+			"dsc_secondary_access_key": {
+				Type:      pluginsdk.TypeString,
+				Computed:  true,
+				Sensitive: true,
 			},
 
 			"private_endpoint_connection": {
@@ -112,6 +165,31 @@ func dataSourceAutomationAccountRead(d *pluginsdk.ResourceData, meta interface{}
 		if props := model.Properties; props != nil {
 			d.Set("private_endpoint_connection", flattenPrivateEndpointConnectionsDataSource(props.PrivateEndpointConnections))
 			d.Set("hybrid_service_url", props.AutomationHybridServiceURL)
+
+			localAuthEnabled := true
+			if val := props.DisableLocalAuth; val != nil && *val {
+				localAuthEnabled = false
+			}
+			d.Set("local_authentication_enabled", localAuthEnabled)
+
+			if err := d.Set("encryption", flattenEncryption(props.Encryption)); err != nil {
+				return fmt.Errorf("setting `encryption`: %+v", err)
+			}
+
+			publicNetworkAccessEnabled := true
+			if props.PublicNetworkAccess != nil {
+				publicNetworkAccessEnabled = *props.PublicNetworkAccess
+			}
+			d.Set("public_network_access_enabled", publicNetworkAccessEnabled)
+
+			skuName := ""
+			if sku := props.Sku; sku != nil {
+				skuName = string(sku.Name)
+			}
+			d.Set("sku_name", skuName)
+		}
+		if err := tags.FlattenAndSet(d, model.Tags); err != nil {
+			return err
 		}
 	}
 
@@ -128,6 +206,10 @@ func dataSourceAutomationAccountRead(d *pluginsdk.ResourceData, meta interface{}
 	d.Set("endpoint", endpoint)
 	d.Set("primary_key", primaryKey)
 	d.Set("secondary_key", secondaryKey)
+
+	d.Set("dsc_server_endpoint", endpoint)
+	d.Set("dsc_primary_access_key", primaryKey)
+	d.Set("dsc_secondary_access_key", secondaryKey)
 
 	return nil
 }

--- a/internal/services/automation/automation_account_data_source_test.go
+++ b/internal/services/automation/automation_account_data_source_test.go
@@ -8,17 +8,28 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 )
 
 type AutomationAccountDataSource struct{}
 
 func TestAccDataSourceAutomationAccount_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_automation_account", "test")
+	resource := acceptance.BuildTestData(t, "azurerm_automation_account", "test")
 
 	data.DataSourceTest(t, []acceptance.TestStep{
 		{
 			Config: AutomationAccountDataSource{}.complete(data),
-			Check:  acceptance.ComposeTestCheckFunc(),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("location").MatchesOtherKey(check.That(resource.ResourceName).Key("location")),
+				check.That(data.ResourceName).Key("sku_name").MatchesOtherKey(check.That(resource.ResourceName).Key("sku_name")),
+				check.That(data.ResourceName).Key("tags.%").MatchesOtherKey(check.That(resource.ResourceName).Key("tags.%")),
+				check.That(data.ResourceName).Key("public_network_access_enabled").MatchesOtherKey(check.That(resource.ResourceName).Key("public_network_access_enabled")),
+				check.That(data.ResourceName).Key("local_authentication_enabled").MatchesOtherKey(check.That(resource.ResourceName).Key("local_authentication_enabled")),
+				check.That(data.ResourceName).Key("dsc_server_endpoint").MatchesOtherKey(check.That(resource.ResourceName).Key("dsc_server_endpoint")),
+				check.That(data.ResourceName).Key("dsc_primary_access_key").MatchesOtherKey(check.That(resource.ResourceName).Key("dsc_primary_access_key")),
+				check.That(data.ResourceName).Key("dsc_secondary_access_key").MatchesOtherKey(check.That(resource.ResourceName).Key("dsc_secondary_access_key")),
+			),
 		},
 	})
 }
@@ -43,6 +54,10 @@ resource "azurerm_automation_account" "test" {
   identity {
     type = "SystemAssigned"
   }
+
+tags = {
+  "Hello" = "World"
+}
 }
 
 data "azurerm_automation_account" "test" {
@@ -54,4 +69,29 @@ output "automation_account_system_managed_identity_principal_id" {
   value = data.azurerm_automation_account.test.identity[0].principal_id
 }
 `, data.RandomInteger, data.Locations.Primary)
+}
+
+func TestAccDataSourceAutomationAccount_encryption(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_automation_account", "test")
+	resource := acceptance.BuildTestData(t, "azurerm_automation_account", "test")
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: AutomationAccountDataSource{}.encryption(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("encryption.#").MatchesOtherKey(check.That(resource.ResourceName).Key("encryption.#")),
+			),
+		},
+	})
+}
+
+func (AutomationAccountDataSource) encryption(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+  %s
+
+  data "azurerm_automation_account" "test" {
+    resource_group_name = azurerm_resource_group.test.name
+    name                = azurerm_automation_account.test.name
+  }
+    `, AutomationAccountResource{}.encryption_userIdentity(data))
 }

--- a/internal/services/automation/automation_account_data_source_test.go
+++ b/internal/services/automation/automation_account_data_source_test.go
@@ -55,9 +55,9 @@ resource "azurerm_automation_account" "test" {
     type = "SystemAssigned"
   }
 
-tags = {
-  "Hello" = "World"
-}
+  tags = {
+    "Hello" = "World"
+  }
 }
 
 data "azurerm_automation_account" "test" {
@@ -89,9 +89,9 @@ func (AutomationAccountDataSource) encryption(data acceptance.TestData) string {
 	return fmt.Sprintf(`
   %s
 
-  data "azurerm_automation_account" "test" {
-    resource_group_name = azurerm_resource_group.test.name
-    name                = azurerm_automation_account.test.name
-  }
+data "azurerm_automation_account" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  name                = azurerm_automation_account.test.name
+}
     `, AutomationAccountResource{}.encryption_userIdentity(data))
 }

--- a/website/docs/d/automation_account.html.markdown
+++ b/website/docs/d/automation_account.html.markdown
@@ -31,40 +31,38 @@ output "automation_account_id" {
 
 ## Attributes Reference
 
-* `id` - The ID of the Automation Account
-
-* `primary_key` - The Primary Access Key for the Automation Account.
-
-* `secondary_key` - The Secondary Access Key for the Automation Account.
-
-* `identity` -  An `identity` block as defined below.
-
-* `endpoint` - The Endpoint for this Automation Account.
-
-* `hybrid_service_url` - The URL of automation hybrid service which is used for 
-hybrid worker on-boarding With this Automation Account.
-
-* `location` -  Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
-
-* `sku_name` -  The SKU of the account. Possible values are `Basic` and `Free`.
-
----
-
-* `local_authentication_enabled` - (Optional) Whether requests using non-AAD authentication are blocked. Defaults to `true`.
-
-* `public_network_access_enabled` - (Optional) Whether public network access is allowed for the automation account. Defaults to `true`.
-
-* `identity` -  An `identity` block as defined below.
-
-* `tags` -  A mapping of tags to assign to the resource.
-
-* `encryption` -  An `encryption` block as defined below.
-
 * `dsc_server_endpoint` - The DSC Server Endpoint associated with this Automation Account.
 
 * `dsc_primary_access_key` - The Primary Access Key for the DSC Endpoint associated with this Automation Account.
 
 * `dsc_secondary_access_key` - The Secondary Access Key for the DSC Endpoint associated with this Automation Account.
+
+* `encryption` -  An `encryption` block as defined below.
+
+* `endpoint` - The Endpoint for this Automation Account.
+
+
+* `hybrid_service_url` - The URL of automation hybrid service which is used for 
+hybrid worker on-boarding With this Automation Account.
+
+* `id` - The ID of the Automation Account
+
+* `identity` -  An `identity` block as defined below.
+
+* `location` -  Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
+
+* `local_authentication_enabled` -  Whether requests using non-AAD authentication are blocked. Defaults to `true`.
+
+* `primary_key` - The Primary Access Key for the Automation Account.
+
+* `public_network_access_enabled` -  Whether public network access is allowed for the automation account. Defaults to `true`.
+
+* `secondary_key` - The Secondary Access Key for the Automation Account.
+
+* `sku_name` -  The SKU of the account. Possible values are `Basic` and `Free`.
+
+* `tags` -  A mapping of tags to assign to the resource.
+
 ---
 
 An `identity` block exports the following:

--- a/website/docs/d/automation_account.html.markdown
+++ b/website/docs/d/automation_account.html.markdown
@@ -37,12 +37,34 @@ output "automation_account_id" {
 
 * `secondary_key` - The Secondary Access Key for the Automation Account.
 
-* `identity` - (Optional) An `identity` block as defined below.
+* `identity` -  An `identity` block as defined below.
 
 * `endpoint` - The Endpoint for this Automation Account.
 
-* `hybrid_service_url` - The URL of automation hybrid service which is used for hybrid worker on-boarding With this Automation Account.
+* `hybrid_service_url` - The URL of automation hybrid service which is used for 
+hybrid worker on-boarding With this Automation Account.
 
+* `location` -  Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
+
+* `sku_name` -  The SKU of the account. Possible values are `Basic` and `Free`.
+
+---
+
+* `local_authentication_enabled` - (Optional) Whether requests using non-AAD authentication are blocked. Defaults to `true`.
+
+* `public_network_access_enabled` - (Optional) Whether public network access is allowed for the automation account. Defaults to `true`.
+
+* `identity` -  An `identity` block as defined below.
+
+* `tags` -  A mapping of tags to assign to the resource.
+
+* `encryption` -  An `encryption` block as defined below.
+
+* `dsc_server_endpoint` - The DSC Server Endpoint associated with this Automation Account.
+
+* `dsc_primary_access_key` - The Primary Access Key for the DSC Endpoint associated with this Automation Account.
+
+* `dsc_secondary_access_key` - The Secondary Access Key for the DSC Endpoint associated with this Automation Account.
 ---
 
 An `identity` block exports the following:


### PR DESCRIPTION
--- PASS: TestAccDataSourceAutomationAccount_complete (81.75s)

Required attributes added to automation_account data source file: 			
"location"
"sku_name"
"tags"
"public_network_access_enabled"
"encryption"
"local_authentication_enabled"
"dsc_server_endpoint"
"dsc_primary_access_key"
"dsc_secondary_access_key"