### PR TITLE
`data.network_interface` - add missing attributes to match resource

### DIFF
--- a/internal/services/network/network_interface_data_source.go
+++ b/internal/services/network/network_interface_data_source.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
@@ -38,6 +39,18 @@ func dataSourceNetworkInterface() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
 			},
+
+			"auxiliary_mode": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
+			"auxiliary_sku": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
+			"edge_zone": commonschema.EdgeZoneComputed(),
 
 			"network_security_group_id": {
 				Type:     pluginsdk.TypeString,
@@ -130,6 +143,11 @@ func dataSourceNetworkInterface() *pluginsdk.Resource {
 				},
 			},
 
+			"internal_domain_name_suffix": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
 			"dns_servers": {
 				Type:     pluginsdk.TypeSet,
 				Computed: true,
@@ -205,6 +223,7 @@ func dataSourceNetworkInterfaceRead(d *pluginsdk.ResourceData, meta interface{})
 	if loc := model.Location; loc != nil {
 		d.Set("location", location.Normalize(*loc))
 	}
+	d.Set("edge_zone", flattenEdgeZoneModel(model.ExtendedLocation))
 
 	if props := model.Properties; props != nil {
 		d.Set("mac_address", props.MacAddress)
@@ -243,8 +262,21 @@ func dataSourceNetworkInterfaceRead(d *pluginsdk.ResourceData, meta interface{})
 		}
 		d.Set("virtual_machine_id", virtualMachineId)
 
+		auxiliaryMode := ""
+		if props.AuxiliaryMode != nil && *props.AuxiliaryMode != networkinterfaces.NetworkInterfaceAuxiliaryModeNone {
+			auxiliaryMode = string(*props.AuxiliaryMode)
+		}
+		d.Set("auxiliary_mode", auxiliaryMode)
+
+		auxiliarySku := ""
+		if props.AuxiliarySku != nil && *props.AuxiliarySku != networkinterfaces.NetworkInterfaceAuxiliarySkuNone {
+			auxiliarySku = string(*props.AuxiliarySku)
+		}
+		d.Set("auxiliary_sku", auxiliarySku)
+
 		var appliedDNSServers []string
 		var dnsServers []string
+		internalDomainNameSuffix := ""
 		if dnsSettings := props.DnsSettings; dnsSettings != nil {
 			if s := dnsSettings.AppliedDnsServers; s != nil {
 				appliedDNSServers = *s
@@ -253,6 +285,8 @@ func dataSourceNetworkInterfaceRead(d *pluginsdk.ResourceData, meta interface{})
 			if s := dnsSettings.DnsServers; s != nil {
 				dnsServers = *s
 			}
+
+			internalDomainNameSuffix = pointer.From(dnsSettings.InternalDomainNameSuffix)
 
 			d.Set("internal_dns_name_label", dnsSettings.InternalDnsNameLabel)
 		}
@@ -265,6 +299,7 @@ func dataSourceNetworkInterfaceRead(d *pluginsdk.ResourceData, meta interface{})
 
 		d.Set("applied_dns_servers", appliedDNSServers)
 		d.Set("dns_servers", dnsServers)
+		d.Set("internal_domain_name_suffix", internalDomainNameSuffix)
 		d.Set("ip_forwarding_enabled", props.EnableIPForwarding)
 		d.Set("accelerated_networking_enabled", props.EnableAcceleratedNetworking)
 	}

--- a/internal/services/network/network_interface_data_source.go
+++ b/internal/services/network/network_interface_data_source.go
@@ -264,7 +264,7 @@ func dataSourceNetworkInterfaceRead(d *pluginsdk.ResourceData, meta interface{})
 
 		d.Set("auxiliary_mode", pointer.FromEnum(props.AuxiliaryMode))
 
-		d.Set("auxiliary_mode", pointer.FromEnum(props.AuxiliarySku))
+		d.Set("auxiliary_sku", pointer.FromEnum(props.AuxiliarySku))
 
 		var appliedDNSServers []string
 		var dnsServers []string

--- a/internal/services/network/network_interface_data_source.go
+++ b/internal/services/network/network_interface_data_source.go
@@ -262,17 +262,9 @@ func dataSourceNetworkInterfaceRead(d *pluginsdk.ResourceData, meta interface{})
 		}
 		d.Set("virtual_machine_id", virtualMachineId)
 
-		auxiliaryMode := ""
-		if props.AuxiliaryMode != nil && *props.AuxiliaryMode != networkinterfaces.NetworkInterfaceAuxiliaryModeNone {
-			auxiliaryMode = string(*props.AuxiliaryMode)
-		}
-		d.Set("auxiliary_mode", auxiliaryMode)
+		d.Set("auxiliary_mode", pointer.FromEnum(props.AuxiliaryMode))
 
-		auxiliarySku := ""
-		if props.AuxiliarySku != nil && *props.AuxiliarySku != networkinterfaces.NetworkInterfaceAuxiliarySkuNone {
-			auxiliarySku = string(*props.AuxiliarySku)
-		}
-		d.Set("auxiliary_sku", auxiliarySku)
+		d.Set("auxiliary_mode", pointer.FromEnum(props.AuxiliarySku))
 
 		var appliedDNSServers []string
 		var dnsServers []string

--- a/internal/services/network/network_interface_data_source_test.go
+++ b/internal/services/network/network_interface_data_source_test.go
@@ -25,6 +25,7 @@ func TestAccDataSourceArmNetworkInterface_basic(t *testing.T) {
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("private_ip_address").HasValue("10.0.2.15"),
+				check.That(data.ResourceName).Key("internal_domain_name_suffix").IsSet(),
 			),
 		},
 	})
@@ -39,4 +40,55 @@ data "azurerm_network_interface" "test" {
   resource_group_name = azurerm_network_interface.test.resource_group_name
 }
 `, NetworkInterfaceResource{}.static(data))
+}
+
+func TestAccDataSourceArmNetworkInterface_auxiliary(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_network_interface", "test")
+	r := NetworkInterfaceDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.auxiliary(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("auxiliary_mode").HasValue("AcceleratedConnections"),
+				check.That(data.ResourceName).Key("auxiliary_sku").HasValue("A2"),
+			),
+		},
+	})
+}
+
+func (NetworkInterfaceDataSource) auxiliary(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_network_interface" "test" {
+  name                = azurerm_network_interface.test.name
+  resource_group_name = azurerm_network_interface.test.resource_group_name
+}
+`, NetworkInterfaceResource{}.auxiliaryAcceleratedConnections(data))
+}
+
+func TestAccDataSourceArmNetworkInterface_edgeZone(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_network_interface", "test")
+	r := NetworkInterfaceDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.edgeZone(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("edge_zone").IsSet(),
+			),
+		},
+	})
+}
+
+func (NetworkInterfaceDataSource) edgeZone(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_network_interface" "test" {
+  name                = azurerm_network_interface.test.name
+  resource_group_name = azurerm_network_interface.test.resource_group_name
+}
+`, NetworkInterfaceResource{}.edgeZone(data))
 }

--- a/internal/services/network/network_interface_data_source_test.go
+++ b/internal/services/network/network_interface_data_source_test.go
@@ -31,17 +31,6 @@ func TestAccDataSourceArmNetworkInterface_basic(t *testing.T) {
 	})
 }
 
-func (NetworkInterfaceDataSource) basic(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-%s
-
-data "azurerm_network_interface" "test" {
-  name                = azurerm_network_interface.test.name
-  resource_group_name = azurerm_network_interface.test.resource_group_name
-}
-`, NetworkInterfaceResource{}.static(data))
-}
-
 func TestAccDataSourceArmNetworkInterface_auxiliary(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_network_interface", "test")
 	r := NetworkInterfaceDataSource{}
@@ -57,17 +46,6 @@ func TestAccDataSourceArmNetworkInterface_auxiliary(t *testing.T) {
 	})
 }
 
-func (NetworkInterfaceDataSource) auxiliary(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-%s
-
-data "azurerm_network_interface" "test" {
-  name                = azurerm_network_interface.test.name
-  resource_group_name = azurerm_network_interface.test.resource_group_name
-}
-`, NetworkInterfaceResource{}.auxiliaryAcceleratedConnections(data))
-}
-
 func TestAccDataSourceArmNetworkInterface_edgeZone(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_network_interface", "test")
 	r := NetworkInterfaceDataSource{}
@@ -80,6 +58,28 @@ func TestAccDataSourceArmNetworkInterface_edgeZone(t *testing.T) {
 			),
 		},
 	})
+}
+
+func (NetworkInterfaceDataSource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_network_interface" "test" {
+  name                = azurerm_network_interface.test.name
+  resource_group_name = azurerm_network_interface.test.resource_group_name
+}
+`, NetworkInterfaceResource{}.static(data))
+}
+
+func (NetworkInterfaceDataSource) auxiliary(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_network_interface" "test" {
+  name                = azurerm_network_interface.test.name
+  resource_group_name = azurerm_network_interface.test.resource_group_name
+}
+`, NetworkInterfaceResource{}.auxiliaryAcceleratedConnections(data))
 }
 
 func (NetworkInterfaceDataSource) edgeZone(data acceptance.TestData) string {

--- a/website/docs/d/network_interface.html.markdown
+++ b/website/docs/d/network_interface.html.markdown
@@ -30,11 +30,15 @@ output "network_interface_id" {
 
 ## Attributes Reference
 
+* `auxiliary_mode` - Specifies the auxiliary mode used to enable network high-performance feature on Network Virtual Appliances (NVAs). This feature offers competitive performance in Connections Per Second (CPS) optimization, along with improvements to handling large amounts of simultaneous connections. Possible values are `AcceleratedConnections`, `Floating`, `MaxConnections` and `None`.
+* `auxiliary_sku` - Specifies the SKU used for the network high-performance feature on Network Virtual Appliances (NVAs). Possible values are `A8`, `A4`, `A1`, `A2` and `None`.
+* `edge_zone` - Specifies the Edge Zone within the Azure Region where this Network Interface should exist. Changing this forces a new Network Interface to be created.
 * `id` - The ID of the Network Interface.
 * `accelerated_networking_enabled` - Indicates if accelerated networking is set on the specified Network Interface.
 * `applied_dns_servers` - List of DNS servers applied to the specified Network Interface.
 * `dns_servers` - The list of DNS servers used by the specified Network Interface.
 * `internal_dns_name_label` - The internal DNS name label of the specified Network Interface.
+* `internal_domain_name_suffix` - Even if `internal_dns_name_label` is not specified, a DNS entry is created for the primary NIC of the VM. This DNS name can be constructed by concatenating the VM name with the value of `internal_domain_name_suffix`.
 * `ip_configuration` - One or more `ip_configuration` blocks as defined below.
 * `ip_forwarding_enabled` - Indicate if IP forwarding is set on the specified Network Interface.
 * `location` - The location of the specified Network Interface.

--- a/website/docs/d/network_interface.html.markdown
+++ b/website/docs/d/network_interface.html.markdown
@@ -30,10 +30,10 @@ output "network_interface_id" {
 
 ## Attributes Reference
 
-* `auxiliary_mode` - Specifies the auxiliary mode used to enable network high-performance feature on Network Virtual Appliances (NVAs). This feature offers competitive performance in Connections Per Second (CPS) optimization, along with improvements to handling large amounts of simultaneous connections. Possible values are `AcceleratedConnections`, `Floating`, `MaxConnections` and `None`.
-* `auxiliary_sku` - Specifies the SKU used for the network high-performance feature on Network Virtual Appliances (NVAs). Possible values are `A8`, `A4`, `A1`, `A2` and `None`.
-* `edge_zone` - Specifies the Edge Zone within the Azure Region where this Network Interface should exist. Changing this forces a new Network Interface to be created.
 * `id` - The ID of the Network Interface.
+* `auxiliary_mode` - Specifies the auxiliary mode used to enable network high-performance feature on Network Virtual Appliances (NVAs). This feature offers competitive performance in Connections Per Second (CPS) optimization, along with improvements to handling large amounts of simultaneous connections
+* `auxiliary_sku` - Specifies the SKU used for the network high-performance feature on Network Virtual Appliances (NVAs).
+* `edge_zone` - Specifies the Edge Zone within the Azure Region where this Network Interface should exist. 
 * `accelerated_networking_enabled` - Indicates if accelerated networking is set on the specified Network Interface.
 * `applied_dns_servers` - List of DNS servers applied to the specified Network Interface.
 * `dns_servers` - The list of DNS servers used by the specified Network Interface.


### PR DESCRIPTION
Added missing resource properties: "auxiliary_mode", "auxiliary_sku", "edge_zone", "internal_domain_name_suffix"
--- PASS: TestAccDataSourceArmNetworkInterface_basic (134.90s)
