### PR TITLE
regression tests 3/21 - automation, azurestackhci, batch, billing, blueprints, bot

### DIFF
--- a/internal/services/automation/automation_account_data_source_test.go
+++ b/internal/services/automation/automation_account_data_source_test.go
@@ -12,6 +12,16 @@ import (
 
 type AutomationAccountDataSource struct{}
 
+func TestAccDataSourceAutomationAccount_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_automation_account", "test")
+	r := AutomationAccountDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccDataSourceAutomationAccount_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_automation_account", "test")
 

--- a/internal/services/automation/automation_account_resource_test.go
+++ b/internal/services/automation/automation_account_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type AutomationAccountResource struct{}
 
+func TestAccAutomationAccount_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_automation_account", "test")
+	r := AutomationAccountResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccAutomationAccount_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_automation_account", "test")
 	r := AutomationAccountResource{}

--- a/internal/services/automation/automation_certificate_resource_test.go
+++ b/internal/services/automation/automation_certificate_resource_test.go
@@ -29,6 +29,16 @@ var (
 
 var testCertBase64 = base64.StdEncoding.EncodeToString(testCertRaw)
 
+func TestAccAutomationCertificate_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_automation_certificate", "test")
+	r := AutomationCertificateResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccAutomationCertificate_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_automation_certificate", "test")
 	r := AutomationCertificateResource{}

--- a/internal/services/automation/automation_connection_certificate_resource_test.go
+++ b/internal/services/automation/automation_connection_certificate_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type AutomationConnectionCertificateResource struct{}
 
+func TestAccAutomationConnectionCertificate_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_automation_connection_certificate", "test")
+	r := AutomationConnectionCertificateResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccAutomationConnectionCertificate_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_automation_connection_certificate", "test")
 	r := AutomationConnectionCertificateResource{}

--- a/internal/services/automation/automation_connection_classic_certificate_resource_test.go
+++ b/internal/services/automation/automation_connection_classic_certificate_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type AutomationConnectionClassicCertificateResource struct{}
 
+func TestAccAutomationConnectionClassicCertificate_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_automation_connection_classic_certificate", "test")
+	r := AutomationConnectionClassicCertificateResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccAutomationConnectionClassicCertificate_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_automation_connection_classic_certificate", "test")
 	r := AutomationConnectionClassicCertificateResource{}

--- a/internal/services/automation/automation_connection_resource_test.go
+++ b/internal/services/automation/automation_connection_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type AutomationConnectionResource struct{}
 
+func TestAccAutomationConnection_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_automation_connection", "test")
+	r := AutomationConnectionResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccAutomationConnection_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_automation_connection", "test")
 	r := AutomationConnectionResource{}

--- a/internal/services/automation/automation_connection_service_principal_resource_test.go
+++ b/internal/services/automation/automation_connection_service_principal_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type AutomationConnectionServicePrincipalResource struct{}
 
+func TestAccAutomationConnectionServicePrincipal_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_automation_connection_service_principal", "test")
+	r := AutomationConnectionServicePrincipalResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccAutomationConnectionServicePrincipal_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_automation_connection_service_principal", "test")
 	r := AutomationConnectionServicePrincipalResource{}

--- a/internal/services/automation/automation_connection_type_resource_test.go
+++ b/internal/services/automation/automation_connection_type_resource_test.go
@@ -70,6 +70,16 @@ resource "azurerm_automation_connection_type" "test" {
 `, a.template(data), data.RandomInteger)
 }
 
+func TestAccAutomationConnectionType_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, automation.AutomationConnectionTypeResource{}.ResourceType(), "test")
+	r := AutomationConnectionTypeResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccAutomationConnectionType_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, automation.AutomationConnectionTypeResource{}.ResourceType(), "test")
 	r := AutomationConnectionTypeResource{}

--- a/internal/services/automation/automation_credential_resource_test.go
+++ b/internal/services/automation/automation_credential_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type AutomationCredentialResource struct{}
 
+func TestAccAutomationCredential_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_automation_credential", "test")
+	r := AutomationCredentialResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccAutomationCredential_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_automation_credential", "test")
 	r := AutomationCredentialResource{}

--- a/internal/services/automation/automation_dsc_configuration_resource_test.go
+++ b/internal/services/automation/automation_dsc_configuration_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type AutomationDscConfigurationResource struct{}
 
+func TestAccAutomationDscConfiguration_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_automation_dsc_configuration", "test")
+	r := AutomationDscConfigurationResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccAutomationDscConfiguration_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_automation_dsc_configuration", "test")
 	r := AutomationDscConfigurationResource{}

--- a/internal/services/automation/automation_dsc_nodeconfiguration_resource_test.go
+++ b/internal/services/automation/automation_dsc_nodeconfiguration_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type AutomationDscNodeConfigurationResource struct{}
 
+func TestAccAutomationDscNodeConfiguration_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_automation_dsc_nodeconfiguration", "test")
+	r := AutomationDscNodeConfigurationResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccAutomationDscNodeConfiguration_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_automation_dsc_nodeconfiguration", "test")
 	r := AutomationDscNodeConfigurationResource{}

--- a/internal/services/automation/automation_hybrid_runbook_worker_group_resource_test.go
+++ b/internal/services/automation/automation_hybrid_runbook_worker_group_resource_test.go
@@ -97,6 +97,16 @@ resource "azurerm_automation_hybrid_runbook_worker_group" "test" {
 `, a.template(data), data.RandomInteger)
 }
 
+func TestAccHybridRunbookWorkerGroup_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, automation.HybridRunbookWorkerGroupResource{}.ResourceType(), "test")
+	r := HybridRunbookWorkerGroupResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccHybridRunbookWorkerGroup_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, automation.HybridRunbookWorkerGroupResource{}.ResourceType(), "test")
 	r := HybridRunbookWorkerGroupResource{}

--- a/internal/services/automation/automation_hybrid_runbook_worker_resource_test.go
+++ b/internal/services/automation/automation_hybrid_runbook_worker_resource_test.go
@@ -137,6 +137,16 @@ resource "azurerm_automation_hybrid_runbook_worker" "test" {
 `, a.template(data), uuid.New().String())
 }
 
+func TestAccHybridRunbookWorker_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, automation.HybridRunbookWorkerResource{}.ResourceType(), "test")
+	r := HybridRunbookWorkerResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccHybridRunbookWorker_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, automation.HybridRunbookWorkerResource{}.ResourceType(), "test")
 	r := HybridRunbookWorkerResource{}

--- a/internal/services/automation/automation_job_schedule_resource_test.go
+++ b/internal/services/automation/automation_job_schedule_resource_test.go
@@ -21,6 +21,16 @@ import (
 
 type AutomationJobScheduleResource struct{}
 
+func TestAccAutomationJobSchedule_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_automation_job_schedule", "test")
+	r := AutomationJobScheduleResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccAutomationJobSchedule_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_automation_job_schedule", "test")
 	r := AutomationJobScheduleResource{}

--- a/internal/services/automation/automation_module_resource_test.go
+++ b/internal/services/automation/automation_module_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type AutomationModuleResource struct{}
 
+func TestAccAutomationModule_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_automation_module", "test")
+	r := AutomationModuleResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccAutomationModule_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_automation_module", "test")
 	r := AutomationModuleResource{}

--- a/internal/services/automation/automation_powershell72_module_resource_test.go
+++ b/internal/services/automation/automation_powershell72_module_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type PowerShell72ModuleResource struct{}
 
+func TestAccAutomationPowerShell72Module_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_automation_powershell72_module", "test")
+	r := PowerShell72ModuleResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccAutomationPowerShell72Module_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_automation_powershell72_module", "test")
 	r := PowerShell72ModuleResource{}

--- a/internal/services/automation/automation_python3_package_resource_test.go
+++ b/internal/services/automation/automation_python3_package_resource_test.go
@@ -31,6 +31,16 @@ func (a Python3PackageResource) Exists(ctx context.Context, client *clients.Clie
 	return pointer.To(resp.Model != nil), nil
 }
 
+func TestAccPython3Package_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, automation.Python3PackageResource{}.ResourceType(), "test")
+	r := Python3PackageResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccPython3Package_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, automation.Python3PackageResource{}.ResourceType(), "test")
 	r := Python3PackageResource{}

--- a/internal/services/automation/automation_runbook_data_source_test.go
+++ b/internal/services/automation/automation_runbook_data_source_test.go
@@ -14,6 +14,16 @@ import (
 
 type AutomationRunbookDataSource struct{}
 
+func TestAccAutomationRunbookDataSource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_automation_runbook", "test")
+	r := AutomationRunbookDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccAutomationRunbookDataSource_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_automation_runbook", "test")
 	r := AutomationRunbookDataSource{}

--- a/internal/services/automation/automation_runbook_resource_test.go
+++ b/internal/services/automation/automation_runbook_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type AutomationRunbookResource struct{}
 
+func TestAccAutomationRunbook_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_automation_runbook", "test")
+	r := AutomationRunbookResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.PSWorkflow(data),
+		},
+	}, "")
+}
+
 func TestAccAutomationRunbook_PSWorkflow(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_automation_runbook", "test")
 	r := AutomationRunbookResource{}

--- a/internal/services/automation/automation_runtime_environment_package_resource_test.go
+++ b/internal/services/automation/automation_runtime_environment_package_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type AutomationRuntimeEnvironmentPackageResource struct{}
 
+func TestAccAutomationRuntimeEnvironmentPackage_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_automation_runtime_environment_package", "test")
+	r := AutomationRuntimeEnvironmentPackageResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccAutomationRuntimeEnvironmentPackage_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_automation_runtime_environment_package", "test")
 	r := AutomationRuntimeEnvironmentPackageResource{}

--- a/internal/services/automation/automation_runtime_environment_resource_test.go
+++ b/internal/services/automation/automation_runtime_environment_resource_test.go
@@ -31,6 +31,16 @@ func (a AutomationRuntimeEnvironmentResource) Exists(ctx context.Context, client
 	return pointer.To(resp.Model != nil), nil
 }
 
+func TestAccAutomationRuntimeEnvironment_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, automation.AutomationRuntimeEnvironmentResource{}.ResourceType(), "test")
+	r := AutomationRuntimeEnvironmentResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.completePowerShell(data),
+		},
+	}, "")
+}
+
 func TestAccAutomationRuntimeEnvironment_completePowerShell(t *testing.T) {
 	data := acceptance.BuildTestData(t, automation.AutomationRuntimeEnvironmentResource{}.ResourceType(), "test")
 	r := AutomationRuntimeEnvironmentResource{}

--- a/internal/services/automation/automation_schedule_resource_test.go
+++ b/internal/services/automation/automation_schedule_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type AutomationScheduleResource struct{}
 
+func TestAccAutomationSchedule_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_automation_schedule", "test")
+	r := AutomationScheduleResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.oneTime_basic(data),
+		},
+	}, "")
+}
+
 func TestAccAutomationSchedule_oneTime_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_automation_schedule", "test")
 	r := AutomationScheduleResource{}

--- a/internal/services/automation/automation_source_control_resource_test.go
+++ b/internal/services/automation/automation_source_control_resource_test.go
@@ -126,6 +126,16 @@ resource "azurerm_automation_source_control" "test" {
 `, s.template(data), data.RandomInteger, s.url, s.token)
 }
 
+func TestAccSourceControl_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, automation.SourceControlResource{}.ResourceType(), "test")
+	r := newSourceControlResource(t)
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccSourceControl_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, automation.SourceControlResource{}.ResourceType(), "test")
 	r := newSourceControlResource(t)

--- a/internal/services/automation/automation_variable_bool_data_source_test.go
+++ b/internal/services/automation/automation_variable_bool_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type AutomationVariableBoolDataSource struct{}
 
+func TestAccDataSourceAzureRMAutomationVariableBool_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_automation_variable_bool", "test")
+	r := AutomationVariableBoolDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccDataSourceAzureRMAutomationVariableBool_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_automation_variable_bool", "test")
 	r := AutomationVariableBoolDataSource{}

--- a/internal/services/automation/automation_variable_bool_resource_test.go
+++ b/internal/services/automation/automation_variable_bool_resource_test.go
@@ -16,6 +16,16 @@ import (
 
 type AutomationVariableBoolResource struct{}
 
+func TestAccAutomationVariableBool_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_automation_variable_bool", "test")
+	r := AutomationVariableBoolResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccAutomationVariableBool_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_automation_variable_bool", "test")
 	r := AutomationVariableBoolResource{}

--- a/internal/services/automation/automation_variable_datetime_data_source_test.go
+++ b/internal/services/automation/automation_variable_datetime_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type AutomationVariableDateTimeDataSouce struct{}
 
+func TestAccDataSourceAzureRMAutomationVariableDateTime_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_automation_variable_datetime", "test")
+	r := AutomationVariableDateTimeDataSouce{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccDataSourceAzureRMAutomationVariableDateTime_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_automation_variable_datetime", "test")
 	r := AutomationVariableDateTimeDataSouce{}

--- a/internal/services/automation/automation_variable_datetime_resource_test.go
+++ b/internal/services/automation/automation_variable_datetime_resource_test.go
@@ -16,6 +16,16 @@ import (
 
 type AutomationVariableDateTimeResource struct{}
 
+func TestAccAutomationVariableDateTime_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_automation_variable_datetime", "test")
+	r := AutomationVariableDateTimeResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccAutomationVariableDateTime_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_automation_variable_datetime", "test")
 	r := AutomationVariableDateTimeResource{}

--- a/internal/services/automation/automation_variable_int_data_source_test.go
+++ b/internal/services/automation/automation_variable_int_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type AutomationVariableIntDataSource struct{}
 
+func TestAccDataSourceAzureRMAutomationVariableInt_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_automation_variable_int", "test")
+	r := AutomationVariableIntDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccDataSourceAzureRMAutomationVariableInt_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_automation_variable_int", "test")
 	r := AutomationVariableIntDataSource{}

--- a/internal/services/automation/automation_variable_int_resource_test.go
+++ b/internal/services/automation/automation_variable_int_resource_test.go
@@ -16,6 +16,16 @@ import (
 
 type AutomationVariableIntResource struct{}
 
+func TestAccAutomationVariableInt_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_automation_variable_int", "test")
+	r := AutomationVariableIntResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccAutomationVariableInt_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_automation_variable_int", "test")
 	r := AutomationVariableIntResource{}

--- a/internal/services/automation/automation_variable_object_data_source_test.go
+++ b/internal/services/automation/automation_variable_object_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type AutomationVariableObjectDataSource struct{}
 
+func TestAccDataSourceAzureRMAutomationVariableObject_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_automation_variable_object", "test")
+	r := AutomationVariableObjectDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccDataSourceAzureRMAutomationVariableObject_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_automation_variable_object", "test")
 	r := AutomationVariableObjectDataSource{}

--- a/internal/services/automation/automation_variable_object_resource_test.go
+++ b/internal/services/automation/automation_variable_object_resource_test.go
@@ -16,6 +16,16 @@ import (
 
 type AutomationVariableObjectResource struct{}
 
+func TestAccAutomationVariableObject_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_automation_variable_object", "test")
+	r := AutomationVariableObjectResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccAutomationVariableObject_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_automation_variable_object", "test")
 	r := AutomationVariableObjectResource{}

--- a/internal/services/automation/automation_variable_string_data_source_test.go
+++ b/internal/services/automation/automation_variable_string_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type AutomationVariableStringDataSource struct{}
 
+func TestAccDataSourceAzureRMAutomationVariableString_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_automation_variable_string", "test")
+	r := AutomationVariableStringDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccDataSourceAzureRMAutomationVariableString_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_automation_variable_string", "test")
 	r := AutomationVariableStringDataSource{}

--- a/internal/services/automation/automation_variable_string_resource_test.go
+++ b/internal/services/automation/automation_variable_string_resource_test.go
@@ -16,6 +16,16 @@ import (
 
 type AutomationVariableStringResource struct{}
 
+func TestAccAutomationVariableString_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_automation_variable_string", "test")
+	r := AutomationVariableStringResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccAutomationVariableString_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_automation_variable_string", "test")
 	r := AutomationVariableStringResource{}

--- a/internal/services/automation/automation_variables_data_source_test.go
+++ b/internal/services/automation/automation_variables_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type AutomationVariablesDataSource struct{}
 
+func TestAccDataSourceAzureRMAutomationVariables_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_automation_variables", "test")
+	r := AutomationVariablesDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccDataSourceAzureRMAutomationVariables_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_automation_variables", "test")
 	r := AutomationVariablesDataSource{}

--- a/internal/services/automation/automation_watcher_resource_test.go
+++ b/internal/services/automation/automation_watcher_resource_test.go
@@ -20,6 +20,16 @@ import (
 
 type WatcherResource struct{}
 
+func TestAccWatcher_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, automation.WatcherResource{}.ResourceType(), "test")
+	r := WatcherResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccWatcher_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, automation.WatcherResource{}.ResourceType(), "test")
 	r := WatcherResource{}

--- a/internal/services/automation/automation_webhook_resource_test.go
+++ b/internal/services/automation/automation_webhook_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type AutomationWebhookResource struct{}
 
+func TestAccAutomationWebhook_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_automation_webhook", "test")
+	r := AutomationWebhookResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccAutomationWebhook_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_automation_webhook", "test")
 	r := AutomationWebhookResource{}

--- a/internal/services/azurestackhci/stack_hci_cluster_data_source_test.go
+++ b/internal/services/azurestackhci/stack_hci_cluster_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type StackHCIClusterDataSource struct{}
 
+func TestAccStackHCIClusterDataSource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_stack_hci_cluster", "test")
+	r := StackHCIClusterDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccStackHCIClusterDataSource_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_stack_hci_cluster", "test")
 	r := StackHCIClusterDataSource{}

--- a/internal/services/azurestackhci/stack_hci_cluster_resource_test.go
+++ b/internal/services/azurestackhci/stack_hci_cluster_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type StackHCIClusterResource struct{}
 
+func TestAccStackHCICluster_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_stack_hci_cluster", "test")
+	r := StackHCIClusterResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccStackHCICluster_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_stack_hci_cluster", "test")
 	r := StackHCIClusterResource{}

--- a/internal/services/azurestackhci/stack_hci_deployment_setting_resource_test.go
+++ b/internal/services/azurestackhci/stack_hci_deployment_setting_resource_test.go
@@ -31,6 +31,17 @@ const (
 	deploymentUserPasswordEnv  = "ARM_TEST_HCI_DEPLOYMENT_USER_PASSWORD"
 )
 
+func TestAccStackHCIDeploymentSetting_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_stack_hci_deployment_setting", "test")
+	r := StackHCIDeploymentSettingResource{}
+
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccStackHCIDeploymentSetting_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_stack_hci_deployment_setting", "test")
 	r := StackHCIDeploymentSettingResource{}

--- a/internal/services/azurestackhci/stack_hci_extension_resource_test.go
+++ b/internal/services/azurestackhci/stack_hci_extension_resource_test.go
@@ -21,6 +21,17 @@ type StackHCIExtensionResource struct{}
 
 const arcSettingIdEnv = "ARM_TEST_STACK_HCI_ARC_SETTING_ID"
 
+func TestAccStackHCIExtension_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_stack_hci_extension", "test")
+	r := StackHCIExtensionResource{}
+
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccStackHCIExtension_basic(t *testing.T) {
 	arcSettingId := os.Getenv(arcSettingIdEnv)
 	if arcSettingId == "" {

--- a/internal/services/azurestackhci/stack_hci_logical_network_resource_test.go
+++ b/internal/services/azurestackhci/stack_hci_logical_network_resource_test.go
@@ -25,6 +25,17 @@ const (
 	customLocationIdEnv = "ARM_TEST_STACK_HCI_CUSTOM_LOCATION_ID"
 )
 
+func TestAccStackHCILogicalNetwork_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_stack_hci_logical_network", "test")
+	r := StackHCILogicalNetworkResource{}
+
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccStackHCILogicalNetwork_dynamic(t *testing.T) {
 	if os.Getenv(customLocationIdEnv) == "" {
 		t.Skipf("skipping since %q has not been specified", customLocationIdEnv)

--- a/internal/services/azurestackhci/stack_hci_marketplace_gallery_image_resource_test.go
+++ b/internal/services/azurestackhci/stack_hci_marketplace_gallery_image_resource_test.go
@@ -22,6 +22,19 @@ type StackHCIMarketplaceGalleryImageResource struct {
 	imageVersion string
 }
 
+func TestAccStackHCIMarketplaceGalleryImage_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_stack_hci_marketplace_gallery_image", "test")
+	r := StackHCIMarketplaceGalleryImageResource{
+		imageVersion: "20348.2402.240607",
+	}
+
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccStackHCIMarketplaceGalleryImage_basic(t *testing.T) {
 	if os.Getenv(customLocationIdEnv) == "" {
 		t.Skipf("skipping since %q has not been specified", customLocationIdEnv)

--- a/internal/services/azurestackhci/stack_hci_network_interface_resource_test.go
+++ b/internal/services/azurestackhci/stack_hci_network_interface_resource_test.go
@@ -19,6 +19,17 @@ import (
 
 type StackHCINetworkInterfaceResource struct{}
 
+func TestAccStackHCINetworkInterface_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_stack_hci_network_interface", "test")
+	r := StackHCINetworkInterfaceResource{}
+
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccStackHCINetworkInterface_basic(t *testing.T) {
 	if os.Getenv(customLocationIdEnv) == "" {
 		t.Skipf("skipping since %q has not been specified", customLocationIdEnv)

--- a/internal/services/azurestackhci/stack_hci_storage_path_data_source_test.go
+++ b/internal/services/azurestackhci/stack_hci_storage_path_data_source_test.go
@@ -14,6 +14,17 @@ import (
 
 type StackHCIStoragePathDataSource struct{}
 
+func TestAccStackHCIStoragePathDataSource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_stack_hci_storage_path", "test")
+	r := StackHCIStoragePathDataSource{}
+
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccStackHCIStoragePathDataSource_basic(t *testing.T) {
 	if os.Getenv(customLocationIdEnv) == "" {
 		t.Skipf("skipping since %q has not been specified", customLocationIdEnv)

--- a/internal/services/azurestackhci/stack_hci_storage_path_resource_test.go
+++ b/internal/services/azurestackhci/stack_hci_storage_path_resource_test.go
@@ -19,6 +19,17 @@ import (
 
 type StackHCIStoragePathResource struct{}
 
+func TestAccStackHCIStoragePath_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_stack_hci_storage_path", "test")
+	r := StackHCIStoragePathResource{}
+
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccStackHCIStoragePath_basic(t *testing.T) {
 	if os.Getenv(customLocationIdEnv) == "" {
 		t.Skipf("skipping since %q has not been specified", customLocationIdEnv)

--- a/internal/services/azurestackhci/stack_hci_virtual_hard_disk_resource_test.go
+++ b/internal/services/azurestackhci/stack_hci_virtual_hard_disk_resource_test.go
@@ -19,6 +19,17 @@ import (
 
 type StackHCIVirtualHardDiskResource struct{}
 
+func TestAccStackHCIVirtualHardDisk_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_stack_hci_virtual_hard_disk", "test")
+	r := StackHCIVirtualHardDiskResource{}
+
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccStackHCIVirtualHardDisk_basic(t *testing.T) {
 	if os.Getenv(customLocationIdEnv) == "" {
 		t.Skipf("skipping since %q has not been specified", customLocationIdEnv)

--- a/internal/services/batch/batch_account_data_source_test.go
+++ b/internal/services/batch/batch_account_data_source_test.go
@@ -15,6 +15,16 @@ import (
 
 type BatchAccountDataSource struct{}
 
+func TestAccBatchAccountDataSource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_batch_account", "test")
+	r := BatchAccountDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccBatchAccountDataSource_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_batch_account", "test")
 	r := BatchAccountDataSource{}

--- a/internal/services/batch/batch_account_resource_test.go
+++ b/internal/services/batch/batch_account_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type BatchAccountResource struct{}
 
+func TestAccBatchAccount_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_batch_account", "test")
+	r := BatchAccountResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccBatchAccount_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_batch_account", "test")
 	r := BatchAccountResource{}

--- a/internal/services/batch/batch_application_data_source_test.go
+++ b/internal/services/batch/batch_application_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type BatchApplicationDataSource struct{}
 
+func TestAccBatchApplicationDataSource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_batch_application", "test")
+	r := BatchApplicationDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccBatchApplicationDataSource_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_batch_application", "test")
 	r := BatchApplicationDataSource{}

--- a/internal/services/batch/batch_application_resource_test.go
+++ b/internal/services/batch/batch_application_resource_test.go
@@ -22,6 +22,17 @@ func (r BatchApplicationResource) basicForResourceIdentity(data acceptance.TestD
 	return r.template(data, "")
 }
 
+func TestAccBatchApplication_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_batch_application", "test")
+	r := BatchApplicationResource{}
+
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.template(data, ""),
+		},
+	}, "")
+}
+
 func TestAccBatchApplication_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_batch_application", "test")
 	r := BatchApplicationResource{}

--- a/internal/services/batch/batch_job_resource_test.go
+++ b/internal/services/batch/batch_job_resource_test.go
@@ -21,6 +21,16 @@ import (
 
 type BatchJobResource struct{}
 
+func TestAccBatchJob_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_batch_job", "test")
+	r := BatchJobResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccBatchJob_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_batch_job", "test")
 	r := BatchJobResource{}

--- a/internal/services/batch/batch_pool_data_source_test.go
+++ b/internal/services/batch/batch_pool_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type BatchPoolDataSource struct{}
 
+func TestAccBatchPoolDataSource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_batch_pool", "test")
+	r := BatchPoolDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccBatchPoolDataSource_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_batch_pool", "test")
 	r := BatchPoolDataSource{}

--- a/internal/services/batch/batch_pool_resource_test.go
+++ b/internal/services/batch/batch_pool_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type BatchPoolResource struct{}
 
+func TestAccBatchPool_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_batch_pool", "test")
+	r := BatchPoolResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccBatchPool_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_batch_pool", "test")
 	r := BatchPoolResource{}

--- a/internal/services/billing/billing_enrollment_account_scope_data_source_test.go
+++ b/internal/services/billing/billing_enrollment_account_scope_data_source_test.go
@@ -12,6 +12,17 @@ import (
 
 type BillingEnrollmentAccountDataSource struct{}
 
+func TestAccBillingEnrollmentAccountDataSource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_billing_enrollment_account_scope", "test")
+	r := BillingEnrollmentAccountDataSource{}
+
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(),
+		},
+	}, "")
+}
+
 func TestAccBillingEnrollmentAccountDataSource_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_billing_enrollment_account_scope", "test")
 

--- a/internal/services/billing/billing_mca_account_scope_data_source_test.go
+++ b/internal/services/billing/billing_mca_account_scope_data_source_test.go
@@ -12,6 +12,17 @@ import (
 
 type BillingMCAAccountDataSource struct{}
 
+func TestAccBillingMCAAccountDataSource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_billing_mca_account_scope", "test")
+	r := BillingMCAAccountDataSource{}
+
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(),
+		},
+	}, "")
+}
+
 func TestAccBillingMCAAccountDataSource_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_billing_mca_account_scope", "test")
 

--- a/internal/services/billing/billing_mpa_account_scope_data_source_test.go
+++ b/internal/services/billing/billing_mpa_account_scope_data_source_test.go
@@ -12,6 +12,17 @@ import (
 
 type BillingMPAAccountDataSource struct{}
 
+func TestAccBillingMPAAccountDataSource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_billing_mpa_account_scope", "test")
+	r := BillingMPAAccountDataSource{}
+
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(),
+		},
+	}, "")
+}
+
 func TestAccBillingMPAAccountDataSource_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_billing_mpa_account_scope", "test")
 

--- a/internal/services/blueprints/blueprint_assignment_resource_test.go
+++ b/internal/services/blueprints/blueprint_assignment_resource_test.go
@@ -19,6 +19,17 @@ import (
 type BlueprintAssignmentResource struct{}
 
 // Scenario: Basic BP, no artefacts etc.  Stored and applied at Subscription.
+func TestAccBlueprintAssignment_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_blueprint_assignment", "test")
+	r := BlueprintAssignmentResource{}
+
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data, "testAcc_basicSubscription", "v0.1_testAcc"),
+		},
+	}, "")
+}
+
 func TestAccBlueprintAssignment_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_blueprint_assignment", "test")
 	r := BlueprintAssignmentResource{}

--- a/internal/services/blueprints/blueprint_definition_data_source_test.go
+++ b/internal/services/blueprints/blueprint_definition_data_source_test.go
@@ -14,6 +14,16 @@ import (
 type BlueprintDefinitionDataSource struct{}
 
 // lintignore:AT001
+func TestAccBlueprintDefinitionDataSource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_blueprint_definition", "test")
+	r := BlueprintDefinitionDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccBlueprintDefinitionDataSource_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_blueprint_definition", "test")
 	r := BlueprintDefinitionDataSource{}

--- a/internal/services/blueprints/blueprint_published_version_data_source_test.go
+++ b/internal/services/blueprints/blueprint_published_version_data_source_test.go
@@ -14,6 +14,17 @@ import (
 type BlueprintPublishedVersionDataSource struct{}
 
 // lintignore:AT001
+func TestAccBlueprintPublishedVersionDataSource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_blueprint_published_version", "test")
+	r := BlueprintPublishedVersionDataSource{}
+
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.atSubscription(data, "testAcc_basicSubscription", "v0.1_testAcc"),
+		},
+	}, "")
+}
+
 func TestAccBlueprintPublishedVersionDataSource_atSubscription(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_blueprint_published_version", "test")
 	r := BlueprintPublishedVersionDataSource{}

--- a/internal/services/bot/bot_channel_alexa_resource_test.go
+++ b/internal/services/bot/bot_channel_alexa_resource_test.go
@@ -20,6 +20,16 @@ import (
 
 type BotChannelAlexaResource struct{}
 
+func TestAccBotChannelAlexa_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_bot_channel_alexa", "test")
+	r := BotChannelAlexaResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccBotChannelAlexa_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_bot_channel_alexa", "test")
 	r := BotChannelAlexaResource{}

--- a/internal/services/bot/bot_channel_direct_line_speech_resource_test.go
+++ b/internal/services/bot/bot_channel_direct_line_speech_resource_test.go
@@ -21,6 +21,16 @@ import (
 
 type BotChannelDirectLineSpeechResource struct{}
 
+func TestAccBotChannelDirectLineSpeech_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_bot_channel_direct_line_speech", "test")
+	r := BotChannelDirectLineSpeechResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccBotChannelDirectLineSpeech_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_bot_channel_direct_line_speech", "test")
 	r := BotChannelDirectLineSpeechResource{}

--- a/internal/services/bot/bot_channel_directline_resource_test.go
+++ b/internal/services/bot/bot_channel_directline_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type BotChannelDirectlineResource struct{}
 
+func TestAccBotChannelDirectline_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_bot_channel_directline", "test")
+	r := BotChannelDirectlineResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicConfig(data),
+		},
+	}, "")
+}
+
 func TestAccBotChannelDirectline_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_bot_channel_directline", "test")
 	r := BotChannelDirectlineResource{}

--- a/internal/services/bot/bot_channel_email_resource_test.go
+++ b/internal/services/bot/bot_channel_email_resource_test.go
@@ -20,6 +20,17 @@ import (
 
 type BotChannelEmailResource struct{}
 
+func TestAccBotChannelEmail_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_bot_channel_email", "test")
+	r := BotChannelEmailResource{}
+
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicConfig(data),
+		},
+	}, "")
+}
+
 func TestAccBotChannelEmail_basic(t *testing.T) {
 	if ok := skipEmailChannel(); ok {
 		t.Skip("Skipping as one of `ARM_TEST_EMAIL`, AND `ARM_TEST_EMAIL_PASSWORD` was not specified")

--- a/internal/services/bot/bot_channel_facebook_resource_test.go
+++ b/internal/services/bot/bot_channel_facebook_resource_test.go
@@ -20,6 +20,16 @@ import (
 
 type BotChannelFacebookResource struct{}
 
+func TestAccBotChannelFacebook_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_bot_channel_facebook", "test")
+	r := BotChannelFacebookResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccBotChannelFacebook_basic(t *testing.T) {
 	skipFacebookChannel(t)
 

--- a/internal/services/bot/bot_channel_line_resource_test.go
+++ b/internal/services/bot/bot_channel_line_resource_test.go
@@ -20,6 +20,16 @@ import (
 
 type BotChannelLineResource struct{}
 
+func TestAccBotChannelLine_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_bot_channel_line", "test")
+	r := BotChannelLineResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccBotChannelLine_basic(t *testing.T) {
 	skipLineChannel(t)
 

--- a/internal/services/bot/bot_channel_ms_teams_resource_test.go
+++ b/internal/services/bot/bot_channel_ms_teams_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type BotChannelMsTeamsResource struct{}
 
+func TestAccBotChannelMsTeams_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_bot_channel_ms_teams", "test")
+	r := BotChannelMsTeamsResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicConfig(data),
+		},
+	}, "")
+}
+
 func TestAccBotChannelMsTeams_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_bot_channel_ms_teams", "test")
 	r := BotChannelMsTeamsResource{}

--- a/internal/services/bot/bot_channel_slack_resource_test.go
+++ b/internal/services/bot/bot_channel_slack_resource_test.go
@@ -20,6 +20,17 @@ import (
 
 type BotChannelSlackResource struct{}
 
+func TestAccBotChannelSlack_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_bot_channel_slack", "test")
+	r := BotChannelSlackResource{}
+
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccBotChannelSlack_basic(t *testing.T) {
 	if ok := skipSlackChannel(); ok {
 		t.Skip("Skipping as one of `ARM_TEST_SLACK_CLIENT_ID`, `ARM_TEST_SLACK_CLIENT_SECRET`, or `ARM_TEST_SLACK_VERIFICATION_TOKEN` was not specified")

--- a/internal/services/bot/bot_channel_sms_resource_test.go
+++ b/internal/services/bot/bot_channel_sms_resource_test.go
@@ -20,6 +20,16 @@ import (
 
 type BotChannelSMSResource struct{}
 
+func TestAccBotChannelSMS_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_bot_channel_sms", "test")
+	r := BotChannelSMSResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccBotChannelSMS_basic(t *testing.T) {
 	skipSMSChannel(t)
 

--- a/internal/services/bot/bot_channel_web_chat_resource_test.go
+++ b/internal/services/bot/bot_channel_web_chat_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type BotChannelWebChatResource struct{}
 
+func TestAccBotChannelWebChat_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_bot_channel_web_chat", "test")
+	r := BotChannelWebChatResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccBotChannelWebChat_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_bot_channel_web_chat", "test")
 	r := BotChannelWebChatResource{}

--- a/internal/services/bot/bot_channels_registration_resource_test.go
+++ b/internal/services/bot/bot_channels_registration_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type BotChannelsRegistrationResource struct{}
 
+func TestAccBotChannelsRegistration_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_bot_channels_registration", "test")
+	r := BotChannelsRegistrationResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicConfig(data),
+		},
+	}, "")
+}
+
 func TestAccBotChannelsRegistration_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_bot_channels_registration", "test")
 	r := BotChannelsRegistrationResource{}

--- a/internal/services/bot/bot_connection_resource_test.go
+++ b/internal/services/bot/bot_connection_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type BotConnectionResource struct{}
 
+func TestAccBotConnection_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_bot_connection", "test")
+	r := BotConnectionResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicConfig(data),
+		},
+	}, "")
+}
+
 func TestAccBotConnection_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_bot_connection", "test")
 	r := BotConnectionResource{}

--- a/internal/services/bot/bot_service_azure_bot_resource_test.go
+++ b/internal/services/bot/bot_service_azure_bot_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type BotServiceAzureBotResource struct{}
 
+func TestAccBotServiceAzureBot_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_bot_service_azure_bot", "test")
+	r := BotServiceAzureBotResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccBotServiceAzureBot_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_bot_service_azure_bot", "test")
 	r := BotServiceAzureBotResource{}

--- a/internal/services/bot/bot_web_app_resource_test.go
+++ b/internal/services/bot/bot_web_app_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type BotWebAppResource struct{}
 
+func TestAccBotWebApp_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_bot_web_app", "test")
+	r := BotWebAppResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicConfig(data),
+		},
+	}, "")
+}
+
 func TestAccBotWebApp_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_bot_web_app", "test")
 	r := BotWebAppResource{}

--- a/internal/services/bot/healthbot_resource_test.go
+++ b/internal/services/bot/healthbot_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type HealthbotResource struct{}
 
+func TestAccBotHealthbot_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_healthbot", "test")
+	r := HealthbotResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccBotHealthbot_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_healthbot", "test")
 	r := HealthbotResource{}


### PR DESCRIPTION
Adds per-resource/data-source regression tests (pattern from #33087) to automation, azurestackhci, batch, billing, blueprints and bot — 74 files.

Notes for review:
* The billing scope data sources use their existing hardcoded-account `basic()` configs.
* `blueprint_assignment` / `blueprint_published_version` reuse the existing literal args (`"testAcc_basicSubscription"`, `"v0.1_testAcc"`).
* `stack_hci_storage_path` (data source) normally runs via `DataSourceTestInSequence`; there is no sequential data-source regression helper yet, so it uses the parallel `DataSourceRegressionTest`.

Part 3 of ~21. No skip/preCheck gating is added to the regression tests for now.