### PR TITLE
regression tests 1/21 - aadb2c, advisor, analysisservices, apimanagement, appconfiguration

### DIFF
--- a/internal/services/aadb2c/aadb2c_directory_data_source_test.go
+++ b/internal/services/aadb2c/aadb2c_directory_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type AadB2cDirectoryDataSource struct{}
 
+func TestAccAadB2cDirectoryDataSource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_aadb2c_directory", "test")
+	r := AadB2cDirectoryDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccAadB2cDirectoryDataSource_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_aadb2c_directory", "test")
 	d := AadB2cDirectoryDataSource{}

--- a/internal/services/aadb2c/aadb2c_directory_resource_test.go
+++ b/internal/services/aadb2c/aadb2c_directory_resource_test.go
@@ -20,6 +20,16 @@ import (
 
 type AadB2cDirectoryResource struct{}
 
+func TestAccAadB2cDirectoryResource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_aadb2c_directory", "test")
+	r := AadB2cDirectoryResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccAadB2cDirectoryResource_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_aadb2c_directory", "test")
 	r := AadB2cDirectoryResource{}

--- a/internal/services/advisor/advisor_recommendations_data_source_test.go
+++ b/internal/services/advisor/advisor_recommendations_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type AdvisorRecommendationsDataSourceTests struct{}
 
+func TestAccAdvisorRecommendationsDataSource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_advisor_recommendations", "test")
+	r := AdvisorRecommendationsDataSourceTests{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.completeConfig(data),
+		},
+	}, "")
+}
+
 func TestAccAdvisorRecommendationsDataSource_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_advisor_recommendations", "test")
 

--- a/internal/services/advisor/advisor_suppression_resource_test.go
+++ b/internal/services/advisor/advisor_suppression_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type AdvisorSuppressionResource struct{}
 
+func TestAccAnalysisServicesServer_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_advisor_suppression", "test")
+	r := AdvisorSuppressionResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccAnalysisServicesServer_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_advisor_suppression", "test")
 	r := AdvisorSuppressionResource{}

--- a/internal/services/analysisservices/analysis_services_server_resource_test.go
+++ b/internal/services/analysisservices/analysis_services_server_resource_test.go
@@ -21,6 +21,16 @@ import (
 
 type AnalysisServicesServerResource struct{}
 
+func TestAccAnalysisServicesServer_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_analysis_services_server", "test")
+	r := AnalysisServicesServerResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccAnalysisServicesServer_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_analysis_services_server", "test")
 	r := AnalysisServicesServerResource{}

--- a/internal/services/apimanagement/api_management_api_data_source_test.go
+++ b/internal/services/apimanagement/api_management_api_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type ApiManagementApiDataSourceResource struct{}
 
+func TestAccDataSourceAzureRMApiManagementApi_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_api_management_api", "test")
+	r := ApiManagementApiDataSourceResource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccDataSourceAzureRMApiManagementApi_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_api_management_api", "test")
 	r := ApiManagementApiDataSourceResource{}

--- a/internal/services/apimanagement/api_management_api_diagnostic_resource_test.go
+++ b/internal/services/apimanagement/api_management_api_diagnostic_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type ApiManagementApiDiagnosticResource struct{}
 
+func TestAccApiManagementApiDiagnostic_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_api_diagnostic", "test")
+	r := ApiManagementApiDiagnosticResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccApiManagementApiDiagnostic_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_api_diagnostic", "test")
 	r := ApiManagementApiDiagnosticResource{}

--- a/internal/services/apimanagement/api_management_api_operation_policy_resource_test.go
+++ b/internal/services/apimanagement/api_management_api_operation_policy_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type ApiManagementApiOperationPolicyResource struct{}
 
+func TestAccApiManagementAPIOperationPolicy_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_api_operation_policy", "test")
+	r := ApiManagementApiOperationPolicyResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccApiManagementAPIOperationPolicy_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_api_operation_policy", "test")
 	r := ApiManagementApiOperationPolicyResource{}

--- a/internal/services/apimanagement/api_management_api_operation_resource_test.go
+++ b/internal/services/apimanagement/api_management_api_operation_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type ApiManagementApiOperationResource struct{}
 
+func TestAccApiManagementApiOperation_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_api_operation", "test")
+	r := ApiManagementApiOperationResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccApiManagementApiOperation_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_api_operation", "test")
 	r := ApiManagementApiOperationResource{}

--- a/internal/services/apimanagement/api_management_api_operation_tag_resource_test.go
+++ b/internal/services/apimanagement/api_management_api_operation_tag_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type ApiManagementApiOperationTagResource struct{}
 
+func TestAccApiManagementApiOperationTag_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_api_operation_tag", "test")
+	r := ApiManagementApiOperationTagResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccApiManagementApiOperationTag_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_api_operation_tag", "test")
 	r := ApiManagementApiOperationTagResource{}

--- a/internal/services/apimanagement/api_management_api_policy_resource_test.go
+++ b/internal/services/apimanagement/api_management_api_policy_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type ApiManagementApiPolicyResource struct{}
 
+func TestAccApiManagementAPIPolicy_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_api_policy", "test")
+	r := ApiManagementApiPolicyResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccApiManagementAPIPolicy_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_api_policy", "test")
 	r := ApiManagementApiPolicyResource{}

--- a/internal/services/apimanagement/api_management_api_release_resource_test.go
+++ b/internal/services/apimanagement/api_management_api_release_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type ApiManagementApiReleaseResource struct{}
 
+func TestAccApiManagementApiRelease_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_api_release", "test")
+	r := ApiManagementApiReleaseResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccApiManagementApiRelease_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_api_release", "test")
 	r := ApiManagementApiReleaseResource{}

--- a/internal/services/apimanagement/api_management_api_resource_test.go
+++ b/internal/services/apimanagement/api_management_api_resource_test.go
@@ -24,6 +24,16 @@ const (
 	SkuNameDeveloper   = "Developer_1"
 )
 
+func TestAccApiManagementApi_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_api", "test")
+	r := ApiManagementApiResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccApiManagementApi_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_api", "test")
 	r := ApiManagementApiResource{}

--- a/internal/services/apimanagement/api_management_api_schema_resource_test.go
+++ b/internal/services/apimanagement/api_management_api_schema_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type ApiManagementApiSchemaResource struct{}
 
+func TestAccApiManagementApiSchema_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_api_schema", "test")
+	r := ApiManagementApiSchemaResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccApiManagementApiSchema_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_api_schema", "test")
 	r := ApiManagementApiSchemaResource{}

--- a/internal/services/apimanagement/api_management_api_tag_description_resource_test.go
+++ b/internal/services/apimanagement/api_management_api_tag_description_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type ApiManagementApiTagDescriptionResource struct{}
 
+func TestAccApiManagementApiTagDescription_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_api_tag_description", "test")
+	r := ApiManagementApiTagDescriptionResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccApiManagementApiTagDescription_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_api_tag_description", "test")
 	r := ApiManagementApiTagDescriptionResource{}

--- a/internal/services/apimanagement/api_management_api_tag_resource_test.go
+++ b/internal/services/apimanagement/api_management_api_tag_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type ApiManagementApiTagResource struct{}
 
+func TestAccApiManagementApiTag_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_api_tag", "test")
+	r := ApiManagementApiTagResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccApiManagementApiTag_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_api_tag", "test")
 	r := ApiManagementApiTagResource{}

--- a/internal/services/apimanagement/api_management_api_version_set_data_source_test.go
+++ b/internal/services/apimanagement/api_management_api_version_set_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type ApiManagementApiVersionSetDataSource struct{}
 
+func TestAccDataSourceApiManagementApiVersionSet_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_api_management_api_version_set", "test")
+	r := ApiManagementApiVersionSetDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccDataSourceApiManagementApiVersionSet_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_api_management_api_version_set", "test")
 	r := ApiManagementApiVersionSetDataSource{}

--- a/internal/services/apimanagement/api_management_api_version_set_resource_test.go
+++ b/internal/services/apimanagement/api_management_api_version_set_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type ApiManagementApiVersionSetResource struct{}
 
+func TestAccApiManagementApiVersionSet_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_api_version_set", "test")
+	r := ApiManagementApiVersionSetResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccApiManagementApiVersionSet_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_api_version_set", "test")
 	r := ApiManagementApiVersionSetResource{}

--- a/internal/services/apimanagement/api_management_authorization_server_resource_test.go
+++ b/internal/services/apimanagement/api_management_authorization_server_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type ApiManagementAuthorizationServerResource struct{}
 
+func TestAccApiManagementAuthorizationServer_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_authorization_server", "test")
+	r := ApiManagementAuthorizationServerResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccApiManagementAuthorizationServer_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_authorization_server", "test")
 	r := ApiManagementAuthorizationServerResource{}

--- a/internal/services/apimanagement/api_management_backend_resource_test.go
+++ b/internal/services/apimanagement/api_management_backend_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type ApiManagementAuthorizationBackendResource struct{}
 
+func TestAccApiManagementBackend_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_backend", "test")
+	r := ApiManagementAuthorizationBackendResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.circuitBreakerRuleComplete(data),
+		},
+	}, "")
+}
+
 func TestAccApiManagementBackend_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_backend", "test")
 	r := ApiManagementAuthorizationBackendResource{}

--- a/internal/services/apimanagement/api_management_certificate_resource_test.go
+++ b/internal/services/apimanagement/api_management_certificate_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type ApiManagementCertificateResource struct{}
 
+func TestAccApiManagementCertificate_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_certificate", "test")
+	r := ApiManagementCertificateResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccApiManagementCertificate_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_certificate", "test")
 	r := ApiManagementCertificateResource{}

--- a/internal/services/apimanagement/api_management_custom_domain_resource_test.go
+++ b/internal/services/apimanagement/api_management_custom_domain_resource_test.go
@@ -20,6 +20,16 @@ import (
 
 type ApiManagementCustomDomainResource struct{}
 
+func TestAccApiManagementCustomDomain_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_custom_domain", "test")
+	r := ApiManagementCustomDomainResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccApiManagementCustomDomain_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_custom_domain", "test")
 	r := ApiManagementCustomDomainResource{}

--- a/internal/services/apimanagement/api_management_data_source_test.go
+++ b/internal/services/apimanagement/api_management_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type ApiManagementDataSource struct{}
 
+func TestAccDataSourceApiManagement_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_api_management", "test")
+	r := ApiManagementDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccDataSourceApiManagement_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_api_management", "test")
 	r := ApiManagementDataSource{}

--- a/internal/services/apimanagement/api_management_diagnostic_resource_test.go
+++ b/internal/services/apimanagement/api_management_diagnostic_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type ApiManagementDiagnosticResource struct{}
 
+func TestAccApiManagementDiagnostic_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_diagnostic", "test")
+	r := ApiManagementDiagnosticResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccApiManagementDiagnostic_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_diagnostic", "test")
 	r := ApiManagementDiagnosticResource{}

--- a/internal/services/apimanagement/api_management_email_template_resource_test.go
+++ b/internal/services/apimanagement/api_management_email_template_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type ApiManagementEmailTemplateResource struct{}
 
+func TestAccApiManagementEmailTemplate_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_email_template", "test")
+	r := ApiManagementEmailTemplateResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccApiManagementEmailTemplate_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_email_template", "test")
 	r := ApiManagementEmailTemplateResource{}

--- a/internal/services/apimanagement/api_management_gateway_api_resource_test.go
+++ b/internal/services/apimanagement/api_management_gateway_api_resource_test.go
@@ -20,6 +20,16 @@ import (
 
 type ApiManagementGatewayAPIResource struct{}
 
+func TestAccApiManagementGatewayApi_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_gateway_api", "test")
+	r := ApiManagementGatewayAPIResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccApiManagementGatewayApi_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_gateway_api", "test")
 	r := ApiManagementGatewayAPIResource{}

--- a/internal/services/apimanagement/api_management_gateway_certificate_authority_resource_test.go
+++ b/internal/services/apimanagement/api_management_gateway_certificate_authority_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type ApiManagementGatewayCertificateAuthorityResource struct{}
 
+func TestAccApiManagementGatewayCertificateAuthority_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_gateway_certificate_authority", "test")
+	r := ApiManagementGatewayCertificateAuthorityResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccApiManagementGatewayCertificateAuthority_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_gateway_certificate_authority", "test")
 	r := ApiManagementGatewayCertificateAuthorityResource{}

--- a/internal/services/apimanagement/api_management_gateway_data_source_test.go
+++ b/internal/services/apimanagement/api_management_gateway_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type ApiManagementGatewayDataSource struct{}
 
+func TestAccDataSourceApiManagementGateway_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_api_management_gateway", "test")
+	r := ApiManagementGatewayDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccDataSourceApiManagementGateway_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_api_management_gateway", "test")
 	r := ApiManagementGatewayDataSource{}

--- a/internal/services/apimanagement/api_management_gateway_host_name_configuration_data_source_test.go
+++ b/internal/services/apimanagement/api_management_gateway_host_name_configuration_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type ApiManagementGatewayHostnameConfigurationDataSource struct{}
 
+func TestAccDataSourceApiManagementGatewayHostnameConfiguration_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_api_management_gateway_host_name_configuration", "test")
+	r := ApiManagementGatewayHostnameConfigurationDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccDataSourceApiManagementGatewayHostnameConfiguration_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_api_management_gateway_host_name_configuration", "test")
 	r := ApiManagementGatewayHostnameConfigurationDataSource{}

--- a/internal/services/apimanagement/api_management_gateway_host_name_configuration_resource_test.go
+++ b/internal/services/apimanagement/api_management_gateway_host_name_configuration_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type ApiManagementGatewayHostNameConfigurationResource struct{}
 
+func TestAccApiManagementGatewayHostNameConfiguration_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_gateway_host_name_configuration", "test")
+	r := ApiManagementGatewayHostNameConfigurationResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccApiManagementGatewayHostNameConfiguration_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_gateway_host_name_configuration", "test")
 	r := ApiManagementGatewayHostNameConfigurationResource{}

--- a/internal/services/apimanagement/api_management_gateway_resource_test.go
+++ b/internal/services/apimanagement/api_management_gateway_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type ApiManagementGatewayResource struct{}
 
+func TestAccApiManagementGateway_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_gateway", "test")
+	r := ApiManagementGatewayResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccApiManagementGateway_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_gateway", "test")
 	r := ApiManagementGatewayResource{}

--- a/internal/services/apimanagement/api_management_global_schema_resource_test.go
+++ b/internal/services/apimanagement/api_management_global_schema_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type ApiManagementGlobalSchemaResource struct{}
 
+func TestAccApiManagementGlobalSchema_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_global_schema", "test")
+	r := ApiManagementGlobalSchemaResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccApiManagementGlobalSchema_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_global_schema", "test")
 	r := ApiManagementGlobalSchemaResource{}

--- a/internal/services/apimanagement/api_management_group_data_source_test.go
+++ b/internal/services/apimanagement/api_management_group_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type ApiManagementGroupDataSource struct{}
 
+func TestAccDataSourceApiManagementGroup_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_api_management_group", "test")
+	r := ApiManagementGroupDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccDataSourceApiManagementGroup_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_api_management_group", "test")
 	r := ApiManagementGroupDataSource{}

--- a/internal/services/apimanagement/api_management_group_resource_test.go
+++ b/internal/services/apimanagement/api_management_group_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type ApiManagementGroupResource struct{}
 
+func TestAccApiManagementGroup_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_group", "test")
+	r := ApiManagementGroupResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccApiManagementGroup_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_group", "test")
 	r := ApiManagementGroupResource{}

--- a/internal/services/apimanagement/api_management_group_user_resource_test.go
+++ b/internal/services/apimanagement/api_management_group_user_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type ApiManagementGroupUserResource struct{}
 
+func TestAccAzureRMApiManagementGroupUser_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_group_user", "test")
+	r := ApiManagementGroupUserResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccAzureRMApiManagementGroupUser_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_group_user", "test")
 	r := ApiManagementGroupUserResource{}

--- a/internal/services/apimanagement/api_management_identity_provider_aad_resource_test.go
+++ b/internal/services/apimanagement/api_management_identity_provider_aad_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type ApiManagementIdentityProviderAADResource struct{}
 
+func TestAccApiManagementIdentityProviderAAD_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_identity_provider_aad", "test")
+	r := ApiManagementIdentityProviderAADResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccApiManagementIdentityProviderAAD_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_identity_provider_aad", "test")
 	r := ApiManagementIdentityProviderAADResource{}

--- a/internal/services/apimanagement/api_management_identity_provider_aadb2c_resource_test.go
+++ b/internal/services/apimanagement/api_management_identity_provider_aadb2c_resource_test.go
@@ -29,6 +29,18 @@ Accordingly, these tests rely on additional environment variables to be set (and
 
 type ApiManagementIdentityProviderAADB2CResource struct{}
 
+func TestAccAzureRMApiManagementIdentityProviderAADB2C_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_identity_provider_aadb2c", "test")
+	r := ApiManagementIdentityProviderAADB2CResource{}
+	b2cConfig := testAccAzureRMApiManagementIdentityProviderAADB2C_getB2CConfig(t)
+
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data, b2cConfig),
+		},
+	}, "")
+}
+
 func TestAccAzureRMApiManagementIdentityProviderAADB2C_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_identity_provider_aadb2c", "test")
 	r := ApiManagementIdentityProviderAADB2CResource{}

--- a/internal/services/apimanagement/api_management_identity_provider_facebook_resource_test.go
+++ b/internal/services/apimanagement/api_management_identity_provider_facebook_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type ApiManagementIdentityProviderFacebookResource struct{}
 
+func TestAccApiManagementIdentityProviderFacebook_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_identity_provider_facebook", "test")
+	r := ApiManagementIdentityProviderFacebookResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccApiManagementIdentityProviderFacebook_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_identity_provider_facebook", "test")
 	r := ApiManagementIdentityProviderFacebookResource{}

--- a/internal/services/apimanagement/api_management_identity_provider_google_resource_test.go
+++ b/internal/services/apimanagement/api_management_identity_provider_google_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type ApiManagementIdentityProviderGoogleResource struct{}
 
+func TestAccApiManagementIdentityProviderGoogle_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_identity_provider_google", "test")
+	r := ApiManagementIdentityProviderGoogleResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccApiManagementIdentityProviderGoogle_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_identity_provider_google", "test")
 	r := ApiManagementIdentityProviderGoogleResource{}

--- a/internal/services/apimanagement/api_management_identity_provider_microsoft_resource_test.go
+++ b/internal/services/apimanagement/api_management_identity_provider_microsoft_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type ApiManagementIdentityProviderMicrosoftResource struct{}
 
+func TestAccApiManagementIdentityProviderMicrosoft_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_identity_provider_microsoft", "test")
+	r := ApiManagementIdentityProviderMicrosoftResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccApiManagementIdentityProviderMicrosoft_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_identity_provider_microsoft", "test")
 	r := ApiManagementIdentityProviderMicrosoftResource{}

--- a/internal/services/apimanagement/api_management_identity_provider_twitter_resource_test.go
+++ b/internal/services/apimanagement/api_management_identity_provider_twitter_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type ApiManagementIdentityProviderTwitterResource struct{}
 
+func TestAccApiManagementIdentityProviderTwitter_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_identity_provider_twitter", "test")
+	r := ApiManagementIdentityProviderTwitterResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccApiManagementIdentityProviderTwitter_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_identity_provider_twitter", "test")
 	r := ApiManagementIdentityProviderTwitterResource{}

--- a/internal/services/apimanagement/api_management_logger_resource_test.go
+++ b/internal/services/apimanagement/api_management_logger_resource_test.go
@@ -20,6 +20,16 @@ import (
 
 type ApiManagementLoggerResource struct{}
 
+func TestAccApiManagementLogger_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_logger", "test")
+	r := ApiManagementLoggerResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicEventHub(data),
+		},
+	}, "")
+}
+
 func TestAccApiManagementLogger_basicEventHub(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_logger", "test")
 	r := ApiManagementLoggerResource{}

--- a/internal/services/apimanagement/api_management_named_value_resource_test.go
+++ b/internal/services/apimanagement/api_management_named_value_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type ApiManagementNamedValueResource struct{}
 
+func TestAccApiManagementNamedValue_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_named_value", "test")
+	r := ApiManagementNamedValueResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccApiManagementNamedValue_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_named_value", "test")
 	r := ApiManagementNamedValueResource{}

--- a/internal/services/apimanagement/api_management_notification_recipient_email_resource_test.go
+++ b/internal/services/apimanagement/api_management_notification_recipient_email_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type ApiManagementNotificationRecipientEmailResource struct{}
 
+func TestAccApiManagementNotificationRecipientEmail_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_notification_recipient_email", "test")
+	r := ApiManagementNotificationRecipientEmailResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccApiManagementNotificationRecipientEmail_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_notification_recipient_email", "test")
 	r := ApiManagementNotificationRecipientEmailResource{}

--- a/internal/services/apimanagement/api_management_notification_recipient_user_resource_test.go
+++ b/internal/services/apimanagement/api_management_notification_recipient_user_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type ApiManagementNotificationRecipientUserResource struct{}
 
+func TestAccApiManagementNotificationRecipientUser_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_notification_recipient_user", "test")
+	r := ApiManagementNotificationRecipientUserResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccApiManagementNotificationRecipientUser_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_notification_recipient_user", "test")
 	r := ApiManagementNotificationRecipientUserResource{}

--- a/internal/services/apimanagement/api_management_openid_connect_provider_resource_test.go
+++ b/internal/services/apimanagement/api_management_openid_connect_provider_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type ApiManagementOpenIDConnectProviderResource struct{}
 
+func TestAccApiManagementOpenIDConnectProvider_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_openid_connect_provider", "test")
+	r := ApiManagementOpenIDConnectProviderResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccApiManagementOpenIDConnectProvider_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_openid_connect_provider", "test")
 	r := ApiManagementOpenIDConnectProviderResource{}

--- a/internal/services/apimanagement/api_management_policy_fragment_resource_test.go
+++ b/internal/services/apimanagement/api_management_policy_fragment_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type ApiManagementPolicyFragmentResource struct{}
 
+func TestAccApiManagementPolicyFragment_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_policy_fragment", "test")
+	r := ApiManagementPolicyFragmentResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccApiManagementPolicyFragment_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_policy_fragment", "test")
 	r := ApiManagementPolicyFragmentResource{}

--- a/internal/services/apimanagement/api_management_policy_resource_test.go
+++ b/internal/services/apimanagement/api_management_policy_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type ApiManagementPolicyResource struct{}
 
+func TestAccApiManagementPolicy_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_policy", "test")
+	r := ApiManagementPolicyResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccApiManagementPolicy_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_policy", "test")
 	r := ApiManagementPolicyResource{}

--- a/internal/services/apimanagement/api_management_product_api_resource_test.go
+++ b/internal/services/apimanagement/api_management_product_api_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type ApiManagementProductAPIResource struct{}
 
+func TestAccApiManagementProductApi_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_product_api", "test")
+	r := ApiManagementProductAPIResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccApiManagementProductApi_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_product_api", "test")
 	r := ApiManagementProductAPIResource{}

--- a/internal/services/apimanagement/api_management_product_data_source_test.go
+++ b/internal/services/apimanagement/api_management_product_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type ApiManagementProductDataSource struct{}
 
+func TestAccDataSourceApiManagementProduct_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_api_management_product", "test")
+	r := ApiManagementProductDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccDataSourceApiManagementProduct_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_api_management_product", "test")
 	r := ApiManagementProductDataSource{}

--- a/internal/services/apimanagement/api_management_product_group_resource_test.go
+++ b/internal/services/apimanagement/api_management_product_group_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type ApiManagementProductGroupResource struct{}
 
+func TestAccApiManagementProductGroup_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_product_group", "test")
+	r := ApiManagementProductGroupResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccApiManagementProductGroup_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_product_group", "test")
 	r := ApiManagementProductGroupResource{}

--- a/internal/services/apimanagement/api_management_product_policy_resource_test.go
+++ b/internal/services/apimanagement/api_management_product_policy_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type ApiManagementProductPolicyResource struct{}
 
+func TestAccApiManagementProductPolicy_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_product_policy", "test")
+	r := ApiManagementProductPolicyResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccApiManagementProductPolicy_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_product_policy", "test")
 	r := ApiManagementProductPolicyResource{}

--- a/internal/services/apimanagement/api_management_product_resource_test.go
+++ b/internal/services/apimanagement/api_management_product_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type ApiManagementProductResource struct{}
 
+func TestAccApiManagementProduct_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_product", "test")
+	r := ApiManagementProductResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccApiManagementProduct_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_product", "test")
 	r := ApiManagementProductResource{}

--- a/internal/services/apimanagement/api_management_product_tag_resource_test.go
+++ b/internal/services/apimanagement/api_management_product_tag_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type ApiManagementProductTagResource struct{}
 
+func TestAccApiManagementProductTag_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_product_tag", "test")
+	r := ApiManagementProductTagResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccApiManagementProductTag_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_product_tag", "test")
 	r := ApiManagementProductTagResource{}

--- a/internal/services/apimanagement/api_management_redis_cache_resource_test.go
+++ b/internal/services/apimanagement/api_management_redis_cache_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type ApimanagementRedisCacheResource struct{}
 
+func TestAccApiManagementRedisCache_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_redis_cache", "test")
+	r := ApimanagementRedisCacheResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccApiManagementRedisCache_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_redis_cache", "test")
 	r := ApimanagementRedisCacheResource{}

--- a/internal/services/apimanagement/api_management_resource_test.go
+++ b/internal/services/apimanagement/api_management_resource_test.go
@@ -23,6 +23,16 @@ import (
 
 type ApiManagementResource struct{}
 
+func TestAccApiManagement_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management", "test")
+	r := ApiManagementResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccApiManagement_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management", "test")
 	r := ApiManagementResource{}

--- a/internal/services/apimanagement/api_management_standalone_gateway_resource_test.go
+++ b/internal/services/apimanagement/api_management_standalone_gateway_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type ApiManagementStandaloneGatewayResource struct{}
 
+func TestAccApiManagementStandaloneGateway_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_standalone_gateway", "test")
+	r := ApiManagementStandaloneGatewayResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccApiManagementStandaloneGateway_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_standalone_gateway", "test")
 	r := ApiManagementStandaloneGatewayResource{}

--- a/internal/services/apimanagement/api_management_subscription_data_source_test.go
+++ b/internal/services/apimanagement/api_management_subscription_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type ApiManagementSubscriptionDataSource struct{}
 
+func TestAccDataSourceApiManagementSubscription_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_api_management_subscription", "test")
+	r := ApiManagementSubscriptionDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccDataSourceApiManagementSubscription_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_api_management_subscription", "test")
 	r := ApiManagementSubscriptionDataSource{}

--- a/internal/services/apimanagement/api_management_subscription_resource_test.go
+++ b/internal/services/apimanagement/api_management_subscription_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type ApiManagementSubscriptionResource struct{}
 
+func TestAccApiManagementSubscription_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_subscription", "test")
+	r := ApiManagementSubscriptionResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccApiManagementSubscription_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_subscription", "test")
 	r := ApiManagementSubscriptionResource{}

--- a/internal/services/apimanagement/api_management_tag_resource_test.go
+++ b/internal/services/apimanagement/api_management_tag_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type ApiManagementTagResource struct{}
 
+func TestAccApiManagementTag_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_tag", "test")
+	r := ApiManagementTagResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccApiManagementTag_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_tag", "test")
 	r := ApiManagementTagResource{}

--- a/internal/services/apimanagement/api_management_user_data_source_test.go
+++ b/internal/services/apimanagement/api_management_user_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type ApiManagementUserDataSource struct{}
 
+func TestAccDataSourceApiManagementUser_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_api_management_user", "test")
+	r := ApiManagementUserDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccDataSourceApiManagementUser_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_api_management_user", "test")
 	r := ApiManagementUserDataSource{}

--- a/internal/services/apimanagement/api_management_user_resource_test.go
+++ b/internal/services/apimanagement/api_management_user_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type ApiManagementUserResource struct{}
 
+func TestAccApiManagementUser_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_user", "test")
+	r := ApiManagementUserResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccApiManagementUser_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_user", "test")
 	r := ApiManagementUserResource{}

--- a/internal/services/apimanagement/api_management_workspace_api_version_set_resource_test.go
+++ b/internal/services/apimanagement/api_management_workspace_api_version_set_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type ApiManagementWorkspaceApiVersionSetResource struct{}
 
+func TestAccApiManagementWorkspaceApiVersionSet_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_workspace_api_version_set", "test")
+	r := ApiManagementWorkspaceApiVersionSetResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccApiManagementWorkspaceApiVersionSet_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_workspace_api_version_set", "test")
 	r := ApiManagementWorkspaceApiVersionSetResource{}

--- a/internal/services/apimanagement/api_management_workspace_certificate_resource_test.go
+++ b/internal/services/apimanagement/api_management_workspace_certificate_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type ApiManagementWorkspaceCertificateResource struct{}
 
+func TestAccApiManagementWorkspaceCertificate_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_workspace_certificate", "test")
+	r := ApiManagementWorkspaceCertificateResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccApiManagementWorkspaceCertificate_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_workspace_certificate", "test")
 	r := ApiManagementWorkspaceCertificateResource{}

--- a/internal/services/apimanagement/api_management_workspace_data_source_test.go
+++ b/internal/services/apimanagement/api_management_workspace_data_source_test.go
@@ -10,6 +10,16 @@ import (
 
 type ApiManagementWorkspaceDataSource struct{}
 
+func TestAccDataSourceApiManagementWorkspace_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_api_management_workspace", "test")
+	r := ApiManagementWorkspaceDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccDataSourceApiManagementWorkspace_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_api_management_workspace", "test")
 	r := ApiManagementWorkspaceDataSource{}

--- a/internal/services/apimanagement/api_management_workspace_named_value_resource_test.go
+++ b/internal/services/apimanagement/api_management_workspace_named_value_resource_test.go
@@ -16,6 +16,16 @@ import (
 
 type ApiManagementWorkspaceNamedValueResource struct{}
 
+func TestAccApiManagementWorkspaceNamedValue_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_workspace_named_value", "test")
+	r := ApiManagementWorkspaceNamedValueResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccApiManagementWorkspaceNamedValue_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_workspace_named_value", "test")
 	r := ApiManagementWorkspaceNamedValueResource{}

--- a/internal/services/apimanagement/api_management_workspace_policy_fragment_resource_test.go
+++ b/internal/services/apimanagement/api_management_workspace_policy_fragment_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type ApiManagementWorkspacePolicyFragmentTestResource struct{}
 
+func TestAccApiManagementWorkspacePolicyFragment_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_workspace_policy_fragment", "test")
+	r := ApiManagementWorkspacePolicyFragmentTestResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccApiManagementWorkspacePolicyFragment_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_workspace_policy_fragment", "test")
 	r := ApiManagementWorkspacePolicyFragmentTestResource{}

--- a/internal/services/apimanagement/api_management_workspace_policy_resource_test.go
+++ b/internal/services/apimanagement/api_management_workspace_policy_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type ApiManagementWorkspacePolicyTestResource struct{}
 
+func TestAccApiManagementWorkspacePolicy_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_workspace_policy", "test")
+	r := ApiManagementWorkspacePolicyTestResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccApiManagementWorkspacePolicy_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_workspace_policy", "test")
 	r := ApiManagementWorkspacePolicyTestResource{}

--- a/internal/services/apimanagement/api_management_workspace_resource_test.go
+++ b/internal/services/apimanagement/api_management_workspace_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type ApiManagementWorkspaceTestResource struct{}
 
+func TestAccApiManagementWorkspace_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_workspace", "test")
+	r := ApiManagementWorkspaceTestResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccApiManagementWorkspace_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_workspace", "test")
 	r := ApiManagementWorkspaceTestResource{}

--- a/internal/services/appconfiguration/app_configuration_data_source_test.go
+++ b/internal/services/appconfiguration/app_configuration_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type AppConfigurationDataSource struct{}
 
+func TestAccAppConfigurationDataSource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_app_configuration", "test")
+	r := AppConfigurationDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccAppConfigurationDataSource_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_app_configuration", "test")
 

--- a/internal/services/appconfiguration/app_configuration_feature_resource_test.go
+++ b/internal/services/appconfiguration/app_configuration_feature_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type AppConfigurationFeatureResource struct{}
 
+func TestAccAppConfigurationFeature_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_app_configuration_feature", "test")
+	r := AppConfigurationFeatureResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccAppConfigurationFeature_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_app_configuration_feature", "test")
 	r := AppConfigurationFeatureResource{}

--- a/internal/services/appconfiguration/app_configuration_key_data_source_test.go
+++ b/internal/services/appconfiguration/app_configuration_key_data_source_test.go
@@ -14,6 +14,16 @@ import (
 
 type AppConfigurationKeyDataSource struct{}
 
+func TestAccAppConfigurationKeyDataSource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_app_configuration_key", "test")
+	r := AppConfigurationKeyDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccAppConfigurationKeyDataSource_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_app_configuration_key", "test")
 	d := AppConfigurationKeyDataSource{}

--- a/internal/services/appconfiguration/app_configuration_key_resource_test.go
+++ b/internal/services/appconfiguration/app_configuration_key_resource_test.go
@@ -20,6 +20,16 @@ import (
 
 type AppConfigurationKeyResource struct{}
 
+func TestAccAppConfigurationKey_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_app_configuration_key", "test")
+	r := AppConfigurationKeyResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccAppConfigurationKey_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_app_configuration_key", "test")
 	r := AppConfigurationKeyResource{}

--- a/internal/services/appconfiguration/app_configuration_keys_data_source_test.go
+++ b/internal/services/appconfiguration/app_configuration_keys_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type AppConfigurationKeysDataSource struct{}
 
+func TestAccAppConfigurationKeysDataSource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_app_configuration_keys", "test")
+	r := AppConfigurationKeysDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.allKeys(data),
+		},
+	}, "")
+}
+
 func TestAccAppConfigurationKeysDataSource_allkeys(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_app_configuration_keys", "test")
 	d := AppConfigurationKeysDataSource{}

--- a/internal/services/appconfiguration/app_configuration_resource_test.go
+++ b/internal/services/appconfiguration/app_configuration_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type AppConfigurationResource struct{}
 
+func TestAccAppConfiguration_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_app_configuration", "test")
+	r := AppConfigurationResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccAppConfiguration_free(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_app_configuration", "test")
 	r := AppConfigurationResource{}


### PR DESCRIPTION
Adds per-resource/data-source regression tests (pattern from #33087) to the aadb2c, advisor, analysisservices, apimanagement and appconfiguration services — 75 files, one ~10-line `_regressionTest` per resource/data source, reusing each file's `complete`/`basic` (or primary) config.

Part 1 of ~21 rolling this out provider-wide. No skip/preCheck gating is added to the regression tests for now; that may be revisited via an azproviderlint check later.