### PR TITLE
`azurerm_databricks_workspace[_root_dbfs_customer_managed_key]` - deprecate `*key_vault_id` args and remove redundant kv existence check

### DIFF
--- a/examples/databricks/managed-services-cross-subscription/main.tf
+++ b/examples/databricks/managed-services-cross-subscription/main.tf
@@ -34,10 +34,7 @@ resource "azurerm_databricks_workspace" "example" {
   sku                         = "premium"
   managed_resource_group_name = "${var.prefix}-DBW-managed-services"
 
-  managed_services_cmk_key_vault_id     = azurerm_key_vault.example.id
   managed_services_cmk_key_vault_key_id = azurerm_key_vault_key.services.id
-
-  managed_disk_cmk_key_vault_id     = azurerm_key_vault.example.id
   managed_disk_cmk_key_vault_key_id = azurerm_key_vault_key.disk.id
 
   tags = {

--- a/examples/databricks/managed-services-cross-subscription/main.tf
+++ b/examples/databricks/managed-services-cross-subscription/main.tf
@@ -35,7 +35,7 @@ resource "azurerm_databricks_workspace" "example" {
   managed_resource_group_name = "${var.prefix}-DBW-managed-services"
 
   managed_services_cmk_key_vault_key_id = azurerm_key_vault_key.services.id
-  managed_disk_cmk_key_vault_key_id = azurerm_key_vault_key.disk.id
+  managed_disk_cmk_key_vault_key_id     = azurerm_key_vault_key.disk.id
 
   tags = {
     Environment = "Sandbox"

--- a/internal/services/databricks/databricks_workspace_resource.go
+++ b/internal/services/databricks/databricks_workspace_resource.go
@@ -26,20 +26,20 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/databricks/validate"
-	resourcesParse "github.com/hashicorp/terraform-provider-azurerm/internal/services/resource/parse"
 	storageValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
 
-//go:generate go run ../../tools/generator-tests resourceidentity -test-name basicForResourceIdentity
+//go:generate go run ../../tools/generator-tests resourceidentity -test-params "premium"
 
 func resourceDatabricksWorkspace() *pluginsdk.Resource {
-	return &pluginsdk.Resource{
+	resource := &pluginsdk.Resource{
 		Create: resourceDatabricksWorkspaceCreate,
 		Read:   resourceDatabricksWorkspaceRead,
 		Update: resourceDatabricksWorkspaceUpdate,
@@ -284,21 +284,10 @@ func resourceDatabricksWorkspace() *pluginsdk.Resource {
 				ValidateFunc: keyvault.ValidateNestedItemID(keyvault.VersionTypeVersioned, keyvault.NestedItemTypeKey),
 			},
 
-			"managed_services_cmk_key_vault_id": {
-				Type:         pluginsdk.TypeString,
-				Optional:     true,
-				ValidateFunc: commonids.ValidateKeyVaultID,
-			},
-
 			"managed_disk_cmk_key_vault_key_id": {
 				Type:         pluginsdk.TypeString,
 				Optional:     true,
 				ValidateFunc: keyvault.ValidateNestedItemID(keyvault.VersionTypeVersioned, keyvault.NestedItemTypeKey),
-			},
-			"managed_disk_cmk_key_vault_id": {
-				Type:         pluginsdk.TypeString,
-				Optional:     true,
-				ValidateFunc: commonids.ValidateKeyVaultID,
 			},
 
 			"managed_disk_cmk_rotation_to_latest_version_enabled": {
@@ -451,8 +440,60 @@ func resourceDatabricksWorkspace() *pluginsdk.Resource {
 
 				return nil
 			}),
+
+			pluginsdk.CustomizeDiffShim(func(ctx context.Context, d *pluginsdk.ResourceDiff, v interface{}) error {
+				// Neither of these arguments can be removed once set
+				for _, k := range []string{"managed_disk_cmk_key_vault_key_id", "managed_services_cmk_key_vault_key_id"} {
+					o, n := d.GetChange(k)
+
+					if o.(string) != "" && n.(string) == "" {
+						// Check RawConfig to prevent replacments on `(known after apply)` values
+						rawConfig := d.GetRawConfig()
+						if rawConfig.IsNull() || !rawConfig.IsKnown() {
+							return nil
+						}
+						rawValues := rawConfig.AsValueMap()
+
+						if !rawValues[k].IsNull() {
+							return nil
+						}
+
+						if err := d.ForceNew(k); err != nil {
+							return err
+						}
+					}
+				}
+
+				return nil
+			}),
 		),
 	}
+
+	if !features.SixPointOh() {
+		resource.Schema["managed_services_cmk_key_vault_id"] = &pluginsdk.Schema{
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: commonids.ValidateKeyVaultID,
+			DiffSuppressFunc: func(_, o, n string, _ *pluginsdk.ResourceData) bool {
+				// Suppress removal diff for 5.x since that does not require an update
+				return o != "" && n == ""
+			},
+			Deprecated: "`managed_services_cmk_key_vault_id` has been deprecated and will be removed in v6.0 of the AzureRM provider. This property is no longer required for cross-subscription scenarios.",
+		}
+
+		resource.Schema["managed_disk_cmk_key_vault_id"] = &pluginsdk.Schema{
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: commonids.ValidateKeyVaultID,
+			DiffSuppressFunc: func(_, o, n string, _ *pluginsdk.ResourceData) bool {
+				// Suppress removal diff for 5.x since that does not require an update
+				return o != "" && n == ""
+			},
+			Deprecated: "`managed_disk_cmk_key_vault_id` has been deprecated and will be removed in v6.0 of the AzureRM provider. This property is no longer required for cross-subscription scenarios.",
+		}
+	}
+
+	return resource
 }
 
 func resourceDatabricksWorkspaceCreate(d *pluginsdk.ResourceData, meta interface{}) error {
@@ -460,12 +501,11 @@ func resourceDatabricksWorkspaceCreate(d *pluginsdk.ResourceData, meta interface
 	acClient := meta.(*clients.Client).DataBricks.AccessConnectorClient
 	lbClient := meta.(*clients.Client).LoadBalancers.LoadBalancersClient
 	subnetsClient := meta.(*clients.Client).Network.Subnets
-	keyVaultsClient := meta.(*clients.Client).KeyVault
-	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id := workspaces.NewWorkspaceID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
+	id := workspaces.NewWorkspaceID(meta.(*clients.Client).Account.SubscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 
 	if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
 		existing, err := client.Get(ctx, id)
@@ -481,20 +521,15 @@ func resourceDatabricksWorkspaceCreate(d *pluginsdk.ResourceData, meta interface
 	}
 
 	var backendPoolName, loadBalancerId string
-	skuName := d.Get("sku").(string)
 	managedResourceGroupName := d.Get("managed_resource_group_name").(string)
-	location := location.Normalize(d.Get("location").(string))
-	backendPool := d.Get("load_balancer_backend_address_pool_id").(string)
 
-	if backendPool != "" {
+	if backendPool := d.Get("load_balancer_backend_address_pool_id").(string); backendPool != "" {
 		backendPoolId, err := loadbalancers.ParseLoadBalancerBackendAddressPoolID(backendPool)
 		if err != nil {
 			return err
 		}
 
-		// Generate the load balancer ID from the Backend Address Pool Id...
-		lbId := loadbalancers.NewLoadBalancerID(backendPoolId.SubscriptionId, backendPoolId.ResourceGroupName, backendPoolId.LoadBalancerName)
-
+		lbId := loadbalancers.NewProviderLoadBalancerID(backendPoolId.SubscriptionId, backendPoolId.ResourceGroupName, backendPoolId.LoadBalancerName)
 		backendPoolName = backendPoolId.BackendAddressPoolName
 		loadBalancerId = lbId.ID()
 
@@ -505,8 +540,7 @@ func resourceDatabricksWorkspaceCreate(d *pluginsdk.ResourceData, meta interface
 		defer locks.UnlockByID(lbId.ID())
 
 		// check to make sure the load balancer exists as referred to by the Backend Address Pool...
-		plbId := loadbalancers.ProviderLoadBalancerId{SubscriptionId: backendPoolId.SubscriptionId, ResourceGroupName: backendPoolId.ResourceGroupName, LoadBalancerName: backendPoolId.LoadBalancerName}
-		lb, err := lbClient.Get(ctx, plbId, loadbalancers.GetOperationOptions{})
+		lb, err := lbClient.Get(ctx, lbId, loadbalancers.GetOperationOptions{})
 		if err != nil {
 			if response.WasNotFound(lb.HttpResponse) {
 				return fmt.Errorf("%s was not found", lbId)
@@ -516,27 +550,17 @@ func resourceDatabricksWorkspaceCreate(d *pluginsdk.ResourceData, meta interface
 	}
 
 	if managedResourceGroupName == "" {
-		// no managed resource group name was provided, we use the default pattern
-		log.Printf("[DEBUG][azurerm_databricks_workspace] no managed resource group id was provided, we use the default pattern.")
+		log.Printf("[DEBUG] no managed resource group name was provided, using the default pattern")
 		managedResourceGroupName = fmt.Sprintf("databricks-rg-%s", id.ResourceGroupName)
 	}
 
-	managedResourceGroupID := resourcesParse.NewResourceGroupID(subscriptionId, managedResourceGroupName).ID()
-	customerEncryptionEnabled := d.Get("customer_managed_key_enabled").(bool)
-	infrastructureEncryptionEnabled := d.Get("infrastructure_encryption_enabled").(bool)
-	defaultStorageFirewallEnabledRaw := d.Get("default_storage_firewall_enabled").(bool)
-	defaultStorageFirewallEnabled := workspaces.DefaultStorageFirewallDisabled
-	if defaultStorageFirewallEnabledRaw {
-		defaultStorageFirewallEnabled = workspaces.DefaultStorageFirewallEnabled
-	}
-	publicNetworkAccessRaw := d.Get("public_network_access_enabled").(bool)
 	publicNetworkAccess := workspaces.PublicNetworkAccessDisabled
-	if publicNetworkAccessRaw {
+	if d.Get("public_network_access_enabled").(bool) {
 		publicNetworkAccess = workspaces.PublicNetworkAccessEnabled
 	}
-	requireNsgRules := d.Get("network_security_group_rules_required").(string)
+
 	customParamsRaw := d.Get("custom_parameters").([]interface{})
-	customParams, pubSubAssoc, priSubAssoc := expandWorkspaceCustomParameters(customParamsRaw, customerEncryptionEnabled, infrastructureEncryptionEnabled, backendPoolName, loadBalancerId)
+	customParams, pubSubAssoc, priSubAssoc := expandWorkspaceCustomParameters(customParamsRaw, d.Get("customer_managed_key_enabled").(bool), d.Get("infrastructure_encryption_enabled").(bool), backendPoolName, loadBalancerId)
 
 	if len(customParamsRaw) > 0 && customParamsRaw[0] != nil {
 		config := customParamsRaw[0].(map[string]interface{})
@@ -562,126 +586,31 @@ func resourceDatabricksWorkspaceCreate(d *pluginsdk.ResourceData, meta interface
 		}
 	}
 
-	// Set up customer-managed keys for managed services encryption (e.g. notebook)
-	setEncrypt := false
-	encrypt := &workspaces.WorkspacePropertiesEncryption{}
-	encrypt.Entities = workspaces.EncryptionEntitiesDefinition{}
-
-	var servicesKeyId string
-	var servicesKeyVaultId string
-	var diskKeyId string
-	var diskKeyVaultId string
-
-	if v, ok := d.GetOk("managed_services_cmk_key_vault_key_id"); ok {
-		servicesKeyId = v.(string)
-	}
-
-	if v, ok := d.GetOk("managed_services_cmk_key_vault_id"); ok {
-		servicesKeyVaultId = v.(string)
-	}
-
-	if v, ok := d.GetOk("managed_disk_cmk_key_vault_key_id"); ok {
-		diskKeyId = v.(string)
-	}
-
-	if v, ok := d.GetOk("managed_disk_cmk_key_vault_id"); ok {
-		diskKeyVaultId = v.(string)
-	}
-
-	// set default subscription as current subscription for key vault look-up...
-	servicesResourceSubscriptionId := commonids.NewSubscriptionID(id.SubscriptionId)
-	diskResourceSubscriptionId := commonids.NewSubscriptionID(id.SubscriptionId)
-
-	if servicesKeyVaultId != "" {
-		// If they passed the 'managed_cmk_key_vault_id' parse the Key Vault ID
-		// to extract the correct key vault subscription for the exists call...
-		v, err := commonids.ParseKeyVaultID(servicesKeyVaultId)
-		if err != nil {
-			return fmt.Errorf("parsing %q as a Key Vault ID: %+v", servicesKeyVaultId, err)
-		}
-
-		servicesResourceSubscriptionId = commonids.NewSubscriptionID(v.SubscriptionId)
-	}
-
-	if servicesKeyId != "" {
-		setEncrypt = true
-		key, err := keyvault.ParseNestedItemID(servicesKeyId, keyvault.VersionTypeVersioned, keyvault.NestedItemTypeKey)
-		if err != nil {
-			return err
-		}
-
-		// make sure the key vault exists
-		if _, err = keyVaultsClient.KeyVaultIDFromBaseUrl(ctx, servicesResourceSubscriptionId, key.KeyVaultBaseURL); err != nil {
-			return fmt.Errorf("retrieving the Resource ID for the customer-managed keys for managed services Key Vault in subscription %q at URL %q: %+v", servicesResourceSubscriptionId, key.KeyVaultBaseURL, err)
-		}
-
-		encrypt.Entities.ManagedServices = &workspaces.EncryptionV2{
-			KeySource: workspaces.EncryptionKeySourceMicrosoftPointKeyvault,
-			KeyVaultProperties: &workspaces.EncryptionV2KeyVaultProperties{
-				KeyName:     key.Name,
-				KeyVersion:  key.Version,
-				KeyVaultUri: key.KeyVaultBaseURL,
-			},
-		}
-	}
-
-	if diskKeyVaultId != "" {
-		// If they passed the 'managed_disk_cmk_key_vault_id' parse the Key Vault ID
-		// to extract the correct key vault subscription for the exists call...
-		v, err := commonids.ParseKeyVaultID(diskKeyVaultId)
-		if err != nil {
-			return fmt.Errorf("parsing %q as a Key Vault ID: %+v", diskKeyVaultId, err)
-		}
-
-		diskResourceSubscriptionId = commonids.NewSubscriptionID(v.SubscriptionId)
-	}
-
-	if diskKeyId != "" {
-		setEncrypt = true
-		key, err := keyvault.ParseNestedItemID(diskKeyId, keyvault.VersionTypeVersioned, keyvault.NestedItemTypeKey)
-		if err != nil {
-			return err
-		}
-
-		// make sure the key vault exists
-		if _, err = keyVaultsClient.KeyVaultIDFromBaseUrl(ctx, diskResourceSubscriptionId, key.KeyVaultBaseURL); err != nil {
-			return fmt.Errorf("retrieving the Resource ID for the customer-managed keys for managed disk Key Vault in subscription %q at URL %q: %+v", diskResourceSubscriptionId, key.KeyVaultBaseURL, err)
-		}
-
-		encrypt.Entities.ManagedDisk = &workspaces.ManagedDiskEncryption{
-			KeySource: workspaces.EncryptionKeySourceMicrosoftPointKeyvault,
-			KeyVaultProperties: workspaces.ManagedDiskEncryptionKeyVaultProperties{
-				KeyName:     key.Name,
-				KeyVersion:  key.Version,
-				KeyVaultUri: key.KeyVaultBaseURL,
-			},
-		}
-	}
-
-	if rotationEnabled := d.Get("managed_disk_cmk_rotation_to_latest_version_enabled").(bool); rotationEnabled {
-		encrypt.Entities.ManagedDisk.RotationToLatestKeyVersionEnabled = pointer.To(rotationEnabled)
+	encryption, err := expandDatabricksWorkspaceEncryption(d)
+	if err != nil {
+		return fmt.Errorf("expanding workspace encryption: %+v", err)
 	}
 
 	workspace := workspaces.Workspace{
 		Sku: &workspaces.Sku{
-			Name: skuName,
+			Name: d.Get("sku").(string),
 		},
-		Location: location,
+		Location: location.Normalize(d.Get("location").(string)),
 		Properties: workspaces.WorkspaceProperties{
-			ComputeMode:            workspaces.ComputeModeHybrid,
-			PublicNetworkAccess:    &publicNetworkAccess,
-			ManagedResourceGroupId: pointer.To(managedResourceGroupID),
-			Parameters:             customParams,
+			ComputeMode:                workspaces.ComputeModeHybrid,
+			PublicNetworkAccess:        &publicNetworkAccess,
+			ManagedResourceGroupId:     pointer.To(commonids.NewResourceGroupID(id.SubscriptionId, managedResourceGroupName).ID()),
+			Parameters:                 customParams,
+			Encryption:                 encryption,
+			EnhancedSecurityCompliance: expandWorkspaceEnhancedSecurity(d.Get("enhanced_security_compliance").([]interface{})),
 		},
 		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
 	}
 
-	if defaultStorageFirewallEnabledRaw {
-		accessConnectorProperties := workspaces.WorkspacePropertiesAccessConnector{}
-		accessConnectorIdRaw := d.Get("access_connector_id").(string)
-		accessConnectorId, err := accessconnector.ParseAccessConnectorID(accessConnectorIdRaw)
+	if d.Get("default_storage_firewall_enabled").(bool) {
+		accessConnectorId, err := accessconnector.ParseAccessConnectorID(d.Get("access_connector_id").(string))
 		if err != nil {
-			return fmt.Errorf("parsing Access Connector ID %s: %+v", accessConnectorIdRaw, err)
+			return err
 		}
 
 		accessConnector, err := acClient.Get(ctx, *accessConnectorId)
@@ -689,37 +618,30 @@ func resourceDatabricksWorkspaceCreate(d *pluginsdk.ResourceData, meta interface
 			return fmt.Errorf("retrieving Access Connector %s: %+v", accessConnectorId.AccessConnectorName, err)
 		}
 
-		if accessConnector.Model.Identity != nil {
+		accessConnectorProperties := workspaces.WorkspacePropertiesAccessConnector{}
+		if model := accessConnector.Model; model != nil && model.Identity != nil {
 			accIdentityId := ""
-			for raw := range accessConnector.Model.Identity.IdentityIds {
+			for raw := range model.Identity.IdentityIds {
 				id, err := commonids.ParseUserAssignedIdentityIDInsensitively(raw)
 				if err != nil {
-					return fmt.Errorf("parsing %q as a User Assigned Identity ID: %+v", raw, err)
+					return err
 				}
 				accIdentityId = id.ID()
 				break
 			}
 
-			accessConnectorProperties.Id = *accessConnector.Model.Id
-			accessConnectorProperties.IdentityType = workspaces.IdentityType(accessConnector.Model.Identity.Type)
+			accessConnectorProperties.Id = pointer.From(model.Id)
+			accessConnectorProperties.IdentityType = workspaces.IdentityType(model.Identity.Type)
 			accessConnectorProperties.UserAssignedIdentityId = &accIdentityId
 		}
 
 		workspace.Properties.AccessConnector = &accessConnectorProperties
-		workspace.Properties.DefaultStorageFirewall = &defaultStorageFirewallEnabled
+		workspace.Properties.DefaultStorageFirewall = pointer.To(workspaces.DefaultStorageFirewallEnabled)
 	}
 
-	if requireNsgRules != "" {
-		requiredNsgRulesConst := workspaces.RequiredNsgRules(requireNsgRules)
-		workspace.Properties.RequiredNsgRules = &requiredNsgRulesConst
+	if requireNsgRules := d.Get("network_security_group_rules_required").(string); requireNsgRules != "" {
+		workspace.Properties.RequiredNsgRules = pointer.ToEnum[workspaces.RequiredNsgRules](requireNsgRules)
 	}
-
-	if setEncrypt {
-		workspace.Properties.Encryption = encrypt
-	}
-
-	enhancedSecurityCompliance := d.Get("enhanced_security_compliance")
-	workspace.Properties.EnhancedSecurityCompliance = expandWorkspaceEnhancedSecurity(enhancedSecurityCompliance.([]interface{}))
 
 	if err := client.CreateOrUpdateCallbackThenPoll(ctx, id, workspace, sdk.SetIDAndIdentityCallback(meta, &id, d)); err != nil {
 		return fmt.Errorf("creating %s: %+v", id, err)
@@ -740,13 +662,6 @@ func resourceDatabricksWorkspaceCreate(d *pluginsdk.ResourceData, meta interface
 		return fmt.Errorf("setting `custom_parameters`: %+v", err)
 	}
 
-	// Always set these even if they are empty to keep the state file
-	// consistent with the configuration file...
-	d.Set("managed_services_cmk_key_vault_key_id", servicesKeyId)
-	d.Set("managed_disk_cmk_key_vault_key_id", diskKeyId)
-	d.Set("managed_services_cmk_key_vault_id", servicesKeyVaultId)
-	d.Set("managed_disk_cmk_key_vault_id", diskKeyVaultId)
-
 	return resourceDatabricksWorkspaceRead(d, meta)
 }
 
@@ -758,17 +673,6 @@ func resourceDatabricksWorkspaceRead(d *pluginsdk.ResourceData, meta interface{}
 	id, err := workspaces.ParseWorkspaceID(d.Id())
 	if err != nil {
 		return err
-	}
-
-	var encryptDiskRotationEnabled bool
-	var servicesKeyVaultId string
-	if v, ok := d.GetOk("managed_services_cmk_key_vault_id"); ok {
-		servicesKeyVaultId = v.(string)
-	}
-
-	var diskKeyVaultId string
-	if v, ok := d.GetOk("managed_disk_cmk_key_vault_id"); ok {
-		diskKeyVaultId = v.(string)
 	}
 
 	resp, err := client.Get(ctx, *id)
@@ -792,12 +696,18 @@ func resourceDatabricksWorkspaceRead(d *pluginsdk.ResourceData, meta interface{}
 			d.Set("sku", sku.Name)
 		}
 
-		managedResourceGroupID, err := resourcesParse.ResourceGroupIDInsensitively(pointer.From(model.Properties.ManagedResourceGroupId))
+		managedResourceGroupID, err := commonids.ParseResourceGroupIDInsensitively(pointer.From(model.Properties.ManagedResourceGroupId))
 		if err != nil {
 			return err
 		}
-		d.Set("managed_resource_group_id", model.Properties.ManagedResourceGroupId)
-		d.Set("managed_resource_group_name", managedResourceGroupID.ResourceGroup)
+
+		if !features.SixPointOh() {
+			d.Set("managed_resource_group_id", model.Properties.ManagedResourceGroupId)
+		} else {
+			d.Set("managed_resource_group_id", managedResourceGroupID.ID())
+		}
+
+		d.Set("managed_resource_group_name", managedResourceGroupID.ResourceGroupName)
 
 		if defaultStorageFirewall := model.Properties.DefaultStorageFirewall; defaultStorageFirewall != nil {
 			d.Set("default_storage_firewall_enabled", *defaultStorageFirewall != workspaces.DefaultStorageFirewallDisabled)
@@ -806,8 +716,7 @@ func resourceDatabricksWorkspaceRead(d *pluginsdk.ResourceData, meta interface{}
 			}
 		}
 
-		publicNetworkAccess := model.Properties.PublicNetworkAccess
-		if publicNetworkAccess != nil {
+		if publicNetworkAccess := model.Properties.PublicNetworkAccess; publicNetworkAccess != nil {
 			d.Set("public_network_access_enabled", *publicNetworkAccess != workspaces.PublicNetworkAccessDisabled)
 			if *publicNetworkAccess == workspaces.PublicNetworkAccessDisabled {
 				if model.Properties.RequiredNsgRules != nil {
@@ -830,8 +739,7 @@ func resourceDatabricksWorkspaceRead(d *pluginsdk.ResourceData, meta interface{}
 
 			// The subnet associations only exist in the statefile, so we need to do a Get before we Set
 			// with what has come back from the Azure response...
-			customParamsRaw := d.Get("custom_parameters").([]interface{})
-			_, pubSubAssoc, priSubAssoc := expandWorkspaceCustomParameters(customParamsRaw, cmkEnabled, infraEnabled, "", "")
+			_, pubSubAssoc, priSubAssoc := expandWorkspaceCustomParameters(d.Get("custom_parameters").([]interface{}), cmkEnabled, infraEnabled, "", "")
 
 			custom, backendPoolReadId := flattenWorkspaceCustomParameters(parameters, pubSubAssoc, priSubAssoc)
 			if err := d.Set("custom_parameters", custom); err != nil {
@@ -867,6 +775,7 @@ func resourceDatabricksWorkspaceRead(d *pluginsdk.ResourceData, meta interface{}
 
 		// customer managed key for managed disk
 		var diskKeyId string
+		var encryptDiskRotationEnabled bool
 		if encryption := model.Properties.Encryption; encryption != nil {
 			if encryptionProps := encryption.Entities.ManagedDisk; encryptionProps != nil {
 				if encryptionProps.KeyVaultProperties.KeyVaultUri != "" {
@@ -881,16 +790,18 @@ func resourceDatabricksWorkspaceRead(d *pluginsdk.ResourceData, meta interface{}
 		}
 
 		d.Set("enhanced_security_compliance", flattenWorkspaceEnhancedSecurity(model.Properties.EnhancedSecurityCompliance))
-
 		d.Set("disk_encryption_set_id", pointer.From(model.Properties.DiskEncryptionSetId))
 
 		// Always set these even if they are empty to keep the state file
 		// consistent with the configuration file...
 		d.Set("managed_services_cmk_key_vault_key_id", servicesKeyId)
-		d.Set("managed_services_cmk_key_vault_id", servicesKeyVaultId)
 		d.Set("managed_disk_cmk_key_vault_key_id", diskKeyId)
-		d.Set("managed_disk_cmk_key_vault_id", diskKeyVaultId)
 		d.Set("managed_disk_cmk_rotation_to_latest_version_enabled", encryptDiskRotationEnabled)
+
+		if !features.SixPointOh() {
+			d.Set("managed_services_cmk_key_vault_id", d.Get("managed_services_cmk_key_vault_id").(string))
+			d.Set("managed_disk_cmk_key_vault_id", d.Get("managed_disk_cmk_key_vault_id").(string))
+		}
 
 		if err := tags.FlattenAndSet(d, model.Tags); err != nil {
 			return err
@@ -925,7 +836,7 @@ func resourceDatabricksWorkspaceDelete(d *pluginsdk.ResourceData, meta interface
 func resourceDatabricksWorkspaceUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).DataBricks.WorkspacesClient
 	acClient := meta.(*clients.Client).DataBricks.AccessConnectorClient
-	keyVaultsClient := meta.(*clients.Client).KeyVault
+
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -944,7 +855,6 @@ func resourceDatabricksWorkspaceUpdate(d *pluginsdk.ResourceData, meta interface
 	}
 
 	model := *existing.Model
-
 	props := model.Properties
 
 	if d.HasChange("sku") {
@@ -1125,112 +1035,17 @@ func resourceDatabricksWorkspaceUpdate(d *pluginsdk.ResourceData, meta interface
 		}
 	}
 
-	// Set up customer-managed keys for managed services encryption (e.g. notebook)
-	setEncrypt := false
-	encrypt := &workspaces.WorkspacePropertiesEncryption{}
-	encrypt.Entities = workspaces.EncryptionEntitiesDefinition{}
-
-	var servicesKeyId string
-	var servicesKeyVaultId string
-	var diskKeyId string
-	var diskKeyVaultId string
-
-	if v, ok := d.GetOk("managed_services_cmk_key_vault_key_id"); ok {
-		servicesKeyId = v.(string)
-	}
-
-	if v, ok := d.GetOk("managed_services_cmk_key_vault_id"); ok {
-		servicesKeyVaultId = v.(string)
-	}
-
-	if v, ok := d.GetOk("managed_disk_cmk_key_vault_key_id"); ok {
-		diskKeyId = v.(string)
-	}
-
-	if v, ok := d.GetOk("managed_disk_cmk_key_vault_id"); ok {
-		diskKeyVaultId = v.(string)
-	}
-
-	// set default subscription as current subscription for key vault look-up...
-	servicesResourceSubscriptionId := commonids.NewSubscriptionID(id.SubscriptionId)
-	diskResourceSubscriptionId := commonids.NewSubscriptionID(id.SubscriptionId)
-
-	if servicesKeyVaultId != "" {
-		// If they passed the 'managed_cmk_key_vault_id' parse the Key Vault ID
-		// to extract the correct key vault subscription for the exists call...
-		v, err := commonids.ParseKeyVaultID(servicesKeyVaultId)
+	if d.HasChanges("managed_services_cmk_key_vault_key_id", "managed_disk_cmk_key_vault_key_id", "managed_disk_cmk_rotation_to_latest_version_enabled") {
+		encryption, err := expandDatabricksWorkspaceEncryption(d)
 		if err != nil {
-			return err
+			return fmt.Errorf("expanding workspace encryption: %+v", err)
 		}
-
-		servicesResourceSubscriptionId = commonids.NewSubscriptionID(v.SubscriptionId)
+		props.Encryption = encryption
 	}
 
-	if servicesKeyId != "" {
-		setEncrypt = true
-		key, err := keyvault.ParseNestedItemID(servicesKeyId, keyvault.VersionTypeVersioned, keyvault.NestedItemTypeKey)
-		if err != nil {
-			return err
-		}
-
-		// make sure the key vault exists
-		if _, err = keyVaultsClient.KeyVaultIDFromBaseUrl(ctx, servicesResourceSubscriptionId, key.KeyVaultBaseURL); err != nil {
-			return fmt.Errorf("retrieving the Resource ID for the customer-managed keys for managed services Key Vault in subscription %q at URL %q: %+v", servicesResourceSubscriptionId, key.KeyVaultBaseURL, err)
-		}
-
-		encrypt.Entities.ManagedServices = &workspaces.EncryptionV2{
-			KeySource: workspaces.EncryptionKeySourceMicrosoftPointKeyvault,
-			KeyVaultProperties: &workspaces.EncryptionV2KeyVaultProperties{
-				KeyName:     key.Name,
-				KeyVersion:  key.Version,
-				KeyVaultUri: key.KeyVaultBaseURL,
-			},
-		}
+	if d.HasChange("enhanced_security_compliance") {
+		props.EnhancedSecurityCompliance = expandWorkspaceEnhancedSecurity(d.Get("enhanced_security_compliance").([]interface{}))
 	}
-
-	if diskKeyVaultId != "" {
-		// If they passed the 'managed_disk_cmk_key_vault_id' parse the Key Vault ID
-		// to extract the correct key vault subscription for the exists call...
-		v, err := commonids.ParseKeyVaultID(diskKeyVaultId)
-		if err != nil {
-			return err
-		}
-
-		diskResourceSubscriptionId = commonids.NewSubscriptionID(v.SubscriptionId)
-	}
-
-	if diskKeyId != "" {
-		setEncrypt = true
-		key, err := keyvault.ParseNestedItemID(diskKeyId, keyvault.VersionTypeVersioned, keyvault.NestedItemTypeKey)
-		if err != nil {
-			return err
-		}
-
-		// make sure the key vault exists
-		if _, err = keyVaultsClient.KeyVaultIDFromBaseUrl(ctx, diskResourceSubscriptionId, key.KeyVaultBaseURL); err != nil {
-			return fmt.Errorf("retrieving the Resource ID for the customer-managed keys for managed disk Key Vault in subscription %q at URL %q: %+v", diskResourceSubscriptionId, key.KeyVaultBaseURL, err)
-		}
-
-		encrypt.Entities.ManagedDisk = &workspaces.ManagedDiskEncryption{
-			KeySource: workspaces.EncryptionKeySourceMicrosoftPointKeyvault,
-			KeyVaultProperties: workspaces.ManagedDiskEncryptionKeyVaultProperties{
-				KeyName:     key.Name,
-				KeyVersion:  key.Version,
-				KeyVaultUri: key.KeyVaultBaseURL,
-			},
-		}
-	}
-
-	if rotationEnabled := d.Get("managed_disk_cmk_rotation_to_latest_version_enabled").(bool); rotationEnabled {
-		encrypt.Entities.ManagedDisk.RotationToLatestKeyVersionEnabled = pointer.To(rotationEnabled)
-	}
-
-	if setEncrypt {
-		props.Encryption = encrypt
-	}
-
-	enhancedSecurityCompliance := d.Get("enhanced_security_compliance")
-	props.EnhancedSecurityCompliance = expandWorkspaceEnhancedSecurity(enhancedSecurityCompliance.([]interface{}))
 
 	model.Properties = props
 
@@ -1239,6 +1054,58 @@ func resourceDatabricksWorkspaceUpdate(d *pluginsdk.ResourceData, meta interface
 	}
 
 	return resourceDatabricksWorkspaceRead(d, meta)
+}
+
+func expandDatabricksWorkspaceEncryption(d *pluginsdk.ResourceData) (*workspaces.WorkspacePropertiesEncryption, error) {
+	diskCMK := d.Get("managed_disk_cmk_key_vault_key_id").(string)
+	servicesCMK := d.Get("managed_services_cmk_key_vault_key_id").(string)
+	if diskCMK == "" && servicesCMK == "" {
+		return nil, nil
+	}
+
+	result := &workspaces.WorkspacePropertiesEncryption{
+		Entities: workspaces.EncryptionEntitiesDefinition{},
+	}
+
+	if diskCMK != "" {
+		key, err := keyvault.ParseNestedItemID(diskCMK, keyvault.VersionTypeVersioned, keyvault.NestedItemTypeKey)
+		if err != nil {
+			return nil, err
+		}
+
+		rotateToLatest := (*bool)(nil)
+		if d.Get("managed_disk_cmk_rotation_to_latest_version_enabled").(bool) {
+			rotateToLatest = pointer.To(true)
+		}
+
+		result.Entities.ManagedDisk = &workspaces.ManagedDiskEncryption{
+			KeySource: workspaces.EncryptionKeySourceMicrosoftPointKeyvault,
+			KeyVaultProperties: workspaces.ManagedDiskEncryptionKeyVaultProperties{
+				KeyName:     key.Name,
+				KeyVaultUri: key.KeyVaultBaseURL,
+				KeyVersion:  key.Version,
+			},
+			RotationToLatestKeyVersionEnabled: rotateToLatest,
+		}
+	}
+
+	if servicesCMK != "" {
+		key, err := keyvault.ParseNestedItemID(servicesCMK, keyvault.VersionTypeVersioned, keyvault.NestedItemTypeKey)
+		if err != nil {
+			return nil, err
+		}
+
+		result.Entities.ManagedServices = &workspaces.EncryptionV2{
+			KeySource: workspaces.EncryptionKeySourceMicrosoftPointKeyvault,
+			KeyVaultProperties: &workspaces.EncryptionV2KeyVaultProperties{
+				KeyName:     key.Name,
+				KeyVaultUri: key.KeyVaultBaseURL,
+				KeyVersion:  key.Version,
+			},
+		}
+	}
+
+	return result, nil
 }
 
 func flattenWorkspaceManagedIdentity(input *workspaces.ManagedIdentityConfiguration) []interface{} {

--- a/internal/services/databricks/databricks_workspace_resource_identity_gen_test.go
+++ b/internal/services/databricks/databricks_workspace_resource_identity_gen_test.go
@@ -25,7 +25,7 @@ func TestAccDatabricksWorkspace_resourceIdentity(t *testing.T) {
 
 	data.ResourceIdentityTest(t, []acceptance.TestStep{
 		{
-			Config: r.basicForResourceIdentity(data),
+			Config: r.basic(data, "premium"),
 			ConfigStateChecks: []statecheck.StateCheck{
 				customstatecheck.ExpectAllIdentityFieldsAreChecked("azurerm_databricks_workspace.test", checkedFields),
 				statecheck.ExpectIdentityValue("azurerm_databricks_workspace.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),

--- a/internal/services/databricks/databricks_workspace_resource_test.go
+++ b/internal/services/databricks/databricks_workspace_resource_test.go
@@ -793,7 +793,7 @@ resource "azurerm_databricks_workspace" "test" {
   access_connector_id              = azurerm_databricks_access_connector.test2.id
   default_storage_firewall_enabled = true
 }
-`, r.template(data), data.RandomInteger, sku)
+`, r.templateVnetWithAccessConnectors(data), data.RandomInteger, sku)
 }
 
 func (r DatabricksWorkspaceResource) sameName(data acceptance.TestData, sku string) string {
@@ -2692,7 +2692,7 @@ resource "azurerm_databricks_access_connector" "test2" {
     type = "SystemAssigned"
   }
 }
-`, r.template(data), data.RandomInteger)
+`, r.templateVnet(data), data.RandomInteger)
 }
 
 func (r DatabricksWorkspaceResource) templateCMK(data acceptance.TestData) string {

--- a/internal/services/databricks/databricks_workspace_resource_test.go
+++ b/internal/services/databricks/databricks_workspace_resource_test.go
@@ -1217,68 +1217,16 @@ resource "azurerm_databricks_workspace" "test" {
 `, data.RandomInteger, data.Locations.Secondary, sku, data.RandomString)
 }
 
-func (DatabricksWorkspaceResource) privateLink(data acceptance.TestData) string {
+func (r DatabricksWorkspaceResource) privateLink(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-databricks-%[1]d"
-  location = "%[2]s"
-}
-
-resource "azurerm_virtual_network" "test" {
-  name                = "acctest-vnet-%[1]d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  address_space       = ["10.0.0.0/16"]
-}
-
-resource "azurerm_subnet" "public" {
-  name                 = "acctest-sn-public-%[1]d"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes     = ["10.0.1.0/24"]
-
-  delegation {
-    name = "acctest"
-
-    service_delegation {
-      name = "Microsoft.Databricks/workspaces"
-
-      actions = [
-        "Microsoft.Network/virtualNetworks/subnets/join/action",
-        "Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action",
-        "Microsoft.Network/virtualNetworks/subnets/unprepareNetworkPolicies/action",
-      ]
-    }
-  }
-}
-
-resource "azurerm_subnet" "private" {
-  name                 = "acctest-sn-private-%[1]d"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes     = ["10.0.2.0/24"]
-
-  delegation {
-    name = "acctest"
-
-    service_delegation {
-      name = "Microsoft.Databricks/workspaces"
-
-      actions = [
-        "Microsoft.Network/virtualNetworks/subnets/join/action",
-        "Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action",
-        "Microsoft.Network/virtualNetworks/subnets/unprepareNetworkPolicies/action",
-      ]
-    }
-  }
-}
+%[1]s
 
 resource "azurerm_subnet" "privatelink" {
-  name                 = "acctest-snpl-%[1]d"
+  name                 = "acctest-snpl-%[2]d"
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.0.3.0/24"]
@@ -1287,11 +1235,11 @@ resource "azurerm_subnet" "privatelink" {
 }
 
 resource "azurerm_databricks_workspace" "test" {
-  name                        = "acctestDBW-%[1]d"
+  name                        = "acctestDBW-%[2]d"
   resource_group_name         = azurerm_resource_group.test.name
   location                    = azurerm_resource_group.test.location
   sku                         = "premium"
-  managed_resource_group_name = "acctestRG-DBW-%[1]d-managed"
+  managed_resource_group_name = "acctestRG-DBW-%[2]d-managed"
 
   public_network_access_enabled         = false
   network_security_group_rules_required = "NoAzureDatabricksRules"
@@ -1313,13 +1261,13 @@ resource "azurerm_databricks_workspace" "test" {
 }
 
 resource "azurerm_private_endpoint" "databricks" {
-  name                = "acctest-endpoint-%[1]d"
+  name                = "acctest-endpoint-%[2]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   subnet_id           = azurerm_subnet.privatelink.id
 
   private_service_connection {
-    name                           = "acctest-psc-%[1]d"
+    name                           = "acctest-psc-%[2]d"
     is_manual_connection           = false
     private_connection_resource_id = azurerm_databricks_workspace.test.id
     subresource_names              = ["databricks_ui_api"]
@@ -1339,7 +1287,7 @@ resource "azurerm_private_dns_cname_record" "test" {
   ttl                 = 300
   record              = "eastus2-c2.azuredatabricks.net"
 }
-`, data.RandomInteger, data.Locations.Secondary)
+`, r.templateVnet(data), data.RandomInteger)
 }
 
 func (r DatabricksWorkspaceResource) secureClusterConnectivity(data acceptance.TestData) string {
@@ -1738,10 +1686,8 @@ provider "azurerm" {
 
 %[2]s
 
-%[3]s
-
 resource "azurerm_subnet" "privatelink" {
-  name                 = "acctest-snpl-%[4]d"
+  name                 = "acctest-snpl-%[3]d"
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.0.3.0/24"]
@@ -1752,11 +1698,11 @@ resource "azurerm_subnet" "privatelink" {
 resource "azurerm_databricks_workspace" "test" {
   depends_on = [azurerm_key_vault_access_policy.managed]
 
-  name                        = "acctestDBW-%[4]d"
+  name                        = "acctestDBW-%[3]d"
   resource_group_name         = azurerm_resource_group.test.name
   location                    = azurerm_resource_group.test.location
   sku                         = "premium"
-  managed_resource_group_name = "acctestRG-DBW-%[4]d-managed"
+  managed_resource_group_name = "acctestRG-DBW-%[3]d-managed"
 
   customer_managed_key_enabled          = true
   managed_services_cmk_key_vault_key_id = azurerm_key_vault_key.test.id
@@ -1789,7 +1735,7 @@ resource "azurerm_databricks_workspace_root_dbfs_customer_managed_key" "test" {
 resource "azurerm_key_vault_access_policy" "managed" {
   key_vault_id = azurerm_key_vault.test.id
   tenant_id    = azurerm_key_vault.test.tenant_id
-  object_id    = "%[5]s"
+  object_id    = "%[4]s"
 
   key_permissions = [
     "Get",
@@ -1817,13 +1763,13 @@ resource "azurerm_key_vault_access_policy" "databricks" {
 resource "azurerm_private_endpoint" "databricks" {
   depends_on = [azurerm_databricks_workspace_root_dbfs_customer_managed_key.test]
 
-  name                = "acctest-endpoint-%[4]d"
+  name                = "acctest-endpoint-%[3]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   subnet_id           = azurerm_subnet.privatelink.id
 
   private_service_connection {
-    name                           = "acctest-psc-%[4]d"
+    name                           = "acctest-psc-%[3]d"
     is_manual_connection           = false
     private_connection_resource_id = azurerm_databricks_workspace.test.id
     subresource_names              = ["databricks_ui_api"]
@@ -1843,7 +1789,7 @@ resource "azurerm_private_dns_cname_record" "test" {
   ttl                 = 300
   record              = "eastus2-c2.azuredatabricks.net"
 }
-`, r.template(data), r.templateVnet(data), r.templateCMK(data), data.RandomInteger, databricksPrincipalID)
+`, r.templateVnet(data), r.templateCMK(data), data.RandomInteger, databricksPrincipalID)
 }
 
 func (DatabricksWorkspaceResource) altSubscriptionCmkComplete(data acceptance.TestData, databricksPrincipalID string, alt *DatabricksWorkspaceAlternateSubscription) string {
@@ -2725,8 +2671,10 @@ resource "azurerm_subnet_network_security_group_association" "private" {
 
 func (r DatabricksWorkspaceResource) templateVnetWithAccessConnectors(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+%[1]s
+
 resource "azurerm_databricks_access_connector" "test" {
-  name                = "acctestDBWACC%[1]d"
+  name                = "acctestDBWACC%[2]d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
 
@@ -2736,7 +2684,7 @@ resource "azurerm_databricks_access_connector" "test" {
 }
 
 resource "azurerm_databricks_access_connector" "test2" {
-  name                = "acctestDBWACC2-%[1]d"
+  name                = "acctestDBWACC2-%[2]d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
 
@@ -2744,7 +2692,7 @@ resource "azurerm_databricks_access_connector" "test2" {
     type = "SystemAssigned"
   }
 }
-`, data.RandomInteger)
+`, r.template(data), data.RandomInteger)
 }
 
 func (r DatabricksWorkspaceResource) templateCMK(data acceptance.TestData) string {

--- a/internal/services/databricks/databricks_workspace_resource_test.go
+++ b/internal/services/databricks/databricks_workspace_resource_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
@@ -399,6 +400,11 @@ func TestAccDatabricksWorkspace_altSubscriptionCmkComplete(t *testing.T) {
 	databricksPrincipalID := getDatabricksPrincipalId(data.Client().SubscriptionID)
 	r := DatabricksWorkspaceResource{}
 
+	ignore := ([]string)(nil)
+	if !features.SixPointOh() {
+		ignore = []string{"managed_services_cmk_key_vault_id", "managed_disk_cmk_key_vault_id"}
+	}
+
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.altSubscriptionCmkComplete(data, databricksPrincipalID, altSubscription),
@@ -406,7 +412,7 @@ func TestAccDatabricksWorkspace_altSubscriptionCmkComplete(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("managed_services_cmk_key_vault_id", "managed_disk_cmk_key_vault_id"),
+		data.ImportStep(ignore...),
 	})
 }
 
@@ -428,7 +434,7 @@ func TestAccDatabricksWorkspace_altSubscriptionCmkKeysInDifferentKeyVaultsAcross
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("managed_services_cmk_key_vault_id", "managed_disk_cmk_key_vault_id"),
+		data.ImportStep(),
 	})
 }
 
@@ -450,7 +456,7 @@ func TestAccDatabricksWorkspace_altSubscriptionCmkServicesOnly(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("managed_services_cmk_key_vault_id"),
+		data.ImportStep(),
 	})
 }
 
@@ -472,7 +478,7 @@ func TestAccDatabricksWorkspace_altSubscriptionCmkDiskOnly(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("managed_disk_cmk_key_vault_id"),
+		data.ImportStep(),
 	})
 }
 
@@ -651,118 +657,33 @@ func (DatabricksWorkspaceResource) Exists(ctx context.Context, clients *clients.
 	return pointer.To(resp.Model != nil), nil
 }
 
-func (DatabricksWorkspaceResource) basic(data acceptance.TestData, sku string) string {
+func (r DatabricksWorkspaceResource) basic(data acceptance.TestData, sku string) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-databricks-%d"
-  location = "%s"
-}
+%[1]s
 
 resource "azurerm_databricks_workspace" "test" {
-  name                = "acctestDBW-%d"
+  name                = "acctestDBW-%[2]d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  sku                 = "%s"
+  sku                 = "%[3]s"
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, sku)
-}
-
-func (DatabricksWorkspaceResource) basicForResourceIdentity(data acceptance.TestData) string {
-	return DatabricksWorkspaceResource{}.basic(data, "premium")
+`, r.template(data), data.RandomInteger, sku)
 }
 
-func (DatabricksWorkspaceResource) defaultStorageFirewall(data acceptance.TestData, sku string) string {
+func (r DatabricksWorkspaceResource) defaultStorageFirewall(data acceptance.TestData, sku string) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-databricks-%[1]d"
-  location = "%[2]s"
-}
-
-resource "azurerm_virtual_network" "test" {
-  name                = "acctest-vnet-%[1]d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  address_space       = ["10.0.0.0/16"]
-}
-
-resource "azurerm_subnet" "public" {
-  name                 = "acctest-sn-public-%[1]d"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes     = ["10.0.1.0/24"]
-
-  delegation {
-    name = "acctest"
-
-    service_delegation {
-      name = "Microsoft.Databricks/workspaces"
-
-      actions = [
-        "Microsoft.Network/virtualNetworks/subnets/join/action",
-        "Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action",
-        "Microsoft.Network/virtualNetworks/subnets/unprepareNetworkPolicies/action",
-      ]
-    }
-  }
-}
-
-resource "azurerm_subnet" "private" {
-  name                 = "acctest-sn-private-%[1]d"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes     = ["10.0.2.0/24"]
-
-  delegation {
-    name = "acctest"
-
-    service_delegation {
-      name = "Microsoft.Databricks/workspaces"
-
-      actions = [
-        "Microsoft.Network/virtualNetworks/subnets/join/action",
-        "Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action",
-        "Microsoft.Network/virtualNetworks/subnets/unprepareNetworkPolicies/action",
-      ]
-    }
-  }
-}
-
-resource "azurerm_network_security_group" "nsg" {
-  name                = "acctest-nsg-private-%[1]d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-}
-
-resource "azurerm_subnet_network_security_group_association" "public" {
-  subnet_id                 = azurerm_subnet.public.id
-  network_security_group_id = azurerm_network_security_group.nsg.id
-}
-
-resource "azurerm_subnet_network_security_group_association" "private" {
-  subnet_id                 = azurerm_subnet.private.id
-  network_security_group_id = azurerm_network_security_group.nsg.id
-}
-
-resource "azurerm_databricks_access_connector" "test" {
-  name                = "acctestDBWACC%[1]d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-
-  identity {
-    type = "SystemAssigned"
-  }
-}
+%[1]s
 
 resource "azurerm_databricks_workspace" "test" {
-  name                = "acctestDBW-%[1]d"
+  name                = "acctestDBW-%[2]d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   sku                 = "%[3]s"
@@ -781,97 +702,19 @@ resource "azurerm_databricks_workspace" "test" {
   default_storage_firewall_enabled = true
 
 }
-`, data.RandomInteger, data.Locations.Primary, sku)
+`, r.templateVnetWithAccessConnectors(data), data.RandomInteger, sku)
 }
 
-func (DatabricksWorkspaceResource) defaultStorageFirewallUpdateToDisabled(data acceptance.TestData, sku string) string {
+func (r DatabricksWorkspaceResource) defaultStorageFirewallUpdateToDisabled(data acceptance.TestData, sku string) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-databricks-%[1]d"
-  location = "%[2]s"
-}
-
-resource "azurerm_virtual_network" "test" {
-  name                = "acctest-vnet-%[1]d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  address_space       = ["10.0.0.0/16"]
-}
-
-resource "azurerm_subnet" "public" {
-  name                 = "acctest-sn-public-%[1]d"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes     = ["10.0.1.0/24"]
-
-  delegation {
-    name = "acctest"
-
-    service_delegation {
-      name = "Microsoft.Databricks/workspaces"
-
-      actions = [
-        "Microsoft.Network/virtualNetworks/subnets/join/action",
-        "Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action",
-        "Microsoft.Network/virtualNetworks/subnets/unprepareNetworkPolicies/action",
-      ]
-    }
-  }
-}
-
-resource "azurerm_subnet" "private" {
-  name                 = "acctest-sn-private-%[1]d"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes     = ["10.0.2.0/24"]
-
-  delegation {
-    name = "acctest"
-
-    service_delegation {
-      name = "Microsoft.Databricks/workspaces"
-
-      actions = [
-        "Microsoft.Network/virtualNetworks/subnets/join/action",
-        "Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action",
-        "Microsoft.Network/virtualNetworks/subnets/unprepareNetworkPolicies/action",
-      ]
-    }
-  }
-}
-
-resource "azurerm_network_security_group" "nsg" {
-  name                = "acctest-nsg-private-%[1]d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-}
-
-resource "azurerm_subnet_network_security_group_association" "public" {
-  subnet_id                 = azurerm_subnet.public.id
-  network_security_group_id = azurerm_network_security_group.nsg.id
-}
-
-resource "azurerm_subnet_network_security_group_association" "private" {
-  subnet_id                 = azurerm_subnet.private.id
-  network_security_group_id = azurerm_network_security_group.nsg.id
-}
-
-resource "azurerm_databricks_access_connector" "test" {
-  name                = "acctestDBWACC%[1]d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-
-  identity {
-    type = "SystemAssigned"
-  }
-}
+%[1]s
 
 resource "azurerm_databricks_workspace" "test" {
-  name                = "acctestDBW-%[1]d"
+  name                = "acctestDBW-%[2]d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   sku                 = "%[3]s"
@@ -890,107 +733,19 @@ resource "azurerm_databricks_workspace" "test" {
   default_storage_firewall_enabled = false
 
 }
-`, data.RandomInteger, data.Locations.Primary, sku)
+`, r.templateVnetWithAccessConnectors(data), data.RandomInteger, sku)
 }
 
-func (DatabricksWorkspaceResource) defaultStorageFirewallFirstConnector(data acceptance.TestData, sku string) string {
+func (r DatabricksWorkspaceResource) defaultStorageFirewallFirstConnector(data acceptance.TestData, sku string) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-databricks-%[1]d"
-  location = "%[2]s"
-}
-
-resource "azurerm_virtual_network" "test" {
-  name                = "acctest-vnet-%[1]d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  address_space       = ["10.0.0.0/16"]
-}
-
-resource "azurerm_subnet" "public" {
-  name                 = "acctest-sn-public-%[1]d"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes     = ["10.0.1.0/24"]
-
-  delegation {
-    name = "acctest"
-
-    service_delegation {
-      name = "Microsoft.Databricks/workspaces"
-
-      actions = [
-        "Microsoft.Network/virtualNetworks/subnets/join/action",
-        "Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action",
-        "Microsoft.Network/virtualNetworks/subnets/unprepareNetworkPolicies/action",
-      ]
-    }
-  }
-}
-
-resource "azurerm_subnet" "private" {
-  name                 = "acctest-sn-private-%[1]d"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes     = ["10.0.2.0/24"]
-
-  delegation {
-    name = "acctest"
-
-    service_delegation {
-      name = "Microsoft.Databricks/workspaces"
-
-      actions = [
-        "Microsoft.Network/virtualNetworks/subnets/join/action",
-        "Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action",
-        "Microsoft.Network/virtualNetworks/subnets/unprepareNetworkPolicies/action",
-      ]
-    }
-  }
-}
-
-resource "azurerm_network_security_group" "nsg" {
-  name                = "acctest-nsg-private-%[1]d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-}
-
-resource "azurerm_subnet_network_security_group_association" "public" {
-  subnet_id                 = azurerm_subnet.public.id
-  network_security_group_id = azurerm_network_security_group.nsg.id
-}
-
-resource "azurerm_subnet_network_security_group_association" "private" {
-  subnet_id                 = azurerm_subnet.private.id
-  network_security_group_id = azurerm_network_security_group.nsg.id
-}
-
-resource "azurerm_databricks_access_connector" "test" {
-  name                = "acctestDBWACC%[1]d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-
-  identity {
-    type = "SystemAssigned"
-  }
-}
-
-resource "azurerm_databricks_access_connector" "test2" {
-  name                = "acctestDBWACC2-%[1]d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-
-  identity {
-    type = "SystemAssigned"
-  }
-}
+%[1]s
 
 resource "azurerm_databricks_workspace" "test" {
-  name                = "acctestDBW-%[1]d"
+  name                = "acctestDBW-%[2]d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   sku                 = "%[3]s"
@@ -1008,107 +763,19 @@ resource "azurerm_databricks_workspace" "test" {
   access_connector_id              = azurerm_databricks_access_connector.test.id
   default_storage_firewall_enabled = true
 }
-`, data.RandomInteger, data.Locations.Primary, sku)
+`, r.templateVnetWithAccessConnectors(data), data.RandomInteger, sku)
 }
 
-func (DatabricksWorkspaceResource) defaultStorageFirewallSecondConnector(data acceptance.TestData, sku string) string {
+func (r DatabricksWorkspaceResource) defaultStorageFirewallSecondConnector(data acceptance.TestData, sku string) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-databricks-%[1]d"
-  location = "%[2]s"
-}
-
-resource "azurerm_virtual_network" "test" {
-  name                = "acctest-vnet-%[1]d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  address_space       = ["10.0.0.0/16"]
-}
-
-resource "azurerm_subnet" "public" {
-  name                 = "acctest-sn-public-%[1]d"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes     = ["10.0.1.0/24"]
-
-  delegation {
-    name = "acctest"
-
-    service_delegation {
-      name = "Microsoft.Databricks/workspaces"
-
-      actions = [
-        "Microsoft.Network/virtualNetworks/subnets/join/action",
-        "Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action",
-        "Microsoft.Network/virtualNetworks/subnets/unprepareNetworkPolicies/action",
-      ]
-    }
-  }
-}
-
-resource "azurerm_subnet" "private" {
-  name                 = "acctest-sn-private-%[1]d"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes     = ["10.0.2.0/24"]
-
-  delegation {
-    name = "acctest"
-
-    service_delegation {
-      name = "Microsoft.Databricks/workspaces"
-
-      actions = [
-        "Microsoft.Network/virtualNetworks/subnets/join/action",
-        "Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action",
-        "Microsoft.Network/virtualNetworks/subnets/unprepareNetworkPolicies/action",
-      ]
-    }
-  }
-}
-
-resource "azurerm_network_security_group" "nsg" {
-  name                = "acctest-nsg-private-%[1]d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-}
-
-resource "azurerm_subnet_network_security_group_association" "public" {
-  subnet_id                 = azurerm_subnet.public.id
-  network_security_group_id = azurerm_network_security_group.nsg.id
-}
-
-resource "azurerm_subnet_network_security_group_association" "private" {
-  subnet_id                 = azurerm_subnet.private.id
-  network_security_group_id = azurerm_network_security_group.nsg.id
-}
-
-resource "azurerm_databricks_access_connector" "test" {
-  name                = "acctestDBWACC%[1]d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-
-  identity {
-    type = "SystemAssigned"
-  }
-}
-
-resource "azurerm_databricks_access_connector" "test2" {
-  name                = "acctestDBWACC2-%[1]d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-
-  identity {
-    type = "SystemAssigned"
-  }
-}
+%[1]s
 
 resource "azurerm_databricks_workspace" "test" {
-  name                = "acctestDBW-%[1]d"
+  name                = "acctestDBW-%[2]d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   sku                 = "%[3]s"
@@ -1126,33 +793,29 @@ resource "azurerm_databricks_workspace" "test" {
   access_connector_id              = azurerm_databricks_access_connector.test2.id
   default_storage_firewall_enabled = true
 }
-`, data.RandomInteger, data.Locations.Primary, sku)
+`, r.template(data), data.RandomInteger, sku)
 }
 
-func (DatabricksWorkspaceResource) sameName(data acceptance.TestData, sku string) string {
+func (r DatabricksWorkspaceResource) sameName(data acceptance.TestData, sku string) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-databricks-%d"
-  location = "%s"
-}
+%[1]s
 
 resource "azurerm_databricks_workspace" "test" {
-  name                = "acctestDBW-%d"
+  name                = "acctestDBW-%[2]d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  sku                 = "%s"
+  sku                 = "%[3]s"
 
-  managed_resource_group_name = "acctestDBW-%d"
+  managed_resource_group_name = "acctestDBW-%[2]d"
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, sku, data.RandomInteger)
+`, r.template(data), data.RandomInteger, sku)
 }
 
-func (DatabricksWorkspaceResource) requiresImport(data acceptance.TestData) string {
-	template := DatabricksWorkspaceResource{}.basic(data, "premium")
+func (r DatabricksWorkspaceResource) requiresImport(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -1162,91 +825,23 @@ resource "azurerm_databricks_workspace" "import" {
   location            = azurerm_databricks_workspace.test.location
   sku                 = azurerm_databricks_workspace.test.sku
 }
-`, template)
+`, r.basic(data, "premium"))
 }
 
-func (DatabricksWorkspaceResource) complete(data acceptance.TestData) string {
+func (r DatabricksWorkspaceResource) complete(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-databricks-%[1]d"
-  location = "%[2]s"
-}
-
-resource "azurerm_virtual_network" "test" {
-  name                = "acctest-vnet-%[1]d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  address_space       = ["10.0.0.0/16"]
-}
-
-resource "azurerm_subnet" "public" {
-  name                 = "acctest-sn-public-%[1]d"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes     = ["10.0.1.0/24"]
-
-  delegation {
-    name = "acctest"
-
-    service_delegation {
-      name = "Microsoft.Databricks/workspaces"
-
-      actions = [
-        "Microsoft.Network/virtualNetworks/subnets/join/action",
-        "Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action",
-        "Microsoft.Network/virtualNetworks/subnets/unprepareNetworkPolicies/action",
-      ]
-    }
-  }
-}
-
-resource "azurerm_subnet" "private" {
-  name                 = "acctest-sn-private-%[1]d"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes     = ["10.0.2.0/24"]
-
-  delegation {
-    name = "acctest"
-
-    service_delegation {
-      name = "Microsoft.Databricks/workspaces"
-
-      actions = [
-        "Microsoft.Network/virtualNetworks/subnets/join/action",
-        "Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action",
-        "Microsoft.Network/virtualNetworks/subnets/unprepareNetworkPolicies/action",
-      ]
-    }
-  }
-}
-
-resource "azurerm_network_security_group" "nsg" {
-  name                = "acctest-nsg-private-%[1]d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-}
-
-resource "azurerm_subnet_network_security_group_association" "public" {
-  subnet_id                 = azurerm_subnet.public.id
-  network_security_group_id = azurerm_network_security_group.nsg.id
-}
-
-resource "azurerm_subnet_network_security_group_association" "private" {
-  subnet_id                 = azurerm_subnet.private.id
-  network_security_group_id = azurerm_network_security_group.nsg.id
-}
+%[1]s
 
 resource "azurerm_databricks_workspace" "test" {
-  name                        = "acctestDBW-%[1]d"
+  name                        = "acctestDBW-%[2]d"
   resource_group_name         = azurerm_resource_group.test.name
   location                    = azurerm_resource_group.test.location
   sku                         = "premium"
-  managed_resource_group_name = "acctestRG-DBW-%[1]d-managed"
+  managed_resource_group_name = "acctestRG-DBW-%[2]d-managed"
 
   custom_parameters {
     no_public_ip        = false
@@ -1263,7 +858,7 @@ resource "azurerm_databricks_workspace" "test" {
     Pricing     = "Premium"
   }
 }
-`, data.RandomInteger, data.Locations.Primary)
+`, r.templateVnet(data), data.RandomInteger)
 }
 
 func (DatabricksWorkspaceResource) completeMissingPublicSubnetDelegation(data acceptance.TestData) string {
@@ -1440,88 +1035,20 @@ resource "azurerm_databricks_workspace" "test" {
 `, data.RandomInteger, data.Locations.Primary)
 }
 
-func (DatabricksWorkspaceResource) extendedUpdateCreate(data acceptance.TestData) string {
+func (r DatabricksWorkspaceResource) extendedUpdateCreate(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-databricks-%[1]d"
-  location = "%[2]s"
-}
-
-resource "azurerm_virtual_network" "test" {
-  name                = "acctest-vnet-%[1]d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  address_space       = ["10.0.0.0/16"]
-}
-
-resource "azurerm_subnet" "public" {
-  name                 = "acctest-sn-public-%[1]d"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes     = ["10.0.1.0/24"]
-
-  delegation {
-    name = "acctest"
-
-    service_delegation {
-      name = "Microsoft.Databricks/workspaces"
-
-      actions = [
-        "Microsoft.Network/virtualNetworks/subnets/join/action",
-        "Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action",
-        "Microsoft.Network/virtualNetworks/subnets/unprepareNetworkPolicies/action",
-      ]
-    }
-  }
-}
-
-resource "azurerm_subnet" "private" {
-  name                 = "acctest-sn-private-%[1]d"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes     = ["10.0.2.0/24"]
-
-  delegation {
-    name = "acctest"
-
-    service_delegation {
-      name = "Microsoft.Databricks/workspaces"
-
-      actions = [
-        "Microsoft.Network/virtualNetworks/subnets/join/action",
-        "Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action",
-        "Microsoft.Network/virtualNetworks/subnets/unprepareNetworkPolicies/action",
-      ]
-    }
-  }
-}
-
-resource "azurerm_network_security_group" "nsg" {
-  name                = "acctest-nsg-private-%[1]d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-}
-
-resource "azurerm_subnet_network_security_group_association" "public" {
-  subnet_id                 = azurerm_subnet.public.id
-  network_security_group_id = azurerm_network_security_group.nsg.id
-}
-
-resource "azurerm_subnet_network_security_group_association" "private" {
-  subnet_id                 = azurerm_subnet.private.id
-  network_security_group_id = azurerm_network_security_group.nsg.id
-}
+%[1]s
 
 resource "azurerm_databricks_workspace" "test" {
-  name                          = "acctestDBW-%[1]d"
+  name                          = "acctestDBW-%[2]d"
   resource_group_name           = azurerm_resource_group.test.name
   location                      = azurerm_resource_group.test.location
   sku                           = "premium"
-  managed_resource_group_name   = "acctestRG-DBW-%[1]d-managed"
+  managed_resource_group_name   = "acctestRG-DBW-%[2]d-managed"
   public_network_access_enabled = true
   customer_managed_key_enabled  = true
 
@@ -1540,91 +1067,23 @@ resource "azurerm_databricks_workspace" "test" {
     Pricing     = "Premium"
   }
 }
-`, data.RandomInteger, data.Locations.Primary)
+`, r.templateVnet(data), data.RandomInteger)
 }
 
-func (DatabricksWorkspaceResource) extendedUpdateUpdate(data acceptance.TestData) string {
+func (r DatabricksWorkspaceResource) extendedUpdateUpdate(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-databricks-%[1]d"
-  location = "%[2]s"
-}
-
-resource "azurerm_virtual_network" "test" {
-  name                = "acctest-vnet-%[1]d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  address_space       = ["10.0.0.0/16"]
-}
-
-resource "azurerm_subnet" "public" {
-  name                 = "acctest-sn-public-%[1]d"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes     = ["10.0.1.0/24"]
-
-  delegation {
-    name = "acctest"
-
-    service_delegation {
-      name = "Microsoft.Databricks/workspaces"
-
-      actions = [
-        "Microsoft.Network/virtualNetworks/subnets/join/action",
-        "Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action",
-        "Microsoft.Network/virtualNetworks/subnets/unprepareNetworkPolicies/action",
-      ]
-    }
-  }
-}
-
-resource "azurerm_subnet" "private" {
-  name                 = "acctest-sn-private-%[1]d"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes     = ["10.0.2.0/24"]
-
-  delegation {
-    name = "acctest"
-
-    service_delegation {
-      name = "Microsoft.Databricks/workspaces"
-
-      actions = [
-        "Microsoft.Network/virtualNetworks/subnets/join/action",
-        "Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action",
-        "Microsoft.Network/virtualNetworks/subnets/unprepareNetworkPolicies/action",
-      ]
-    }
-  }
-}
-
-resource "azurerm_network_security_group" "nsg" {
-  name                = "acctest-nsg-private-%[1]d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-}
-
-resource "azurerm_subnet_network_security_group_association" "public" {
-  subnet_id                 = azurerm_subnet.public.id
-  network_security_group_id = azurerm_network_security_group.nsg.id
-}
-
-resource "azurerm_subnet_network_security_group_association" "private" {
-  subnet_id                 = azurerm_subnet.private.id
-  network_security_group_id = azurerm_network_security_group.nsg.id
-}
+%[1]s
 
 resource "azurerm_databricks_workspace" "test" {
-  name                                  = "acctestDBW-%[1]d"
+  name                                  = "acctestDBW-%[2]d"
   resource_group_name                   = azurerm_resource_group.test.name
   location                              = azurerm_resource_group.test.location
   sku                                   = "premium"
-  managed_resource_group_name           = "acctestRG-DBW-%[1]d-managed"
+  managed_resource_group_name           = "acctestRG-DBW-%[2]d-managed"
   public_network_access_enabled         = false
   network_security_group_rules_required = "NoAzureDatabricksRules"
   customer_managed_key_enabled          = false
@@ -1644,93 +1103,25 @@ resource "azurerm_databricks_workspace" "test" {
     Pricing     = "Premium"
   }
 }
-`, data.RandomInteger, data.Locations.Primary)
+`, r.templateVnet(data), data.RandomInteger)
 }
 
-func (DatabricksWorkspaceResource) completeUpdate(data acceptance.TestData) string {
+func (r DatabricksWorkspaceResource) completeUpdate(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-databricks-%[1]d"
-  location = "%[2]s"
-}
-
-resource "azurerm_virtual_network" "test" {
-  name                = "acctest-vnet-%[1]d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  address_space       = ["10.0.0.0/16"]
-}
-
-resource "azurerm_subnet" "public" {
-  name                 = "acctest-sn-public-%[1]d"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes     = ["10.0.1.0/24"]
-
-  delegation {
-    name = "acctest"
-
-    service_delegation {
-      name = "Microsoft.Databricks/workspaces"
-
-      actions = [
-        "Microsoft.Network/virtualNetworks/subnets/join/action",
-        "Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action",
-        "Microsoft.Network/virtualNetworks/subnets/unprepareNetworkPolicies/action",
-      ]
-    }
-  }
-}
-
-resource "azurerm_subnet" "private" {
-  name                 = "acctest-sn-private-%[1]d"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes     = ["10.0.2.0/24"]
-
-  delegation {
-    name = "acctest"
-
-    service_delegation {
-      name = "Microsoft.Databricks/workspaces"
-
-      actions = [
-        "Microsoft.Network/virtualNetworks/subnets/join/action",
-        "Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action",
-        "Microsoft.Network/virtualNetworks/subnets/unprepareNetworkPolicies/action",
-      ]
-    }
-  }
-}
-
-resource "azurerm_network_security_group" "nsg" {
-  name                = "acctest-nsg-private-%[1]d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-}
-
-resource "azurerm_subnet_network_security_group_association" "public" {
-  subnet_id                 = azurerm_subnet.public.id
-  network_security_group_id = azurerm_network_security_group.nsg.id
-}
-
-resource "azurerm_subnet_network_security_group_association" "private" {
-  subnet_id                 = azurerm_subnet.private.id
-  network_security_group_id = azurerm_network_security_group.nsg.id
-}
+%[1]s
 
 resource "azurerm_databricks_workspace" "test" {
   depends_on = [azurerm_subnet_network_security_group_association.public, azurerm_subnet_network_security_group_association.private]
 
-  name                        = "acctestDBW-%[1]d"
+  name                        = "acctestDBW-%[2]d"
   resource_group_name         = azurerm_resource_group.test.name
   location                    = azurerm_resource_group.test.location
   sku                         = "premium"
-  managed_resource_group_name = "acctestRG-DBW-%[1]d-managed"
+  managed_resource_group_name = "acctestRG-DBW-%[2]d-managed"
 
   custom_parameters {
     no_public_ip        = true
@@ -1746,7 +1137,7 @@ resource "azurerm_databricks_workspace" "test" {
     Pricing = "Premium"
   }
 }
-`, data.RandomInteger, data.Locations.Primary)
+`, r.templateVnet(data), data.RandomInteger)
 }
 
 func (DatabricksWorkspaceResource) machineLearning(data acceptance.TestData, sku string) string {
@@ -1895,22 +1286,6 @@ resource "azurerm_subnet" "privatelink" {
   private_endpoint_network_policies = "Enabled"
 }
 
-resource "azurerm_network_security_group" "nsg" {
-  name                = "acctest-nsg-%[1]d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-}
-
-resource "azurerm_subnet_network_security_group_association" "public" {
-  subnet_id                 = azurerm_subnet.public.id
-  network_security_group_id = azurerm_network_security_group.nsg.id
-}
-
-resource "azurerm_subnet_network_security_group_association" "private" {
-  subnet_id                 = azurerm_subnet.private.id
-  network_security_group_id = azurerm_network_security_group.nsg.id
-}
-
 resource "azurerm_databricks_workspace" "test" {
   name                        = "acctestDBW-%[1]d"
   resource_group_name         = azurerm_resource_group.test.name
@@ -1967,88 +1342,20 @@ resource "azurerm_private_dns_cname_record" "test" {
 `, data.RandomInteger, data.Locations.Secondary)
 }
 
-func (DatabricksWorkspaceResource) secureClusterConnectivity(data acceptance.TestData) string {
+func (r DatabricksWorkspaceResource) secureClusterConnectivity(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-databricks-%[1]d"
-  location = "%[2]s"
-}
-
-resource "azurerm_virtual_network" "test" {
-  name                = "acctest-vnet-%[1]d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  address_space       = ["10.0.0.0/16"]
-}
-
-resource "azurerm_subnet" "public" {
-  name                 = "acctest-sn-public-%[1]d"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes     = ["10.0.1.0/24"]
-
-  delegation {
-    name = "acctest"
-
-    service_delegation {
-      name = "Microsoft.Databricks/workspaces"
-
-      actions = [
-        "Microsoft.Network/virtualNetworks/subnets/join/action",
-        "Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action",
-        "Microsoft.Network/virtualNetworks/subnets/unprepareNetworkPolicies/action",
-      ]
-    }
-  }
-}
-
-resource "azurerm_subnet" "private" {
-  name                 = "acctest-sn-private-%[1]d"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes     = ["10.0.2.0/24"]
-
-  delegation {
-    name = "acctest"
-
-    service_delegation {
-      name = "Microsoft.Databricks/workspaces"
-
-      actions = [
-        "Microsoft.Network/virtualNetworks/subnets/join/action",
-        "Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action",
-        "Microsoft.Network/virtualNetworks/subnets/unprepareNetworkPolicies/action",
-      ]
-    }
-  }
-}
-
-resource "azurerm_network_security_group" "nsg" {
-  name                = "acctest-nsg-%[1]d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-}
-
-resource "azurerm_subnet_network_security_group_association" "public" {
-  subnet_id                 = azurerm_subnet.public.id
-  network_security_group_id = azurerm_network_security_group.nsg.id
-}
-
-resource "azurerm_subnet_network_security_group_association" "private" {
-  subnet_id                 = azurerm_subnet.private.id
-  network_security_group_id = azurerm_network_security_group.nsg.id
-}
+%[1]s
 
 resource "azurerm_databricks_workspace" "test" {
-  name                        = "acctestDBW-%[1]d"
+  name                        = "acctestDBW-%[2]d"
   resource_group_name         = azurerm_resource_group.test.name
   location                    = azurerm_resource_group.test.location
   sku                         = "premium"
-  managed_resource_group_name = "acctestRG-DBW-%[1]d-managed"
+  managed_resource_group_name = "acctestRG-DBW-%[2]d-managed"
 
   public_network_access_enabled = true
 
@@ -2067,91 +1374,23 @@ resource "azurerm_databricks_workspace" "test" {
     Pricing     = "Premium"
   }
 }
-`, data.RandomInteger, data.Locations.Primary)
+`, r.templateVnet(data), data.RandomInteger)
 }
 
-func (DatabricksWorkspaceResource) loadBalancerSecureClusterConnectivity(data acceptance.TestData) string {
+func (r DatabricksWorkspaceResource) loadBalancerSecureClusterConnectivity(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-databricks-%[1]d"
-  location = "%[2]s"
-}
-
-resource "azurerm_virtual_network" "test" {
-  name                = "acctest-vnet-%[1]d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  address_space       = ["10.0.0.0/16"]
-}
-
-resource "azurerm_subnet" "public" {
-  name                 = "acctest-sn-public-%[1]d"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes     = ["10.0.1.0/24"]
-
-  delegation {
-    name = "acctest"
-
-    service_delegation {
-      name = "Microsoft.Databricks/workspaces"
-
-      actions = [
-        "Microsoft.Network/virtualNetworks/subnets/join/action",
-        "Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action",
-        "Microsoft.Network/virtualNetworks/subnets/unprepareNetworkPolicies/action",
-      ]
-    }
-  }
-}
-
-resource "azurerm_subnet" "private" {
-  name                 = "acctest-sn-private-%[1]d"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes     = ["10.0.2.0/24"]
-
-  delegation {
-    name = "acctest"
-
-    service_delegation {
-      name = "Microsoft.Databricks/workspaces"
-
-      actions = [
-        "Microsoft.Network/virtualNetworks/subnets/join/action",
-        "Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action",
-        "Microsoft.Network/virtualNetworks/subnets/unprepareNetworkPolicies/action",
-      ]
-    }
-  }
-}
-
-resource "azurerm_network_security_group" "nsg" {
-  name                = "acctest-nsg-%[1]d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-}
-
-resource "azurerm_subnet_network_security_group_association" "public" {
-  subnet_id                 = azurerm_subnet.public.id
-  network_security_group_id = azurerm_network_security_group.nsg.id
-}
-
-resource "azurerm_subnet_network_security_group_association" "private" {
-  subnet_id                 = azurerm_subnet.private.id
-  network_security_group_id = azurerm_network_security_group.nsg.id
-}
+%[1]s
 
 resource "azurerm_databricks_workspace" "test" {
-  name                        = "acctestDBW-%[1]d"
+  name                        = "acctestDBW-%[2]d"
   resource_group_name         = azurerm_resource_group.test.name
   location                    = azurerm_resource_group.test.location
   sku                         = "premium"
-  managed_resource_group_name = "acctestRG-DBW-%[1]d-managed"
+  managed_resource_group_name = "acctestRG-DBW-%[2]d-managed"
 
   public_network_access_enabled         = true
   load_balancer_backend_address_pool_id = azurerm_lb_backend_address_pool.test.id
@@ -2173,7 +1412,7 @@ resource "azurerm_databricks_workspace" "test" {
 }
 
 resource "azurerm_public_ip" "test" {
-  name                    = "acctestpublicip-%[1]d"
+  name                    = "acctestpublicip-%[2]d"
   location                = azurerm_resource_group.test.location
   resource_group_name     = azurerm_resource_group.test.name
   idle_timeout_in_minutes = 4
@@ -2183,20 +1422,20 @@ resource "azurerm_public_ip" "test" {
 }
 
 resource "azurerm_lb" "test" {
-  name                = "acctest-loadbalancer-%[1]d"
+  name                = "acctest-loadbalancer-%[2]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
 
   sku = "Standard"
 
   frontend_ip_configuration {
-    name                 = "acctest-PIP-%[1]d"
+    name                 = "acctest-PIP-%[2]d"
     public_ip_address_id = azurerm_public_ip.test.id
   }
 }
 
 resource "azurerm_lb_outbound_rule" "test" {
-  name                     = "OutboundRule-%[1]d"
+  name                     = "OutboundRule-%[2]d"
   loadbalancer_id          = azurerm_lb.test.id
   protocol                 = "All"
   tcp_reset_enabled        = true
@@ -2212,54 +1451,48 @@ resource "azurerm_lb_outbound_rule" "test" {
 
 resource "azurerm_lb_backend_address_pool" "test" {
   loadbalancer_id = azurerm_lb.test.id
-  name            = "be-%[1]d"
+  name            = "be-%[2]d"
 }
-`, data.RandomInteger, data.Locations.Primary)
+`, r.templateVnet(data), data.RandomInteger)
 }
 
-func (DatabricksWorkspaceResource) infrastructureEncryption(data acceptance.TestData, sku string) string {
+func (r DatabricksWorkspaceResource) infrastructureEncryption(data acceptance.TestData, sku string) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-databricks-%[1]d"
-  location = "%[2]s"
-}
+%[1]s
 
 resource "azurerm_databricks_workspace" "test" {
-  name                = "acctestDBW-%[1]d"
+  name                = "acctestDBW-%[2]d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   sku                 = "%[3]s"
 
   infrastructure_encryption_enabled = true
 }
-`, data.RandomInteger, data.Locations.Primary, sku, data.RandomString)
+`, r.template(data), data.RandomInteger, sku)
 }
 
-func (DatabricksWorkspaceResource) managedServices(data acceptance.TestData, databricksPrincipalID string) string {
+func (r DatabricksWorkspaceResource) managedServices(data acceptance.TestData, databricksPrincipalID string) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
-data "azurerm_client_config" "current" {}
+%[1]s
 
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-databricks-%[1]d"
-  location = "%[2]s"
-}
+%[2]s
 
 resource "azurerm_databricks_workspace" "test" {
   depends_on = [azurerm_key_vault_access_policy.managed]
 
-  name                        = "acctestDBW-%[1]d"
+  name                        = "acctestDBW-%[3]d"
   resource_group_name         = azurerm_resource_group.test.name
   location                    = azurerm_resource_group.test.location
   sku                         = "premium"
-  managed_resource_group_name = "acctestRG-DBW-%[1]d-managed"
+  managed_resource_group_name = "acctestRG-DBW-%[3]d-managed"
 
   managed_services_cmk_key_vault_key_id = azurerm_key_vault_key.test.id
 
@@ -2267,59 +1500,6 @@ resource "azurerm_databricks_workspace" "test" {
     Environment = "Production"
     Pricing     = "Premium"
   }
-}
-
-resource "azurerm_key_vault" "test" {
-  name                       = "acctest-kv-%[3]s"
-  location                   = azurerm_resource_group.test.location
-  resource_group_name        = azurerm_resource_group.test.name
-  rbac_authorization_enabled = false
-  tenant_id                  = data.azurerm_client_config.current.tenant_id
-  sku_name                   = "premium"
-
-  soft_delete_retention_days = 7
-}
-
-resource "azurerm_key_vault_key" "test" {
-  depends_on = [azurerm_key_vault_access_policy.terraform]
-
-  name         = "acctest-certificate"
-  key_vault_id = azurerm_key_vault.test.id
-  key_type     = "RSA"
-  key_size     = 2048
-
-  key_opts = [
-    "decrypt",
-    "encrypt",
-    "sign",
-    "unwrapKey",
-    "verify",
-    "wrapKey",
-  ]
-}
-
-resource "azurerm_key_vault_access_policy" "terraform" {
-  key_vault_id = azurerm_key_vault.test.id
-  tenant_id    = azurerm_key_vault.test.tenant_id
-  object_id    = data.azurerm_client_config.current.object_id
-
-  key_permissions = [
-    "Get",
-    "List",
-    "Create",
-    "Decrypt",
-    "Encrypt",
-    "GetRotationPolicy",
-    "Sign",
-    "UnwrapKey",
-    "Verify",
-    "WrapKey",
-    "Delete",
-    "Restore",
-    "Recover",
-    "Update",
-    "Purge",
-  ]
 }
 
 resource "azurerm_key_vault_access_policy" "managed" {
@@ -2334,30 +1514,27 @@ resource "azurerm_key_vault_access_policy" "managed" {
     "WrapKey",
   ]
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, databricksPrincipalID)
+`, r.template(data), r.templateCMK(data), data.RandomInteger, databricksPrincipalID)
 }
 
-func (DatabricksWorkspaceResource) managedServicesAndRootDbfsCMK(data acceptance.TestData, databricksPrincipalID string) string {
+func (r DatabricksWorkspaceResource) managedServicesAndRootDbfsCMK(data acceptance.TestData, databricksPrincipalID string) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
-data "azurerm_client_config" "current" {}
+%[1]s
 
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-databricks-%[1]d"
-  location = "%[2]s"
-}
+%[2]s
 
 resource "azurerm_databricks_workspace" "test" {
   depends_on = [azurerm_key_vault_access_policy.managed]
 
-  name                        = "acctestDBW-%[1]d"
+  name                        = "acctestDBW-%[3]d"
   resource_group_name         = azurerm_resource_group.test.name
   location                    = azurerm_resource_group.test.location
   sku                         = "premium"
-  managed_resource_group_name = "acctestRG-DBW-%[1]d-managed"
+  managed_resource_group_name = "acctestRG-DBW-%[3]d-managed"
 
   customer_managed_key_enabled          = true
   managed_services_cmk_key_vault_key_id = azurerm_key_vault_key.test.id
@@ -2373,59 +1550,6 @@ resource "azurerm_databricks_workspace_root_dbfs_customer_managed_key" "test" {
 
   workspace_id     = azurerm_databricks_workspace.test.id
   key_vault_key_id = azurerm_key_vault_key.test.id
-}
-
-resource "azurerm_key_vault" "test" {
-  name                       = "acctest-kv-%[3]s"
-  location                   = azurerm_resource_group.test.location
-  resource_group_name        = azurerm_resource_group.test.name
-  rbac_authorization_enabled = false
-  tenant_id                  = data.azurerm_client_config.current.tenant_id
-  sku_name                   = "premium"
-
-  soft_delete_retention_days = 7
-}
-
-resource "azurerm_key_vault_key" "test" {
-  depends_on = [azurerm_key_vault_access_policy.terraform]
-
-  name         = "acctest-certificate"
-  key_vault_id = azurerm_key_vault.test.id
-  key_type     = "RSA"
-  key_size     = 2048
-
-  key_opts = [
-    "decrypt",
-    "encrypt",
-    "sign",
-    "unwrapKey",
-    "verify",
-    "wrapKey",
-  ]
-}
-
-resource "azurerm_key_vault_access_policy" "terraform" {
-  key_vault_id = azurerm_key_vault.test.id
-  tenant_id    = azurerm_key_vault.test.tenant_id
-  object_id    = data.azurerm_client_config.current.object_id
-
-  key_permissions = [
-    "Get",
-    "List",
-    "Create",
-    "Decrypt",
-    "Encrypt",
-    "GetRotationPolicy",
-    "Sign",
-    "UnwrapKey",
-    "Verify",
-    "WrapKey",
-    "Delete",
-    "Restore",
-    "Recover",
-    "Update",
-    "Purge",
-  ]
 }
 
 resource "azurerm_key_vault_access_policy" "managed" {
@@ -2455,30 +1579,27 @@ resource "azurerm_key_vault_access_policy" "databricks" {
     "WrapKey",
   ]
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, databricksPrincipalID)
+`, r.template(data), r.templateCMK(data), data.RandomInteger, databricksPrincipalID)
 }
 
-func (DatabricksWorkspaceResource) managedDiskCMK(data acceptance.TestData, databricksPrincipalID string) string {
+func (r DatabricksWorkspaceResource) managedDiskCMK(data acceptance.TestData, databricksPrincipalID string) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
-data "azurerm_client_config" "current" {}
+%[1]s
 
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-databricks-%[1]d"
-  location = "%[2]s"
-}
+%[2]s
 
 resource "azurerm_databricks_workspace" "test" {
   depends_on = [azurerm_key_vault_access_policy.managed]
 
-  name                        = "acctestDBW-%[1]d"
+  name                        = "acctestDBW-%[3]d"
   resource_group_name         = azurerm_resource_group.test.name
   location                    = azurerm_resource_group.test.location
   sku                         = "premium"
-  managed_resource_group_name = "acctestRG-DBW-%[1]d-managed"
+  managed_resource_group_name = "acctestRG-DBW-%[3]d-managed"
 
   customer_managed_key_enabled      = true
   managed_disk_cmk_key_vault_key_id = azurerm_key_vault_key.test.id
@@ -2487,59 +1608,6 @@ resource "azurerm_databricks_workspace" "test" {
     Environment = "Production"
     Pricing     = "Premium"
   }
-}
-
-resource "azurerm_key_vault" "test" {
-  name                       = "acctest-kv-%[3]s"
-  location                   = azurerm_resource_group.test.location
-  resource_group_name        = azurerm_resource_group.test.name
-  rbac_authorization_enabled = false
-  tenant_id                  = data.azurerm_client_config.current.tenant_id
-  sku_name                   = "premium"
-
-  soft_delete_retention_days = 7
-}
-
-resource "azurerm_key_vault_key" "test" {
-  depends_on = [azurerm_key_vault_access_policy.terraform]
-
-  name         = "acctest-certificate"
-  key_vault_id = azurerm_key_vault.test.id
-  key_type     = "RSA"
-  key_size     = 2048
-
-  key_opts = [
-    "decrypt",
-    "encrypt",
-    "sign",
-    "unwrapKey",
-    "verify",
-    "wrapKey",
-  ]
-}
-
-resource "azurerm_key_vault_access_policy" "terraform" {
-  key_vault_id = azurerm_key_vault.test.id
-  tenant_id    = azurerm_key_vault.test.tenant_id
-  object_id    = data.azurerm_client_config.current.object_id
-
-  key_permissions = [
-    "Get",
-    "List",
-    "Create",
-    "Decrypt",
-    "Encrypt",
-    "GetRotationPolicy",
-    "Sign",
-    "UnwrapKey",
-    "Verify",
-    "WrapKey",
-    "Delete",
-    "Restore",
-    "Recover",
-    "Update",
-    "Purge",
-  ]
 }
 
 resource "azurerm_key_vault_access_policy" "managed" {
@@ -2572,56 +1640,48 @@ resource "azurerm_key_vault_access_policy" "databricks" {
     "WrapKey",
   ]
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, databricksPrincipalID)
+`, r.template(data), r.templateCMK(data), data.RandomInteger, databricksPrincipalID)
 }
 
-func (DatabricksWorkspaceResource) managedDiskCMKRotationDisabled(data acceptance.TestData) string {
+func (r DatabricksWorkspaceResource) managedDiskCMKRotationDisabled(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
-data "azurerm_client_config" "current" {}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-databricks-%[1]d"
-  location = "%[2]s"
-}
+%[1]s
 
 resource "azurerm_databricks_workspace" "test" {
-  name                        = "acctestDBW-%[1]d"
+  name                        = "acctestDBW-%[2]d"
   resource_group_name         = azurerm_resource_group.test.name
   location                    = azurerm_resource_group.test.location
   sku                         = "premium"
-  managed_resource_group_name = "acctestRG-DBW-%[1]d-managed"
+  managed_resource_group_name = "acctestRG-DBW-%[2]d-managed"
   tags = {
     State = "CMKDisabled"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+`, r.template(data), data.RandomInteger)
 }
 
-func (DatabricksWorkspaceResource) managedDiskCMKRotationEnabled(data acceptance.TestData, databricksPrincipalID string) string {
+func (r DatabricksWorkspaceResource) managedDiskCMKRotationEnabled(data acceptance.TestData, databricksPrincipalID string) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
-data "azurerm_client_config" "current" {}
+%[1]s
 
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-databricks-%[1]d"
-  location = "%[2]s"
-}
+%[2]s
 
 resource "azurerm_databricks_workspace" "test" {
   depends_on = [azurerm_key_vault_access_policy.databricks]
 
-  name                        = "acctestDBW-%[1]d"
+  name                        = "acctestDBW-%[3]d"
   resource_group_name         = azurerm_resource_group.test.name
   location                    = azurerm_resource_group.test.location
   sku                         = "premium"
-  managed_resource_group_name = "acctestRG-DBW-%[1]d-managed"
+  managed_resource_group_name = "acctestRG-DBW-%[3]d-managed"
 
   customer_managed_key_enabled                        = true
   managed_disk_cmk_key_vault_key_id                   = azurerm_key_vault_key.test.id
@@ -2630,59 +1690,6 @@ resource "azurerm_databricks_workspace" "test" {
   tags = {
     State = "CMKEnabled"
   }
-}
-
-resource "azurerm_key_vault" "test" {
-  name                       = "acctest-kv-%[3]s"
-  location                   = azurerm_resource_group.test.location
-  resource_group_name        = azurerm_resource_group.test.name
-  rbac_authorization_enabled = false
-  tenant_id                  = data.azurerm_client_config.current.tenant_id
-  sku_name                   = "premium"
-
-  soft_delete_retention_days = 7
-}
-
-resource "azurerm_key_vault_key" "test" {
-  depends_on = [azurerm_key_vault_access_policy.terraform]
-
-  name         = "acctest-certificate"
-  key_vault_id = azurerm_key_vault.test.id
-  key_type     = "RSA"
-  key_size     = 2048
-
-  key_opts = [
-    "decrypt",
-    "encrypt",
-    "sign",
-    "unwrapKey",
-    "verify",
-    "wrapKey",
-  ]
-}
-
-resource "azurerm_key_vault_access_policy" "terraform" {
-  key_vault_id = azurerm_key_vault.test.id
-  tenant_id    = azurerm_key_vault.test.tenant_id
-  object_id    = data.azurerm_client_config.current.object_id
-
-  key_permissions = [
-    "Get",
-    "List",
-    "Create",
-    "Decrypt",
-    "Encrypt",
-    "GetRotationPolicy",
-    "Sign",
-    "UnwrapKey",
-    "Verify",
-    "WrapKey",
-    "Delete",
-    "Restore",
-    "Recover",
-    "Update",
-    "Purge",
-  ]
 }
 
 resource "azurerm_key_vault_access_policy" "databricks" {
@@ -2718,73 +1725,23 @@ resource "azurerm_key_vault_access_policy" "diskencryption" {
     "WrapKey",
   ]
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, databricksPrincipalID)
+`, r.template(data), r.templateCMK(data), data.RandomInteger, databricksPrincipalID)
 }
 
-func (DatabricksWorkspaceResource) managedServicesRootDbfsCMKAndPrivateLink(data acceptance.TestData, databricksPrincipalID string) string {
+func (r DatabricksWorkspaceResource) managedServicesRootDbfsCMKAndPrivateLink(data acceptance.TestData, databricksPrincipalID string) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
-data "azurerm_client_config" "current" {}
+%[1]s
 
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-databricks-%[1]d"
-  location = "%[2]s"
-}
+%[2]s
 
-resource "azurerm_virtual_network" "test" {
-  name                = "acctest-vnet-%[1]d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  address_space       = ["10.0.0.0/16"]
-}
-
-resource "azurerm_subnet" "public" {
-  name                 = "acctest-sn-public-%[1]d"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes     = ["10.0.1.0/24"]
-
-  delegation {
-    name = "acctest"
-
-    service_delegation {
-      name = "Microsoft.Databricks/workspaces"
-
-      actions = [
-        "Microsoft.Network/virtualNetworks/subnets/join/action",
-        "Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action",
-        "Microsoft.Network/virtualNetworks/subnets/unprepareNetworkPolicies/action",
-      ]
-    }
-  }
-}
-
-resource "azurerm_subnet" "private" {
-  name                 = "acctest-sn-private-%[1]d"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes     = ["10.0.2.0/24"]
-
-  delegation {
-    name = "acctest"
-
-    service_delegation {
-      name = "Microsoft.Databricks/workspaces"
-
-      actions = [
-        "Microsoft.Network/virtualNetworks/subnets/join/action",
-        "Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action",
-        "Microsoft.Network/virtualNetworks/subnets/unprepareNetworkPolicies/action",
-      ]
-    }
-  }
-}
+%[3]s
 
 resource "azurerm_subnet" "privatelink" {
-  name                 = "acctest-snpl-%[1]d"
+  name                 = "acctest-snpl-%[4]d"
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.0.3.0/24"]
@@ -2792,30 +1749,14 @@ resource "azurerm_subnet" "privatelink" {
   private_endpoint_network_policies = "Enabled"
 }
 
-resource "azurerm_network_security_group" "nsg" {
-  name                = "acctest-nsg-%[1]d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-}
-
-resource "azurerm_subnet_network_security_group_association" "public" {
-  subnet_id                 = azurerm_subnet.public.id
-  network_security_group_id = azurerm_network_security_group.nsg.id
-}
-
-resource "azurerm_subnet_network_security_group_association" "private" {
-  subnet_id                 = azurerm_subnet.private.id
-  network_security_group_id = azurerm_network_security_group.nsg.id
-}
-
 resource "azurerm_databricks_workspace" "test" {
   depends_on = [azurerm_key_vault_access_policy.managed]
 
-  name                        = "acctestDBW-%[1]d"
+  name                        = "acctestDBW-%[4]d"
   resource_group_name         = azurerm_resource_group.test.name
   location                    = azurerm_resource_group.test.location
   sku                         = "premium"
-  managed_resource_group_name = "acctestRG-DBW-%[1]d-managed"
+  managed_resource_group_name = "acctestRG-DBW-%[4]d-managed"
 
   customer_managed_key_enabled          = true
   managed_services_cmk_key_vault_key_id = azurerm_key_vault_key.test.id
@@ -2845,63 +1786,10 @@ resource "azurerm_databricks_workspace_root_dbfs_customer_managed_key" "test" {
   key_vault_key_id = azurerm_key_vault_key.test.id
 }
 
-resource "azurerm_key_vault" "test" {
-  name                       = "acctest-kv-%[3]s"
-  location                   = azurerm_resource_group.test.location
-  resource_group_name        = azurerm_resource_group.test.name
-  rbac_authorization_enabled = false
-  tenant_id                  = data.azurerm_client_config.current.tenant_id
-  sku_name                   = "premium"
-
-  soft_delete_retention_days = 7
-}
-
-resource "azurerm_key_vault_key" "test" {
-  depends_on = [azurerm_key_vault_access_policy.terraform]
-
-  name         = "acctest-certificate"
-  key_vault_id = azurerm_key_vault.test.id
-  key_type     = "RSA"
-  key_size     = 2048
-
-  key_opts = [
-    "decrypt",
-    "encrypt",
-    "sign",
-    "unwrapKey",
-    "verify",
-    "wrapKey",
-  ]
-}
-
-resource "azurerm_key_vault_access_policy" "terraform" {
-  key_vault_id = azurerm_key_vault.test.id
-  tenant_id    = azurerm_key_vault.test.tenant_id
-  object_id    = data.azurerm_client_config.current.object_id
-
-  key_permissions = [
-    "Get",
-    "List",
-    "Create",
-    "Decrypt",
-    "Encrypt",
-    "GetRotationPolicy",
-    "Sign",
-    "UnwrapKey",
-    "Verify",
-    "WrapKey",
-    "Delete",
-    "Restore",
-    "Recover",
-    "Update",
-    "Purge",
-  ]
-}
-
 resource "azurerm_key_vault_access_policy" "managed" {
   key_vault_id = azurerm_key_vault.test.id
   tenant_id    = azurerm_key_vault.test.tenant_id
-  object_id    = "%[4]s"
+  object_id    = "%[5]s"
 
   key_permissions = [
     "Get",
@@ -2929,13 +1817,13 @@ resource "azurerm_key_vault_access_policy" "databricks" {
 resource "azurerm_private_endpoint" "databricks" {
   depends_on = [azurerm_databricks_workspace_root_dbfs_customer_managed_key.test]
 
-  name                = "acctest-endpoint-%[1]d"
+  name                = "acctest-endpoint-%[4]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   subnet_id           = azurerm_subnet.privatelink.id
 
   private_service_connection {
-    name                           = "acctest-psc-%[1]d"
+    name                           = "acctest-psc-%[4]d"
     is_manual_connection           = false
     private_connection_resource_id = azurerm_databricks_workspace.test.id
     subresource_names              = ["databricks_ui_api"]
@@ -2955,11 +1843,12 @@ resource "azurerm_private_dns_cname_record" "test" {
   ttl                 = 300
   record              = "eastus2-c2.azuredatabricks.net"
 }
-`, data.RandomInteger, data.Locations.Secondary, data.RandomString, databricksPrincipalID)
+`, r.template(data), r.templateVnet(data), r.templateCMK(data), data.RandomInteger, databricksPrincipalID)
 }
 
 func (DatabricksWorkspaceResource) altSubscriptionCmkComplete(data acceptance.TestData, databricksPrincipalID string, alt *DatabricksWorkspaceAlternateSubscription) string {
-	return fmt.Sprintf(`
+	if !features.SixPointOh() {
+		return fmt.Sprintf(`
 provider "azurerm" {
   features {
     resource_group {
@@ -3003,6 +1892,151 @@ resource "azurerm_databricks_workspace" "test" {
 
   managed_disk_cmk_key_vault_id     = azurerm_key_vault.keyVault.id
   managed_disk_cmk_key_vault_key_id = azurerm_key_vault_key.disk.id
+
+  tags = {
+    Environment = "Sandbox"
+    Pricing     = "Premium"
+  }
+}
+
+# Create this in a different subscription...
+resource "azurerm_key_vault" "keyVault" {
+  provider = azurerm-alt
+
+  name                       = "kv-altsub-%[3]s"
+  resource_group_name        = azurerm_resource_group.keyVault.name
+  rbac_authorization_enabled = false
+  location                   = azurerm_resource_group.keyVault.location
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "premium"
+
+  soft_delete_retention_days = 7
+}
+
+resource "azurerm_key_vault_key" "services" {
+  provider   = azurerm-alt
+  depends_on = [azurerm_key_vault_access_policy.terraform]
+
+  name         = "acctest-services-certificate"
+  key_vault_id = azurerm_key_vault.keyVault.id
+  key_type     = "RSA"
+  key_size     = 2048
+
+  key_opts = [
+    "decrypt",
+    "encrypt",
+    "sign",
+    "unwrapKey",
+    "verify",
+    "wrapKey",
+  ]
+}
+
+resource "azurerm_key_vault_key" "disk" {
+  provider   = azurerm-alt
+  depends_on = [azurerm_key_vault_access_policy.terraform]
+
+  name         = "acctest-disk-certificate"
+  key_vault_id = azurerm_key_vault.keyVault.id
+  key_type     = "RSA"
+  key_size     = 2048
+
+  key_opts = [
+    "decrypt",
+    "encrypt",
+    "sign",
+    "unwrapKey",
+    "verify",
+    "wrapKey",
+  ]
+}
+
+resource "azurerm_key_vault_access_policy" "terraform" {
+  provider = azurerm-alt
+
+  key_vault_id = azurerm_key_vault.keyVault.id
+  tenant_id    = azurerm_key_vault.keyVault.tenant_id
+  object_id    = data.azurerm_client_config.current.object_id
+
+  key_permissions = [
+    "Get",
+    "List",
+    "Create",
+    "Decrypt",
+    "Encrypt",
+    "Sign",
+    "UnwrapKey",
+    "Verify",
+    "WrapKey",
+    "Delete",
+    "Restore",
+    "Recover",
+    "Update",
+    "Purge",
+    "GetRotationPolicy",
+    "SetRotationPolicy",
+  ]
+}
+
+resource "azurerm_key_vault_access_policy" "managed" {
+  provider = azurerm-alt
+
+  key_vault_id = azurerm_key_vault.keyVault.id
+  tenant_id    = azurerm_key_vault.keyVault.tenant_id
+  object_id    = "%[4]s"
+
+  key_permissions = [
+    "Get",
+    "UnwrapKey",
+    "WrapKey",
+    "GetRotationPolicy",
+    "SetRotationPolicy",
+  ]
+}
+`, data.RandomInteger, data.Locations.Secondary, data.RandomString, databricksPrincipalID, alt.tenantID, alt.subscriptionID)
+	}
+
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}
+
+provider "azurerm-alt" {
+  features {}
+
+  tenant_id       = "%[5]s"
+  subscription_id = "%[6]s"
+}
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-databricks-pri-sub-complete-%[1]d"
+  location = "West Europe"
+}
+
+resource "azurerm_resource_group" "keyVault" {
+  provider = azurerm-alt
+
+  name     = "acctestRG-databricks-alt-sub-complete-%[1]d"
+  location = "West Europe"
+}
+
+resource "azurerm_databricks_workspace" "test" {
+  depends_on = [azurerm_key_vault_access_policy.managed]
+
+  name                        = "acctest-databricks-pri-sub-%[1]d"
+  resource_group_name         = azurerm_resource_group.test.name
+  location                    = azurerm_resource_group.test.location
+  sku                         = "premium"
+  managed_resource_group_name = "databricks-pri-sub-managed-rg-%[1]d"
+
+  managed_services_cmk_key_vault_key_id = azurerm_key_vault_key.services.id
+  managed_disk_cmk_key_vault_key_id     = azurerm_key_vault_key.disk.id
 
   tags = {
     Environment = "Sandbox"
@@ -3152,11 +2186,8 @@ resource "azurerm_databricks_workspace" "test" {
   sku                         = "premium"
   managed_resource_group_name = "databricks-pri-sub-managed-rg-%[1]d"
 
-  managed_services_cmk_key_vault_id     = azurerm_key_vault.keyVaultAlt.id
   managed_services_cmk_key_vault_key_id = azurerm_key_vault_key.servicesAlt.id
-
-  managed_disk_cmk_key_vault_id     = azurerm_key_vault.keyVault.id
-  managed_disk_cmk_key_vault_key_id = azurerm_key_vault_key.disk.id
+  managed_disk_cmk_key_vault_key_id     = azurerm_key_vault_key.disk.id
 
   tags = {
     Environment = "Sandbox"
@@ -3350,7 +2381,6 @@ resource "azurerm_databricks_workspace" "test" {
   sku                         = "premium"
   managed_resource_group_name = "databricks-pri-sub-managed-rg-%[1]d"
 
-  managed_services_cmk_key_vault_id     = azurerm_key_vault.keyVault.id
   managed_services_cmk_key_vault_key_id = azurerm_key_vault_key.services.id
 
   tags = {
@@ -3477,7 +2507,6 @@ resource "azurerm_databricks_workspace" "test" {
   sku                         = "premium"
   managed_resource_group_name = "databricks-pri-sub-managed-rg-%[1]d"
 
-  managed_disk_cmk_key_vault_id     = azurerm_key_vault.keyVault.id
   managed_disk_cmk_key_vault_key_id = azurerm_key_vault_key.disk.id
 
   tags = {
@@ -3564,7 +2593,7 @@ resource "azurerm_key_vault_access_policy" "managed" {
 `, data.RandomInteger, data.Locations.Secondary, data.RandomString, databricksPrincipalID, alt.tenantID, alt.subscriptionID)
 }
 
-func (DatabricksWorkspaceResource) enhancedSecurityCompliance(data acceptance.TestData, sku string, automaticClusterUpdateEnabled bool, complianceSecurityProfileEnabled bool, complianceSecurityProfileStandards []string, enhancedSecurityMonitoringEnabled bool) string {
+func (r DatabricksWorkspaceResource) enhancedSecurityCompliance(data acceptance.TestData, sku string, automaticClusterUpdateEnabled bool, complianceSecurityProfileEnabled bool, complianceSecurityProfileStandards []string, enhancedSecurityMonitoringEnabled bool) string {
 	complianceSecurityProfileStandardsStr := ""
 	if len(complianceSecurityProfileStandards) > 0 {
 		complianceSecurityProfileStandardsStr = fmt.Sprintf(`"%s"`, strings.Join(complianceSecurityProfileStandards, `", "`))
@@ -3575,47 +2604,204 @@ provider "azurerm" {
   features {}
 }
 
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-databricks-%d"
-  location = "%s"
-}
+%[1]s
 
 resource "azurerm_databricks_workspace" "test" {
-  name                = "acctestDBW-%d"
+  name                = "acctestDBW-%[2]d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  sku                 = "%s"
+  sku                 = "%[3]s"
 
   enhanced_security_compliance {
-    automatic_cluster_update_enabled      = %t
-    compliance_security_profile_enabled   = %t
-    compliance_security_profile_standards = [%s]
-    enhanced_security_monitoring_enabled  = %t
+    automatic_cluster_update_enabled      = %[4]t
+    compliance_security_profile_enabled   = %[5]t
+    compliance_security_profile_standards = [%[6]s]
+    enhanced_security_monitoring_enabled  = %[7]t
   }
 }
-  `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, sku, automaticClusterUpdateEnabled, complianceSecurityProfileEnabled, complianceSecurityProfileStandardsStr, enhancedSecurityMonitoringEnabled)
+  `, r.template(data), data.RandomInteger, sku, automaticClusterUpdateEnabled, complianceSecurityProfileEnabled, complianceSecurityProfileStandardsStr, enhancedSecurityMonitoringEnabled)
 }
 
-func (DatabricksWorkspaceResource) workspaceForceDelete(data acceptance.TestData, forceDelete bool) string {
+func (r DatabricksWorkspaceResource) workspaceForceDelete(data acceptance.TestData, forceDelete bool) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {
     databricks_workspace {
-      force_delete = %t
+      force_delete = %[2]t
     }
   }
 }
 
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-databricks-%d"
-  location = "%s"
-}
+%[1]s
 
 resource "azurerm_databricks_workspace" "test" {
-  name                = "acctestDBW-%d"
+  name                = "acctestDBW-%[3]d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   sku                 = "premium"
 }
-  `, forceDelete, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+  `, r.template(data), forceDelete, data.RandomInteger)
+}
+
+func (DatabricksWorkspaceResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-databricks-%[1]d"
+  location = "%[2]s"
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (r DatabricksWorkspaceResource) templateVnet(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctest-vnet-%[2]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  address_space       = ["10.0.0.0/16"]
+}
+
+resource "azurerm_subnet" "public" {
+  name                 = "acctest-sn-public-%[2]d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.1.0/24"]
+
+  delegation {
+    name = "acctest"
+
+    service_delegation {
+      name = "Microsoft.Databricks/workspaces"
+
+      actions = [
+        "Microsoft.Network/virtualNetworks/subnets/join/action",
+        "Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action",
+        "Microsoft.Network/virtualNetworks/subnets/unprepareNetworkPolicies/action",
+      ]
+    }
+  }
+}
+
+resource "azurerm_subnet" "private" {
+  name                 = "acctest-sn-private-%[2]d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.2.0/24"]
+
+  delegation {
+    name = "acctest"
+
+    service_delegation {
+      name = "Microsoft.Databricks/workspaces"
+
+      actions = [
+        "Microsoft.Network/virtualNetworks/subnets/join/action",
+        "Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action",
+        "Microsoft.Network/virtualNetworks/subnets/unprepareNetworkPolicies/action",
+      ]
+    }
+  }
+}
+
+resource "azurerm_network_security_group" "nsg" {
+  name                = "acctest-nsg-private-%[2]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet_network_security_group_association" "public" {
+  subnet_id                 = azurerm_subnet.public.id
+  network_security_group_id = azurerm_network_security_group.nsg.id
+}
+
+resource "azurerm_subnet_network_security_group_association" "private" {
+  subnet_id                 = azurerm_subnet.private.id
+  network_security_group_id = azurerm_network_security_group.nsg.id
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r DatabricksWorkspaceResource) templateVnetWithAccessConnectors(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azurerm_databricks_access_connector" "test" {
+  name                = "acctestDBWACC%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+resource "azurerm_databricks_access_connector" "test2" {
+  name                = "acctestDBWACC2-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+`, data.RandomInteger)
+}
+
+func (r DatabricksWorkspaceResource) templateCMK(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_key_vault" "test" {
+  name                       = "acctest-kv-%[1]s"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  rbac_authorization_enabled = false
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "premium"
+
+  soft_delete_retention_days = 7
+}
+
+resource "azurerm_key_vault_key" "test" {
+  depends_on = [azurerm_key_vault_access_policy.terraform]
+
+  name         = "acctest-certificate"
+  key_vault_id = azurerm_key_vault.test.id
+  key_type     = "RSA"
+  key_size     = 2048
+
+  key_opts = [
+    "decrypt",
+    "encrypt",
+    "sign",
+    "unwrapKey",
+    "verify",
+    "wrapKey",
+  ]
+}
+
+resource "azurerm_key_vault_access_policy" "terraform" {
+  key_vault_id = azurerm_key_vault.test.id
+  tenant_id    = azurerm_key_vault.test.tenant_id
+  object_id    = data.azurerm_client_config.current.object_id
+
+  key_permissions = [
+    "Get",
+    "List",
+    "Create",
+    "Decrypt",
+    "Encrypt",
+    "GetRotationPolicy",
+    "Sign",
+    "UnwrapKey",
+    "Verify",
+    "WrapKey",
+    "Delete",
+    "Restore",
+    "Recover",
+    "Update",
+    "Purge",
+  ]
+}
+`, data.RandomString)
 }

--- a/internal/services/databricks/databricks_workspace_resource_test.go
+++ b/internal/services/databricks/databricks_workspace_resource_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/databricks/2026-01-01/workspaces"
+	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -610,6 +611,24 @@ func TestAccDatabricksWorkspace_withForceDeleteSetToFalse(t *testing.T) {
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.workspaceForceDelete(data, false),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+	})
+}
+
+func TestAccDatabricksWorkspace_managedServicesAndDiskCMKManagedHSM(t *testing.T) {
+	if os.Getenv("ARM_TEST_HSM_KEY") == "" {
+		t.Skip("Skipping as ARM_TEST_HSM_KEY is not specified")
+	}
+
+	data := acceptance.BuildTestData(t, "azurerm_databricks_workspace", "test")
+	r := DatabricksWorkspaceResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.managedServicesAndDiskCMKManagedHSM(data, getDatabricksPrincipalId(data.Client().SubscriptionID)),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -2589,6 +2608,28 @@ resource "azurerm_databricks_workspace" "test" {
   `, r.template(data), forceDelete, data.RandomInteger)
 }
 
+func (r DatabricksWorkspaceResource) managedServicesAndDiskCMKManagedHSM(data acceptance.TestData, databricksPrincipalID string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_databricks_workspace" "test" {
+  depends_on = [azurerm_key_vault_managed_hardware_security_module_role_assignment.workspace]
+
+  name                = "acctestDBW-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  sku                 = "premium"
+
+  managed_services_cmk_key_vault_key_id = azurerm_key_vault_managed_hardware_security_module_key.test.versioned_id
+  managed_disk_cmk_key_vault_key_id     = azurerm_key_vault_managed_hardware_security_module_key.test.versioned_id
+}
+`, r.templateCMKManagedHSM(data, databricksPrincipalID), data.RandomInteger)
+}
+
 func (DatabricksWorkspaceResource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
@@ -2752,4 +2793,164 @@ resource "azurerm_key_vault_access_policy" "terraform" {
   ]
 }
 `, data.RandomString)
+}
+
+func (r DatabricksWorkspaceResource) templateCMKManagedHSM(data acceptance.TestData, databricksPrincipalID string) string {
+	roleAssignmentName1, _ := uuid.GenerateUUID()
+	roleAssignmentName2, _ := uuid.GenerateUUID()
+	roleAssignmentName3, _ := uuid.GenerateUUID()
+
+	return fmt.Sprintf(`
+%[1]s
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_key_vault" "test" {
+  name                       = "acctest%[2]s"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  rbac_authorization_enabled = false
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "standard"
+  soft_delete_retention_days = 7
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+    key_permissions = [
+      "Create",
+      "Delete",
+      "Get",
+      "Purge",
+      "Recover",
+      "Update",
+      "GetRotationPolicy",
+    ]
+    secret_permissions = [
+      "Delete",
+      "Get",
+      "Set",
+    ]
+    certificate_permissions = [
+      "Create",
+      "Delete",
+      "DeleteIssuers",
+      "Get",
+      "Purge",
+      "Update"
+    ]
+  }
+  tags = {
+    environment = "Production"
+  }
+}
+
+resource "azurerm_key_vault_certificate" "cert" {
+  count        = 3
+  name         = "acctesthsmcert${count.index}"
+  key_vault_id = azurerm_key_vault.test.id
+  certificate_policy {
+    issuer_parameters {
+      name = "Self"
+    }
+    key_properties {
+      exportable = true
+      key_size   = 2048
+      key_type   = "RSA"
+      reuse_key  = true
+    }
+    lifetime_action {
+      action {
+        action_type = "AutoRenew"
+      }
+      trigger {
+        days_before_expiry = 30
+      }
+    }
+    secret_properties {
+      content_type = "application/x-pkcs12"
+    }
+    x509_certificate_properties {
+      extended_key_usage = []
+      key_usage = [
+        "cRLSign",
+        "dataEncipherment",
+        "digitalSignature",
+        "keyAgreement",
+        "keyCertSign",
+        "keyEncipherment",
+      ]
+      subject            = "CN=hello-world"
+      validity_in_months = 12
+    }
+  }
+}
+
+resource "azurerm_key_vault_managed_hardware_security_module" "test" {
+  name                                      = "acctestkvHsm%[2]s"
+  resource_group_name                       = azurerm_resource_group.test.name
+  location                                  = azurerm_resource_group.test.location
+  sku_name                                  = "Standard_B1"
+  tenant_id                                 = data.azurerm_client_config.current.tenant_id
+  admin_object_ids                          = [data.azurerm_client_config.current.object_id]
+  purge_protection_enabled                  = true
+  soft_delete_retention_days                = 7
+  security_domain_key_vault_certificate_ids = [for cert in azurerm_key_vault_certificate.cert : cert.id]
+  security_domain_quorum                    = 3
+}
+
+data "azurerm_key_vault_managed_hardware_security_module_role_definition" "crypto-officer" {
+  name           = "515eb02d-2335-4d2d-92f2-b1cbdf9c3778"
+  managed_hsm_id = azurerm_key_vault_managed_hardware_security_module.test.id
+}
+
+data "azurerm_key_vault_managed_hardware_security_module_role_definition" "crypto-user" {
+  name           = "21dbd100-6940-42c2-9190-5d6cb909625b"
+  managed_hsm_id = azurerm_key_vault_managed_hardware_security_module.test.id
+}
+
+data "azurerm_key_vault_managed_hardware_security_module_role_definition" "encrypt-user" {
+  name           = "33413926-3206-4cdd-b39a-83574fe37a17"
+  managed_hsm_id = azurerm_key_vault_managed_hardware_security_module.test.id
+}
+
+resource "azurerm_key_vault_managed_hardware_security_module_role_assignment" "test" {
+  managed_hsm_id     = azurerm_key_vault_managed_hardware_security_module.test.id
+  name               = "%[3]s"
+  scope              = "/keys"
+  role_definition_id = data.azurerm_key_vault_managed_hardware_security_module_role_definition.crypto-officer.resource_manager_id
+  principal_id       = data.azurerm_client_config.current.object_id
+}
+
+resource "azurerm_key_vault_managed_hardware_security_module_role_assignment" "test1" {
+  managed_hsm_id     = azurerm_key_vault_managed_hardware_security_module.test.id
+  name               = "%[4]s"
+  scope              = "/keys"
+  role_definition_id = data.azurerm_key_vault_managed_hardware_security_module_role_definition.crypto-user.resource_manager_id
+  principal_id       = data.azurerm_client_config.current.object_id
+
+  depends_on = [azurerm_key_vault_managed_hardware_security_module_role_assignment.test]
+}
+
+resource "azurerm_key_vault_managed_hardware_security_module_role_assignment" "workspace" {
+  managed_hsm_id     = azurerm_key_vault_managed_hardware_security_module.test.id
+  name               = "%[5]s"
+  scope              = "/keys"
+  role_definition_id = data.azurerm_key_vault_managed_hardware_security_module_role_definition.crypto-user.resource_manager_id
+  principal_id       = "%[6]s"
+
+  depends_on = [azurerm_key_vault_managed_hardware_security_module_role_assignment.test1]
+}
+
+resource "azurerm_key_vault_managed_hardware_security_module_key" "test" {
+  name           = "acctestHSMK-%[2]s"
+  managed_hsm_id = azurerm_key_vault_managed_hardware_security_module.test.id
+  key_type       = "RSA-HSM"
+  key_size       = 2048
+  key_opts       = ["unwrapKey", "wrapKey"]
+
+  depends_on = [
+    azurerm_key_vault_managed_hardware_security_module_role_assignment.test,
+    azurerm_key_vault_managed_hardware_security_module_role_assignment.test1
+  ]
+}`, r.template(data), data.RandomString, roleAssignmentName1, roleAssignmentName2, roleAssignmentName3, databricksPrincipalID)
 }

--- a/internal/services/databricks/databricks_workspace_root_dbfs_customer_managed_key_resource.go
+++ b/internal/services/databricks/databricks_workspace_root_dbfs_customer_managed_key_resource.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -27,7 +28,7 @@ import (
 //go:generate go run ../../tools/generator-tests resourceidentity -parent-id "workspace_id"
 
 func resourceDatabricksWorkspaceRootDbfsCustomerManagedKey() *pluginsdk.Resource {
-	return &pluginsdk.Resource{
+	r := &pluginsdk.Resource{
 		Create: databricksWorkspaceRootDbfsCustomerManagedKeyCreate,
 		Read:   databricksWorkspaceRootDbfsCustomerManagedKeyRead,
 		Update: databricksWorkspaceRootDbfsCustomerManagedKeyUpdate,
@@ -69,19 +70,28 @@ func resourceDatabricksWorkspaceRootDbfsCustomerManagedKey() *pluginsdk.Resource
 				Required:     true,
 				ValidateFunc: keyvault.ValidateNestedItemID(keyvault.VersionTypeAny, keyvault.NestedItemTypeKey),
 			},
-
-			"key_vault_id": {
-				Type:         pluginsdk.TypeString,
-				Optional:     true,
-				ValidateFunc: commonids.ValidateKeyVaultID,
-			},
 		},
 	}
+
+	if !features.SixPointOh() {
+		r.Schema["key_vault_id"] = &pluginsdk.Schema{
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: commonids.ValidateKeyVaultID,
+			DiffSuppressFunc: func(_, o, n string, _ *pluginsdk.ResourceData) bool {
+				// Suppress removal diff for 5.x since that does not require an update
+				return o != "" && n == ""
+			},
+			Deprecated: "`key_vault_id` has been deprecated and will be removed in v6.0 of the AzureRM provider. This property is no longer required for cross-subscription scenarios.",
+		}
+	}
+
+	return r
 }
 
 func databricksWorkspaceRootDbfsCustomerManagedKeyCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	workspaceClient := meta.(*clients.Client).DataBricks.WorkspacesClient
-	keyVaultsClient := meta.(*clients.Client).KeyVault
+
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -128,27 +138,6 @@ func databricksWorkspaceRootDbfsCustomerManagedKeyCreate(d *pluginsdk.ResourceDa
 		return err
 	}
 
-	dbfsSubscriptionId := commonids.NewSubscriptionID(id.SubscriptionId)
-	keyVaultId := d.Get("key_vault_id").(string)
-	if keyVaultId != "" {
-		parsedKeyVaultID, err := commonids.ParseKeyVaultID(keyVaultId)
-		if err != nil {
-			return err
-		}
-		dbfsSubscriptionId = commonids.NewSubscriptionID(parsedKeyVaultID.SubscriptionId)
-	}
-
-	// make sure the key vault exists
-	// TODO: consider removing this check and deprecating the `key_vault_id` property.
-	// 1. The check can be time consuming when there are many KVs present in a subscription.
-	// 2. The API request will fail if the KV doesn't exist, both that error and this check happen at apply time after a successful plan regardless.
-	// 3. It doesn't work with Managed HSM vaults (hence the conditional)
-	if !key.IsManagedHSM() {
-		if keyVaultIdRaw, err := keyVaultsClient.KeyVaultIDFromBaseUrl(ctx, dbfsSubscriptionId, key.KeyVaultBaseURL); err != nil || keyVaultIdRaw == nil {
-			return fmt.Errorf("retrieving the Resource ID for the Key Vault at URL %q: %+v", key.KeyVaultBaseURL, err)
-		}
-	}
-
 	params.Encryption = &workspaces.WorkspaceEncryptionParameter{
 		Value: &workspaces.Encryption{
 			KeySource:   pointer.To(workspaces.KeySourceMicrosoftPointKeyvault),
@@ -166,10 +155,6 @@ func databricksWorkspaceRootDbfsCustomerManagedKeyCreate(d *pluginsdk.ResourceDa
 	if err := pluginsdk.SetResourceIdentityData(d, id); err != nil {
 		return err
 	}
-
-	// Always set this even if it's empty to keep the state file
-	// consistent with the configuration file...
-	d.Set("key_vault_id", keyVaultId)
 
 	return databricksWorkspaceRootDbfsCustomerManagedKeyRead(d, meta)
 }
@@ -215,14 +200,16 @@ func databricksWorkspaceRootDbfsCustomerManagedKeyRead(d *pluginsdk.ResourceData
 	}
 
 	d.Set("workspace_id", id.ID())
-	d.Set("key_vault_id", d.Get("key_vault_id").(string))
+	if !features.SixPointOh() {
+		d.Set("key_vault_id", d.Get("key_vault_id").(string))
+	}
 
 	return pluginsdk.SetResourceIdentityData(d, id)
 }
 
 func databricksWorkspaceRootDbfsCustomerManagedKeyUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	workspaceClient := meta.(*clients.Client).DataBricks.WorkspacesClient
-	keyVaultsClient := meta.(*clients.Client).KeyVault
+
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -261,23 +248,6 @@ func databricksWorkspaceRootDbfsCustomerManagedKeyUpdate(d *pluginsdk.ResourceDa
 		return err
 	}
 
-	dbfsSubscriptionId := commonids.NewSubscriptionID(id.SubscriptionId)
-	keyVaultId := d.Get("key_vault_id").(string)
-	if keyVaultId != "" {
-		parsedKeyVaultID, err := commonids.ParseKeyVaultID(keyVaultId)
-		if err != nil {
-			return err
-		}
-		dbfsSubscriptionId = commonids.NewSubscriptionID(parsedKeyVaultID.SubscriptionId)
-	}
-
-	// make sure the key vault exists
-	if !key.IsManagedHSM() {
-		if _, err := keyVaultsClient.KeyVaultIDFromBaseUrl(ctx, dbfsSubscriptionId, key.KeyVaultBaseURL); err != nil {
-			return fmt.Errorf("retrieving the Resource ID for the Key Vault in subscription %q at URL %q: %+v", dbfsSubscriptionId, key.KeyVaultBaseURL, err)
-		}
-	}
-
 	existing.Model.Properties.Parameters.Encryption = &workspaces.WorkspaceEncryptionParameter{
 		Value: &workspaces.Encryption{
 			KeySource:   pointer.To(workspaces.KeySourceMicrosoftPointKeyvault),
@@ -290,10 +260,6 @@ func databricksWorkspaceRootDbfsCustomerManagedKeyUpdate(d *pluginsdk.ResourceDa
 	if err = workspaceClient.CreateOrUpdateThenPoll(ctx, *id, *existing.Model); err != nil {
 		return fmt.Errorf("updating Root DBFS Customer Managed Key for %s: %+v", *id, err)
 	}
-
-	// Always set this even if it's empty to keep the state file
-	// consistent with the configuration file...
-	d.Set("key_vault_id", keyVaultId)
 
 	return databricksWorkspaceRootDbfsCustomerManagedKeyRead(d, meta)
 }

--- a/internal/services/databricks/databricks_workspace_root_dbfs_customer_managed_key_resource_test.go
+++ b/internal/services/databricks/databricks_workspace_root_dbfs_customer_managed_key_resource_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
@@ -131,6 +132,11 @@ func TestAccDatabricksWorkspaceRootDbfsCustomerManagedKey_basicAltSubscription(t
 	data := acceptance.BuildTestData(t, "azurerm_databricks_workspace_root_dbfs_customer_managed_key", "test")
 	r := DatabricksWorkspaceRootDbfsCustomerManagedKeyResource{}
 
+	ignore := ([]string)(nil)
+	if !features.SixPointOh() {
+		ignore = []string{"key_vault_id"}
+	}
+
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.basicAltSubscription(data, altSubscription),
@@ -138,8 +144,7 @@ func TestAccDatabricksWorkspaceRootDbfsCustomerManagedKey_basicAltSubscription(t
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		// `key_vault_id` is always set into state based on config, so it will be missing during imports
-		data.ImportStep("key_vault_id"),
+		data.ImportStep(ignore...),
 	})
 }
 
@@ -253,7 +258,8 @@ resource "azurerm_databricks_workspace_root_dbfs_customer_managed_key" "test" {
 }
 
 func (r DatabricksWorkspaceRootDbfsCustomerManagedKeyResource) basicAltSubscription(data acceptance.TestData, alternate *DatabricksWorkspaceAlternateSubscription) string {
-	return fmt.Sprintf(`
+	if !features.SixPointOh() {
+		return fmt.Sprintf(`
 
 provider "azurerm" {
   features {}
@@ -265,6 +271,23 @@ resource "azurerm_databricks_workspace_root_dbfs_customer_managed_key" "test" {
   workspace_id     = azurerm_databricks_workspace.test.id
   key_vault_key_id = azurerm_key_vault_key.test.id
   key_vault_id     = azurerm_key_vault.test.id
+
+  depends_on = [azurerm_key_vault_access_policy.databricks]
+}
+`, r.keyVaultAltSubscriptionTemplate(data, alternate), data.RandomInteger)
+	}
+
+	return fmt.Sprintf(`
+
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_databricks_workspace_root_dbfs_customer_managed_key" "test" {
+  workspace_id     = azurerm_databricks_workspace.test.id
+  key_vault_key_id = azurerm_key_vault_key.test.id
 
   depends_on = [azurerm_key_vault_access_policy.databricks]
 }

--- a/website/docs/6.0-upgrade-guide.html.markdown
+++ b/website/docs/6.0-upgrade-guide.html.markdown
@@ -80,6 +80,16 @@ Please follow the format in the example below for listing breaking changes in re
 
 ---
 
+### `azurerm_databricks_workspace`
+
+* The deprecated `managed_disk_cmk_key_vault_id` property has been removed.
+* The deprecated `managed_services_cmk_key_vault_id` property has been removed.
+* The value of the `managed_resource_group_id` property is now normalized to the canonical resource ID format. 
+
+### `azurerm_databricks_workspace_root_dbfs_customer_managed_key`
+
+* The deprecated `key_vault_id` property has been removed.
+
 ## Breaking Changes in Data Sources
 
 Please follow the format in the example below for listing breaking changes in data sources:

--- a/website/docs/r/databricks_workspace.html.markdown
+++ b/website/docs/r/databricks_workspace.html.markdown
@@ -50,15 +50,7 @@ The following arguments are supported:
 
 * `managed_services_cmk_key_vault_id` - (Optional) Resource ID of the Key Vault which contains the `managed_services_cmk_key_vault_key_id` key.
 
--> **Note:** The `managed_services_cmk_key_vault_id` field is only required if the Key Vault exists in a different subscription than the Databricks Workspace. If the `managed_services_cmk_key_vault_id` field is not specified it is assumed that the `managed_services_cmk_key_vault_key_id` is hosted in the same subscriptioin as the Databricks Workspace.
-
--> **Note:** If you are using multiple service principals to execute Terraform across subscriptions you will need to add an additional `azurerm_key_vault_access_policy` resource granting the service principal access to the key vault in that subscription.
-
 * `managed_disk_cmk_key_vault_id` - (Optional) Resource ID of the Key Vault which contains the `managed_disk_cmk_key_vault_key_id` key.
-
--> **Note:** The `managed_disk_cmk_key_vault_id` field is only required if the Key Vault exists in a different subscription than the Databricks Workspace. If the `managed_disk_cmk_key_vault_id` field is not specified it is assumed that the `managed_disk_cmk_key_vault_key_id` is hosted in the same subscriptioin as the Databricks Workspace.
-
--> **Note:** If you are using multiple service principals to execute Terraform across subscriptions you will need to add an additional `azurerm_key_vault_access_policy` resource granting the service principal access to the key vault in that subscription.
 
 * `managed_services_cmk_key_vault_key_id` - (Optional) Customer managed encryption properties for the Databricks Workspace managed resources(e.g. Notebooks and Artifacts).
 
@@ -153,7 +145,6 @@ An `enhanced_security_compliance` block supports the following:
 * [Databricks Workspace with Root Databricks File System Customer Managed Keys](https://github.com/hashicorp/terraform-provider-azurerm/tree/main/examples/databricks/customer-managed-key/dbfs)
 * [Databricks Workspace with Root Databricks File System Customer Managed Keys in a Different Subscription](https://github.com/hashicorp/terraform-provider-azurerm/tree/main/examples/databricks/customer-managed-key/dbfs-cross-subscription)
 * [Databricks Workspace with Customer Managed Keys for Managed Services](https://github.com/hashicorp/terraform-provider-azurerm/tree/main/examples/databricks/customer-managed-key/managed-services)
-* [Databricks Workspace with Customer Managed Keys for Managed Services with Key Vault and Key in a Different Subscription](https://github.com/hashicorp/terraform-provider-azurerm/tree/main/examples/databricks/customer-managed-key/managed-services-cross-subscription)
 
 ## Attributes Reference
 
@@ -167,7 +158,7 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `managed_resource_group_id` - The ID of the Managed Resource Group created by the Databricks Workspace.
 
-* `workspace_url` - The workspace URL which is of the format 'adb-{workspaceId}.{random}.azuredatabricks.net'
+* `workspace_url` - The workspace URL which is of the format `adb-{workspaceId}.{random}.azuredatabricks.net`
 
 * `workspace_id` - The unique identifier of the databricks workspace in Databricks control plane.
 

--- a/website/docs/r/databricks_workspace_root_dbfs_customer_managed_key.html.markdown
+++ b/website/docs/r/databricks_workspace_root_dbfs_customer_managed_key.html.markdown
@@ -122,10 +122,6 @@ The following arguments are supported:
 
 * `key_vault_id` - (Optional) Specifies the Resource ID of the Key Vault which contains the `key_vault_key_id`.
 
--> **Note:** The `key_vault_id` field only needs to be specified if the Key Vault which contains the `key_vault_key_id` exists in a different subscription than the Databricks Workspace. If the `key_vault_id` field is not specified it is assumed that the `key_vault_key_id` is hosted in the same subscription as the Databricks Workspace. Does not apply to managed HSM vaults.
-
--> **Note:** If you are using multiple service principals to execute Terraform across subscriptions you will need to add an additional `azurerm_key_vault_access_policy` resource granting the service principal access to the key vault in that subscription.
-
 ## Attributes Reference
 
 In addition to the Arguments listed above - the following Attributes are exported:


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Removes Key Vault existence checks that required `*key_vault_id` args on cross-subscription scenarios. This was an artificial limitation introduced by the provider. The key vault lookup is slow in subscriptions with many instances and provides no additional value since the API provides a clear enough error message and both failures happen at apply time after a plan has already been approved.

### `azurerm_databricks_workspace`:
- deprecates the `managed_disk_cmk_key_vault_id` and `managed_services_cmk_key_vault_id` arguments
- removes the key vault existence check
- fix a bug that would allow removal of either `*key_id` argument but would not actually send this to the API causing a persistent diff. Resource now forces recreation on removal of CMK arguments as the API does not support this.
- refactor resource file to improve readability and fix potential panics
- refactor test file to remove excessive duplication

### `azurerm_databricks_workspace_root_dbfs_customer_managed_key`

- deprecates the `key_vault_id` argument
- removes the key vault existence check

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Supersedes #31528


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
