### PR TITLE
`azurerm_mysql_flexible_database` - Suppress diff for charset/collation

### DIFF
--- a/internal/services/mysql/mysql_flexible_database_resource.go
+++ b/internal/services/mysql/mysql_flexible_database_resource.go
@@ -81,8 +81,9 @@ func mysqlFlexibleDatabaseCharsetDiffSuppress(key, oldValue, newValue string, re
 		mysqlFlexibleDatabaseAliasDiff(oldValue, newValue, "utf8", "utf8mb3")
 }
 
-func mysqlFlexibleDatabaseCollationDiffSuppress(_, oldValue, newValue string, _ *schema.ResourceData) bool {
-	return mysqlFlexibleDatabaseAliasDiff(oldValue, newValue, "utf8_unicode_ci", "utf8mb3_unicode_ci")
+func mysqlFlexibleDatabaseCollationDiffSuppress(key, oldValue, newValue string, resourceData *schema.ResourceData) bool {
+	return suppress.CaseDifference(key, oldValue, newValue, resourceData) ||
+		mysqlFlexibleDatabaseAliasDiff(oldValue, newValue, "utf8_unicode_ci", "utf8mb3_unicode_ci")
 }
 
 func mysqlFlexibleDatabaseAliasDiff(oldValue, newValue, firstAlias, secondAlias string) bool {

--- a/internal/services/mysql/mysql_flexible_database_resource.go
+++ b/internal/services/mysql/mysql_flexible_database_resource.go
@@ -5,6 +5,7 @@ package mysql
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -62,16 +63,31 @@ func resourceMySqlFlexibleDatabase() *pluginsdk.Resource {
 				Type:             pluginsdk.TypeString,
 				Required:         true,
 				ForceNew:         true,
-				DiffSuppressFunc: suppress.CaseDifference,
+				DiffSuppressFunc: mysqlFlexibleDatabaseCharsetDiffSuppress,
 			},
 
 			"collation": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:             pluginsdk.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				DiffSuppressFunc: mysqlFlexibleDatabaseCollationDiffSuppress,
 			},
 		},
 	}
+}
+
+func mysqlFlexibleDatabaseCharsetDiffSuppress(key, oldValue, newValue string, resourceData *schema.ResourceData) bool {
+	return suppress.CaseDifference(key, oldValue, newValue, resourceData) ||
+		mysqlFlexibleDatabaseAliasDiff(oldValue, newValue, "utf8", "utf8mb3")
+}
+
+func mysqlFlexibleDatabaseCollationDiffSuppress(_, oldValue, newValue string, _ *schema.ResourceData) bool {
+	return mysqlFlexibleDatabaseAliasDiff(oldValue, newValue, "utf8_unicode_ci", "utf8mb3_unicode_ci")
+}
+
+func mysqlFlexibleDatabaseAliasDiff(oldValue, newValue, firstAlias, secondAlias string) bool {
+	return strings.EqualFold(oldValue, firstAlias) && strings.EqualFold(newValue, secondAlias) ||
+		strings.EqualFold(oldValue, secondAlias) && strings.EqualFold(newValue, firstAlias)
 }
 
 func resourceMySqlFlexibleDatabaseCreate(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/mysql/mysql_flexible_database_resource_test.go
+++ b/internal/services/mysql/mysql_flexible_database_resource_test.go
@@ -60,7 +60,7 @@ func TestAccMySQLFlexibleDatabase_charsetUppercase(t *testing.T) {
 			Config: r.charsetUppercase(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("charset").HasValue("utf8mb3_unicode_ci"),
+				check.That(data.ResourceName).Key("charset").HasValue("utf8mb3"),
 			),
 		},
 		data.ImportStep(),
@@ -92,7 +92,7 @@ func TestAccMySQLFlexibleDatabase_collationUppercase(t *testing.T) {
 			Config: r.collationUppercase(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("collation").HasValue("utf8_unicode_ci"),
+				check.That(data.ResourceName).Key("collation").HasValue("utf8mb3_unicode_ci"),
 			),
 		},
 		data.ImportStep(),

--- a/internal/services/mysql/mysql_flexible_database_resource_test.go
+++ b/internal/services/mysql/mysql_flexible_database_resource_test.go
@@ -60,7 +60,7 @@ func TestAccMySQLFlexibleDatabase_charsetUppercase(t *testing.T) {
 			Config: r.charsetUppercase(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("charset").HasValue("utf8"),
+				check.That(data.ResourceName).Key("charset").HasValue("utf8mb3"),
 			),
 		},
 		data.ImportStep(),
@@ -76,10 +76,29 @@ func TestAccMySQLFlexibleDatabase_charsetMixedcase(t *testing.T) {
 			Config: r.charsetMixedcase(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("charset").HasValue("utf8"),
+				check.That(data.ResourceName).Key("charset").HasValue("utf8mb3"),
 			),
 		},
 		data.ImportStep(),
+	})
+}
+
+func TestAccMySQLFlexibleDatabase_utf8Aliases(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_mysql_flexible_database", "test")
+	r := MysqlFlexibleDatabaseResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.charsetAndCollation(data, "utf8mb3", "utf8mb3_unicode_ci"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		{
+			Config:             r.charsetAndCollation(data, "utf8", "utf8_unicode_ci"),
+			PlanOnly:           true,
+			ExpectNonEmptyPlan: false,
+		},
 	})
 }
 
@@ -97,34 +116,8 @@ func (r MysqlFlexibleDatabaseResource) Exists(ctx context.Context, clients *clie
 	return pointer.To(resp.Model != nil), nil
 }
 
-func (MysqlFlexibleDatabaseResource) basic(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-resource "azurerm_mysql_flexible_server" "test" {
-  name                   = "acctest-fs-%d"
-  resource_group_name    = azurerm_resource_group.test.name
-  location               = azurerm_resource_group.test.location
-  administrator_login    = "adminTerraform"
-  administrator_password = "QAZwsx123"
-  sku_name               = "B_Standard_B1ms"
-  zone                   = "1"
-}
-
-resource "azurerm_mysql_flexible_database" "test" {
-  name                = "acctestdb_%d"
-  resource_group_name = azurerm_resource_group.test.name
-  server_name         = azurerm_mysql_flexible_server.test.name
-  charset             = "utf8"
-  collation           = "utf8_unicode_ci"
-}
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+func (r MysqlFlexibleDatabaseResource) basic(data acceptance.TestData) string {
+	return r.charsetAndCollation(data, "utf8", "utf8_unicode_ci")
 }
 
 func (r MysqlFlexibleDatabaseResource) requiresImport(data acceptance.TestData) string {
@@ -141,7 +134,15 @@ resource "azurerm_mysql_flexible_database" "import" {
 `, r.basic(data))
 }
 
-func (MysqlFlexibleDatabaseResource) charsetUppercase(data acceptance.TestData) string {
+func (r MysqlFlexibleDatabaseResource) charsetUppercase(data acceptance.TestData) string {
+	return r.charsetAndCollation(data, "UTF8", "utf8_unicode_ci")
+}
+
+func (r MysqlFlexibleDatabaseResource) charsetMixedcase(data acceptance.TestData) string {
+	return r.charsetAndCollation(data, "Utf8", "utf8_unicode_ci")
+}
+
+func (MysqlFlexibleDatabaseResource) charsetAndCollation(data acceptance.TestData, charset, collation string) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -165,38 +166,8 @@ resource "azurerm_mysql_flexible_database" "test" {
   name                = "acctestdb_%d"
   resource_group_name = azurerm_resource_group.test.name
   server_name         = azurerm_mysql_flexible_server.test.name
-  charset             = "UTF8"
-  collation           = "utf8_unicode_ci"
+  charset             = "%s"
+  collation           = "%s"
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
-}
-
-func (MysqlFlexibleDatabaseResource) charsetMixedcase(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-resource "azurerm_mysql_flexible_server" "test" {
-  name                   = "acctest-fs-%d"
-  resource_group_name    = azurerm_resource_group.test.name
-  location               = azurerm_resource_group.test.location
-  administrator_login    = "adminTerraform"
-  administrator_password = "QAZwsx123"
-  sku_name               = "B_Standard_B1ms"
-  zone                   = "1"
-}
-
-resource "azurerm_mysql_flexible_database" "test" {
-  name                = "acctestdb_%d"
-  resource_group_name = azurerm_resource_group.test.name
-  server_name         = azurerm_mysql_flexible_server.test.name
-  charset             = "Utf8"
-  collation           = "utf8_unicode_ci"
-}
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, charset, collation)
 }

--- a/internal/services/mysql/mysql_flexible_database_resource_test.go
+++ b/internal/services/mysql/mysql_flexible_database_resource_test.go
@@ -60,7 +60,7 @@ func TestAccMySQLFlexibleDatabase_charsetUppercase(t *testing.T) {
 			Config: r.charsetUppercase(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("charset").HasValue("utf8mb3"),
+				check.That(data.ResourceName).Key("charset").HasValue("utf8mb3_unicode_ci"),
 			),
 		},
 		data.ImportStep(),
@@ -151,7 +151,7 @@ resource "azurerm_mysql_flexible_database" "import" {
 }
 
 func (r MysqlFlexibleDatabaseResource) charsetUppercase(data acceptance.TestData) string {
-	return r.charsetAndCollation(data, "UTF8", "utf8_unicode_ci")
+	return r.charsetAndCollation(data, "UTF8", "UTF8_UNICODE_CI")
 }
 
 func (r MysqlFlexibleDatabaseResource) charsetMixedcase(data acceptance.TestData) string {

--- a/internal/services/mysql/mysql_flexible_database_resource_test.go
+++ b/internal/services/mysql/mysql_flexible_database_resource_test.go
@@ -83,6 +83,22 @@ func TestAccMySQLFlexibleDatabase_charsetMixedcase(t *testing.T) {
 	})
 }
 
+func TestAccMySQLFlexibleDatabase_collationUppercase(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_mysql_flexible_database", "test")
+	r := MysqlFlexibleDatabaseResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.collationUppercase(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("collation").HasValue("utf8_unicode_ci"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccMySQLFlexibleDatabase_utf8Aliases(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_mysql_flexible_database", "test")
 	r := MysqlFlexibleDatabaseResource{}
@@ -140,6 +156,10 @@ func (r MysqlFlexibleDatabaseResource) charsetUppercase(data acceptance.TestData
 
 func (r MysqlFlexibleDatabaseResource) charsetMixedcase(data acceptance.TestData) string {
 	return r.charsetAndCollation(data, "Utf8", "utf8_unicode_ci")
+}
+
+func (r MysqlFlexibleDatabaseResource) collationUppercase(data acceptance.TestData) string {
+	return r.charsetAndCollation(data, "utf8", "UTF8_UNICODE_CI")
 }
 
 func (MysqlFlexibleDatabaseResource) charsetAndCollation(data acceptance.TestData, charset, collation string) string {

--- a/website/docs/r/mysql_flexible_database.html.markdown
+++ b/website/docs/r/mysql_flexible_database.html.markdown
@@ -44,15 +44,15 @@ resource "azurerm_mysql_flexible_database" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the MySQL Database, which needs [to be a valid MySQL identifier](https://dev.mysql.com/doc/refman/5.7/en/identifiers.html). Changing this forces a new resource to be created.
+* `name` - (Required) Specifies the name of the MySQL Database, which needs [to be a valid MySQL identifier](https://dev.mysql.com/doc/refman/8.4/en/identifiers.html). Changing this forces a new resource to be created.
 
 * `server_name` - (Required) Specifies the name of the MySQL Flexible Server. Changing this forces a new resource to be created.
 
 * `resource_group_name` - (Required) The name of the resource group in which the MySQL Server exists. Changing this forces a new resource to be created.
 
-* `charset` - (Required) Specifies the Charset for the MySQL Database, which needs [to be a valid MySQL Charset](https://dev.mysql.com/doc/refman/5.7/en/charset-charsets.html). Changing this forces a new resource to be created.
+* `charset` - (Required) Specifies the Charset for the MySQL Database, which needs [to be a valid MySQL Charset](https://dev.mysql.com/doc/refman/8.4/en/charset-charsets.html). Changing this forces a new resource to be created.
 
-* `collation` - (Required) Specifies the Collation for the MySQL Database, which needs [to be a valid MySQL Collation](https://dev.mysql.com/doc/refman/5.7/en/charset-mysql.html). Changing this forces a new resource to be created.
+* `collation` - (Required) Specifies the Collation for the MySQL Database, which needs [to be a valid MySQL Collation](https://dev.mysql.com/doc/refman/8.4/en/charset-mysql.html). Changing this forces a new resource to be created.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Suppress diff for `utf8`/`utf8mb3` and `utf8_unicode_ci`/`utf8mb3_unicode_ci` since the API responses are now with `*mb3*` alias


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_mysql_flexible_database` - Fix `utf8` charset/collation diff issue [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
