### PR TITLE
Attributes added `data.express.route` - add support for `IPV6  + 1 attribute`

### DIFF
--- a/internal/services/network/express_route_circuit_peering_data_source.go
+++ b/internal/services/network/express_route_circuit_peering_data_source.go
@@ -60,6 +60,100 @@ func dataSourceExpressRouteCircuitPeering() *pluginsdk.Resource {
 				Computed: true,
 			},
 
+			"ipv6": {
+				Type:     pluginsdk.TypeList,
+				Computed: true,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"microsoft_peering": {
+							Type:     pluginsdk.TypeList,
+							Computed: true,
+							Elem: &pluginsdk.Resource{
+								Schema: map[string]*pluginsdk.Schema{
+									"advertised_public_prefixes": {
+										Type:     pluginsdk.TypeList,
+										Computed: true,
+										Elem: &pluginsdk.Schema{
+											Type: pluginsdk.TypeString,
+										},
+									},
+
+									"customer_asn": {
+										Type:     pluginsdk.TypeInt,
+										Computed: true,
+									},
+
+									"routing_registry_name": {
+										Type:     pluginsdk.TypeString,
+										Computed: true,
+									},
+
+									"advertised_communities": {
+										Type:     pluginsdk.TypeList,
+										Computed: true,
+										Elem: &pluginsdk.Schema{
+											Type: pluginsdk.TypeString,
+										},
+									},
+								},
+							},
+						},
+
+						"primary_peer_address_prefix": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+
+						"secondary_peer_address_prefix": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+
+						"enabled": {
+							Type:     pluginsdk.TypeBool,
+							Computed: true,
+						},
+
+						"route_filter_id": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+
+			"microsoft_peering_config": {
+				Type:     pluginsdk.TypeList,
+				Computed: true,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"advertised_public_prefixes": {
+							Type:     pluginsdk.TypeList,
+							Computed: true,
+							Elem:     &pluginsdk.Schema{Type: pluginsdk.TypeString},
+						},
+
+						"customer_asn": {
+							Type:     pluginsdk.TypeInt,
+							Computed: true,
+						},
+
+						"routing_registry_name": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+
+						"advertised_communities": {
+							Type:     pluginsdk.TypeList,
+							Computed: true,
+							Elem: &pluginsdk.Schema{
+								Type: pluginsdk.TypeString,
+							},
+						},
+					},
+				},
+			},
+
 			"vlan_id": {
 				Type:     pluginsdk.TypeInt,
 				Computed: true,
@@ -142,6 +236,14 @@ func dataSourceExpressRouteCircuitPeeringRead(d *pluginsdk.ResourceData, meta in
 				routeFilterId = *props.RouteFilter.Id
 			}
 			d.Set("route_filter_id", routeFilterId)
+
+			config := flattenExpressRouteCircuitPeeringMicrosoftConfig(props.MicrosoftPeeringConfig)
+			if err := d.Set("microsoft_peering_config", config); err != nil {
+				return fmt.Errorf("setting `microsoft_peering_config`: %+v", err)
+			}
+			if err := d.Set("ipv6", flattenExpressRouteCircuitIpv6PeeringConfig(props.IPv6PeeringConfig)); err != nil {
+				return fmt.Errorf("setting `ipv6`: %+v", err)
+			}
 		}
 	}
 

--- a/internal/services/network/express_route_circuit_peering_data_source_test.go
+++ b/internal/services/network/express_route_circuit_peering_data_source_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 )
 
 type ExpressRouteCircuitPeeringDataSource struct{}
@@ -34,4 +35,31 @@ data "azurerm_express_route_circuit_peering" "data" {
   resource_group_name        = azurerm_express_route_circuit_peering.test.resource_group_name
 }
 `, ExpressRouteCircuitPeeringResource{}.privatePeering(data))
+}
+
+func testAccDataSourceExpressRouteCircuitPeering_microsoftPeering(t *testing.T) {
+	dataSource := acceptance.BuildTestData(t, "data.azurerm_express_route_circuit_peering", "data")
+	d := ExpressRouteCircuitPeeringDataSource{}
+
+	dataSource.DataSourceTestInSequence(t, []acceptance.TestStep{
+		{
+			Config: d.microsoftPeering(dataSource),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(dataSource.ResourceName).Key("microsoft_peering_config.#").HasValue("1"),
+				check.That(dataSource.ResourceName).Key("ipv6.#").HasValue("1"),
+			),
+		},
+	})
+}
+
+func (d ExpressRouteCircuitPeeringDataSource) microsoftPeering(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_express_route_circuit_peering" "data" {
+  peering_type               = azurerm_express_route_circuit_peering.test.peering_type
+  express_route_circuit_name = azurerm_express_route_circuit_peering.test.express_route_circuit_name
+  resource_group_name        = azurerm_express_route_circuit_peering.test.resource_group_name
+}
+`, ExpressRouteCircuitPeeringResource{}.msPeeringIpv6(data))
 }

--- a/internal/services/network/express_route_circuit_peering_resource_test.go
+++ b/internal/services/network/express_route_circuit_peering_resource_test.go
@@ -330,20 +330,20 @@ resource "azurerm_express_route_circuit_peering" "test" {
   express_route_circuit_name    = azurerm_express_route_circuit.test.name
   resource_group_name           = azurerm_resource_group.test.name
   peer_asn                      = 100
-  primary_peer_address_prefix   = "192.168.7.0/30"
-  secondary_peer_address_prefix = "192.168.8.0/30"
+  primary_peer_address_prefix   = "192.168.13.0/30"
+  secondary_peer_address_prefix = "192.168.14.0/30"
   vlan_id                       = 300
 
   microsoft_peering_config {
-    advertised_public_prefixes = ["123.4.0.0/24"]
+    advertised_public_prefixes = ["123.6.0.0/24"]
   }
 
   ipv6 {
-    primary_peer_address_prefix   = "2002:db03::/126"
-    secondary_peer_address_prefix = "2003:db03::/126"
+    primary_peer_address_prefix   = "2002:db06::/126"
+    secondary_peer_address_prefix = "2003:db06::/126"
 
     microsoft_peering {
-      advertised_public_prefixes = ["2002:db01::/126"]
+      advertised_public_prefixes = ["2002:db06::/126"]
       advertised_communities     = ["regionalCommunity"]
     }
   }

--- a/internal/services/network/express_route_circuit_resource_test.go
+++ b/internal/services/network/express_route_circuit_resource_test.go
@@ -52,6 +52,7 @@ func TestAccExpressRouteCircuit_sequential(t *testing.T) {
 			"microsoftPeeringIpv6":                testAccExpressRouteCircuitPeering_microsoftPeeringIpv6,
 			"microsoftPeeringIpv6CustomerRouting": testAccExpressRouteCircuitPeering_microsoftPeeringIpv6CustomerRouting,
 			"microsoftPeeringIpv6WithRouteFilter": testAccExpressRouteCircuitPeering_microsoftPeeringIpv6WithRouteFilter,
+			"microsoftPeeringDataSource":          testAccDataSourceExpressRouteCircuitPeering_microsoftPeering,
 		},
 		"authorization": {
 			"basic":          testAccExpressRouteCircuitAuthorization_basic,

--- a/website/docs/d/express_route_circuit_peering.html.markdown
+++ b/website/docs/d/express_route_circuit_peering.html.markdown
@@ -56,6 +56,32 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the ExpressRoute Circuit Peering.
 
+---
+
+A `microsoft_peering_config` block contains:
+
+* `advertised_public_prefixes` - A list of Advertised Public Prefixes.
+
+* `customer_asn` - The CustomerASN of the peering.
+
+* `routing_registry_name` - he Routing Registry against which the AS number and prefixes are registered.
+
+* `advertised_communities` - The communities of Bgp Peering specified for microsoft peering.
+
+---
+
+A `ipv6` block contains:
+
+* `primary_peer_address_prefix` - A subnet for the primary link.
+
+* `secondary_peer_address_prefix` - A subnet for the secondary link.
+
+* `enabled` - A boolean value indicating whether the IPv6 peering is enabled. Defaults to `true`.
+
+* `microsoft_peering` - A `microsoft_peering` block as defined below. 
+
+* `route_filter_id` - The ID of the Route Filter.
+
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/configure#define-operation-timeouts) for certain actions:


### PR DESCRIPTION
Missing resource properties added into data source: "ipv6", "microsoft_peering_config"