### PR TITLE
linters - AZS004 complete enum lists to PossibleValuesFor<Enum>() 3/4 - services h-n (hdinsight ... network)

### DIFF
--- a/internal/services/hdinsight/schema.go
+++ b/internal/services/hdinsight/schema.go
@@ -36,13 +36,10 @@ func SchemaHDInsightName() *pluginsdk.Schema {
 
 func SchemaHDInsightTier() *pluginsdk.Schema {
 	return &pluginsdk.Schema{
-		Type:     pluginsdk.TypeString,
-		Required: true,
-		ForceNew: true,
-		ValidateFunc: validation.StringInSlice([]string{
-			string(clusters.TierStandard),
-			string(clusters.TierPremium),
-		}, false),
+		Type:         pluginsdk.TypeString,
+		Required:     true,
+		ForceNew:     true,
+		ValidateFunc: validation.StringInSlice(clusters.PossibleValuesForTier(), false),
 	}
 }
 
@@ -252,14 +249,11 @@ func SchemaHDInsightsNetwork() *pluginsdk.Schema {
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
 				"connection_direction": {
-					Type:     pluginsdk.TypeString,
-					Optional: true,
-					ForceNew: true,
-					Default:  string(clusters.ResourceProviderConnectionInbound),
-					ValidateFunc: validation.StringInSlice([]string{
-						string(clusters.ResourceProviderConnectionInbound),
-						string(clusters.ResourceProviderConnectionOutbound),
-					}, false),
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ForceNew:     true,
+					Default:      string(clusters.ResourceProviderConnectionInbound),
+					ValidateFunc: validation.StringInSlice(clusters.PossibleValuesForResourceProviderConnection(), false),
 				},
 
 				"private_link_enabled": {
@@ -1004,12 +998,9 @@ func SchemaHDInsightPrivateLinkConfigurationIpConfiguration() *pluginsdk.Schema 
 				},
 
 				"private_ip_allocation_method": {
-					Type:     pluginsdk.TypeString,
-					Optional: true,
-					ValidateFunc: validation.StringInSlice([]string{
-						string(clusters.PrivateIPAllocationMethodDynamic),
-						string(clusters.PrivateIPAllocationMethodStatic),
-					}, false),
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringInSlice(clusters.PossibleValuesForPrivateIPAllocationMethod(), false),
 				},
 
 				"subnet_id": {
@@ -1282,16 +1273,8 @@ func SchemaHDInsightNodeDefinition(schemaLocation string, definition HDInsightNo
 											Type:     pluginsdk.TypeList,
 											Required: true,
 											Elem: &pluginsdk.Schema{
-												Type: pluginsdk.TypeString,
-												ValidateFunc: validation.StringInSlice([]string{
-													string(clusters.DaysOfWeekMonday),
-													string(clusters.DaysOfWeekTuesday),
-													string(clusters.DaysOfWeekWednesday),
-													string(clusters.DaysOfWeekThursday),
-													string(clusters.DaysOfWeekFriday),
-													string(clusters.DaysOfWeekSaturday),
-													string(clusters.DaysOfWeekSunday),
-												}, false),
+												Type:         pluginsdk.TypeString,
+												ValidateFunc: validation.StringInSlice(clusters.PossibleValuesForDaysOfWeek(), false),
 											},
 										},
 
@@ -1467,16 +1450,8 @@ func SchemaHDInsightNodeDefinitionKafka(schemaLocation string, definition HDInsi
 											Type:     pluginsdk.TypeList,
 											Required: true,
 											Elem: &pluginsdk.Schema{
-												Type: pluginsdk.TypeString,
-												ValidateFunc: validation.StringInSlice([]string{
-													string(clusters.DaysOfWeekMonday),
-													string(clusters.DaysOfWeekTuesday),
-													string(clusters.DaysOfWeekWednesday),
-													string(clusters.DaysOfWeekThursday),
-													string(clusters.DaysOfWeekFriday),
-													string(clusters.DaysOfWeekSaturday),
-													string(clusters.DaysOfWeekSunday),
-												}, false),
+												Type:         pluginsdk.TypeString,
+												ValidateFunc: validation.StringInSlice(clusters.PossibleValuesForDaysOfWeek(), false),
 											},
 										},
 

--- a/internal/services/healthcare/healthcare_fhir_service_resource.go
+++ b/internal/services/healthcare/healthcare_fhir_service_resource.go
@@ -72,14 +72,11 @@ func resourceHealthcareApisFhirService() *pluginsdk.Resource {
 			"location": commonschema.Location(),
 
 			"kind": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Default:  string(fhirservices.FhirServiceKindFhirNegativeRFour),
-				ValidateFunc: validation.StringInSlice([]string{
-					string(fhirservices.FhirServiceKindFhirNegativeRFour),
-					string(fhirservices.FhirServiceKindFhirNegativeStuThree),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Default:      string(fhirservices.FhirServiceKindFhirNegativeRFour),
+				ValidateFunc: validation.StringInSlice(fhirservices.PossibleValuesForFhirServiceKind(), false),
 			},
 
 			"access_policy_object_ids": {

--- a/internal/services/healthcare/healthcare_medtech_service_fhir_destination_resource.go
+++ b/internal/services/healthcare/healthcare_medtech_service_fhir_destination_resource.go
@@ -75,12 +75,9 @@ func resourceHealthcareApisMedTechServiceFhirDestination() *pluginsdk.Resource {
 			},
 
 			"destination_identity_resolution_type": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(iotconnectors.IotIdentityResolutionTypeCreate),
-					string(iotconnectors.IotIdentityResolutionTypeLookup),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(iotconnectors.PossibleValuesForIotIdentityResolutionType(), false),
 			},
 
 			"destination_fhir_mapping_json": {

--- a/internal/services/healthcare/healthcare_service_resource.go
+++ b/internal/services/healthcare/healthcare_service_resource.go
@@ -57,14 +57,10 @@ func resourceHealthcareService() *pluginsdk.Resource {
 			"resource_group_name": commonschema.ResourceGroupName(),
 
 			"kind": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				Default:  string(service.KindFhir),
-				ValidateFunc: validation.StringInSlice([]string{
-					string(service.KindFhir),
-					string(service.KindFhirNegativeRFour),
-					string(service.KindFhirNegativeStuThree),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				Default:      string(service.KindFhir),
+				ValidateFunc: validation.StringInSlice(service.PossibleValuesForKind(), false),
 			},
 
 			"identity": commonschema.SystemAssignedIdentityOptional(),

--- a/internal/services/hsm/dedicated_hardware_security_module_resource.go
+++ b/internal/services/hsm/dedicated_hardware_security_module_resource.go
@@ -58,18 +58,10 @@ func resourceDedicatedHardwareSecurityModule() *pluginsdk.Resource {
 			"location": commonschema.Location(),
 
 			"sku_name": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(dedicatedhsms.SkuNameSafeNetLunaNetworkHSMASevenNineZero),
-					string(dedicatedhsms.SkuNamePayShieldOneZeroKLMKOneCPSSixZero),
-					string(dedicatedhsms.SkuNamePayShieldOneZeroKLMKOneCPSTwoFiveZero),
-					string(dedicatedhsms.SkuNamePayShieldOneZeroKLMKOneCPSTwoFiveZeroZero),
-					string(dedicatedhsms.SkuNamePayShieldOneZeroKLMKTwoCPSSixZero),
-					string(dedicatedhsms.SkuNamePayShieldOneZeroKLMKTwoCPSTwoFiveZero),
-					string(dedicatedhsms.SkuNamePayShieldOneZeroKLMKTwoCPSTwoFiveZeroZero),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(dedicatedhsms.PossibleValuesForSkuName(), false),
 			},
 
 			"network_profile": {

--- a/internal/services/iotcentral/iotcentral_application_network_rule_set_resource.go
+++ b/internal/services/iotcentral/iotcentral_application_network_rule_set_resource.go
@@ -52,13 +52,10 @@ func (r IotCentralApplicationNetworkRuleSetResource) Arguments() map[string]*plu
 		},
 
 		"default_action": {
-			Type:     pluginsdk.TypeString,
-			Optional: true,
-			Default:  string(apps.NetworkActionDeny),
-			ValidateFunc: validation.StringInSlice([]string{
-				string(apps.NetworkActionAllow),
-				string(apps.NetworkActionDeny),
-			}, false),
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			Default:      string(apps.NetworkActionDeny),
+			ValidateFunc: validation.StringInSlice(apps.PossibleValuesForNetworkAction(), false),
 		},
 
 		"ip_rule": {

--- a/internal/services/iotcentral/iotcentral_application_resource.go
+++ b/internal/services/iotcentral/iotcentral_application_resource.go
@@ -84,14 +84,10 @@ func resourceIotCentralApplication() *pluginsdk.Resource {
 			},
 
 			"sku": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(apps.AppSkuSTOne),
-					string(apps.AppSkuSTTwo),
-					string(apps.AppSkuSTZero),
-				}, false),
-				Default: string(apps.AppSkuSTOne),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(apps.PossibleValuesForAppSku(), false),
+				Default:      string(apps.AppSkuSTOne),
 			},
 			"template": {
 				Type:         pluginsdk.TypeString,

--- a/internal/services/iothub/iothub_device_update_account_resource.go
+++ b/internal/services/iothub/iothub_device_update_account_resource.go
@@ -55,14 +55,11 @@ func (r IotHubDeviceUpdateAccountResource) Arguments() map[string]*pluginsdk.Sch
 		},
 
 		"sku": {
-			Type:     pluginsdk.TypeString,
-			ForceNew: true,
-			Optional: true,
-			Default:  deviceupdates.SKUStandard,
-			ValidateFunc: validation.StringInSlice([]string{
-				string(deviceupdates.SKUFree),
-				string(deviceupdates.SKUStandard),
-			}, false),
+			Type:         pluginsdk.TypeString,
+			ForceNew:     true,
+			Optional:     true,
+			Default:      deviceupdates.SKUStandard,
+			ValidateFunc: validation.StringInSlice(deviceupdates.PossibleValuesForSKU(), false),
 		},
 
 		"tags": commonschema.Tags(),

--- a/internal/services/iothub/iothub_dps_resource.go
+++ b/internal/services/iothub/iothub_dps_resource.go
@@ -149,27 +149,19 @@ func resourceIotHubDPS() *pluginsdk.Resource {
 							}, false),
 						},
 						"target": {
-							Type:     pluginsdk.TypeString,
-							Optional: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(iotdpsresource.IPFilterTargetTypeAll),
-								string(iotdpsresource.IPFilterTargetTypeServiceApi),
-								string(iotdpsresource.IPFilterTargetTypeDeviceApi),
-							}, false),
+							Type:         pluginsdk.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice(iotdpsresource.PossibleValuesForIPFilterTargetType(), false),
 						},
 					},
 				},
 			},
 
 			"allocation_policy": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				Default:  string(iotdpsresource.AllocationPolicyHashed),
-				ValidateFunc: validation.StringInSlice([]string{
-					string(iotdpsresource.AllocationPolicyHashed),
-					string(iotdpsresource.AllocationPolicyGeoLatency),
-					string(iotdpsresource.AllocationPolicyStatic),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				Default:      string(iotdpsresource.AllocationPolicyHashed),
+				ValidateFunc: validation.StringInSlice(iotdpsresource.PossibleValuesForAllocationPolicy(), false),
 			},
 
 			"data_residency_enabled": {

--- a/internal/services/keyvault/key_vault_resource.go
+++ b/internal/services/keyvault/key_vault_resource.go
@@ -86,12 +86,9 @@ func resourceKeyVault() *pluginsdk.Resource {
 			},
 
 			"sku_name": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(vaults.SkuNameStandard),
-					string(vaults.SkuNamePremium),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(vaults.PossibleValuesForSkuName(), false),
 			},
 
 			"tenant_id": {
@@ -154,20 +151,14 @@ func resourceKeyVault() *pluginsdk.Resource {
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
 						"default_action": {
-							Type:     pluginsdk.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(vaults.NetworkRuleActionAllow),
-								string(vaults.NetworkRuleActionDeny),
-							}, false),
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(vaults.PossibleValuesForNetworkRuleAction(), false),
 						},
 						"bypass": {
-							Type:     pluginsdk.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(vaults.NetworkRuleBypassOptionsNone),
-								string(vaults.NetworkRuleBypassOptionsAzureServices),
-							}, false),
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(vaults.PossibleValuesForNetworkRuleBypassOptions(), false),
 						},
 						"ip_rules": {
 							Type:     pluginsdk.TypeSet,

--- a/internal/services/legacy/virtual_machine_resource.go
+++ b/internal/services/legacy/virtual_machine_resource.go
@@ -216,13 +216,10 @@ func resourceVirtualMachine() *pluginsdk.Resource {
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
 						"os_type": {
-							Type:     pluginsdk.TypeString,
-							Optional: true,
-							Computed: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(virtualmachines.OperatingSystemTypesLinux),
-								string(virtualmachines.OperatingSystemTypesWindows),
-							}, false),
+							Type:         pluginsdk.TypeString,
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: validation.StringInSlice(virtualmachines.PossibleValuesForOperatingSystemTypes(), false),
 						},
 
 						"name": {

--- a/internal/services/legacy/virtual_machine_scale_set_resource.go
+++ b/internal/services/legacy/virtual_machine_scale_set_resource.go
@@ -127,13 +127,9 @@ func resourceVirtualMachineScaleSet() *pluginsdk.Resource {
 			},
 
 			"upgrade_policy_mode": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(virtualmachinescalesets.UpgradeModeAutomatic),
-					string(virtualmachinescalesets.UpgradeModeManual),
-					string(virtualmachinescalesets.UpgradeModeRolling),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(virtualmachinescalesets.PossibleValuesForUpgradeMode(), false),
 			},
 
 			"health_probe_id": {
@@ -210,13 +206,10 @@ func resourceVirtualMachineScaleSet() *pluginsdk.Resource {
 			},
 
 			"eviction_policy": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(virtualmachinescalesets.VirtualMachineEvictionPolicyTypesDeallocate),
-					string(virtualmachinescalesets.VirtualMachineEvictionPolicyTypesDelete),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(virtualmachinescalesets.PossibleValuesForVirtualMachineEvictionPolicyTypes(), false),
 			},
 
 			"os_profile": {

--- a/internal/services/loadbalancer/lb_backend_address_pool_resource.go
+++ b/internal/services/loadbalancer/lb_backend_address_pool_resource.go
@@ -85,11 +85,7 @@ func resourceArmLoadBalancerBackendAddressPool() *pluginsdk.Resource {
 							Type:     pluginsdk.TypeString,
 							Required: true,
 							ValidateFunc: validation.StringInSlice(
-								[]string{
-									string(loadbalancers.GatewayLoadBalancerTunnelInterfaceTypeNone),
-									string(loadbalancers.GatewayLoadBalancerTunnelInterfaceTypeInternal),
-									string(loadbalancers.GatewayLoadBalancerTunnelInterfaceTypeExternal),
-								},
+								loadbalancers.PossibleValuesForGatewayLoadBalancerTunnelInterfaceType(),
 								false,
 							),
 						},
@@ -98,11 +94,7 @@ func resourceArmLoadBalancerBackendAddressPool() *pluginsdk.Resource {
 							Type:     pluginsdk.TypeString,
 							Required: true,
 							ValidateFunc: validation.StringInSlice(
-								[]string{
-									string(loadbalancers.GatewayLoadBalancerTunnelProtocolNone),
-									string(loadbalancers.GatewayLoadBalancerTunnelProtocolNative),
-									string(loadbalancers.GatewayLoadBalancerTunnelProtocolVXLAN),
-								},
+								loadbalancers.PossibleValuesForGatewayLoadBalancerTunnelProtocol(),
 								false,
 							),
 						},

--- a/internal/services/loadbalancer/lb_probe_resource.go
+++ b/internal/services/loadbalancer/lb_probe_resource.go
@@ -61,14 +61,10 @@ func resourceArmLoadBalancerProbe() *pluginsdk.Resource {
 			},
 
 			"protocol": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				Default:  string(loadbalancers.ProbeProtocolTcp),
-				ValidateFunc: validation.StringInSlice([]string{
-					string(loadbalancers.ProbeProtocolHTTP),
-					string(loadbalancers.ProbeProtocolHTTPS),
-					string(loadbalancers.ProbeProtocolTcp),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				Default:      string(loadbalancers.ProbeProtocolTcp),
+				ValidateFunc: validation.StringInSlice(loadbalancers.PossibleValuesForProbeProtocol(), false),
 			},
 
 			"port": {

--- a/internal/services/loadbalancer/lb_resource.go
+++ b/internal/services/loadbalancer/lb_resource.go
@@ -65,26 +65,19 @@ func resourceArmLoadBalancer() *pluginsdk.Resource {
 			"edge_zone": commonschema.EdgeZoneOptionalForceNew(),
 
 			"sku": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				Default:  string(loadbalancers.LoadBalancerSkuNameStandard),
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(loadbalancers.LoadBalancerSkuNameBasic),
-					string(loadbalancers.LoadBalancerSkuNameStandard),
-					string(loadbalancers.LoadBalancerSkuNameGateway),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				Default:      string(loadbalancers.LoadBalancerSkuNameStandard),
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(loadbalancers.PossibleValuesForLoadBalancerSkuName(), false),
 			},
 
 			"sku_tier": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				Default:  string(loadbalancers.LoadBalancerSkuTierRegional),
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(loadbalancers.LoadBalancerSkuTierRegional),
-					string(loadbalancers.LoadBalancerSkuTierGlobal),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				Default:      string(loadbalancers.LoadBalancerSkuTierRegional),
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(loadbalancers.PossibleValuesForLoadBalancerSkuTier(), false),
 			},
 
 			"frontend_ip_configuration": {
@@ -120,11 +113,8 @@ func resourceArmLoadBalancer() *pluginsdk.Resource {
 							Type:     pluginsdk.TypeString,
 							Optional: true,
 							// Not using O+C here causes drift
-							Computed: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(loadbalancers.IPVersionIPvFour),
-								string(loadbalancers.IPVersionIPvSix),
-							}, false),
+							Computed:     true,
+							ValidateFunc: validation.StringInSlice(loadbalancers.PossibleValuesForIPVersion(), false),
 						},
 
 						"public_ip_address_id": {
@@ -141,13 +131,10 @@ func resourceArmLoadBalancer() *pluginsdk.Resource {
 						},
 
 						"private_ip_address_allocation": {
-							Type:     pluginsdk.TypeString,
-							Optional: true,
-							Computed: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(loadbalancers.IPAllocationMethodDynamic),
-								string(loadbalancers.IPAllocationMethodStatic),
-							}, true),
+							Type:             pluginsdk.TypeString,
+							Optional:         true,
+							Computed:         true,
+							ValidateFunc:     validation.StringInSlice(loadbalancers.PossibleValuesForIPAllocationMethod(), true),
 							DiffSuppressFunc: suppress.CaseDifference,
 						},
 

--- a/internal/services/loganalytics/log_analytics_linked_storage_account_resource.go
+++ b/internal/services/loganalytics/log_analytics_linked_storage_account_resource.go
@@ -48,16 +48,10 @@ func resourceLogAnalyticsLinkedStorageAccount() *pluginsdk.Resource {
 
 		Schema: map[string]*pluginsdk.Schema{
 			"data_source_type": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(linkedstorageaccounts.DataSourceTypeCustomLogs),
-					string(linkedstorageaccounts.DataSourceTypeAzureWatson),
-					string(linkedstorageaccounts.DataSourceTypeQuery),
-					string(linkedstorageaccounts.DataSourceTypeAlerts),
-					string(linkedstorageaccounts.DataSourceTypeIngestion),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(linkedstorageaccounts.PossibleValuesForDataSourceType(), false),
 			},
 
 			"resource_group_name": commonschema.ResourceGroupName(),

--- a/internal/services/loganalytics/log_analytics_workspace_resource.go
+++ b/internal/services/loganalytics/log_analytics_workspace_resource.go
@@ -92,25 +92,17 @@ func resourceLogAnalyticsWorkspace() *pluginsdk.Resource {
 			"identity": commonschema.SystemOrUserAssignedIdentityOptional(),
 
 			"internet_ingestion_access_type": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				Default:  string(workspaces.PublicNetworkAccessTypeEnabled),
-				ValidateFunc: validation.StringInSlice([]string{
-					string(workspaces.PublicNetworkAccessTypeEnabled),
-					string(workspaces.PublicNetworkAccessTypeDisabled),
-					string(workspaces.PublicNetworkAccessTypeSecuredByPerimeter),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				Default:      string(workspaces.PublicNetworkAccessTypeEnabled),
+				ValidateFunc: validation.StringInSlice(workspaces.PossibleValuesForPublicNetworkAccessType(), false),
 			},
 
 			"internet_query_access_type": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				Default:  string(workspaces.PublicNetworkAccessTypeEnabled),
-				ValidateFunc: validation.StringInSlice([]string{
-					string(workspaces.PublicNetworkAccessTypeEnabled),
-					string(workspaces.PublicNetworkAccessTypeDisabled),
-					string(workspaces.PublicNetworkAccessTypeSecuredByPerimeter),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				Default:      string(workspaces.PublicNetworkAccessTypeEnabled),
+				ValidateFunc: validation.StringInSlice(workspaces.PossibleValuesForPublicNetworkAccessType(), false),
 			},
 
 			"sku": {

--- a/internal/services/loganalytics/log_analytics_workspace_table_resource.go
+++ b/internal/services/loganalytics/log_analytics_workspace_table_resource.go
@@ -63,13 +63,10 @@ func (r LogAnalyticsWorkspaceTableResource) Arguments() map[string]*pluginsdk.Sc
 		},
 
 		"plan": {
-			Type:     pluginsdk.TypeString,
-			Optional: true,
-			Default:  string(tables.TablePlanEnumAnalytics),
-			ValidateFunc: validation.StringInSlice([]string{
-				string(tables.TablePlanEnumAnalytics),
-				string(tables.TablePlanEnumBasic),
-			}, false),
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			Default:      string(tables.TablePlanEnumAnalytics),
+			ValidateFunc: validation.StringInSlice(tables.PossibleValuesForTablePlanEnum(), false),
 		},
 
 		"retention_in_days": {

--- a/internal/services/logic/logic_app_standard_resource.go
+++ b/internal/services/logic/logic_app_standard_resource.go
@@ -173,21 +173,9 @@ func (r LogicAppResource) Arguments() map[string]*pluginsdk.Schema {
 					},
 
 					"type": {
-						Type:     pluginsdk.TypeString,
-						Required: true,
-						ValidateFunc: validation.StringInSlice([]string{
-							string(webapps.ConnectionStringTypeApiHub),
-							string(webapps.ConnectionStringTypeCustom),
-							string(webapps.ConnectionStringTypeDocDb),
-							string(webapps.ConnectionStringTypeEventHub),
-							string(webapps.ConnectionStringTypeMySql),
-							string(webapps.ConnectionStringTypeNotificationHub),
-							string(webapps.ConnectionStringTypePostgreSQL),
-							string(webapps.ConnectionStringTypeRedisCache),
-							string(webapps.ConnectionStringTypeServiceBus),
-							string(webapps.ConnectionStringTypeSQLAzure),
-							string(webapps.ConnectionStringTypeSQLServer),
-						}, false),
+						Type:         pluginsdk.TypeString,
+						Required:     true,
+						ValidateFunc: validation.StringInSlice(webapps.PossibleValuesForConnectionStringType(), false),
 					},
 
 					"value": {

--- a/internal/services/machinelearning/machine_learning_compute_cluster_resource.go
+++ b/internal/services/machinelearning/machine_learning_compute_cluster_resource.go
@@ -68,7 +68,7 @@ func resourceComputeCluster() *pluginsdk.Resource {
 				Type:         pluginsdk.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringInSlice([]string{string(machinelearningcomputes.VMPriorityDedicated), string(machinelearningcomputes.VMPriorityLowPriority)}, false),
+				ValidateFunc: validation.StringInSlice(machinelearningcomputes.PossibleValuesForVMPriority(), false),
 			},
 
 			"identity": commonschema.SystemAssignedUserAssignedIdentityOptional(),

--- a/internal/services/machinelearning/machine_learning_compute_instance_resource.go
+++ b/internal/services/machinelearning/machine_learning_compute_instance_resource.go
@@ -71,12 +71,10 @@ func resourceComputeInstance() *pluginsdk.Resource {
 			},
 
 			"authorization_type": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(machinelearningcomputes.ComputeInstanceAuthorizationTypePersonal),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(machinelearningcomputes.PossibleValuesForComputeInstanceAuthorizationType(), false),
 			},
 
 			"assign_to_user": {

--- a/internal/services/machinelearning/machine_learning_datastore_blobstorage_resource.go
+++ b/internal/services/machinelearning/machine_learning_datastore_blobstorage_resource.go
@@ -96,11 +96,7 @@ func (r MachineLearningDataStoreBlobStorage) Arguments() map[string]*pluginsdk.S
 		"service_data_auth_identity": {
 			Type:     pluginsdk.TypeString,
 			Optional: true,
-			ValidateFunc: validation.StringInSlice([]string{
-				string(datastore.ServiceDataAccessAuthIdentityNone),
-				string(datastore.ServiceDataAccessAuthIdentityWorkspaceSystemAssignedIdentity),
-				string(datastore.ServiceDataAccessAuthIdentityWorkspaceUserAssignedIdentity),
-			},
+			ValidateFunc: validation.StringInSlice(datastore.PossibleValuesForServiceDataAccessAuthIdentity(),
 				false),
 			Default: string(datastore.ServiceDataAccessAuthIdentityNone),
 		},

--- a/internal/services/machinelearning/machine_learning_datastore_datalake_gen2_resource.go
+++ b/internal/services/machinelearning/machine_learning_datastore_datalake_gen2_resource.go
@@ -117,11 +117,7 @@ func (r MachineLearningDataStoreDataLakeGen2) Arguments() map[string]*pluginsdk.
 		"service_data_identity": {
 			Type:     pluginsdk.TypeString,
 			Optional: true,
-			ValidateFunc: validation.StringInSlice([]string{
-				string(datastore.ServiceDataAccessAuthIdentityNone),
-				string(datastore.ServiceDataAccessAuthIdentityWorkspaceSystemAssignedIdentity),
-				string(datastore.ServiceDataAccessAuthIdentityWorkspaceUserAssignedIdentity),
-			},
+			ValidateFunc: validation.StringInSlice(datastore.PossibleValuesForServiceDataAccessAuthIdentity(),
 				false),
 			Default: string(datastore.ServiceDataAccessAuthIdentityNone),
 		},

--- a/internal/services/machinelearning/machine_learning_datastore_fileshare_resource.go
+++ b/internal/services/machinelearning/machine_learning_datastore_fileshare_resource.go
@@ -99,11 +99,7 @@ func (r MachineLearningDataStoreFileShare) Arguments() map[string]*pluginsdk.Sch
 		"service_data_identity": {
 			Type:     pluginsdk.TypeString,
 			Optional: true,
-			ValidateFunc: validation.StringInSlice([]string{
-				string(datastore.ServiceDataAccessAuthIdentityNone),
-				string(datastore.ServiceDataAccessAuthIdentityWorkspaceSystemAssignedIdentity),
-				string(datastore.ServiceDataAccessAuthIdentityWorkspaceUserAssignedIdentity),
-			},
+			ValidateFunc: validation.StringInSlice(datastore.PossibleValuesForServiceDataAccessAuthIdentity(),
 				false),
 			Default: string(datastore.ServiceDataAccessAuthIdentityNone),
 		},

--- a/internal/services/machinelearning/machine_learning_inference_cluster_resource.go
+++ b/internal/services/machinelearning/machine_learning_inference_cluster_resource.go
@@ -67,15 +67,11 @@ func resourceAksInferenceCluster() *pluginsdk.Resource {
 			},
 
 			"cluster_purpose": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Default:  string(machinelearningcomputes.ClusterPurposeFastProd),
-				ValidateFunc: validation.StringInSlice([]string{
-					string(machinelearningcomputes.ClusterPurposeDevTest),
-					string(machinelearningcomputes.ClusterPurposeFastProd),
-					string(machinelearningcomputes.ClusterPurposeDenseProd),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Default:      string(machinelearningcomputes.ClusterPurposeFastProd),
+				ValidateFunc: validation.StringInSlice(machinelearningcomputes.PossibleValuesForClusterPurpose(), false),
 			},
 
 			"description": {

--- a/internal/services/maintenance/maintenance_assignment_dynamic_scope_resource.go
+++ b/internal/services/maintenance/maintenance_assignment_dynamic_scope_resource.go
@@ -128,13 +128,10 @@ func (MaintenanceDynamicScopeResource) Arguments() map[string]*pluginsdk.Schema 
 					},
 
 					"tag_filter": {
-						Type:     pluginsdk.TypeString,
-						Optional: true,
-						Default:  configurationassignments.TagOperatorsAny,
-						ValidateFunc: validation.StringInSlice([]string{
-							string(configurationassignments.TagOperatorsAny),
-							string(configurationassignments.TagOperatorsAll),
-						}, true),
+						Type:         pluginsdk.TypeString,
+						Optional:     true,
+						Default:      configurationassignments.TagOperatorsAny,
+						ValidateFunc: validation.StringInSlice(configurationassignments.PossibleValuesForTagOperators(), true),
 						RequiredWith: []string{
 							"filter.0.tags",
 						},

--- a/internal/services/managedapplications/managed_application_definition_resource.go
+++ b/internal/services/managedapplications/managed_application_definition_resource.go
@@ -60,14 +60,10 @@ func resourceManagedApplicationDefinition() *pluginsdk.Resource {
 			},
 
 			"lock_level": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(applicationdefinitions.ApplicationLockLevelCanNotDelete),
-					string(applicationdefinitions.ApplicationLockLevelNone),
-					string(applicationdefinitions.ApplicationLockLevelReadOnly),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(applicationdefinitions.PossibleValuesForApplicationLockLevel(), false),
 			},
 
 			"authorization": {

--- a/internal/services/manageddevopspools/managed_devops_pool_resource.go
+++ b/internal/services/manageddevopspools/managed_devops_pool_resource.go
@@ -117,14 +117,10 @@ func (ManagedDevOpsPoolResource) Arguments() map[string]*pluginsdk.Schema {
 						Elem: &pluginsdk.Resource{
 							Schema: map[string]*pluginsdk.Schema{
 								"kind": {
-									Type:     pluginsdk.TypeString,
-									Required: true,
-									ForceNew: true,
-									ValidateFunc: validation.StringInSlice([]string{
-										string(pools.AzureDevOpsPermissionTypeCreatorOnly),
-										string(pools.AzureDevOpsPermissionTypeInherit),
-										string(pools.AzureDevOpsPermissionTypeSpecificAccounts),
-									}, false),
+									Type:         pluginsdk.TypeString,
+									Required:     true,
+									ForceNew:     true,
+									ValidateFunc: validation.StringInSlice(pools.PossibleValuesForAzureDevOpsPermissionType(), false),
 								},
 
 								"administrator_account": {

--- a/internal/services/managedhsm/key_vault_managed_hardware_security_module_resource.go
+++ b/internal/services/managedhsm/key_vault_managed_hardware_security_module_resource.go
@@ -126,20 +126,14 @@ func resourceKeyVaultManagedHardwareSecurityModule() *pluginsdk.Resource {
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
 						"default_action": {
-							Type:     pluginsdk.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(managedhsms.NetworkRuleActionAllow),
-								string(managedhsms.NetworkRuleActionDeny),
-							}, false),
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(managedhsms.PossibleValuesForNetworkRuleAction(), false),
 						},
 						"bypass": {
-							Type:     pluginsdk.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(managedhsms.NetworkRuleBypassOptionsNone),
-								string(managedhsms.NetworkRuleBypassOptionsAzureServices),
-							}, false),
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(managedhsms.PossibleValuesForNetworkRuleBypassOptions(), false),
 						},
 					},
 				},

--- a/internal/services/maps/maps_account_resource.go
+++ b/internal/services/maps/maps_account_resource.go
@@ -58,14 +58,10 @@ func resourceMapsAccount() *pluginsdk.Resource {
 			"location": commonschema.Location(),
 
 			"sku_name": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(accounts.NameSZero),
-					string(accounts.NameSOne),
-					string(accounts.NameGTwo),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(accounts.PossibleValuesForName(), false),
 			},
 
 			"cors": {

--- a/internal/services/monitor/monitor_autoscale_setting_resource.go
+++ b/internal/services/monitor/monitor_autoscale_setting_resource.go
@@ -181,28 +181,14 @@ func resourceMonitorAutoScaleSetting() *pluginsdk.Resource {
 													ValidateFunc: validate.ISO8601Duration,
 												},
 												"time_aggregation": {
-													Type:     pluginsdk.TypeString,
-													Required: true,
-													ValidateFunc: validation.StringInSlice([]string{
-														string(autoscalesettings.TimeAggregationTypeAverage),
-														string(autoscalesettings.TimeAggregationTypeCount),
-														string(autoscalesettings.TimeAggregationTypeMaximum),
-														string(autoscalesettings.TimeAggregationTypeMinimum),
-														string(autoscalesettings.TimeAggregationTypeTotal),
-														string(autoscalesettings.TimeAggregationTypeLast),
-													}, false),
+													Type:         pluginsdk.TypeString,
+													Required:     true,
+													ValidateFunc: validation.StringInSlice(autoscalesettings.PossibleValuesForTimeAggregationType(), false),
 												},
 												"operator": {
-													Type:     pluginsdk.TypeString,
-													Required: true,
-													ValidateFunc: validation.StringInSlice([]string{
-														string(autoscalesettings.ComparisonOperationTypeEquals),
-														string(autoscalesettings.ComparisonOperationTypeGreaterThan),
-														string(autoscalesettings.ComparisonOperationTypeGreaterThanOrEqual),
-														string(autoscalesettings.ComparisonOperationTypeLessThan),
-														string(autoscalesettings.ComparisonOperationTypeLessThanOrEqual),
-														string(autoscalesettings.ComparisonOperationTypeNotEquals),
-													}, false),
+													Type:         pluginsdk.TypeString,
+													Required:     true,
+													ValidateFunc: validation.StringInSlice(autoscalesettings.PossibleValuesForComparisonOperationType(), false),
 												},
 												"threshold": {
 													Type:     pluginsdk.TypeFloat,
@@ -232,12 +218,9 @@ func resourceMonitorAutoScaleSetting() *pluginsdk.Resource {
 															},
 
 															"operator": {
-																Type:     pluginsdk.TypeString,
-																Required: true,
-																ValidateFunc: validation.StringInSlice([]string{
-																	string(autoscalesettings.ScaleRuleMetricDimensionOperationTypeEquals),
-																	string(autoscalesettings.ScaleRuleMetricDimensionOperationTypeNotEquals),
-																}, false),
+																Type:         pluginsdk.TypeString,
+																Required:     true,
+																ValidateFunc: validation.StringInSlice(autoscalesettings.PossibleValuesForScaleRuleMetricDimensionOperationType(), false),
 															},
 
 															"values": {
@@ -269,14 +252,9 @@ func resourceMonitorAutoScaleSetting() *pluginsdk.Resource {
 													}, false),
 												},
 												"type": {
-													Type:     pluginsdk.TypeString,
-													Required: true,
-													ValidateFunc: validation.StringInSlice([]string{
-														string(autoscalesettings.ScaleTypeChangeCount),
-														string(autoscalesettings.ScaleTypeExactCount),
-														string(autoscalesettings.ScaleTypePercentChangeCount),
-														string(autoscalesettings.ScaleTypeServiceAllowedNextValue),
-													}, false),
+													Type:         pluginsdk.TypeString,
+													Required:     true,
+													ValidateFunc: validation.StringInSlice(autoscalesettings.PossibleValuesForScaleType(), false),
 												},
 												"value": {
 													Type:         pluginsdk.TypeInt,

--- a/internal/services/monitor/monitor_metric_alert_resource.go
+++ b/internal/services/monitor/monitor_metric_alert_resource.go
@@ -154,15 +154,9 @@ func resourceMonitorMetricAlert() *pluginsdk.Resource {
 							},
 						},
 						"operator": {
-							Type:     pluginsdk.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(metricalerts.OperatorEquals),
-								string(metricalerts.OperatorGreaterThan),
-								string(metricalerts.OperatorGreaterThanOrEqual),
-								string(metricalerts.OperatorLessThan),
-								string(metricalerts.OperatorLessThanOrEqual),
-							}, false),
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(metricalerts.PossibleValuesForOperator(), false),
 						},
 						"threshold": {
 							Type:     pluginsdk.TypeFloat,
@@ -239,22 +233,14 @@ func resourceMonitorMetricAlert() *pluginsdk.Resource {
 							},
 						},
 						"operator": {
-							Type:     pluginsdk.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(metricalerts.DynamicThresholdOperatorLessThan),
-								string(metricalerts.DynamicThresholdOperatorGreaterThan),
-								string(metricalerts.DynamicThresholdOperatorGreaterOrLessThan),
-							}, false),
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(metricalerts.PossibleValuesForDynamicThresholdOperator(), false),
 						},
 						"alert_sensitivity": {
-							Type:     pluginsdk.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(metricalerts.DynamicThresholdSensitivityLow),
-								string(metricalerts.DynamicThresholdSensitivityMedium),
-								string(metricalerts.DynamicThresholdSensitivityHigh),
-							}, false),
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(metricalerts.PossibleValuesForDynamicThresholdSensitivity(), false),
 						},
 
 						"evaluation_total_count": {

--- a/internal/services/monitor/monitor_scheduled_query_rules_alert_v2_resource.go
+++ b/internal/services/monitor/monitor_scheduled_query_rules_alert_v2_resource.go
@@ -139,15 +139,9 @@ func (r ScheduledQueryRulesAlertV2Resource) Arguments() map[string]*pluginsdk.Sc
 					},
 
 					"time_aggregation_method": {
-						Type:     pluginsdk.TypeString,
-						Required: true,
-						ValidateFunc: validation.StringInSlice([]string{
-							string(scheduledqueryrules.TimeAggregationCount),
-							string(scheduledqueryrules.TimeAggregationAverage),
-							string(scheduledqueryrules.TimeAggregationMinimum),
-							string(scheduledqueryrules.TimeAggregationMaximum),
-							string(scheduledqueryrules.TimeAggregationTotal),
-						}, false),
+						Type:         pluginsdk.TypeString,
+						Required:     true,
+						ValidateFunc: validation.StringInSlice(scheduledqueryrules.PossibleValuesForTimeAggregation(), false),
 					},
 
 					"threshold": {
@@ -167,12 +161,9 @@ func (r ScheduledQueryRulesAlertV2Resource) Arguments() map[string]*pluginsdk.Sc
 								},
 
 								"operator": {
-									Type:     pluginsdk.TypeString,
-									Required: true,
-									ValidateFunc: validation.StringInSlice([]string{
-										string(scheduledqueryrules.DimensionOperatorInclude),
-										string(scheduledqueryrules.DimensionOperatorExclude),
-									}, false),
+									Type:         pluginsdk.TypeString,
+									Required:     true,
+									ValidateFunc: validation.StringInSlice(scheduledqueryrules.PossibleValuesForDimensionOperator(), false),
 								},
 
 								"values": {

--- a/internal/services/monitor/monitor_smart_detector_alert_rule_resource.go
+++ b/internal/services/monitor/monitor_smart_detector_alert_rule_resource.go
@@ -88,13 +88,7 @@ func resourceMonitorSmartDetectorAlertRule() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeString,
 				Required: true,
 				ValidateFunc: validation.StringInSlice(
-					[]string{
-						string(smartdetectoralertrules.SeveritySevZero),
-						string(smartdetectoralertrules.SeveritySevOne),
-						string(smartdetectoralertrules.SeveritySevTwo),
-						string(smartdetectoralertrules.SeveritySevThree),
-						string(smartdetectoralertrules.SeveritySevFour),
-					}, false,
+					smartdetectoralertrules.PossibleValuesForSeverity(), false,
 				),
 			},
 

--- a/internal/services/mssql/mssql_database_resource.go
+++ b/internal/services/mssql/mssql_database_resource.go
@@ -1605,12 +1605,9 @@ func resourceMsSqlDatabaseSchema() map[string]*pluginsdk.Schema {
 		},
 
 		"enclave_type": {
-			Type:     pluginsdk.TypeString,
-			Optional: true,
-			ValidateFunc: validation.StringInSlice([]string{
-				string(databases.AlwaysEncryptedEnclaveTypeVBS),
-				string(databases.AlwaysEncryptedEnclaveTypeDefault),
-			}, false),
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.StringInSlice(databases.PossibleValuesForAlwaysEncryptedEnclaveType(), false),
 		},
 
 		"license_type": {

--- a/internal/services/mssql/mssql_database_vulnerability_assessment_rule_baseline_resource.go
+++ b/internal/services/mssql/mssql_database_vulnerability_assessment_rule_baseline_resource.go
@@ -60,14 +60,11 @@ func resourceMsSqlDatabaseVulnerabilityAssessmentRuleBaseline() *pluginsdk.Resou
 			},
 
 			"baseline_name": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Default:  string(databasevulnerabilityassessmentrulebaselines.VulnerabilityAssessmentPolicyBaselineNameDefault),
-				ValidateFunc: validation.StringInSlice([]string{
-					string(databasevulnerabilityassessmentrulebaselines.VulnerabilityAssessmentPolicyBaselineNameDefault),
-					string(databasevulnerabilityassessmentrulebaselines.VulnerabilityAssessmentPolicyBaselineNameMaster),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Default:      string(databasevulnerabilityassessmentrulebaselines.VulnerabilityAssessmentPolicyBaselineNameDefault),
+				ValidateFunc: validation.StringInSlice(databasevulnerabilityassessmentrulebaselines.PossibleValuesForVulnerabilityAssessmentPolicyBaselineName(), false),
 			},
 
 			"baseline_result": {

--- a/internal/services/mssql/mssql_elasticpool_resource.go
+++ b/internal/services/mssql/mssql_elasticpool_resource.go
@@ -185,22 +185,16 @@ func resourceMsSqlElasticPool() *pluginsdk.Resource {
 			// DC skus, where elasticpools allows 'Default' but will error if you try to set the
 			// 'enclave_type' to 'VBS' for DC skus...
 			"enclave_type": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(databases.AlwaysEncryptedEnclaveTypeVBS),
-					string(databases.AlwaysEncryptedEnclaveTypeDefault),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(databases.PossibleValuesForAlwaysEncryptedEnclaveType(), false),
 			},
 
 			"license_type": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				Computed: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(elasticpools.ElasticPoolLicenseTypeBasePrice),
-					string(elasticpools.ElasticPoolLicenseTypeLicenseIncluded),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringInSlice(elasticpools.PossibleValuesForElasticPoolLicenseType(), false),
 			},
 
 			"high_availability_replica_count": {

--- a/internal/services/mssql/mssql_failover_group_resource.go
+++ b/internal/services/mssql/mssql_failover_group_resource.go
@@ -124,12 +124,9 @@ func (r MsSqlFailoverGroupResource) Arguments() map[string]*pluginsdk.Schema {
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
 					"mode": {
-						Type:     pluginsdk.TypeString,
-						Required: true,
-						ValidateFunc: validation.StringInSlice([]string{
-							string(failovergroups.ReadWriteEndpointFailoverPolicyAutomatic),
-							string(failovergroups.ReadWriteEndpointFailoverPolicyManual),
-						}, false),
+						Type:         pluginsdk.TypeString,
+						Required:     true,
+						ValidateFunc: validation.StringInSlice(failovergroups.PossibleValuesForReadWriteEndpointFailoverPolicy(), false),
 					},
 					"grace_minutes": {
 						Type:         pluginsdk.TypeInt,

--- a/internal/services/mssql/mssql_virtual_machine_availability_group_listener_resource.go
+++ b/internal/services/mssql/mssql_virtual_machine_availability_group_listener_resource.go
@@ -202,28 +202,28 @@ func (r MsSqlVirtualMachineAvailabilityGroupListenerResource) Arguments() map[st
 						Type:         pluginsdk.TypeString,
 						Required:     true,
 						ForceNew:     true,
-						ValidateFunc: validation.StringInSlice([]string{string(availabilitygrouplisteners.RolePrimary), string(availabilitygrouplisteners.RoleSecondary)}, false),
+						ValidateFunc: validation.StringInSlice(availabilitygrouplisteners.PossibleValuesForRole(), false),
 					},
 
 					"commit": {
 						Type:         pluginsdk.TypeString,
 						Required:     true,
 						ForceNew:     true,
-						ValidateFunc: validation.StringInSlice([]string{string(availabilitygrouplisteners.CommitSynchronousCommit), string(availabilitygrouplisteners.CommitAsynchronousCommit)}, false),
+						ValidateFunc: validation.StringInSlice(availabilitygrouplisteners.PossibleValuesForCommit(), false),
 					},
 
 					"failover_mode": {
 						Type:         pluginsdk.TypeString,
 						Required:     true,
 						ForceNew:     true,
-						ValidateFunc: validation.StringInSlice([]string{string(availabilitygrouplisteners.FailoverManual), string(availabilitygrouplisteners.FailoverAutomatic)}, false),
+						ValidateFunc: validation.StringInSlice(availabilitygrouplisteners.PossibleValuesForFailover(), false),
 					},
 
 					"readable_secondary": {
 						Type:         pluginsdk.TypeString,
 						Required:     true,
 						ForceNew:     true,
-						ValidateFunc: validation.StringInSlice([]string{string(availabilitygrouplisteners.ReadableSecondaryNo), string(availabilitygrouplisteners.ReadableSecondaryReadOnly), string(availabilitygrouplisteners.ReadableSecondaryAll)}, false),
+						ValidateFunc: validation.StringInSlice(availabilitygrouplisteners.PossibleValuesForReadableSecondary(), false),
 					},
 				},
 			},

--- a/internal/services/mssql/mssql_virtual_machine_group_resource.go
+++ b/internal/services/mssql/mssql_virtual_machine_group_resource.go
@@ -83,12 +83,9 @@ func (r MsSqlVirtualMachineGroupResource) Arguments() map[string]*pluginsdk.Sche
 		},
 
 		"sql_image_sku": {
-			Type:     pluginsdk.TypeString,
-			Required: true,
-			ValidateFunc: validation.StringInSlice([]string{
-				string(sqlvirtualmachinegroups.SqlVMGroupImageSkuDeveloper),
-				string(sqlvirtualmachinegroups.SqlVMGroupImageSkuEnterprise),
-			}, false),
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: validation.StringInSlice(sqlvirtualmachinegroups.PossibleValuesForSqlVMGroupImageSku(), false),
 		},
 
 		"wsfc_domain_profile": {
@@ -98,13 +95,10 @@ func (r MsSqlVirtualMachineGroupResource) Arguments() map[string]*pluginsdk.Sche
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
 					"cluster_subnet_type": {
-						Type:     pluginsdk.TypeString,
-						Required: true,
-						ForceNew: true,
-						ValidateFunc: validation.StringInSlice([]string{
-							string(sqlvirtualmachinegroups.ClusterSubnetTypeMultiSubnet),
-							string(sqlvirtualmachinegroups.ClusterSubnetTypeSingleSubnet),
-						}, false),
+						Type:         pluginsdk.TypeString,
+						Required:     true,
+						ForceNew:     true,
+						ValidateFunc: validation.StringInSlice(sqlvirtualmachinegroups.PossibleValuesForClusterSubnetType(), false),
 					},
 
 					"fqdn": {

--- a/internal/services/mssql/mssql_virtual_machine_resource.go
+++ b/internal/services/mssql/mssql_virtual_machine_resource.go
@@ -64,14 +64,10 @@ func resourceMsSqlVirtualMachine() *pluginsdk.Resource {
 			},
 
 			"sql_license_type": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(sqlvirtualmachines.SqlServerLicenseTypePAYG),
-					string(sqlvirtualmachines.SqlServerLicenseTypeAHUB),
-					string(sqlvirtualmachines.SqlServerLicenseTypeDR),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(sqlvirtualmachines.PossibleValuesForSqlServerLicenseType(), false),
 			},
 
 			"auto_backup": {
@@ -97,10 +93,7 @@ func resourceMsSqlVirtualMachine() *pluginsdk.Resource {
 										Type:             pluginsdk.TypeString,
 										Required:         true,
 										DiffSuppressFunc: suppress.CaseDifference,
-										ValidateFunc: validation.StringInSlice([]string{
-											string(sqlvirtualmachines.FullBackupFrequencyTypeDaily),
-											string(sqlvirtualmachines.FullBackupFrequencyTypeWeekly),
-										}, false),
+										ValidateFunc:     validation.StringInSlice(sqlvirtualmachines.PossibleValuesForFullBackupFrequencyType(), false),
 									},
 
 									"full_backup_start_hour": {
@@ -126,16 +119,8 @@ func resourceMsSqlVirtualMachine() *pluginsdk.Resource {
 										Optional: true,
 										MinItems: 1,
 										Elem: &pluginsdk.Schema{
-											Type: pluginsdk.TypeString,
-											ValidateFunc: validation.StringInSlice([]string{
-												string(sqlvirtualmachines.AutoBackupDaysOfWeekMonday),
-												string(sqlvirtualmachines.AutoBackupDaysOfWeekTuesday),
-												string(sqlvirtualmachines.AutoBackupDaysOfWeekWednesday),
-												string(sqlvirtualmachines.AutoBackupDaysOfWeekThursday),
-												string(sqlvirtualmachines.AutoBackupDaysOfWeekFriday),
-												string(sqlvirtualmachines.AutoBackupDaysOfWeekSaturday),
-												string(sqlvirtualmachines.AutoBackupDaysOfWeekSunday),
-											}, false),
+											Type:         pluginsdk.TypeString,
+											ValidateFunc: validation.StringInSlice(sqlvirtualmachines.PossibleValuesForAutoBackupDaysOfWeek(), false),
 										},
 									},
 								},
@@ -312,14 +297,10 @@ func resourceMsSqlVirtualMachine() *pluginsdk.Resource {
 			},
 
 			"sql_connectivity_type": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				Default:  string(sqlvirtualmachines.ConnectivityTypePRIVATE),
-				ValidateFunc: validation.StringInSlice([]string{
-					string(sqlvirtualmachines.ConnectivityTypeLOCAL),
-					string(sqlvirtualmachines.ConnectivityTypePRIVATE),
-					string(sqlvirtualmachines.ConnectivityTypePUBLIC),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				Default:      string(sqlvirtualmachines.ConnectivityTypePRIVATE),
+				ValidateFunc: validation.StringInSlice(sqlvirtualmachines.PossibleValuesForConnectivityType(), false),
 			},
 
 			"sql_connectivity_update_password": {
@@ -401,22 +382,14 @@ func resourceMsSqlVirtualMachine() *pluginsdk.Resource {
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
 						"disk_type": {
-							Type:     pluginsdk.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(sqlvirtualmachines.DiskConfigurationTypeNEW),
-								string(sqlvirtualmachines.DiskConfigurationTypeEXTEND),
-								string(sqlvirtualmachines.DiskConfigurationTypeADD),
-							}, false),
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(sqlvirtualmachines.PossibleValuesForDiskConfigurationType(), false),
 						},
 						"storage_workload_type": {
-							Type:     pluginsdk.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(sqlvirtualmachines.SqlWorkloadTypeGENERAL),
-								string(sqlvirtualmachines.SqlWorkloadTypeOLTP),
-								string(sqlvirtualmachines.SqlWorkloadTypeDW),
-							}, false),
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(sqlvirtualmachines.PossibleValuesForSqlWorkloadType(), false),
 						},
 						"system_db_on_data_disk_enabled": {
 							Type:     pluginsdk.TypeBool,

--- a/internal/services/mssqlmanagedinstance/mssql_managed_instance_failover_group_resource.go
+++ b/internal/services/mssqlmanagedinstance/mssql_managed_instance_failover_group_resource.go
@@ -102,12 +102,9 @@ func (r MsSqlManagedInstanceFailoverGroupResource) Arguments() map[string]*plugi
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
 					"mode": {
-						Type:     pluginsdk.TypeString,
-						Required: true,
-						ValidateFunc: validation.StringInSlice([]string{
-							string(instancefailovergroups.ReadWriteEndpointFailoverPolicyAutomatic),
-							string(instancefailovergroups.ReadWriteEndpointFailoverPolicyManual),
-						}, false),
+						Type:         pluginsdk.TypeString,
+						Required:     true,
+						ValidateFunc: validation.StringInSlice(instancefailovergroups.PossibleValuesForReadWriteEndpointFailoverPolicy(), false),
 					},
 
 					"grace_minutes": {

--- a/internal/services/mysql/mysql_flexible_server_resource.go
+++ b/internal/services/mysql/mysql_flexible_server_resource.go
@@ -112,15 +112,10 @@ func resourceMysqlFlexibleServer() *pluginsdk.Resource {
 			},
 
 			"create_mode": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(servers.CreateModeDefault),
-					string(servers.CreateModeGeoRestore),
-					string(servers.CreateModePointInTimeRestore),
-					string(servers.CreateModeReplica),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(servers.PossibleValuesForCreateMode(), false),
 			},
 
 			"customer_managed_key": {
@@ -314,14 +309,10 @@ func resourceMysqlFlexibleServer() *pluginsdk.Resource {
 			},
 
 			"version": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				Computed: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(servers.ServerVersionFivePointSeven),
-					string(servers.ServerVersionEightPointZeroPointTwoOne),
-					string(validate.ServerVersionEightPointFour),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringInSlice(servers.PossibleValuesForServerVersion(), false),
 			},
 
 			"zone": commonschema.ZoneSingleOptionalComputed(),

--- a/internal/services/mysql/mysql_flexible_server_resource.go
+++ b/internal/services/mysql/mysql_flexible_server_resource.go
@@ -309,10 +309,14 @@ func resourceMysqlFlexibleServer() *pluginsdk.Resource {
 			},
 
 			"version": {
-				Type:         pluginsdk.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validation.StringInSlice(servers.PossibleValuesForServerVersion(), false),
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				Computed: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(servers.ServerVersionFivePointSeven),
+					string(servers.ServerVersionEightPointZeroPointTwoOne),
+					string(validate.ServerVersionEightPointFour),
+				}, false),
 			},
 
 			"zone": commonschema.ZoneSingleOptionalComputed(),

--- a/internal/services/netapp/netapp_pool_resource.go
+++ b/internal/services/netapp/netapp_pool_resource.go
@@ -81,24 +81,18 @@ func resourceNetAppPool() *pluginsdk.Resource {
 			},
 
 			"qos_type": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				Default:  string(capacitypools.QosTypeAuto),
-				ValidateFunc: validation.StringInSlice([]string{
-					string(capacitypools.QosTypeAuto),
-					string(capacitypools.QosTypeManual),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				Default:      string(capacitypools.QosTypeAuto),
+				ValidateFunc: validation.StringInSlice(capacitypools.PossibleValuesForQosType(), false),
 			},
 
 			"encryption_type": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Default:  capacitypools.EncryptionTypeSingle,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(capacitypools.EncryptionTypeSingle),
-					string(capacitypools.EncryptionTypeDouble),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Default:      capacitypools.EncryptionTypeSingle,
+				ValidateFunc: validation.StringInSlice(capacitypools.PossibleValuesForEncryptionType(), false),
 			},
 
 			"cool_access_enabled": {

--- a/internal/services/network/application_gateway_resource.go
+++ b/internal/services/network/application_gateway_resource.go
@@ -60,24 +60,15 @@ func sslProfileSchema(computed bool) *pluginsdk.Schema {
 					Type:     pluginsdk.TypeList,
 					Optional: true,
 					Elem: &pluginsdk.Schema{
-						Type: pluginsdk.TypeString,
-						ValidateFunc: validation.StringInSlice([]string{
-							string(applicationgateways.ApplicationGatewaySslProtocolTLSvOneZero),
-							string(applicationgateways.ApplicationGatewaySslProtocolTLSvOneOne),
-							string(applicationgateways.ApplicationGatewaySslProtocolTLSvOneTwo),
-							string(applicationgateways.ApplicationGatewaySslProtocolTLSvOneThree),
-						}, false),
+						Type:         pluginsdk.TypeString,
+						ValidateFunc: validation.StringInSlice(applicationgateways.PossibleValuesForApplicationGatewaySslProtocol(), false),
 					},
 				},
 
 				"policy_type": {
-					Type:     pluginsdk.TypeString,
-					Optional: true,
-					ValidateFunc: validation.StringInSlice([]string{
-						string(applicationgateways.ApplicationGatewaySslPolicyTypeCustom),
-						string(applicationgateways.ApplicationGatewaySslPolicyTypeCustomVTwo),
-						string(applicationgateways.ApplicationGatewaySslPolicyTypePredefined),
-					}, false),
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringInSlice(applicationgateways.PossibleValuesForApplicationGatewaySslPolicyType(), false),
 				},
 
 				"policy_name": {
@@ -95,14 +86,9 @@ func sslProfileSchema(computed bool) *pluginsdk.Schema {
 				},
 
 				"min_protocol_version": {
-					Type:     pluginsdk.TypeString,
-					Optional: true,
-					ValidateFunc: validation.StringInSlice([]string{
-						string(applicationgateways.ApplicationGatewaySslProtocolTLSvOneZero),
-						string(applicationgateways.ApplicationGatewaySslProtocolTLSvOneOne),
-						string(applicationgateways.ApplicationGatewaySslProtocolTLSvOneTwo),
-						string(applicationgateways.ApplicationGatewaySslProtocolTLSvOneThree),
-					}, false),
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringInSlice(applicationgateways.PossibleValuesForApplicationGatewaySslProtocol(), false),
 				},
 			},
 		},
@@ -420,13 +406,10 @@ func resourceApplicationGateway() *pluginsdk.Resource {
 						},
 
 						"private_ip_address_allocation": {
-							Type:     pluginsdk.TypeString,
-							Optional: true,
-							Default:  string(applicationgateways.IPAllocationMethodDynamic),
-							ValidateFunc: validation.StringInSlice([]string{
-								string(applicationgateways.IPAllocationMethodDynamic),
-								string(applicationgateways.IPAllocationMethodStatic),
-							}, false),
+							Type:         pluginsdk.TypeString,
+							Optional:     true,
+							Default:      string(applicationgateways.IPAllocationMethodDynamic),
+							ValidateFunc: validation.StringInSlice(applicationgateways.PossibleValuesForIPAllocationMethod(), false),
 						},
 
 						"private_link_configuration_name": {
@@ -772,12 +755,9 @@ func resourceApplicationGateway() *pluginsdk.Resource {
 									},
 
 									"private_ip_address_allocation": {
-										Type:     pluginsdk.TypeString,
-										Required: true,
-										ValidateFunc: validation.StringInSlice([]string{
-											string(applicationgateways.IPAllocationMethodDynamic),
-											string(applicationgateways.IPAllocationMethodStatic),
-										}, false),
+										Type:         pluginsdk.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringInSlice(applicationgateways.PossibleValuesForIPAllocationMethod(), false),
 									},
 
 									"primary": {
@@ -808,12 +788,9 @@ func resourceApplicationGateway() *pluginsdk.Resource {
 						},
 
 						"rule_type": {
-							Type:     pluginsdk.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(applicationgateways.ApplicationGatewayRequestRoutingRuleTypeBasic),
-								string(applicationgateways.ApplicationGatewayRequestRoutingRuleTypePathBasedRouting),
-							}, false),
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(applicationgateways.PossibleValuesForApplicationGatewayRequestRoutingRuleType(), false),
 						},
 
 						"http_listener_name": {
@@ -964,14 +941,9 @@ func resourceApplicationGateway() *pluginsdk.Resource {
 						},
 
 						"redirect_type": {
-							Type:     pluginsdk.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(applicationgateways.ApplicationGatewayRedirectTypePermanent),
-								string(applicationgateways.ApplicationGatewayRedirectTypeTemporary),
-								string(applicationgateways.ApplicationGatewayRedirectTypeFound),
-								string(applicationgateways.ApplicationGatewayRedirectTypeSeeOther),
-							}, false),
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(applicationgateways.PossibleValuesForApplicationGatewayRedirectType(), false),
 						},
 
 						"target_listener_name": {
@@ -1036,30 +1008,15 @@ func resourceApplicationGateway() *pluginsdk.Resource {
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
 						"name": {
-							Type:     pluginsdk.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(applicationgateways.ApplicationGatewaySkuNameBasic),
-								string(applicationgateways.ApplicationGatewaySkuNameStandardSmall),
-								string(applicationgateways.ApplicationGatewaySkuNameStandardMedium),
-								string(applicationgateways.ApplicationGatewaySkuNameStandardLarge),
-								string(applicationgateways.ApplicationGatewaySkuNameStandardVTwo),
-								string(applicationgateways.ApplicationGatewaySkuNameWAFLarge),
-								string(applicationgateways.ApplicationGatewaySkuNameWAFMedium),
-								string(applicationgateways.ApplicationGatewaySkuNameWAFVTwo),
-							}, false),
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(applicationgateways.PossibleValuesForApplicationGatewaySkuName(), false),
 						},
 
 						"tier": {
-							Type:     pluginsdk.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(applicationgateways.ApplicationGatewayTierBasic),
-								string(applicationgateways.ApplicationGatewayTierStandard),
-								string(applicationgateways.ApplicationGatewayTierStandardVTwo),
-								string(applicationgateways.ApplicationGatewayTierWAF),
-								string(applicationgateways.ApplicationGatewayTierWAFVTwo),
-							}, false),
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(applicationgateways.PossibleValuesForApplicationGatewayTier(), false),
 						},
 
 						"capacity": {
@@ -1135,14 +1092,9 @@ func resourceApplicationGateway() *pluginsdk.Resource {
 						},
 
 						"protocol": {
-							Type:     pluginsdk.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(applicationgateways.ApplicationGatewayProtocolHTTP),
-								string(applicationgateways.ApplicationGatewayProtocolHTTPS),
-								string(applicationgateways.ApplicationGatewayProtocolTcp),
-								string(applicationgateways.ApplicationGatewayProtocolTls),
-							}, false),
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(applicationgateways.PossibleValuesForApplicationGatewayProtocol(), false),
 						},
 
 						"timeout": {
@@ -1618,12 +1570,9 @@ func resourceApplicationGateway() *pluginsdk.Resource {
 						},
 
 						"firewall_mode": {
-							Type:     pluginsdk.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(applicationgateways.ApplicationGatewayFirewallModeDetection),
-								string(applicationgateways.ApplicationGatewayFirewallModePrevention),
-							}, false),
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(applicationgateways.PossibleValuesForApplicationGatewayFirewallMode(), false),
 						},
 
 						"rule_set_type": {
@@ -1683,31 +1632,15 @@ func resourceApplicationGateway() *pluginsdk.Resource {
 							Elem: &pluginsdk.Resource{
 								Schema: map[string]*pluginsdk.Schema{
 									"match_variable": {
-										Type:     pluginsdk.TypeString,
-										Required: true,
-										ValidateFunc: validation.StringInSlice([]string{
-											string(webapplicationfirewallpolicies.OwaspCrsExclusionEntryMatchVariableRequestArgKeys),
-											string(webapplicationfirewallpolicies.OwaspCrsExclusionEntryMatchVariableRequestArgNames),
-											string(webapplicationfirewallpolicies.OwaspCrsExclusionEntryMatchVariableRequestArgValues),
-											string(webapplicationfirewallpolicies.OwaspCrsExclusionEntryMatchVariableRequestCookieKeys),
-											string(webapplicationfirewallpolicies.OwaspCrsExclusionEntryMatchVariableRequestCookieNames),
-											string(webapplicationfirewallpolicies.OwaspCrsExclusionEntryMatchVariableRequestCookieValues),
-											string(webapplicationfirewallpolicies.OwaspCrsExclusionEntryMatchVariableRequestHeaderKeys),
-											string(webapplicationfirewallpolicies.OwaspCrsExclusionEntryMatchVariableRequestHeaderNames),
-											string(webapplicationfirewallpolicies.OwaspCrsExclusionEntryMatchVariableRequestHeaderValues),
-										}, false),
+										Type:         pluginsdk.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringInSlice(webapplicationfirewallpolicies.PossibleValuesForOwaspCrsExclusionEntryMatchVariable(), false),
 									},
 
 									"selector_match_operator": {
-										Type: pluginsdk.TypeString,
-										ValidateFunc: validation.StringInSlice([]string{
-											string(webapplicationfirewallpolicies.OwaspCrsExclusionEntrySelectorMatchOperatorContains),
-											string(webapplicationfirewallpolicies.OwaspCrsExclusionEntrySelectorMatchOperatorEndsWith),
-											string(webapplicationfirewallpolicies.OwaspCrsExclusionEntrySelectorMatchOperatorEquals),
-											string(webapplicationfirewallpolicies.OwaspCrsExclusionEntrySelectorMatchOperatorEqualsAny),
-											string(webapplicationfirewallpolicies.OwaspCrsExclusionEntrySelectorMatchOperatorStartsWith),
-										}, false),
-										Optional: true,
+										Type:         pluginsdk.TypeString,
+										ValidateFunc: validation.StringInSlice(webapplicationfirewallpolicies.PossibleValuesForOwaspCrsExclusionEntrySelectorMatchOperator(), false),
+										Optional:     true,
 									},
 									"selector": {
 										ValidateFunc: validation.StringIsNotEmpty,

--- a/internal/services/network/express_route_circuit_peering_data_source.go
+++ b/internal/services/network/express_route_circuit_peering_data_source.go
@@ -28,13 +28,9 @@ func dataSourceExpressRouteCircuitPeering() *pluginsdk.Resource {
 
 		Schema: map[string]*pluginsdk.Schema{
 			"peering_type": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(expressroutecircuitpeerings.ExpressRoutePeeringTypeAzurePrivatePeering),
-					string(expressroutecircuitpeerings.ExpressRoutePeeringTypeAzurePublicPeering),
-					string(expressroutecircuitpeerings.ExpressRoutePeeringTypeMicrosoftPeering),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(expressroutecircuitpeerings.PossibleValuesForExpressRoutePeeringType(), false),
 			},
 
 			"express_route_circuit_name": {

--- a/internal/services/network/express_route_circuit_peering_resource.go
+++ b/internal/services/network/express_route_circuit_peering_resource.go
@@ -45,13 +45,9 @@ func resourceExpressRouteCircuitPeering() *pluginsdk.Resource {
 
 		Schema: map[string]*pluginsdk.Schema{
 			"peering_type": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(expressroutecircuitpeerings.ExpressRoutePeeringTypeAzurePrivatePeering),
-					string(expressroutecircuitpeerings.ExpressRoutePeeringTypeAzurePublicPeering),
-					string(expressroutecircuitpeerings.ExpressRoutePeeringTypeMicrosoftPeering),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(expressroutecircuitpeerings.PossibleValuesForExpressRoutePeeringType(), false),
 			},
 
 			"express_route_circuit_name": {

--- a/internal/services/network/express_route_circuit_resource.go
+++ b/internal/services/network/express_route_circuit_resource.go
@@ -71,23 +71,15 @@ func resourceExpressRouteCircuit() *pluginsdk.Resource {
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
 						"tier": {
-							Type:     pluginsdk.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(expressroutecircuits.ExpressRouteCircuitSkuTierBasic),
-								string(expressroutecircuits.ExpressRouteCircuitSkuTierLocal),
-								string(expressroutecircuits.ExpressRouteCircuitSkuTierStandard),
-								string(expressroutecircuits.ExpressRouteCircuitSkuTierPremium),
-							}, false),
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(expressroutecircuits.PossibleValuesForExpressRouteCircuitSkuTier(), false),
 						},
 
 						"family": {
-							Type:     pluginsdk.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(expressroutecircuits.ExpressRouteCircuitSkuFamilyMeteredData),
-								string(expressroutecircuits.ExpressRouteCircuitSkuFamilyUnlimitedData),
-							}, false),
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(expressroutecircuits.PossibleValuesForExpressRouteCircuitSkuFamily(), false),
 						},
 					},
 				},

--- a/internal/services/network/express_route_port_resource.go
+++ b/internal/services/network/express_route_port_resource.go
@@ -42,15 +42,10 @@ var expressRoutePortSchema = &pluginsdk.Schema{
 				Default:  false,
 			},
 			"macsec_cipher": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				Default:  string(expressrouteports.ExpressRouteLinkMacSecCipherGcmAesOneTwoEight),
-				ValidateFunc: validation.StringInSlice([]string{
-					string(expressrouteports.ExpressRouteLinkMacSecCipherGcmAesOneTwoEight),
-					string(expressrouteports.ExpressRouteLinkMacSecCipherGcmAesTwoFiveSix),
-					string(expressrouteports.ExpressRouteLinkMacSecCipherGcmAesXpnOneTwoEight),
-					string(expressrouteports.ExpressRouteLinkMacSecCipherGcmAesXpnTwoFiveSix),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				Default:      string(expressrouteports.ExpressRouteLinkMacSecCipherGcmAesOneTwoEight),
+				ValidateFunc: validation.StringInSlice(expressrouteports.PossibleValuesForExpressRouteLinkMacSecCipher(), false),
 			},
 			"macsec_ckn_keyvault_secret_id": {
 				Type:         pluginsdk.TypeString,
@@ -141,25 +136,19 @@ func resourceArmExpressRoutePort() *pluginsdk.Resource {
 			},
 
 			"encapsulation": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(expressrouteports.ExpressRoutePortsEncapsulationDotOneQ),
-					string(expressrouteports.ExpressRoutePortsEncapsulationQinQ),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(expressrouteports.PossibleValuesForExpressRoutePortsEncapsulation(), false),
 			},
 
 			"identity": commonschema.SystemAssignedUserAssignedIdentityOptional(),
 
 			"billing_type": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				Default:  string(expressrouteports.ExpressRoutePortsBillingTypeMeteredData),
-				ValidateFunc: validation.StringInSlice([]string{
-					string(expressrouteports.ExpressRoutePortsBillingTypeMeteredData),
-					string(expressrouteports.ExpressRoutePortsBillingTypeUnlimitedData),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				Default:      string(expressrouteports.ExpressRoutePortsBillingTypeMeteredData),
+				ValidateFunc: validation.StringInSlice(expressrouteports.PossibleValuesForExpressRoutePortsBillingType(), false),
 			},
 
 			"link1": expressRoutePortSchema,

--- a/internal/services/network/network_connection_monitor_resource.go
+++ b/internal/services/network/network_connection_monitor_resource.go
@@ -91,16 +91,9 @@ func resourceNetworkConnectionMonitorSchema() map[string]*pluginsdk.Schema {
 					},
 
 					"coverage_level": {
-						Type:     pluginsdk.TypeString,
-						Optional: true,
-						ValidateFunc: validation.StringInSlice([]string{
-							string(connectionmonitors.CoverageLevelAboveAverage),
-							string(connectionmonitors.CoverageLevelAverage),
-							string(connectionmonitors.CoverageLevelBelowAverage),
-							string(connectionmonitors.CoverageLevelDefault),
-							string(connectionmonitors.CoverageLevelFull),
-							string(connectionmonitors.CoverageLevelLow),
-						}, false),
+						Type:         pluginsdk.TypeString,
+						Optional:     true,
+						ValidateFunc: validation.StringInSlice(connectionmonitors.PossibleValuesForCoverageLevel(), false),
 					},
 
 					"excluded_ip_addresses": {
@@ -134,24 +127,20 @@ func resourceNetworkConnectionMonitorSchema() map[string]*pluginsdk.Schema {
 											},
 
 											"type": {
-												Type:     pluginsdk.TypeString,
-												Optional: true,
-												Default:  string(connectionmonitors.ConnectionMonitorEndpointFilterItemTypeAgentAddress),
-												ValidateFunc: validation.StringInSlice([]string{
-													string(connectionmonitors.ConnectionMonitorEndpointFilterItemTypeAgentAddress),
-												}, false),
+												Type:         pluginsdk.TypeString,
+												Optional:     true,
+												Default:      string(connectionmonitors.ConnectionMonitorEndpointFilterItemTypeAgentAddress),
+												ValidateFunc: validation.StringInSlice(connectionmonitors.PossibleValuesForConnectionMonitorEndpointFilterItemType(), false),
 											},
 										},
 									},
 								},
 
 								"type": {
-									Type:     pluginsdk.TypeString,
-									Optional: true,
-									Default:  string(connectionmonitors.ConnectionMonitorEndpointFilterTypeInclude),
-									ValidateFunc: validation.StringInSlice([]string{
-										string(connectionmonitors.ConnectionMonitorEndpointFilterTypeInclude),
-									}, false),
+									Type:         pluginsdk.TypeString,
+									Optional:     true,
+									Default:      string(connectionmonitors.ConnectionMonitorEndpointFilterTypeInclude),
+									ValidateFunc: validation.StringInSlice(connectionmonitors.PossibleValuesForConnectionMonitorEndpointFilterType(), false),
 								},
 							},
 						},
@@ -211,13 +200,9 @@ func resourceNetworkConnectionMonitorSchema() map[string]*pluginsdk.Schema {
 					},
 
 					"protocol": {
-						Type:     pluginsdk.TypeString,
-						Required: true,
-						ValidateFunc: validation.StringInSlice([]string{
-							string(connectionmonitors.ConnectionMonitorTestConfigurationProtocolTcp),
-							string(connectionmonitors.ConnectionMonitorTestConfigurationProtocolHTTP),
-							string(connectionmonitors.ConnectionMonitorTestConfigurationProtocolIcmp),
-						}, false),
+						Type:         pluginsdk.TypeString,
+						Required:     true,
+						ValidateFunc: validation.StringInSlice(connectionmonitors.PossibleValuesForConnectionMonitorTestConfigurationProtocol(), false),
 					},
 
 					"http_configuration": {
@@ -227,13 +212,10 @@ func resourceNetworkConnectionMonitorSchema() map[string]*pluginsdk.Schema {
 						Elem: &pluginsdk.Resource{
 							Schema: map[string]*pluginsdk.Schema{
 								"method": {
-									Type:     pluginsdk.TypeString,
-									Optional: true,
-									Default:  string(connectionmonitors.HTTPConfigurationMethodGet),
-									ValidateFunc: validation.StringInSlice([]string{
-										string(connectionmonitors.HTTPConfigurationMethodGet),
-										string(connectionmonitors.HTTPConfigurationMethodPost),
-									}, false),
+									Type:         pluginsdk.TypeString,
+									Optional:     true,
+									Default:      string(connectionmonitors.HTTPConfigurationMethodGet),
+									ValidateFunc: validation.StringInSlice(connectionmonitors.PossibleValuesForHTTPConfigurationMethod(), false),
 								},
 
 								"path": {
@@ -302,12 +284,9 @@ func resourceNetworkConnectionMonitorSchema() map[string]*pluginsdk.Schema {
 					},
 
 					"preferred_ip_version": {
-						Type:     pluginsdk.TypeString,
-						Optional: true,
-						ValidateFunc: validation.StringInSlice([]string{
-							string(connectionmonitors.PreferredIPVersionIPvFour),
-							string(connectionmonitors.PreferredIPVersionIPvSix),
-						}, false),
+						Type:         pluginsdk.TypeString,
+						Optional:     true,
+						ValidateFunc: validation.StringInSlice(connectionmonitors.PossibleValuesForPreferredIPVersion(), false),
 					},
 
 					// lintignore:XS003
@@ -351,12 +330,9 @@ func resourceNetworkConnectionMonitorSchema() map[string]*pluginsdk.Schema {
 								},
 
 								"destination_port_behavior": {
-									Type:     pluginsdk.TypeString,
-									Optional: true,
-									ValidateFunc: validation.StringInSlice([]string{
-										string(connectionmonitors.DestinationPortBehaviorNone),
-										string(connectionmonitors.DestinationPortBehaviorListenIfAvailable),
-									}, false),
+									Type:         pluginsdk.TypeString,
+									Optional:     true,
+									ValidateFunc: validation.StringInSlice(connectionmonitors.PossibleValuesForDestinationPortBehavior(), false),
 								},
 							},
 						},

--- a/internal/services/network/network_interface_resource.go
+++ b/internal/services/network/network_interface_resource.go
@@ -88,22 +88,16 @@ func resourceNetworkInterface() *pluginsdk.Resource {
 						},
 
 						"private_ip_address_version": {
-							Type:     pluginsdk.TypeString,
-							Optional: true,
-							Default:  string(networkinterfaces.IPVersionIPvFour),
-							ValidateFunc: validation.StringInSlice([]string{
-								string(networkinterfaces.IPVersionIPvFour),
-								string(networkinterfaces.IPVersionIPvSix),
-							}, false),
+							Type:         pluginsdk.TypeString,
+							Optional:     true,
+							Default:      string(networkinterfaces.IPVersionIPvFour),
+							ValidateFunc: validation.StringInSlice(networkinterfaces.PossibleValuesForIPVersion(), false),
 						},
 
 						"private_ip_address_allocation": {
-							Type:     pluginsdk.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(networkinterfaces.IPAllocationMethodDynamic),
-								string(networkinterfaces.IPAllocationMethodStatic),
-							}, false),
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(networkinterfaces.PossibleValuesForIPAllocationMethod(), false),
 						},
 
 						"public_ip_address_id": {

--- a/internal/services/network/network_manager_admin_rule_resource.go
+++ b/internal/services/network/network_manager_admin_rule_resource.go
@@ -68,22 +68,15 @@ func (r ManagerAdminRuleResource) Arguments() map[string]*pluginsdk.Schema {
 		},
 
 		"action": {
-			Type:     pluginsdk.TypeString,
-			Required: true,
-			ValidateFunc: validation.StringInSlice([]string{
-				string(adminrules.SecurityConfigurationRuleAccessAllow),
-				string(adminrules.SecurityConfigurationRuleAccessDeny),
-				string(adminrules.SecurityConfigurationRuleAccessAlwaysAllow),
-			}, false),
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: validation.StringInSlice(adminrules.PossibleValuesForSecurityConfigurationRuleAccess(), false),
 		},
 
 		"direction": {
-			Type:     pluginsdk.TypeString,
-			Required: true,
-			ValidateFunc: validation.StringInSlice([]string{
-				string(adminrules.SecurityConfigurationRuleDirectionInbound),
-				string(adminrules.SecurityConfigurationRuleDirectionOutbound),
-			}, false),
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: validation.StringInSlice(adminrules.PossibleValuesForSecurityConfigurationRuleDirection(), false),
 		},
 
 		"priority": {
@@ -93,16 +86,9 @@ func (r ManagerAdminRuleResource) Arguments() map[string]*pluginsdk.Schema {
 		},
 
 		"protocol": {
-			Type:     pluginsdk.TypeString,
-			Required: true,
-			ValidateFunc: validation.StringInSlice([]string{
-				string(adminrules.SecurityConfigurationRuleProtocolAh),
-				string(adminrules.SecurityConfigurationRuleProtocolAny),
-				string(adminrules.SecurityConfigurationRuleProtocolIcmp),
-				string(adminrules.SecurityConfigurationRuleProtocolEsp),
-				string(adminrules.SecurityConfigurationRuleProtocolTcp),
-				string(adminrules.SecurityConfigurationRuleProtocolUdp),
-			}, false),
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: validation.StringInSlice(adminrules.PossibleValuesForSecurityConfigurationRuleProtocol(), false),
 		},
 
 		"description": {

--- a/internal/services/network/network_manager_connectivity_configuration_resource.go
+++ b/internal/services/network/network_manager_connectivity_configuration_resource.go
@@ -114,12 +114,9 @@ func (r ManagerConnectivityConfigurationResource) Arguments() map[string]*plugin
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
 					"group_connectivity": {
-						Type:     pluginsdk.TypeString,
-						Required: true,
-						ValidateFunc: validation.StringInSlice([]string{
-							string(connectivityconfigurations.GroupConnectivityNone),
-							string(connectivityconfigurations.GroupConnectivityDirectlyConnected),
-						}, false),
+						Type:         pluginsdk.TypeString,
+						Required:     true,
+						ValidateFunc: validation.StringInSlice(connectivityconfigurations.PossibleValuesForGroupConnectivity(), false),
 					},
 
 					"global_mesh_enabled": {
@@ -142,12 +139,9 @@ func (r ManagerConnectivityConfigurationResource) Arguments() map[string]*plugin
 		},
 
 		"connectivity_topology": {
-			Type:     pluginsdk.TypeString,
-			Required: true,
-			ValidateFunc: validation.StringInSlice([]string{
-				string(connectivityconfigurations.ConnectivityTopologyHubAndSpoke),
-				string(connectivityconfigurations.ConnectivityTopologyMesh),
-			}, false),
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: validation.StringInSlice(connectivityconfigurations.PossibleValuesForConnectivityTopology(), false),
 		},
 
 		"connected_group_address_overlap_enabled": {

--- a/internal/services/network/network_manager_security_admin_configuration_resource.go
+++ b/internal/services/network/network_manager_security_admin_configuration_resource.go
@@ -60,12 +60,8 @@ func (r ManagerSecurityAdminConfigurationResource) Arguments() map[string]*plugi
 			Optional: true,
 			MaxItems: 1,
 			Elem: &pluginsdk.Schema{
-				Type: pluginsdk.TypeString,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(securityadminconfigurations.NetworkIntentPolicyBasedServiceAll),
-					string(securityadminconfigurations.NetworkIntentPolicyBasedServiceAllowRulesOnly),
-					string(securityadminconfigurations.NetworkIntentPolicyBasedServiceNone),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				ValidateFunc: validation.StringInSlice(securityadminconfigurations.PossibleValuesForNetworkIntentPolicyBasedService(), false),
 			},
 		},
 

--- a/internal/services/network/network_security_group_resource.go
+++ b/internal/services/network/network_security_group_resource.go
@@ -84,16 +84,9 @@ func resourceNetworkSecurityGroup() *pluginsdk.Resource {
 						},
 
 						"protocol": {
-							Type:     pluginsdk.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(networksecuritygroups.SecurityRuleProtocolAny),
-								string(networksecuritygroups.SecurityRuleProtocolTcp),
-								string(networksecuritygroups.SecurityRuleProtocolUdp),
-								string(networksecuritygroups.SecurityRuleProtocolIcmp),
-								string(networksecuritygroups.SecurityRuleProtocolAh),
-								string(networksecuritygroups.SecurityRuleProtocolEsp),
-							}, false),
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(networksecuritygroups.PossibleValuesForSecurityRuleProtocol(), false),
 						},
 
 						"source_port_range": {
@@ -165,12 +158,9 @@ func resourceNetworkSecurityGroup() *pluginsdk.Resource {
 						},
 
 						"access": {
-							Type:     pluginsdk.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(networksecuritygroups.SecurityRuleAccessAllow),
-								string(networksecuritygroups.SecurityRuleAccessDeny),
-							}, false),
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(networksecuritygroups.PossibleValuesForSecurityRuleAccess(), false),
 						},
 
 						"priority": {
@@ -180,12 +170,9 @@ func resourceNetworkSecurityGroup() *pluginsdk.Resource {
 						},
 
 						"direction": {
-							Type:     pluginsdk.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(networksecuritygroups.SecurityRuleDirectionInbound),
-								string(networksecuritygroups.SecurityRuleDirectionOutbound),
-							}, false),
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(networksecuritygroups.PossibleValuesForSecurityRuleDirection(), false),
 						},
 					},
 				},

--- a/internal/services/network/network_security_rule_resource.go
+++ b/internal/services/network/network_security_rule_resource.go
@@ -67,16 +67,9 @@ func resourceNetworkSecurityRule() *pluginsdk.Resource {
 			},
 
 			"protocol": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(securityrules.SecurityRuleProtocolAny),
-					string(securityrules.SecurityRuleProtocolTcp),
-					string(securityrules.SecurityRuleProtocolUdp),
-					string(securityrules.SecurityRuleProtocolIcmp),
-					string(securityrules.SecurityRuleProtocolAh),
-					string(securityrules.SecurityRuleProtocolEsp),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(securityrules.PossibleValuesForSecurityRuleProtocol(), false),
 			},
 
 			"source_port_range": {
@@ -162,12 +155,9 @@ func resourceNetworkSecurityRule() *pluginsdk.Resource {
 			},
 
 			"access": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(securityrules.SecurityRuleAccessAllow),
-					string(securityrules.SecurityRuleAccessDeny),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(securityrules.PossibleValuesForSecurityRuleAccess(), false),
 			},
 
 			"priority": {
@@ -177,12 +167,9 @@ func resourceNetworkSecurityRule() *pluginsdk.Resource {
 			},
 
 			"direction": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(securityrules.SecurityRuleDirectionInbound),
-					string(securityrules.SecurityRuleDirectionOutbound),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(securityrules.PossibleValuesForSecurityRuleDirection(), false),
 			},
 		},
 	}

--- a/internal/services/network/public_ip_prefix_resource.go
+++ b/internal/services/network/public_ip_prefix_resource.go
@@ -92,14 +92,11 @@ func resourcePublicIpPrefix() *pluginsdk.Resource {
 			},
 
 			"ip_version": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				Default:  string(publicipprefixes.IPVersionIPvFour),
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(publicipprefixes.IPVersionIPvFour),
-					string(publicipprefixes.IPVersionIPvSix),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				Default:      string(publicipprefixes.IPVersionIPvFour),
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(publicipprefixes.PossibleValuesForIPVersion(), false),
 			},
 
 			"zones": commonschema.ZonesMultipleOptionalForceNew(),

--- a/internal/services/network/public_ip_resource.go
+++ b/internal/services/network/public_ip_resource.go
@@ -65,24 +65,17 @@ func resourcePublicIp() *pluginsdk.Resource {
 			"resource_group_name": commonschema.ResourceGroupName(),
 
 			"allocation_method": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(publicipaddresses.IPAllocationMethodStatic),
-					string(publicipaddresses.IPAllocationMethodDynamic),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(publicipaddresses.PossibleValuesForIPAllocationMethod(), false),
 			},
 
 			// Optional
 			"ddos_protection_mode": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(publicipaddresses.DdosSettingsProtectionModeDisabled),
-					string(publicipaddresses.DdosSettingsProtectionModeEnabled),
-					string(publicipaddresses.DdosSettingsProtectionModeVirtualNetworkInherited),
-				}, false),
-				Default: string(publicipaddresses.DdosSettingsProtectionModeVirtualNetworkInherited),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(publicipaddresses.PossibleValuesForDdosSettingsProtectionMode(), false),
+				Default:      string(publicipaddresses.DdosSettingsProtectionModeVirtualNetworkInherited),
 			},
 
 			"ddos_protection_plan_id": {
@@ -94,14 +87,11 @@ func resourcePublicIp() *pluginsdk.Resource {
 			"edge_zone": commonschema.EdgeZoneOptionalForceNew(),
 
 			"ip_version": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				Default:  string(publicipaddresses.IPVersionIPvFour),
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(publicipaddresses.IPVersionIPvFour),
-					string(publicipaddresses.IPVersionIPvSix),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				Default:      string(publicipaddresses.IPVersionIPvFour),
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(publicipaddresses.PossibleValuesForIPVersion(), false),
 			},
 
 			"sku": {
@@ -114,14 +104,11 @@ func resourcePublicIp() *pluginsdk.Resource {
 			},
 
 			"sku_tier": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				Default:  string(publicipaddresses.PublicIPAddressSkuTierRegional),
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(publicipaddresses.PublicIPAddressSkuTierGlobal),
-					string(publicipaddresses.PublicIPAddressSkuTierRegional),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				Default:      string(publicipaddresses.PublicIPAddressSkuTierRegional),
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(publicipaddresses.PossibleValuesForPublicIPAddressSkuTier(), false),
 			},
 
 			"idle_timeout_in_minutes": {

--- a/internal/services/network/public_ips_data_source.go
+++ b/internal/services/network/public_ips_data_source.go
@@ -50,12 +50,9 @@ func dataSourcePublicIPSchema() map[string]*pluginsdk.Schema {
 		},
 
 		"allocation_type": {
-			Type:     pluginsdk.TypeString,
-			Optional: true,
-			ValidateFunc: validation.StringInSlice([]string{
-				string(publicipaddresses.IPAllocationMethodDynamic),
-				string(publicipaddresses.IPAllocationMethodStatic),
-			}, false),
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.StringInSlice(publicipaddresses.PossibleValuesForIPAllocationMethod(), false),
 		},
 
 		"public_ips": {

--- a/internal/services/network/route_map_resource.go
+++ b/internal/services/network/route_map_resource.go
@@ -143,15 +143,9 @@ func (r RouteMapResource) Arguments() map[string]*pluginsdk.Schema {
 								},
 
 								"type": {
-									Type:     pluginsdk.TypeString,
-									Required: true,
-									ValidateFunc: validation.StringInSlice([]string{
-										string(virtualwans.RouteMapActionTypeAdd),
-										string(virtualwans.RouteMapActionTypeDrop),
-										string(virtualwans.RouteMapActionTypeRemove),
-										string(virtualwans.RouteMapActionTypeReplace),
-										string(virtualwans.RouteMapActionTypeUnknown),
-									}, false),
+									Type:         pluginsdk.TypeString,
+									Required:     true,
+									ValidateFunc: validation.StringInSlice(virtualwans.PossibleValuesForRouteMapActionType(), false),
 								},
 							},
 						},
@@ -163,15 +157,9 @@ func (r RouteMapResource) Arguments() map[string]*pluginsdk.Schema {
 						Elem: &pluginsdk.Resource{
 							Schema: map[string]*pluginsdk.Schema{
 								"match_condition": {
-									Type:     pluginsdk.TypeString,
-									Required: true,
-									ValidateFunc: validation.StringInSlice([]string{
-										string(virtualwans.RouteMapMatchConditionContains),
-										string(virtualwans.RouteMapMatchConditionEquals),
-										string(virtualwans.RouteMapMatchConditionNotContains),
-										string(virtualwans.RouteMapMatchConditionNotEquals),
-										string(virtualwans.RouteMapMatchConditionUnknown),
-									}, false),
+									Type:         pluginsdk.TypeString,
+									Required:     true,
+									ValidateFunc: validation.StringInSlice(virtualwans.PossibleValuesForRouteMapMatchCondition(), false),
 								},
 
 								"as_path": {
@@ -205,14 +193,10 @@ func (r RouteMapResource) Arguments() map[string]*pluginsdk.Schema {
 					},
 
 					"next_step_if_matched": {
-						Type:     pluginsdk.TypeString,
-						Optional: true,
-						Default:  string(virtualwans.NextStepUnknown),
-						ValidateFunc: validation.StringInSlice([]string{
-							string(virtualwans.NextStepContinue),
-							string(virtualwans.NextStepTerminate),
-							string(virtualwans.NextStepUnknown),
-						}, false),
+						Type:         pluginsdk.TypeString,
+						Optional:     true,
+						Default:      string(virtualwans.NextStepUnknown),
+						ValidateFunc: validation.StringInSlice(virtualwans.PossibleValuesForNextStep(), false),
 					},
 				},
 			},

--- a/internal/services/network/route_resource.go
+++ b/internal/services/network/route_resource.go
@@ -69,15 +69,9 @@ func resourceRoute() *pluginsdk.Resource {
 			},
 
 			"next_hop_type": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(routes.RouteNextHopTypeVirtualNetworkGateway),
-					string(routes.RouteNextHopTypeVnetLocal),
-					string(routes.RouteNextHopTypeInternet),
-					string(routes.RouteNextHopTypeVirtualAppliance),
-					string(routes.RouteNextHopTypeNone),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(routes.PossibleValuesForRouteNextHopType(), false),
 			},
 
 			"next_hop_in_ip_address": {

--- a/internal/services/network/route_server_resource.go
+++ b/internal/services/network/route_server_resource.go
@@ -89,14 +89,10 @@ func resourceRouteServer() *pluginsdk.Resource {
 			},
 
 			"hub_routing_preference": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				Default:  string(virtualwans.HubRoutingPreferenceExpressRoute),
-				ValidateFunc: validation.StringInSlice([]string{
-					string(virtualwans.HubRoutingPreferenceASPath),
-					string(virtualwans.HubRoutingPreferenceExpressRoute),
-					string(virtualwans.HubRoutingPreferenceVpnGateway),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				Default:      string(virtualwans.HubRoutingPreferenceExpressRoute),
+				ValidateFunc: validation.StringInSlice(virtualwans.PossibleValuesForHubRoutingPreference(), false),
 			},
 
 			"virtual_router_ips": {

--- a/internal/services/network/route_table_resource.go
+++ b/internal/services/network/route_table_resource.go
@@ -80,15 +80,9 @@ func resourceRouteTable() *pluginsdk.Resource {
 						},
 
 						"next_hop_type": {
-							Type:     pluginsdk.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(routetables.RouteNextHopTypeVirtualNetworkGateway),
-								string(routetables.RouteNextHopTypeVnetLocal),
-								string(routetables.RouteNextHopTypeInternet),
-								string(routetables.RouteNextHopTypeVirtualAppliance),
-								string(routetables.RouteNextHopTypeNone),
-							}, false),
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(routetables.PossibleValuesForRouteNextHopType(), false),
 						},
 
 						"next_hop_in_ip_address": {

--- a/internal/services/network/virtual_hub_connection_resource.go
+++ b/internal/services/network/virtual_hub_connection_resource.go
@@ -136,14 +136,11 @@ func resourceVirtualHubConnection() *pluginsdk.Resource {
 						},
 
 						"static_vnet_local_route_override_criteria": {
-							Type:     pluginsdk.TypeString,
-							Optional: true,
-							ForceNew: true,
-							Default:  string(virtualwans.VnetLocalRouteOverrideCriteriaContains),
-							ValidateFunc: validation.StringInSlice([]string{
-								string(virtualwans.VnetLocalRouteOverrideCriteriaContains),
-								string(virtualwans.VnetLocalRouteOverrideCriteriaEqual),
-							}, false),
+							Type:         pluginsdk.TypeString,
+							Optional:     true,
+							ForceNew:     true,
+							Default:      string(virtualwans.VnetLocalRouteOverrideCriteriaContains),
+							ValidateFunc: validation.StringInSlice(virtualwans.PossibleValuesForVnetLocalRouteOverrideCriteria(), false),
 						},
 
 						"static_vnet_propagate_static_routes_enabled": {

--- a/internal/services/network/virtual_hub_ip_resource.go
+++ b/internal/services/network/virtual_hub_ip_resource.go
@@ -80,13 +80,10 @@ func resourceVirtualHubIP() *pluginsdk.Resource {
 			},
 
 			"private_ip_allocation_method": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				Default:  virtualwans.IPAllocationMethodDynamic,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(virtualwans.IPAllocationMethodDynamic),
-					string(virtualwans.IPAllocationMethodStatic),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				Default:      virtualwans.IPAllocationMethodDynamic,
+				ValidateFunc: validation.StringInSlice(virtualwans.PossibleValuesForIPAllocationMethod(), false),
 			},
 		},
 	}

--- a/internal/services/network/virtual_hub_resource.go
+++ b/internal/services/network/virtual_hub_resource.go
@@ -131,14 +131,10 @@ func resourceVirtualHub() *pluginsdk.Resource {
 			"tags": commonschema.Tags(),
 
 			"hub_routing_preference": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				Default:  string(virtualwans.HubRoutingPreferenceExpressRoute),
-				ValidateFunc: validation.StringInSlice([]string{
-					string(virtualwans.HubRoutingPreferenceExpressRoute),
-					string(virtualwans.HubRoutingPreferenceVpnGateway),
-					string(virtualwans.HubRoutingPreferenceASPath),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				Default:      string(virtualwans.HubRoutingPreferenceExpressRoute),
+				ValidateFunc: validation.StringInSlice(virtualwans.PossibleValuesForHubRoutingPreference(), false),
 			},
 
 			"default_route_table_id": {

--- a/internal/services/network/virtual_hub_security_partner_provider_resource.go
+++ b/internal/services/network/virtual_hub_security_partner_provider_resource.go
@@ -54,14 +54,10 @@ func resourceVirtualHubSecurityPartnerProvider() *pluginsdk.Resource {
 			"location": commonschema.Location(),
 
 			"security_provider_name": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(securitypartnerproviders.SecurityProviderNameZScaler),
-					string(securitypartnerproviders.SecurityProviderNameIBoss),
-					string(securitypartnerproviders.SecurityProviderNameCheckpoint),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(securitypartnerproviders.PossibleValuesForSecurityProviderName(), false),
 			},
 
 			"virtual_hub_id": {

--- a/internal/services/network/virtual_network_gateway_connection_resource.go
+++ b/internal/services/network/virtual_network_gateway_connection_resource.go
@@ -173,26 +173,19 @@ func resourceVirtualNetworkGatewayConnection() *pluginsdk.Resource {
 			},
 
 			"connection_protocol": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(virtualnetworkgatewayconnections.VirtualNetworkGatewayConnectionProtocolIKEvOne),
-					string(virtualnetworkgatewayconnections.VirtualNetworkGatewayConnectionProtocolIKEvTwo),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(virtualnetworkgatewayconnections.PossibleValuesForVirtualNetworkGatewayConnectionProtocol(), false),
 			},
 
 			"connection_mode": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(virtualnetworkgatewayconnections.VirtualNetworkGatewayConnectionModeInitiatorOnly),
-					string(virtualnetworkgatewayconnections.VirtualNetworkGatewayConnectionModeResponderOnly),
-					string(virtualnetworkgatewayconnections.VirtualNetworkGatewayConnectionModeDefault),
-				}, false),
-				Default: string(virtualnetworkgatewayconnections.VirtualNetworkGatewayConnectionModeDefault),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(virtualnetworkgatewayconnections.PossibleValuesForVirtualNetworkGatewayConnectionMode(), false),
+				Default:      string(virtualnetworkgatewayconnections.VirtualNetworkGatewayConnectionModeDefault),
 			},
 
 			"traffic_selector_policy": {
@@ -245,90 +238,39 @@ func resourceVirtualNetworkGatewayConnection() *pluginsdk.Resource {
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
 						"dh_group": {
-							Type:     pluginsdk.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(virtualnetworkgatewayconnections.DhGroupDHGroupOne),
-								string(virtualnetworkgatewayconnections.DhGroupDHGroupOneFour),
-								string(virtualnetworkgatewayconnections.DhGroupDHGroupTwo),
-								string(virtualnetworkgatewayconnections.DhGroupDHGroupTwoZeroFourEight),
-								string(virtualnetworkgatewayconnections.DhGroupDHGroupTwoFour),
-								string(virtualnetworkgatewayconnections.DhGroupECPTwoFiveSix),
-								string(virtualnetworkgatewayconnections.DhGroupECPThreeEightFour),
-								string(virtualnetworkgatewayconnections.DhGroupNone),
-							}, false),
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(virtualnetworkgatewayconnections.PossibleValuesForDhGroup(), false),
 						},
 
 						"ike_encryption": {
-							Type:     pluginsdk.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(virtualnetworkgatewayconnections.IkeEncryptionAESOneTwoEight),
-								string(virtualnetworkgatewayconnections.IkeEncryptionAESOneNineTwo),
-								string(virtualnetworkgatewayconnections.IkeEncryptionAESTwoFiveSix),
-								string(virtualnetworkgatewayconnections.IkeEncryptionDES),
-								string(virtualnetworkgatewayconnections.IkeEncryptionDESThree),
-								string(virtualnetworkgatewayconnections.IkeEncryptionGCMAESOneTwoEight),
-								string(virtualnetworkgatewayconnections.IkeEncryptionGCMAESTwoFiveSix),
-							}, false),
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(virtualnetworkgatewayconnections.PossibleValuesForIkeEncryption(), false),
 						},
 
 						"ike_integrity": {
-							Type:     pluginsdk.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(virtualnetworkgatewayconnections.IkeIntegrityGCMAESOneTwoEight),
-								string(virtualnetworkgatewayconnections.IkeIntegrityGCMAESTwoFiveSix),
-								string(virtualnetworkgatewayconnections.IkeIntegrityMDFive),
-								string(virtualnetworkgatewayconnections.IkeIntegritySHAOne),
-								string(virtualnetworkgatewayconnections.IkeIntegritySHATwoFiveSix),
-								string(virtualnetworkgatewayconnections.IkeIntegritySHAThreeEightFour),
-							}, false),
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(virtualnetworkgatewayconnections.PossibleValuesForIkeIntegrity(), false),
 						},
 
 						"ipsec_encryption": {
-							Type:     pluginsdk.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(virtualnetworkgatewayconnections.IPsecEncryptionAESOneTwoEight),
-								string(virtualnetworkgatewayconnections.IPsecEncryptionAESOneNineTwo),
-								string(virtualnetworkgatewayconnections.IPsecEncryptionAESTwoFiveSix),
-								string(virtualnetworkgatewayconnections.IPsecEncryptionDES),
-								string(virtualnetworkgatewayconnections.IPsecEncryptionDESThree),
-								string(virtualnetworkgatewayconnections.IPsecEncryptionGCMAESOneTwoEight),
-								string(virtualnetworkgatewayconnections.IPsecEncryptionGCMAESOneNineTwo),
-								string(virtualnetworkgatewayconnections.IPsecEncryptionGCMAESTwoFiveSix),
-								string(virtualnetworkgatewayconnections.IPsecEncryptionNone),
-							}, false),
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(virtualnetworkgatewayconnections.PossibleValuesForIPsecEncryption(), false),
 						},
 
 						"ipsec_integrity": {
-							Type:     pluginsdk.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(virtualnetworkgatewayconnections.IPsecIntegrityGCMAESOneTwoEight),
-								string(virtualnetworkgatewayconnections.IPsecIntegrityGCMAESOneNineTwo),
-								string(virtualnetworkgatewayconnections.IPsecIntegrityGCMAESTwoFiveSix),
-								string(virtualnetworkgatewayconnections.IPsecIntegrityMDFive),
-								string(virtualnetworkgatewayconnections.IPsecIntegritySHAOne),
-								string(virtualnetworkgatewayconnections.IPsecIntegritySHATwoFiveSix),
-							}, false),
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(virtualnetworkgatewayconnections.PossibleValuesForIPsecIntegrity(), false),
 						},
 
 						"pfs_group": {
-							Type:     pluginsdk.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(virtualnetworkgatewayconnections.PfsGroupECPTwoFiveSix),
-								string(virtualnetworkgatewayconnections.PfsGroupECPThreeEightFour),
-								string(virtualnetworkgatewayconnections.PfsGroupNone),
-								string(virtualnetworkgatewayconnections.PfsGroupPFSOne),
-								string(virtualnetworkgatewayconnections.PfsGroupPFSOneFour),
-								string(virtualnetworkgatewayconnections.PfsGroupPFSTwo),
-								string(virtualnetworkgatewayconnections.PfsGroupPFSTwoZeroFourEight),
-								string(virtualnetworkgatewayconnections.PfsGroupPFSTwoFour),
-								string(virtualnetworkgatewayconnections.PfsGroupPFSMM),
-							}, false),
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(virtualnetworkgatewayconnections.PossibleValuesForPfsGroup(), false),
 						},
 
 						"sa_datasize": {

--- a/internal/services/network/virtual_network_gateway_nat_rule_resource.go
+++ b/internal/services/network/virtual_network_gateway_nat_rule_resource.go
@@ -98,25 +98,19 @@ func resourceVirtualNetworkGatewayNatRule() *pluginsdk.Resource {
 			},
 
 			"mode": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Default:  string(virtualnetworkgateways.VpnNatRuleModeEgressSnat),
-				ValidateFunc: validation.StringInSlice([]string{
-					string(virtualnetworkgateways.VpnNatRuleModeEgressSnat),
-					string(virtualnetworkgateways.VpnNatRuleModeIngressSnat),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Default:      string(virtualnetworkgateways.VpnNatRuleModeEgressSnat),
+				ValidateFunc: validation.StringInSlice(virtualnetworkgateways.PossibleValuesForVpnNatRuleMode(), false),
 			},
 
 			"type": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Default:  string(virtualnetworkgateways.VpnNatRuleTypeStatic),
-				ValidateFunc: validation.StringInSlice([]string{
-					string(virtualnetworkgateways.VpnNatRuleTypeStatic),
-					string(virtualnetworkgateways.VpnNatRuleTypeDynamic),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Default:      string(virtualnetworkgateways.VpnNatRuleTypeStatic),
+				ValidateFunc: validation.StringInSlice(virtualnetworkgateways.PossibleValuesForVpnNatRuleType(), false),
 			},
 
 			"ip_configuration_id": {

--- a/internal/services/network/virtual_network_gateway_resource.go
+++ b/internal/services/network/virtual_network_gateway_resource.go
@@ -73,14 +73,11 @@ func resourceVirtualNetworkGateway() *pluginsdk.Resource {
 			},
 
 			"vpn_type": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Default:  string(virtualnetworkgateways.VpnTypeRouteBased),
-				ValidateFunc: validation.StringInSlice([]string{
-					string(virtualnetworkgateways.VpnTypeRouteBased),
-					string(virtualnetworkgateways.VpnTypePolicyBased),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Default:      string(virtualnetworkgateways.VpnTypeRouteBased),
+				ValidateFunc: validation.StringInSlice(virtualnetworkgateways.PossibleValuesForVpnType(), false),
 			},
 
 			"edge_zone": commonschema.EdgeZoneOptionalForceNew(),
@@ -119,15 +116,11 @@ func resourceVirtualNetworkGateway() *pluginsdk.Resource {
 			},
 
 			"generation": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(virtualnetworkgateways.VpnGatewayGenerationGenerationOne),
-					string(virtualnetworkgateways.VpnGatewayGenerationGenerationTwo),
-					string(virtualnetworkgateways.VpnGatewayGenerationNone),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(virtualnetworkgateways.PossibleValuesForVpnGatewayGeneration(), false),
 			},
 
 			"ip_configuration": {
@@ -148,13 +141,10 @@ func resourceVirtualNetworkGateway() *pluginsdk.Resource {
 						},
 
 						"private_ip_address_allocation": {
-							Type:     pluginsdk.TypeString,
-							Optional: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(virtualnetworkgateways.IPAllocationMethodStatic),
-								string(virtualnetworkgateways.IPAllocationMethodDynamic),
-							}, false),
-							Default: string(virtualnetworkgateways.IPAllocationMethodDynamic),
+							Type:         pluginsdk.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice(virtualnetworkgateways.PossibleValuesForIPAllocationMethod(), false),
+							Default:      string(virtualnetworkgateways.IPAllocationMethodDynamic),
 						},
 
 						"subnet_id": {
@@ -196,13 +186,9 @@ func resourceVirtualNetworkGateway() *pluginsdk.Resource {
 									},
 
 									"type": {
-										Type:     pluginsdk.TypeString,
-										Required: true,
-										ValidateFunc: validation.StringInSlice([]string{
-											string(virtualnetworkgateways.VpnPolicyMemberAttributeTypeAADGroupId),
-											string(virtualnetworkgateways.VpnPolicyMemberAttributeTypeCertificateGroupId),
-											string(virtualnetworkgateways.VpnPolicyMemberAttributeTypeRadiusAzureGroupId),
-										}, false),
+										Type:         pluginsdk.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringInSlice(virtualnetworkgateways.PossibleValuesForVpnPolicyMemberAttributeType(), false),
 									},
 
 									"value": {
@@ -308,90 +294,39 @@ func resourceVirtualNetworkGateway() *pluginsdk.Resource {
 							Elem: &pluginsdk.Resource{
 								Schema: map[string]*pluginsdk.Schema{
 									"dh_group": {
-										Type:     pluginsdk.TypeString,
-										Required: true,
-										ValidateFunc: validation.StringInSlice([]string{
-											string(virtualnetworkgateways.DhGroupDHGroupOne),
-											string(virtualnetworkgateways.DhGroupDHGroupOneFour),
-											string(virtualnetworkgateways.DhGroupDHGroupTwo),
-											string(virtualnetworkgateways.DhGroupDHGroupTwoZeroFourEight),
-											string(virtualnetworkgateways.DhGroupDHGroupTwoFour),
-											string(virtualnetworkgateways.DhGroupECPTwoFiveSix),
-											string(virtualnetworkgateways.DhGroupECPThreeEightFour),
-											string(virtualnetworkgateways.DhGroupNone),
-										}, false),
+										Type:         pluginsdk.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringInSlice(virtualnetworkgateways.PossibleValuesForDhGroup(), false),
 									},
 
 									"ike_encryption": {
-										Type:     pluginsdk.TypeString,
-										Required: true,
-										ValidateFunc: validation.StringInSlice([]string{
-											string(virtualnetworkgateways.IkeEncryptionAESOneTwoEight),
-											string(virtualnetworkgateways.IkeEncryptionAESOneNineTwo),
-											string(virtualnetworkgateways.IkeEncryptionAESTwoFiveSix),
-											string(virtualnetworkgateways.IkeEncryptionDES),
-											string(virtualnetworkgateways.IkeEncryptionDESThree),
-											string(virtualnetworkgateways.IkeEncryptionGCMAESOneTwoEight),
-											string(virtualnetworkgateways.IkeEncryptionGCMAESTwoFiveSix),
-										}, false),
+										Type:         pluginsdk.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringInSlice(virtualnetworkgateways.PossibleValuesForIkeEncryption(), false),
 									},
 
 									"ike_integrity": {
-										Type:     pluginsdk.TypeString,
-										Required: true,
-										ValidateFunc: validation.StringInSlice([]string{
-											string(virtualnetworkgateways.IkeIntegrityGCMAESOneTwoEight),
-											string(virtualnetworkgateways.IkeIntegrityGCMAESTwoFiveSix),
-											string(virtualnetworkgateways.IkeIntegrityMDFive),
-											string(virtualnetworkgateways.IkeIntegritySHAOne),
-											string(virtualnetworkgateways.IkeIntegritySHATwoFiveSix),
-											string(virtualnetworkgateways.IkeIntegritySHAThreeEightFour),
-										}, false),
+										Type:         pluginsdk.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringInSlice(virtualnetworkgateways.PossibleValuesForIkeIntegrity(), false),
 									},
 
 									"ipsec_encryption": {
-										Type:     pluginsdk.TypeString,
-										Required: true,
-										ValidateFunc: validation.StringInSlice([]string{
-											string(virtualnetworkgateways.IPsecEncryptionAESOneTwoEight),
-											string(virtualnetworkgateways.IPsecEncryptionAESOneNineTwo),
-											string(virtualnetworkgateways.IPsecEncryptionAESTwoFiveSix),
-											string(virtualnetworkgateways.IPsecEncryptionDES),
-											string(virtualnetworkgateways.IPsecEncryptionDESThree),
-											string(virtualnetworkgateways.IPsecEncryptionGCMAESOneTwoEight),
-											string(virtualnetworkgateways.IPsecEncryptionGCMAESOneNineTwo),
-											string(virtualnetworkgateways.IPsecEncryptionGCMAESTwoFiveSix),
-											string(virtualnetworkgateways.IPsecEncryptionNone),
-										}, false),
+										Type:         pluginsdk.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringInSlice(virtualnetworkgateways.PossibleValuesForIPsecEncryption(), false),
 									},
 
 									"ipsec_integrity": {
-										Type:     pluginsdk.TypeString,
-										Required: true,
-										ValidateFunc: validation.StringInSlice([]string{
-											string(virtualnetworkgateways.IPsecIntegrityGCMAESOneTwoEight),
-											string(virtualnetworkgateways.IPsecIntegrityGCMAESOneNineTwo),
-											string(virtualnetworkgateways.IPsecIntegrityGCMAESTwoFiveSix),
-											string(virtualnetworkgateways.IPsecIntegrityMDFive),
-											string(virtualnetworkgateways.IPsecIntegritySHAOne),
-											string(virtualnetworkgateways.IPsecIntegritySHATwoFiveSix),
-										}, false),
+										Type:         pluginsdk.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringInSlice(virtualnetworkgateways.PossibleValuesForIPsecIntegrity(), false),
 									},
 
 									"pfs_group": {
-										Type:     pluginsdk.TypeString,
-										Required: true,
-										ValidateFunc: validation.StringInSlice([]string{
-											string(virtualnetworkgateways.PfsGroupECPTwoFiveSix),
-											string(virtualnetworkgateways.PfsGroupECPThreeEightFour),
-											string(virtualnetworkgateways.PfsGroupNone),
-											string(virtualnetworkgateways.PfsGroupPFSOne),
-											string(virtualnetworkgateways.PfsGroupPFSOneFour),
-											string(virtualnetworkgateways.PfsGroupPFSTwo),
-											string(virtualnetworkgateways.PfsGroupPFSTwoZeroFourEight),
-											string(virtualnetworkgateways.PfsGroupPFSTwoFour),
-											string(virtualnetworkgateways.PfsGroupPFSMM),
-										}, false),
+										Type:         pluginsdk.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringInSlice(virtualnetworkgateways.PossibleValuesForPfsGroup(), false),
 									},
 
 									"sa_lifetime_in_seconds": {
@@ -497,12 +432,8 @@ func resourceVirtualNetworkGateway() *pluginsdk.Resource {
 							Computed: true,
 							MaxItems: 3,
 							Elem: &pluginsdk.Schema{
-								Type: pluginsdk.TypeString,
-								ValidateFunc: validation.StringInSlice([]string{
-									string(virtualnetworkgateways.VpnAuthenticationTypeCertificate),
-									string(virtualnetworkgateways.VpnAuthenticationTypeAAD),
-									string(virtualnetworkgateways.VpnAuthenticationTypeRadius),
-								}, false),
+								Type:         pluginsdk.TypeString,
+								ValidateFunc: validation.StringInSlice(virtualnetworkgateways.PossibleValuesForVpnAuthenticationType(), false),
 							},
 						},
 
@@ -511,12 +442,8 @@ func resourceVirtualNetworkGateway() *pluginsdk.Resource {
 							Optional: true,
 							Computed: true,
 							Elem: &pluginsdk.Schema{
-								Type: pluginsdk.TypeString,
-								ValidateFunc: validation.StringInSlice([]string{
-									string(virtualnetworkgateways.VpnClientProtocolIkeVTwo),
-									string(virtualnetworkgateways.VpnClientProtocolOpenVPN),
-									string(virtualnetworkgateways.VpnClientProtocolSSTP),
-								}, false),
+								Type:         pluginsdk.TypeString,
+								ValidateFunc: validation.StringInSlice(virtualnetworkgateways.PossibleValuesForVpnClientProtocol(), false),
 							},
 						},
 					},

--- a/internal/services/network/virtual_network_resource.go
+++ b/internal/services/network/virtual_network_resource.go
@@ -134,12 +134,9 @@ func resourceVirtualNetworkSchema() map[string]*pluginsdk.Schema {
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
 					"enforcement": {
-						Type:     pluginsdk.TypeString,
-						Required: true,
-						ValidateFunc: validation.StringInSlice([]string{
-							string(virtualnetworks.VirtualNetworkEncryptionEnforcementDropUnencrypted),
-							string(virtualnetworks.VirtualNetworkEncryptionEnforcementAllowUnencrypted),
-						}, false),
+						Type:         pluginsdk.TypeString,
+						Required:     true,
+						ValidateFunc: validation.StringInSlice(virtualnetworks.PossibleValuesForVirtualNetworkEncryptionEnforcement(), false),
 					},
 				},
 			},

--- a/internal/services/network/virtual_wan_resource.go
+++ b/internal/services/network/virtual_wan_resource.go
@@ -65,15 +65,10 @@ func resourceVirtualWan() *pluginsdk.Resource {
 			},
 
 			"office365_local_breakout_category": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(virtualwans.OfficeTrafficCategoryAll),
-					string(virtualwans.OfficeTrafficCategoryNone),
-					string(virtualwans.OfficeTrafficCategoryOptimize),
-					string(virtualwans.OfficeTrafficCategoryOptimizeAndAllow),
-				}, false),
-				Default: string(virtualwans.OfficeTrafficCategoryNone),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(virtualwans.PossibleValuesForOfficeTrafficCategory(), false),
+				Default:      string(virtualwans.OfficeTrafficCategoryNone),
 			},
 
 			"type": {

--- a/internal/services/network/vpn_gateway_nat_rule_resource.go
+++ b/internal/services/network/vpn_gateway_nat_rule_resource.go
@@ -103,25 +103,19 @@ func resourceVPNGatewayNatRule() *pluginsdk.Resource {
 			},
 
 			"mode": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Default:  string(virtualwans.VpnNatRuleModeEgressSnat),
-				ValidateFunc: validation.StringInSlice([]string{
-					string(virtualwans.VpnNatRuleModeEgressSnat),
-					string(virtualwans.VpnNatRuleModeIngressSnat),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Default:      string(virtualwans.VpnNatRuleModeEgressSnat),
+				ValidateFunc: validation.StringInSlice(virtualwans.PossibleValuesForVpnNatRuleMode(), false),
 			},
 
 			"type": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Default:  string(virtualwans.VpnNatRuleTypeStatic),
-				ValidateFunc: validation.StringInSlice([]string{
-					string(virtualwans.VpnNatRuleTypeStatic),
-					string(virtualwans.VpnNatRuleTypeDynamic),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Default:      string(virtualwans.VpnNatRuleTypeStatic),
+				ValidateFunc: validation.StringInSlice(virtualwans.PossibleValuesForVpnNatRuleType(), false),
 			},
 		},
 	}

--- a/internal/services/network/vpn_server_configuration_policy_group_resource.go
+++ b/internal/services/network/vpn_server_configuration_policy_group_resource.go
@@ -66,13 +66,9 @@ func resourceVPNServerConfigurationPolicyGroup() *pluginsdk.Resource {
 						},
 
 						"type": {
-							Type:     pluginsdk.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(virtualwans.VpnPolicyMemberAttributeTypeAADGroupId),
-								string(virtualwans.VpnPolicyMemberAttributeTypeCertificateGroupId),
-								string(virtualwans.VpnPolicyMemberAttributeTypeRadiusAzureGroupId),
-							}, false),
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(virtualwans.PossibleValuesForVpnPolicyMemberAttributeType(), false),
 						},
 
 						"value": {

--- a/internal/services/network/vpn_server_configuration_resource.go
+++ b/internal/services/network/vpn_server_configuration_resource.go
@@ -56,12 +56,8 @@ func resourceVPNServerConfiguration() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeList,
 				Required: true,
 				Elem: &pluginsdk.Schema{
-					Type: pluginsdk.TypeString,
-					ValidateFunc: validation.StringInSlice([]string{
-						string(virtualwans.VpnAuthenticationTypeAAD),
-						string(virtualwans.VpnAuthenticationTypeCertificate),
-						string(virtualwans.VpnAuthenticationTypeRadius),
-					}, false),
+					Type:         pluginsdk.TypeString,
+					ValidateFunc: validation.StringInSlice(virtualwans.PossibleValuesForVpnAuthenticationType(), false),
 				},
 			},
 

--- a/internal/services/network/web_application_firewall_policy_resource.go
+++ b/internal/services/network/web_application_firewall_policy_resource.go
@@ -103,18 +103,9 @@ func resourceWebApplicationFirewallPolicy() *pluginsdk.Resource {
 										Elem: &pluginsdk.Resource{
 											Schema: map[string]*pluginsdk.Schema{
 												"variable_name": {
-													Type:     pluginsdk.TypeString,
-													Required: true,
-													ValidateFunc: validation.StringInSlice([]string{
-														string(webapplicationfirewallpolicies.WebApplicationFirewallMatchVariableRemoteAddr),
-														string(webapplicationfirewallpolicies.WebApplicationFirewallMatchVariableRequestMethod),
-														string(webapplicationfirewallpolicies.WebApplicationFirewallMatchVariableQueryString),
-														string(webapplicationfirewallpolicies.WebApplicationFirewallMatchVariablePostArgs),
-														string(webapplicationfirewallpolicies.WebApplicationFirewallMatchVariableRequestUri),
-														string(webapplicationfirewallpolicies.WebApplicationFirewallMatchVariableRequestHeaders),
-														string(webapplicationfirewallpolicies.WebApplicationFirewallMatchVariableRequestBody),
-														string(webapplicationfirewallpolicies.WebApplicationFirewallMatchVariableRequestCookies),
-													}, false),
+													Type:         pluginsdk.TypeString,
+													Required:     true,
+													ValidateFunc: validation.StringInSlice(webapplicationfirewallpolicies.PossibleValuesForWebApplicationFirewallMatchVariable(), false),
 												},
 												"selector": {
 													Type:     pluginsdk.TypeString,
@@ -124,22 +115,9 @@ func resourceWebApplicationFirewallPolicy() *pluginsdk.Resource {
 										},
 									},
 									"operator": {
-										Type:     pluginsdk.TypeString,
-										Required: true,
-										ValidateFunc: validation.StringInSlice([]string{
-											string(webapplicationfirewallpolicies.WebApplicationFirewallOperatorAny),
-											string(webapplicationfirewallpolicies.WebApplicationFirewallOperatorIPMatch),
-											string(webapplicationfirewallpolicies.WebApplicationFirewallOperatorGeoMatch),
-											string(webapplicationfirewallpolicies.WebApplicationFirewallOperatorEqual),
-											string(webapplicationfirewallpolicies.WebApplicationFirewallOperatorContains),
-											string(webapplicationfirewallpolicies.WebApplicationFirewallOperatorLessThan),
-											string(webapplicationfirewallpolicies.WebApplicationFirewallOperatorGreaterThan),
-											string(webapplicationfirewallpolicies.WebApplicationFirewallOperatorLessThanOrEqual),
-											string(webapplicationfirewallpolicies.WebApplicationFirewallOperatorGreaterThanOrEqual),
-											string(webapplicationfirewallpolicies.WebApplicationFirewallOperatorBeginsWith),
-											string(webapplicationfirewallpolicies.WebApplicationFirewallOperatorEndsWith),
-											string(webapplicationfirewallpolicies.WebApplicationFirewallOperatorRegex),
-										}, false),
+										Type:         pluginsdk.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringInSlice(webapplicationfirewallpolicies.PossibleValuesForWebApplicationFirewallOperator(), false),
 									},
 									"negation_condition": {
 										Type:     pluginsdk.TypeBool,
@@ -161,13 +139,9 @@ func resourceWebApplicationFirewallPolicy() *pluginsdk.Resource {
 							Required: true,
 						},
 						"rule_type": {
-							Type:     pluginsdk.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(webapplicationfirewallpolicies.WebApplicationFirewallRuleTypeMatchRule),
-								string(webapplicationfirewallpolicies.WebApplicationFirewallRuleTypeRateLimitRule),
-								string(webapplicationfirewallpolicies.WebApplicationFirewallRuleTypeInvalid),
-							}, false),
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(webapplicationfirewallpolicies.PossibleValuesForWebApplicationFirewallRuleType(), false),
 						},
 						"name": {
 							Type:     pluginsdk.TypeString,
@@ -205,19 +179,9 @@ func resourceWebApplicationFirewallPolicy() *pluginsdk.Resource {
 							Elem: &pluginsdk.Resource{
 								Schema: map[string]*pluginsdk.Schema{
 									"match_variable": {
-										Type:     pluginsdk.TypeString,
-										Required: true,
-										ValidateFunc: validation.StringInSlice([]string{
-											string(webapplicationfirewallpolicies.OwaspCrsExclusionEntryMatchVariableRequestArgKeys),
-											string(webapplicationfirewallpolicies.OwaspCrsExclusionEntryMatchVariableRequestArgNames),
-											string(webapplicationfirewallpolicies.OwaspCrsExclusionEntryMatchVariableRequestArgValues),
-											string(webapplicationfirewallpolicies.OwaspCrsExclusionEntryMatchVariableRequestCookieKeys),
-											string(webapplicationfirewallpolicies.OwaspCrsExclusionEntryMatchVariableRequestCookieNames),
-											string(webapplicationfirewallpolicies.OwaspCrsExclusionEntryMatchVariableRequestCookieValues),
-											string(webapplicationfirewallpolicies.OwaspCrsExclusionEntryMatchVariableRequestHeaderKeys),
-											string(webapplicationfirewallpolicies.OwaspCrsExclusionEntryMatchVariableRequestHeaderNames),
-											string(webapplicationfirewallpolicies.OwaspCrsExclusionEntryMatchVariableRequestHeaderValues),
-										}, false),
+										Type:         pluginsdk.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringInSlice(webapplicationfirewallpolicies.PossibleValuesForOwaspCrsExclusionEntryMatchVariable(), false),
 									},
 									"selector": {
 										Type:         pluginsdk.TypeString,
@@ -225,15 +189,9 @@ func resourceWebApplicationFirewallPolicy() *pluginsdk.Resource {
 										ValidateFunc: validation.NoZeroValues,
 									},
 									"selector_match_operator": {
-										Type:     pluginsdk.TypeString,
-										Required: true,
-										ValidateFunc: validation.StringInSlice([]string{
-											string(webapplicationfirewallpolicies.OwaspCrsExclusionEntrySelectorMatchOperatorContains),
-											string(webapplicationfirewallpolicies.OwaspCrsExclusionEntrySelectorMatchOperatorEndsWith),
-											string(webapplicationfirewallpolicies.OwaspCrsExclusionEntrySelectorMatchOperatorEquals),
-											string(webapplicationfirewallpolicies.OwaspCrsExclusionEntrySelectorMatchOperatorEqualsAny),
-											string(webapplicationfirewallpolicies.OwaspCrsExclusionEntrySelectorMatchOperatorStartsWith),
-										}, false),
+										Type:         pluginsdk.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringInSlice(webapplicationfirewallpolicies.PossibleValuesForOwaspCrsExclusionEntrySelectorMatchOperator(), false),
 									},
 									"excluded_rule_set": {
 										Type:     pluginsdk.TypeList,
@@ -323,15 +281,9 @@ func resourceWebApplicationFirewallPolicy() *pluginsdk.Resource {
 															},
 
 															"action": {
-																Type:     pluginsdk.TypeString,
-																Optional: true,
-																ValidateFunc: validation.StringInSlice([]string{
-																	string(webapplicationfirewallpolicies.ActionTypeAllow),
-																	string(webapplicationfirewallpolicies.ActionTypeAnomalyScoring),
-																	string(webapplicationfirewallpolicies.ActionTypeBlock),
-																	string(webapplicationfirewallpolicies.ActionTypeJSChallenge),
-																	string(webapplicationfirewallpolicies.ActionTypeLog),
-																}, false),
+																Type:         pluginsdk.TypeString,
+																Optional:     true,
+																ValidateFunc: validation.StringInSlice(webapplicationfirewallpolicies.PossibleValuesForActionType(), false),
 															},
 														},
 													},
@@ -359,13 +311,10 @@ func resourceWebApplicationFirewallPolicy() *pluginsdk.Resource {
 						},
 
 						"mode": {
-							Type:     pluginsdk.TypeString,
-							Optional: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(webapplicationfirewallpolicies.WebApplicationFirewallModePrevention),
-								string(webapplicationfirewallpolicies.WebApplicationFirewallModeDetection),
-							}, false),
-							Default: string(webapplicationfirewallpolicies.WebApplicationFirewallModePrevention),
+							Type:         pluginsdk.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice(webapplicationfirewallpolicies.PossibleValuesForWebApplicationFirewallMode(), false),
+							Default:      string(webapplicationfirewallpolicies.WebApplicationFirewallModePrevention),
 						},
 
 						"request_body_check": {


### PR DESCRIPTION
Part 3/4 of splitting #33162 (services hdinsight through network, 76 files).

Converts complete hand-written `validation.StringInSlice` enum value lists to the generated `PossibleValuesFor<Enum>()` helpers, so new enum values are picked up automatically on SDK upgrades. No validation behavior changes - only lists proven complete by the AZS004 check are converted.

Deliberately left as-is across the series: 235 lists missing values from their enum (accepting new values is a behavior change needing per-case review) and 69 lists referencing track-1 SDK enums whose `Possible<Enum>Values()` helpers return typed slices rather than `[]string`. AZS004 stays disabled in .golangci.yml until these are resolved (comment updated in part 4/4).