### PR TITLE
`data.api_management_workspace` - add support for `description`

### DIFF
--- a/internal/services/apimanagement/api_management_workspace_data_source.go
+++ b/internal/services/apimanagement/api_management_workspace_data_source.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2024-05-01/apimanagementservice"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2024-05-01/workspace"
@@ -16,6 +17,7 @@ import (
 type ApiManagementWorkspaceDataSourceModel struct {
 	Name            string `tfschema:"name"`
 	ApiManagementId string `tfschema:"api_management_id"`
+	Description     string `tfschema:"description"`
 	DisplayName     string `tfschema:"display_name"`
 }
 
@@ -43,6 +45,10 @@ func (d ApiManagementWorkspaceDataSource) Attributes() map[string]*schema.Schema
 			Type:        pluginsdk.TypeString,
 			Computed:    true,
 			Description: "The display name of the API Management Workspace.",
+		},
+		"description": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
 		},
 	}
 }
@@ -89,6 +95,7 @@ func (d ApiManagementWorkspaceDataSource) Read() sdk.ResourceFunc {
 
 			if model := resp.Model; model != nil {
 				if props := model.Properties; props != nil {
+					state.Description = pointer.From(props.Description)
 					state.DisplayName = props.DisplayName
 				}
 			}

--- a/website/docs/d/api_management_workspace.html.markdown
+++ b/website/docs/d/api_management_workspace.html.markdown
@@ -52,6 +52,8 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `id` - The ID of the API Management Workspace.
 
+* `description` - The description of the API Management Workspace.
+
 * `display_name` - The display name of the API Management Workspace.
 
 ## Timeouts


### PR DESCRIPTION
Added missing resource properties: "description"
--- PASS: TestAccDataSourceApiManagementWorkspace_basic (1695.60s)
