### PR TITLE
Attributes added `data.public_ip` - add missing attributes to match resource

### DIFF
--- a/internal/services/network/public_ip_data_source.go
+++ b/internal/services/network/public_ip_data_source.go
@@ -58,7 +58,8 @@ func dataSourcePublicIP() *pluginsdk.Resource {
 			},
 
 			"sku_tier": {
-				Type: pluginsdk.TypeString,
+				Type:     pluginsdk.TypeString,
+				Computed: true,
 			},
 
 			"allocation_method": {

--- a/internal/services/network/public_ip_data_source.go
+++ b/internal/services/network/public_ip_data_source.go
@@ -40,9 +40,26 @@ func dataSourcePublicIP() *pluginsdk.Resource {
 
 			"location": commonschema.LocationComputed(),
 
+			"domain_name_label_scope": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
+			"edge_zone": commonschema.EdgeZoneComputed(),
+
+			"public_ip_prefix_id": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
 			"sku": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
+			},
+
+			"sku_tier": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
 			},
 
 			"allocation_method": {
@@ -125,10 +142,12 @@ func dataSourcePublicIPRead(d *pluginsdk.ResourceData, meta interface{}) error {
 
 	if model := resp.Model; model != nil {
 		d.Set("location", location.NormalizeNilable(model.Location))
+		d.Set("edge_zone", flattenEdgeZoneNew(model.ExtendedLocation))
 		d.Set("zones", zones.FlattenUntyped(model.Zones))
 		skuName := ""
 		if sku := model.Sku; sku != nil {
 			skuName = string(pointer.From(sku.Name))
+			d.Set("sku_tier", string(pointer.From(sku.Tier)))
 		}
 		d.Set("sku", skuName)
 
@@ -136,6 +155,7 @@ func dataSourcePublicIPRead(d *pluginsdk.ResourceData, meta interface{}) error {
 			domainNameLabel := ""
 			fqdn := ""
 			reverseFqdn := ""
+			domainNameLabelScope := ""
 			if dnsSettings := props.DnsSettings; dnsSettings != nil {
 				if dnsSettings.DomainNameLabel != nil {
 					domainNameLabel = *dnsSettings.DomainNameLabel
@@ -146,6 +166,7 @@ func dataSourcePublicIPRead(d *pluginsdk.ResourceData, meta interface{}) error {
 				if dnsSettings.ReverseFqdn != nil {
 					reverseFqdn = *dnsSettings.ReverseFqdn
 				}
+				domainNameLabelScope = pointer.FromEnum(dnsSettings.DomainNameLabelScope)
 			}
 
 			if ddosSetting := props.DdosSettings; ddosSetting != nil {
@@ -155,7 +176,12 @@ func dataSourcePublicIPRead(d *pluginsdk.ResourceData, meta interface{}) error {
 				}
 			}
 
+			if publicIpPrefix := props.PublicIPPrefix; publicIpPrefix != nil {
+				d.Set("public_ip_prefix_id", publicIpPrefix.Id)
+			}
+
 			d.Set("domain_name_label", domainNameLabel)
+			d.Set("domain_name_label_scope", domainNameLabelScope)
 			d.Set("fqdn", fqdn)
 			d.Set("reverse_fqdn", reverseFqdn)
 

--- a/internal/services/network/public_ip_data_source.go
+++ b/internal/services/network/public_ip_data_source.go
@@ -58,7 +58,7 @@ func dataSourcePublicIP() *pluginsdk.Resource {
 			},
 
 			"sku_tier": {
-				Type:     pluginsdk.TypeString,
+				Type: pluginsdk.TypeString,
 			},
 
 			"allocation_method": {

--- a/internal/services/network/public_ip_data_source.go
+++ b/internal/services/network/public_ip_data_source.go
@@ -59,7 +59,6 @@ func dataSourcePublicIP() *pluginsdk.Resource {
 
 			"sku_tier": {
 				Type:     pluginsdk.TypeString,
-				Optional: true,
 			},
 
 			"allocation_method": {

--- a/internal/services/network/public_ip_data_source_test.go
+++ b/internal/services/network/public_ip_data_source_test.go
@@ -34,6 +34,7 @@ func TestAccDataSourcePublicIP_static(t *testing.T) {
 				check.That(data.ResourceName).Key("tags.%").HasValue("1"),
 				check.That(data.ResourceName).Key("tags.environment").HasValue("test"),
 				check.That(data.ResourceName).Key("ip_tags.RoutingPreference").HasValue("Internet"),
+				check.That(data.ResourceName).Key("sku_tier").HasValue("Regional"),
 			),
 		},
 	})
@@ -130,4 +131,79 @@ data "azurerm_public_ip" "test" {
   resource_group_name = azurerm_resource_group.test.name
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, ipVersion)
+}
+
+func TestAccDataSourcePublicIP_prefixAndDomainNameScope(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_public_ip", "test")
+	r := PublicIPDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.prefixAndDomainNameScope(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("public_ip_prefix_id").IsSet(),
+				check.That(data.ResourceName).Key("domain_name_label_scope").HasValue("TenantReuse"),
+			),
+		},
+	})
+}
+
+func (PublicIPDataSource) prefixAndDomainNameScope(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_public_ip_prefix" "test" {
+  name                = "acctestpublicipprefix-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_public_ip" "test" {
+  name                    = "acctestpublicip-%[1]d"
+  location                = azurerm_resource_group.test.location
+  resource_group_name     = azurerm_resource_group.test.name
+  allocation_method       = "Static"
+  sku                     = "Standard"
+  public_ip_prefix_id     = azurerm_public_ip_prefix.test.id
+  domain_name_label       = "acctest-%[1]d"
+  domain_name_label_scope = "TenantReuse"
+}
+
+data "azurerm_public_ip" "test" {
+  name                = azurerm_public_ip.test.name
+  resource_group_name = azurerm_resource_group.test.name
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func TestAccDataSourcePublicIP_edgeZone(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_public_ip", "test")
+	r := PublicIPDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.edgeZone(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("edge_zone").IsSet(),
+			),
+		},
+	})
+}
+
+func (PublicIPDataSource) edgeZone(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_public_ip" "test" {
+  name                = azurerm_public_ip.test.name
+  resource_group_name = azurerm_resource_group.test.name
+}
+`, PublicIpResource{}.edgeZone(data))
 }

--- a/website/docs/d/public_ip.html.markdown
+++ b/website/docs/d/public_ip.html.markdown
@@ -113,7 +113,7 @@ output "public_ip_address" {
 * `ip_address` - The IP address value that was allocated.
 * `ip_version` - The IP version being used, for example `IPv4` or `IPv6`.
 * `location` - The region that this public ip exists.
-* `public_ip_prefix_id` - If specified then public IP address allocated will be provided from the public IP prefix resource. Changing this forces a new resource to be created.
+* `public_ip_prefix_id` - If specified then public IP address allocated will be provided from the public IP prefix resource. 
 * `reverse_fqdn` - The fully qualified domain name that resolves to this public IP address.
 * `sku` - The SKU of the Public IP.
 * `sku_tier` - The SKU Tier that should be used for the Public IP. Possible values are `Regional` and `Global`. Defaults to `Regional`. Changing this forces a new resource to be created.

--- a/website/docs/d/public_ip.html.markdown
+++ b/website/docs/d/public_ip.html.markdown
@@ -116,7 +116,7 @@ output "public_ip_address" {
 * `public_ip_prefix_id` - If specified then public IP address allocated will be provided from the public IP prefix resource. 
 * `reverse_fqdn` - The fully qualified domain name that resolves to this public IP address.
 * `sku` - The SKU of the Public IP.
-* `sku_tier` - The SKU Tier that should be used for the Public IP. Possible values are `Regional` and `Global`. Defaults to `Regional`. Changing this forces a new resource to be created.
+* `sku_tier` - The SKU Tier that is used for the Public IP. 
 * `ip_tags` - A mapping of tags to assigned to the resource.
 * `tags` - A mapping of tags to assigned to the resource.
 * `zones` - A list of Availability Zones in which this Public IP is located.

--- a/website/docs/d/public_ip.html.markdown
+++ b/website/docs/d/public_ip.html.markdown
@@ -105,7 +105,7 @@ output "public_ip_address" {
 * `allocation_method` - The allocation method for this IP address. Possible values are `Static` or `Dynamic`.
 * `domain_name_label` - The label for the Domain Name.
 * `domain_name_label_scope` - Scope for the domain name label.`.
-* `edge_zone` - Specifies the Edge Zone within the Azure Region where this Public IP should exist. Changing this forces a new Public IP to be created.
+* `edge_zone` - The Edge Zone within the Azure Region where this Public IP exists.
 * `idle_timeout_in_minutes` - Specifies the timeout for the TCP idle connection.
 * `ddos_protection_mode` - The DDoS protection mode of the public IP.
 * `ddos_protection_plan_id` - The ID of DDoS protection plan associated with the public IP. 

--- a/website/docs/d/public_ip.html.markdown
+++ b/website/docs/d/public_ip.html.markdown
@@ -104,7 +104,7 @@ output "public_ip_address" {
 * `id` - The ID of the Public IP address.
 * `allocation_method` - The allocation method for this IP address. Possible values are `Static` or `Dynamic`.
 * `domain_name_label` - The label for the Domain Name.
-* `domain_name_label_scope` - Scope for the domain name label. If a domain name label scope is specified, an A DNS record is created for the public IP in the Microsoft Azure DNS system with a hashed value includes in FQDN. Possible values are `NoReuse`, `ResourceGroupReuse`, `SubscriptionReuse` and `TenantReuse`.
+* `domain_name_label_scope` - Scope for the domain name label.`.
 * `edge_zone` - Specifies the Edge Zone within the Azure Region where this Public IP should exist. Changing this forces a new Public IP to be created.
 * `idle_timeout_in_minutes` - Specifies the timeout for the TCP idle connection.
 * `ddos_protection_mode` - The DDoS protection mode of the public IP.

--- a/website/docs/d/public_ip.html.markdown
+++ b/website/docs/d/public_ip.html.markdown
@@ -104,6 +104,8 @@ output "public_ip_address" {
 * `id` - The ID of the Public IP address.
 * `allocation_method` - The allocation method for this IP address. Possible values are `Static` or `Dynamic`.
 * `domain_name_label` - The label for the Domain Name.
+* `domain_name_label_scope` - Scope for the domain name label. If a domain name label scope is specified, an A DNS record is created for the public IP in the Microsoft Azure DNS system with a hashed value includes in FQDN. Possible values are `NoReuse`, `ResourceGroupReuse`, `SubscriptionReuse` and `TenantReuse`.
+* `edge_zone` - Specifies the Edge Zone within the Azure Region where this Public IP should exist. Changing this forces a new Public IP to be created.
 * `idle_timeout_in_minutes` - Specifies the timeout for the TCP idle connection.
 * `ddos_protection_mode` - The DDoS protection mode of the public IP.
 * `ddos_protection_plan_id` - The ID of DDoS protection plan associated with the public IP. 
@@ -111,8 +113,10 @@ output "public_ip_address" {
 * `ip_address` - The IP address value that was allocated.
 * `ip_version` - The IP version being used, for example `IPv4` or `IPv6`.
 * `location` - The region that this public ip exists.
+* `public_ip_prefix_id` - If specified then public IP address allocated will be provided from the public IP prefix resource. Changing this forces a new resource to be created.
 * `reverse_fqdn` - The fully qualified domain name that resolves to this public IP address.
 * `sku` - The SKU of the Public IP.
+* `sku_tier` - The SKU Tier that should be used for the Public IP. Possible values are `Regional` and `Global`. Defaults to `Regional`. Changing this forces a new resource to be created.
 * `ip_tags` - A mapping of tags to assigned to the resource.
 * `tags` - A mapping of tags to assigned to the resource.
 * `zones` - A list of Availability Zones in which this Public IP is located.

--- a/website/docs/d/public_ip.html.markdown
+++ b/website/docs/d/public_ip.html.markdown
@@ -104,7 +104,7 @@ output "public_ip_address" {
 * `id` - The ID of the Public IP address.
 * `allocation_method` - The allocation method for this IP address. Possible values are `Static` or `Dynamic`.
 * `domain_name_label` - The label for the Domain Name.
-* `domain_name_label_scope` - Scope for the domain name label.`.
+* `domain_name_label_scope` - Scope for the domain name label.
 * `edge_zone` - The Edge Zone within the Azure Region where this Public IP exists.
 * `idle_timeout_in_minutes` - Specifies the timeout for the TCP idle connection.
 * `ddos_protection_mode` - The DDoS protection mode of the public IP.


### PR DESCRIPTION
--- PASS: TestAccDataSourcePublicIPPrefix_basic (84.70s)
data source "azurerm_public_ip"  Added missing resource properties: "domain_name_label_scope", "edge_zone", "public_ip_prefix_id", "sku_tier"