### PR TITLE
regression tests 5/21 - compute, confidentialledger, connections, consumption, containerapps

### DIFF
--- a/internal/services/compute/availability_set_data_source_test.go
+++ b/internal/services/compute/availability_set_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type AvailabilitySetDataSource struct{}
 
+func TestAccDataSourceAvailabilitySet_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_availability_set", "test")
+	r := AvailabilitySetDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccDataSourceAvailabilitySet_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_availability_set", "test")
 	r := AvailabilitySetDataSource{}

--- a/internal/services/compute/availability_set_resource_test.go
+++ b/internal/services/compute/availability_set_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type AvailabilitySetResource struct{}
 
+func TestAccAvailabilitySet_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_availability_set", "test")
+	r := AvailabilitySetResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccAvailabilitySet_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_availability_set", "test")
 	r := AvailabilitySetResource{}

--- a/internal/services/compute/capacity_reservation_group_resource_test.go
+++ b/internal/services/compute/capacity_reservation_group_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type CapacityReservationGroupResource struct{}
 
+func TestAccCapacityReservationGroup_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_capacity_reservation_group", "test")
+	r := CapacityReservationGroupResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccCapacityReservationGroup_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_capacity_reservation_group", "test")
 	r := CapacityReservationGroupResource{}

--- a/internal/services/compute/capacity_reservation_resource_test.go
+++ b/internal/services/compute/capacity_reservation_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type CapacityReservationResource struct{}
 
+func TestAccCapacityReservation_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_capacity_reservation", "test")
+	r := CapacityReservationResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccCapacityReservation_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_capacity_reservation", "test")
 	r := CapacityReservationResource{}

--- a/internal/services/compute/dedicated_host_data_source_test.go
+++ b/internal/services/compute/dedicated_host_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type DedicatedHostDataSource struct{}
 
+func TestAccDataSourceAzureRMDedicatedHost_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_dedicated_host", "test")
+	r := DedicatedHostDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccDataSourceAzureRMDedicatedHost_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_dedicated_host", "test")
 	r := DedicatedHostDataSource{}

--- a/internal/services/compute/dedicated_host_group_data_source_test.go
+++ b/internal/services/compute/dedicated_host_group_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type DedicatedHostGroupDataSource struct{}
 
+func TestAccDataSourceDedicatedHostGroup_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_dedicated_host_group", "test")
+	r := DedicatedHostGroupDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccDataSourceDedicatedHostGroup_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_dedicated_host_group", "test")
 	r := DedicatedHostGroupDataSource{}

--- a/internal/services/compute/dedicated_host_group_resource_test.go
+++ b/internal/services/compute/dedicated_host_group_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type DedicatedHostGroupResource struct{}
 
+func TestAccDedicatedHostGroup_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_dedicated_host_group", "test")
+	r := DedicatedHostGroupResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccDedicatedHostGroup_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_dedicated_host_group", "test")
 	r := DedicatedHostGroupResource{}

--- a/internal/services/compute/dedicated_host_resource_test.go
+++ b/internal/services/compute/dedicated_host_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type DedicatedHostResource struct{}
 
+func TestAccDedicatedHost_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_dedicated_host", "test")
+	r := DedicatedHostResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccDedicatedHost_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_dedicated_host", "test")
 	r := DedicatedHostResource{}

--- a/internal/services/compute/disk_access_data_source_test.go
+++ b/internal/services/compute/disk_access_data_source_test.go
@@ -13,6 +13,20 @@ import (
 
 type DiskAccessDataSource struct{}
 
+func TestAccDataSourceDiskAccess_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_disk_access", "test")
+	r := DiskAccessDataSource{}
+
+	name := fmt.Sprintf("acctestdiskaccess-%d", data.RandomInteger)
+	resourceGroupName := fmt.Sprintf("acctestRG-%d", data.RandomInteger)
+
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data, name, resourceGroupName),
+		},
+	}, "")
+}
+
 func TestAccDataSourceDiskAccess_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_disk_access", "test")
 	r := DiskAccessDataSource{}

--- a/internal/services/compute/disk_access_resource_test.go
+++ b/internal/services/compute/disk_access_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type DiskAccessResource struct{}
 
+func TestAccDiskAccess_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_disk_access", "test")
+	r := DiskAccessResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.empty(data),
+		},
+	}, "")
+}
+
 func TestAccDiskAccess_empty(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_disk_access", "test")
 	r := DiskAccessResource{}

--- a/internal/services/compute/disk_encryption_set_data_source_test.go
+++ b/internal/services/compute/disk_encryption_set_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type DiskEncryptionSetDataSource struct{}
 
+func TestAccDataSourceDiskEncryptionSet_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_disk_encryption_set", "test")
+	r := DiskEncryptionSetDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccDataSourceDiskEncryptionSet_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_disk_encryption_set", "test")
 	r := DiskEncryptionSetDataSource{}

--- a/internal/services/compute/disk_encryption_set_resource_test.go
+++ b/internal/services/compute/disk_encryption_set_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type DiskEncryptionSetResource struct{}
 
+func TestAccDiskEncryptionSet_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_disk_encryption_set", "test")
+	r := DiskEncryptionSetResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccDiskEncryptionSet_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_disk_encryption_set", "test")
 	r := DiskEncryptionSetResource{}

--- a/internal/services/compute/gallery_application_resource_test.go
+++ b/internal/services/compute/gallery_application_resource_test.go
@@ -20,6 +20,16 @@ import (
 
 type GalleryApplicationResource struct{}
 
+func TestAccGalleryApplication_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_gallery_application", "test")
+	r := GalleryApplicationResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccGalleryApplication_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_gallery_application", "test")
 	r := GalleryApplicationResource{}

--- a/internal/services/compute/gallery_application_version_resource_test.go
+++ b/internal/services/compute/gallery_application_version_resource_test.go
@@ -20,6 +20,16 @@ import (
 
 type GalleryApplicationVersionResource struct{}
 
+func TestAccGalleryApplicationVersion_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_gallery_application_version", "test")
+	r := GalleryApplicationVersionResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccGalleryApplicationVersion_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_gallery_application_version", "test")
 	r := GalleryApplicationVersionResource{}

--- a/internal/services/compute/image_data_source_test.go
+++ b/internal/services/compute/image_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type ImageDataSource struct{}
 
+func TestAccDataSourceImage_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_image", "test")
+	r := ImageDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccDataSourceImage_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_image", "test")
 	r := ImageDataSource{}

--- a/internal/services/compute/image_resource_test.go
+++ b/internal/services/compute/image_resource_test.go
@@ -23,6 +23,16 @@ import (
 
 type ImageResource struct{}
 
+func TestAccImage_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_image", "test")
+	r := ImageResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.setupManagedDisks(data),
+		},
+	}, "")
+}
+
 func TestAccImage_standaloneImage(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_image", "test")
 	r := ImageResource{}

--- a/internal/services/compute/images_data_source_test.go
+++ b/internal/services/compute/images_data_source_test.go
@@ -14,6 +14,16 @@ import (
 
 type ImagesDataSource struct{}
 
+func TestAccDataSourceAzureRMImages_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_images", "test")
+	r := ImagesDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccDataSourceAzureRMImages_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_images", "test")
 	r := ImagesDataSource{}

--- a/internal/services/compute/linux_virtual_machine_resource_auth_test.go
+++ b/internal/services/compute/linux_virtual_machine_resource_auth_test.go
@@ -11,6 +11,17 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 )
 
+func TestAccLinuxVirtualMachine_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+	r := LinuxVirtualMachineResource{}
+
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authPassword(data),
+		},
+	}, "")
+}
+
 func TestAccLinuxVirtualMachine_authPassword(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
 	r := LinuxVirtualMachineResource{}

--- a/internal/services/compute/linux_virtual_machine_scale_set_resource_auth_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_resource_auth_test.go
@@ -11,6 +11,17 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 )
 
+func TestAccLinuxVirtualMachineScaleSet_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine_scale_set", "test")
+	r := LinuxVirtualMachineScaleSetResource{}
+
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authPassword(data),
+		},
+	}, "")
+}
+
 func TestAccLinuxVirtualMachineScaleSet_authPassword(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine_scale_set", "test")
 	r := LinuxVirtualMachineScaleSetResource{}

--- a/internal/services/compute/managed_disk_data_source_test.go
+++ b/internal/services/compute/managed_disk_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type ManagedDiskDataSource struct{}
 
+func TestAccDataSourceManagedDisk_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_managed_disk", "test")
+	r := ManagedDiskDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.diskAccess(data),
+		},
+	}, "")
+}
+
 func TestAccDataSourceManagedDisk_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_managed_disk", "test")
 	r := ManagedDiskDataSource{}

--- a/internal/services/compute/managed_disk_resource_test.go
+++ b/internal/services/compute/managed_disk_resource_test.go
@@ -22,6 +22,16 @@ import (
 
 type ManagedDiskResource struct{}
 
+func TestAccManagedDisk_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_managed_disk", "test")
+	r := ManagedDiskResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.empty(data),
+		},
+	}, "")
+}
+
 func TestAccManagedDisk_empty(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_managed_disk", "test")
 	r := ManagedDiskResource{}

--- a/internal/services/compute/managed_disk_sas_token_resource_test.go
+++ b/internal/services/compute/managed_disk_sas_token_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type ManagedDiskSASTokenResource struct{}
 
+func TestAccManagedDiskSASToken_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_managed_disk_sas_token", "test")
+	r := ManagedDiskSASTokenResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccManagedDiskSASToken_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_managed_disk_sas_token", "test")
 	r := ManagedDiskSASTokenResource{}

--- a/internal/services/compute/managed_disks_data_source_test.go
+++ b/internal/services/compute/managed_disks_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type ManagedDisksDataSource struct{}
 
+func TestAccDataSourceManagedDisks_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_managed_disks", "test")
+	r := ManagedDisksDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccDataSourceManagedDisks_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_managed_disks", "test")
 	r := ManagedDisksDataSource{}

--- a/internal/services/compute/marketplace_agreement_resource_test.go
+++ b/internal/services/compute/marketplace_agreement_resource_test.go
@@ -20,6 +20,27 @@ import (
 
 type MarketplaceAgreementResource struct{}
 
+func TestAccMarketplaceAgreement_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_marketplace_agreement", "test")
+	r := MarketplaceAgreementResource{}
+	offer := "waf"
+
+	data.ResourceRegressionAdditionalStepsTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.empty(),
+			Check: acceptance.ComposeTestCheckFunc(
+				data.CheckWithClientWithoutResource(r.cancelExistingAgreement(offer)),
+			),
+		},
+		{
+			Config: r.basic(offer),
+		},
+		{
+			Config: r.basic(offer),
+		},
+	}, "")
+}
+
 func TestAccMarketplaceAgreement_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_marketplace_agreement", "test")
 	r := MarketplaceAgreementResource{}

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_data_source_test.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_data_source_test.go
@@ -14,6 +14,16 @@ import (
 
 type OrchestratedVirtualMachineScaleSetDataSource struct{}
 
+func TestAccOrchestratedVMSSDataSource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_orchestrated_virtual_machine_scale_set", "test")
+	r := OrchestratedVirtualMachineScaleSetDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccOrchestratedVMSSDataSource_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_orchestrated_virtual_machine_scale_set", "test")
 	d := OrchestratedVirtualMachineScaleSetDataSource{}

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_test.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type OrchestratedVirtualMachineScaleSetResource struct{}
 
+func TestAccOrchestratedVirtualMachineScaleSet_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_orchestrated_virtual_machine_scale_set", "test")
+	r := OrchestratedVirtualMachineScaleSetResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccOrchestratedVirtualMachineScaleSet_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_orchestrated_virtual_machine_scale_set", "test")
 	r := OrchestratedVirtualMachineScaleSetResource{}

--- a/internal/services/compute/platform_image_data_source_test.go
+++ b/internal/services/compute/platform_image_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type PlatformImageDataSource struct{}
 
+func TestAccDataSourcePlatformImage_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_platform_image", "test")
+	r := PlatformImageDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccDataSourcePlatformImage_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_platform_image", "test")
 	r := PlatformImageDataSource{}

--- a/internal/services/compute/proximity_placement_group_data_source_test.go
+++ b/internal/services/compute/proximity_placement_group_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type ProximityPlacementGroupDataSource struct{}
 
+func TestAccProximityPlacementGroupDataSource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_proximity_placement_group", "test")
+	r := ProximityPlacementGroupDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccProximityPlacementGroupDataSource_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_proximity_placement_group", "test")
 	r := ProximityPlacementGroupDataSource{}

--- a/internal/services/compute/proximity_placement_group_resource_test.go
+++ b/internal/services/compute/proximity_placement_group_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type ProximityPlacementGroupResource struct{}
 
+func TestAccProximityPlacementGroup_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_proximity_placement_group", "test")
+	r := ProximityPlacementGroupResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccProximityPlacementGroup_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_proximity_placement_group", "test")
 	r := ProximityPlacementGroupResource{}

--- a/internal/services/compute/shared_image_data_source_test.go
+++ b/internal/services/compute/shared_image_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type SharedImageDataSource struct{}
 
+func TestAccDataSourceSharedImage_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_shared_image", "test")
+	r := SharedImageDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.withHibernationEnabled(data),
+		},
+	}, "")
+}
+
 func TestAccDataSourceSharedImage_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_shared_image", "test")
 	r := SharedImageDataSource{}

--- a/internal/services/compute/shared_image_gallery_data_source_test.go
+++ b/internal/services/compute/shared_image_gallery_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type SharedImageGalleryDataSource struct{}
 
+func TestAccDataSourceSharedImageGallery_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_shared_image_gallery", "test")
+	r := SharedImageGalleryDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccDataSourceSharedImageGallery_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_shared_image_gallery", "test")
 	r := SharedImageGalleryDataSource{}

--- a/internal/services/compute/shared_image_gallery_resource_test.go
+++ b/internal/services/compute/shared_image_gallery_resource_test.go
@@ -20,6 +20,16 @@ import (
 
 type SharedImageGalleryResource struct{}
 
+func TestAccSharedImageGallery_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_shared_image_gallery", "test")
+	r := SharedImageGalleryResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccSharedImageGallery_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_shared_image_gallery", "test")
 	r := SharedImageGalleryResource{}

--- a/internal/services/compute/shared_image_resource_test.go
+++ b/internal/services/compute/shared_image_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type SharedImageResource struct{}
 
+func TestAccSharedImage_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_shared_image", "test")
+	r := SharedImageResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccSharedImage_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_shared_image", "test")
 	r := SharedImageResource{}

--- a/internal/services/compute/shared_image_version_data_source_test.go
+++ b/internal/services/compute/shared_image_version_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type SharedImageVersionDataSource struct{}
 
+func TestAccDataSourceSharedImageVersion_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_shared_image_version", "test")
+	r := SharedImageVersionDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccDataSourceSharedImageVersion_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_shared_image_version", "test")
 	r := SharedImageVersionDataSource{}

--- a/internal/services/compute/shared_image_version_resource_test.go
+++ b/internal/services/compute/shared_image_version_resource_test.go
@@ -20,6 +20,16 @@ import (
 
 type SharedImageVersionResource struct{}
 
+func TestAccSharedImageVersion_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_shared_image_version", "test")
+	r := SharedImageVersionResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.setup(data),
+		},
+	}, "")
+}
+
 func TestAccSharedImageVersion_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_shared_image_version", "test")
 	r := SharedImageVersionResource{}

--- a/internal/services/compute/shared_image_versions_data_source_test.go
+++ b/internal/services/compute/shared_image_versions_data_source_test.go
@@ -14,6 +14,16 @@ import (
 
 type SharedImageVersionsDataSource struct{}
 
+func TestAccDataSourceSharedImageVersions_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_shared_image_versions", "test")
+	r := SharedImageVersionsDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccDataSourceSharedImageVersions_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_shared_image_versions", "test")
 	r := SharedImageVersionsDataSource{}

--- a/internal/services/compute/snapshot_data_source_test.go
+++ b/internal/services/compute/snapshot_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type SnapshotDataSource struct{}
 
+func TestAccDataSourceSnapshot_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_snapshot", "test")
+	r := SnapshotDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccDataSourceSnapshot_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_snapshot", "snapshot")
 	r := SnapshotDataSource{}

--- a/internal/services/compute/snapshot_resource_test.go
+++ b/internal/services/compute/snapshot_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type SnapshotResource struct{}
 
+func TestAccSnapshot_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_snapshot", "test")
+	r := SnapshotResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.fromManagedDisk(data),
+		},
+	}, "")
+}
+
 func TestAccSnapshot_fromManagedDisk(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_snapshot", "test")
 	r := SnapshotResource{}

--- a/internal/services/compute/ssh_public_key_data_source_test.go
+++ b/internal/services/compute/ssh_public_key_data_source_test.go
@@ -13,6 +13,19 @@ import (
 
 type SSHPublicKeyDataSource struct{}
 
+func TestAccDataSourceAzureSshPublicKey_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_ssh_public_key", "test")
+	r := SSHPublicKeyDataSource{}
+
+	key1 := "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC+wWK73dCr+jgQOAxNsHAnNNNMEMWOHYEccp6wJm2gotpr9katuF/ZAdou5AaW1C61slRkHRkpRRX9FA9CYBiitZgvCCz+3nWNN7l/Up54Zps/pHWGZLHNJZRYyAB6j5yVLMVHIHriY49d/GZTZVNB8GoJv9Gakwc/fuEZYYl4YDFiGMBP///TzlI4jhiJzjKnEvqPFki5p2ZRJqcbCiF4pJrxUQR/RXqVFQdbRLZgYfJ8xGB878RENq3yQ39d8dVOkq4edbkzwcUmwwwkYVPIoDGsYLaRHnG+To7FvMeyO7xDVQkMKzopTQV8AuKpyvpqu0a9pWOMaiCyDytO7GGN you@me.com"
+
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.template(data, key1),
+		},
+	}, "")
+}
+
 func TestAccDataSourceAzureSshPublicKey_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_ssh_public_key", "test")
 	r := SSHPublicKeyDataSource{}

--- a/internal/services/compute/ssh_public_key_resource_test.go
+++ b/internal/services/compute/ssh_public_key_resource_test.go
@@ -18,6 +18,19 @@ import (
 
 type SSHPublicKeyResource struct{}
 
+func TestAccSshPublicKey_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_ssh_public_key", "test")
+	r := SSHPublicKeyResource{}
+
+	key1 := "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC+wWK73dCr+jgQOAxNsHAnNNNMEMWOHYEccp6wJm2gotpr9katuF/ZAdou5AaW1C61slRkHRkpRRX9FA9CYBiitZgvCCz+3nWNN7l/Up54Zps/pHWGZLHNJZRYyAB6j5yVLMVHIHriY49d/GZTZVNB8GoJv9Gakwc/fuEZYYl4YDFiGMBP///TzlI4jhiJzjKnEvqPFki5p2ZRJqcbCiF4pJrxUQR/RXqVFQdbRLZgYfJ8xGB878RENq3yQ39d8dVOkq4edbkzwcUmwwwkYVPIoDGsYLaRHnG+To7FvMeyO7xDVQkMKzopTQV8AuKpyvpqu0a9pWOMaiCyDytO7GGN you@me.com"
+
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.template(data, key1),
+		},
+	}, "")
+}
+
 func TestAccSshPublicKey_CreateUpdate(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_ssh_public_key", "test")
 	r := SSHPublicKeyResource{}

--- a/internal/services/compute/virtual_machine_data_disk_attachment_resource_test.go
+++ b/internal/services/compute/virtual_machine_data_disk_attachment_resource_test.go
@@ -21,6 +21,16 @@ import (
 
 type VirtualMachineDataDiskAttachmentResource struct{}
 
+func TestAccVirtualMachineDataDiskAttachment_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_virtual_machine_data_disk_attachment", "test")
+	r := VirtualMachineDataDiskAttachmentResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccVirtualMachineDataDiskAttachment_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_virtual_machine_data_disk_attachment", "test")
 	r := VirtualMachineDataDiskAttachmentResource{}

--- a/internal/services/compute/virtual_machine_data_source_test.go
+++ b/internal/services/compute/virtual_machine_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type VirtualMachineDataSource struct{}
 
+func TestAccDataSourceAzureRMVirtualMachine_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_virtual_machine", "test")
+	r := VirtualMachineDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basicLinux(data),
+		},
+	}, "")
+}
+
 func TestAccDataSourceAzureRMVirtualMachine_basicLinux(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_virtual_machine", "test")
 	r := VirtualMachineDataSource{}

--- a/internal/services/compute/virtual_machine_extension_resource_test.go
+++ b/internal/services/compute/virtual_machine_extension_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type VirtualMachineExtensionResource struct{}
 
+func TestAccVirtualMachineExtension_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_virtual_machine_extension", "test")
+	r := VirtualMachineExtensionResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccVirtualMachineExtension_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_virtual_machine_extension", "test")
 	r := VirtualMachineExtensionResource{}

--- a/internal/services/compute/virtual_machine_gallery_application_assignment_resource_test.go
+++ b/internal/services/compute/virtual_machine_gallery_application_assignment_resource_test.go
@@ -21,6 +21,16 @@ import (
 
 type VirtualMachineGalleryApplicationAssignmentResource struct{}
 
+func TestAccVirtualMachineGalleryApplicationAssignment_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_virtual_machine_gallery_application_assignment", "test")
+	r := VirtualMachineGalleryApplicationAssignmentResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccVirtualMachineGalleryApplicationAssignment_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_virtual_machine_gallery_application_assignment", "test")
 	r := VirtualMachineGalleryApplicationAssignmentResource{}

--- a/internal/services/compute/virtual_machine_implicit_data_disk_from_source_resource_test.go
+++ b/internal/services/compute/virtual_machine_implicit_data_disk_from_source_resource_test.go
@@ -24,6 +24,16 @@ import (
 
 type VirtualMachineImplicitDataDiskFromSourceResource struct{}
 
+func TestAccVirtualMachineImplicitDataDiskFromSource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_virtual_machine_implicit_data_disk_from_source", "test")
+	r := VirtualMachineImplicitDataDiskFromSourceResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccVirtualMachineImplicitDataDiskFromSource_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_virtual_machine_implicit_data_disk_from_source", "test")
 	r := VirtualMachineImplicitDataDiskFromSourceResource{}

--- a/internal/services/compute/virtual_machine_restore_point_collection_resource_test.go
+++ b/internal/services/compute/virtual_machine_restore_point_collection_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type VirtualMachineRestorePointCollectionResource struct{}
 
+func TestAccVirtualMachineRestorePointCollection_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_virtual_machine_restore_point_collection", "test")
+	r := VirtualMachineRestorePointCollectionResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccVirtualMachineRestorePointCollection_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_virtual_machine_restore_point_collection", "test")
 	r := VirtualMachineRestorePointCollectionResource{}

--- a/internal/services/compute/virtual_machine_restore_point_resource_test.go
+++ b/internal/services/compute/virtual_machine_restore_point_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type VirtualMachineRestorePointResource struct{}
 
+func TestAccVirtualMachineRestorePoint_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_virtual_machine_restore_point", "test")
+	r := VirtualMachineRestorePointResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccVirtualMachineRestorePoint_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_virtual_machine_restore_point", "test")
 	r := VirtualMachineRestorePointResource{}

--- a/internal/services/compute/virtual_machine_run_command_resource_test.go
+++ b/internal/services/compute/virtual_machine_run_command_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type VirtualMachineRunCommandTestResource struct{}
 
+func TestAccVirtualMachineRunCommand_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_virtual_machine_run_command", "test")
+	r := VirtualMachineRunCommandTestResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccVirtualMachineRunCommand_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_virtual_machine_run_command", "test")
 	r := VirtualMachineRunCommandTestResource{}

--- a/internal/services/compute/virtual_machine_scale_set_data_source_test.go
+++ b/internal/services/compute/virtual_machine_scale_set_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type VirtualMachineScaleSetDataSource struct{}
 
+func TestAccDataSourceVirtualMachineScaleSet_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_virtual_machine_scale_set", "test")
+	r := VirtualMachineScaleSetDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basicLinux(data),
+		},
+	}, "")
+}
+
 func TestAccDataSourceVirtualMachineScaleSet_basicLinux(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_virtual_machine_scale_set", "test")
 	r := VirtualMachineScaleSetDataSource{}

--- a/internal/services/compute/virtual_machine_scale_set_extension_resource_test.go
+++ b/internal/services/compute/virtual_machine_scale_set_extension_resource_test.go
@@ -18,6 +18,16 @@ import (
 
 type VirtualMachineScaleSetExtensionResource struct{}
 
+func TestAccVirtualMachineScaleSetExtension_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_virtual_machine_scale_set_extension", "test")
+	r := VirtualMachineScaleSetExtensionResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicLinux(data),
+		},
+	}, "")
+}
+
 func TestAccVirtualMachineScaleSetExtension_basicLinux(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_virtual_machine_scale_set_extension", "test")
 	r := VirtualMachineScaleSetExtensionResource{}

--- a/internal/services/compute/virtual_machine_scale_set_standby_pool_resource_test.go
+++ b/internal/services/compute/virtual_machine_scale_set_standby_pool_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type StandbyPoolStandbyVirtualMachinePoolResource struct{}
 
+func TestAccStandbyPoolStandbyVirtualMachinePool_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_virtual_machine_scale_set_standby_pool", "test")
+	r := StandbyPoolStandbyVirtualMachinePoolResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccStandbyPoolStandbyVirtualMachinePool_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_virtual_machine_scale_set_standby_pool", "test")
 	r := StandbyPoolStandbyVirtualMachinePoolResource{}

--- a/internal/services/compute/windows_virtual_machine_resource_auth_test.go
+++ b/internal/services/compute/windows_virtual_machine_resource_auth_test.go
@@ -11,6 +11,17 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 )
 
+func TestAccWindowsVirtualMachine_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+	r := WindowsVirtualMachineResource{}
+
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authPassword(data),
+		},
+	}, "")
+}
+
 func TestAccWindowsVirtualMachine_authPassword(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
 	r := WindowsVirtualMachineResource{}

--- a/internal/services/compute/windows_virtual_machine_scale_set_resource_auth_test.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_resource_auth_test.go
@@ -11,6 +11,17 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 )
 
+func TestAccWindowsVirtualMachineScaleSet_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine_scale_set", "test")
+	r := WindowsVirtualMachineScaleSetResource{}
+
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authPassword(data),
+		},
+	}, "")
+}
+
 func TestAccWindowsVirtualMachineScaleSet_authPassword(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine_scale_set", "test")
 	r := WindowsVirtualMachineScaleSetResource{}

--- a/internal/services/confidentialledger/confidential_ledger_data_source_test.go
+++ b/internal/services/confidentialledger/confidential_ledger_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type ConfidentialLedgerDataSource struct{}
 
+func TestAccConfidentialLedgerDataSource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_confidential_ledger", "test")
+	r := ConfidentialLedgerDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccConfidentialLedgerDataSource_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_confidential_ledger", "test")
 

--- a/internal/services/confidentialledger/confidential_ledger_resource_test.go
+++ b/internal/services/confidentialledger/confidential_ledger_resource_test.go
@@ -25,8 +25,20 @@ func TestAccConfidentialLedger_sequential(t *testing.T) {
 			"private":        testAccConfidentialLedger_private,
 			"requiresImport": testAccConfidentialLedger_requiresImport,
 			"certBased":      testAccConfidentialLedger_certBased,
+			"regression":     testAccConfidentialLedger_regressionTest,
 		},
 	})
+}
+
+func testAccConfidentialLedger_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_confidential_ledger", "test")
+	r := ConfidentialLedgerResource{}
+
+	data.ResourceSequentialRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.public(data),
+		},
+	}, "")
 }
 
 func testAccConfidentialLedger_public(t *testing.T) {

--- a/internal/services/connections/api_connection_data_source_test.go
+++ b/internal/services/connections/api_connection_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type ApiConnectionDataSource struct{}
 
+func TestAccApiConnectionDataSource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_api_connection", "test")
+	r := ApiConnectionDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccApiConnectionDataSource_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_api_connection", "test")
 	r := ApiConnectionDataSource{}

--- a/internal/services/connections/api_connection_resource_test.go
+++ b/internal/services/connections/api_connection_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type ApiConnectionTestResource struct{}
 
+func TestAccApiConnection_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_connection", "test")
+	r := ApiConnectionTestResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccApiConnection_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_connection", "test")
 	r := ApiConnectionTestResource{}

--- a/internal/services/connections/managed_api_data_source_test.go
+++ b/internal/services/connections/managed_api_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type ManagedApiTestDataSource struct{}
 
+func TestAccDataSourceManagedApi_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_managed_api", "test")
+	r := ManagedApiTestDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccDataSourceManagedApi_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_managed_api", "test")
 	r := ManagedApiTestDataSource{}

--- a/internal/services/consumption/consumption_budget_management_group_resource_test.go
+++ b/internal/services/consumption/consumption_budget_management_group_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type ConsumptionBudgetManagementGroupResource struct{}
 
+func TestAccConsumptionBudgetManagementGroup_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_consumption_budget_management_group", "test")
+	r := ConsumptionBudgetManagementGroupResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccConsumptionBudgetManagementGroup_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_consumption_budget_management_group", "test")
 	r := ConsumptionBudgetManagementGroupResource{}

--- a/internal/services/consumption/consumption_budget_resource_group_data_source_test.go
+++ b/internal/services/consumption/consumption_budget_resource_group_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type ConsumptionBudgetResourceGroupDataSource struct{}
 
+func TestAccDataSourceConsumptionBudgetResourceGroup_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_consumption_budget_resource_group", "test")
+	r := ConsumptionBudgetResourceGroupDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccDataSourceConsumptionBudgetResourceGroup_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_consumption_budget_resource_group", "test")
 	r := ConsumptionBudgetResourceGroupDataSource{}

--- a/internal/services/consumption/consumption_budget_resource_group_resource_test.go
+++ b/internal/services/consumption/consumption_budget_resource_group_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type ConsumptionBudgetResourceGroupResource struct{}
 
+func TestAccConsumptionBudgetResourceGroup_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_consumption_budget_resource_group", "test")
+	r := ConsumptionBudgetResourceGroupResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccConsumptionBudgetResourceGroup_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_consumption_budget_resource_group", "test")
 	r := ConsumptionBudgetResourceGroupResource{}

--- a/internal/services/consumption/consumption_budget_subscription_data_source_test.go
+++ b/internal/services/consumption/consumption_budget_subscription_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type ConsumptionBudgetSubscriptionDataSource struct{}
 
+func TestAccDataSourceConsumptionBudgetSubscription_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_consumption_budget_subscription", "test")
+	r := ConsumptionBudgetSubscriptionDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccDataSourceConsumptionBudgetSubscription_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_consumption_budget_subscription", "test")
 	r := ConsumptionBudgetSubscriptionDataSource{}

--- a/internal/services/consumption/consumption_budget_subscription_resource_test.go
+++ b/internal/services/consumption/consumption_budget_subscription_resource_test.go
@@ -24,6 +24,16 @@ func consumptionBudgetTestStartDate() time.Time {
 
 type ConsumptionBudgetSubscriptionResource struct{}
 
+func TestAccConsumptionBudgetSubscription_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_consumption_budget_subscription", "test")
+	r := ConsumptionBudgetSubscriptionResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccConsumptionBudgetSubscription_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_consumption_budget_subscription", "test")
 	r := ConsumptionBudgetSubscriptionResource{}

--- a/internal/services/containerapps/container_app_custom_domain_resource_test.go
+++ b/internal/services/containerapps/container_app_custom_domain_resource_test.go
@@ -56,6 +56,17 @@ func (r ContainerAppCustomDomainResource) Exists(ctx context.Context, client *cl
 	return pointer.To(false), nil
 }
 
+func TestAccContainerAppCustomDomainResource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_app_custom_domain", "test")
+	r := ContainerAppCustomDomainResource{}
+
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccContainerAppCustomDomainResource_basic(t *testing.T) {
 	if os.Getenv("ARM_TEST_DNS_ZONE") == "" || os.Getenv("ARM_TEST_DATA_RESOURCE_GROUP") == "" {
 		t.Skipf("Skipping as either ARM_TEST_DNS_ZONE or ARM_TEST_DATA_RESOURCE_GROUP is not set")

--- a/internal/services/containerapps/container_app_data_source_test.go
+++ b/internal/services/containerapps/container_app_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type ContainerAppDataSource struct{}
 
+func TestAccContainerAppDataSource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_container_app", "test")
+	r := ContainerAppDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccContainerAppDataSource_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_container_app", "test")
 	r := ContainerAppDataSource{}

--- a/internal/services/containerapps/container_app_environment_certificate_data_source_test.go
+++ b/internal/services/containerapps/container_app_environment_certificate_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type ContainerAppEnvironmentCertificateDataSource struct{}
 
+func TestAccContainerAppEnvironmentCertificateDataSource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_container_app_environment_certificate", "test")
+	r := ContainerAppEnvironmentCertificateDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccContainerAppEnvironmentCertificateDataSource_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_container_app_environment_certificate", "test")
 	r := ContainerAppEnvironmentCertificateDataSource{}

--- a/internal/services/containerapps/container_app_environment_certificate_resource_test.go
+++ b/internal/services/containerapps/container_app_environment_certificate_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type ContainerAppEnvironmentCertificateResource struct{}
 
+func TestAccContainerAppEnvironmentCertificate_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_app_environment_certificate", "test")
+	r := ContainerAppEnvironmentCertificateResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccContainerAppEnvironmentCertificate_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_container_app_environment_certificate", "test")
 	r := ContainerAppEnvironmentCertificateResource{}

--- a/internal/services/containerapps/container_app_environment_custom_domain_resource_test.go
+++ b/internal/services/containerapps/container_app_environment_custom_domain_resource_test.go
@@ -43,6 +43,17 @@ func (r ContainerAppEnvironmentCustomDomainResource) Exists(ctx context.Context,
 	return pointer.To(false), nil
 }
 
+func TestAccContainerAppEnvironmentCustomDomainResource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_app_environment_custom_domain", "test")
+	r := ContainerAppEnvironmentCustomDomainResource{}
+
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccContainerAppEnvironmentCustomDomainResource_basic(t *testing.T) {
 	if os.Getenv("ARM_TEST_DNS_ZONE") == "" || os.Getenv("ARM_TEST_DATA_RESOURCE_GROUP") == "" {
 		t.Skipf("Skipping as either ARM_TEST_DNS_ZONE or ARM_TEST_DATA_RESOURCE_GROUP is not set")

--- a/internal/services/containerapps/container_app_environment_dapr_component_resource_test.go
+++ b/internal/services/containerapps/container_app_environment_dapr_component_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type ContainerAppEnvironmentDaprComponentResource struct{}
 
+func TestAccContainerAppEnvironmentDaprComponent_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_app_environment_dapr_component", "test")
+	r := ContainerAppEnvironmentDaprComponentResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccContainerAppEnvironmentDaprComponent_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_container_app_environment_dapr_component", "test")
 	r := ContainerAppEnvironmentDaprComponentResource{}

--- a/internal/services/containerapps/container_app_environment_data_source_test.go
+++ b/internal/services/containerapps/container_app_environment_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type ContainerAppEnvironmentDataSource struct{}
 
+func TestAccContainerAppEnvironmentDataSource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_container_app_environment", "test")
+	r := ContainerAppEnvironmentDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccContainerAppEnvironmentDataSource_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_container_app_environment", "test")
 	r := ContainerAppEnvironmentDataSource{}

--- a/internal/services/containerapps/container_app_environment_managed_certificate_resource_test.go
+++ b/internal/services/containerapps/container_app_environment_managed_certificate_resource_test.go
@@ -20,6 +20,17 @@ import (
 
 type ContainerAppEnvironmentManagedCertificateResource struct{}
 
+func TestAccContainerAppEnvironmentManagedCertificate_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_app_environment_managed_certificate", "test")
+	r := ContainerAppEnvironmentManagedCertificateResource{}
+
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccContainerAppEnvironmentManagedCertificate_basic(t *testing.T) {
 	if os.Getenv("ARM_TEST_DNS_ZONE") == "" || os.Getenv("ARM_TEST_DATA_RESOURCE_GROUP") == "" {
 		t.Skipf("Skipping as either ARM_TEST_DNS_ZONE or ARM_TEST_DATA_RESOURCE_GROUP is not set")

--- a/internal/services/containerapps/container_app_environment_resource_test.go
+++ b/internal/services/containerapps/container_app_environment_resource_test.go
@@ -26,6 +26,16 @@ type containerAppEnvironmentAlternateSubscription struct {
 	subscriptionId string
 }
 
+func TestAccContainerAppEnvironment_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_app_environment", "test")
+	r := ContainerAppEnvironmentResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccContainerAppEnvironment_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_container_app_environment", "test")
 	r := ContainerAppEnvironmentResource{}

--- a/internal/services/containerapps/container_app_environment_storage_data_source_test.go
+++ b/internal/services/containerapps/container_app_environment_storage_data_source_test.go
@@ -13,6 +13,16 @@ import (
 
 type ContainerAppEnvironmentStorageDataSource struct{}
 
+func TestAccContainerAppEnvironmentStorageDataSource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_container_app_environment_storage", "test")
+	r := ContainerAppEnvironmentStorageDataSource{}
+	data.DataSourceRegressionTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccContainerAppEnvironmentStorageDataSource_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_container_app_environment_storage", "test")
 	r := ContainerAppEnvironmentStorageDataSource{}

--- a/internal/services/containerapps/container_app_environment_storage_resource_test.go
+++ b/internal/services/containerapps/container_app_environment_storage_resource_test.go
@@ -19,6 +19,16 @@ import (
 
 type ContainerAppEnvironmentStorageResource struct{}
 
+func TestAccContainerAppEnvironmentStorage_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_app_environment_storage", "test")
+	r := ContainerAppEnvironmentStorageResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccContainerAppEnvironmentStorage_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_container_app_environment_storage", "test")
 	r := ContainerAppEnvironmentStorageResource{}

--- a/internal/services/containerapps/container_app_job_resource_test.go
+++ b/internal/services/containerapps/container_app_job_resource_test.go
@@ -35,6 +35,16 @@ func (r ContainerAppJobResource) Exists(ctx context.Context, client *clients.Cli
 	return pointer.To(true), nil
 }
 
+func TestAccContainerAppJob_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_app_job", "test")
+	r := ContainerAppJobResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+		},
+	}, "")
+}
+
 func TestAccContainerAppJob_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_container_app_job", "test")
 	r := ContainerAppJobResource{}

--- a/internal/services/containerapps/container_app_resource_test.go
+++ b/internal/services/containerapps/container_app_resource_test.go
@@ -20,6 +20,16 @@ import (
 
 type ContainerAppResource struct{}
 
+func TestAccContainerAppResource_regressionTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_app", "test")
+	r := ContainerAppResource{}
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+		},
+	}, "")
+}
+
 func TestAccContainerAppResource_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_container_app", "test")
 	r := ContainerAppResource{}


### PR DESCRIPTION
Adds per-resource/data-source regression tests (pattern from #33087) to compute, confidentialledger, connections, consumption and containerapps — 76 files.

Notes for review:
* The linux/windows VM and VMSS resources keep their tests split across `*_resource_<topic>_test.go` files; each resource's regression test lives in its `_resource_auth_test.go` using `authPassword(data)`.
* `marketplace_agreement` (resource) uses `ResourceRegressionAdditionalStepsTest` since it needs the cancel-existing-agreement setup step; the `marketplace_agreement` data source is intentionally skipped for the same reason (no multi-step data-source regression helper).
* `confidential_ledger` runs via `RunTestsInSequence`, so the regression test is an unexported func wired into the sequence map using `ResourceSequentialRegressionTest`.

Part 5 of ~21. No skip/preCheck gating is added to the regression tests for now.