### PR TITLE
regression tests 2/21 - applicationinsights, appservice, arckubernetes, arcresourcebridge, attestation, authorization, automanage

### DIFF
--- a/internal/services/applicationinsights/application_insights_analytics_item_resource_test.go
+++ b/internal/services/applicationinsights/application_insights_analytics_item_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type AppInsightsAnalyticsItemResource struct{}
 
+func TestAccApplicationInsightsAnalyticsItem_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_application_insights_analytics_item", "test")
+	r := AppInsightsAnalyticsItemResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccApplicationInsightsAnalyticsItem_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_application_insights_analytics_item", "test")
 	r := AppInsightsAnalyticsItemResource{}

--- a/internal/services/applicationinsights/application_insights_api_key_resource_test.go
+++ b/internal/services/applicationinsights/application_insights_api_key_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type AppInsightsAPIKey struct{}
 
+func TestAccApplicationInsightsAPIKey_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_application_insights_api_key", "test")
+	r := AppInsightsAPIKey{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.multipleKeys(data),
+		},
+	}, "")
+}
+
 func TestAccApplicationInsightsAPIKey_no_permission(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_application_insights_api_key", "test")
 	r := AppInsightsAPIKey{}

--- a/internal/services/applicationinsights/application_insights_data_source_test.go
+++ b/internal/services/applicationinsights/application_insights_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type AppInsightsDataSource struct{}
 
+func TestAccApplicationInsightsDataSource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_application_insights", "test")
+	r := AppInsightsDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccApplicationInsightsDataSource_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_application_insights", "test")
 

--- a/internal/services/applicationinsights/application_insights_resource_test.go
+++ b/internal/services/applicationinsights/application_insights_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type ApplicationInsightsResource struct{}
 
+func TestAccApplicationInsights_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_application_insights", "test")
+	r := ApplicationInsightsResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicWorkspaceMode(data),
+		},
+	}, "")
+}
+
 func TestAccApplicationInsights_basicWeb(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_application_insights", "test")
 	r := ApplicationInsightsResource{}

--- a/internal/services/applicationinsights/application_insights_smart_detection_rule_resource_test.go
+++ b/internal/services/applicationinsights/application_insights_smart_detection_rule_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type AppInsightsSmartDetectionRule struct{}
 
+func TestAccApplicationInsightsSmartDetectionRule_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_application_insights_smart_detection_rule", "test")
+	r := AppInsightsSmartDetectionRule{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccApplicationInsightsSmartDetectionRule_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_application_insights_smart_detection_rule", "test")
 	r := AppInsightsSmartDetectionRule{}

--- a/internal/services/applicationinsights/application_insights_standard_web_test_resource_test.go
+++ b/internal/services/applicationinsights/application_insights_standard_web_test_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type ApplicationInsightsStandardWebTestResource struct{}
 
+func TestAccApplicationInsightsStandardWebTest_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_application_insights_standard_web_test", "test")
+	r := ApplicationInsightsStandardWebTestResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicConfig(data),
+		},
+	}, "")
+}
+
 func TestAccApplicationInsightsStandardWebTest_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_application_insights_standard_web_test", "test")
 	r := ApplicationInsightsStandardWebTestResource{}

--- a/internal/services/applicationinsights/application_insights_web_test_resource_test.go
+++ b/internal/services/applicationinsights/application_insights_web_test_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type ApplicationInsightsWebTestResource struct{}
 
+func TestAccApplicationInsightsWebTests_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_application_insights_web_test", "test")
+	r := ApplicationInsightsWebTestResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccApplicationInsightsWebTests_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_application_insights_web_test", "test")
 	r := ApplicationInsightsWebTestResource{}

--- a/internal/services/applicationinsights/application_insights_workbook_resource_test.go
+++ b/internal/services/applicationinsights/application_insights_workbook_resource_test.go
@@ -20,6 +20,16 @@ import (
 
 type ApplicationInsightsWorkbookResource struct{}
 
+func TestAccApplicationInsightsWorkbook_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_application_insights_workbook", "test")
+	r := ApplicationInsightsWorkbookResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccApplicationInsightsWorkbook_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_application_insights_workbook", "test")
 	r := ApplicationInsightsWorkbookResource{}

--- a/internal/services/applicationinsights/application_insights_workbook_template_resource_test.go
+++ b/internal/services/applicationinsights/application_insights_workbook_template_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type ApplicationInsightsWorkbookTemplateResource struct{}
 
+func TestAccApplicationInsightsWorkbookTemplate_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_application_insights_workbook_template", "test")
+	r := ApplicationInsightsWorkbookTemplateResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccApplicationInsightsWorkbookTemplate_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_application_insights_workbook_template", "test")
 	r := ApplicationInsightsWorkbookTemplateResource{}

--- a/internal/services/appservice/app_service_environment_v3_data_source_test.go
+++ b/internal/services/appservice/app_service_environment_v3_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type AppServiceEnvironmentV3DataSource struct{}
 
+func TestAccAppServiceEnvironmentV3DataSource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_app_service_environment_v3", "test")
+	r := AppServiceEnvironmentV3DataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccAppServiceEnvironmentV3DataSource_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_app_service_environment_v3", "test")
 

--- a/internal/services/appservice/app_service_environment_v3_resource_test.go
+++ b/internal/services/appservice/app_service_environment_v3_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type AppServiceEnvironmentV3Resource struct{}
 
+func TestAccAppServiceEnvironmentV3_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_app_service_environment_v3", "test")
+	r := AppServiceEnvironmentV3Resource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccAppServiceEnvironmentV3_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_app_service_environment_v3", "test")
 	r := AppServiceEnvironmentV3Resource{}

--- a/internal/services/appservice/app_service_source_control_resource_test.go
+++ b/internal/services/appservice/app_service_source_control_resource_test.go
@@ -22,6 +22,16 @@ import (
 
 type AppServiceSourceControlResource struct{}
 
+func TestAccSourceControlResource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_app_service_source_control", "test")
+	r := AppServiceSourceControlResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.windowsExternalGit(data),
+		},
+	}, "")
+}
+
 func TestAccSourceControlResource_windowsExternalGit(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_app_service_source_control", "test")
 	r := AppServiceSourceControlResource{}

--- a/internal/services/appservice/app_service_source_control_slot_resource_test.go
+++ b/internal/services/appservice/app_service_source_control_slot_resource_test.go
@@ -22,6 +22,16 @@ import (
 
 type SourceControlSlotResource struct{}
 
+func TestAccSourceControlSlotResource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_app_service_source_control_slot", "test")
+	r := SourceControlSlotResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.windowsExternalGit(data),
+		},
+	}, "")
+}
+
 func TestAccSourceControlSlotResource_windowsExternalGit(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_app_service_source_control_slot", "test")
 	r := SourceControlSlotResource{}

--- a/internal/services/appservice/function_app_active_slot_resource_test.go
+++ b/internal/services/appservice/function_app_active_slot_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type FunctionApActiveSlotResource struct{}
 
+func TestAccFunctionAppActiveSlot_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_function_app_active_slot", "test")
+	r := FunctionApActiveSlotResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicWindows(data),
+		},
+	}, "")
+}
+
 func TestAccFunctionAppActiveSlot_basicWindows(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_function_app_active_slot", "test")
 	r := FunctionApActiveSlotResource{}

--- a/internal/services/appservice/function_app_flex_consumption_resource_test.go
+++ b/internal/services/appservice/function_app_flex_consumption_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type FunctionAppFlexConsumptionResource struct{}
 
+func TestAccFunctionAppFlexConsumption_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_function_app_flex_consumption", "test")
+	r := FunctionAppFlexConsumptionResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccFunctionAppFlexConsumption_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_function_app_flex_consumption", "test")
 	r := FunctionAppFlexConsumptionResource{}

--- a/internal/services/appservice/function_app_function_resource_test.go
+++ b/internal/services/appservice/function_app_function_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type FunctionAppFunctionResource struct{}
 
+func TestAccFunctionAppFunction_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_function_app_function", "test")
+	r := FunctionAppFunctionResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccFunctionAppFunction_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_function_app_function", "test")
 	r := FunctionAppFunctionResource{}

--- a/internal/services/appservice/function_app_hybrid_connection_resource_test.go
+++ b/internal/services/appservice/function_app_hybrid_connection_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type FunctionAppHybridConnectionResource struct{}
 
+func TestAccFunctionAppHybridConnection_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_function_app_hybrid_connection", "test")
+	r := FunctionAppHybridConnectionResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccFunctionAppHybridConnection_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_function_app_hybrid_connection", "test")
 	r := FunctionAppHybridConnectionResource{}

--- a/internal/services/appservice/linux_function_app_data_source_test.go
+++ b/internal/services/appservice/linux_function_app_data_source_test.go
@@ -14,6 +14,16 @@ import (
 
 type LinuxFunctionAppDataSource struct{}
 
+func TestAccLinuxFunctionAppDataSource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_linux_function_app", "test")
+	r := LinuxFunctionAppDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.standardComplete(data),
+		},
+	}, "")
+}
+
 func TestAccLinuxFunctionAppDataSource_standardComplete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_linux_function_app", "test")
 	d := LinuxFunctionAppDataSource{}

--- a/internal/services/appservice/linux_function_app_resource_test.go
+++ b/internal/services/appservice/linux_function_app_resource_test.go
@@ -31,6 +31,16 @@ const (
 )
 
 // Plan types
+func TestAccLinuxFunctionApp_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_function_app", "test")
+	r := LinuxFunctionAppResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.withIPRestrictions(data),
+		},
+	}, "")
+}
+
 func TestAccLinuxFunctionApp_basicBasicPlan(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_linux_function_app", "test")
 	r := LinuxFunctionAppResource{}

--- a/internal/services/appservice/linux_function_app_slot_resource_test.go
+++ b/internal/services/appservice/linux_function_app_slot_resource_test.go
@@ -23,6 +23,16 @@ type LinuxFunctionAppSlotResource struct{}
 
 // Plan types
 
+func TestAccLinuxFunctionAppSlot_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_function_app_slot", "test")
+	r := LinuxFunctionAppSlotResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.consumptionComplete(data),
+		},
+	}, "")
+}
+
 func TestAccLinuxFunctionAppSlot_basicConsumptionPlan(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_linux_function_app_slot", "test")
 	r := LinuxFunctionAppSlotResource{}

--- a/internal/services/appservice/linux_web_app_data_source_test.go
+++ b/internal/services/appservice/linux_web_app_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type LinuxWebAppDataSource struct{}
 
+func TestAccLinuxWebAppDataSource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_linux_web_app", "test")
+	r := LinuxWebAppDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccLinuxWebAppDataSource_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_linux_web_app", "test")
 	d := LinuxWebAppDataSource{}

--- a/internal/services/appservice/linux_web_app_resource_test.go
+++ b/internal/services/appservice/linux_web_app_resource_test.go
@@ -21,6 +21,16 @@ import (
 
 type LinuxWebAppResource struct{}
 
+func TestAccLinuxWebApp_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_web_app", "test")
+	r := LinuxWebAppResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccLinuxWebApp_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_linux_web_app", "test")
 	r := LinuxWebAppResource{}

--- a/internal/services/appservice/linux_web_app_slot_resource_test.go
+++ b/internal/services/appservice/linux_web_app_slot_resource_test.go
@@ -21,6 +21,16 @@ import (
 
 type LinuxWebAppSlotResource struct{}
 
+func TestAccLinuxWebAppSlot_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_web_app_slot", "test")
+	r := LinuxWebAppSlotResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccLinuxWebAppSlot_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_linux_web_app_slot", "test")
 	r := LinuxWebAppSlotResource{}

--- a/internal/services/appservice/service_plan_data_source_test.go
+++ b/internal/services/appservice/service_plan_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type ServicePlanDataSource struct{}
 
+func TestAccServicePlanDataSource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_service_plan", "test")
+	r := ServicePlanDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccServicePlanDataSource_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_service_plan", "test")
 	d := ServicePlanDataSource{}

--- a/internal/services/appservice/service_plan_resource_test.go
+++ b/internal/services/appservice/service_plan_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type ServicePlanResource struct{}
 
+func TestAccServicePlan_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_service_plan", "test")
+	r := ServicePlanResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccServicePlan_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_service_plan", "test")
 	r := ServicePlanResource{}

--- a/internal/services/appservice/source_control_token_data_source_test.go
+++ b/internal/services/appservice/source_control_token_data_source_test.go
@@ -14,6 +14,18 @@ import (
 
 type AppServiceGithubTokenDataSource struct{}
 
+func TestAccSourceControlGitHubTokenDataSource_regressionTest(t *testing.T) {
+	token := os.Getenv("ARM_GITHUB_ACCESS_TOKEN")
+	data := acceptance.BuildTestData(t, "data.azurerm_source_control_token", "test")
+	r := AppServiceGithubTokenDataSource{}
+
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(token),
+		},
+	}, "")
+}
+
 func TestAccSourceControlGitHubTokenDataSource_basic(t *testing.T) {
 	token := os.Getenv("ARM_GITHUB_ACCESS_TOKEN")
 	if token == "" {

--- a/internal/services/appservice/source_control_token_resource_test.go
+++ b/internal/services/appservice/source_control_token_resource_test.go
@@ -22,6 +22,18 @@ import (
 
 type AppServiceGitHubTokenResource struct{}
 
+func TestAccSourceControlGitHubToken_regressionTest(t *testing.T) {
+	token := os.Getenv("ARM_GITHUB_ACCESS_TOKEN")
+	data := acceptance.BuildTestData(t, "azurerm_source_control_token", "test")
+	r := AppServiceGitHubTokenResource{}
+
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(token),
+		},
+	}, "")
+}
+
 func TestAccSourceControlGitHubToken_basic(t *testing.T) {
 	token := os.Getenv("ARM_GITHUB_ACCESS_TOKEN")
 	if token == "" {

--- a/internal/services/appservice/static_web_app_custom_domain_resource_test.go
+++ b/internal/services/appservice/static_web_app_custom_domain_resource_test.go
@@ -20,6 +20,16 @@ import (
 
 type StaticWebAppCustomDomainResource struct{}
 
+func TestAccAzureStaticWebAppCustomDomain_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_static_web_app_custom_domain", "test")
+	r := StaticWebAppCustomDomainResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccAzureStaticWebAppCustomDomain_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_static_web_app_custom_domain", "test")
 	r := StaticWebAppCustomDomainResource{}

--- a/internal/services/appservice/static_web_app_data_source_test.go
+++ b/internal/services/appservice/static_web_app_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type StaticWebAppDataSource struct{}
 
+func TestAccAzureStaticWebAppDataSource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_static_web_app", "test")
+	r := StaticWebAppDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccAzureStaticWebAppDataSource_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_static_web_app", "test")
 	r := StaticWebAppDataSource{}

--- a/internal/services/appservice/static_web_app_function_app_registration_resource_test.go
+++ b/internal/services/appservice/static_web_app_function_app_registration_resource_test.go
@@ -20,6 +20,16 @@ import (
 
 type StaticWebAppFunctionAppRegistrationResource struct{}
 
+func TestStaticWebAppFunctionAppRegistrationResource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_static_web_app_function_app_registration", "test")
+	r := StaticWebAppFunctionAppRegistrationResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestStaticWebAppFunctionAppRegistrationResource_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_static_web_app_function_app_registration", "test")
 	r := StaticWebAppFunctionAppRegistrationResource{}

--- a/internal/services/appservice/static_web_app_resource_test.go
+++ b/internal/services/appservice/static_web_app_resource_test.go
@@ -20,6 +20,16 @@ import (
 
 type StaticWebAppResource struct{}
 
+func TestAccStaticWebApp_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_static_web_app", "test")
+	r := StaticWebAppResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccStaticWebApp_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_static_web_app", "test")
 	r := StaticWebAppResource{}

--- a/internal/services/appservice/web_app_active_slot_resource_test.go
+++ b/internal/services/appservice/web_app_active_slot_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type WebAppActiveSlotResource struct{}
 
+func TestWebAppAccActiveSlot_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_web_app_active_slot", "test")
+	r := WebAppActiveSlotResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicWindows(data),
+		},
+	}, "")
+}
+
 func TestWebAppAccActiveSlot_basicWindows(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_web_app_active_slot", "test")
 	r := WebAppActiveSlotResource{}

--- a/internal/services/appservice/web_app_hybrid_connection_resource_test.go
+++ b/internal/services/appservice/web_app_hybrid_connection_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type WebAppHybridConnectionResource struct{}
 
+func TestAccWebAppHybridConnection_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_web_app_hybrid_connection", "test")
+	r := WebAppHybridConnectionResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccWebAppHybridConnection_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_web_app_hybrid_connection", "test")
 	r := WebAppHybridConnectionResource{}

--- a/internal/services/appservice/windows_function_app_data_source_test.go
+++ b/internal/services/appservice/windows_function_app_data_source_test.go
@@ -14,6 +14,16 @@ import (
 
 type WindowsFunctionAppDataSource struct{}
 
+func TestAccWindowsFunctionAppDataSource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_windows_function_app", "test")
+	r := WindowsFunctionAppDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccWindowsFunctionAppDataSource_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_windows_function_app", "test")
 	d := WindowsFunctionAppDataSource{}

--- a/internal/services/appservice/windows_function_app_resource_test.go
+++ b/internal/services/appservice/windows_function_app_resource_test.go
@@ -23,6 +23,16 @@ import (
 type WindowsFunctionAppResource struct{}
 
 // Plan types
+func TestAccWindowsFunctionApp_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_function_app", "test")
+	r := WindowsFunctionAppResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.stickySettings(data),
+		},
+	}, "")
+}
+
 func TestAccWindowsFunctionApp_basicBasicPlan(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_windows_function_app", "test")
 	r := WindowsFunctionAppResource{}

--- a/internal/services/appservice/windows_function_app_slot_resource_test.go
+++ b/internal/services/appservice/windows_function_app_slot_resource_test.go
@@ -23,6 +23,16 @@ type WindowsFunctionAppSlotResource struct{}
 
 // Plan types
 
+func TestAccWindowsFunctionAppSlot_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_function_app_slot", "test")
+	r := WindowsFunctionAppSlotResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.consumptionComplete(data),
+		},
+	}, "")
+}
+
 func TestAccWindowsFunctionAppSlot_basicConsumptionPlan(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_windows_function_app_slot", "test")
 	r := WindowsFunctionAppSlotResource{}

--- a/internal/services/appservice/windows_web_app_data_source_test.go
+++ b/internal/services/appservice/windows_web_app_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type WindowsWebAppDataSource struct{}
 
+func TestAccWindowsWebAppDataSource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_windows_web_app", "test")
+	r := WindowsWebAppDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccWindowsWebAppDataSource_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_windows_web_app", "test")
 	d := WindowsWebAppDataSource{}

--- a/internal/services/appservice/windows_web_app_resource_test.go
+++ b/internal/services/appservice/windows_web_app_resource_test.go
@@ -21,6 +21,16 @@ import (
 
 type WindowsWebAppResource struct{}
 
+func TestAccWindowsWebApp_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_web_app", "test")
+	r := WindowsWebAppResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccWindowsWebApp_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_windows_web_app", "test")
 	r := WindowsWebAppResource{}

--- a/internal/services/appservice/windows_web_app_slot_resource_test.go
+++ b/internal/services/appservice/windows_web_app_slot_resource_test.go
@@ -20,6 +20,16 @@ import (
 
 type WindowsWebAppSlotResource struct{}
 
+func TestAccWindowsWebAppSlot_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_web_app_slot", "test")
+	r := WindowsWebAppSlotResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccWindowsWebAppSlot_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_windows_web_app_slot", "test")
 	r := WindowsWebAppSlotResource{}

--- a/internal/services/arckubernetes/arc_kubernetes_cluster_extension_resource_test.go
+++ b/internal/services/arckubernetes/arc_kubernetes_cluster_extension_resource_test.go
@@ -19,6 +19,17 @@ import (
 
 type ArcKubernetesClusterExtensionResource struct{}
 
+func TestAccArcKubernetesClusterExtension_regressionTest(t *testing.T) {
+	credential, privateKey, publicKey := ArcKubernetesClusterResource{}.getCredentials(t)
+	data := acceptance.BuildTestData(t, "azurerm_arc_kubernetes_cluster_extension", "test")
+	r := ArcKubernetesClusterExtensionResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data, credential, privateKey, publicKey),
+		},
+	}, "")
+}
+
 func TestAccArcKubernetesClusterExtension_basic(t *testing.T) {
 	credential, privateKey, publicKey := ArcKubernetesClusterResource{}.getCredentials(t)
 	data := acceptance.BuildTestData(t, "azurerm_arc_kubernetes_cluster_extension", "test")

--- a/internal/services/arckubernetes/arc_kubernetes_cluster_resource_test.go
+++ b/internal/services/arckubernetes/arc_kubernetes_cluster_resource_test.go
@@ -27,6 +27,17 @@ import (
 
 type ArcKubernetesClusterResource struct{}
 
+func TestAccArcKubernetesCluster_regressionTest(t *testing.T) {
+	credential, privateKey, publicKey := ArcKubernetesClusterResource{}.getCredentials(t)
+	data := acceptance.BuildTestData(t, "azurerm_arc_kubernetes_cluster", "test")
+	r := ArcKubernetesClusterResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data, credential, privateKey, publicKey),
+		},
+	}, "")
+}
+
 func TestAccArcKubernetesCluster_basic(t *testing.T) {
 	credential, privateKey, publicKey := ArcKubernetesClusterResource{}.getCredentials(t)
 	data := acceptance.BuildTestData(t, "azurerm_arc_kubernetes_cluster", "test")

--- a/internal/services/arckubernetes/arc_kubernetes_flux_configuration_resource_test.go
+++ b/internal/services/arckubernetes/arc_kubernetes_flux_configuration_resource_test.go
@@ -22,6 +22,17 @@ import (
 
 type ArcKubernetesFluxConfigurationResource struct{}
 
+func TestAccArcKubernetesFluxConfiguration_regressionTest(t *testing.T) {
+	credential, privateKey, publicKey := ArcKubernetesClusterResource{}.getCredentials(t)
+	data := acceptance.BuildTestData(t, "azurerm_arc_kubernetes_flux_configuration", "test")
+	r := ArcKubernetesFluxConfigurationResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data, credential, privateKey, publicKey),
+		},
+	}, "")
+}
+
 func TestAccArcKubernetesFluxConfiguration_basic(t *testing.T) {
 	credential, privateKey, publicKey := ArcKubernetesClusterResource{}.getCredentials(t)
 	data := acceptance.BuildTestData(t, "azurerm_arc_kubernetes_flux_configuration", "test")

--- a/internal/services/arckubernetes/arc_kubernetes_provisioned_cluster_resource_test.go
+++ b/internal/services/arckubernetes/arc_kubernetes_provisioned_cluster_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type ArcKubernetesProvisionedClusterResource struct{}
 
+func TestAccArcKubernetesProvisionedCluster_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_arc_kubernetes_provisioned_cluster", "test")
+	r := ArcKubernetesProvisionedClusterResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccArcKubernetesProvisionedCluster_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_arc_kubernetes_provisioned_cluster", "test")
 	r := ArcKubernetesProvisionedClusterResource{}

--- a/internal/services/arcresourcebridge/arc_resource_bridge_appliance_data_source_test.go
+++ b/internal/services/arcresourcebridge/arc_resource_bridge_appliance_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type ArcResourceBridgeApplianceDataSource struct{}
 
+func TestAccArcResourceBridgeApplianceDataSource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_arc_resource_bridge_appliance", "test")
+	r := ArcResourceBridgeApplianceDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccArcResourceBridgeApplianceDataSource_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_arc_resource_bridge_appliance", "test")
 	d := ArcResourceBridgeApplianceDataSource{}

--- a/internal/services/arcresourcebridge/arc_resource_bridge_appliance_resource_test.go
+++ b/internal/services/arcresourcebridge/arc_resource_bridge_appliance_resource_test.go
@@ -22,6 +22,16 @@ import (
 
 type ArcResourceBridgeApplianceResource struct{}
 
+func TestAccArcResourceBridgeAppliance_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_arc_resource_bridge_appliance", "test")
+	r := ArcResourceBridgeApplianceResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccArcResourceBridgeAppliance_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_arc_resource_bridge_appliance", "test")
 	r := ArcResourceBridgeApplianceResource{}

--- a/internal/services/attestation/attestation_provider_data_source_test.go
+++ b/internal/services/attestation/attestation_provider_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type AttestationProviderDataSource struct{}
 
+func TestAccAttestationProviderDataSource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_attestation_provider", "test")
+	r := AttestationProviderDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccAttestationProviderDataSource_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_attestation_provider", "test")
 	resource := acceptance.BuildTestData(t, "azurerm_attestation_provider", "test")

--- a/internal/services/attestation/attestation_provider_resource_test.go
+++ b/internal/services/attestation/attestation_provider_resource_test.go
@@ -36,6 +36,19 @@ func (r AttestationProviderResource) basicForResourceIdentity(data acceptance.Te
 	return r.basic(data)
 }
 
+func TestAccAttestationProvider_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_attestation_provider", "test")
+	r := AttestationProviderResource{
+		name: fmt.Sprintf("acctestap%s", data.RandomStringOfLength(10)),
+	}
+
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccAttestationProvider_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_attestation_provider", "test")
 	r := AttestationProviderResource{

--- a/internal/services/authorization/client_config_data_source_test.go
+++ b/internal/services/authorization/client_config_data_source_test.go
@@ -14,6 +14,16 @@ import (
 
 type ClientConfigDataSource struct{}
 
+func TestAccClientConfigDataSource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_client_config", "current")
+
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: ClientConfigDataSource{}.basic(),
+		},
+	}, "")
+}
+
 func TestAccClientConfigDataSource_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_client_config", "current")
 	clientId := os.Getenv("ARM_CLIENT_ID")

--- a/internal/services/authorization/marketplace_role_assignment_resource_test.go
+++ b/internal/services/authorization/marketplace_role_assignment_resource_test.go
@@ -26,6 +26,20 @@ import (
 
 type RoleAssignmentMarketplaceResource struct{}
 
+func TestAccRoleAssignmentMarketplace_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_marketplace_role_assignment", "test")
+	r := RoleAssignmentMarketplaceResource{}
+	roleName := "Reader"
+
+	data.ResourceSequentialRegressionTest(t, r, []acceptance.TestStep{
+		{
+			// Last error may cause the role already assigned. Need to delete it before a new test.
+			PreConfig: r.deleteAssignedRole(t, roleName),
+			Config:    r.emptyNameConfig(roleName),
+		},
+	}, "")
+}
+
 func TestAccRoleAssignmentMarketplace_emptyName(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_marketplace_role_assignment", "test")
 	r := RoleAssignmentMarketplaceResource{}

--- a/internal/services/authorization/pim_active_role_assignment_resource_test.go
+++ b/internal/services/authorization/pim_active_role_assignment_resource_test.go
@@ -21,6 +21,16 @@ import (
 
 type PimActiveRoleAssignmentResource struct{}
 
+func TestAccPimActiveRoleAssignment_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_pim_active_role_assignment", "test")
+	r := PimActiveRoleAssignmentResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.noExpiration(data),
+		},
+	}, "")
+}
+
 func TestAccPimActiveRoleAssignment_noExpiration(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_pim_active_role_assignment", "test")
 	r := PimActiveRoleAssignmentResource{}

--- a/internal/services/authorization/pim_eligible_role_assignment_resource_test.go
+++ b/internal/services/authorization/pim_eligible_role_assignment_resource_test.go
@@ -21,6 +21,16 @@ import (
 
 type PimEligibleRoleAssignmentResource struct{}
 
+func TestAccPimEligibleRoleAssignment_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_pim_eligible_role_assignment", "test")
+	r := PimEligibleRoleAssignmentResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.noExpiration(data),
+		},
+	}, "")
+}
+
 func TestAccPimEligibleRoleAssignment_noExpiration(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_pim_eligible_role_assignment", "test")
 	r := PimEligibleRoleAssignmentResource{}

--- a/internal/services/authorization/role_assignment_resource_test.go
+++ b/internal/services/authorization/role_assignment_resource_test.go
@@ -20,6 +20,16 @@ import (
 
 type RoleAssignmentResource struct{}
 
+func TestAccRoleAssignment_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_role_assignment", "test")
+	r := RoleAssignmentResource{}
+	data.ResourceSequentialRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.subscriptionScoped(data),
+		},
+	}, "")
+}
+
 func TestAccRoleAssignment_emptyName(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_role_assignment", "test")
 	r := RoleAssignmentResource{}

--- a/internal/services/authorization/role_assignments_data_source_test.go
+++ b/internal/services/authorization/role_assignments_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type RoleAssignmentsDataSource struct{}
 
+func TestAccRoleAssignmentsDataSource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_role_assignments", "test")
+	r := RoleAssignmentsDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccRoleAssignmentsDataSource_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_role_assignments", "test")
 	d := RoleAssignmentsDataSource{}

--- a/internal/services/authorization/role_definition_data_source_test.go
+++ b/internal/services/authorization/role_definition_data_source_test.go
@@ -15,6 +15,17 @@ import (
 
 type RoleDefinitionDataSource struct{}
 
+func TestAccRoleDefinitionDataSource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_role_definition", "test")
+	id := uuid.New().String()
+
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: RoleDefinitionDataSource{}.basic(id, data),
+		},
+	}, "")
+}
+
 func TestAccRoleDefinitionDataSource_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_role_definition", "test")
 	id := uuid.New().String()

--- a/internal/services/authorization/role_definition_resource_test.go
+++ b/internal/services/authorization/role_definition_resource_test.go
@@ -20,6 +20,16 @@ import (
 
 type RoleDefinitionResource struct{}
 
+func TestAccRoleDefinition_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_role_definition", "test")
+	r := RoleDefinitionResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.emptyId(data),
+		},
+	}, "")
+}
+
 func TestAccRoleDefinition_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_role_definition", "test")
 	r := RoleDefinitionResource{}

--- a/internal/services/authorization/role_management_policy_data_source_test.go
+++ b/internal/services/authorization/role_management_policy_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type RoleManagementPolicyDataSource struct{}
 
+func TestAccRoleManagementPolicyDataSource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_role_management_policy", "test")
+	r := RoleManagementPolicyDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.managementGroup(data),
+		},
+	}, "")
+}
+
 func TestAccRoleManagementPolicyDataSource_managementGroup(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_role_management_policy", "test")
 	r := RoleManagementPolicyDataSource{}

--- a/internal/services/authorization/role_management_policy_resource_test.go
+++ b/internal/services/authorization/role_management_policy_resource_test.go
@@ -20,6 +20,16 @@ import (
 
 type RoleManagementPolicyResource struct{}
 
+func TestAccRoleManagementPolicy_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_role_management_policy", "test")
+	r := RoleManagementPolicyResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.managementGroup(data),
+		},
+	}, "")
+}
+
 func TestAccRoleManagementPolicy_managementGroup(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_role_management_policy", "test")
 	r := RoleManagementPolicyResource{}

--- a/internal/services/automanage/arc_machine_automanage_configuration_assignment_resource_test.go
+++ b/internal/services/automanage/arc_machine_automanage_configuration_assignment_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type ArcMachineAutomanageConfigurationAssignmentResource struct{}
 
+func TestAccArcMachineAutomanageConfigurationAssignment_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_arc_machine_automanage_configuration_assignment", "test")
+	r := ArcMachineAutomanageConfigurationAssignmentResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccArcMachineAutomanageConfigurationAssignment_complete(t *testing.T) {
 	t.Skip("The deprecation check prevents the creation of a hybrid compute machine resource using os.Getenv(\"ARM_CLIENT_SECRET\")")
 	data := acceptance.BuildTestData(t, "azurerm_arc_machine_automanage_configuration_assignment", "test")

--- a/internal/services/automanage/automanage_configuration_resource_test.go
+++ b/internal/services/automanage/automanage_configuration_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type AutomanageConfigurationResource struct{}
 
+func TestAccAutoManageConfigurationProfile_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_automanage_configuration", "test")
+	r := AutomanageConfigurationResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccAutoManageConfigurationProfile_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_automanage_configuration", "test")
 	r := AutomanageConfigurationResource{}

--- a/internal/services/automanage/virtual_machine_automanage_configuration_assignment_resource_test.go
+++ b/internal/services/automanage/virtual_machine_automanage_configuration_assignment_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type VirtualMachineAutomanageConfigurationAssignmentResource struct{}
 
+func TestAccVirtualMachineConfigurationAssignment_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_virtual_machine_automanage_configuration_assignment", "test")
+	r := VirtualMachineAutomanageConfigurationAssignmentResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccVirtualMachineConfigurationAssignment_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_virtual_machine_automanage_configuration_assignment", "test")
 	r := VirtualMachineAutomanageConfigurationAssignmentResource{}


### PR DESCRIPTION
Adds per-resource/data-source regression tests (pattern from #33087) to applicationinsights, appservice, arckubernetes, arcresourcebridge, attestation, authorization and automanage — 60 files.

Notes for review:
* `source_control_token` (resource + data source) keep their `os.Getenv("ARM_GITHUB_ACCESS_TOKEN")` line because the config takes the token as an argument; same for the arckubernetes `getCredentials(t)` helper (which skips internally when unset).
* `marketplace_role_assignment` uses `ResourceSequentialRegressionTest` to match the file's sequential tests.

Part 2 of ~21. No skip/preCheck gating is added to the regression tests for now.