### PR TITLE
`azurerm_(linux|windows)_virtual_machine` - support in place updates of `capacity_reservation_group_id` for zonal vm

### DIFF
--- a/internal/services/compute/linux_virtual_machine_resource.go
+++ b/internal/services/compute/linux_virtual_machine_resource.go
@@ -1241,7 +1241,10 @@ func resourceLinuxVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interface
 
 	if d.HasChange("capacity_reservation_group_id") {
 		shouldUpdate = true
-		shouldDeallocate = true
+
+		if _, ok := d.GetOk("zone"); !ok {
+			shouldDeallocate = true
+		}
 
 		if v, ok := d.GetOk("capacity_reservation_group_id"); ok {
 			update.Properties.CapacityReservation = &virtualmachines.CapacityReservationProfile{
@@ -1250,6 +1253,7 @@ func resourceLinuxVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interface
 				},
 			}
 		} else {
+			shouldDeallocate = true
 			update.Properties.CapacityReservation = &virtualmachines.CapacityReservationProfile{
 				CapacityReservationGroup: &virtualmachines.SubResource{},
 			}

--- a/internal/services/compute/linux_virtual_machine_resource.go
+++ b/internal/services/compute/linux_virtual_machine_resource.go
@@ -1242,11 +1242,11 @@ func resourceLinuxVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interface
 	if d.HasChange("capacity_reservation_group_id") {
 		shouldUpdate = true
 
-		if _, ok := d.GetOk("zone"); !ok {
-			shouldDeallocate = true
-		}
-
 		if v, ok := d.GetOk("capacity_reservation_group_id"); ok {
+			if _, ok := d.GetOk("zone"); !ok {
+				shouldDeallocate = true
+			}
+
 			update.Properties.CapacityReservation = &virtualmachines.CapacityReservationProfile{
 				CapacityReservationGroup: &virtualmachines.SubResource{
 					Id: pointer.To(v.(string)),

--- a/internal/services/compute/linux_virtual_machine_resource_scaling_test.go
+++ b/internal/services/compute/linux_virtual_machine_resource_scaling_test.go
@@ -48,7 +48,7 @@ func TestAccLinuxVirtualMachine_scalingCapacityReservationGroup(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.scalingCapacityReservationGroup(data),
+			Config: r.scalingCapacityReservationGroup(data, false, "azurerm_capacity_reservation_group.test.id"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -58,69 +58,41 @@ func TestAccLinuxVirtualMachine_scalingCapacityReservationGroup(t *testing.T) {
 }
 
 func TestAccLinuxVirtualMachine_scalingCapacityReservationGroupUpdate(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
-	r := LinuxVirtualMachineResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.scalingCapacityReservationGroupInitial(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.scalingCapacityReservationGroup(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.scalingCapacityReservationGroupUpdate(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.scalingCapacityReservationGroupRemoved(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-	})
+	testAccLinuxVirtualMachineScalingCapacityReservationGroupUpdate(t, false)
 }
 
 func TestAccLinuxVirtualMachine_scalingCapacityReservationGroupZonalUpdate(t *testing.T) {
+	testAccLinuxVirtualMachineScalingCapacityReservationGroupUpdate(t, true)
+}
+
+func testAccLinuxVirtualMachineScalingCapacityReservationGroupUpdate(t *testing.T, zonal bool) {
 	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
 	r := LinuxVirtualMachineResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.scalingCapacityReservationGroupZonal(data, ""),
+			Config: r.scalingCapacityReservationGroup(data, zonal, ""),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config: r.scalingCapacityReservationGroupZonal(data, "azurerm_capacity_reservation_group.test1.id"),
+			Config: r.scalingCapacityReservationGroup(data, zonal, "azurerm_capacity_reservation_group.test.id"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config: r.scalingCapacityReservationGroupZonal(data, "azurerm_capacity_reservation_group.test2.id"),
+			Config: r.scalingCapacityReservationGroup(data, zonal, "azurerm_capacity_reservation_group.test2.id"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config: r.scalingCapacityReservationGroupZonal(data, ""),
+			Config: r.scalingCapacityReservationGroup(data, zonal, ""),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -415,7 +387,17 @@ resource "azurerm_linux_virtual_machine" "test" {
 `, r.template(data), data.RandomInteger, data.RandomInteger)
 }
 
-func (r LinuxVirtualMachineResource) scalingCapacityReservationGroupInitial(data acceptance.TestData) string {
+func (r LinuxVirtualMachineResource) scalingCapacityReservationGroup(data acceptance.TestData, zonal bool, crgId string) string {
+	zones, zone, crgText := "", "", ""
+	if zonal {
+		zones = `zones = ["3"]`
+		zone = `zone = "3"`
+	}
+
+	if crgId != "" {
+		crgText = fmt.Sprintf(`capacity_reservation_group_id = %s`, crgId)
+	}
+
 	return fmt.Sprintf(`
 %[1]s
 
@@ -423,74 +405,44 @@ resource "azurerm_capacity_reservation_group" "test" {
   name                = "acctest-ccrg-%[2]d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
+  %[3]s
 }
 
 resource "azurerm_capacity_reservation" "test" {
   name                          = "acctest-ccr-%[2]d"
   capacity_reservation_group_id = azurerm_capacity_reservation_group.test.id
   sku {
-    name     = "Standard_F2"
+    name     = "Standard_D2s_v3"
     capacity = 1
   }
+  %[4]s
 }
 
-resource "azurerm_linux_virtual_machine" "test" {
-  name                = "acctestVM-%[2]d"
+resource "azurerm_capacity_reservation_group" "test2" {
+  name                = "acctest-ccrg2-%[2]d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  size                = "Standard_F2"
-  admin_username      = "adminuser"
-  network_interface_ids = [
-    azurerm_network_interface.test.id,
-  ]
-
-  admin_ssh_key {
-    username   = "adminuser"
-    public_key = local.first_public_key
-  }
-
-  os_disk {
-    caching              = "ReadWrite"
-    storage_account_type = "Standard_LRS"
-  }
-
-  source_image_reference {
-    publisher = "Canonical"
-    offer     = "0001-com-ubuntu-server-jammy"
-    sku       = "22_04-lts"
-    version   = "latest"
-  }
-}
-`, r.template(data), data.RandomInteger)
+  %[3]s
 }
 
-func (r LinuxVirtualMachineResource) scalingCapacityReservationGroup(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-%[1]s
-
-resource "azurerm_capacity_reservation_group" "test" {
-  name                = "acctest-ccrg-%[2]d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-}
-
-resource "azurerm_capacity_reservation" "test" {
-  name                          = "acctest-ccr-%[2]d"
-  capacity_reservation_group_id = azurerm_capacity_reservation_group.test.id
+resource "azurerm_capacity_reservation" "test2" {
+  name                          = "acctest-ccr2-%[2]d"
+  capacity_reservation_group_id = azurerm_capacity_reservation_group.test2.id
   sku {
-    name     = "Standard_F2"
+    name     = "Standard_D2s_v3"
     capacity = 1
   }
+  %[4]s
 }
 
 resource "azurerm_linux_virtual_machine" "test" {
   name                = "acctestVM-%[2]d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  size                = "Standard_F2"
+  size                = "Standard_D2s_v3"
   admin_username      = "adminuser"
-
-  capacity_reservation_group_id = azurerm_capacity_reservation_group.test.id
+  %[4]s
+  %[5]s
 
   network_interface_ids = [
     azurerm_network_interface.test.id,
@@ -515,210 +467,10 @@ resource "azurerm_linux_virtual_machine" "test" {
 
   depends_on = [
     azurerm_capacity_reservation.test,
+    azurerm_capacity_reservation.test2
   ]
 }
-`, r.template(data), data.RandomInteger)
-}
-
-func (r LinuxVirtualMachineResource) scalingCapacityReservationGroupUpdate(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-%[1]s
-
-resource "azurerm_capacity_reservation_group" "test" {
-  name                = "acctest-ccrg-%[2]d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-}
-
-resource "azurerm_capacity_reservation" "test" {
-  name                          = "acctest-ccr-%[2]d"
-  capacity_reservation_group_id = azurerm_capacity_reservation_group.test.id
-  sku {
-    name     = "Standard_F2"
-    capacity = 1
-  }
-}
-
-resource "azurerm_capacity_reservation_group" "test2" {
-  name                = "acctest-ccrg2-%[2]d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-}
-
-resource "azurerm_capacity_reservation" "test2" {
-  name                          = "acctest-ccr-%[2]d"
-  capacity_reservation_group_id = azurerm_capacity_reservation_group.test2.id
-  sku {
-    name     = "Standard_F2"
-    capacity = 1
-  }
-}
-
-resource "azurerm_linux_virtual_machine" "test" {
-  name                = "acctestVM-%[2]d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  size                = "Standard_F2"
-  admin_username      = "adminuser"
-
-  capacity_reservation_group_id = azurerm_capacity_reservation_group.test2.id
-
-  network_interface_ids = [
-    azurerm_network_interface.test.id,
-  ]
-
-  admin_ssh_key {
-    username   = "adminuser"
-    public_key = local.first_public_key
-  }
-
-  os_disk {
-    caching              = "ReadWrite"
-    storage_account_type = "Standard_LRS"
-  }
-
-  source_image_reference {
-    publisher = "Canonical"
-    offer     = "0001-com-ubuntu-server-jammy"
-    sku       = "22_04-lts"
-    version   = "latest"
-  }
-
-  depends_on = [
-    azurerm_capacity_reservation.test2,
-  ]
-}
-`, r.template(data), data.RandomInteger)
-}
-
-func (r LinuxVirtualMachineResource) scalingCapacityReservationGroupRemoved(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-%[1]s
-
-resource "azurerm_capacity_reservation_group" "test2" {
-  name                = "acctest-ccrg2-%[2]d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-}
-
-resource "azurerm_capacity_reservation" "test2" {
-  name                          = "acctest-ccr-%[2]d"
-  capacity_reservation_group_id = azurerm_capacity_reservation_group.test2.id
-  sku {
-    name     = "Standard_F2"
-    capacity = 1
-  }
-}
-
-resource "azurerm_linux_virtual_machine" "test" {
-  name                = "acctestVM-%[2]d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  size                = "Standard_F2"
-  admin_username      = "adminuser"
-
-  network_interface_ids = [
-    azurerm_network_interface.test.id,
-  ]
-
-  admin_ssh_key {
-    username   = "adminuser"
-    public_key = local.first_public_key
-  }
-
-  os_disk {
-    caching              = "ReadWrite"
-    storage_account_type = "Standard_LRS"
-  }
-
-  source_image_reference {
-    publisher = "Canonical"
-    offer     = "0001-com-ubuntu-server-jammy"
-    sku       = "22_04-lts"
-    version   = "latest"
-  }
-}
-`, r.template(data), data.RandomInteger)
-}
-
-func (r LinuxVirtualMachineResource) scalingCapacityReservationGroupZonal(data acceptance.TestData, crg string) string {
-	crgText := ""
-	if crg != "" {
-		crgText = fmt.Sprintf(`capacity_reservation_group_id = %s`, crg)
-	}
-	return fmt.Sprintf(`
-%[1]s
-
-resource "azurerm_capacity_reservation_group" "test1" {
-  name                = "acctest-ccrg1-%[2]d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  zones               = ["3"]
-}
-
-resource "azurerm_capacity_reservation" "test1" {
-  name                          = "acctest-ccr1-%[2]d"
-  capacity_reservation_group_id = azurerm_capacity_reservation_group.test1.id
-  zone                          = "3"
-  sku {
-    name     = "Standard_D2s_v3"
-    capacity = 1
-  }
-}
-
-resource "azurerm_capacity_reservation_group" "test2" {
-  name                = "acctest-ccrg2-%[2]d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  zones               = ["3"]
-}
-
-resource "azurerm_capacity_reservation" "test2" {
-  name                          = "acctest-ccr2-%[2]d"
-  capacity_reservation_group_id = azurerm_capacity_reservation_group.test2.id
-  zone                          = "3"
-  sku {
-    name     = "Standard_D2s_v3"
-    capacity = 1
-  }
-}
-
-resource "azurerm_linux_virtual_machine" "test" {
-  name                = "acctestVM-%[2]d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  size                = "Standard_D2s_v3"
-  admin_username      = "adminuser"
-  zone                = "3"
-  %[3]s
-
-  network_interface_ids = [
-    azurerm_network_interface.test.id,
-  ]
-
-  admin_ssh_key {
-    username   = "adminuser"
-    public_key = local.first_public_key
-  }
-
-  os_disk {
-    caching              = "ReadWrite"
-    storage_account_type = "Standard_LRS"
-  }
-
-  source_image_reference {
-    publisher = "Canonical"
-    offer     = "0001-com-ubuntu-server-jammy"
-    sku       = "22_04-lts"
-    version   = "latest"
-  }
-
-  depends_on = [
-    azurerm_capacity_reservation.test1,
-    azurerm_capacity_reservation.test2,
-  ]
-}
-`, r.template(data), data.RandomInteger, crgText)
+`, r.template(data), data.RandomInteger, zones, zone, crgText)
 }
 
 func (r LinuxVirtualMachineResource) scalingDedicatedHostInitial(data acceptance.TestData) string {

--- a/internal/services/compute/linux_virtual_machine_resource_scaling_test.go
+++ b/internal/services/compute/linux_virtual_machine_resource_scaling_test.go
@@ -93,6 +93,42 @@ func TestAccLinuxVirtualMachine_scalingCapacityReservationGroupUpdate(t *testing
 	})
 }
 
+func TestAccLinuxVirtualMachine_scalingCapacityReservationGroupZonalUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+	r := LinuxVirtualMachineResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.scalingCapacityReservationGroupZonal(data, ""),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.scalingCapacityReservationGroupZonal(data, "azurerm_capacity_reservation_group.test1.id"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.scalingCapacityReservationGroupZonal(data, "azurerm_capacity_reservation_group.test2.id"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.scalingCapacityReservationGroupZonal(data, ""),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccLinuxVirtualMachine_scalingDedicatedHost(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
 	r := LinuxVirtualMachineResource{}
@@ -603,6 +639,86 @@ resource "azurerm_linux_virtual_machine" "test" {
   }
 }
 `, r.template(data), data.RandomInteger)
+}
+
+func (r LinuxVirtualMachineResource) scalingCapacityReservationGroupZonal(data acceptance.TestData, crg string) string {
+	crgText := ""
+	if crg != "" {
+		crgText = fmt.Sprintf(`capacity_reservation_group_id = %s`, crg)
+	}
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_capacity_reservation_group" "test1" {
+  name                = "acctest-ccrg1-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  zones               = ["3"]
+}
+
+resource "azurerm_capacity_reservation" "test1" {
+  name                          = "acctest-ccr1-%[2]d"
+  capacity_reservation_group_id = azurerm_capacity_reservation_group.test1.id
+  zone                          = "3"
+  sku {
+    name     = "Standard_D2s_v3"
+    capacity = 1
+  }
+}
+
+resource "azurerm_capacity_reservation_group" "test2" {
+  name                = "acctest-ccrg2-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  zones               = ["3"]
+}
+
+resource "azurerm_capacity_reservation" "test2" {
+  name                          = "acctest-ccr2-%[2]d"
+  capacity_reservation_group_id = azurerm_capacity_reservation_group.test2.id
+  zone                          = "3"
+  sku {
+    name     = "Standard_D2s_v3"
+    capacity = 1
+  }
+}
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                = "acctestVM-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_D2s_v3"
+  admin_username      = "adminuser"
+  zone                = "3"
+  %[3]s
+
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "0001-com-ubuntu-server-jammy"
+    sku       = "22_04-lts"
+    version   = "latest"
+  }
+
+  depends_on = [
+    azurerm_capacity_reservation.test1,
+    azurerm_capacity_reservation.test2,
+  ]
+}
+`, r.template(data), data.RandomInteger, crgText)
 }
 
 func (r LinuxVirtualMachineResource) scalingDedicatedHostInitial(data acceptance.TestData) string {

--- a/internal/services/compute/windows_virtual_machine_resource.go
+++ b/internal/services/compute/windows_virtual_machine_resource.go
@@ -1374,11 +1374,11 @@ func resourceWindowsVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interfa
 	if d.HasChange("capacity_reservation_group_id") {
 		shouldUpdate = true
 
-		if _, ok := d.GetOk("zone"); !ok {
-			shouldDeallocate = true
-		}
-
 		if v, ok := d.GetOk("capacity_reservation_group_id"); ok {
+			if _, ok := d.GetOk("zone"); !ok {
+				shouldDeallocate = true
+			}
+
 			update.Properties.CapacityReservation = &virtualmachines.CapacityReservationProfile{
 				CapacityReservationGroup: &virtualmachines.SubResource{
 					Id: pointer.To(v.(string)),

--- a/internal/services/compute/windows_virtual_machine_resource.go
+++ b/internal/services/compute/windows_virtual_machine_resource.go
@@ -1373,7 +1373,10 @@ func resourceWindowsVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interfa
 
 	if d.HasChange("capacity_reservation_group_id") {
 		shouldUpdate = true
-		shouldDeallocate = true
+
+		if _, ok := d.GetOk("zone"); !ok {
+			shouldDeallocate = true
+		}
 
 		if v, ok := d.GetOk("capacity_reservation_group_id"); ok {
 			update.Properties.CapacityReservation = &virtualmachines.CapacityReservationProfile{
@@ -1382,6 +1385,7 @@ func resourceWindowsVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interfa
 				},
 			}
 		} else {
+			shouldDeallocate = true
 			update.Properties.CapacityReservation = &virtualmachines.CapacityReservationProfile{
 				CapacityReservationGroup: &virtualmachines.SubResource{},
 			}

--- a/internal/services/compute/windows_virtual_machine_resource_scaling_test.go
+++ b/internal/services/compute/windows_virtual_machine_resource_scaling_test.go
@@ -48,7 +48,7 @@ func TestAccWindowsVirtualMachine_scalingCapacityReservationGroup(t *testing.T) 
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.scalingCapacityReservationGroup(data),
+			Config: r.scalingCapacityReservationGroup(data, false, "azurerm_capacity_reservation_group.test.id"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -58,69 +58,41 @@ func TestAccWindowsVirtualMachine_scalingCapacityReservationGroup(t *testing.T) 
 }
 
 func TestAccWindowsVirtualMachine_scalingCapacityReservationGroupUpdate(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
-	r := WindowsVirtualMachineResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.scalingCapacityReservationGroupInitial(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep("admin_password"),
-		{
-			Config: r.scalingCapacityReservationGroup(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep("admin_password"),
-		{
-			Config: r.scalingCapacityReservationGroupUpdate(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep("admin_password"),
-		{
-			Config: r.scalingCapacityReservationGroupRemoved(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep("admin_password"),
-	})
+	testAccWindowsVirtualMachineScalingCapacityReservationGroupUpdate(t, false)
 }
 
 func TestAccWindowsVirtualMachine_scalingCapacityReservationGroupZonalUpdate(t *testing.T) {
+	testAccWindowsVirtualMachineScalingCapacityReservationGroupUpdate(t, true)
+}
+
+func testAccWindowsVirtualMachineScalingCapacityReservationGroupUpdate(t *testing.T, zonal bool) {
 	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
 	r := WindowsVirtualMachineResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.scalingCapacityReservationGroupZonal(data, ""),
+			Config: r.scalingCapacityReservationGroup(data, zonal, ""),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep("admin_password"),
 		{
-			Config: r.scalingCapacityReservationGroupZonal(data, "azurerm_capacity_reservation_group.test1.id"),
+			Config: r.scalingCapacityReservationGroup(data, zonal, "azurerm_capacity_reservation_group.test.id"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep("admin_password"),
 		{
-			Config: r.scalingCapacityReservationGroupZonal(data, "azurerm_capacity_reservation_group.test2.id"),
+			Config: r.scalingCapacityReservationGroup(data, zonal, "azurerm_capacity_reservation_group.test2.id"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep("admin_password"),
 		{
-			Config: r.scalingCapacityReservationGroupZonal(data, ""),
+			Config: r.scalingCapacityReservationGroup(data, zonal, ""),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -407,7 +379,17 @@ resource "azurerm_windows_virtual_machine" "test" {
 `, r.template(data), data.RandomInteger)
 }
 
-func (r WindowsVirtualMachineResource) scalingCapacityReservationGroupInitial(data acceptance.TestData) string {
+func (r WindowsVirtualMachineResource) scalingCapacityReservationGroup(data acceptance.TestData, zonal bool, crgId string) string {
+	zones, zone, crgText := "", "", ""
+	if zonal {
+		zones = `zones = ["3"]`
+		zone = `zone = "3"`
+	}
+
+	if crgId != "" {
+		crgText = fmt.Sprintf(`capacity_reservation_group_id = %s`, crgId)
+	}
+
 	return fmt.Sprintf(`
 %[1]s
 
@@ -415,71 +397,45 @@ resource "azurerm_capacity_reservation_group" "test" {
   name                = "acctest-ccrg-%[2]d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
+  %[3]s
 }
 
 resource "azurerm_capacity_reservation" "test" {
   name                          = "acctest-ccr-%[2]d"
   capacity_reservation_group_id = azurerm_capacity_reservation_group.test.id
   sku {
-    name     = "Standard_F2"
+    name     = "Standard_D2s_v3"
     capacity = 1
   }
+  %[4]s
 }
 
-resource "azurerm_windows_virtual_machine" "test" {
-  name                = local.vm_name
+resource "azurerm_capacity_reservation_group" "test2" {
+  name                = "acctest-ccrg2-%[2]d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  size                = "Standard_F2"
-  admin_username      = "adminuser"
-  admin_password      = "P@$$w0rd1234!"
-  network_interface_ids = [
-    azurerm_network_interface.test.id,
-  ]
-
-  os_disk {
-    caching              = "ReadWrite"
-    storage_account_type = "Standard_LRS"
-  }
-
-  source_image_reference {
-    publisher = "MicrosoftWindowsServer"
-    offer     = "WindowsServer"
-    sku       = "2016-Datacenter"
-    version   = "latest"
-  }
-}
-`, r.template(data), data.RandomInteger)
+  %[3]s
 }
 
-func (r WindowsVirtualMachineResource) scalingCapacityReservationGroup(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-%[1]s
-
-resource "azurerm_capacity_reservation_group" "test" {
-  name                = "acctest-ccrg-%[2]d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-}
-
-resource "azurerm_capacity_reservation" "test" {
-  name                          = "acctest-ccr-%[2]d"
-  capacity_reservation_group_id = azurerm_capacity_reservation_group.test.id
+resource "azurerm_capacity_reservation" "test2" {
+  name                          = "acctest-ccr2-%[2]d"
+  capacity_reservation_group_id = azurerm_capacity_reservation_group.test2.id
   sku {
-    name     = "Standard_F2"
+    name     = "Standard_D2s_v3"
     capacity = 1
   }
+  %[4]s
 }
 
 resource "azurerm_windows_virtual_machine" "test" {
   name                = local.vm_name
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  size                = "Standard_F2"
+  size                = "Standard_D2s_v3"
   admin_username      = "adminuser"
   admin_password      = "P@$$w0rd1234!"
-
-  capacity_reservation_group_id = azurerm_capacity_reservation_group.test.id
+  %[4]s
+  %[5]s
 
   network_interface_ids = [
     azurerm_network_interface.test.id,
@@ -499,198 +455,10 @@ resource "azurerm_windows_virtual_machine" "test" {
 
   depends_on = [
     azurerm_capacity_reservation.test,
+    azurerm_capacity_reservation.test2
   ]
 }
-`, r.template(data), data.RandomInteger)
-}
-
-func (r WindowsVirtualMachineResource) scalingCapacityReservationGroupUpdate(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-%[1]s
-
-resource "azurerm_capacity_reservation_group" "test" {
-  name                = "acctest-ccrg-%[2]d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-}
-
-resource "azurerm_capacity_reservation" "test" {
-  name                          = "acctest-ccr-%[2]d"
-  capacity_reservation_group_id = azurerm_capacity_reservation_group.test.id
-  sku {
-    name     = "Standard_F2"
-    capacity = 1
-  }
-}
-
-resource "azurerm_capacity_reservation_group" "test2" {
-  name                = "acctest-ccrg2-%[2]d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-}
-
-resource "azurerm_capacity_reservation" "test2" {
-  name                          = "acctest-ccr-%[2]d"
-  capacity_reservation_group_id = azurerm_capacity_reservation_group.test2.id
-  sku {
-    name     = "Standard_F2"
-    capacity = 1
-  }
-}
-
-resource "azurerm_windows_virtual_machine" "test" {
-  name                = local.vm_name
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  size                = "Standard_F2"
-  admin_username      = "adminuser"
-  admin_password      = "P@$$w0rd1234!"
-
-  capacity_reservation_group_id = azurerm_capacity_reservation_group.test2.id
-
-  network_interface_ids = [
-    azurerm_network_interface.test.id,
-  ]
-
-  os_disk {
-    caching              = "ReadWrite"
-    storage_account_type = "Standard_LRS"
-  }
-
-  source_image_reference {
-    publisher = "MicrosoftWindowsServer"
-    offer     = "WindowsServer"
-    sku       = "2016-Datacenter"
-    version   = "latest"
-  }
-
-  depends_on = [
-    azurerm_capacity_reservation.test2,
-  ]
-}
-`, r.template(data), data.RandomInteger)
-}
-
-func (r WindowsVirtualMachineResource) scalingCapacityReservationGroupRemoved(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-%[1]s
-
-resource "azurerm_capacity_reservation_group" "test2" {
-  name                = "acctest-ccrg2-%[2]d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-}
-
-resource "azurerm_capacity_reservation" "test2" {
-  name                          = "acctest-ccr-%[2]d"
-  capacity_reservation_group_id = azurerm_capacity_reservation_group.test2.id
-  sku {
-    name     = "Standard_F2"
-    capacity = 1
-  }
-}
-
-resource "azurerm_windows_virtual_machine" "test" {
-  name                = local.vm_name
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  size                = "Standard_F2"
-  admin_username      = "adminuser"
-  admin_password      = "P@$$w0rd1234!"
-
-  network_interface_ids = [
-    azurerm_network_interface.test.id,
-  ]
-
-  os_disk {
-    caching              = "ReadWrite"
-    storage_account_type = "Standard_LRS"
-  }
-
-  source_image_reference {
-    publisher = "MicrosoftWindowsServer"
-    offer     = "WindowsServer"
-    sku       = "2016-Datacenter"
-    version   = "latest"
-  }
-}
-`, r.template(data), data.RandomInteger)
-}
-
-func (r WindowsVirtualMachineResource) scalingCapacityReservationGroupZonal(data acceptance.TestData, crg string) string {
-	crgText := ""
-	if crg != "" {
-		crgText = fmt.Sprintf(`capacity_reservation_group_id = %s`, crg)
-	}
-	return fmt.Sprintf(`
-%[1]s
-
-resource "azurerm_capacity_reservation_group" "test1" {
-  name                = "acctest-ccrg1-%[2]d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  zones               = ["3"]
-}
-
-resource "azurerm_capacity_reservation" "test1" {
-  name                          = "acctest-ccr1-%[2]d"
-  capacity_reservation_group_id = azurerm_capacity_reservation_group.test1.id
-  zone                          = "3"
-  sku {
-    name     = "Standard_D2s_v3"
-    capacity = 1
-  }
-}
-
-resource "azurerm_capacity_reservation_group" "test2" {
-  name                = "acctest-ccrg2-%[2]d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  zones               = ["3"]
-}
-
-resource "azurerm_capacity_reservation" "test2" {
-  name                          = "acctest-ccr2-%[2]d"
-  capacity_reservation_group_id = azurerm_capacity_reservation_group.test2.id
-  zone                          = "3"
-  sku {
-    name     = "Standard_D2s_v3"
-    capacity = 1
-  }
-}
-
-resource "azurerm_windows_virtual_machine" "test" {
-  name                = local.vm_name
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  size                = "Standard_D2s_v3"
-  admin_username      = "adminuser"
-  admin_password      = "P@$$w0rd1234!"
-  zone                = "3"
-  %[3]s
-
-  network_interface_ids = [
-    azurerm_network_interface.test.id,
-  ]
-
-  os_disk {
-    caching              = "ReadWrite"
-    storage_account_type = "Standard_LRS"
-  }
-
-  source_image_reference {
-    publisher = "MicrosoftWindowsServer"
-    offer     = "WindowsServer"
-    sku       = "2016-Datacenter"
-    version   = "latest"
-  }
-
-  depends_on = [
-    azurerm_capacity_reservation.test1,
-    azurerm_capacity_reservation.test2,
-  ]
-}
-`, r.template(data), data.RandomInteger, crgText)
+`, r.template(data), data.RandomInteger, zones, zone, crgText)
 }
 
 func (r WindowsVirtualMachineResource) scalingDedicatedHostInitial(data acceptance.TestData) string {

--- a/internal/services/compute/windows_virtual_machine_resource_scaling_test.go
+++ b/internal/services/compute/windows_virtual_machine_resource_scaling_test.go
@@ -93,6 +93,42 @@ func TestAccWindowsVirtualMachine_scalingCapacityReservationGroupUpdate(t *testi
 	})
 }
 
+func TestAccWindowsVirtualMachine_scalingCapacityReservationGroupZonalUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+	r := WindowsVirtualMachineResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.scalingCapacityReservationGroupZonal(data, ""),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			Config: r.scalingCapacityReservationGroupZonal(data, "azurerm_capacity_reservation_group.test1.id"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			Config: r.scalingCapacityReservationGroupZonal(data, "azurerm_capacity_reservation_group.test2.id"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			Config: r.scalingCapacityReservationGroupZonal(data, ""),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
 func TestAccWindowsVirtualMachine_scalingDedicatedHost(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
 	r := WindowsVirtualMachineResource{}
@@ -579,6 +615,82 @@ resource "azurerm_windows_virtual_machine" "test" {
   }
 }
 `, r.template(data), data.RandomInteger)
+}
+
+func (r WindowsVirtualMachineResource) scalingCapacityReservationGroupZonal(data acceptance.TestData, crg string) string {
+	crgText := ""
+	if crg != "" {
+		crgText = fmt.Sprintf(`capacity_reservation_group_id = %s`, crg)
+	}
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_capacity_reservation_group" "test1" {
+  name                = "acctest-ccrg1-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  zones               = ["3"]
+}
+
+resource "azurerm_capacity_reservation" "test1" {
+  name                          = "acctest-ccr1-%[2]d"
+  capacity_reservation_group_id = azurerm_capacity_reservation_group.test1.id
+  zone                          = "3"
+  sku {
+    name     = "Standard_D2s_v3"
+    capacity = 1
+  }
+}
+
+resource "azurerm_capacity_reservation_group" "test2" {
+  name                = "acctest-ccrg2-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  zones               = ["3"]
+}
+
+resource "azurerm_capacity_reservation" "test2" {
+  name                          = "acctest-ccr2-%[2]d"
+  capacity_reservation_group_id = azurerm_capacity_reservation_group.test2.id
+  zone                          = "3"
+  sku {
+    name     = "Standard_D2s_v3"
+    capacity = 1
+  }
+}
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_D2s_v3"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
+  zone                = "3"
+  %[3]s
+
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+
+  depends_on = [
+    azurerm_capacity_reservation.test1,
+    azurerm_capacity_reservation.test2,
+  ]
+}
+`, r.template(data), data.RandomInteger, crgText)
 }
 
 func (r WindowsVirtualMachineResource) scalingDedicatedHostInitial(data acceptance.TestData) string {

--- a/website/docs/r/linux_virtual_machine.html.markdown
+++ b/website/docs/r/linux_virtual_machine.html.markdown
@@ -138,6 +138,8 @@ The following arguments are supported:
 
 ~> **Note:** `capacity_reservation_group_id` cannot be used with `availability_set_id` or `proximity_placement_group_id`
 
+~> **Note:** Associating or changing `capacity_reservation_group_id` on a Virtual Machine with a `zone` configured is applied in-place. Removing the association, or any change on a Virtual Machine without a `zone` configured, requires the Virtual Machine to be deallocated and restarted.
+
 * `computer_name` - (Optional) Specifies the Hostname which should be used for this Virtual Machine. If unspecified this defaults to the value for the `name` field. If the value of the `name` field is not a valid `computer_name`, then you must specify `computer_name`. Changing this forces a new resource to be created.
 
 * `custom_data` - (Optional) The Base64-Encoded Custom Data which should be used for this Virtual Machine. Changing this forces a new resource to be created.

--- a/website/docs/r/windows_virtual_machine.html.markdown
+++ b/website/docs/r/windows_virtual_machine.html.markdown
@@ -133,6 +133,8 @@ The following arguments are supported:
 
 ~> **Note:** `capacity_reservation_group_id` cannot be used with `availability_set_id` or `proximity_placement_group_id`
 
+~> **Note:** Associating or changing `capacity_reservation_group_id` on a Virtual Machine with a `zone` configured is applied in-place. Removing the association, or any change on a Virtual Machine without a `zone` configured, requires the Virtual Machine to be deallocated and restarted.
+
 * `computer_name` - (Optional) Specifies the Hostname which should be used for this Virtual Machine. If unspecified this defaults to the value for the `name` field. If the value of the `name` field is not a valid `computer_name`, then you must specify `computer_name`. Changing this forces a new resource to be created.
 
 * `custom_data` - (Optional) The Base64-Encoded Custom Data which should be used for this Virtual Machine. Changing this forces a new resource to be created.


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR is to supports in place updates for `capacity_reservation_group_id` of VM that has `zone` property without deallocation as it is supported by Azure now: 

- https://learn.microsoft.com/en-us/azure/virtual-machines/capacity-reservation-associate-vm?tabs=api1%2Capi2%2Capi3#zonal-virtual-machine 

Currently feature is in public preview but will be GA by Sep.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

<img width="787" height="555" alt="image" src="https://github.com/user-attachments/assets/c8dbe3de-fee5-45c3-b8ea-c515e48094f9" />

https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_COMPUTE/731177?buildTab=

Failed test also failed on main

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_(linux|windows)_virtual_machine` - support in place updates of `capacity_reservation_group_id` property for vm with `zone` property [GH-33172]



<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
