### PR TITLE
Attributes added `data.public_id` - add support for `custom_ip_prefix_id + 1 attribute`

### DIFF
--- a/internal/services/network/public_ip_prefix_data_source.go
+++ b/internal/services/network/public_ip_prefix_data_source.go
@@ -103,9 +103,7 @@ func dataSourcePublicIpPrefixRead(d *pluginsdk.ResourceData, meta interface{}) e
 		if props := model.Properties; props != nil {
 			d.Set("prefix_length", props.PrefixLength)
 			d.Set("ip_prefix", props.IPPrefix)
-			if version := props.PublicIPAddressVersion; version != nil {
-				d.Set("ip_version", string(*version))
-			}
+			d.Set("ip_version", string(pointer.From(props.PublicIPAddressVersion)))
 
 			customIpPrefixId := ""
 			if props.CustomIPPrefix != nil {

--- a/internal/services/network/public_ip_prefix_data_source.go
+++ b/internal/services/network/public_ip_prefix_data_source.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/zones"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/customipprefixes"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/publicipprefixes"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -36,6 +37,16 @@ func dataSourcePublicIpPrefix() *pluginsdk.Resource {
 			"location": commonschema.LocationComputed(),
 
 			"resource_group_name": commonschema.ResourceGroupNameForDataSource(),
+
+			"custom_ip_prefix_id": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
+			"ip_version": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
 
 			"sku": {
 				Type:     pluginsdk.TypeString,
@@ -92,6 +103,19 @@ func dataSourcePublicIpPrefixRead(d *pluginsdk.ResourceData, meta interface{}) e
 		if props := model.Properties; props != nil {
 			d.Set("prefix_length", props.PrefixLength)
 			d.Set("ip_prefix", props.IPPrefix)
+			if version := props.PublicIPAddressVersion; version != nil {
+				d.Set("ip_version", string(*version))
+			}
+
+			customIpPrefixId := ""
+			if props.CustomIPPrefix != nil {
+				id, err := customipprefixes.ParseCustomIPPrefixID(pointer.From(props.CustomIPPrefix.Id))
+				if err != nil {
+					return err
+				}
+				customIpPrefixId = id.ID()
+			}
+			d.Set("custom_ip_prefix_id", customIpPrefixId)
 		}
 		return tags.FlattenAndSet(d, model.Tags)
 	}

--- a/internal/services/network/public_ip_prefix_data_source_test.go
+++ b/internal/services/network/public_ip_prefix_data_source_test.go
@@ -74,7 +74,7 @@ data "azurerm_public_ip_prefix" "test" {
 `, resourceGroupName, data.Locations.Primary, name)
 }
 
-func TestAccDataSourcePublicIpPrefix_customIpPrefix(t *testing.T) {
+func TestAccDataSourcePublicIPPrefix_customIpPrefix(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_public_ip_prefix", "test")
 	r := PublicIPPrefixDataSource{}
 

--- a/internal/services/network/public_ip_prefix_data_source_test.go
+++ b/internal/services/network/public_ip_prefix_data_source_test.go
@@ -5,6 +5,7 @@ package network_test
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/publicipprefixes"
@@ -33,6 +34,7 @@ func TestAccDataSourcePublicIPPrefix_basic(t *testing.T) {
 				check.That(data.ResourceName).Key("ip_prefix").Exists(),
 				check.That(data.ResourceName).Key("tags.%").HasValue("1"),
 				check.That(data.ResourceName).Key("tags.env").HasValue("test"),
+				check.That(data.ResourceName).Key("ip_version").HasValue(string(publicipprefixes.IPVersionIPvFour)),
 			),
 		},
 	})
@@ -70,4 +72,34 @@ data "azurerm_public_ip_prefix" "test" {
   resource_group_name = azurerm_resource_group.test.name
 }
 `, resourceGroupName, data.Locations.Primary, name)
+}
+
+func TestAccDataSourcePublicIpPrefix_customIpPrefix(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_public_ip_prefix", "test")
+	r := PublicIPPrefixDataSource{}
+
+	if os.Getenv("ARM_TEST_CUSTOM_IP_PREFIX_ID") == "" {
+		t.Skip("ARM_TEST_CUSTOM_IP_PREFIX_ID env var not set")
+	}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.customIpPrefix(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("ip_version").HasValue(string(publicipprefixes.IPVersionIPvSix)),
+				check.That(data.ResourceName).Key("custom_ip_prefix_id").HasValue(os.Getenv("ARM_TEST_CUSTOM_IP_PREFIX_ID")),
+			),
+		},
+	})
+}
+
+func (PublicIPPrefixDataSource) customIpPrefix(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_public_ip_prefix" "test" {
+  name                = azurerm_public_ip_prefix.test.name
+  resource_group_name = azurerm_resource_group.test.name
+}
+`, PublicIpPrefixResource{}.customIpPrefix(data))
 }

--- a/website/docs/d/public_ip_prefix.html.markdown
+++ b/website/docs/d/public_ip_prefix.html.markdown
@@ -30,9 +30,10 @@ output "public_ip_prefix" {
 * `resource_group_name` - Specifies the name of the resource group.
 
 ## Attributes Reference
-
+* `custom_ip_prefix_id` - The Custom IP Prefix ID associated with the Public IP Prefix. Changing this forces a new resource to be created.
 * `id` - The ID of the Public IP Prefix.
 * `ip_prefix` - The Public IP address range, in CIDR notation.
+* `ip_version` - The IP Version to use, `IPv6` or `IPv4`. Changing this forces a new resource to be created. Default is `IPv4`.
 * `location` - The supported Azure location where the resource exists.
 * `sku` - The SKU of the Public IP Prefix.
 * `sku_tier` - The SKU Tier of the Public IP.

--- a/website/docs/d/public_ip_prefix.html.markdown
+++ b/website/docs/d/public_ip_prefix.html.markdown
@@ -34,7 +34,7 @@ output "public_ip_prefix" {
 * `custom_ip_prefix_id` - The Custom IP Prefix ID associated with the Public IP Prefix. 
 * `id` - The ID of the Public IP Prefix.
 * `ip_prefix` - The Public IP address range, in CIDR notation.
-* `ip_version` - The IP Version to use, `IPv6` or `IPv4`. Changing this forces a new resource to be created. Default is `IPv4`.
+* `ip_version` - The IP Version in use. 
 * `location` - The supported Azure location where the resource exists.
 * `sku` - The SKU of the Public IP Prefix.
 * `sku_tier` - The SKU Tier of the Public IP.

--- a/website/docs/d/public_ip_prefix.html.markdown
+++ b/website/docs/d/public_ip_prefix.html.markdown
@@ -31,7 +31,7 @@ output "public_ip_prefix" {
 
 ## Attributes Reference
 
-* `custom_ip_prefix_id` - The Custom IP Prefix ID associated with the Public IP Prefix. Changing this forces a new resource to be created.
+* `custom_ip_prefix_id` - The Custom IP Prefix ID associated with the Public IP Prefix. 
 * `id` - The ID of the Public IP Prefix.
 * `ip_prefix` - The Public IP address range, in CIDR notation.
 * `ip_version` - The IP Version to use, `IPv6` or `IPv4`. Changing this forces a new resource to be created. Default is `IPv4`.

--- a/website/docs/d/public_ip_prefix.html.markdown
+++ b/website/docs/d/public_ip_prefix.html.markdown
@@ -30,6 +30,7 @@ output "public_ip_prefix" {
 * `resource_group_name` - Specifies the name of the resource group.
 
 ## Attributes Reference
+
 * `custom_ip_prefix_id` - The Custom IP Prefix ID associated with the Public IP Prefix. Changing this forces a new resource to be created.
 * `id` - The ID of the Public IP Prefix.
 * `ip_prefix` - The Public IP address range, in CIDR notation.


### PR DESCRIPTION
data source "azurerm_public_ip_prefix" Added missing resource properties: "custom_ip_prefix_id", "ip_version"
--- PASS: TestAccDataSourcePublicIPPrefix_basic (84.22s)