### PR TITLE
Feat/mssql vm use storage pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ FEATURES:
 
 ENHANCEMENTS:
 
+* `azurerm_mssql_virtual_machine` - add support for `use_storage_pool` to the `storage_settings` and `temp_db_settings` blocks ([#33179](https://github.com/hashicorp/terraform-provider-azurerm/issues/33179))
 * dependencies: `go` - update to `1.26.6` ([#33141](https://github.com/hashicorp/terraform-provider-azurerm/issues/33141))
 * dependencies: `go-azure-sdk` - update to `v0.20260811.1225050` ([#33079](https://github.com/hashicorp/terraform-provider-azurerm/issues/33079))
 * `azurerm_cdn_frontdoor_batch_rule_set` - allow `/` as an input to `rule.conditions.request_path.values` ([#33023](https://github.com/hashicorp/terraform-provider-azurerm/issues/33023))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ FEATURES:
 
 ENHANCEMENTS:
 
-* `azurerm_mssql_virtual_machine` - add support for `use_storage_pool` to the `storage_settings` and `temp_db_settings` blocks ([#33179](https://github.com/hashicorp/terraform-provider-azurerm/issues/33179))
+* `azurerm_mssql_virtual_machine` - add support for `use_storage_pool` to the `storage_settings` and `temp_db_settings` blocks ([#30846](https://github.com/hashicorp/terraform-provider-azurerm/issues/30846))
 * dependencies: `go` - update to `1.26.6` ([#33141](https://github.com/hashicorp/terraform-provider-azurerm/issues/33141))
 * dependencies: `go-azure-sdk` - update to `v0.20260811.1225050` ([#33079](https://github.com/hashicorp/terraform-provider-azurerm/issues/33079))
 * `azurerm_cdn_frontdoor_batch_rule_set` - allow `/` as an input to `rule.conditions.request_path.values` ([#33023](https://github.com/hashicorp/terraform-provider-azurerm/issues/33023))

--- a/internal/services/mssql/helper/sql_virtual_machine_storage_settings.go
+++ b/internal/services/mssql/helper/sql_virtual_machine_storage_settings.go
@@ -27,6 +27,11 @@ func StorageSettingSchema() *pluginsdk.Schema {
 					Required:     true,
 					ValidateFunc: validation.StringIsNotEmpty,
 				},
+				"use_storage_pool": {
+					Type:     pluginsdk.TypeBool,
+					Optional: true,
+					Default:  true,
+				},
 			},
 		},
 	}
@@ -75,6 +80,11 @@ func SQLTempDBStorageSettingSchema() *pluginsdk.Schema {
 					Elem: &pluginsdk.Schema{
 						Type: pluginsdk.TypeInt,
 					},
+				},
+				"use_storage_pool": {
+					Type:     pluginsdk.TypeBool,
+					Optional: true,
+					Default:  false,
 				},
 			},
 		},

--- a/internal/services/mssql/mssql_virtual_machine_resource.go
+++ b/internal/services/mssql/mssql_virtual_machine_resource.go
@@ -1280,6 +1280,7 @@ func expandSqlVirtualMachineDataStorageSettings(input []interface{}) *sqlvirtual
 	return &sqlvirtualmachines.SQLStorageSettings{
 		Luns:            expandSqlVirtualMachineStorageSettingsLuns(dataStorageSettings["luns"].([]interface{})),
 		DefaultFilePath: pointer.To(dataStorageSettings["default_file_path"].(string)),
+		UseStoragePool:  pointer.To(dataStorageSettings["use_storage_pool"].(bool)),
 	}
 }
 
@@ -1308,6 +1309,10 @@ func flattenSqlVirtualMachineStorageSettings(input *sqlvirtualmachines.SQLStorag
 		attrs["default_file_path"] = *input.DefaultFilePath
 	}
 
+	if input.UseStoragePool != nil {
+		attrs["use_storage_pool"] = *input.UseStoragePool
+	}
+
 	return []interface{}{attrs}
 }
 
@@ -1325,6 +1330,7 @@ func expandSqlVirtualMachineTempDbSettings(input []interface{}) *sqlvirtualmachi
 		DataGrowth:      pointer.To(int64(tempDbSettings["data_file_growth_in_mb"].(int))),
 		LogFileSize:     pointer.To(int64(tempDbSettings["log_file_size_mb"].(int))),
 		LogGrowth:       pointer.To(int64(tempDbSettings["log_file_growth_mb"].(int))),
+		UseStoragePool:  pointer.To(tempDbSettings["use_storage_pool"].(bool)),
 	}
 }
 
@@ -1360,6 +1366,10 @@ func flattenSqlVirtualMachineTempDbSettings(input *sqlvirtualmachines.SQLTempDbS
 
 	if input.LogGrowth != nil {
 		attrs["log_file_growth_mb"] = *input.LogGrowth
+	}
+
+	if input.UseStoragePool != nil {
+		attrs["use_storage_pool"] = *input.UseStoragePool
 	}
 
 	return []interface{}{attrs}

--- a/internal/services/mssql/mssql_virtual_machine_resource_test.go
+++ b/internal/services/mssql/mssql_virtual_machine_resource_test.go
@@ -278,6 +278,34 @@ func TestAccMsSqlVirtualMachine_storageConfiguration(t *testing.T) {
 	})
 }
 
+func TestAccMsSqlVirtualMachine_storageConfigurationUseStoragePool(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_mssql_virtual_machine", "test")
+	r := MssqlVirtualMachineResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.storageConfigurationUseStoragePool(data, true, false),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("storage_configuration.0.data_settings.0.use_storage_pool").HasValue("true"),
+				check.That(data.ResourceName).Key("storage_configuration.0.log_settings.0.use_storage_pool").HasValue("true"),
+				check.That(data.ResourceName).Key("storage_configuration.0.temp_db_settings.0.use_storage_pool").HasValue("false"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.storageConfigurationUseStoragePool(data, false, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("storage_configuration.0.data_settings.0.use_storage_pool").HasValue("false"),
+				check.That(data.ResourceName).Key("storage_configuration.0.log_settings.0.use_storage_pool").HasValue("false"),
+				check.That(data.ResourceName).Key("storage_configuration.0.temp_db_settings.0.use_storage_pool").HasValue("true"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccMsSqlVirtualMachine_storageConfigurationSystemDbOnDataDisk(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_mssql_virtual_machine", "test")
 	r := MssqlVirtualMachineResource{}
@@ -1026,6 +1054,61 @@ resource "azurerm_mssql_virtual_machine" "test" {
   ]
 }
 `, r.template(data), data.RandomInteger)
+}
+
+func (r MssqlVirtualMachineResource) storageConfigurationUseStoragePool(data acceptance.TestData, dataLogPool bool, tempDbPool bool) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_managed_disk" "test" {
+  name                 = "accmd-sqlvm-%[2]d"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  storage_account_type = "Standard_LRS"
+  create_option        = "Empty"
+  disk_size_gb         = 10
+}
+
+resource "azurerm_virtual_machine_data_disk_attachment" "test" {
+  managed_disk_id    = azurerm_managed_disk.test.id
+  virtual_machine_id = azurerm_virtual_machine.test.id
+  lun                = "0"
+  caching            = "None"
+}
+
+resource "azurerm_mssql_virtual_machine" "test" {
+  virtual_machine_id = azurerm_virtual_machine.test.id
+  sql_license_type   = "PAYG"
+
+  storage_configuration {
+    disk_type             = "NEW"
+    storage_workload_type = "OLTP"
+
+    data_settings {
+      luns              = [0]
+      default_file_path = "F:\\SQLData"
+      use_storage_pool  = %[3]t
+    }
+
+    log_settings {
+      luns              = [0]
+      default_file_path = "F:\\SQLLog"
+      use_storage_pool  = %[3]t
+    }
+
+    temp_db_settings {
+      luns              = [0]
+      default_file_path = "F:\\SQLTemp"
+      log_file_size_mb  = 512
+      use_storage_pool  = %[4]t
+    }
+  }
+
+  depends_on = [
+    azurerm_virtual_machine_data_disk_attachment.test
+  ]
+}
+`, r.template(data), data.RandomInteger, dataLogPool, tempDbPool)
 }
 
 func (r MssqlVirtualMachineResource) storageConfigurationSystemDbOnDataDisk(data acceptance.TestData, enabled bool) string {

--- a/website/docs/r/mssql_virtual_machine.html.markdown
+++ b/website/docs/r/mssql_virtual_machine.html.markdown
@@ -172,6 +172,8 @@ The `storage_settings` block supports the following:
 
 * `luns` - (Required) A list of Logical Unit Numbers for the disks.
 
+* `use_storage_pool` - (Optional) Specifies whether to use the storage pool for the SQL Server. Defaults to `true`.
+
 ---
 
 The `temp_db_settings` block supports the following:
@@ -179,6 +181,8 @@ The `temp_db_settings` block supports the following:
 * `default_file_path` - (Required) The SQL Server default path
 
 * `luns` - (Required) A list of Logical Unit Numbers for the disks.
+
+* `use_storage_pool` - (Optional) Specifies whether to use the storage pool for TempDB. Defaults to `false`.
 
 * `data_file_count` - (Optional) The SQL Server default file count. This value defaults to `8`
 


### PR DESCRIPTION
Community Note

- Please vote on this PR by adding a :thumbsup: reaction to the original PR to help the community and maintainers prioritize for review
- Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

Description

azurerm_mssql_virtual_machine - add support for the use_storage_pool property to storage_settings and temp_db_settings blocks

The Azure API (2023-10-01) exposes useStoragePool on both SQLStorageSettings and SQLTempDbSettings, but the provider had no way to set or read it. This PR wires the field end-to-end: schema definition, expand, flatten, and documentation.

- storage_settings.use_storage_pool — optional bool, defaults to true (matches Azure API default)
- temp_db_settings.use_storage_pool — optional bool, defaults to false (matches Azure API default)

Both defaults are chosen to preserve existing behavior for configurations that omit the field.

PR Checklist

- [x] I have followed the guidelines in our Contributing Documentation.
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate closing keywords below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.

Changes to existing Resource / Data Source
                                                                                                                                                                                               - [x] I have added an explanation of what my changes do and why I'd like you to incl- [x] I have written new tests for my resource or datasource changes & updated any r- [x] I have successfully run tests with my changes locally. If not, please provide ges that prevented you running the tests.Testing
                                                                                                                                                                                               make build and make test (unit tests) pass locally.A new acceptance test TestAccMsSqlVirtualMachine_storageConfigurationUseStoragePool es two steps:1. use_storage_pool = true on data_settings/log_settings, false on temp_db_settings2. Inverted values — verifying the field round-trips correctly on update
Full acceptance test execution against Azure was not performed locally (requires live ARM credentials), but the test is structured identically to existing storage configuration acceptance tesin the same file.
                                                                                                                                                                                               Change Log- azurerm_mssql_virtual_machine - add support for use_storage_pool to storage_settinocks [GH-30846]This is a (please select all that apply):

- [x] Enhancement                                                                                                                                                                              
Related Issue(s)

Closes #30846                                                                                                                                                                                  
AI Assistance Disclosure                                                                                                                                                                       
- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs                                                                                                          
Code generation, expand/flatten wiring, documentation, changelog, and acceptance test were authored with Claude Code (claude.ai/code). All output was reviewed and verified by the contributor prior to submission. PR responses will be authored by the human contributor.

Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider

Changes to Security Controls

No changes to security controls.