### PR TITLE
Attributes added `data.private_link` - add support for `fqdns  + 1 attribute`

### DIFF
--- a/internal/services/network/private_link_service_data_source.go
+++ b/internal/services/network/private_link_service_data_source.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
@@ -42,6 +43,19 @@ func dataSourcePrivateLinkService() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeList,
 				Computed: true,
 				Elem:     &pluginsdk.Schema{Type: pluginsdk.TypeString},
+			},
+
+			"destination_ip_address": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
+			"fqdns": {
+				Type:     pluginsdk.TypeList,
+				Computed: true,
+				Elem: &pluginsdk.Schema{
+					Type: pluginsdk.TypeString,
+				},
 			},
 
 			"proxy_protocol_enabled": {
@@ -127,6 +141,8 @@ func dataSourcePrivateLinkServiceRead(d *pluginsdk.ResourceData, meta interface{
 
 			d.Set("proxy_protocol_enabled", props.EnableProxyProtocol)
 
+			d.Set("destination_ip_address", pointer.From(props.DestinationIPAddress))
+
 			if autoApproval := props.AutoApproval; autoApproval != nil {
 				if err := d.Set("auto_approval_subscription_ids", helpers.FlattenStringSlice(autoApproval.Subscriptions)); err != nil {
 					return fmt.Errorf("setting `auto_approval_subscription_ids`: %+v", err)
@@ -147,6 +163,9 @@ func dataSourcePrivateLinkServiceRead(d *pluginsdk.ResourceData, meta interface{
 				if err := d.Set("load_balancer_frontend_ip_configuration_ids", dataSourceFlattenPrivateLinkServiceFrontendIPConfiguration(props.LoadBalancerFrontendIPConfigurations)); err != nil {
 					return fmt.Errorf("setting `load_balancer_frontend_ip_configuration_ids`: %+v", err)
 				}
+			}
+			if err := d.Set("fqdns", helpers.FlattenStringSlice(props.Fqdns)); err != nil {
+				return fmt.Errorf("setting `fqdns`: %+v", err)
 			}
 		}
 		if err := tags.FlattenAndSet(d, model.Tags); err != nil {

--- a/website/docs/d/private_link_service.html.markdown
+++ b/website/docs/d/private_link_service.html.markdown
@@ -41,7 +41,11 @@ The following attributes are exported:
 
 * `auto_approval_subscription_ids` - The list of subscription(s) globally unique identifiers that will be auto approved to use the private link service.
 
+* `destination_ip_address` - The destination IP address of the Private Link Service.
+
 * `enable_proxy_protocol` - Does the Private Link Service support the Proxy Protocol?
+
+* `fqdns` - List of FQDNs allowed for the Private Link Service.
 
 * `load_balancer_frontend_ip_configuration_ids` - The list of Standard Load Balancer(SLB) resource IDs. The Private Link service is tied to the frontend IP address of a SLB. All traffic destined for the private link service will reach the frontend of the SLB. You can configure SLB rules to direct this traffic to appropriate backend pools where your applications are running.
 


### PR DESCRIPTION
Added missing resource properties to data source: "destination_ip_address", "fqdns"
--- PASS: TestAccDataSourcePrivateLinkService_complete (134.95s)