### PR TITLE
tooling: /test add `-f`/`-force` flag to bypass max-builds-per-pr, surface tctest errors in failure comment 

### DIFF
--- a/.github/workflows/teamcity-run-tests-on-comment.yaml
+++ b/.github/workflows/teamcity-run-tests-on-comment.yaml
@@ -2,8 +2,9 @@
 name: TeamCity Run Tests on Comment
 
 # Lets maintainers trigger TeamCity acceptance test runs by commenting
-# '/test [-b] [-s service] <TestPrefix>' on a PR. Verifies terraform-azure team
+# '/test [-b] [-f] [-s service] <TestPrefix>' on a PR. Verifies terraform-azure team
 # membership (or the allow-list) before dispatching via katbyte/tctest.
+# -f/-force bypasses the max-builds-per-pr limit.
 
 on:
   issue_comment:
@@ -111,12 +112,12 @@ jobs:
         with:
           path: ~/go/bin/tctest
           # keep this key in sync with the pinned version installed below
-          key: tctest-${{ runner.os }}-v1.0.0
+          key: tctest-${{ runner.os }}-v1.2.0
 
       - name: Install tctest
         if: steps.cache-tctest.outputs.cache-hit != 'true'
         run: |
-          go install github.com/katbyte/tctest@v1.0.0
+          go install github.com/katbyte/tctest@v1.2.0
 
       - name: Get PR commit SHA
         id: get-pr-sha
@@ -150,21 +151,32 @@ jobs:
 
           # Initialize default values
           beta=false
+          force=false
           service=""
 
           # Parse flags using getopts
           # Split FLAGS_STRING on whitespace WITHOUT eval - eval would execute
           # command substitutions embedded in the (untrusted) comment text
           read -ra FLAGS <<< "$FLAGS_STRING"
+
+          # getopts only handles single-char flags, so map the long spellings to -f
+          for i in "${!FLAGS[@]}"; do
+            case "${FLAGS[$i]}" in
+              -force|--force) FLAGS[$i]="-f" ;;
+            esac
+          done
+
           set -- "${FLAGS[@]}"
 
-          while getopts ":bs:" opt; do
+          while getopts ":bfs:" opt; do
             case "$opt" in
               b) beta=true ;;
+              f) force=true ;;
               s) service="$OPTARG" ;;
               *)
-                echo "Usage: /test [-b] [-s service_name]"
+                echo "Usage: /test [-b] [-f] [-s service_name]"
                 echo "  -b: Test beta version"
+                echo "  -f: Force - bypass the max-builds-per-pr limit"
                 echo "  -s: Specify service name"
                 exit 1
                 ;;
@@ -174,25 +186,48 @@ jobs:
           echo "Running tctest for PR #${PR_NUMBER}"
           echo "PR commit SHA: ${PR_SHA}"
           echo "Beta version: ${beta}"
+          echo "Force: ${force}"
           echo "Service: ${service:-all}"
 
-          service_flag=()
+          extra_flags=()
           if [ "$service" != "" ]; then
-            service_flag=(--service "$service")
+            extra_flags+=(--service "$service")
+          fi
+          if [ "$force" = true ]; then
+            extra_flags+=(--max-builds-per-pr 0)
           fi
 
           builds='[]'
+          err_log=$(mktemp)
+
+          # Always publish captured stderr so the failure comment can say why tctest failed,
+          # even when a failing run_tctest exits the script via set -e
+          finish() {
+            {
+              echo "errors<<TCTEST_ERR_EOF"
+              cat "$err_log"
+              echo "TCTEST_ERR_EOF"
+            } >> "$GITHUB_OUTPUT"
+          }
+          trap finish EXIT
 
           run_tctest() {
-            local out
-            out=$(tctest pr "${PR_NUMBER}" -c -q --reappend-split-character --build-type-id-add-service-suffix --properties "TRACKING_ID=${PR_SHA}" "$@" --json)
+            local out rc=0 err
+            err=$(mktemp)
+            out=$(tctest pr "${PR_NUMBER}" -c -q --reappend-split-character --build-type-id-add-service-suffix --properties "TRACKING_ID=${PR_SHA}" "$@" --json 2>"$err") || rc=$?
+            cat "$err" >&2
+            cat "$err" >> "$err_log"
+            rm -f "$err"
+            if [ "$rc" -ne 0 ]; then
+              exit "$rc"
+            fi
             echo "$out"
             builds=$(printf '%s\n%s\n' "$builds" "${out:-[]}" | jq -s 'add')
           }
 
-          run_tctest "${service_flag[@]}"
+          run_tctest "${extra_flags[@]}"
           if [ "$beta" = true ]; then
-            run_tctest "${service_flag[@]}" --build-type-id TF_AzureRM_AZURERM_BETA_VERSION_SERVICE_PUBLIC
+            run_tctest "${extra_flags[@]}" --build-type-id TF_AzureRM_AZURERM_BETA_VERSION_SERVICE_PUBLIC
           fi
 
           {
@@ -215,6 +250,36 @@ jobs:
               comment_id: context.payload.comment.id,
               content: 'rocket'
             });
+
+            // hide previous /test failure comments now that a run has succeeded
+            try {
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                per_page: 100
+              });
+              const failures = comments.filter(c =>
+                c.user?.type === 'Bot' &&
+                c.body?.startsWith('❌') &&
+                (c.body.includes('TeamCity') || c.body.includes('would trigger builds'))
+              );
+              for (const c of failures) {
+                await github.graphql(
+                  `mutation($id: ID!) {
+                    minimizeComment(input: { subjectId: $id, classifier: OUTDATED }) {
+                      minimizedComment { isMinimized }
+                    }
+                  }`,
+                  { id: c.node_id }
+                );
+              }
+              if (failures.length > 0) {
+                core.info(`Minimized ${failures.length} previous failure comment(s)`);
+              }
+            } catch (error) {
+              core.warning(`Unable to minimize previous failure comments: ${error.message}`);
+            }
 
             let builds = [];
             try {
@@ -240,14 +305,34 @@ jobs:
       - name: Comment on failure
         if: failure()
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        env:
+          TCTEST_ERRORS: ${{ steps.run-tctest.outputs.errors }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            // strip ANSI colour codes from captured tctest stderr
+            const errors = (process.env.TCTEST_ERRORS || '').replace(/\u001b\[[0-9;]*m/g, '').trim();
+
+            let body;
+            const limit = errors.match(/would trigger (\d+) service builds, exceeding --max-builds-per-pr limit of (\d+)/);
+            if (limit) {
+              body = `❌ This would trigger builds on **${limit[1]}** services, exceeding the limit of ${limit[2]}.\n\n` +
+                `Re-run with \`/test -f\` (or \`/test -force\`) to run them anyway.`;
+            } else {
+              body = '❌ Failed to trigger TeamCity tests.';
+              if (errors) {
+                body += `\n\n\`\`\`\n${errors.slice(-1500)}\n\`\`\``;
+              }
+            }
+            body += `\n\nSee the [workflow logs](${runUrl}) for details.`;
+
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: '❌ Failed to trigger TeamCity tests. Please check the workflow logs for details.'
+              body
             });
 
   unauthorized-comment:

--- a/.github/workflows/teamcity-run-tests-on-comment.yaml
+++ b/.github/workflows/teamcity-run-tests-on-comment.yaml
@@ -5,6 +5,11 @@ name: TeamCity Run Tests on Comment
 # '/test [-b] [-f] [-s service] <TestPrefix>' on a PR. Verifies terraform-azure team
 # membership (or the allow-list) before dispatching via katbyte/tctest.
 # -f/-force bypasses the max-builds-per-pr limit.
+#
+# SECURITY: the failure comment may only ever contain tctest's stderr, which is
+# limited to trigger/discovery errors (bad flags, merge conflicts, GitHub/TeamCity
+# API errors). tctest is invoked without --wait, so it never fetches TeamCity build
+# logs and no build/test output can ever be echoed back onto a public PR.
 
 on:
   issue_comment:
@@ -112,12 +117,12 @@ jobs:
         with:
           path: ~/go/bin/tctest
           # keep this key in sync with the pinned version installed below
-          key: tctest-${{ runner.os }}-v1.2.0
+          key: tctest-${{ runner.os }}-v1.3.0
 
       - name: Install tctest
         if: steps.cache-tctest.outputs.cache-hit != 'true'
         run: |
-          go install github.com/katbyte/tctest@v1.2.0
+          go install github.com/katbyte/tctest@v1.3.0
 
       - name: Get PR commit SHA
         id: get-pr-sha
@@ -320,6 +325,12 @@ jobs:
             if (limit) {
               body = `❌ This would trigger builds on **${limit[1]}** services, exceeding the limit of ${limit[2]}.\n\n` +
                 `Re-run with \`/test -f\` (or \`/test -force\`) to run them anyway.`;
+            } else if (errors.includes('has merge conflicts')) {
+              body = '❌ This PR has merge conflicts — TeamCity tests cannot run until they are resolved.\n\n' +
+                'Merge the base branch (or rebase), then comment `/test` again.';
+            } else if (errors.includes('no builds were triggered')) {
+              body = '❌ No TeamCity builds were triggered — no acceptance tests could be discovered from this PR\'s changed files.\n\n' +
+                'If this PR does have acceptance tests, re-run with an explicit prefix, e.g. `/test TestAccFoo`.';
             } else {
               body = '❌ Failed to trigger TeamCity tests.';
               if (errors) {

--- a/.github/workflows/teamcity-run-tests-on-comment.yaml
+++ b/.github/workflows/teamcity-run-tests-on-comment.yaml
@@ -6,9 +6,10 @@ name: TeamCity Run Tests on Comment
 # membership (or the allow-list) before dispatching via katbyte/tctest.
 # -f/-force bypasses the max-builds-per-pr limit.
 #
-# SECURITY: the failure comment may only ever contain tctest's stderr, which is
-# limited to trigger/discovery errors (bad flags, merge conflicts, GitHub/TeamCity
-# API errors). tctest is invoked without --wait, so it never fetches TeamCity build
+# SECURITY: tctest's captured stderr is only ever analyzed to pick a canned failure
+# message - it is never included in the comment body, since comment bodies bypass the
+# secret masking applied to workflow logs (e.g. TCTEST_SERVER appearing in an HTTP
+# error URL). tctest is invoked without --wait, so it never fetches TeamCity build
 # logs and no build/test output can ever be echoed back onto a public PR.
 
 on:
@@ -332,10 +333,9 @@ jobs:
               body = '❌ No TeamCity builds were triggered — no acceptance tests could be discovered from this PR\'s changed files.\n\n' +
                 'If this PR does have acceptance tests, re-run with an explicit prefix, e.g. `/test TestAccFoo`.';
             } else {
+              // unrecognized error: never post raw stderr (comment bodies bypass the
+              // secret masking that workflow logs get) - point at the logs instead
               body = '❌ Failed to trigger TeamCity tests.';
-              if (errors) {
-                body += `\n\n\`\`\`\n${errors.slice(-1500)}\n\`\`\``;
-              }
             }
             body += `\n\nSee the [workflow logs](${runUrl}) for details.`;
 

--- a/.teamcity/scripts/post_github_comment.sh
+++ b/.teamcity/scripts/post_github_comment.sh
@@ -17,6 +17,16 @@ LABEL_OUTDATED="%env.LABEL_OUTDATED%"
 LABEL_NEW_FAILURE="%env.LABEL_NEW_FAILURE%"
 APPLY_TESTING_LABELS_ENABLED="%env.APPLY_TESTING_LABELS_ENABLED%"
 TRACKING_ID="%TRACKING_ID%"
+BUILD_VCS_NUMBER="%build.vcs.number%"
+
+# Builds triggered outside of /test (TeamCity UI, tctest without --properties) have no
+# TRACKING_ID and inherit the "0" default. Since one test run is now split into several
+# per-service builds, a zero tracking id would make each build's comment minimize its
+# sibling builds' still-valid comments. Fall back to the VCS revision so builds of the
+# same revision share a tracking id and never minimize each other.
+if [ "$TRACKING_ID" = "0" ] || [ -z "$TRACKING_ID" ]; then
+  TRACKING_ID="$BUILD_VCS_NUMBER"
+fi
 
 if [ "$POST_GITHUB_COMMENT" != "true" ]; then
   echo "GitHub commenting disabled — skipping."
@@ -381,13 +391,19 @@ echo "Fetching existing comments..."
 COMMENTS_JSON=$(github_api_request "/issues/${PR_NUMBER}/comments")
 
 # Filter comments that should be minimized (teamcity-test-results or /test comments)
-# but exclude those with the current tracking ID
+# but exclude those with the current tracking ID. Without a usable tracking id we
+# cannot tell sibling builds of the current run from stale ones, so minimize nothing.
+COMMENT_IDS=""
+if [ -n "$TRACKING_ID" ] && [ "$TRACKING_ID" != "0" ]; then
 COMMENT_IDS=$(echo "$COMMENTS_JSON" | jq -r --arg tracking_id "$TRACKING_ID" '
   .[] |
   select(.body | type == "string" and (contains("<!-- teamcity-test-results -->") or startswith("/test"))) |
   select(.body | contains("tracking-id:" + $tracking_id) | not) |
   .node_id
 ' 2>&1 | grep -v "^jq:")
+else
+  echo "No usable tracking id; skipping minimization of previous comments"
+fi
 
 if [ -n "$COMMENT_IDS" ]; then
   echo "Found previous comments to minimize"


### PR DESCRIPTION
also upgrade to tctest v1.3.0 and prevent the minimizing of `tctest prs 12345 -c` comments