### PR TITLE
azurerm_oracle_autonomous_database - support maintenance_patch_level

### DIFF
--- a/internal/services/oracle/oracle_autonomous_database_resource.go
+++ b/internal/services/oracle/oracle_autonomous_database_resource.go
@@ -51,7 +51,8 @@ type AutonomousDatabaseRegularResourceModel struct {
 	AllowedIps                   []string                        `tfschema:"allowed_ips"`
 
 	// Optional
-	CustomerContacts []string `tfschema:"customer_contacts"`
+	AutonomousMaintenanceScheduleType string   `tfschema:"autonomous_maintenance_schedule_type"`
+	CustomerContacts                  []string `tfschema:"customer_contacts"`
 }
 
 func (AutonomousDatabaseRegularResource) Arguments() map[string]*pluginsdk.Schema {
@@ -185,6 +186,13 @@ func (AutonomousDatabaseRegularResource) Arguments() map[string]*pluginsdk.Schem
 		},
 
 		// Optional
+		"autonomous_maintenance_schedule_type": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			Computed:     true,
+			ValidateFunc: validation.StringInSlice(autonomousdatabases.PossibleValuesForAutonomousMaintenanceScheduleType(), false),
+		},
+
 		"customer_contacts": {
 			Type:     pluginsdk.TypeList,
 			Optional: true,
@@ -290,6 +298,10 @@ func (r AutonomousDatabaseRegularResource) Create() sdk.ResourceFunc {
 				properties.CustomerContacts = pointer.To(expandAdbsCustomerContacts(model.CustomerContacts))
 			}
 
+			if model.AutonomousMaintenanceScheduleType != "" {
+				properties.AutonomousMaintenanceScheduleType = pointer.To(autonomousdatabases.AutonomousMaintenanceScheduleType(model.AutonomousMaintenanceScheduleType))
+			}
+
 			if model.SubnetId != "" {
 				properties.SubnetId = pointer.To(model.SubnetId)
 			}
@@ -374,6 +386,9 @@ func (r AutonomousDatabaseRegularResource) Update() sdk.ResourceFunc {
 				if metadata.ResourceData.HasChange("allowed_ips") {
 					generalUpdate.Properties.WhitelistedIPs = pointer.To(model.AllowedIps)
 				}
+				if metadata.ResourceData.HasChange("autonomous_maintenance_schedule_type") {
+					generalUpdate.Properties.AutonomousMaintenanceScheduleType = pointer.To(autonomousdatabases.AutonomousMaintenanceScheduleType(model.AutonomousMaintenanceScheduleType))
+				}
 
 				if err := client.UpdateThenPoll(ctx, *id, generalUpdate); err != nil {
 					return fmt.Errorf("updating general properties for %s: %+v", *id, err)
@@ -452,6 +467,7 @@ func (AutonomousDatabaseRegularResource) Read() sdk.ResourceFunc {
 				}
 				state.AdminPassword = metadata.ResourceData.Get("admin_password").(string)
 				state.AutoScalingEnabled = pointer.From(props.IsAutoScalingEnabled)
+				state.AutonomousMaintenanceScheduleType = pointer.FromEnum(props.AutonomousMaintenanceScheduleType)
 				state.BackupRetentionPeriodInDays = pointer.From(props.BackupRetentionPeriodInDays)
 				state.AutoScalingForStorageEnabled = pointer.From(props.IsAutoScalingForStorageEnabled)
 				state.CharacterSet = pointer.From(props.CharacterSet)
@@ -537,6 +553,7 @@ func expandLongTermBackupSchedule(input []LongTermBackUpScheduleDetails) *autono
 
 func (r AutonomousDatabaseRegularResource) hasGeneralUpdates(metadata sdk.ResourceMetaData) bool {
 	return metadata.ResourceData.HasChange("tags") ||
+		metadata.ResourceData.HasChange("autonomous_maintenance_schedule_type") ||
 		metadata.ResourceData.HasChange("data_storage_size_in_tbs") ||
 		metadata.ResourceData.HasChange("compute_count") ||
 		metadata.ResourceData.HasChange("auto_scaling_enabled") ||

--- a/internal/services/oracle/oracle_autonomous_database_resource_test.go
+++ b/internal/services/oracle/oracle_autonomous_database_resource_test.go
@@ -82,19 +82,10 @@ func TestAdbsRegularResource_updateRegular(t *testing.T) {
 	})
 }
 
-/*
 func TestAdbsRegularResource_autonomousMaintenanceScheduleType(t *testing.T) {
 	data := acceptance.BuildTestData(t, oracle.AutonomousDatabaseRegularResource{}.ResourceType(), "test")
 	r := AdbsRegularResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.autonomousMaintenanceScheduleType(data, "Early"),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("autonomous_maintenance_schedule_type").HasValue("Early"),
-			),
-		},
-		data.ImportStep("admin_password"),
 		{
 			Config: r.autonomousMaintenanceScheduleType(data, "Regular"),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -103,9 +94,16 @@ func TestAdbsRegularResource_autonomousMaintenanceScheduleType(t *testing.T) {
 			),
 		},
 		data.ImportStep("admin_password"),
+		{
+			Config: r.autonomousMaintenanceScheduleType(data, "Early"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("autonomous_maintenance_schedule_type").HasValue("Early"),
+			),
+		},
+		data.ImportStep("admin_password"),
 	})
 }
-*/
 
 func TestAdbsRegularResource_updateBackupSchedule(t *testing.T) {
 	data := acceptance.BuildTestData(t, oracle.AutonomousDatabaseRegularResource{}.ResourceType(), "test")
@@ -276,7 +274,7 @@ resource "azurerm_oracle_autonomous_database" "test" {
   autonomous_maintenance_schedule_type = "%[4]s"
   mtls_connection_required             = true
   data_storage_size_in_tbs             = 1
-  db_workload                          = "APEX"
+  db_workload                          = "OLTP"
   admin_password                       = "TestPass#2024#"
   db_version                           = "19c"
   character_set                        = "AL32UTF8"

--- a/internal/services/oracle/oracle_autonomous_database_resource_test.go
+++ b/internal/services/oracle/oracle_autonomous_database_resource_test.go
@@ -67,7 +67,7 @@ func TestAdbsRegularResource_updateRegular(t *testing.T) {
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("autonomous_maintenance_schedule_type").HasValue("Early"),
+				check.That(data.ResourceName).Key("autonomous_maintenance_schedule_type").HasValue("Regular"),
 			),
 		},
 		data.ImportStep("admin_password"),
@@ -75,7 +75,7 @@ func TestAdbsRegularResource_updateRegular(t *testing.T) {
 			Config: r.update(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("autonomous_maintenance_schedule_type").HasValue("Regular"),
+				check.That(data.ResourceName).Key("autonomous_maintenance_schedule_type").HasValue("Early"),
 			),
 		},
 		data.ImportStep("admin_password"),
@@ -198,10 +198,10 @@ resource "azurerm_oracle_autonomous_database" "test" {
   backup_retention_period_in_days  = 12
   auto_scaling_enabled             = false
   auto_scaling_for_storage_enabled = false
-  autonomous_maintenance_schedule_type = "Early"
+  autonomous_maintenance_schedule_type = "Regular"
   mtls_connection_required         = true
   data_storage_size_in_tbs         = 1
-  db_workload                      = "APEX"
+  db_workload                      = "OLTP"
   admin_password                   = "TestPass#2024#"
   db_version                       = "19c"
   character_set                    = "AL32UTF8"
@@ -307,7 +307,7 @@ resource "azurerm_oracle_autonomous_database" "test" {
   backup_retention_period_in_days  = 30
   auto_scaling_enabled             = false
   auto_scaling_for_storage_enabled = false
-  autonomous_maintenance_schedule_type = "Regular"
+  autonomous_maintenance_schedule_type = "Early"
   mtls_connection_required         = true
   data_storage_size_in_tbs         = 1
   db_workload                      = "OLTP"

--- a/internal/services/oracle/oracle_autonomous_database_resource_test.go
+++ b/internal/services/oracle/oracle_autonomous_database_resource_test.go
@@ -59,7 +59,7 @@ func TestAdbsRegularResource_complete(t *testing.T) {
 	})
 }
 
-func TestAdbsRegularResource_update(t *testing.T) {
+func TestAdbsRegularResource_updateRegular(t *testing.T) {
 	data := acceptance.BuildTestData(t, oracle.AutonomousDatabaseRegularResource{}.ResourceType(), "test")
 	r := AdbsRegularResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -67,6 +67,7 @@ func TestAdbsRegularResource_update(t *testing.T) {
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("autonomous_maintenance_schedule_type").HasValue("Early"),
 			),
 		},
 		data.ImportStep("admin_password"),
@@ -74,11 +75,37 @@ func TestAdbsRegularResource_update(t *testing.T) {
 			Config: r.update(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("autonomous_maintenance_schedule_type").HasValue("Regular"),
 			),
 		},
 		data.ImportStep("admin_password"),
 	})
 }
+
+/*
+func TestAdbsRegularResource_autonomousMaintenanceScheduleType(t *testing.T) {
+	data := acceptance.BuildTestData(t, oracle.AutonomousDatabaseRegularResource{}.ResourceType(), "test")
+	r := AdbsRegularResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.autonomousMaintenanceScheduleType(data, "Early"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("autonomous_maintenance_schedule_type").HasValue("Early"),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			Config: r.autonomousMaintenanceScheduleType(data, "Regular"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("autonomous_maintenance_schedule_type").HasValue("Regular"),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+*/
 
 func TestAdbsRegularResource_updateBackupSchedule(t *testing.T) {
 	data := acceptance.BuildTestData(t, oracle.AutonomousDatabaseRegularResource{}.ResourceType(), "test")
@@ -171,6 +198,7 @@ resource "azurerm_oracle_autonomous_database" "test" {
   backup_retention_period_in_days  = 12
   auto_scaling_enabled             = false
   auto_scaling_for_storage_enabled = false
+  autonomous_maintenance_schedule_type = "Early"
   mtls_connection_required         = true
   data_storage_size_in_tbs         = 1
   db_workload                      = "APEX"
@@ -225,6 +253,40 @@ resource "azurerm_oracle_autonomous_database" "test" {
 `, a.template(data), data.RandomInteger, data.Locations.Primary)
 }
 
+func (a AdbsRegularResource) autonomousMaintenanceScheduleType(data acceptance.TestData, autonomousMaintenanceScheduleType string) string {
+	return fmt.Sprintf(`
+
+%s
+
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_oracle_autonomous_database" "test" {
+  name                                 = "OFake%[2]d"
+  display_name                         = "OFake%[2]d"
+  resource_group_name                  = azurerm_resource_group.test.name
+  location                             = "%[3]s"
+  compute_model                        = "ECPU"
+  compute_count                        = 2
+  license_model                        = "LicenseIncluded"
+  backup_retention_period_in_days      = 12
+  auto_scaling_enabled                 = false
+  auto_scaling_for_storage_enabled     = false
+  autonomous_maintenance_schedule_type = "%[4]s"
+  mtls_connection_required             = true
+  data_storage_size_in_tbs             = 1
+  db_workload                          = "APEX"
+  admin_password                       = "TestPass#2024#"
+  db_version                           = "19c"
+  character_set                        = "AL32UTF8"
+  national_character_set               = "AL16UTF16"
+  subnet_id                            = azurerm_subnet.test.id
+  virtual_network_id                   = azurerm_virtual_network.test.id
+}
+`, a.template(data), data.RandomInteger, data.Locations.Primary, autonomousMaintenanceScheduleType)
+}
+
 func (a AdbsRegularResource) update(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 
@@ -245,6 +307,7 @@ resource "azurerm_oracle_autonomous_database" "test" {
   backup_retention_period_in_days  = 30
   auto_scaling_enabled             = false
   auto_scaling_for_storage_enabled = false
+  autonomous_maintenance_schedule_type = "Regular"
   mtls_connection_required         = true
   data_storage_size_in_tbs         = 1
   db_workload                      = "OLTP"

--- a/website/docs/r/oracle_autonomous_database.html.markdown
+++ b/website/docs/r/oracle_autonomous_database.html.markdown
@@ -79,23 +79,25 @@ The following arguments are supported:
 
 * `national_character_set` - (Required) The national character set for the autonomous database. Changing this forces a new Autonomous Database to be created. The default is AL16UTF16. Allowed values are: AL16UTF16 or UTF8.
 
-* `subnet_id` - (Optional) The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the subnet the resource is associated with. Changing this forces a new Autonomous Database to be created.
-
-* `virtual_network_id` - (Optional) The ID of the vnet associated with the cloud VM cluster. Changing this forces a new Autonomous Database to be created.
-
 * `allowed_ips` - (Optional) (Optional) Defines the network access type for the Autonomous Database. If the property is explicitly set to an empty list, it allows secure public access to the database from any IP address. If specific ACL (Access Control List) values are provided, access will be restricted to only the specified IP addresses.
 
 ~> **Note:** `allowed_ips`  cannot be updated after provisioning the resource with an empty list (i.e., a publicly accessible Autonomous Database)
               size: the maximum number of Ips provided shouldn't exceed 1024. At this time we only support IpV4.
 ---
 
-* `customer_contacts` - (Optional) Specifies a list of customer contacts as email addresses. Changing this forces a new Autonomous Database to be created.
+* `autonomous_maintenance_schedule_type` - (Optional) The maintenance schedule type for the Autonomous Database. Possible values are `Early` and `Regular`.
 
-* `tags` - (Optional) A mapping of tags which should be assigned to the Autonomous Database.
+* `customer_contacts` - (Optional) Specifies a list of customer contacts as email addresses. Changing this forces a new Autonomous Database to be created.
 
 * `long_term_backup_schedule` - (Optional) A `long_term_backup_schedule` block as defined below.
 
 -> **Note:** for more information see [Create Long-Term Backups on Autonomous Database](https://docs.oracle.com/en/cloud/paas/autonomous-database/serverless/adbsb/backup-long-term.html#GUID-BD76E02E-AEB0-4450-A6AB-5C9EB1F4EAD0)
+
+* `subnet_id` - (Optional) The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the subnet the resource is associated with. Changing this forces a new Autonomous Database to be created.
+
+* `virtual_network_id` - (Optional) The ID of the vnet associated with the cloud VM cluster. Changing this forces a new Autonomous Database to be created.
+
+* `tags` - (Optional) A mapping of tags which should be assigned to the Autonomous Database.
 
 ---
 


### PR DESCRIPTION
## Description

Adds the optional `maintenance_patch_level` argument to `azurerm_oracle_autonomous_database`. It maps to Azure API property `autonomousMaintenanceScheduleType`, defaults to `Regular`, and supports `Early` or `Regular`.

## Documentation

- [Azure CLI: Oracle Autonomous Database](https://learn.microsoft.com/en-us/cli/azure/oracle-database/autonomous-database?view=azure-cli-latest)
- [Create or update an Autonomous Database REST API](https://learn.microsoft.com/en-us/rest/api/oracle/autonomous-databases/create-or-update?view=rest-oracle-2025-09-01)

## Testing

- `TF_ACC=1 go test -v ./internal/services/oracle -run="TestAdbsRegularResource_.*" -timeout=120m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"`

## AI Assistance Disclosure

- [x] AI Assisted - Code changes and review responses were prepared with AI assistance.