### PR TITLE
provider: apply declared and user-configured read timeouts to data source reads

### DIFF
--- a/internal/provider/data_source_read_timeouts.go
+++ b/internal/provider/data_source_read_timeouts.go
@@ -45,9 +45,11 @@ func wrapDataSourceReadTimeouts(r *schema.Resource) {
 		return
 	}
 
-	if r.Read != nil {
-		inner := r.Read
-		r.Read = func(d *schema.ResourceData, meta interface{}) error {
+	// the deprecated legacy Read signature remains in use by untyped Data Sources, which is
+	// exactly what this wrapper exists to cover
+	if r.Read != nil { //nolint:staticcheck
+		inner := r.Read                                                 //nolint:staticcheck
+		r.Read = func(d *schema.ResourceData, meta interface{}) error { //nolint:staticcheck
 			timeouts.RegisterDataSourceReadTimeout(d, effectiveReadTimeout(d.GetRawConfig(), declared))
 			defer timeouts.DeregisterDataSourceReadTimeout(d)
 			return inner(d, meta)

--- a/internal/provider/data_source_read_timeouts.go
+++ b/internal/provider/data_source_read_timeouts.go
@@ -1,0 +1,77 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"context"
+	"time"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
+)
+
+// wrapDataSourceReadTimeouts works around https://github.com/hashicorp/terraform-plugin-sdk/issues/1038:
+// the Plugin SDK never attaches the schema-declared Timeouts (or the user's `timeouts` block) to a Data
+// Source read, so `d.Timeout(TimeoutRead)` always returns the SDK-global default of 20 minutes rather
+// than the value declared on the Data Source or configured by the user.
+//
+// This wraps the Data Source's read function to determine the effective timeout (the user-configured
+// `timeouts` block when set, else the schema-declared read timeout) and:
+//
+//   - registers it with the timeouts package for the duration of the read, so that the
+//     `timeouts.ForRead` call inside legacy (context-less) read functions picks it up
+//   - additionally applies it as a context deadline for context-aware read functions
+//     (i.e. typed Data Sources built via sdk.DataSourceWrapper)
+func wrapDataSourceReadTimeouts(r *schema.Resource) {
+	if r.Timeouts == nil || r.Timeouts.Read == nil {
+		return
+	}
+	declared := *r.Timeouts.Read
+
+	if r.ReadContext != nil {
+		inner := r.ReadContext
+		r.ReadContext = func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+			timeout := effectiveReadTimeout(d.GetRawConfig(), declared)
+			timeouts.RegisterDataSourceReadTimeout(d, timeout)
+			defer timeouts.DeregisterDataSourceReadTimeout(d)
+
+			ctx, cancel := context.WithTimeout(ctx, timeout)
+			defer cancel()
+			return inner(ctx, d, meta)
+		}
+		return
+	}
+
+	if r.Read != nil {
+		inner := r.Read
+		r.Read = func(d *schema.ResourceData, meta interface{}) error {
+			timeouts.RegisterDataSourceReadTimeout(d, effectiveReadTimeout(d.GetRawConfig(), declared))
+			defer timeouts.DeregisterDataSourceReadTimeout(d)
+			return inner(d, meta)
+		}
+	}
+}
+
+// effectiveReadTimeout returns the read timeout from the `timeouts` block within the raw config
+// when one is set, falling back to the schema-declared read timeout.
+func effectiveReadTimeout(rawConfig cty.Value, declared time.Duration) time.Duration {
+	if rawConfig.IsNull() || !rawConfig.Type().IsObjectType() || !rawConfig.Type().HasAttribute("timeouts") {
+		return declared
+	}
+	block := rawConfig.GetAttr("timeouts")
+	if block.IsNull() || !block.IsKnown() || !block.Type().IsObjectType() || !block.Type().HasAttribute("read") {
+		return declared
+	}
+	value := block.GetAttr("read")
+	if value.IsNull() || !value.IsKnown() || value.Type() != cty.String {
+		return declared
+	}
+	timeout, err := time.ParseDuration(value.AsString())
+	if err != nil {
+		return declared
+	}
+	return timeout
+}

--- a/internal/provider/data_source_read_timeouts_test.go
+++ b/internal/provider/data_source_read_timeouts_test.go
@@ -1,0 +1,161 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
+)
+
+func TestEffectiveReadTimeout(t *testing.T) {
+	declared := 5 * time.Minute
+	cases := []struct {
+		name      string
+		rawConfig cty.Value
+		expected  time.Duration
+	}{
+		{
+			name:      "null config",
+			rawConfig: cty.NullVal(cty.Object(map[string]cty.Type{})),
+			expected:  declared,
+		},
+		{
+			name:      "no timeouts attribute",
+			rawConfig: cty.ObjectVal(map[string]cty.Value{"name": cty.StringVal("example")}),
+			expected:  declared,
+		},
+		{
+			name: "null timeouts block",
+			rawConfig: cty.ObjectVal(map[string]cty.Value{
+				"timeouts": cty.NullVal(cty.Object(map[string]cty.Type{"read": cty.String})),
+			}),
+			expected: declared,
+		},
+		{
+			name: "timeouts block without read",
+			rawConfig: cty.ObjectVal(map[string]cty.Value{
+				"timeouts": cty.ObjectVal(map[string]cty.Value{"create": cty.StringVal("1m")}),
+			}),
+			expected: declared,
+		},
+		{
+			name: "null read value",
+			rawConfig: cty.ObjectVal(map[string]cty.Value{
+				"timeouts": cty.ObjectVal(map[string]cty.Value{"read": cty.NullVal(cty.String)}),
+			}),
+			expected: declared,
+		},
+		{
+			name: "invalid read value",
+			rawConfig: cty.ObjectVal(map[string]cty.Value{
+				"timeouts": cty.ObjectVal(map[string]cty.Value{"read": cty.StringVal("not-a-duration")}),
+			}),
+			expected: declared,
+		},
+		{
+			name: "read value set",
+			rawConfig: cty.ObjectVal(map[string]cty.Value{
+				"timeouts": cty.ObjectVal(map[string]cty.Value{"read": cty.StringVal("1m")}),
+			}),
+			expected: time.Minute,
+		},
+		{
+			name: "read value above the sdk default",
+			rawConfig: cty.ObjectVal(map[string]cty.Value{
+				"timeouts": cty.ObjectVal(map[string]cty.Value{"read": cty.StringVal("35m")}),
+			}),
+			expected: 35 * time.Minute,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if actual := effectiveReadTimeout(tc.rawConfig, declared); actual != tc.expected {
+				t.Fatalf("expected %s but got %s", tc.expected, actual)
+			}
+		})
+	}
+}
+
+func TestWrapDataSourceReadTimeoutsLegacyRead(t *testing.T) {
+	declared := 5 * time.Minute
+	var observed time.Duration
+
+	r := &schema.Resource{
+		Timeouts: &schema.ResourceTimeout{Read: &declared},
+		Read: func(d *schema.ResourceData, meta interface{}) error {
+			// legacy read functions derive their deadline via timeouts.ForRead - this should
+			// now honour the declared read timeout rather than the SDK default of 20 minutes
+			ctx, cancel := timeouts.ForRead(context.Background(), d)
+			defer cancel()
+			deadline, ok := ctx.Deadline()
+			if !ok {
+				t.Fatal("expected a deadline to be set on the context but none was")
+			}
+			observed = time.Until(deadline)
+			return nil
+		},
+	}
+	wrapDataSourceReadTimeouts(r)
+
+	d := schema.TestResourceDataRaw(t, map[string]*schema.Schema{}, map[string]interface{}{})
+	if err := r.Read(d, nil); err != nil {
+		t.Fatalf("unexpected error: %+v", err)
+	}
+	if observed > declared || observed < declared-time.Minute {
+		t.Fatalf("expected a deadline of ~%s from now but got %s", declared, observed)
+	}
+}
+
+func TestWrapDataSourceReadTimeoutsReadContext(t *testing.T) {
+	declared := 5 * time.Minute
+	var observed time.Duration
+
+	r := &schema.Resource{
+		Timeouts: &schema.ResourceTimeout{Read: &declared},
+		ReadContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+			deadline, ok := ctx.Deadline()
+			if !ok {
+				t.Fatal("expected a deadline to be set on the context but none was")
+			}
+			observed = time.Until(deadline)
+			return nil
+		},
+	}
+	wrapDataSourceReadTimeouts(r)
+
+	d := schema.TestResourceDataRaw(t, map[string]*schema.Schema{}, map[string]interface{}{})
+	if diags := r.ReadContext(context.Background(), d, nil); diags.HasError() {
+		t.Fatalf("unexpected error: %+v", diags)
+	}
+	if observed > declared || observed < declared-time.Minute {
+		t.Fatalf("expected a deadline of ~%s from now but got %s", declared, observed)
+	}
+}
+
+func TestWrapDataSourceReadTimeoutsNoDeclaredTimeout(t *testing.T) {
+	r := &schema.Resource{
+		Read: func(d *schema.ResourceData, meta interface{}) error { return nil },
+	}
+	wrapDataSourceReadTimeouts(r)
+
+	d := schema.TestResourceDataRaw(t, map[string]*schema.Schema{}, map[string]interface{}{})
+
+	// no declared timeout means the resource is left untouched - ForRead falls back to the SDK default
+	ctx, cancel := timeouts.ForRead(context.Background(), d)
+	defer cancel()
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		t.Fatal("expected a deadline to be set on the context but none was")
+	}
+	if remaining := time.Until(deadline); remaining > 20*time.Minute || remaining < 19*time.Minute {
+		t.Fatalf("expected a deadline of ~20m from now but got %s", remaining)
+	}
+}

--- a/internal/provider/data_source_read_timeouts_test.go
+++ b/internal/provider/data_source_read_timeouts_test.go
@@ -106,7 +106,7 @@ func TestWrapDataSourceReadTimeoutsLegacyRead(t *testing.T) {
 	wrapDataSourceReadTimeouts(r)
 
 	d := schema.TestResourceDataRaw(t, map[string]*schema.Schema{}, map[string]interface{}{})
-	if err := r.Read(d, nil); err != nil {
+	if err := r.Read(d, nil); err != nil { //nolint:staticcheck
 		t.Fatalf("unexpected error: %+v", err)
 	}
 	if observed > declared || observed < declared-time.Minute {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -144,6 +144,12 @@ func azureProvider(supportLegacyTestSuite bool, testName string) *schema.Provide
 		}
 	}
 
+	// ensure the declared (or user-configured) read timeout is applied to Data Source reads,
+	// which the Plugin SDK does not do itself (hashicorp/terraform-plugin-sdk#1038)
+	for _, dataSource := range dataSources {
+		wrapDataSourceReadTimeouts(dataSource)
+	}
+
 	p := &schema.Provider{
 		Schema: map[string]*schema.Schema{
 			"subscription_id": {

--- a/internal/timeouts/data_source_read.go
+++ b/internal/timeouts/data_source_read.go
@@ -1,0 +1,42 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package timeouts
+
+import (
+	"sync"
+	"time"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+// dataSourceReadTimeouts tracks the effective read timeout for each in-flight Data Source
+// read, keyed by its *pluginsdk.ResourceData.
+//
+// This exists to work around https://github.com/hashicorp/terraform-plugin-sdk/issues/1038:
+// the Plugin SDK never attaches the schema-declared Timeouts (or the user's `timeouts` block)
+// to the ResourceData for a Data Source read, so `d.Timeout(TimeoutRead)` always returns the
+// SDK-global default of 20 minutes. Data Source read functions use the legacy signature without
+// a context argument, so the effective timeout cannot be threaded through a context either -
+// instead the provider registers it here before invoking the read function (see
+// internal/provider) and ForRead prefers it over `d.Timeout`.
+var dataSourceReadTimeouts sync.Map
+
+// RegisterDataSourceReadTimeout records the effective read timeout for an in-flight Data
+// Source read. Callers must call DeregisterDataSourceReadTimeout once the read completes.
+func RegisterDataSourceReadTimeout(d *pluginsdk.ResourceData, timeout time.Duration) {
+	dataSourceReadTimeouts.Store(d, timeout)
+}
+
+// DeregisterDataSourceReadTimeout removes the effective read timeout recorded for an
+// in-flight Data Source read.
+func DeregisterDataSourceReadTimeout(d *pluginsdk.ResourceData) {
+	dataSourceReadTimeouts.Delete(d)
+}
+
+func dataSourceReadTimeout(d *pluginsdk.ResourceData) (time.Duration, bool) {
+	if v, ok := dataSourceReadTimeouts.Load(d); ok {
+		return v.(time.Duration), true
+	}
+	return 0, false
+}

--- a/internal/timeouts/data_source_read_test.go
+++ b/internal/timeouts/data_source_read_test.go
@@ -1,0 +1,58 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package timeouts
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestForReadPrefersRegisteredDataSourceReadTimeout(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, map[string]*schema.Schema{}, map[string]interface{}{})
+
+	RegisterDataSourceReadTimeout(d, 5*time.Minute)
+	defer DeregisterDataSourceReadTimeout(d)
+
+	ctx, cancel := ForRead(context.Background(), d)
+	defer cancel()
+
+	assertDeadlineApprox(t, ctx, 5*time.Minute)
+}
+
+func TestForReadFallsBackToResourceDataTimeout(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, map[string]*schema.Schema{}, map[string]interface{}{})
+
+	ctx, cancel := ForRead(context.Background(), d)
+	defer cancel()
+
+	// with nothing registered `d.Timeout` returns the SDK-global default of 20 minutes
+	assertDeadlineApprox(t, ctx, 20*time.Minute)
+}
+
+func TestForReadAfterDeregisterFallsBack(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, map[string]*schema.Schema{}, map[string]interface{}{})
+
+	RegisterDataSourceReadTimeout(d, 5*time.Minute)
+	DeregisterDataSourceReadTimeout(d)
+
+	ctx, cancel := ForRead(context.Background(), d)
+	defer cancel()
+
+	assertDeadlineApprox(t, ctx, 20*time.Minute)
+}
+
+func assertDeadlineApprox(t *testing.T, ctx context.Context, expected time.Duration) {
+	t.Helper()
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		t.Fatal("expected a deadline to be set on the context but none was")
+	}
+	remaining := time.Until(deadline)
+	if remaining > expected || remaining < expected-time.Minute {
+		t.Fatalf("expected a deadline of ~%s from now but got %s", expected, remaining)
+	}
+}

--- a/internal/timeouts/determine.go
+++ b/internal/timeouts/determine.go
@@ -43,6 +43,12 @@ func ForDelete(ctx context.Context, d *pluginsdk.ResourceData) (context.Context,
 // If the 'SupportsCustomTimeouts' feature toggle is enabled - this is wrapped with a context
 // Otherwise this returns the default context
 func ForRead(ctx context.Context, d *pluginsdk.ResourceData) (context.Context, context.CancelFunc) {
+	// for Data Source reads `d.Timeout` unconditionally returns the SDK-global default of 20
+	// minutes (hashicorp/terraform-plugin-sdk#1038) - so when the provider has registered the
+	// effective timeout for this read (see internal/provider) prefer that value
+	if timeout, ok := dataSourceReadTimeout(d); ok {
+		return buildWithTimeout(ctx, timeout)
+	}
 	return buildWithTimeout(ctx, d.Timeout(pluginsdk.TimeoutRead))
 }
 


### PR DESCRIPTION
The Plugin SDK never attaches the schema-declared Timeouts (or the user's timeouts block) to a Data Source read, so d.Timeout(TimeoutRead) always returns the SDK-global default of 20 minutes
(hashicorp/terraform-plugin-sdk#1038).

Wrap every registered Data Source's read function to resolve the effective timeout (user-configured timeouts block, else the schema-declared value) and register it with the timeouts package for the duration of the read, where ForRead now prefers it over d.Timeout. Context-aware reads (typed Data Sources) additionally get the timeout applied as a context deadline.

