### PR TITLE
regression tests 4/21 - cdn, chaosstudio, codesigning, cognitive, communication

### DIFF
--- a/internal/services/cdn/cdn_endpoint_custom_domain_resource_test.go
+++ b/internal/services/cdn/cdn_endpoint_custom_domain_resource_test.go
@@ -38,6 +38,18 @@ func NewCdnEndpointCustomDomainResource(dnsZoneRg, dnsZoneName string) *CdnEndpo
 	}
 }
 
+func TestAccCdnEndpointCustomDomain_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_endpoint_custom_domain", "test")
+
+	r := NewCdnEndpointCustomDomainResource(os.Getenv("ARM_TEST_DATA_RESOURCE_GROUP"), os.Getenv("ARM_TEST_DNS_ZONE"))
+
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccCdnEndpointCustomDomain_basic(t *testing.T) {
 	if cdn.IsCdnDeprecatedForCreation() {
 		t.Skip(cdn.CreateDeprecationMessage)

--- a/internal/services/cdn/cdn_endpoint_resource_test.go
+++ b/internal/services/cdn/cdn_endpoint_resource_test.go
@@ -20,6 +20,16 @@ import (
 
 type CdnEndpointResource struct{}
 
+func TestAccCdnEndpoint_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_endpoint", "test")
+	r := CdnEndpointResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccCdnEndpoint_basic(t *testing.T) {
 	if cdn.IsCdnDeprecatedForCreation() {
 		t.Skip(cdn.CreateDeprecationMessage)

--- a/internal/services/cdn/cdn_frontdoor_batch_rule_set_data_source_test.go
+++ b/internal/services/cdn/cdn_frontdoor_batch_rule_set_data_source_test.go
@@ -14,6 +14,16 @@ import (
 
 type CdnFrontDoorBatchRuleSetDataSource struct{}
 
+func TestAccCdnFrontDoorBatchRuleSetDataSource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_cdn_frontdoor_batch_rule_set", "test")
+	r := CdnFrontDoorBatchRuleSetDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccCdnFrontDoorBatchRuleSetDataSource_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_cdn_frontdoor_batch_rule_set", "test")
 	d := CdnFrontDoorBatchRuleSetDataSource{}

--- a/internal/services/cdn/cdn_frontdoor_batch_rule_set_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_batch_rule_set_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type CdnFrontdoorBatchRuleSetResource struct{}
 
+func TestAccCdnFrontDoorBatchRuleSet_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_batch_rule_set", "test")
+	r := CdnFrontdoorBatchRuleSetResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccCdnFrontDoorBatchRuleSet_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_batch_rule_set", "test")
 	r := CdnFrontdoorBatchRuleSetResource{}

--- a/internal/services/cdn/cdn_frontdoor_custom_domain_association_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_custom_domain_association_resource_test.go
@@ -23,6 +23,16 @@ type CdnFrontDoorCustomDomainAssociationResource struct{}
 
 // NOTE: There isn't a complete test case because the basic and the
 // update together equals what the complete test case would be...
+func TestAccCdnFrontDoorCustomDomainAssociation_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_custom_domain_association", "test")
+	r := CdnFrontDoorCustomDomainAssociationResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccCdnFrontDoorCustomDomainAssociation_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_custom_domain_association", "test")
 	r := CdnFrontDoorCustomDomainAssociationResource{}

--- a/internal/services/cdn/cdn_frontdoor_custom_domain_data_source_test.go
+++ b/internal/services/cdn/cdn_frontdoor_custom_domain_data_source_test.go
@@ -14,6 +14,16 @@ import (
 
 type CdnFrontDoorCustomDomainDataSource struct{}
 
+func TestAccCdnFrontDoorCustomDomainDataSource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_cdn_frontdoor_custom_domain", "test")
+	r := CdnFrontDoorCustomDomainDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccCdnFrontDoorCustomDomainDataSource_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_cdn_frontdoor_custom_domain", "test")
 	d := CdnFrontDoorCustomDomainDataSource{}

--- a/internal/services/cdn/cdn_frontdoor_custom_domain_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_custom_domain_resource_test.go
@@ -20,6 +20,16 @@ import (
 
 type CdnFrontDoorCustomDomainResource struct{}
 
+func TestAccCdnFrontDoorCustomDomain_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_custom_domain", "test")
+	r := CdnFrontDoorCustomDomainResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccCdnFrontDoorCustomDomain_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_custom_domain", "test")
 	r := CdnFrontDoorCustomDomainResource{}

--- a/internal/services/cdn/cdn_frontdoor_endpoint_data_source_test.go
+++ b/internal/services/cdn/cdn_frontdoor_endpoint_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type CdnFrontDoorEndpointDataSource struct{}
 
+func TestAccCdnFrontDoorEndpointDataSource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_cdn_frontdoor_endpoint", "test")
+	r := CdnFrontDoorEndpointDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccCdnFrontDoorEndpointDataSource_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_cdn_frontdoor_endpoint", "test")
 	d := CdnFrontDoorEndpointDataSource{}

--- a/internal/services/cdn/cdn_frontdoor_endpoint_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_endpoint_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type CdnFrontDoorEndpointResource struct{}
 
+func TestAccCdnFrontDoorEndpoint_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_endpoint", "test")
+	r := CdnFrontDoorEndpointResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccCdnFrontDoorEndpoint_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_endpoint", "test")
 	r := CdnFrontDoorEndpointResource{}

--- a/internal/services/cdn/cdn_frontdoor_firewall_policy_data_source_test.go
+++ b/internal/services/cdn/cdn_frontdoor_firewall_policy_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type CdnFrontDoorFirewallPolicyDataSource struct{}
 
+func TestAccCdnFrontDoorFirewallPolicyDataSource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_cdn_frontdoor_firewall_policy", "test")
+	r := CdnFrontDoorFirewallPolicyDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccCdnFrontDoorFirewallPolicyDataSource_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_cdn_frontdoor_firewall_policy", "test")
 	d := CdnFrontDoorFirewallPolicyDataSource{}

--- a/internal/services/cdn/cdn_frontdoor_firewall_policy_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_firewall_policy_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type CdnFrontDoorFirewallPolicyResource struct{}
 
+func TestAccCdnFrontDoorFirewallPolicy_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_firewall_policy", "test")
+	r := CdnFrontDoorFirewallPolicyResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccCdnFrontDoorFirewallPolicy_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_firewall_policy", "test")
 	r := CdnFrontDoorFirewallPolicyResource{}

--- a/internal/services/cdn/cdn_frontdoor_origin_group_data_source_test.go
+++ b/internal/services/cdn/cdn_frontdoor_origin_group_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type CdnFrontDoorOriginGroupDataSource struct{}
 
+func TestAccCdnFrontDoorOriginGroupDataSource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_cdn_frontdoor_origin_group", "test")
+	r := CdnFrontDoorOriginGroupDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccCdnFrontDoorOriginGroupDataSource_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_cdn_frontdoor_origin_group", "test")
 	d := CdnFrontDoorOriginGroupDataSource{}

--- a/internal/services/cdn/cdn_frontdoor_origin_group_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_origin_group_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type CdnFrontDoorOriginGroupResource struct{}
 
+func TestAccCdnFrontDoorOriginGroup_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_origin_group", "test")
+	r := CdnFrontDoorOriginGroupResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccCdnFrontDoorOriginGroup_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_origin_group", "test")
 	r := CdnFrontDoorOriginGroupResource{}

--- a/internal/services/cdn/cdn_frontdoor_origin_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_origin_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type CdnFrontDoorOriginResource struct{}
 
+func TestAccCdnFrontDoorOrigin_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_origin", "test")
+	r := CdnFrontDoorOriginResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccCdnFrontDoorOrigin_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_origin", "test")
 	r := CdnFrontDoorOriginResource{}

--- a/internal/services/cdn/cdn_frontdoor_profile_data_source_test.go
+++ b/internal/services/cdn/cdn_frontdoor_profile_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type CdnFrontDoorProfileDataSource struct{}
 
+func TestAccCdnFrontDoorProfileDataSource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_cdn_frontdoor_profile", "test")
+	r := CdnFrontDoorProfileDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccCdnFrontDoorProfileDataSource_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_cdn_frontdoor_profile", "test")
 	d := CdnFrontDoorProfileDataSource{}

--- a/internal/services/cdn/cdn_frontdoor_profile_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_profile_resource_test.go
@@ -20,6 +20,16 @@ import (
 
 type CdnFrontDoorProfileResource struct{}
 
+func TestAccCdnFrontDoorProfile_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_profile", "test")
+	r := CdnFrontDoorProfileResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccCdnFrontDoorProfile_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_profile", "test")
 	r := CdnFrontDoorProfileResource{}

--- a/internal/services/cdn/cdn_frontdoor_route_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_route_resource_test.go
@@ -22,6 +22,16 @@ type CdnFrontDoorRouteResource struct{}
 // in the meantime I will use the link_to_default_domain_enabled to make the
 // Frontdoor endpoint our "Custom Domain".
 
+func TestAccCdnFrontDoorRoute_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_route", "test")
+	r := CdnFrontDoorRouteResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccCdnFrontDoorRoute_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_route", "test")
 	r := CdnFrontDoorRouteResource{}

--- a/internal/services/cdn/cdn_frontdoor_rule_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_rule_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type CdnFrontDoorRuleResource struct{}
 
+func TestAccCdnFrontDoorRule_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_rule", "test")
+	r := CdnFrontDoorRuleResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.disableCacheError(data),
+		},
+	}, "")
+}
+
 func TestAccCdnFrontDoorRule_basic_unattachedRoute(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_rule", "test")
 	r := CdnFrontDoorRuleResource{}

--- a/internal/services/cdn/cdn_frontdoor_rule_set_data_source_test.go
+++ b/internal/services/cdn/cdn_frontdoor_rule_set_data_source_test.go
@@ -14,6 +14,16 @@ import (
 
 type CdnFrontDoorRuleSetDataSource struct{}
 
+func TestAccCdnFrontDoorRuleSetDataSource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_cdn_frontdoor_rule_set", "test")
+	r := CdnFrontDoorRuleSetDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.batchRuleSet(data),
+		},
+	}, "")
+}
+
 func TestAccCdnFrontDoorRuleSetDataSource_basic_unattachedRoute(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_cdn_frontdoor_rule_set", "test")
 	d := CdnFrontDoorRuleSetDataSource{}

--- a/internal/services/cdn/cdn_frontdoor_rule_set_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_rule_set_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type CdnFrontDoorRuleSetResource struct{}
 
+func TestAccCdnFrontDoorRuleSet_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_rule_set", "test")
+	r := CdnFrontdoorBatchRuleSetResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.disableCacheAndNoOriginGroup(data),
+		},
+	}, "")
+}
+
 func TestAccCdnFrontDoorRuleSet_basic_unattachedRoute(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_rule_set", "test")
 	r := CdnFrontDoorRuleSetResource{}

--- a/internal/services/cdn/cdn_frontdoor_secret_data_source_test.go
+++ b/internal/services/cdn/cdn_frontdoor_secret_data_source_test.go
@@ -16,6 +16,17 @@ type CdnFrontdoorSecretResourceDataSource struct {
 }
 
 // NOTE: This is currently not testable due to the cert requirements of the service
+func TestAccCdnFrontDoorSecretDataSource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_cdn_frontdoor_secret", "test")
+	r := CdnFrontdoorSecretResource{os.Getenv("ARM_TEST_DO_NOT_RUN_CDN_FRONT_DOOR_CUSTOM_DOMAIN")}
+
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccCdnFrontDoorSecretDataSource_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_cdn_frontdoor_secret", "test")
 	r := CdnFrontdoorSecretResource{os.Getenv("ARM_TEST_DO_NOT_RUN_CDN_FRONT_DOOR_CUSTOM_DOMAIN")}

--- a/internal/services/cdn/cdn_frontdoor_secret_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_secret_resource_test.go
@@ -22,6 +22,17 @@ type CdnFrontdoorSecretResource struct {
 	DoNotRunFrontDoorCustomDomainTests string
 }
 
+func TestAccCdnFrontDoorSecret_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_secret", "test")
+	r := CdnFrontdoorSecretResource{os.Getenv("ARM_TEST_DO_NOT_RUN_CDN_FRONT_DOOR_CUSTOM_DOMAIN")}
+
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccCdnFrontDoorSecret_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_secret", "test")
 	r := CdnFrontdoorSecretResource{os.Getenv("ARM_TEST_DO_NOT_RUN_CDN_FRONT_DOOR_CUSTOM_DOMAIN")}

--- a/internal/services/cdn/cdn_frontdoor_security_policy_data_source_test.go
+++ b/internal/services/cdn/cdn_frontdoor_security_policy_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type CdnFrontDoorSecurityPolicyDataSource struct{}
 
+func TestAccCdnFrontDoorSecurityPolicyDataSource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_cdn_frontdoor_security_policy", "test")
+	r := CdnFrontDoorSecurityPolicyDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccCdnFrontDoorSecurityPolicyDataSource_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_cdn_frontdoor_security_policy", "test")
 	d := CdnFrontDoorSecurityPolicyDataSource{}

--- a/internal/services/cdn/cdn_frontdoor_security_policy_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_security_policy_resource_test.go
@@ -20,6 +20,16 @@ import (
 
 type CdnFrontDoorSecurityPolicyResource struct{}
 
+func TestAccCdnFrontDoorSecurityPolicy_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_security_policy", "test")
+	r := CdnFrontDoorSecurityPolicyResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccCdnFrontDoorSecurityPolicy_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_security_policy", "test")
 	r := CdnFrontDoorSecurityPolicyResource{}

--- a/internal/services/cdn/cdn_profile_data_source_test.go
+++ b/internal/services/cdn/cdn_profile_data_source_test.go
@@ -14,6 +14,16 @@ import (
 
 type CdnProfileDataSource struct{}
 
+func TestAccCdnProfileDataSource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_cdn_profile", "test")
+	r := CdnProfileDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccCdnProfileDataSource_basic(t *testing.T) {
 	if cdn.IsCdnDeprecatedForCreation() {
 		t.Skip(cdn.CreateDeprecationMessage)

--- a/internal/services/cdn/cdn_profile_resource_test.go
+++ b/internal/services/cdn/cdn_profile_resource_test.go
@@ -21,6 +21,16 @@ import (
 
 type CdnProfileResource struct{}
 
+func TestAccCdnProfile_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_profile", "test")
+	r := CdnProfileResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccCdnProfile_basic(t *testing.T) {
 	if cdn.IsCdnDeprecatedForCreation() {
 		t.Skip(cdn.CreateDeprecationMessage)

--- a/internal/services/chaosstudio/chaos_studio_capability_resource_test.go
+++ b/internal/services/chaosstudio/chaos_studio_capability_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type ChaosStudioCapabilityTestResource struct{}
 
+func TestAccChaosStudioCapability_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_chaos_studio_capability", "test")
+	r := ChaosStudioCapabilityTestResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccChaosStudioCapability_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_chaos_studio_capability", "test")
 	r := ChaosStudioCapabilityTestResource{}

--- a/internal/services/chaosstudio/chaos_studio_experiment_resource_test.go
+++ b/internal/services/chaosstudio/chaos_studio_experiment_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type ChaosStudioExperimentTestResource struct{}
 
+func TestAccChaosStudioExperiment_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_chaos_studio_experiment", "test")
+	r := ChaosStudioExperimentTestResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccChaosStudioExperiment_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_chaos_studio_experiment", "test")
 	r := ChaosStudioExperimentTestResource{}

--- a/internal/services/codesigning/trusted_signing_account_data_source_test.go
+++ b/internal/services/codesigning/trusted_signing_account_data_source_test.go
@@ -14,6 +14,16 @@ import (
 
 type TrustedSigningAccountDataSource struct{}
 
+func TestAccTrustedSigningAccountDataSource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_trusted_signing_account", "test")
+	r := TrustedSigningAccountDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccTrustedSigningAccountDataSource_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_trusted_signing_account", "test")
 	r := TrustedSigningAccountDataSource{}

--- a/internal/services/codesigning/trusted_signing_account_resource_test.go
+++ b/internal/services/codesigning/trusted_signing_account_resource_test.go
@@ -31,6 +31,16 @@ func (a TrustedSigningAccountResource) Exists(ctx context.Context, client *clien
 	return pointer.To(resp.Model != nil), nil
 }
 
+func TestAccTrustedSigningAccount_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, codesigning.TrustedSigningAccountResource{}.ResourceType(), "test")
+	r := TrustedSigningAccountResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccTrustedSigningAccount_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, codesigning.TrustedSigningAccountResource{}.ResourceType(), "test")
 	r := TrustedSigningAccountResource{}

--- a/internal/services/cognitive/cognitive_account_connection_account_key_resource_test.go
+++ b/internal/services/cognitive/cognitive_account_connection_account_key_resource_test.go
@@ -20,6 +20,16 @@ import (
 
 type CognitiveAccountConnectionAccountKeyResource struct{}
 
+func TestAccCognitiveAccountConnectionAccountKey_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cognitive_account_connection_account_key", "test")
+	r := CognitiveAccountConnectionAccountKeyResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccCognitiveAccountConnectionAccountKey_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cognitive_account_connection_account_key", "test")
 	r := CognitiveAccountConnectionAccountKeyResource{}

--- a/internal/services/cognitive/cognitive_account_connection_account_managed_identity_resource_test.go
+++ b/internal/services/cognitive/cognitive_account_connection_account_managed_identity_resource_test.go
@@ -20,6 +20,16 @@ import (
 
 type CognitiveAccountConnectionAccountManagedIdentityResource struct{}
 
+func TestAccCognitiveAccountConnectionAccountManagedIdentity_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cognitive_account_connection_account_managed_identity", "test")
+	r := CognitiveAccountConnectionAccountManagedIdentityResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccCognitiveAccountConnectionAccountManagedIdentity_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cognitive_account_connection_account_managed_identity", "test")
 	r := CognitiveAccountConnectionAccountManagedIdentityResource{}

--- a/internal/services/cognitive/cognitive_account_connection_api_key_resource_test.go
+++ b/internal/services/cognitive/cognitive_account_connection_api_key_resource_test.go
@@ -20,6 +20,16 @@ import (
 
 type CognitiveAccountConnectionApiKeyResource struct{}
 
+func TestAccCognitiveAccountConnectionApiKey_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cognitive_account_connection_api_key", "test")
+	r := CognitiveAccountConnectionApiKeyResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccCognitiveAccountConnectionApiKey_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cognitive_account_connection_api_key", "test")
 	r := CognitiveAccountConnectionApiKeyResource{}

--- a/internal/services/cognitive/cognitive_account_connection_custom_keys_resource_test.go
+++ b/internal/services/cognitive/cognitive_account_connection_custom_keys_resource_test.go
@@ -20,6 +20,16 @@ import (
 
 type CognitiveAccountConnectionCustomKeysResource struct{}
 
+func TestAccCognitiveAccountConnectionCustomKeys_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cognitive_account_connection_custom_keys", "test")
+	r := CognitiveAccountConnectionCustomKeysResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccCognitiveAccountConnectionCustomKeys_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cognitive_account_connection_custom_keys", "test")
 	r := CognitiveAccountConnectionCustomKeysResource{}

--- a/internal/services/cognitive/cognitive_account_connection_entra_id_resource_test.go
+++ b/internal/services/cognitive/cognitive_account_connection_entra_id_resource_test.go
@@ -20,6 +20,16 @@ import (
 
 type CognitiveAccountConnectionEntraIdResource struct{}
 
+func TestAccCognitiveAccountConnectionEntraID_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cognitive_account_connection_entra_id", "test")
+	r := CognitiveAccountConnectionEntraIdResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccCognitiveAccountConnectionEntraID_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cognitive_account_connection_entra_id", "test")
 	r := CognitiveAccountConnectionEntraIdResource{}

--- a/internal/services/cognitive/cognitive_account_customer_managed_key_resource_test.go
+++ b/internal/services/cognitive/cognitive_account_customer_managed_key_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type CognitiveAccountCustomerManagedKeyResource struct{}
 
+func TestAccCognitiveAccountCustomerManagedKey_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cognitive_account_customer_managed_key", "test")
+	r := CognitiveAccountCustomerManagedKeyResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccCognitiveAccountCustomerManagedKey_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cognitive_account_customer_managed_key", "test")
 	r := CognitiveAccountCustomerManagedKeyResource{}

--- a/internal/services/cognitive/cognitive_account_data_source_test.go
+++ b/internal/services/cognitive/cognitive_account_data_source_test.go
@@ -14,6 +14,16 @@ import (
 
 type CognitiveAccountDataSource struct{}
 
+func TestAccCognitiveAccountDataSource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_cognitive_account", "test")
+	r := CognitiveAccountDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccCognitiveAccountDataSource_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_cognitive_account", "test")
 	r := CognitiveAccountDataSource{}

--- a/internal/services/cognitive/cognitive_account_project_data_source_test.go
+++ b/internal/services/cognitive/cognitive_account_project_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type CognitiveAccountProjectDataSource struct{}
 
+func TestAccCognitiveAccountProjectDataSource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_cognitive_account_project", "test")
+	r := CognitiveAccountProjectDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccCognitiveAccountProjectDataSource_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_cognitive_account_project", "test")
 	r := CognitiveAccountProjectDataSource{}

--- a/internal/services/cognitive/cognitive_account_project_resource_test.go
+++ b/internal/services/cognitive/cognitive_account_project_resource_test.go
@@ -15,6 +15,16 @@ import (
 
 type CognitiveAccountProjectResource struct{}
 
+func TestAccCognitiveAccountProject_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cognitive_account_project", "test")
+	r := CognitiveAccountProjectResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccCognitiveAccountProject_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cognitive_account_project", "test")
 	r := CognitiveAccountProjectResource{}

--- a/internal/services/cognitive/cognitive_account_rai_blocklist_resource_test.go
+++ b/internal/services/cognitive/cognitive_account_rai_blocklist_resource_test.go
@@ -25,8 +25,20 @@ func TestAccCognitiveRaiBlocklist_sequential(t *testing.T) {
 			"requiresImport": TestAccCognitiveRaiBlocklist_requiresImport,
 			"complete":       TestAccCognitiveRaiBlocklist_complete,
 			"update":         TestAccCognitiveRaiBlocklist_update,
+			"regression":     TestAccCognitiveRaiBlocklist_regressionTest,
 		},
 	})
+}
+
+func TestAccCognitiveRaiBlocklist_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cognitive_account_rai_blocklist", "test")
+	r := CognitiveRaiBlocklistTestResource{}
+
+	data.ResourceSequentialRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
 }
 
 func TestAccCognitiveRaiBlocklist_basic(t *testing.T) {

--- a/internal/services/cognitive/cognitive_account_rai_policy_resource_test.go
+++ b/internal/services/cognitive/cognitive_account_rai_policy_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type RaiPolicyTestResource struct{}
 
+func TestAccCognitiveAccountRaiPolicy_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cognitive_account_rai_policy", "test")
+	r := RaiPolicyTestResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccCognitiveAccountRaiPolicy_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cognitive_account_rai_policy", "test")
 	r := RaiPolicyTestResource{}

--- a/internal/services/cognitive/cognitive_account_resource_test.go
+++ b/internal/services/cognitive/cognitive_account_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type CognitiveAccountResource struct{}
 
+func TestAccCognitiveAccount_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cognitive_account", "test")
+	r := CognitiveAccountResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccCognitiveAccount_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cognitive_account", "test")
 	r := CognitiveAccountResource{}

--- a/internal/services/cognitive/cognitive_deployment_resource_test.go
+++ b/internal/services/cognitive/cognitive_deployment_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type CognitiveDeploymentTestResource struct{}
 
+func TestAccCognitiveDeployment_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cognitive_deployment", "test")
+	r := CognitiveDeploymentTestResource{}
+	data.ResourceSequentialRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccCognitiveDeployment_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cognitive_deployment", "test")
 	r := CognitiveDeploymentTestResource{}

--- a/internal/services/communication/communication_service_data_source_test.go
+++ b/internal/services/communication/communication_service_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type CommunicationServiceDataSource struct{}
 
+func TestAccCommunicationServiceDataSource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_communication_service", "test")
+	r := CommunicationServiceDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccCommunicationServiceDataSource_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_communication_service", "test")
 	d := CommunicationServiceDataSource{}

--- a/internal/services/communication/communication_service_email_domain_association_resource_test.go
+++ b/internal/services/communication/communication_service_email_domain_association_resource_test.go
@@ -22,6 +22,16 @@ import (
 
 type CommunicationServiceEmailDomainAssociationResource struct{}
 
+func TestAccCommunicationServiceEmailDomainAssociationResource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_communication_service_email_domain_association", "test")
+	r := CommunicationServiceEmailDomainAssociationResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccCommunicationServiceEmailDomainAssociationResource_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_communication_service_email_domain_association", "test")
 	r := CommunicationServiceEmailDomainAssociationResource{}

--- a/internal/services/communication/communication_service_resource_test.go
+++ b/internal/services/communication/communication_service_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type CommunicationServiceResource struct{}
 
+func TestAccCommunicationService_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_communication_service", "test")
+	r := CommunicationServiceResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccCommunicationService_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_communication_service", "test")
 	r := CommunicationServiceResource{}

--- a/internal/services/communication/email_communication_service_domain_resource_test.go
+++ b/internal/services/communication/email_communication_service_domain_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type EmailCommunicationServiceDomainResource struct{}
 
+func TestAccEmailServiceDomain_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_email_communication_service_domain", "test")
+	r := EmailCommunicationServiceDomainResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccEmailServiceDomain_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_email_communication_service_domain", "test")
 	r := EmailCommunicationServiceDomainResource{}

--- a/internal/services/communication/email_communication_service_domain_sender_username_resource_test.go
+++ b/internal/services/communication/email_communication_service_domain_sender_username_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type EmailCommunicationServiceDomainSenderUsernameResource struct{}
 
+func TestAccEmailServiceDomainSenderUsername_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_email_communication_service_domain_sender_username", "test")
+	r := EmailCommunicationServiceDomainSenderUsernameResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccEmailServiceDomainSenderUsername_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_email_communication_service_domain_sender_username", "test")
 	r := EmailCommunicationServiceDomainSenderUsernameResource{}

--- a/internal/services/communication/email_communication_service_resource_test.go
+++ b/internal/services/communication/email_communication_service_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type EmailCommunicationServiceResource struct{}
 
+func TestAccEmailService_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_email_communication_service", "test")
+	r := EmailCommunicationServiceResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccEmailService_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_email_communication_service", "test")
 	r := EmailCommunicationServiceResource{}


### PR DESCRIPTION
Adds per-resource/data-source regression tests (pattern from #33087) to cdn, chaosstudio, codesigning, cognitive and communication — 49 files.

Notes for review:
* `cognitive_account_rai_blocklist` runs via `RunTestsInSequence`, so the regression test is wired into the sequence map and uses `ResourceSequentialRegressionTest`.
* `cdn_endpoint_custom_domain` / `cdn_frontdoor_secret` keep their env-based constructors since the test resource needs those values.

Part 4 of ~21. No skip/preCheck gating is added to the regression tests for now.