### PR TITLE
`azurerm_(linux|windows)_virtual_machine_scale_set` - support in place association of `capacity_reservation_group_id` for uniform, zonal vmss

### DIFF
--- a/internal/services/compute/linux_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_resource.go
@@ -788,10 +788,14 @@ func resourceLinuxVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData, meta i
 			}
 			// capacityReservation is not exposed on the PATCH update model, so it can only be set via PUT, which preserves the write-only values omitted from the GET model
 			existing.Model.Properties.VirtualMachineProfile.CapacityReservation = capacityReservation
+
+			// singlePlacementGroup must be false before the API will accept a capacity reservation, and this
+			// PUT runs ahead of the PATCH in performUpdate that would otherwise carry the change
+			existing.Model.Properties.SinglePlacementGroup = pointer.To(d.Get("single_placement_group").(bool))
 		}
 
 		if err := client.CreateOrUpdateThenPoll(ctx, *id, *existing.Model, virtualmachinescalesets.DefaultCreateOrUpdateOperationOptions()); err != nil {
-			return fmt.Errorf("identity / capacity reservation group for Linux %s: %+v", id, err)
+			return fmt.Errorf("updating identity / capacity reservation group for Linux %s: %+v", id, err)
 		}
 	}
 

--- a/internal/services/compute/linux_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_resource.go
@@ -102,6 +102,18 @@ func resourceLinuxVirtualMachineScaleSet() *pluginsdk.Resource {
 
 				return nil
 			}),
+
+			// Azure only allows associating (not changing/removing) a capacity reservation group in-place for zonal scale sets.
+			pluginsdk.ForceNewIf("capacity_reservation_group_id", func(ctx context.Context, d *pluginsdk.ResourceDiff, _ interface{}) bool {
+				if _, ok := d.GetOk("zones"); ok {
+					oldRaw, _ := d.GetChange("capacity_reservation_group_id")
+					oldCRG := oldRaw.(string)
+					if oldCRG == "" {
+						return false
+					}
+				}
+				return true
+			}),
 		),
 	}
 }
@@ -753,20 +765,33 @@ func resourceLinuxVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData, meta i
 		updateProps.AutomaticRepairsPolicy = automaticRepairsPolicy
 	}
 
-	if d.HasChange("identity") {
-		identityExpanded, err := identity.ExpandSystemAndUserAssignedMap(d.Get("identity").([]interface{}))
-		if err != nil {
-			return fmt.Errorf("expanding `identity`: %+v", err)
+	if d.HasChange("identity") || d.HasChange("capacity_reservation_group_id") {
+		if d.HasChange("identity") {
+			identityExpanded, err := identity.ExpandSystemAndUserAssignedMap(d.Get("identity").([]interface{}))
+			if err != nil {
+				return fmt.Errorf("expanding `identity`: %+v", err)
+			}
+
+			existing.Model.Identity = identityExpanded
+			// Removing a user-assigned identity using PATCH requires setting it to `null` in the payload which
+			// 1. The go-azure-sdk for resource manager doesn't support at the moment
+			// 2. The expand identity function doesn't behave this way
+			// For the moment updating the identity with the PUT circumvents this API behaviour
+			// See https://github.com/hashicorp/terraform-provider-azurerm/issues/25058 for more details
 		}
 
-		existing.Model.Identity = identityExpanded
-		// Removing a user-assigned identity using PATCH requires setting it to `null` in the payload which
-		// 1. The go-azure-sdk for resource manager doesn't support at the moment
-		// 2. The expand identity function doesn't behave this way
-		// For the moment updating the identity with the PUT circumvents this API behaviour
-		// See https://github.com/hashicorp/terraform-provider-azurerm/issues/25058 for more details
+		if d.HasChange("capacity_reservation_group_id") {
+			capacityReservation := &virtualmachinescalesets.CapacityReservationProfile{
+				CapacityReservationGroup: &virtualmachinescalesets.SubResource{},
+			}
+			if v, ok := d.GetOk("capacity_reservation_group_id"); ok {
+				capacityReservation.CapacityReservationGroup.Id = pointer.To(v.(string))
+			}
+			existing.Model.Properties.VirtualMachineProfile.CapacityReservation = capacityReservation
+		}
+
 		if err := client.CreateOrUpdateThenPoll(ctx, *id, *existing.Model, virtualmachinescalesets.DefaultCreateOrUpdateOperationOptions()); err != nil {
-			return fmt.Errorf("updating identity for Linux %s: %+v", id, err)
+			return fmt.Errorf("updating Linux %s: %+v", id, err)
 		}
 	}
 
@@ -1203,7 +1228,6 @@ func resourceLinuxVirtualMachineScaleSetSchema() map[string]*pluginsdk.Schema {
 		"capacity_reservation_group_id": {
 			Type:         pluginsdk.TypeString,
 			Optional:     true,
-			ForceNew:     true,
 			ValidateFunc: capacityreservationgroups.ValidateCapacityReservationGroupID,
 			ConflictsWith: []string{
 				"proximity_placement_group_id",

--- a/internal/services/compute/linux_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_resource.go
@@ -111,9 +111,9 @@ func resourceLinuxVirtualMachineScaleSet() *pluginsdk.Resource {
 			}),
 
 			pluginsdk.ForceNewIf("capacity_reservation_group_id", func(ctx context.Context, d *pluginsdk.ResourceDiff, _ interface{}) bool {
-				oldZones, _ := d.GetChange("zones")
 				oldCRG, _ := d.GetChange("capacity_reservation_group_id")
-				// in-place association is only supported when adding a CRG to an already-zonal scale set
+				oldZones, _ := d.GetChange("zones")
+				// In-place association is only supported when adding a CRG to an already-zonal scale set. Updating or de-associating still requires a force new (actually requires deallocation).
 				return oldZones.(*schema.Set).Len() == 0 || oldCRG.(string) != ""
 			}),
 		),
@@ -705,6 +705,23 @@ func resourceLinuxVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData, meta i
 		updateProps.VirtualMachineProfile.DiagnosticsProfile = expandBootDiagnosticsVMSS(bootDiagnosticsRaw)
 	}
 
+	if d.HasChange("capacity_reservation_group_id") {
+		// capacityReservation is not exposed on the PATCH update model, so it can only be set via PUT,
+		// which preserves the write-only values omitted from the GET model
+		existing.Model.Properties.VirtualMachineProfile.CapacityReservation = &virtualmachinescalesets.CapacityReservationProfile{
+			CapacityReservationGroup: &virtualmachinescalesets.SubResource{
+				Id: pointer.To(d.Get("capacity_reservation_group_id").(string)),
+			},
+		}
+
+		// The API rejects a CRG unless singlePlacementGroup is false. Existing still holds the stale value
+		// when both change together. So applied the new value here.
+		existing.Model.Properties.SinglePlacementGroup = pointer.To(d.Get("single_placement_group").(bool))
+		if err := client.CreateOrUpdateThenPoll(ctx, *id, *existing.Model, virtualmachinescalesets.DefaultCreateOrUpdateOperationOptions()); err != nil {
+			return fmt.Errorf("updating capacity reservation group for Linux %s: %+v", id, err)
+		}
+	}
+
 	if d.HasChange("do_not_run_extensions_on_overprovisioned_machines") {
 		v := d.Get("do_not_run_extensions_on_overprovisioned_machines").(bool)
 		updateProps.DoNotRunExtensionsOnOverprovisionedVMs = pointer.To(v)
@@ -764,38 +781,20 @@ func resourceLinuxVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData, meta i
 		updateProps.AutomaticRepairsPolicy = automaticRepairsPolicy
 	}
 
-	if d.HasChange("identity") || d.HasChange("capacity_reservation_group_id") {
-		if d.HasChange("identity") {
-			identityExpanded, err := identity.ExpandSystemAndUserAssignedMap(d.Get("identity").([]interface{}))
-			if err != nil {
-				return fmt.Errorf("expanding `identity`: %+v", err)
-			}
-
-			existing.Model.Identity = identityExpanded
-			// Removing a user-assigned identity using PATCH requires setting it to `null` in the payload which
-			// 1. The go-azure-sdk for resource manager doesn't support at the moment
-			// 2. The expand identity function doesn't behave this way
-			// For the moment updating the identity with the PUT circumvents this API behaviour
-			// See https://github.com/hashicorp/terraform-provider-azurerm/issues/25058 for more details
+	if d.HasChange("identity") {
+		identityExpanded, err := identity.ExpandSystemAndUserAssignedMap(d.Get("identity").([]interface{}))
+		if err != nil {
+			return fmt.Errorf("expanding `identity`: %+v", err)
 		}
 
-		if d.HasChange("capacity_reservation_group_id") {
-			capacityReservation := &virtualmachinescalesets.CapacityReservationProfile{
-				CapacityReservationGroup: &virtualmachinescalesets.SubResource{},
-			}
-			if v, ok := d.GetOk("capacity_reservation_group_id"); ok {
-				capacityReservation.CapacityReservationGroup.Id = pointer.To(v.(string))
-			}
-			// capacityReservation is not exposed on the PATCH update model, so it can only be set via PUT, which preserves the write-only values omitted from the GET model
-			existing.Model.Properties.VirtualMachineProfile.CapacityReservation = capacityReservation
-
-			// singlePlacementGroup must be false before the API will accept a capacity reservation, and this
-			// PUT runs ahead of the PATCH in performUpdate that would otherwise carry the change
-			existing.Model.Properties.SinglePlacementGroup = pointer.To(d.Get("single_placement_group").(bool))
-		}
-
+		existing.Model.Identity = identityExpanded
+		// Removing a user-assigned identity using PATCH requires setting it to `null` in the payload which
+		// 1. The go-azure-sdk for resource manager doesn't support at the moment
+		// 2. The expand identity function doesn't behave this way
+		// For the moment updating the identity with the PUT circumvents this API behaviour
+		// See https://github.com/hashicorp/terraform-provider-azurerm/issues/25058 for more details
 		if err := client.CreateOrUpdateThenPoll(ctx, *id, *existing.Model, virtualmachinescalesets.DefaultCreateOrUpdateOperationOptions()); err != nil {
-			return fmt.Errorf("updating identity / capacity reservation group for Linux %s: %+v", id, err)
+			return fmt.Errorf("updating identity for Linux %s: %+v", id, err)
 		}
 	}
 

--- a/internal/services/compute/linux_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_resource.go
@@ -5,6 +5,7 @@ package compute
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"time"
@@ -100,19 +101,20 @@ func resourceLinuxVirtualMachineScaleSet() *pluginsdk.Resource {
 					}
 				}
 
+				if diff.Get("capacity_reservation_group_id").(string) != "" {
+					if diff.Get("single_placement_group").(bool) {
+						return errors.New("`single_placement_group` must be set to `false` when `capacity_reservation_group_id` is specified")
+					}
+				}
+
 				return nil
 			}),
 
-			// Azure only allows associating (not changing/removing) a capacity reservation group in-place for zonal scale sets.
 			pluginsdk.ForceNewIf("capacity_reservation_group_id", func(ctx context.Context, d *pluginsdk.ResourceDiff, _ interface{}) bool {
-				if _, ok := d.GetOk("zones"); ok {
-					oldRaw, _ := d.GetChange("capacity_reservation_group_id")
-					oldCRG := oldRaw.(string)
-					if oldCRG == "" {
-						return false
-					}
-				}
-				return true
+				oldZones, _ := d.GetChange("zones")
+				oldCRG, _ := d.GetChange("capacity_reservation_group_id")
+				// in-place association is only supported when adding a CRG to an already-zonal scale set
+				return oldZones.(*schema.Set).Len() == 0 || oldCRG.(string) != ""
 			}),
 		),
 	}
@@ -271,9 +273,6 @@ func resourceLinuxVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData, meta i
 	}
 
 	if v, ok := d.GetOk("capacity_reservation_group_id"); ok {
-		if d.Get("single_placement_group").(bool) {
-			return fmt.Errorf("`single_placement_group` must be set to `false` when `capacity_reservation_group_id` is specified")
-		}
 		virtualMachineProfile.CapacityReservation = &virtualmachinescalesets.CapacityReservationProfile{
 			CapacityReservationGroup: &virtualmachinescalesets.SubResource{
 				Id: pointer.To(v.(string)),
@@ -787,11 +786,12 @@ func resourceLinuxVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData, meta i
 			if v, ok := d.GetOk("capacity_reservation_group_id"); ok {
 				capacityReservation.CapacityReservationGroup.Id = pointer.To(v.(string))
 			}
+			// capacityReservation is not exposed on the PATCH update model, so it can only be set via PUT, which preserves the write-only values omitted from the GET model
 			existing.Model.Properties.VirtualMachineProfile.CapacityReservation = capacityReservation
 		}
 
 		if err := client.CreateOrUpdateThenPoll(ctx, *id, *existing.Model, virtualmachinescalesets.DefaultCreateOrUpdateOperationOptions()); err != nil {
-			return fmt.Errorf("updating Linux %s: %+v", id, err)
+			return fmt.Errorf("identity / capacity reservation group for Linux %s: %+v", id, err)
 		}
 	}
 

--- a/internal/services/compute/linux_virtual_machine_scale_set_resource_scaling_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_resource_scaling_test.go
@@ -32,14 +32,44 @@ func TestAccLinuxVirtualMachineScaleSet_scalingCapacityReservationGroupId(t *tes
 	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine_scale_set", "test")
 	r := LinuxVirtualMachineScaleSetResource{}
 
-	data.ResourceTest(t, r, []acceptance.TestStep{
+	data.ResourceTestIgnoreRecreate(t, r, []acceptance.TestStep{
 		{
-			Config: r.scalingCapacityReservationGroupId(data),
+			Config: r.scalingCapacityReservationGroupId(data, ""),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep("admin_password"),
+		{
+			Config: r.scalingCapacityReservationGroupId(data, "azurerm_capacity_reservation_group.test.id"),
+			ConfigPlanChecks: resource.ConfigPlanChecks{
+				PreApply: []plancheck.PlanCheck{
+					plancheck.ExpectResourceAction(data.ResourceName, plancheck.ResourceActionReplace),
+				},
+			},
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			Config:   r.scalingCapacityReservationGroupId(data, "azurerm_capacity_reservation_group.test2.id"),
+			PlanOnly: true,
+			ConfigPlanChecks: resource.ConfigPlanChecks{
+				PreApply: []plancheck.PlanCheck{
+					plancheck.ExpectResourceAction(data.ResourceName, plancheck.ResourceActionReplace),
+				},
+			},
+		},
+		{
+			Config:   r.scalingCapacityReservationGroupId(data, ""),
+			PlanOnly: true,
+			ConfigPlanChecks: resource.ConfigPlanChecks{
+				PreApply: []plancheck.PlanCheck{
+					plancheck.ExpectResourceAction(data.ResourceName, plancheck.ResourceActionReplace),
+				},
+			},
+		},
 	})
 }
 
@@ -47,7 +77,7 @@ func TestAccLinuxVirtualMachineScaleSet_scalingCapacityReservationGroupIdZonal(t
 	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine_scale_set", "test")
 	r := LinuxVirtualMachineScaleSetResource{}
 
-	data.ResourceTest(t, r, []acceptance.TestStep{
+	data.ResourceTestIgnoreRecreate(t, r, []acceptance.TestStep{
 		{
 			Config: r.scalingCapacityReservationGroupIdZonal(data, ""),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -67,6 +97,24 @@ func TestAccLinuxVirtualMachineScaleSet_scalingCapacityReservationGroupIdZonal(t
 			),
 		},
 		data.ImportStep("admin_password"),
+		{
+			Config:   r.scalingCapacityReservationGroupIdZonal(data, "azurerm_capacity_reservation_group.test2.id"),
+			PlanOnly: true,
+			ConfigPlanChecks: resource.ConfigPlanChecks{
+				PreApply: []plancheck.PlanCheck{
+					plancheck.ExpectResourceAction(data.ResourceName, plancheck.ResourceActionReplace),
+				},
+			},
+		},
+		{
+			Config:   r.scalingCapacityReservationGroupIdZonal(data, ""),
+			PlanOnly: true,
+			ConfigPlanChecks: resource.ConfigPlanChecks{
+				PreApply: []plancheck.PlanCheck{
+					plancheck.ExpectResourceAction(data.ResourceName, plancheck.ResourceActionReplace),
+				},
+			},
+		},
 	})
 }
 
@@ -415,7 +463,12 @@ resource "azurerm_monitor_autoscale_setting" "test" {
 `, r.template(data), data.RandomInteger)
 }
 
-func (r LinuxVirtualMachineScaleSetResource) scalingCapacityReservationGroupId(data acceptance.TestData) string {
+func (r LinuxVirtualMachineScaleSetResource) scalingCapacityReservationGroupId(data acceptance.TestData, crgId string) string {
+	crgText := ""
+	if crgId != "" {
+		crgText = fmt.Sprintf("capacity_reservation_group_id = %s", crgId)
+	}
+
 	return fmt.Sprintf(`
 %[1]s
 
@@ -434,20 +487,34 @@ resource "azurerm_capacity_reservation" "test" {
   }
 }
 
-resource "azurerm_linux_virtual_machine_scale_set" "test" {
-  name                = "acctestvmss-%[2]d"
+resource "azurerm_capacity_reservation_group" "test2" {
+  name                = "acctest-ccrg2-%[2]d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  sku                 = "Standard_F2"
-  instances           = 1
-  admin_username      = "adminuser"
-  admin_password      = "P@ssword1234!"
+}
 
+resource "azurerm_capacity_reservation" "test2" {
+  name                          = "acctest-ccr2-%[2]d"
+  capacity_reservation_group_id = azurerm_capacity_reservation_group.test2.id
+  sku {
+    name     = "Standard_F2"
+    capacity = 1
+  }
+}
+
+resource "azurerm_linux_virtual_machine_scale_set" "test" {
+  name                            = "acctestvmss-%[2]d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  sku                             = "Standard_F2"
+  instances                       = 1
+  admin_username                  = "adminuser"
+  admin_password                  = "P@ssword1234!"
   disable_password_authentication = false
+  single_placement_group          = false
+  platform_fault_domain_count     = 3
 
-  single_placement_group        = false
-  platform_fault_domain_count   = 3
-  capacity_reservation_group_id = azurerm_capacity_reservation_group.test.id
+  %[3]s
 
   source_image_reference {
     publisher = "Canonical"
@@ -474,15 +541,16 @@ resource "azurerm_linux_virtual_machine_scale_set" "test" {
 
   depends_on = [
     azurerm_capacity_reservation.test,
+    azurerm_capacity_reservation.test2,
   ]
 }
-`, r.template(data), data.RandomInteger)
+`, r.template(data), data.RandomInteger, crgText)
 }
 
 func (r LinuxVirtualMachineScaleSetResource) scalingCapacityReservationGroupIdZonal(data acceptance.TestData, crg string) string {
 	crgText := ""
 	if crg != "" {
-		crgText = fmt.Sprintf("capacity_reservation_group_id = %s", crg)
+		crgText = fmt.Sprintf("capacity_reservation_group_id = %s\n  single_placement_group = false", crg)
 	}
 	return fmt.Sprintf(`
 %[1]s
@@ -504,6 +572,23 @@ resource "azurerm_capacity_reservation" "test" {
   zone = "3"
 }
 
+resource "azurerm_capacity_reservation_group" "test2" {
+  name                = "acctest-ccrg2-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  zones               = ["3"]
+}
+
+resource "azurerm_capacity_reservation" "test2" {
+  name                          = "acctest-ccr2-%[2]d"
+  capacity_reservation_group_id = azurerm_capacity_reservation_group.test2.id
+  sku {
+    name     = "Standard_D2s_v3"
+    capacity = 1
+  }
+  zone = "3"
+}
+
 resource "azurerm_linux_virtual_machine_scale_set" "test" {
   name                            = "acctestvmss-%[2]d"
   resource_group_name             = azurerm_resource_group.test.name
@@ -514,10 +599,10 @@ resource "azurerm_linux_virtual_machine_scale_set" "test" {
   admin_password                  = "P@ssword1234!"
   zones                           = ["3"]
   disable_password_authentication = false
+  platform_fault_domain_count     = 1
 
-  single_placement_group      = false
-  platform_fault_domain_count = 1
-%[3]s
+  %[3]s
+
   source_image_reference {
     publisher = "Canonical"
     offer     = "0001-com-ubuntu-server-jammy"
@@ -543,6 +628,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "test" {
 
   depends_on = [
     azurerm_capacity_reservation.test,
+    azurerm_capacity_reservation.test2,
   ]
 }
 `, r.template(data), data.RandomInteger, crgText)

--- a/internal/services/compute/linux_virtual_machine_scale_set_resource_scaling_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_resource_scaling_test.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 )
@@ -55,6 +57,11 @@ func TestAccLinuxVirtualMachineScaleSet_scalingCapacityReservationGroupIdZonal(t
 		data.ImportStep("admin_password"),
 		{
 			Config: r.scalingCapacityReservationGroupIdZonal(data, "azurerm_capacity_reservation_group.test.id"),
+			ConfigPlanChecks: resource.ConfigPlanChecks{
+				PreApply: []plancheck.PlanCheck{
+					plancheck.ExpectResourceAction(data.ResourceName, plancheck.ResourceActionUpdate),
+				},
+			},
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),

--- a/internal/services/compute/linux_virtual_machine_scale_set_resource_scaling_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_resource_scaling_test.go
@@ -35,6 +35,11 @@ func TestAccLinuxVirtualMachineScaleSet_scalingCapacityReservationGroupId(t *tes
 	data.ResourceTestIgnoreRecreate(t, r, []acceptance.TestStep{
 		{
 			Config: r.scalingCapacityReservationGroupId(data, ""),
+			ConfigPlanChecks: resource.ConfigPlanChecks{
+				PreApply: []plancheck.PlanCheck{
+					plancheck.ExpectResourceAction(data.ResourceName, plancheck.ResourceActionCreate),
+				},
+			},
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -53,8 +58,7 @@ func TestAccLinuxVirtualMachineScaleSet_scalingCapacityReservationGroupId(t *tes
 		},
 		data.ImportStep("admin_password"),
 		{
-			Config:   r.scalingCapacityReservationGroupId(data, "azurerm_capacity_reservation_group.test2.id"),
-			PlanOnly: true,
+			Config: r.scalingCapacityReservationGroupId(data, "azurerm_capacity_reservation_group.test2.id"),
 			ConfigPlanChecks: resource.ConfigPlanChecks{
 				PreApply: []plancheck.PlanCheck{
 					plancheck.ExpectResourceAction(data.ResourceName, plancheck.ResourceActionReplace),
@@ -62,8 +66,7 @@ func TestAccLinuxVirtualMachineScaleSet_scalingCapacityReservationGroupId(t *tes
 			},
 		},
 		{
-			Config:   r.scalingCapacityReservationGroupId(data, ""),
-			PlanOnly: true,
+			Config: r.scalingCapacityReservationGroupId(data, ""),
 			ConfigPlanChecks: resource.ConfigPlanChecks{
 				PreApply: []plancheck.PlanCheck{
 					plancheck.ExpectResourceAction(data.ResourceName, plancheck.ResourceActionReplace),
@@ -80,6 +83,11 @@ func TestAccLinuxVirtualMachineScaleSet_scalingCapacityReservationGroupIdZonal(t
 	data.ResourceTestIgnoreRecreate(t, r, []acceptance.TestStep{
 		{
 			Config: r.scalingCapacityReservationGroupIdZonal(data, ""),
+			ConfigPlanChecks: resource.ConfigPlanChecks{
+				PreApply: []plancheck.PlanCheck{
+					plancheck.ExpectResourceAction(data.ResourceName, plancheck.ResourceActionCreate),
+				},
+			},
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -98,8 +106,7 @@ func TestAccLinuxVirtualMachineScaleSet_scalingCapacityReservationGroupIdZonal(t
 		},
 		data.ImportStep("admin_password"),
 		{
-			Config:   r.scalingCapacityReservationGroupIdZonal(data, "azurerm_capacity_reservation_group.test2.id"),
-			PlanOnly: true,
+			Config: r.scalingCapacityReservationGroupIdZonal(data, "azurerm_capacity_reservation_group.test2.id"),
 			ConfigPlanChecks: resource.ConfigPlanChecks{
 				PreApply: []plancheck.PlanCheck{
 					plancheck.ExpectResourceAction(data.ResourceName, plancheck.ResourceActionReplace),
@@ -107,8 +114,7 @@ func TestAccLinuxVirtualMachineScaleSet_scalingCapacityReservationGroupIdZonal(t
 			},
 		},
 		{
-			Config:   r.scalingCapacityReservationGroupIdZonal(data, ""),
-			PlanOnly: true,
+			Config: r.scalingCapacityReservationGroupIdZonal(data, ""),
 			ConfigPlanChecks: resource.ConfigPlanChecks{
 				PreApply: []plancheck.PlanCheck{
 					plancheck.ExpectResourceAction(data.ResourceName, plancheck.ResourceActionReplace),

--- a/internal/services/compute/linux_virtual_machine_scale_set_resource_scaling_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_resource_scaling_test.go
@@ -41,6 +41,28 @@ func TestAccLinuxVirtualMachineScaleSet_scalingCapacityReservationGroupId(t *tes
 	})
 }
 
+func TestAccLinuxVirtualMachineScaleSet_scalingCapacityReservationGroupIdZonal(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine_scale_set", "test")
+	r := LinuxVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.scalingCapacityReservationGroupIdZonal(data, ""),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			Config: r.scalingCapacityReservationGroupIdZonal(data, "azurerm_capacity_reservation_group.test.id"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
 func TestAccLinuxVirtualMachineScaleSet_defaultInstanceCount(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine_scale_set", "test")
 	r := LinuxVirtualMachineScaleSetResource{}
@@ -448,6 +470,75 @@ resource "azurerm_linux_virtual_machine_scale_set" "test" {
   ]
 }
 `, r.template(data), data.RandomInteger)
+}
+
+func (r LinuxVirtualMachineScaleSetResource) scalingCapacityReservationGroupIdZonal(data acceptance.TestData, crg string) string {
+	crgText := ""
+	if crg != "" {
+		crgText = fmt.Sprintf("capacity_reservation_group_id = %s", crg)
+	}
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_capacity_reservation_group" "test" {
+  name                = "acctest-ccrg-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  zones               = ["3"]
+}
+
+resource "azurerm_capacity_reservation" "test" {
+  name                          = "acctest-ccr-%[2]d"
+  capacity_reservation_group_id = azurerm_capacity_reservation_group.test.id
+  sku {
+    name     = "Standard_D2s_v3"
+    capacity = 1
+  }
+  zone = "3"
+}
+
+resource "azurerm_linux_virtual_machine_scale_set" "test" {
+  name                            = "acctestvmss-%[2]d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  sku                             = "Standard_D2s_v3"
+  instances                       = 1
+  admin_username                  = "adminuser"
+  admin_password                  = "P@ssword1234!"
+  zones                           = ["3"]
+  disable_password_authentication = false
+
+  single_placement_group      = false
+  platform_fault_domain_count = 1
+%[3]s
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "0001-com-ubuntu-server-jammy"
+    sku       = "22_04-lts"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name    = "example"
+    primary = true
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurerm_subnet.test.id
+    }
+  }
+
+  depends_on = [
+    azurerm_capacity_reservation.test,
+  ]
+}
+`, r.template(data), data.RandomInteger, crgText)
 }
 
 func (r LinuxVirtualMachineScaleSetResource) scalingHostGroupId(data acceptance.TestData) string {

--- a/internal/services/compute/windows_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_resource.go
@@ -109,9 +109,9 @@ func resourceWindowsVirtualMachineScaleSet() *pluginsdk.Resource {
 			}),
 
 			pluginsdk.ForceNewIf("capacity_reservation_group_id", func(ctx context.Context, d *pluginsdk.ResourceDiff, _ interface{}) bool {
-				oldZones, _ := d.GetChange("zones")
 				oldCRG, _ := d.GetChange("capacity_reservation_group_id")
-				// in-place association is only supported when adding a CRG to an already-zonal scale set
+				oldZones, _ := d.GetChange("zones")
+				// In-place association is only supported when adding a CRG to an already-zonal scale set. Updating or de-associating still requires a force new (actually requires deallocation).
 				return oldZones.(*schema.Set).Len() == 0 || oldCRG.(string) != ""
 			}),
 		),
@@ -716,19 +716,17 @@ func resourceWindowsVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData, meta
 	}
 
 	if d.HasChange("capacity_reservation_group_id") {
-		capacityReservation := &virtualmachinescalesets.CapacityReservationProfile{
-			CapacityReservationGroup: &virtualmachinescalesets.SubResource{},
+		// capacityReservation is not exposed on the PATCH update model, so it can only be set via PUT,
+		// which preserves the write-only values omitted from the GET model
+		existing.Model.Properties.VirtualMachineProfile.CapacityReservation = &virtualmachinescalesets.CapacityReservationProfile{
+			CapacityReservationGroup: &virtualmachinescalesets.SubResource{
+				Id: pointer.To(d.Get("capacity_reservation_group_id").(string)),
+			},
 		}
-		if v, ok := d.GetOk("capacity_reservation_group_id"); ok {
-			capacityReservation.CapacityReservationGroup.Id = pointer.To(v.(string))
-		}
-		// capacityReservation is not exposed on the PATCH update model, so it can only be set via PUT, which preserves the write-only values omitted from the GET model
-		existing.Model.Properties.VirtualMachineProfile.CapacityReservation = capacityReservation
 
-		// singlePlacementGroup must be false before the API will accept a capacity reservation, and this
-		// PUT runs ahead of the PATCH in performUpdate that would otherwise carry the change
+		// The API rejects a CRG unless singlePlacementGroup is false. Existing still holds the stale value
+		// when both change together. So applied the new value here.
 		existing.Model.Properties.SinglePlacementGroup = pointer.To(d.Get("single_placement_group").(bool))
-
 		if err := client.CreateOrUpdateThenPoll(ctx, *id, *existing.Model, virtualmachinescalesets.DefaultCreateOrUpdateOperationOptions()); err != nil {
 			return fmt.Errorf("updating capacity reservation group for Windows %s: %+v", id, err)
 		}

--- a/internal/services/compute/windows_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_resource.go
@@ -5,6 +5,7 @@ package compute
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"time"
@@ -98,19 +99,20 @@ func resourceWindowsVirtualMachineScaleSet() *pluginsdk.Resource {
 					}
 				}
 
+				if diff.Get("capacity_reservation_group_id").(string) != "" {
+					if diff.Get("single_placement_group").(bool) {
+						return errors.New("`single_placement_group` must be set to `false` when `capacity_reservation_group_id` is specified")
+					}
+				}
+
 				return nil
 			}),
 
-			// Azure only allows associating (not changing/removing) a capacity reservation group in-place for zonal scale sets.
 			pluginsdk.ForceNewIf("capacity_reservation_group_id", func(ctx context.Context, d *pluginsdk.ResourceDiff, _ interface{}) bool {
-				if _, ok := d.GetOk("zones"); ok {
-					oldRaw, _ := d.GetChange("capacity_reservation_group_id")
-					oldCRG := oldRaw.(string)
-					if oldCRG == "" {
-						return false
-					}
-				}
-				return true
+				oldZones, _ := d.GetChange("zones")
+				oldCRG, _ := d.GetChange("capacity_reservation_group_id")
+				// in-place association is only supported when adding a CRG to an already-zonal scale set
+				return oldZones.(*schema.Set).Len() == 0 || oldCRG.(string) != ""
 			}),
 		),
 	}
@@ -269,9 +271,6 @@ func resourceWindowsVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData, meta
 	}
 
 	if v, ok := d.GetOk("capacity_reservation_group_id"); ok {
-		if d.Get("single_placement_group").(bool) {
-			return fmt.Errorf("`single_placement_group` must be set to `false` when `capacity_reservation_group_id` is specified")
-		}
 		virtualMachineProfile.CapacityReservation = &virtualmachinescalesets.CapacityReservationProfile{
 			CapacityReservationGroup: &virtualmachinescalesets.SubResource{
 				Id: pointer.To(v.(string)),
@@ -724,10 +723,12 @@ func resourceWindowsVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData, meta
 			capacityReservation.CapacityReservationGroup.Id = pointer.To(v.(string))
 		}
 		existing.Model.Properties.VirtualMachineProfile.CapacityReservation = capacityReservation
+		// capacityReservation is not exposed on the PATCH update model, so it can only be set via PUT, which preserves the write-only values omitted from the GET model
 		if err := client.CreateOrUpdateThenPoll(ctx, *id, *existing.Model, virtualmachinescalesets.DefaultCreateOrUpdateOperationOptions()); err != nil {
 			return fmt.Errorf("updating Windows %s: %+v", id, err)
 		}
 	}
+
 	if d.HasChange("do_not_run_extensions_on_overprovisioned_machines") {
 		v := d.Get("do_not_run_extensions_on_overprovisioned_machines").(bool)
 		updateProps.DoNotRunExtensionsOnOverprovisionedVMs = pointer.To(v)

--- a/internal/services/compute/windows_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_resource.go
@@ -722,10 +722,15 @@ func resourceWindowsVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData, meta
 		if v, ok := d.GetOk("capacity_reservation_group_id"); ok {
 			capacityReservation.CapacityReservationGroup.Id = pointer.To(v.(string))
 		}
-		existing.Model.Properties.VirtualMachineProfile.CapacityReservation = capacityReservation
 		// capacityReservation is not exposed on the PATCH update model, so it can only be set via PUT, which preserves the write-only values omitted from the GET model
+		existing.Model.Properties.VirtualMachineProfile.CapacityReservation = capacityReservation
+
+		// singlePlacementGroup must be false before the API will accept a capacity reservation, and this
+		// PUT runs ahead of the PATCH in performUpdate that would otherwise carry the change
+		existing.Model.Properties.SinglePlacementGroup = pointer.To(d.Get("single_placement_group").(bool))
+
 		if err := client.CreateOrUpdateThenPoll(ctx, *id, *existing.Model, virtualmachinescalesets.DefaultCreateOrUpdateOperationOptions()); err != nil {
-			return fmt.Errorf("updating Windows %s: %+v", id, err)
+			return fmt.Errorf("updating capacity reservation group for Windows %s: %+v", id, err)
 		}
 	}
 

--- a/internal/services/compute/windows_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_resource.go
@@ -100,6 +100,18 @@ func resourceWindowsVirtualMachineScaleSet() *pluginsdk.Resource {
 
 				return nil
 			}),
+
+			// Azure only allows associating (not changing/removing) a capacity reservation group in-place for zonal scale sets.
+			pluginsdk.ForceNewIf("capacity_reservation_group_id", func(ctx context.Context, d *pluginsdk.ResourceDiff, _ interface{}) bool {
+				if _, ok := d.GetOk("zones"); ok {
+					oldRaw, _ := d.GetChange("capacity_reservation_group_id")
+					oldCRG := oldRaw.(string)
+					if oldCRG == "" {
+						return false
+					}
+				}
+				return true
+			}),
 		),
 	}
 }
@@ -704,6 +716,18 @@ func resourceWindowsVirtualMachineScaleSetUpdate(d *pluginsdk.ResourceData, meta
 		updateProps.VirtualMachineProfile.DiagnosticsProfile = expandBootDiagnosticsVMSS(bootDiagnosticsRaw)
 	}
 
+	if d.HasChange("capacity_reservation_group_id") {
+		capacityReservation := &virtualmachinescalesets.CapacityReservationProfile{
+			CapacityReservationGroup: &virtualmachinescalesets.SubResource{},
+		}
+		if v, ok := d.GetOk("capacity_reservation_group_id"); ok {
+			capacityReservation.CapacityReservationGroup.Id = pointer.To(v.(string))
+		}
+		existing.Model.Properties.VirtualMachineProfile.CapacityReservation = capacityReservation
+		if err := client.CreateOrUpdateThenPoll(ctx, *id, *existing.Model, virtualmachinescalesets.DefaultCreateOrUpdateOperationOptions()); err != nil {
+			return fmt.Errorf("updating Windows %s: %+v", id, err)
+		}
+	}
 	if d.HasChange("do_not_run_extensions_on_overprovisioned_machines") {
 		v := d.Get("do_not_run_extensions_on_overprovisioned_machines").(bool)
 		updateProps.DoNotRunExtensionsOnOverprovisionedVMs = pointer.To(v)
@@ -1221,7 +1245,6 @@ func resourceWindowsVirtualMachineScaleSetSchema() map[string]*pluginsdk.Schema 
 		"capacity_reservation_group_id": {
 			Type:         pluginsdk.TypeString,
 			Optional:     true,
-			ForceNew:     true,
 			ValidateFunc: capacityreservationgroups.ValidateCapacityReservationGroupID,
 			ConflictsWith: []string{
 				"proximity_placement_group_id",

--- a/internal/services/compute/windows_virtual_machine_scale_set_resource_scaling_test.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_resource_scaling_test.go
@@ -32,14 +32,44 @@ func TestAccWindowsVirtualMachineScaleSet_scalingCapacityReservationGroupId(t *t
 	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine_scale_set", "test")
 	r := WindowsVirtualMachineScaleSetResource{}
 
-	data.ResourceTest(t, r, []acceptance.TestStep{
+	data.ResourceTestIgnoreRecreate(t, r, []acceptance.TestStep{
 		{
-			Config: r.scalingCapacityReservationGroupId(data),
+			Config: r.scalingCapacityReservationGroupId(data, ""),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep("admin_password"),
+		{
+			Config: r.scalingCapacityReservationGroupId(data, "azurerm_capacity_reservation_group.test.id"),
+			ConfigPlanChecks: resource.ConfigPlanChecks{
+				PreApply: []plancheck.PlanCheck{
+					plancheck.ExpectResourceAction(data.ResourceName, plancheck.ResourceActionReplace),
+				},
+			},
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			Config:   r.scalingCapacityReservationGroupId(data, "azurerm_capacity_reservation_group.test2.id"),
+			PlanOnly: true,
+			ConfigPlanChecks: resource.ConfigPlanChecks{
+				PreApply: []plancheck.PlanCheck{
+					plancheck.ExpectResourceAction(data.ResourceName, plancheck.ResourceActionReplace),
+				},
+			},
+		},
+		{
+			Config:   r.scalingCapacityReservationGroupId(data, ""),
+			PlanOnly: true,
+			ConfigPlanChecks: resource.ConfigPlanChecks{
+				PreApply: []plancheck.PlanCheck{
+					plancheck.ExpectResourceAction(data.ResourceName, plancheck.ResourceActionReplace),
+				},
+			},
+		},
 	})
 }
 
@@ -47,13 +77,17 @@ func TestAccWindowsVirtualMachineScaleSet_scalingCapacityReservationGroupIdZonal
 	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine_scale_set", "test")
 	r := WindowsVirtualMachineScaleSetResource{}
 
-	data.ResourceTest(t, r, []acceptance.TestStep{
+	data.ResourceTestIgnoreRecreate(t, r, []acceptance.TestStep{
 		{
 			Config: r.scalingCapacityReservationGroupIdZonal(data, ""),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
+		data.ImportStep(
+			"additional_unattend_content.0.content",
+			"admin_password",
+		),
 		{
 			Config: r.scalingCapacityReservationGroupIdZonal(data, "azurerm_capacity_reservation_group.test.id"),
 			ConfigPlanChecks: resource.ConfigPlanChecks{
@@ -69,6 +103,24 @@ func TestAccWindowsVirtualMachineScaleSet_scalingCapacityReservationGroupIdZonal
 			"additional_unattend_content.0.content",
 			"admin_password",
 		),
+		{
+			Config:   r.scalingCapacityReservationGroupIdZonal(data, "azurerm_capacity_reservation_group.test2.id"),
+			PlanOnly: true,
+			ConfigPlanChecks: resource.ConfigPlanChecks{
+				PreApply: []plancheck.PlanCheck{
+					plancheck.ExpectResourceAction(data.ResourceName, plancheck.ResourceActionReplace),
+				},
+			},
+		},
+		{
+			Config:   r.scalingCapacityReservationGroupIdZonal(data, ""),
+			PlanOnly: true,
+			ConfigPlanChecks: resource.ConfigPlanChecks{
+				PreApply: []plancheck.PlanCheck{
+					plancheck.ExpectResourceAction(data.ResourceName, plancheck.ResourceActionReplace),
+				},
+			},
+		},
 	})
 }
 
@@ -429,7 +481,12 @@ resource "azurerm_monitor_autoscale_setting" "test" {
 `, r.template(data))
 }
 
-func (r WindowsVirtualMachineScaleSetResource) scalingCapacityReservationGroupId(data acceptance.TestData) string {
+func (r WindowsVirtualMachineScaleSetResource) scalingCapacityReservationGroupId(data acceptance.TestData, crgId string) string {
+	crgText := ""
+	if crgId != "" {
+		crgText = fmt.Sprintf("capacity_reservation_group_id = %s", crgId)
+	}
+
 	return fmt.Sprintf(`
 %[1]s
 
@@ -448,6 +505,21 @@ resource "azurerm_capacity_reservation" "test" {
   }
 }
 
+resource "azurerm_capacity_reservation_group" "test2" {
+  name                = "acctest-ccrg2-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_capacity_reservation" "test2" {
+  name                          = "acctest-ccr2-%[2]d"
+  capacity_reservation_group_id = azurerm_capacity_reservation_group.test2.id
+  sku {
+    name     = "Standard_F2"
+    capacity = 1
+  }
+}
+
 resource "azurerm_windows_virtual_machine_scale_set" "test" {
   name                = local.vm_name
   resource_group_name = azurerm_resource_group.test.name
@@ -457,9 +529,10 @@ resource "azurerm_windows_virtual_machine_scale_set" "test" {
   admin_username      = "adminuser"
   admin_password      = "P@ssword1234!"
 
-  single_placement_group        = false
-  platform_fault_domain_count   = 3
-  capacity_reservation_group_id = azurerm_capacity_reservation_group.test.id
+  single_placement_group      = false
+  platform_fault_domain_count = 3
+
+  %[3]s
 
   source_image_reference {
     publisher = "MicrosoftWindowsServer"
@@ -486,15 +559,16 @@ resource "azurerm_windows_virtual_machine_scale_set" "test" {
 
   depends_on = [
     azurerm_capacity_reservation.test,
+    azurerm_capacity_reservation.test2,
   ]
 }
-`, r.template(data), data.RandomInteger)
+`, r.template(data), data.RandomInteger, crgText)
 }
 
 func (r WindowsVirtualMachineScaleSetResource) scalingCapacityReservationGroupIdZonal(data acceptance.TestData, crg string) string {
 	crgText := ""
 	if crg != "" {
-		crgText = fmt.Sprintf("capacity_reservation_group_id = %s", crg)
+		crgText = fmt.Sprintf("capacity_reservation_group_id = %s\n  single_placement_group = false", crg)
 	}
 
 	return fmt.Sprintf(`
@@ -517,6 +591,23 @@ resource "azurerm_capacity_reservation" "test" {
   zone = "3"
 }
 
+resource "azurerm_capacity_reservation_group" "test2" {
+  name                = "acctest-ccrg2-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  zones               = ["3"]
+}
+
+resource "azurerm_capacity_reservation" "test2" {
+  name                          = "acctest-ccr2-%[2]d"
+  capacity_reservation_group_id = azurerm_capacity_reservation_group.test2.id
+  sku {
+    name     = "Standard_D2s_v3"
+    capacity = 1
+  }
+  zone = "3"
+}
+
 resource "azurerm_windows_virtual_machine_scale_set" "test" {
   name                = local.vm_name
   resource_group_name = azurerm_resource_group.test.name
@@ -527,9 +618,9 @@ resource "azurerm_windows_virtual_machine_scale_set" "test" {
   admin_password      = "P@ssword1234!"
   zones               = ["3"]
 
-  single_placement_group      = false
   platform_fault_domain_count = 1
-%[3]s
+
+  %[3]s
 
   additional_unattend_content {
     setting = "AutoLogon"
@@ -561,6 +652,7 @@ resource "azurerm_windows_virtual_machine_scale_set" "test" {
 
   depends_on = [
     azurerm_capacity_reservation.test,
+    azurerm_capacity_reservation.test2,
   ]
 }
 `, r.template(data), data.RandomInteger, crgText)

--- a/internal/services/compute/windows_virtual_machine_scale_set_resource_scaling_test.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_resource_scaling_test.go
@@ -41,6 +41,28 @@ func TestAccWindowsVirtualMachineScaleSet_scalingCapacityReservationGroupId(t *t
 	})
 }
 
+func TestAccWindowsVirtualMachineScaleSet_scalingCapacityReservationGroupIdZonal(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine_scale_set", "test")
+	r := WindowsVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.scalingCapacityReservationGroupIdZonal(data, ""),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			Config: r.scalingCapacityReservationGroupIdZonal(data, "azurerm_capacity_reservation_group.test.id"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
 func TestAccWindowsVirtualMachineScaleSet_scalingHostGroupId(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine_scale_set", "test")
 	r := WindowsVirtualMachineScaleSetResource{}
@@ -458,6 +480,75 @@ resource "azurerm_windows_virtual_machine_scale_set" "test" {
   ]
 }
 `, r.template(data), data.RandomInteger)
+}
+
+func (r WindowsVirtualMachineScaleSetResource) scalingCapacityReservationGroupIdZonal(data acceptance.TestData, crg string) string {
+	crgText := ""
+	if crg != "" {
+		crgText = fmt.Sprintf("capacity_reservation_group_id = %s", crg)
+	}
+
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_capacity_reservation_group" "test" {
+  name                = "acctest-ccrg-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  zones               = ["3"]
+}
+
+resource "azurerm_capacity_reservation" "test" {
+  name                          = "acctest-ccr-%[2]d"
+  capacity_reservation_group_id = azurerm_capacity_reservation_group.test.id
+  sku {
+    name     = "Standard_D2s_v3"
+    capacity = 1
+  }
+  zone = "3"
+}
+
+resource "azurerm_windows_virtual_machine_scale_set" "test" {
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  sku                 = "Standard_D2s_v3"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+  zones               = ["3"]
+
+  single_placement_group      = false
+  platform_fault_domain_count = 1
+%[3]s
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2019-Datacenter"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name    = "example"
+    primary = true
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurerm_subnet.test.id
+    }
+  }
+
+  depends_on = [
+    azurerm_capacity_reservation.test,
+  ]
+}
+`, r.template(data), data.RandomInteger, crgText)
 }
 
 func (r WindowsVirtualMachineScaleSetResource) scalingHostGroupId(data acceptance.TestData) string {

--- a/internal/services/compute/windows_virtual_machine_scale_set_resource_scaling_test.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_resource_scaling_test.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 )
@@ -52,14 +54,21 @@ func TestAccWindowsVirtualMachineScaleSet_scalingCapacityReservationGroupIdZonal
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("admin_password"),
 		{
 			Config: r.scalingCapacityReservationGroupIdZonal(data, "azurerm_capacity_reservation_group.test.id"),
+			ConfigPlanChecks: resource.ConfigPlanChecks{
+				PreApply: []plancheck.PlanCheck{
+					plancheck.ExpectResourceAction(data.ResourceName, plancheck.ResourceActionUpdate),
+				},
+			},
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("admin_password"),
+		data.ImportStep(
+			"additional_unattend_content.0.content",
+			"admin_password",
+		),
 	})
 }
 
@@ -521,6 +530,12 @@ resource "azurerm_windows_virtual_machine_scale_set" "test" {
   single_placement_group      = false
   platform_fault_domain_count = 1
 %[3]s
+
+  additional_unattend_content {
+    setting = "AutoLogon"
+    content = "<AutoLogon><Username>myadmin</Username><Password><Value>P@ssword1234!</Value></Password><Enabled>true</Enabled><LogonCount>1</LogonCount></AutoLogon>"
+  }
+
   source_image_reference {
     publisher = "MicrosoftWindowsServer"
     offer     = "WindowsServer"

--- a/internal/services/compute/windows_virtual_machine_scale_set_resource_scaling_test.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_resource_scaling_test.go
@@ -35,6 +35,11 @@ func TestAccWindowsVirtualMachineScaleSet_scalingCapacityReservationGroupId(t *t
 	data.ResourceTestIgnoreRecreate(t, r, []acceptance.TestStep{
 		{
 			Config: r.scalingCapacityReservationGroupId(data, ""),
+			ConfigPlanChecks: resource.ConfigPlanChecks{
+				PreApply: []plancheck.PlanCheck{
+					plancheck.ExpectResourceAction(data.ResourceName, plancheck.ResourceActionCreate),
+				},
+			},
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -53,8 +58,7 @@ func TestAccWindowsVirtualMachineScaleSet_scalingCapacityReservationGroupId(t *t
 		},
 		data.ImportStep("admin_password"),
 		{
-			Config:   r.scalingCapacityReservationGroupId(data, "azurerm_capacity_reservation_group.test2.id"),
-			PlanOnly: true,
+			Config: r.scalingCapacityReservationGroupId(data, "azurerm_capacity_reservation_group.test2.id"),
 			ConfigPlanChecks: resource.ConfigPlanChecks{
 				PreApply: []plancheck.PlanCheck{
 					plancheck.ExpectResourceAction(data.ResourceName, plancheck.ResourceActionReplace),
@@ -62,8 +66,7 @@ func TestAccWindowsVirtualMachineScaleSet_scalingCapacityReservationGroupId(t *t
 			},
 		},
 		{
-			Config:   r.scalingCapacityReservationGroupId(data, ""),
-			PlanOnly: true,
+			Config: r.scalingCapacityReservationGroupId(data, ""),
 			ConfigPlanChecks: resource.ConfigPlanChecks{
 				PreApply: []plancheck.PlanCheck{
 					plancheck.ExpectResourceAction(data.ResourceName, plancheck.ResourceActionReplace),
@@ -80,6 +83,11 @@ func TestAccWindowsVirtualMachineScaleSet_scalingCapacityReservationGroupIdZonal
 	data.ResourceTestIgnoreRecreate(t, r, []acceptance.TestStep{
 		{
 			Config: r.scalingCapacityReservationGroupIdZonal(data, ""),
+			ConfigPlanChecks: resource.ConfigPlanChecks{
+				PreApply: []plancheck.PlanCheck{
+					plancheck.ExpectResourceAction(data.ResourceName, plancheck.ResourceActionCreate),
+				},
+			},
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -104,8 +112,7 @@ func TestAccWindowsVirtualMachineScaleSet_scalingCapacityReservationGroupIdZonal
 			"admin_password",
 		),
 		{
-			Config:   r.scalingCapacityReservationGroupIdZonal(data, "azurerm_capacity_reservation_group.test2.id"),
-			PlanOnly: true,
+			Config: r.scalingCapacityReservationGroupIdZonal(data, "azurerm_capacity_reservation_group.test2.id"),
 			ConfigPlanChecks: resource.ConfigPlanChecks{
 				PreApply: []plancheck.PlanCheck{
 					plancheck.ExpectResourceAction(data.ResourceName, plancheck.ResourceActionReplace),
@@ -113,8 +120,7 @@ func TestAccWindowsVirtualMachineScaleSet_scalingCapacityReservationGroupIdZonal
 			},
 		},
 		{
-			Config:   r.scalingCapacityReservationGroupIdZonal(data, ""),
-			PlanOnly: true,
+			Config: r.scalingCapacityReservationGroupIdZonal(data, ""),
 			ConfigPlanChecks: resource.ConfigPlanChecks{
 				PreApply: []plancheck.PlanCheck{
 					plancheck.ExpectResourceAction(data.ResourceName, plancheck.ResourceActionReplace),

--- a/website/docs/r/linux_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/linux_virtual_machine_scale_set.html.markdown
@@ -130,7 +130,9 @@ resource "azurerm_linux_virtual_machine_scale_set" "example" {
 
 * `boot_diagnostics` - (Optional) A `boot_diagnostics` block as defined below.
 
-* `capacity_reservation_group_id` - (Optional) Specifies the ID of the Capacity Reservation Group which the Virtual Machine Scale Set should be allocated to. Changing this forces a new resource to be created.
+* `capacity_reservation_group_id` - (Optional) Specifies the ID of the Capacity Reservation Group which the Virtual Machine Scale Set should be allocated to.
+
+~> **Note:** Associating a `capacity_reservation_group_id` with a Virtual Machine Scale Set with `zones` configured is applied in-place. Changing or removing an existing `capacity_reservation_group_id`, or any change on a Virtual Machine Scale Set without `zones` configured, forces a new resource to be created.
 
 -> **Note:** `capacity_reservation_group_id` cannot be used with `proximity_placement_group_id`
 

--- a/website/docs/r/windows_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/windows_virtual_machine_scale_set.html.markdown
@@ -119,7 +119,9 @@ resource "azurerm_windows_virtual_machine_scale_set" "example" {
 
 * `boot_diagnostics` - (Optional) A `boot_diagnostics` block as defined below.
 
-* `capacity_reservation_group_id` - (Optional) Specifies the ID of the Capacity Reservation Group which the Virtual Machine Scale Set should be allocated to. Changing this forces a new resource to be created.
+* `capacity_reservation_group_id` - (Optional) Specifies the ID of the Capacity Reservation Group which the Virtual Machine Scale Set should be allocated to.
+
+~> **Note:** Associating a `capacity_reservation_group_id` with a Virtual Machine Scale Set with `zones` configured is applied in-place. Changing or removing an existing `capacity_reservation_group_id`, or any change on a Virtual Machine Scale Set without `zones` configured, forces a new resource to be created.
 
 ~> **Note:** `capacity_reservation_group_id` cannot be used with `proximity_placement_group_id`
 


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR is to supports in place association for `capacity_reservation_group_id` of VMSS that has `zones` property without deallocation as it is supported by Azure now:

https://learn.microsoft.com/en-us/azure/virtual-machines/capacity-reservation-associate-virtual-machine-scale-set?tabs=api1%2Capi2

Currently feature is in public preview but will be GA by Sep. 

Different from VM, VMSS can only update in place with association and not update ( capacity_reservation_group = "A" => capacity_reservation_group = "B"). 

Notes that `capacity_reservation_group_id` was set to be `forceNew`. API actually allow it to be updated without recreate the VMSS via deallocate instances => apply change => restart instances. Since this PR is just for introduce this new feature, we didn't apply the deallocate/restart flow and just expand on the `foreceNew` behavior. 

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

<img width="792" height="223" alt="image" src="https://github.com/user-attachments/assets/ea0c269f-2447-46fd-8962-4f9f1e1134e6" />

Test with parameters TEST_PREFIX=TestAcc(Linux|Windows)VirtualMachineScaleSet_scaling
https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_COMPUTE/734720?buildTab=tests

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_(linux|windows)_virtual_machine` - support in place association of `capacity_reservation_group_id` for uniform vmss with `zones` property [https://github.com/hashicorp/terraform-provider-azurerm/pull/33199]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
