### PR TITLE
`azurerm_public_ip` - Allow in-place upgrade for `sku` property

### DIFF
--- a/internal/services/network/public_ip_resource.go
+++ b/internal/services/network/public_ip_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -225,13 +226,13 @@ func resourcePublicIp() *pluginsdk.Resource {
 }
 
 func isPublicIpSkuUpgrade(oldSku string, newSku string) bool {
-	publicIpSkuUpgradeOrder := map[string]int{
-		strings.ToLower(string(publicipaddresses.PublicIPAddressSkuNameBasic)):        1,
-		strings.ToLower(string(publicipaddresses.PublicIPAddressSkuNameStandard)):     2,
-		strings.ToLower(string(publicipaddresses.PublicIPAddressSkuNameStandardVTwo)): 3,
+	publicIpSkuUpgradeOrder := []string{
+		strings.ToLower(string(publicipaddresses.PublicIPAddressSkuNameBasic)),
+		strings.ToLower(string(publicipaddresses.PublicIPAddressSkuNameStandard)),
+		strings.ToLower(string(publicipaddresses.PublicIPAddressSkuNameStandardVTwo)),
 	}
 
-	return publicIpSkuUpgradeOrder[strings.ToLower(newSku)] > publicIpSkuUpgradeOrder[strings.ToLower(oldSku)]
+	return slices.Index(publicIpSkuUpgradeOrder, strings.ToLower(newSku)) > slices.Index(publicIpSkuUpgradeOrder, strings.ToLower(oldSku))
 }
 
 func isStandardPublicIpSku(sku string) bool {

--- a/internal/services/network/public_ip_resource.go
+++ b/internal/services/network/public_ip_resource.go
@@ -227,17 +227,17 @@ func resourcePublicIp() *pluginsdk.Resource {
 
 func isPublicIpSkuUpgrade(oldSku string, newSku string) bool {
 	publicIpSkuUpgradeOrder := []string{
-		strings.ToLower(string(publicipaddresses.PublicIPAddressSkuNameBasic)),
-		strings.ToLower(string(publicipaddresses.PublicIPAddressSkuNameStandard)),
-		strings.ToLower(string(publicipaddresses.PublicIPAddressSkuNameStandardVTwo)),
+		string(publicipaddresses.PublicIPAddressSkuNameBasic),
+		string(publicipaddresses.PublicIPAddressSkuNameStandard),
+		string(publicipaddresses.PublicIPAddressSkuNameStandardVTwo),
 	}
 
-	return slices.Index(publicIpSkuUpgradeOrder, strings.ToLower(newSku)) > slices.Index(publicIpSkuUpgradeOrder, strings.ToLower(oldSku))
+	return slices.Index(publicIpSkuUpgradeOrder, newSku) > slices.Index(publicIpSkuUpgradeOrder, oldSku)
 }
 
 func isStandardPublicIpSku(sku string) bool {
-	return strings.EqualFold(sku, string(publicipaddresses.PublicIPAddressSkuNameStandard)) ||
-		strings.EqualFold(sku, string(publicipaddresses.PublicIPAddressSkuNameStandardVTwo))
+	return sku == string(publicipaddresses.PublicIPAddressSkuNameStandard) ||
+		sku == string(publicipaddresses.PublicIPAddressSkuNameStandardVTwo)
 }
 
 const publicIPBasicSkuCreateDeprecationMessage = "creation of new `Basic` SKU public IP addresses is no longer permitted following its deprecation on March 31, 2025. This also affects `allocation_method` set to `Dynamic`, as it is only available with the `Basic` SKU. For more information, see https://azure.microsoft.com/updates/upgrade-to-standard-sku-public-ip-addresses-in-azure-by-30-september-2025-basic-sku-will-be-retired/"

--- a/internal/services/network/public_ip_resource.go
+++ b/internal/services/network/public_ip_resource.go
@@ -225,7 +225,7 @@ func resourcePublicIp() *pluginsdk.Resource {
 }
 
 func isPublicIpSkuUpgrade(oldSku string, newSku string) bool {
-	var publicIpSkuUpgradeOrder = map[string]int{
+	publicIpSkuUpgradeOrder := map[string]int{
 		strings.ToLower(string(publicipaddresses.PublicIPAddressSkuNameBasic)):        1,
 		strings.ToLower(string(publicipaddresses.PublicIPAddressSkuNameStandard)):     2,
 		strings.ToLower(string(publicipaddresses.PublicIPAddressSkuNameStandardVTwo)): 3,

--- a/internal/services/network/public_ip_resource.go
+++ b/internal/services/network/public_ip_resource.go
@@ -224,13 +224,13 @@ func resourcePublicIp() *pluginsdk.Resource {
 	}
 }
 
-var publicIpSkuUpgradeOrder = map[string]int{
-	strings.ToLower(string(publicipaddresses.PublicIPAddressSkuNameBasic)):        1,
-	strings.ToLower(string(publicipaddresses.PublicIPAddressSkuNameStandard)):     2,
-	strings.ToLower(string(publicipaddresses.PublicIPAddressSkuNameStandardVTwo)): 3,
-}
-
 func isPublicIpSkuUpgrade(oldSku string, newSku string) bool {
+	var publicIpSkuUpgradeOrder = map[string]int{
+		strings.ToLower(string(publicipaddresses.PublicIPAddressSkuNameBasic)):        1,
+		strings.ToLower(string(publicipaddresses.PublicIPAddressSkuNameStandard)):     2,
+		strings.ToLower(string(publicipaddresses.PublicIPAddressSkuNameStandardVTwo)): 3,
+	}
+
 	return publicIpSkuUpgradeOrder[strings.ToLower(newSku)] > publicIpSkuUpgradeOrder[strings.ToLower(oldSku)]
 }
 

--- a/internal/services/network/public_ip_resource.go
+++ b/internal/services/network/public_ip_resource.go
@@ -105,11 +105,9 @@ func resourcePublicIp() *pluginsdk.Resource {
 			},
 
 			"sku": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Default:  string(publicipaddresses.PublicIPAddressSkuNameStandard),
-				// https://azure.microsoft.com/en-us/updates/upgrade-to-standard-sku-public-ip-addresses-in-azure-by-30-september-2025-basic-sku-will-be-retired/
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				Default:      string(publicipaddresses.PublicIPAddressSkuNameStandard),
 				ValidateFunc: validation.StringInSlice(publicipaddresses.PossibleValuesForPublicIPAddressSkuName(), false),
 			},
 
@@ -208,11 +206,37 @@ func resourcePublicIp() *pluginsdk.Resource {
 				}
 				return nil
 			}),
+			pluginsdk.CustomizeDiffShim(func(_ context.Context, d *pluginsdk.ResourceDiff, _ interface{}) error {
+				sku := d.Get("sku").(string)
+				allocationMethod := d.Get("allocation_method").(string)
+				if isStandardPublicIpSku(sku) && !strings.EqualFold(allocationMethod, string(publicipaddresses.IPAllocationMethodStatic)) {
+					return errors.New("`allocation_method` must be set to `Static` when `sku` is set to `Standard` or `StandardV2`")
+				}
+				return nil
+			}),
+			pluginsdk.ForceNewIfChange("sku", func(ctx context.Context, old, new, meta interface{}) bool {
+				return !isPublicIpSkuUpgrade(old.(string), new.(string))
+			}),
 			pluginsdk.ForceNewIfChange("domain_name_label_scope", func(ctx context.Context, old, new, meta interface{}) bool {
 				return old.(string) != "" || new.(string) == ""
 			}),
 		),
 	}
+}
+
+var publicIpSkuUpgradeOrder = map[string]int{
+	strings.ToLower(string(publicipaddresses.PublicIPAddressSkuNameBasic)):        1,
+	strings.ToLower(string(publicipaddresses.PublicIPAddressSkuNameStandard)):     2,
+	strings.ToLower(string(publicipaddresses.PublicIPAddressSkuNameStandardVTwo)): 3,
+}
+
+func isPublicIpSkuUpgrade(oldSku string, newSku string) bool {
+	return publicIpSkuUpgradeOrder[strings.ToLower(newSku)] > publicIpSkuUpgradeOrder[strings.ToLower(oldSku)]
+}
+
+func isStandardPublicIpSku(sku string) bool {
+	return strings.EqualFold(sku, string(publicipaddresses.PublicIPAddressSkuNameStandard)) ||
+		strings.EqualFold(sku, string(publicipaddresses.PublicIPAddressSkuNameStandardVTwo))
 }
 
 const publicIPBasicSkuCreateDeprecationMessage = "creation of new `Basic` SKU public IP addresses is no longer permitted following its deprecation on March 31, 2025. This also affects `allocation_method` set to `Dynamic`, as it is only available with the `Basic` SKU. For more information, see https://azure.microsoft.com/updates/upgrade-to-standard-sku-public-ip-addresses-in-azure-by-30-september-2025-basic-sku-will-be-retired/"
@@ -241,7 +265,7 @@ func resourcePublicIpCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	sku := d.Get("sku").(string)
 	ipAllocationMethod := d.Get("allocation_method").(string)
 
-	if strings.EqualFold(sku, string(publicipaddresses.PublicIPAddressSkuNameStandard)) || strings.EqualFold(sku, string(publicipaddresses.PublicIPAddressSkuNameStandardVTwo)) {
+	if isStandardPublicIpSku(sku) {
 		if !strings.EqualFold(ipAllocationMethod, string(publicipaddresses.IPAllocationMethodStatic)) {
 			return fmt.Errorf("`allocation_method` must be set to `Static` when `sku` is set to `Standard` or `StandardV2`")
 		}
@@ -363,6 +387,15 @@ func resourcePublicIpUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	}
 
 	payload := existing.Model
+
+	if d.HasChange("sku") {
+		if payload.Sku == nil {
+			payload.Sku = &publicipaddresses.PublicIPAddressSku{
+				Tier: pointer.ToEnum[publicipaddresses.PublicIPAddressSkuTier](d.Get("sku_tier").(string)),
+			}
+		}
+		payload.Sku.Name = pointer.ToEnum[publicipaddresses.PublicIPAddressSkuName](d.Get("sku").(string))
+	}
 
 	if d.HasChange("allocation_method") {
 		payload.Properties.PublicIPAllocationMethod = pointer.ToEnum[publicipaddresses.IPAllocationMethod](d.Get("allocation_method").(string))

--- a/internal/services/network/public_ip_resource_test.go
+++ b/internal/services/network/public_ip_resource_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/publicipaddresses"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -429,6 +431,61 @@ func TestAccPublicIp_standardV2RegionalTier(t *testing.T) {
 				check.That(data.ResourceName).Key("ip_address").Exists(),
 				check.That(data.ResourceName).Key("sku").HasValue(string(publicipaddresses.PublicIPAddressSkuNameStandardVTwo)),
 				check.That(data.ResourceName).Key("sku_tier").HasValue(string(publicipaddresses.PublicIPAddressSkuTierRegional)),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccPublicIp_skuUpgradeStandardToStandardV2(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_public_ip", "test")
+	r := PublicIpResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.skuTier(data, string(publicipaddresses.PublicIPAddressSkuNameStandard), string(publicipaddresses.PublicIPAddressSkuTierRegional)),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("ip_address").Exists(),
+				check.That(data.ResourceName).Key("sku").HasValue(string(publicipaddresses.PublicIPAddressSkuNameStandard)),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.skuTier(data, string(publicipaddresses.PublicIPAddressSkuNameStandardVTwo), string(publicipaddresses.PublicIPAddressSkuTierRegional)),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("ip_address").Exists(),
+				check.That(data.ResourceName).Key("sku").HasValue(string(publicipaddresses.PublicIPAddressSkuNameStandardVTwo)),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccPublicIp_skuDowngradeRequiresReplacement(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_public_ip", "test")
+	r := PublicIpResource{}
+
+	data.ResourceTestIgnoreRecreate(t, r, []acceptance.TestStep{
+		{
+			Config: r.skuTier(data, string(publicipaddresses.PublicIPAddressSkuNameStandardVTwo), string(publicipaddresses.PublicIPAddressSkuTierRegional)),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("sku").HasValue(string(publicipaddresses.PublicIPAddressSkuNameStandardVTwo)),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.skuTier(data, string(publicipaddresses.PublicIPAddressSkuNameStandard), string(publicipaddresses.PublicIPAddressSkuTierRegional)),
+			ConfigPlanChecks: resource.ConfigPlanChecks{
+				PreApply: []plancheck.PlanCheck{
+					plancheck.ExpectResourceAction(data.ResourceName, plancheck.ResourceActionReplace),
+				},
+			},
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("sku").HasValue(string(publicipaddresses.PublicIPAddressSkuNameStandard)),
 			),
 		},
 		data.ImportStep(),

--- a/internal/services/network/public_ip_resource_test.go
+++ b/internal/services/network/public_ip_resource_test.go
@@ -13,8 +13,6 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/publicipaddresses"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -447,7 +445,6 @@ func TestAccPublicIp_skuUpgradeStandardToStandardV2(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("ip_address").Exists(),
-				check.That(data.ResourceName).Key("sku").HasValue(string(publicipaddresses.PublicIPAddressSkuNameStandard)),
 			),
 		},
 		data.ImportStep(),
@@ -456,36 +453,6 @@ func TestAccPublicIp_skuUpgradeStandardToStandardV2(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("ip_address").Exists(),
-				check.That(data.ResourceName).Key("sku").HasValue(string(publicipaddresses.PublicIPAddressSkuNameStandardVTwo)),
-			),
-		},
-		data.ImportStep(),
-	})
-}
-
-func TestAccPublicIp_skuDowngradeRequiresReplacement(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_public_ip", "test")
-	r := PublicIpResource{}
-
-	data.ResourceTestIgnoreRecreate(t, r, []acceptance.TestStep{
-		{
-			Config: r.skuTier(data, string(publicipaddresses.PublicIPAddressSkuNameStandardVTwo), string(publicipaddresses.PublicIPAddressSkuTierRegional)),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("sku").HasValue(string(publicipaddresses.PublicIPAddressSkuNameStandardVTwo)),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.skuTier(data, string(publicipaddresses.PublicIPAddressSkuNameStandard), string(publicipaddresses.PublicIPAddressSkuTierRegional)),
-			ConfigPlanChecks: resource.ConfigPlanChecks{
-				PreApply: []plancheck.PlanCheck{
-					plancheck.ExpectResourceAction(data.ResourceName, plancheck.ResourceActionReplace),
-				},
-			},
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("sku").HasValue(string(publicipaddresses.PublicIPAddressSkuNameStandard)),
 			),
 		},
 		data.ImportStep(),

--- a/website/docs/r/public_ip.html.markdown
+++ b/website/docs/r/public_ip.html.markdown
@@ -80,7 +80,9 @@ The following arguments are supported:
 
 * `reverse_fqdn` - (Optional) A fully qualified domain name that resolves to this public IP address. If the reverseFqdn is specified, then a PTR DNS record is created pointing from the IP address in the in-addr.arpa domain to the reverse FQDN.
 
-* `sku` - (Optional) The SKU of the Public IP. Possible values are `Basic`, `Standard`, and `StandardV2`. Defaults to `Standard`. Changing this forces a new resource to be created.
+* `sku` - (Optional) The SKU of the Public IP. Possible values are `Basic`, `Standard`, and `StandardV2`. Defaults to `Standard`.
+
+-> **Note:** `sku` can only be upgraded in-place, following the path `Basic` -> `Standard` -> `StandardV2`. An in-place upgrade retains the allocated IP address. Downgrading the `sku` forces a new resource to be created, which results in a new IP address being allocated.
 
 -> **Note:** Public IP `Standard` and `StandardV2` SKUs require `allocation_method` to be set to `Static`.
 


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Currently, for the `sku` property in this resource, it is set to `ForceNew`, which means whenever the user changes it, the resource is recreated and a new IP is assigned. This change stops it from recreating when the `sku` property is changed to be upgraded, which means that the user can maintain their IP.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_public_ip` - Allow in-place upgrade for `sku` property


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.
