### PR TITLE
Attributes added `data.ip_group` - add support for `firewall_ids  + 1 attribute`

### DIFF
--- a/internal/services/network/ip_group_data_source.go
+++ b/internal/services/network/ip_group_data_source.go
@@ -11,6 +11,8 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/azurefirewalls"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/firewallpolicies"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/ipgroups"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -40,6 +42,22 @@ func dataSourceIpGroup() *pluginsdk.Resource {
 				Computed: true,
 				Elem:     &pluginsdk.Schema{Type: pluginsdk.TypeString},
 				Set:      pluginsdk.HashString,
+			},
+
+			"firewall_ids": {
+				Type:     pluginsdk.TypeList,
+				Computed: true,
+				Elem: &pluginsdk.Schema{
+					Type: pluginsdk.TypeString,
+				},
+			},
+
+			"firewall_policy_ids": {
+				Type:     pluginsdk.TypeList,
+				Computed: true,
+				Elem: &pluginsdk.Schema{
+					Type: pluginsdk.TypeString,
+				},
 			},
 
 			"tags": commonschema.TagsDataSource(),
@@ -77,6 +95,26 @@ func dataSourceIpGroupRead(d *pluginsdk.ResourceData, meta interface{}) error {
 			if err := d.Set("cidrs", props.IPAddresses); err != nil {
 				return fmt.Errorf("setting `cidrs`: %+v", err)
 			}
+
+			firewallIDs := make([]string, 0)
+			for _, idStr := range getIds(props.Firewalls) {
+				firewallID, err := azurefirewalls.ParseAzureFirewallIDInsensitively(idStr)
+				if err != nil {
+					return fmt.Errorf("parsing Azure Firewall ID %q: %+v", idStr, err)
+				}
+				firewallIDs = append(firewallIDs, firewallID.ID())
+			}
+			d.Set("firewall_ids", firewallIDs)
+
+			firewallPolicyIDs := make([]string, 0)
+			for _, idStr := range getIds(props.FirewallPolicies) {
+				policyID, err := firewallpolicies.ParseFirewallPolicyIDInsensitively(idStr)
+				if err != nil {
+					return fmt.Errorf("parsing Azure Firewall Policy ID %q: %+v", idStr, err)
+				}
+				firewallPolicyIDs = append(firewallPolicyIDs, policyID.ID())
+			}
+			d.Set("firewall_policy_ids", firewallPolicyIDs)
 		}
 		return tags.FlattenAndSet(d, model.Tags)
 	}

--- a/website/docs/d/ip_group.html.markdown
+++ b/website/docs/d/ip_group.html.markdown
@@ -37,6 +37,10 @@ output "cidrs" {
 
 * `cidrs` - A list of CIDRs or IP addresses.
 
+* `firewall_ids` - A list of ID of Firewall.
+
+* `firewall_policy_ids` - A list of ID of Firewall Policy`.
+
 * `tags` - A mapping of tags assigned to the resource.
 
 ## Timeouts


### PR DESCRIPTION
Added missing resource properties to data source: "firewall_ids", "firewall_policy_ids"
--- PASS: TestAccDataSourceIPGroup_basic (88.31s)
