### PR TITLE
azurerm_firewall: support for the autoscale_configuration block

### DIFF
--- a/internal/services/firewall/firewall_data_source.go
+++ b/internal/services/firewall/firewall_data_source.go
@@ -49,6 +49,23 @@ func firewallDataSource() *pluginsdk.Resource {
 				Computed: true,
 			},
 
+			"autoscale_configuration": {
+				Type:     pluginsdk.TypeList,
+				Computed: true,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"min_capacity": {
+							Type:     pluginsdk.TypeInt,
+							Computed: true,
+						},
+						"max_capacity": {
+							Type:     pluginsdk.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+
 			"firewall_policy_id": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
@@ -208,6 +225,10 @@ func firewallDataSourceRead(d *pluginsdk.ResourceData, meta interface{}) error {
 
 			if policy := props.FirewallPolicy; policy != nil {
 				d.Set("firewall_policy_id", policy.Id)
+			}
+
+			if err := d.Set("autoscale_configuration", flattenFirewallAutoscaleConfiguration(props.AutoscaleConfiguration)); err != nil {
+				return fmt.Errorf("setting `autoscale_configuration`: %+v", err)
 			}
 
 			if sku := props.Sku; sku != nil {

--- a/internal/services/firewall/firewall_data_source_test.go
+++ b/internal/services/firewall/firewall_data_source_test.go
@@ -91,6 +91,21 @@ func TestAccFirewallDataSource_inVirtualhub(t *testing.T) {
 	})
 }
 
+func TestAccFirewallDataSource_autoscaleConfiguration(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_firewall", "test")
+	r := FirewallDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.autoscaleConfiguration(data, 2, 5),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("autoscale_configuration.0.min_capacity").HasValue("2"),
+				check.That(data.ResourceName).Key("autoscale_configuration.0.max_capacity").HasValue("5"),
+			),
+		},
+	})
+}
+
 func (FirewallDataSource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -187,4 +202,15 @@ data "azurerm_firewall" "test" {
   resource_group_name = azurerm_resource_group.test.name
 }
 `, FirewallResource{}.inVirtualHub(data, pipCount))
+}
+
+func (FirewallDataSource) autoscaleConfiguration(data acceptance.TestData, minCapacity int, maxCapacity int) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_firewall" "test" {
+  name                = azurerm_firewall.test.name
+  resource_group_name = azurerm_resource_group.test.name
+}
+`, FirewallResource{}.autoscaleConfiguration(data, minCapacity, maxCapacity))
 }

--- a/internal/services/firewall/firewall_resource.go
+++ b/internal/services/firewall/firewall_resource.go
@@ -88,6 +88,28 @@ func resourceFirewall() *pluginsdk.Resource {
 				}, false),
 			},
 
+			"autoscale_configuration": {
+				Type:     pluginsdk.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"min_capacity": {
+							Type:         pluginsdk.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntAtLeast(2),
+							AtLeastOneOf: []string{"autoscale_configuration.0.min_capacity", "autoscale_configuration.0.max_capacity"},
+						},
+						"max_capacity": {
+							Type:         pluginsdk.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntAtLeast(2),
+							AtLeastOneOf: []string{"autoscale_configuration.0.min_capacity", "autoscale_configuration.0.max_capacity"},
+						},
+					},
+				},
+			},
+
 			"firewall_policy_id": {
 				Type:         pluginsdk.TypeString,
 				Optional:     true,
@@ -316,6 +338,8 @@ func resourceFirewallCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 		parameters.Properties.FirewallPolicy = &azurefirewalls.SubResource{Id: &policyId}
 	}
 
+	parameters.Properties.AutoscaleConfiguration = expandFirewallAutoscaleConfiguration(d.Get("autoscale_configuration").([]interface{}))
+
 	vhub, hubIpAddresses, ok := expandFirewallVirtualHubSetting(existing.Model, d.Get("virtual_hub").([]interface{}))
 	if ok {
 		parameters.Properties.VirtualHub = vhub
@@ -461,6 +485,10 @@ func resourceFirewallSetFlatten(d *pluginsdk.ResourceData, id *azurefirewalls.Az
 
 			if err := d.Set("private_ip_ranges", flattenFirewallPrivateIpRange(props.AdditionalProperties)); err != nil {
 				return fmt.Errorf("setting `private_ip_ranges`: %+v", err)
+			}
+
+			if err := d.Set("autoscale_configuration", flattenFirewallAutoscaleConfiguration(props.AutoscaleConfiguration)); err != nil {
+				return fmt.Errorf("setting `autoscale_configuration`: %+v", err)
 			}
 
 			firewallPolicyId := ""
@@ -735,6 +763,40 @@ func flattenFirewallPrivateIpRange(input *map[string]string) []interface{} {
 		rangeSlice = strings.Split(attrs["Network.SNAT.PrivateRanges"], ",")
 	}
 	return helpers.FlattenStringSlice(&rangeSlice)
+}
+
+func expandFirewallAutoscaleConfiguration(input []interface{}) *azurefirewalls.AzureFirewallAutoscaleConfiguration {
+	if len(input) == 0 || input[0] == nil {
+		return nil
+	}
+
+	v := input[0].(map[string]interface{})
+
+	output := azurefirewalls.AzureFirewallAutoscaleConfiguration{}
+
+	// the API uses `null` to reset a value back to the service default, so only send the values which have been configured
+	if minCapacity := v["min_capacity"].(int); minCapacity != 0 {
+		output.MinCapacity = pointer.To(int64(minCapacity))
+	}
+
+	if maxCapacity := v["max_capacity"].(int); maxCapacity != 0 {
+		output.MaxCapacity = pointer.To(int64(maxCapacity))
+	}
+
+	return &output
+}
+
+func flattenFirewallAutoscaleConfiguration(input *azurefirewalls.AzureFirewallAutoscaleConfiguration) []interface{} {
+	if input == nil {
+		return []interface{}{}
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"min_capacity": int(pointer.From(input.MinCapacity)),
+			"max_capacity": int(pointer.From(input.MaxCapacity)),
+		},
+	}
 }
 
 func expandFirewallVirtualHubSetting(existing *azurefirewalls.AzureFirewall, input []interface{}) (vhub *azurefirewalls.SubResource, ipAddresses *azurefirewalls.HubIPAddresses, ok bool) {

--- a/internal/services/firewall/firewall_resource.go
+++ b/internal/services/firewall/firewall_resource.go
@@ -280,6 +280,10 @@ func resourceFirewallCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 		return fmt.Errorf("validating %s: %+v", id, err)
 	}
 
+	if err := validateFirewallAutoscaleConfiguration(d.Get("sku_tier").(string), d.Get("autoscale_configuration").([]interface{})); err != nil {
+		return fmt.Errorf("validating %s: %+v", id, err)
+	}
+
 	location := location.Normalize(d.Get("location").(string))
 	t := d.Get("tags").(map[string]interface{})
 	i := d.Get("ip_configuration").([]interface{})
@@ -884,6 +888,18 @@ func flattenFirewallVirtualHubSetting(props *azurefirewalls.AzureFirewallPropert
 			"private_ip_address":  privateIp,
 		},
 	}
+}
+
+func validateFirewallAutoscaleConfiguration(skuTier string, configs []interface{}) error {
+	if len(configs) == 0 {
+		return nil
+	}
+
+	if skuTier == string(azurefirewalls.AzureFirewallSkuTierBasic) {
+		return fmt.Errorf("`autoscale_configuration` cannot be configured when `sku_tier` is set to `Basic`")
+	}
+
+	return nil
 }
 
 func validateFirewallIPConfigurationSettings(configs []interface{}) error {

--- a/internal/services/firewall/firewall_resource_test.go
+++ b/internal/services/firewall/firewall_resource_test.go
@@ -407,6 +407,118 @@ func TestAccFirewall_autoscaleConfiguration(t *testing.T) {
 	})
 }
 
+func TestAccFirewall_autoscaleConfigurationStandard(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_firewall", "test")
+	r := FirewallResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.autoscaleConfigurationWithSkuTier(data, standard, 2, 5),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("sku_tier").HasValue(standard),
+				check.That(data.ResourceName).Key("autoscale_configuration.0.min_capacity").HasValue("2"),
+				check.That(data.ResourceName).Key("autoscale_configuration.0.max_capacity").HasValue("5"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccFirewall_autoscaleConfigurationPremium(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_firewall", "test")
+	r := FirewallResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.autoscaleConfigurationWithSkuTier(data, premium, 2, 5),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("sku_tier").HasValue(premium),
+				check.That(data.ResourceName).Key("autoscale_configuration.0.min_capacity").HasValue("2"),
+				check.That(data.ResourceName).Key("autoscale_configuration.0.max_capacity").HasValue("5"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccFirewall_autoscaleConfigurationBasic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_firewall", "test")
+	r := FirewallResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config:      r.autoscaleConfigurationBasic(data, 2, 5),
+			ExpectError: regexp.MustCompile("`autoscale_configuration` cannot be configured when `sku_tier` is set to `Basic`"),
+		},
+	})
+}
+
+func TestAccFirewall_autoscaleConfigurationPinned(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_firewall", "test")
+	r := FirewallResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.autoscaleConfiguration(data, 3, 3),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("autoscale_configuration.0.min_capacity").HasValue("3"),
+				check.That(data.ResourceName).Key("autoscale_configuration.0.max_capacity").HasValue("3"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.autoscaleConfiguration(data, 4, 4),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("autoscale_configuration.0.min_capacity").HasValue("4"),
+				check.That(data.ResourceName).Key("autoscale_configuration.0.max_capacity").HasValue("4"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccFirewall_autoscaleConfigurationInVirtualHubStandard(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_firewall", "test")
+	r := FirewallResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.autoscaleConfigurationInVirtualHub(data, standard, 2, 5),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("sku_name").HasValue("AZFW_Hub"),
+				check.That(data.ResourceName).Key("sku_tier").HasValue(standard),
+				check.That(data.ResourceName).Key("autoscale_configuration.0.min_capacity").HasValue("2"),
+				check.That(data.ResourceName).Key("autoscale_configuration.0.max_capacity").HasValue("5"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccFirewall_autoscaleConfigurationInVirtualHubPremium(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_firewall", "test")
+	r := FirewallResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.autoscaleConfigurationInVirtualHub(data, premium, 2, 5),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("sku_name").HasValue("AZFW_Hub"),
+				check.That(data.ResourceName).Key("sku_tier").HasValue(premium),
+				check.That(data.ResourceName).Key("autoscale_configuration.0.min_capacity").HasValue("2"),
+				check.That(data.ResourceName).Key("autoscale_configuration.0.max_capacity").HasValue("5"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (FirewallResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := azurefirewalls.ParseAzureFirewallID(state.ID)
 	if err != nil {
@@ -1366,4 +1478,187 @@ resource "azurerm_firewall" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, minCapacity, maxCapacity)
+}
+
+func (FirewallResource) autoscaleConfigurationWithSkuTier(data acceptance.TestData, skuTier string, minCapacity int, maxCapacity int) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-fw-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%[1]d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "AzureFirewallSubnet"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.1.0/24"]
+}
+
+resource "azurerm_public_ip" "test" {
+  name                = "acctestpip%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+}
+
+resource "azurerm_firewall" "test" {
+  name                = "acctestfirewall%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku_name            = "AZFW_VNet"
+  sku_tier            = "%[3]s"
+
+  ip_configuration {
+    name                 = "configuration"
+    subnet_id            = azurerm_subnet.test.id
+    public_ip_address_id = azurerm_public_ip.test.id
+  }
+
+  autoscale_configuration {
+    min_capacity = %[4]d
+    max_capacity = %[5]d
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, skuTier, minCapacity, maxCapacity)
+}
+
+func (FirewallResource) autoscaleConfigurationBasic(data acceptance.TestData, minCapacity int, maxCapacity int) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-fw-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%[1]d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "AzureFirewallSubnet"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.1.0/24"]
+}
+
+resource "azurerm_subnet" "test_mgmt" {
+  name                 = "AzureFirewallManagementSubnet"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.2.0/24"]
+}
+
+resource "azurerm_public_ip" "test" {
+  name                = "acctestpip%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+}
+
+resource "azurerm_public_ip" "test_mgmt" {
+  name                = "acctestmgmtpip%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+}
+
+resource "azurerm_firewall" "test" {
+  name                = "acctestfirewall%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku_name            = "AZFW_VNet"
+  sku_tier            = "Basic"
+
+  ip_configuration {
+    name                 = "configuration"
+    subnet_id            = azurerm_subnet.test.id
+    public_ip_address_id = azurerm_public_ip.test.id
+  }
+
+  management_ip_configuration {
+    name                 = "management_configuration"
+    subnet_id            = azurerm_subnet.test_mgmt.id
+    public_ip_address_id = azurerm_public_ip.test_mgmt.id
+  }
+
+  autoscale_configuration {
+    min_capacity = %[3]d
+    max_capacity = %[4]d
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, minCapacity, maxCapacity)
+}
+
+func (FirewallResource) autoscaleConfigurationInVirtualHub(data acceptance.TestData, skuTier string, minCapacity int, maxCapacity int) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-fw-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_firewall_policy" "test" {
+  name                = "acctest-firewallpolicy-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  sku                 = "%[3]s"
+}
+
+resource "azurerm_virtual_wan" "test" {
+  name                = "acctest-virtualwan-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_virtual_hub" "test" {
+  name                = "acctest-virtualhub-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  virtual_wan_id      = azurerm_virtual_wan.test.id
+  address_prefix      = "10.0.1.0/24"
+}
+
+resource "azurerm_firewall" "test" {
+  name                = "acctest-firewall-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku_name            = "AZFW_Hub"
+  sku_tier            = "%[3]s"
+
+  virtual_hub {
+    virtual_hub_id  = azurerm_virtual_hub.test.id
+    public_ip_count = 1
+  }
+
+  firewall_policy_id = azurerm_firewall_policy.test.id
+
+  autoscale_configuration {
+    min_capacity = %[4]d
+    max_capacity = %[5]d
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, skuTier, minCapacity, maxCapacity)
 }

--- a/internal/services/firewall/firewall_resource_test.go
+++ b/internal/services/firewall/firewall_resource_test.go
@@ -374,6 +374,39 @@ func TestAccFirewall_privateRanges(t *testing.T) {
 	})
 }
 
+func TestAccFirewall_autoscaleConfiguration(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_firewall", "test")
+	r := FirewallResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.autoscaleConfiguration(data, 2, 5),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("autoscale_configuration.0.min_capacity").HasValue("2"),
+				check.That(data.ResourceName).Key("autoscale_configuration.0.max_capacity").HasValue("5"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.autoscaleConfiguration(data, 3, 10),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("autoscale_configuration.0.min_capacity").HasValue("3"),
+				check.That(data.ResourceName).Key("autoscale_configuration.0.max_capacity").HasValue("10"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (FirewallResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := azurefirewalls.ParseAzureFirewallID(state.ID)
 	if err != nil {
@@ -1279,4 +1312,58 @@ resource "azurerm_firewall" "test" {
   threat_intel_mode = "Deny"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func (FirewallResource) autoscaleConfiguration(data acceptance.TestData, minCapacity int, maxCapacity int) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-fw-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "AzureFirewallSubnet"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.1.0/24"]
+}
+
+resource "azurerm_public_ip" "test" {
+  name                = "acctestpip%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+}
+
+resource "azurerm_firewall" "test" {
+  name                = "acctestfirewall%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku_name            = "AZFW_VNet"
+  sku_tier            = "Standard"
+
+  ip_configuration {
+    name                 = "configuration"
+    subnet_id            = azurerm_subnet.test.id
+    public_ip_address_id = azurerm_public_ip.test.id
+  }
+
+  autoscale_configuration {
+    min_capacity = %d
+    max_capacity = %d
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, minCapacity, maxCapacity)
 }

--- a/website/docs/d/firewall.html.markdown
+++ b/website/docs/d/firewall.html.markdown
@@ -42,6 +42,8 @@ The following attributes are exported:
 
 * `sku_tier` - The SKU tier of the Azure Firewall.
 
+* `autoscale_configuration` - An `autoscale_configuration` block as defined below.
+
 * `firewall_policy_id` - The ID of the Firewall Policy applied to the Azure Firewall.
 
 * `ip_configuration` - A `ip_configuration` block as defined below.
@@ -59,6 +61,14 @@ The following attributes are exported:
 * `zones` - A list of Availability Zones in which this Azure Firewall is located.
 
 * `tags` - A mapping of tags assigned to the Azure Firewall.
+
+---
+
+An `autoscale_configuration` block exports the following:
+
+* `min_capacity` - The minimum number of capacity units for the Azure Firewall.
+
+* `max_capacity` - The maximum number of capacity units for the Azure Firewall.
 
 ---
 

--- a/website/docs/r/firewall.html.markdown
+++ b/website/docs/r/firewall.html.markdown
@@ -70,6 +70,8 @@ The following arguments are supported:
 
 * `sku_tier` - (Required) SKU tier of the Firewall. Possible values are `Premium`, `Standard` and `Basic`.
 
+* `autoscale_configuration` - (Optional) An `autoscale_configuration` block as documented below.
+
 * `firewall_policy_id` - (Optional) The ID of the Firewall Policy applied to this Firewall.
 
 * `ip_configuration` - (Optional) An `ip_configuration` block as documented below.
@@ -91,6 +93,16 @@ The following arguments are supported:
 -> **Note:** Availability Zones are [only supported in several regions at this time](https://docs.microsoft.com/azure/availability-zones/az-overview).
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
+
+---
+
+An `autoscale_configuration` block supports the following:
+
+* `min_capacity` - (Optional) The minimum number of capacity units for this Firewall. Possible values are at least `2`. Omitting this resets the value to the service default.
+
+* `max_capacity` - (Optional) The maximum number of capacity units for this Firewall. Possible values are at least `2`. Omitting this resets the value to the service default.
+
+-> **Note:** At least one of `min_capacity` and `max_capacity` must be specified.
 
 ---
 


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Support for autoscaleConfiguration in azurerm_firewall


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_firewall` - support for the `autoscale_configuration` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [x] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #31707


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

model: Claude Opus 5.0
prompt: 

> Implement autoscaleConfiguration based off of the official documentation
> 
> [Azure Firewalls - Create Or Update - REST API (Azure Firewall) | Microsoft Learn](https://learn.microsoft.com/en-us/rest/api/firewall/azure-firewalls/create-or-update?view=rest-firewall-2025-07-01&viewFallbackFrom=rest-firewall-2025-05-01&tabs=HTTP)
> 
> implement both the resource and data provider
> 
> Follow terraform provider plugins best practices
> 
> contributing\topics
> 
> Include tests as well which you should see in this folder
> 
> the goal is to open a new PR

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

N/A

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
