### PR TITLE
`azurerm_storage_account` - add `skip_storing_access_keys` feature flag

### DIFF
--- a/internal/features/defaults.go
+++ b/internal/features/defaults.go
@@ -69,7 +69,8 @@ func Default() UserFeatures {
 			ScaleToZeroOnDelete:       true,
 		},
 		Storage: StorageFeatures{
-			DataPlaneAvailable: true,
+			DataPlaneAvailable:    true,
+			SkipStoringAccessKeys: false,
 		},
 		Subscription: SubscriptionFeatures{
 			PreventCancellationOnDestroy: false,

--- a/internal/features/user_flags.go
+++ b/internal/features/user_flags.go
@@ -99,7 +99,8 @@ type AppConfigurationFeatures struct {
 }
 
 type StorageFeatures struct {
-	DataPlaneAvailable bool
+	DataPlaneAvailable    bool
+	SkipStoringAccessKeys bool
 }
 
 type SubscriptionFeatures struct {

--- a/internal/provider/features.go
+++ b/internal/provider/features.go
@@ -365,6 +365,12 @@ func schemaFeatures(supportLegacyTestSuite bool) *pluginsdk.Schema {
 						Optional: true,
 						Default:  true,
 					},
+
+					"skip_storing_access_keys": {
+						Type:     pluginsdk.TypeBool,
+						Optional: true,
+						Default:  false,
+					},
 				},
 			},
 		},
@@ -721,6 +727,9 @@ func expandFeatures(input []interface{}) features.UserFeatures {
 			storageRaw := items[0].(map[string]interface{})
 			if v, ok := storageRaw["data_plane_available"]; ok {
 				featuresMap.Storage.DataPlaneAvailable = v.(bool)
+			}
+			if v, ok := storageRaw["skip_storing_access_keys"]; ok {
+				featuresMap.Storage.SkipStoringAccessKeys = v.(bool)
 			}
 		}
 	}

--- a/internal/provider/features_test.go
+++ b/internal/provider/features_test.go
@@ -83,7 +83,8 @@ func TestExpandFeatures(t *testing.T) {
 					RecoverSoftDeletedBackupProtectedVM: true,
 				},
 				Storage: features.StorageFeatures{
-					DataPlaneAvailable: true,
+					DataPlaneAvailable:    true,
+					SkipStoringAccessKeys: false,
 				},
 				Subscription: features.SubscriptionFeatures{
 					PreventCancellationOnDestroy: false,
@@ -178,7 +179,8 @@ func TestExpandFeatures(t *testing.T) {
 					},
 					"storage": []interface{}{
 						map[string]interface{}{
-							"data_plane_available": true,
+							"data_plane_available":     true,
+							"skip_storing_access_keys": true,
 						},
 					},
 					"subscription": []interface{}{
@@ -288,7 +290,8 @@ func TestExpandFeatures(t *testing.T) {
 					RecoverSoftDeletedBackupProtectedVM: true,
 				},
 				Storage: features.StorageFeatures{
-					DataPlaneAvailable: true,
+					DataPlaneAvailable:    true,
+					SkipStoringAccessKeys: true,
 				},
 				Subscription: features.SubscriptionFeatures{
 					PreventCancellationOnDestroy: true,
@@ -397,7 +400,8 @@ func TestExpandFeatures(t *testing.T) {
 					},
 					"storage": []interface{}{
 						map[string]interface{}{
-							"data_plane_available": false,
+							"data_plane_available":     false,
+							"skip_storing_access_keys": false,
 						},
 					},
 					"subscription": []interface{}{
@@ -507,7 +511,8 @@ func TestExpandFeatures(t *testing.T) {
 					RecoverSoftDeletedBackupProtectedVM: false,
 				},
 				Storage: features.StorageFeatures{
-					DataPlaneAvailable: false,
+					DataPlaneAvailable:    false,
+					SkipStoringAccessKeys: false,
 				},
 				Subscription: features.SubscriptionFeatures{
 					PreventCancellationOnDestroy: false,
@@ -1542,24 +1547,27 @@ func TestExpandFeaturesStorage(t *testing.T) {
 			},
 			Expected: features.UserFeatures{
 				Storage: features.StorageFeatures{
-					DataPlaneAvailable: true,
+					DataPlaneAvailable:    true,
+					SkipStoringAccessKeys: false,
 				},
 			},
 		},
 		{
-			Name: "Storage Data Plane on Create is Disabled",
+			Name: "Storage Data Plane on Create is Disabled and Skip Storing Access Keys is Enabled",
 			Input: []interface{}{
 				map[string]interface{}{
 					"storage": []interface{}{
 						map[string]interface{}{
-							"data_plane_available": false,
+							"data_plane_available":     false,
+							"skip_storing_access_keys": true,
 						},
 					},
 				},
 			},
 			Expected: features.UserFeatures{
 				Storage: features.StorageFeatures{
-					DataPlaneAvailable: false,
+					DataPlaneAvailable:    false,
+					SkipStoringAccessKeys: true,
 				},
 			},
 		},

--- a/internal/provider/framework/config.go
+++ b/internal/provider/framework/config.go
@@ -426,6 +426,11 @@ func (p *ProviderConfig) Load(ctx context.Context, data *ProviderModel, tfVersio
 			if !feature[0].DataPlaneAvailable.IsNull() && !feature[0].DataPlaneAvailable.IsUnknown() {
 				f.Storage.DataPlaneAvailable = feature[0].DataPlaneAvailable.ValueBool()
 			}
+
+			f.Storage.SkipStoringAccessKeys = false
+			if !feature[0].SkipStoringAccessKeys.IsNull() && !feature[0].SkipStoringAccessKeys.IsUnknown() {
+				f.Storage.SkipStoringAccessKeys = feature[0].SkipStoringAccessKeys.ValueBool()
+			}
 		}
 
 		if !features.Subscription.IsNull() && !features.Subscription.IsUnknown() {

--- a/internal/provider/framework/config_test.go
+++ b/internal/provider/framework/config_test.go
@@ -306,7 +306,8 @@ func defaultFeaturesList() types.List {
 	managedDiskList, _ := basetypes.NewListValue(types.ObjectType{}.WithAttributeTypes(ManagedDiskAttributes), []attr.Value{managedDisk})
 
 	storage, _ := basetypes.NewObjectValueFrom(context.Background(), StorageAttributes, map[string]attr.Value{
-		"data_plane_available": basetypes.NewBoolNull(),
+		"data_plane_available":     basetypes.NewBoolNull(),
+		"skip_storing_access_keys": basetypes.NewBoolNull(),
 	})
 	storageList, _ := basetypes.NewListValue(types.ObjectType{}.WithAttributeTypes(StorageAttributes), []attr.Value{storage})
 

--- a/internal/provider/framework/model.go
+++ b/internal/provider/framework/model.go
@@ -220,11 +220,13 @@ var ManagedDiskAttributes = map[string]attr.Type{
 }
 
 type Storage struct {
-	DataPlaneAvailable types.Bool `tfsdk:"data_plane_available"`
+	DataPlaneAvailable    types.Bool `tfsdk:"data_plane_available"`
+	SkipStoringAccessKeys types.Bool `tfsdk:"skip_storing_access_keys"`
 }
 
 var StorageAttributes = map[string]attr.Type{
-	"data_plane_available": types.BoolType,
+	"data_plane_available":     types.BoolType,
+	"skip_storing_access_keys": types.BoolType,
 }
 
 type Subscription struct {

--- a/internal/provider/framework/provider.go
+++ b/internal/provider/framework/provider.go
@@ -486,6 +486,9 @@ func (p *azureRmFrameworkProvider) Schema(_ context.Context, _ provider.SchemaRe
 									"data_plane_available": schema.BoolAttribute{
 										Optional: true,
 									},
+									"skip_storing_access_keys": schema.BoolAttribute{
+										Optional: true,
+									},
 								},
 							},
 						},

--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -1818,9 +1818,6 @@ func resourceStorageAccountFlatten(ctx context.Context, d *pluginsdk.ResourceDat
 		return fmt.Errorf("could not determine Storage domain suffix for environment %q", meta.(*clients.Client).Account.Environment.Name)
 	}
 
-	listKeysOpts := storageaccounts.DefaultListKeysOperationOptions()
-	listKeysOpts.Expand = pointer.To(storageaccounts.ExpandKerb)
-
 	supportLevel := storageAccountServiceSupportLevel{
 		supportBlob:          false,
 		supportQueue:         false,
@@ -1980,18 +1977,23 @@ func resourceStorageAccountFlatten(ctx context.Context, d *pluginsdk.ResourceDat
 	endpoints := flattenAccountEndpoints(primaryEndpoints, secondaryEndpoints, routingPreference)
 	endpoints.set(d)
 
-	keys, err := client.ListKeys(ctx, id, listKeysOpts)
-	if err != nil {
-		hasWriteLock := response.WasConflict(keys.HttpResponse)
-		doesntHavePermissions := response.WasForbidden(keys.HttpResponse) || response.WasStatusCode(keys.HttpResponse, http.StatusUnauthorized)
-		if !hasWriteLock && !doesntHavePermissions {
-			return fmt.Errorf("listing Keys for %s: %+v", id, err)
-		}
-	}
-
 	storageAccountKeys := make([]storageaccounts.StorageAccountKey, 0)
-	if keys.Model != nil && keys.Model.Keys != nil {
-		storageAccountKeys = *keys.Model.Keys
+	if !meta.(*clients.Client).Features.Storage.SkipStoringAccessKeys {
+		listKeysOpts := storageaccounts.DefaultListKeysOperationOptions()
+		listKeysOpts.Expand = pointer.To(storageaccounts.ExpandKerb)
+
+		keys, err := client.ListKeys(ctx, id, listKeysOpts)
+		if err != nil {
+			hasWriteLock := response.WasConflict(keys.HttpResponse)
+			doesntHavePermissions := response.WasForbidden(keys.HttpResponse) || response.WasStatusCode(keys.HttpResponse, http.StatusUnauthorized)
+			if !hasWriteLock && !doesntHavePermissions {
+				return fmt.Errorf("listing Keys for %s: %+v", id, err)
+			}
+		}
+
+		if keys.Model != nil && keys.Model.Keys != nil {
+			storageAccountKeys = *keys.Model.Keys
+		}
 	}
 	keysAndConnectionStrings := flattenAccountAccessKeysAndConnectionStrings(id.StorageAccountName, *storageDomainSuffix, storageAccountKeys, endpoints)
 	keysAndConnectionStrings.set(d)

--- a/internal/services/storage/storage_account_resource_test.go
+++ b/internal/services/storage/storage_account_resource_test.go
@@ -1746,6 +1746,47 @@ func TestAccStorageAccount_noDataPlane(t *testing.T) {
 	})
 }
 
+func TestAccStorageAccount_skipStoringAccessKeys(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_account", "test")
+	r := StorageAccountResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.skipStoringAccessKeys(data, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("primary_access_key").IsEmpty(),
+				check.That(data.ResourceName).Key("primary_connection_string").IsEmpty(),
+				check.That(data.ResourceName).Key("secondary_access_key").IsEmpty(),
+				check.That(data.ResourceName).Key("secondary_connection_string").IsEmpty(),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.skipStoringAccessKeys(data, false),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("primary_access_key").IsNotEmpty(),
+				check.That(data.ResourceName).Key("primary_connection_string").IsNotEmpty(),
+				check.That(data.ResourceName).Key("secondary_connection_string").IsNotEmpty(),
+				check.That(data.ResourceName).Key("secondary_access_key").IsNotEmpty(),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.skipStoringAccessKeys(data, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("primary_access_key").IsEmpty(),
+				check.That(data.ResourceName).Key("primary_connection_string").IsEmpty(),
+				check.That(data.ResourceName).Key("secondary_access_key").IsEmpty(),
+				check.That(data.ResourceName).Key("secondary_connection_string").IsEmpty(),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (r StorageAccountResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := commonids.ParseStorageAccountID(state.ID)
 	if err != nil {
@@ -4863,4 +4904,30 @@ resource "azurerm_storage_account" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}
+
+func (r StorageAccountResource) skipStoringAccessKeys(data acceptance.TestData, enabled bool) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    storage {
+      skip_storing_access_keys = %t
+    }
+  }
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-storage-%d"
+  location = "%s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                = "unlikely23exst2acct%s"
+  resource_group_name = azurerm_resource_group.test.name
+
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+`, enabled, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }

--- a/website/docs/guides/features-block.html.markdown
+++ b/website/docs/guides/features-block.html.markdown
@@ -105,6 +105,7 @@ provider "azurerm" {
 
     storage {
       data_plane_available = false
+      skip_storing_access_keys = true
     }
 
     subscription {
@@ -331,6 +332,10 @@ The `storage` block supports the following:
 * `data_plane_available` - Should the `azurerm_storage_account` resource use data plane APIs? Defaults to `true`.
 
 -> **Note:** This feature flag is intended for use with `azurerm_storage_account` resources that will not use the `queue_properties` and `static_website` blocks. Setting this to `false` will bypass availability checks.
+
+* `skip_storing_access_keys` - Should the `azurerm_storage_account` resource avoid storing access keys or connection strings in state? Defaults to `false`.
+
+-> **Note:** Enabling this feature removes access keys and connection strings from the current state during refresh. However, previously stored credentials may remain in historical state versions maintained by the configured backend.
 
 ---
 


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This adds the `skip_storing_access_keys` flag to the provider's storage features so users can prevent access keys and connection strings from being stored in Terraform state.
Since these values are sensitive, it's preferable not to store them unless they're needed.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

```console
$ make acctests SERVICE="storage" TESTARGS='-run=TestAccStorageAccount_skipStoringAccessKeys'
TF_ACC=1 go test -v ./internal/services/storage -run=TestAccStorageAccount_skipStoringAccessKeys -timeout 180m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccStorageAccount_skipStoringAccessKeys
=== PAUSE TestAccStorageAccount_skipStoringAccessKeys
=== CONT  TestAccStorageAccount_skipStoringAccessKeys
--- PASS: TestAccStorageAccount_skipStoringAccessKeys (176.30s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/storage       178.191s
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_storage_account` - add `skip_storing_access_keys` feature flag to omit access keys from state


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #32437


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
