### PR TITLE
linters - AZS004 complete enum lists to PossibleValuesFor<Enum>() 4/4 - services n-t (newrelic ... trafficmanager)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -94,7 +94,7 @@ linters:
             - AZR004 #Resource IDs should not be compared with == or != - to fix in a later commit
             - AZR003 # d.Get should not be used within a Delete function as it does not work as expected during deletion - 9 findings to fix later
             - AZS003 # TypeList blocks where every property is optional with no default allow empty blocks - 290 findings to fix later
-            - AZS004 # hand-written enum value lists instead of PossibleValuesFor<Enum>() - 884 findings (235 lists missing values) to fix after this is merged
+            - AZS004 # hand-written enum value lists instead of PossibleValuesFor<Enum>() - 304 findings: 235 lists missing values to review + 69 track-1 SDK enums whose helpers return typed slices
             - AZS005 # resources with no corresponding data source - 768 findings, to determine if to be fixed later
             - AZS006 # data sources missing properties that exist on the resource - 185 findings, todo later
       tfproviderlint:

--- a/internal/services/newrelic/new_relic_monitor_resource.go
+++ b/internal/services/newrelic/new_relic_monitor_resource.go
@@ -125,14 +125,11 @@ func (r NewRelicMonitorResource) Arguments() map[string]*pluginsdk.Schema {
 					},
 
 					"usage_type": {
-						Type:     pluginsdk.TypeString,
-						Optional: true,
-						ForceNew: true,
-						Default:  string(monitors.UsageTypePAYG),
-						ValidateFunc: validation.StringInSlice([]string{
-							string(monitors.UsageTypeCOMMITTED),
-							string(monitors.UsageTypePAYG),
-						}, false),
+						Type:         pluginsdk.TypeString,
+						Optional:     true,
+						ForceNew:     true,
+						Default:      string(monitors.UsageTypePAYG),
+						ValidateFunc: validation.StringInSlice(monitors.PossibleValuesForUsageType(), false),
 					},
 				},
 			},
@@ -177,14 +174,11 @@ func (r NewRelicMonitorResource) Arguments() map[string]*pluginsdk.Schema {
 		},
 
 		"account_creation_source": {
-			Type:     pluginsdk.TypeString,
-			Optional: true,
-			ForceNew: true,
-			Default:  string(monitors.AccountCreationSourceLIFTR),
-			ValidateFunc: validation.StringInSlice([]string{
-				string(monitors.AccountCreationSourceLIFTR),
-				string(monitors.AccountCreationSourceNEWRELIC),
-			}, false),
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ForceNew:     true,
+			Default:      string(monitors.AccountCreationSourceLIFTR),
+			ValidateFunc: validation.StringInSlice(monitors.PossibleValuesForAccountCreationSource(), false),
 		},
 
 		"account_id": {
@@ -214,14 +208,11 @@ func (r NewRelicMonitorResource) Arguments() map[string]*pluginsdk.Schema {
 		},
 
 		"org_creation_source": {
-			Type:     pluginsdk.TypeString,
-			Optional: true,
-			ForceNew: true,
-			Default:  string(monitors.OrgCreationSourceLIFTR),
-			ValidateFunc: validation.StringInSlice([]string{
-				string(monitors.OrgCreationSourceLIFTR),
-				string(monitors.OrgCreationSourceNEWRELIC),
-			}, false),
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ForceNew:     true,
+			Default:      string(monitors.OrgCreationSourceLIFTR),
+			ValidateFunc: validation.StringInSlice(monitors.PossibleValuesForOrgCreationSource(), false),
 		},
 
 		"user_id": {

--- a/internal/services/newrelic/new_relic_tag_rule_resource.go
+++ b/internal/services/newrelic/new_relic_tag_rule_resource.go
@@ -82,12 +82,9 @@ func (r NewRelicTagRuleResource) Arguments() map[string]*pluginsdk.Schema {
 					},
 
 					"action": {
-						Type:     pluginsdk.TypeString,
-						Required: true,
-						ValidateFunc: validation.StringInSlice([]string{
-							string(tagrules.TagActionExclude),
-							string(tagrules.TagActionInclude),
-						}, false),
+						Type:         pluginsdk.TypeString,
+						Required:     true,
+						ValidateFunc: validation.StringInSlice(tagrules.PossibleValuesForTagAction(), false),
 					},
 
 					"value": {
@@ -116,12 +113,9 @@ func (r NewRelicTagRuleResource) Arguments() map[string]*pluginsdk.Schema {
 					},
 
 					"action": {
-						Type:     pluginsdk.TypeString,
-						Required: true,
-						ValidateFunc: validation.StringInSlice([]string{
-							string(tagrules.TagActionExclude),
-							string(tagrules.TagActionInclude),
-						}, false),
+						Type:         pluginsdk.TypeString,
+						Required:     true,
+						ValidateFunc: validation.StringInSlice(tagrules.PossibleValuesForTagAction(), false),
 					},
 
 					"value": {

--- a/internal/services/notificationhub/notification_hub_namespace_resource.go
+++ b/internal/services/notificationhub/notification_hub_namespace_resource.go
@@ -61,13 +61,9 @@ func resourceNotificationHubNamespace() *pluginsdk.Resource {
 			"location": commonschema.Location(),
 
 			"sku_name": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(namespaces.SkuNameBasic),
-					string(namespaces.SkuNameFree),
-					string(namespaces.SkuNameStandard),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(namespaces.PossibleValuesForSkuName(), false),
 			},
 
 			"enabled": {
@@ -78,13 +74,10 @@ func resourceNotificationHubNamespace() *pluginsdk.Resource {
 			},
 
 			"namespace_type": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(namespaces.NamespaceTypeMessaging),
-					string(namespaces.NamespaceTypeNotificationHub),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(namespaces.PossibleValuesForNamespaceType(), false),
 			},
 
 			"zone_redundancy_enabled": {

--- a/internal/services/oracle/oracle_autonomous_database_resource.go
+++ b/internal/services/oracle/oracle_autonomous_database_resource.go
@@ -139,13 +139,10 @@ func (AutonomousDatabaseRegularResource) Arguments() map[string]*pluginsdk.Schem
 		},
 
 		"license_model": {
-			Type:     pluginsdk.TypeString,
-			Required: true,
-			ForceNew: true,
-			ValidateFunc: validation.StringInSlice([]string{
-				string(autonomousdatabases.LicenseModelLicenseIncluded),
-				string(autonomousdatabases.LicenseModelBringYourOwnLicense),
-			}, false),
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringInSlice(autonomousdatabases.PossibleValuesForLicenseModel(), false),
 		},
 
 		"long_term_backup_schedule": {

--- a/internal/services/policy/policy_virtual_machine_configuration_assignment_resource.go
+++ b/internal/services/policy/policy_virtual_machine_configuration_assignment_resource.go
@@ -70,14 +70,9 @@ func resourcePolicyVirtualMachineConfigurationAssignmentSchema() map[string]*plu
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
 					"assignment_type": {
-						Type:     pluginsdk.TypeString,
-						Optional: true,
-						ValidateFunc: validation.StringInSlice([]string{
-							string(guestconfigurationassignments.AssignmentTypeAudit),
-							string(guestconfigurationassignments.AssignmentTypeDeployAndAutoCorrect),
-							string(guestconfigurationassignments.AssignmentTypeApplyAndAutoCorrect),
-							string(guestconfigurationassignments.AssignmentTypeApplyAndMonitor),
-						}, false),
+						Type:         pluginsdk.TypeString,
+						Optional:     true,
+						ValidateFunc: validation.StringInSlice(guestconfigurationassignments.PossibleValuesForAssignmentType(), false),
 					},
 
 					"content_hash": {

--- a/internal/services/policy/resource_group_policy_remediation_resource.go
+++ b/internal/services/policy/resource_group_policy_remediation_resource.go
@@ -102,13 +102,10 @@ func resourceArmResourceGroupPolicyRemediation() *pluginsdk.Resource {
 			},
 
 			"resource_discovery_mode": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				Default:  string(remediations.ResourceDiscoveryModeExistingNonCompliant),
-				ValidateFunc: validation.StringInSlice([]string{
-					string(remediations.ResourceDiscoveryModeExistingNonCompliant),
-					string(remediations.ResourceDiscoveryModeReEvaluateCompliance),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				Default:      string(remediations.ResourceDiscoveryModeExistingNonCompliant),
+				ValidateFunc: validation.StringInSlice(remediations.PossibleValuesForResourceDiscoveryMode(), false),
 			},
 		},
 	}

--- a/internal/services/policy/resource_policy_remediation_resource.go
+++ b/internal/services/policy/resource_policy_remediation_resource.go
@@ -104,13 +104,10 @@ func resourceArmResourcePolicyRemediation() *pluginsdk.Resource {
 			},
 
 			"resource_discovery_mode": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				Default:  string(remediations.ResourceDiscoveryModeExistingNonCompliant),
-				ValidateFunc: validation.StringInSlice([]string{
-					string(remediations.ResourceDiscoveryModeExistingNonCompliant),
-					string(remediations.ResourceDiscoveryModeReEvaluateCompliance),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				Default:      string(remediations.ResourceDiscoveryModeExistingNonCompliant),
+				ValidateFunc: validation.StringInSlice(remediations.PossibleValuesForResourceDiscoveryMode(), false),
 			},
 		},
 	}

--- a/internal/services/policy/subscription_policy_remediation_resource.go
+++ b/internal/services/policy/subscription_policy_remediation_resource.go
@@ -101,13 +101,10 @@ func resourceArmSubscriptionPolicyRemediation() *pluginsdk.Resource {
 			},
 
 			"resource_discovery_mode": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				Default:  string(remediations.ResourceDiscoveryModeExistingNonCompliant),
-				ValidateFunc: validation.StringInSlice([]string{
-					string(remediations.ResourceDiscoveryModeExistingNonCompliant),
-					string(remediations.ResourceDiscoveryModeReEvaluateCompliance),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				Default:      string(remediations.ResourceDiscoveryModeExistingNonCompliant),
+				ValidateFunc: validation.StringInSlice(remediations.PossibleValuesForResourceDiscoveryMode(), false),
 			},
 		},
 	}

--- a/internal/services/postgres/postgresql_flexible_server_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_resource.go
@@ -172,19 +172,10 @@ func resourcePostgresqlFlexibleServer() *pluginsdk.Resource {
 			},
 
 			"version": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				Computed: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(servers.PostgresMajorVersionOneOne),
-					string(servers.PostgresMajorVersionOneTwo),
-					string(servers.PostgresMajorVersionOneThree),
-					string(servers.PostgresMajorVersionOneFour),
-					string(servers.PostgresMajorVersionOneFive),
-					string(servers.PostgresMajorVersionOneSix),
-					string(servers.PostgresMajorVersionOneSeven),
-					string(servers.PostgresMajorVersionOneEight),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringInSlice(servers.PossibleValuesForPostgresMajorVersion(), false),
 			},
 
 			"zone": commonschema.ZoneSingleOptional(),
@@ -286,12 +277,9 @@ func resourcePostgresqlFlexibleServer() *pluginsdk.Resource {
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
 						"mode": {
-							Type:     pluginsdk.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(servers.HighAvailabilityModeZoneRedundant),
-								string(servers.HighAvailabilityModeSameZone),
-							}, false),
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(servers.PossibleValuesForHighAvailabilityMode(), false),
 						},
 
 						"standby_availability_zone": commonschema.ZoneSingleOptional(),

--- a/internal/services/powerbi/powerbi_embedded_resource.go
+++ b/internal/services/powerbi/powerbi_embedded_resource.go
@@ -79,14 +79,11 @@ func resourcePowerBIEmbedded() *pluginsdk.Resource {
 			},
 
 			"mode": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				Default:  string(capacities.ModeGenTwo),
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(capacities.ModeGenOne),
-					string(capacities.ModeGenTwo),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				Default:      string(capacities.ModeGenTwo),
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(capacities.PossibleValuesForMode(), false),
 			},
 
 			"tags": commonschema.Tags(),

--- a/internal/services/recoveryservices/recovery_services_vault_resource.go
+++ b/internal/services/recoveryservices/recovery_services_vault_resource.go
@@ -103,25 +103,18 @@ func resourceRecoveryServicesVault() *pluginsdk.Resource {
 
 			// set `immutability` to Computed, because it will start to return from the service once it has been set.
 			"immutability": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				Computed: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(vaults.ImmutabilityStateLocked),
-					string(vaults.ImmutabilityStateUnlocked),
-					string(vaults.ImmutabilityStateDisabled),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringInSlice(vaults.PossibleValuesForImmutabilityState(), false),
 			},
 
 			"tags": commonschema.Tags(),
 
 			"sku": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(vaults.SkuNameRSZero),
-					string(vaults.SkuNameStandard),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(vaults.PossibleValuesForSkuName(), false),
 			},
 
 			"storage_mode_type": {

--- a/internal/services/recoveryservices/site_recovery_replication_recovery_plan_resource.go
+++ b/internal/services/recoveryservices/site_recovery_replication_recovery_plan_resource.go
@@ -220,11 +220,8 @@ func replicationRecoveryPlanActionSchema() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeSet,
 				Required: true,
 				Elem: &pluginsdk.Schema{
-					Type: pluginsdk.TypeString,
-					ValidateFunc: validation.StringInSlice([]string{
-						string(replicationrecoveryplans.PossibleOperationsDirectionsPrimaryToRecovery),
-						string(replicationrecoveryplans.PossibleOperationsDirectionsRecoveryToPrimary),
-					}, false),
+					Type:         pluginsdk.TypeString,
+					ValidateFunc: validation.StringInSlice(replicationrecoveryplans.PossibleValuesForPossibleOperationsDirections(), false),
 				},
 			},
 
@@ -248,12 +245,9 @@ func replicationRecoveryPlanActionSchema() *pluginsdk.Resource {
 			},
 
 			"fabric_location": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(replicationrecoveryplans.RecoveryPlanActionLocationPrimary),
-					string(replicationrecoveryplans.RecoveryPlanActionLocationRecovery),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(replicationrecoveryplans.PossibleValuesForRecoveryPlanActionLocation(), false),
 			},
 
 			"manual_action_instruction": {

--- a/internal/services/redis/redis_cache_resource.go
+++ b/internal/services/redis/redis_cache_resource.go
@@ -96,13 +96,9 @@ func resourceRedisCache() *pluginsdk.Resource {
 			},
 
 			"sku_name": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(redisresources.SkuNameBasic),
-					string(redisresources.SkuNameStandard),
-					string(redisresources.SkuNamePremium),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(redisresources.PossibleValuesForSkuName(), false),
 			},
 
 			"minimum_tls_version": {

--- a/internal/services/redis/redis_linked_server_resource.go
+++ b/internal/services/redis/redis_linked_server_resource.go
@@ -64,13 +64,10 @@ func resourceRedisLinkedServer() *pluginsdk.Resource {
 			"resource_group_name": commonschema.ResourceGroupName(),
 
 			"server_role": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(linkedserver.ReplicationRolePrimary),
-					string(linkedserver.ReplicationRoleSecondary),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(linkedserver.PossibleValuesForReplicationRole(), false),
 			},
 
 			"name": {

--- a/internal/services/relay/relay_namespace_resource.go
+++ b/internal/services/relay/relay_namespace_resource.go
@@ -53,11 +53,9 @@ func resourceRelayNamespace() *pluginsdk.Resource {
 			"resource_group_name": commonschema.ResourceGroupName(),
 
 			"sku_name": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(namespaces.SkuNameStandard),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(namespaces.PossibleValuesForSkuName(), false),
 			},
 
 			"metric_id": {

--- a/internal/services/resource/resource_deployment_script_common.go
+++ b/internal/services/resource/resource_deployment_script_common.go
@@ -97,15 +97,11 @@ func getDeploymentScriptArguments(kind DeploymentScriptKind) map[string]*plugins
 		},
 
 		"cleanup_preference": {
-			Type:     pluginsdk.TypeString,
-			Optional: true,
-			ForceNew: true,
-			ValidateFunc: validation.StringInSlice([]string{
-				string(deploymentscripts.CleanupOptionsOnSuccess),
-				string(deploymentscripts.CleanupOptionsOnExpiration),
-				string(deploymentscripts.CleanupOptionsAlways),
-			}, false),
-			Default: string(deploymentscripts.CleanupOptionsAlways),
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringInSlice(deploymentscripts.PossibleValuesForCleanupOptions(), false),
+			Default:      string(deploymentscripts.CleanupOptionsAlways),
 		},
 
 		"container": {

--- a/internal/services/search/search_service_resource.go
+++ b/internal/services/search/search_service_resource.go
@@ -65,17 +65,9 @@ func resourceSearchService() *pluginsdk.Resource {
 			"resource_group_name": commonschema.ResourceGroupName(),
 
 			"sku": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(services.SkuNameFree),
-					string(services.SkuNameBasic),
-					string(services.SkuNameStandard),
-					string(services.SkuNameStandardTwo),
-					string(services.SkuNameStandardThree),
-					string(services.SkuNameStorageOptimizedLOne),
-					string(services.SkuNameStorageOptimizedLTwo),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(services.PossibleValuesForSkuName(), false),
 			},
 
 			"replica_count": {
@@ -106,23 +98,17 @@ func resourceSearchService() *pluginsdk.Resource {
 			},
 
 			"authentication_failure_mode": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(services.AadAuthFailureModeHTTPFourZeroOneWithBearerChallenge),
-					string(services.AadAuthFailureModeHTTPFourZeroThree),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(services.PossibleValuesForAadAuthFailureMode(), false),
 			},
 
 			"hosting_mode": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Default:  string(services.HostingModeDefault),
-				ValidateFunc: validation.StringInSlice([]string{
-					string(services.HostingModeDefault),
-					string(services.HostingModeHighDensity),
-				}, true),
+				Type:                  pluginsdk.TypeString,
+				Optional:              true,
+				ForceNew:              true,
+				Default:               string(services.HostingModeDefault),
+				ValidateFunc:          validation.StringInSlice(services.PossibleValuesForHostingMode(), true),
 				DiffSuppressFunc:      suppress.CaseDifference, // Breaking change introduced in https://github.com/Azure/azure-rest-api-specs/pull/37579 that changed the case of the Enum value
 				DiffSuppressOnRefresh: true,
 			},
@@ -202,13 +188,10 @@ func resourceSearchService() *pluginsdk.Resource {
 			},
 
 			"network_rule_bypass_option": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(services.SearchBypassAzureServices),
-					string(services.SearchBypassNone),
-				}, false),
-				Default: string(services.SearchBypassNone),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(services.PossibleValuesForSearchBypass(), false),
+				Default:      string(services.SearchBypassNone),
 			},
 
 			"identity": commonschema.SystemAssignedUserAssignedIdentityOptional(),

--- a/internal/services/securitycenter/security_center_automation_resource.go
+++ b/internal/services/securitycenter/security_center_automation_resource.go
@@ -132,21 +132,9 @@ func resourceSecurityCenterAutomation() *pluginsdk.Resource {
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
 						"event_source": {
-							Type:     pluginsdk.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(automations.EventSourceAlerts),
-								string(automations.EventSourceAssessments),
-								string(automations.EventSourceAssessmentsSnapshot),
-								string(automations.EventSourceRegulatoryComplianceAssessment),
-								string(automations.EventSourceRegulatoryComplianceAssessmentSnapshot),
-								string(automations.EventSourceSecureScoreControls),
-								string(automations.EventSourceSecureScoreControlsSnapshot),
-								string(automations.EventSourceSecureScores),
-								string(automations.EventSourceSecureScoresSnapshot),
-								string(automations.EventSourceSubAssessments),
-								string(automations.EventSourceSubAssessmentsSnapshot),
-							}, false),
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(automations.PossibleValuesForEventSource(), false),
 						},
 
 						"rule_set": {
@@ -168,29 +156,14 @@ func resourceSecurityCenterAutomation() *pluginsdk.Resource {
 													Required: true,
 												},
 												"operator": {
-													Type:     pluginsdk.TypeString,
-													Required: true,
-													ValidateFunc: validation.StringInSlice([]string{
-														string(automations.OperatorContains),
-														string(automations.OperatorEndsWith),
-														string(automations.OperatorEquals),
-														string(automations.OperatorGreaterThan),
-														string(automations.OperatorGreaterThanOrEqualTo),
-														string(automations.OperatorLesserThan),
-														string(automations.OperatorLesserThanOrEqualTo),
-														string(automations.OperatorNotEquals),
-														string(automations.OperatorStartsWith),
-													}, false),
+													Type:         pluginsdk.TypeString,
+													Required:     true,
+													ValidateFunc: validation.StringInSlice(automations.PossibleValuesForOperator(), false),
 												},
 												"property_type": {
-													Type:     pluginsdk.TypeString,
-													Required: true,
-													ValidateFunc: validation.StringInSlice([]string{
-														string(automations.PropertyTypeInteger),
-														string(automations.PropertyTypeString),
-														string(automations.PropertyTypeBoolean),
-														string(automations.PropertyTypeNumber),
-													}, false),
+													Type:         pluginsdk.TypeString,
+													Required:     true,
+													ValidateFunc: validation.StringInSlice(automations.PossibleValuesForPropertyType(), false),
 												},
 											},
 										},

--- a/internal/services/sentinel/sentinel_alert_rule_anomaly_built_in_resource.go
+++ b/internal/services/sentinel/sentinel_alert_rule_anomaly_built_in_resource.go
@@ -88,12 +88,9 @@ func (r AlertRuleAnomalyBuiltInResource) Arguments() map[string]*schema.Schema {
 		},
 
 		"mode": {
-			Type:     pluginsdk.TypeString,
-			Required: true,
-			ValidateFunc: validation.StringInSlice([]string{
-				string(securitymlanalyticssettings.SettingsStatusProduction),
-				string(securitymlanalyticssettings.SettingsStatusFlighting),
-			}, false),
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: validation.StringInSlice(securitymlanalyticssettings.PossibleValuesForSettingsStatus(), false),
 		},
 	}
 }

--- a/internal/services/sentinel/sentinel_alert_rule_anomaly_duplicate_resource.go
+++ b/internal/services/sentinel/sentinel_alert_rule_anomaly_duplicate_resource.go
@@ -86,12 +86,9 @@ func (r AlertRuleAnomalyDuplicateResource) Arguments() map[string]*schema.Schema
 		},
 
 		"mode": {
-			Type:     pluginsdk.TypeString,
-			Required: true,
-			ValidateFunc: validation.StringInSlice([]string{
-				string(securitymlanalyticssettings.SettingsStatusProduction),
-				string(securitymlanalyticssettings.SettingsStatusFlighting),
-			}, false),
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: validation.StringInSlice(securitymlanalyticssettings.PossibleValuesForSettingsStatus(), false),
 		},
 
 		"multi_select_observation": {

--- a/internal/services/sentinel/sentinel_alert_rule_fusion_resource.go
+++ b/internal/services/sentinel/sentinel_alert_rule_fusion_resource.go
@@ -99,12 +99,7 @@ func resourceSentinelAlertRuleFusion() *pluginsdk.Resource {
 										Elem: &pluginsdk.Schema{
 											Type: pluginsdk.TypeString,
 											ValidateFunc: validation.StringInSlice(
-												[]string{
-													string(alertrules.AlertSeverityHigh),
-													string(alertrules.AlertSeverityMedium),
-													string(alertrules.AlertSeverityLow),
-													string(alertrules.AlertSeverityInformational),
-												},
+												alertrules.PossibleValuesForAlertSeverity(),
 												false,
 											),
 										},

--- a/internal/services/sentinel/sentinel_alert_rule_ms_security_incident_resource.go
+++ b/internal/services/sentinel/sentinel_alert_rule_ms_security_incident_resource.go
@@ -60,17 +60,9 @@ func resourceSentinelAlertRuleMsSecurityIncident() *pluginsdk.Resource {
 			},
 
 			"product_filter": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(alertrules.MicrosoftSecurityProductNameMicrosoftCloudAppSecurity),
-					string(alertrules.MicrosoftSecurityProductNameAzureSecurityCenter),
-					string(alertrules.MicrosoftSecurityProductNameAzureActiveDirectoryIdentityProtection),
-					string(alertrules.MicrosoftSecurityProductNameAzureSecurityCenterForIoT),
-					string(alertrules.MicrosoftSecurityProductNameAzureAdvancedThreatProtection),
-					string(alertrules.MicrosoftSecurityProductNameMicrosoftDefenderAdvancedThreatProtection),
-					string(alertrules.MicrosoftSecurityProductNameOfficeThreeSixFiveAdvancedThreatProtection),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(alertrules.PossibleValuesForMicrosoftSecurityProductName(), false),
 			},
 
 			"severity_filter": {
@@ -78,13 +70,8 @@ func resourceSentinelAlertRuleMsSecurityIncident() *pluginsdk.Resource {
 				Required: true,
 				MinItems: 1,
 				Elem: &pluginsdk.Schema{
-					Type: pluginsdk.TypeString,
-					ValidateFunc: validation.StringInSlice([]string{
-						string(alertrules.AlertSeverityHigh),
-						string(alertrules.AlertSeverityMedium),
-						string(alertrules.AlertSeverityLow),
-						string(alertrules.AlertSeverityInformational),
-					}, false),
+					Type:         pluginsdk.TypeString,
+					ValidateFunc: validation.StringInSlice(alertrules.PossibleValuesForAlertSeverity(), false),
 				},
 			},
 

--- a/internal/services/sentinel/sentinel_data_connector_threat_intelligence_taxii_resource.go
+++ b/internal/services/sentinel/sentinel_data_connector_threat_intelligence_taxii_resource.go
@@ -79,11 +79,7 @@ func (r DataConnectorThreatIntelligenceTAXIIResource) Arguments() map[string]*pl
 			Type:     pluginsdk.TypeString,
 			Optional: true,
 			Default:  string(dataconnectors.PollingFrequencyOnceAnHour),
-			ValidateFunc: validation.StringInSlice([]string{
-				string(dataconnectors.PollingFrequencyOnceAMinute),
-				string(dataconnectors.PollingFrequencyOnceAnHour),
-				string(dataconnectors.PollingFrequencyOnceADay),
-			},
+			ValidateFunc: validation.StringInSlice(dataconnectors.PossibleValuesForPollingFrequency(),
 				false),
 		},
 		"lookback_date": {

--- a/internal/services/sentinel/sentinel_metadata_resource.go
+++ b/internal/services/sentinel/sentinel_metadata_resource.go
@@ -167,13 +167,9 @@ func (a MetadataResource) Arguments() map[string]*pluginsdk.Schema {
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*schema.Schema{
 					"tier": {
-						Type:     pluginsdk.TypeString,
-						Required: true,
-						ValidateFunc: validation.StringInSlice([]string{
-							string(sentinelmetadata.SupportTierCommunity),
-							string(sentinelmetadata.SupportTierMicrosoft),
-							string(sentinelmetadata.SupportTierPartner),
-						}, false),
+						Type:         pluginsdk.TypeString,
+						Required:     true,
+						ValidateFunc: validation.StringInSlice(sentinelmetadata.PossibleValuesForSupportTier(), false),
 					},
 
 					"name": {

--- a/internal/services/servicebus/servicebus_namespace_resource.go
+++ b/internal/services/servicebus/servicebus_namespace_resource.go
@@ -81,13 +81,9 @@ func resourceServiceBusNamespace() *pluginsdk.Resource {
 			"identity": commonschema.SystemAssignedUserAssignedIdentityOptional(),
 
 			"sku": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(namespaces.SkuNameBasic),
-					string(namespaces.SkuNameStandard),
-					string(namespaces.SkuNamePremium),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(namespaces.PossibleValuesForSkuName(), false),
 			},
 
 			"capacity": {
@@ -185,13 +181,10 @@ func resourceServiceBusNamespace() *pluginsdk.Resource {
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
 						"default_action": {
-							Type:     pluginsdk.TypeString,
-							Optional: true,
-							Default:  string(namespaces.DefaultActionAllow),
-							ValidateFunc: validation.StringInSlice([]string{
-								string(namespaces.DefaultActionAllow),
-								string(namespaces.DefaultActionDeny),
-							}, false),
+							Type:         pluginsdk.TypeString,
+							Optional:     true,
+							Default:      string(namespaces.DefaultActionAllow),
+							ValidateFunc: validation.StringInSlice(namespaces.PossibleValuesForDefaultAction(), false),
 						},
 
 						"public_network_access_enabled": {

--- a/internal/services/servicebus/servicebus_subscription_rule_resource.go
+++ b/internal/services/servicebus/servicebus_subscription_rule_resource.go
@@ -61,12 +61,9 @@ func resourceServicebusSubscriptionRuleSchema() map[string]*pluginsdk.Schema {
 		},
 
 		"filter_type": {
-			Type:     pluginsdk.TypeString,
-			Required: true,
-			ValidateFunc: validation.StringInSlice([]string{
-				string(subscriptions.FilterTypeSqlFilter),
-				string(subscriptions.FilterTypeCorrelationFilter),
-			}, false),
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: validation.StringInSlice(subscriptions.PossibleValuesForFilterType(), false),
 		},
 
 		"action": {

--- a/internal/services/serviceconnector/app_service_connection_resource.go
+++ b/internal/services/serviceconnector/app_service_connection_resource.go
@@ -79,12 +79,9 @@ func (r AppServiceConnectorResource) Arguments() map[string]*schema.Schema {
 		"secret_store": secretStoreSchema(),
 
 		"vnet_solution": {
-			Type:     pluginsdk.TypeString,
-			Optional: true,
-			ValidateFunc: validation.StringInSlice([]string{
-				string(servicelinker.VNetSolutionTypeServiceEndpoint),
-				string(servicelinker.VNetSolutionTypePrivateLink),
-			}, false),
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.StringInSlice(servicelinker.PossibleValuesForVNetSolutionType(), false),
 		},
 
 		"authentication": authInfoSchema(),

--- a/internal/services/serviceconnector/function_app_connection_resource.go
+++ b/internal/services/serviceconnector/function_app_connection_resource.go
@@ -76,12 +76,9 @@ func (r FunctionAppConnectorResource) Arguments() map[string]*schema.Schema {
 		"secret_store": secretStoreSchema(),
 
 		"vnet_solution": {
-			Type:     pluginsdk.TypeString,
-			Optional: true,
-			ValidateFunc: validation.StringInSlice([]string{
-				string(servicelinker.VNetSolutionTypeServiceEndpoint),
-				string(servicelinker.VNetSolutionTypePrivateLink),
-			}, false),
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.StringInSlice(servicelinker.PossibleValuesForVNetSolutionType(), false),
 		},
 
 		"authentication": authInfoSchema(),

--- a/internal/services/serviceconnector/spring_cloud_connection_resource.go
+++ b/internal/services/serviceconnector/spring_cloud_connection_resource.go
@@ -75,12 +75,9 @@ func (r SpringCloudConnectorResource) Arguments() map[string]*schema.Schema {
 		"secret_store": secretStoreSchema(),
 
 		"vnet_solution": {
-			Type:     pluginsdk.TypeString,
-			Optional: true,
-			ValidateFunc: validation.StringInSlice([]string{
-				string(servicelinker.VNetSolutionTypeServiceEndpoint),
-				string(servicelinker.VNetSolutionTypePrivateLink),
-			}, false),
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.StringInSlice(servicelinker.PossibleValuesForVNetSolutionType(), false),
 		},
 
 		"authentication": authInfoSchema(),

--- a/internal/services/servicefabric/service_fabric_cluster_resource.go
+++ b/internal/services/servicefabric/service_fabric_cluster_resource.go
@@ -56,42 +56,27 @@ func resourceServiceFabricCluster() *pluginsdk.Resource {
 			"location": commonschema.Location(),
 
 			"reliability_level": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(cluster.ReliabilityLevelNone),
-					string(cluster.ReliabilityLevelBronze),
-					string(cluster.ReliabilityLevelSilver),
-					string(cluster.ReliabilityLevelGold),
-					string(cluster.ReliabilityLevelPlatinum),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(cluster.PossibleValuesForReliabilityLevel(), false),
 			},
 
 			"upgrade_mode": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(cluster.UpgradeModeAutomatic),
-					string(cluster.UpgradeModeManual),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(cluster.PossibleValuesForUpgradeMode(), false),
 			},
 
 			"service_fabric_zonal_upgrade_mode": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(cluster.SfZonalUpgradeModeHierarchical),
-					string(cluster.SfZonalUpgradeModeParallel),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(cluster.PossibleValuesForSfZonalUpgradeMode(), false),
 			},
 
 			"vmss_zonal_upgrade_mode": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(cluster.VMSSZonalUpgradeModeHierarchical),
-					string(cluster.VMSSZonalUpgradeModeParallel),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(cluster.PossibleValuesForVMSSZonalUpgradeMode(), false),
 			},
 
 			"cluster_code_version": {
@@ -503,14 +488,10 @@ func resourceServiceFabricCluster() *pluginsdk.Resource {
 							ValidateFunc: validate.PortNumber,
 						},
 						"durability_level": {
-							Type:     pluginsdk.TypeString,
-							Optional: true,
-							Default:  string(cluster.DurabilityLevelBronze),
-							ValidateFunc: validation.StringInSlice([]string{
-								string(cluster.DurabilityLevelBronze),
-								string(cluster.DurabilityLevelSilver),
-								string(cluster.DurabilityLevelGold),
-							}, false),
+							Type:         pluginsdk.TypeString,
+							Optional:     true,
+							Default:      string(cluster.DurabilityLevelBronze),
+							ValidateFunc: validation.StringInSlice(cluster.PossibleValuesForDurabilityLevel(), false),
 						},
 
 						"application_ports": {

--- a/internal/services/servicefabricmanaged/service_fabric_managed_cluster_resource.go
+++ b/internal/services/servicefabricmanaged/service_fabric_managed_cluster_resource.go
@@ -206,26 +206,19 @@ func (k ClusterResource) Arguments() map[string]*pluginsdk.Schema {
 		},
 		"lb_rule": lbRulesSchema(),
 		"sku": {
-			Type:     pluginsdk.TypeString,
-			Optional: true,
-			Default:  "Basic",
-			ForceNew: true,
-			ValidateFunc: validation.StringInSlice([]string{
-				string(managedcluster.SkuNameBasic),
-				string(managedcluster.SkuNameStandard),
-			}, false),
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			Default:      "Basic",
+			ForceNew:     true,
+			ValidateFunc: validation.StringInSlice(managedcluster.PossibleValuesForSkuName(), false),
 		},
 		"subnet_id": commonschema.ResourceIDReferenceOptionalForceNew(&commonids.SubnetId{}),
 		"tags":      commonschema.Tags(),
 		"upgrade_wave": {
-			Type:     pluginsdk.TypeString,
-			Optional: true,
-			Default:  managedcluster.ClusterUpgradeCadenceWaveZero,
-			ValidateFunc: validation.StringInSlice([]string{
-				string(managedcluster.ClusterUpgradeCadenceWaveZero),
-				string(managedcluster.ClusterUpgradeCadenceWaveOne),
-				string(managedcluster.ClusterUpgradeCadenceWaveTwo),
-			}, false),
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			Default:      managedcluster.ClusterUpgradeCadenceWaveZero,
+			ValidateFunc: validation.StringInSlice(managedcluster.PossibleValuesForClusterUpgradeCadence(), false),
 		},
 	}
 }
@@ -1004,14 +997,10 @@ func nodeTypeSchema() *pluginsdk.Schema {
 					},
 				},
 				"data_disk_type": {
-					Type:     pluginsdk.TypeString,
-					Optional: true,
-					Default:  string(nodetype.DiskTypeStandardLRS),
-					ValidateFunc: validation.StringInSlice([]string{
-						string(nodetype.DiskTypeStandardLRS),
-						string(nodetype.DiskTypeStandardSSDLRS),
-						string(nodetype.DiskTypePremiumLRS),
-					}, false),
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					Default:      string(nodetype.DiskTypeStandardLRS),
+					ValidateFunc: validation.StringInSlice(nodetype.PossibleValuesForDiskType(), false),
 				},
 				"ephemeral_port_range": {
 					Type:     pluginsdk.TypeString,
@@ -1136,13 +1125,9 @@ func lbRulesSchema() *pluginsdk.Schema {
 					ValidateFunc: validation.IntBetween(1, 65535),
 				},
 				"probe_protocol": {
-					Type:     pluginsdk.TypeString,
-					Required: true,
-					ValidateFunc: validation.StringInSlice([]string{
-						string(managedcluster.ProbeProtocolHTTP),
-						string(managedcluster.ProbeProtocolHTTPS),
-						string(managedcluster.ProbeProtocolTcp),
-					}, false),
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringInSlice(managedcluster.PossibleValuesForProbeProtocol(), false),
 				},
 				"probe_request_path": {
 					Type:         pluginsdk.TypeString,
@@ -1150,12 +1135,9 @@ func lbRulesSchema() *pluginsdk.Schema {
 					ValidateFunc: validation.StringIsNotWhiteSpace,
 				},
 				"protocol": {
-					Type:     pluginsdk.TypeString,
-					Required: true,
-					ValidateFunc: validation.StringInSlice([]string{
-						string(managedcluster.ProtocolTcp),
-						string(managedcluster.ProtocolUdp),
-					}, false),
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringInSlice(managedcluster.PossibleValuesForProtocol(), false),
 				},
 			},
 		},

--- a/internal/services/signalr/signalr_service_network_acl_resource.go
+++ b/internal/services/signalr/signalr_service_network_acl_resource.go
@@ -53,12 +53,9 @@ func resourceArmSignalRServiceNetworkACL() *pluginsdk.Resource {
 			},
 
 			"default_action": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(signalr.ACLActionAllow),
-					string(signalr.ACLActionDeny),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(signalr.PossibleValuesForACLAction(), false),
 			},
 
 			"public_network": {
@@ -72,13 +69,8 @@ func resourceArmSignalRServiceNetworkACL() *pluginsdk.Resource {
 							Optional:      true,
 							ConflictsWith: []string{"public_network.0.denied_request_types"},
 							Elem: &pluginsdk.Schema{
-								Type: pluginsdk.TypeString,
-								ValidateFunc: validation.StringInSlice([]string{
-									string(signalr.SignalRRequestTypeClientConnection),
-									string(signalr.SignalRRequestTypeRESTAPI),
-									string(signalr.SignalRRequestTypeServerConnection),
-									string(signalr.SignalRRequestTypeTrace),
-								}, false),
+								Type:         pluginsdk.TypeString,
+								ValidateFunc: validation.StringInSlice(signalr.PossibleValuesForSignalRRequestType(), false),
 							},
 						},
 
@@ -87,13 +79,8 @@ func resourceArmSignalRServiceNetworkACL() *pluginsdk.Resource {
 							Optional:      true,
 							ConflictsWith: []string{"public_network.0.allowed_request_types"},
 							Elem: &pluginsdk.Schema{
-								Type: pluginsdk.TypeString,
-								ValidateFunc: validation.StringInSlice([]string{
-									string(signalr.SignalRRequestTypeClientConnection),
-									string(signalr.SignalRRequestTypeRESTAPI),
-									string(signalr.SignalRRequestTypeServerConnection),
-									string(signalr.SignalRRequestTypeTrace),
-								}, false),
+								Type:         pluginsdk.TypeString,
+								ValidateFunc: validation.StringInSlice(signalr.PossibleValuesForSignalRRequestType(), false),
 							},
 						},
 					},
@@ -115,13 +102,8 @@ func resourceArmSignalRServiceNetworkACL() *pluginsdk.Resource {
 							Type:     pluginsdk.TypeSet,
 							Optional: true,
 							Elem: &pluginsdk.Schema{
-								Type: pluginsdk.TypeString,
-								ValidateFunc: validation.StringInSlice([]string{
-									string(signalr.SignalRRequestTypeClientConnection),
-									string(signalr.SignalRRequestTypeRESTAPI),
-									string(signalr.SignalRRequestTypeServerConnection),
-									string(signalr.SignalRRequestTypeTrace),
-								}, false),
+								Type:         pluginsdk.TypeString,
+								ValidateFunc: validation.StringInSlice(signalr.PossibleValuesForSignalRRequestType(), false),
 							},
 						},
 
@@ -129,13 +111,8 @@ func resourceArmSignalRServiceNetworkACL() *pluginsdk.Resource {
 							Type:     pluginsdk.TypeSet,
 							Optional: true,
 							Elem: &pluginsdk.Schema{
-								Type: pluginsdk.TypeString,
-								ValidateFunc: validation.StringInSlice([]string{
-									string(signalr.SignalRRequestTypeClientConnection),
-									string(signalr.SignalRRequestTypeRESTAPI),
-									string(signalr.SignalRRequestTypeServerConnection),
-									string(signalr.SignalRRequestTypeTrace),
-								}, false),
+								Type:         pluginsdk.TypeString,
+								ValidateFunc: validation.StringInSlice(signalr.PossibleValuesForSignalRRequestType(), false),
 							},
 						},
 					},

--- a/internal/services/signalr/web_pubsub_network_acl_resource.go
+++ b/internal/services/signalr/web_pubsub_network_acl_resource.go
@@ -53,13 +53,10 @@ func resourceWebpubsubNetworkACL() *pluginsdk.Resource {
 			"web_pubsub_id": commonschema.ResourceIDReferenceRequiredForceNew(&webpubsub.WebPubSubId{}),
 
 			"default_action": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				Default:  webpubsub.ACLActionDeny,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(webpubsub.ACLActionAllow),
-					string(webpubsub.ACLActionDeny),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				Default:      webpubsub.ACLActionDeny,
+				ValidateFunc: validation.StringInSlice(webpubsub.PossibleValuesForACLAction(), false),
 			},
 
 			"public_network": {

--- a/internal/services/springcloud/spring_cloud_configuration_service_resource.go
+++ b/internal/services/springcloud/spring_cloud_configuration_service_resource.go
@@ -78,12 +78,9 @@ func (s SpringCloudConfigurationServiceResource) Arguments() map[string]*schema.
 		},
 
 		"generation": {
-			Type:     pluginsdk.TypeString,
-			Optional: true,
-			ValidateFunc: validation.StringInSlice([]string{
-				string(appplatform.ConfigurationServiceGenerationGenOne),
-				string(appplatform.ConfigurationServiceGenerationGenTwo),
-			}, false),
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.StringInSlice(appplatform.PossibleValuesForConfigurationServiceGeneration(), false),
 		},
 
 		"refresh_interval_in_seconds": {

--- a/internal/services/springcloud/spring_cloud_customized_accelerator_resource.go
+++ b/internal/services/springcloud/spring_cloud_customized_accelerator_resource.go
@@ -218,13 +218,10 @@ func (s SpringCloudCustomizedAcceleratorResource) Arguments() map[string]*schema
 		},
 
 		"accelerator_type": {
-			Type:     pluginsdk.TypeString,
-			Optional: true,
-			Default:  appplatform.CustomizedAcceleratorTypeAccelerator,
-			ValidateFunc: validation.StringInSlice([]string{
-				string(appplatform.CustomizedAcceleratorTypeAccelerator),
-				string(appplatform.CustomizedAcceleratorTypeFragment),
-			}, false),
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			Default:      appplatform.CustomizedAcceleratorTypeAccelerator,
+			ValidateFunc: validation.StringInSlice(appplatform.PossibleValuesForCustomizedAcceleratorType(), false),
 		},
 
 		"description": {

--- a/internal/services/springcloud/spring_cloud_gateway_resource.go
+++ b/internal/services/springcloud/spring_cloud_gateway_resource.go
@@ -173,14 +173,8 @@ func (s SpringCloudGatewayResource) Arguments() map[string]*pluginsdk.Schema {
 			Type:     pluginsdk.TypeList,
 			Optional: true,
 			Elem: &pluginsdk.Schema{
-				Type: pluginsdk.TypeString,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(appplatform.ApmTypeAppDynamics),
-					string(appplatform.ApmTypeApplicationInsights),
-					string(appplatform.ApmTypeDynatrace),
-					string(appplatform.ApmTypeElasticAPM),
-					string(appplatform.ApmTypeNewRelic),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				ValidateFunc: validation.StringInSlice(appplatform.PossibleValuesForApmType(), false),
 			},
 		},
 

--- a/internal/services/storage/storage_account_network_rules_resource.go
+++ b/internal/services/storage/storage_account_network_rules_resource.go
@@ -59,13 +59,8 @@ func resourceStorageAccountNetworkRules() *pluginsdk.Resource {
 				Optional: true,
 				Computed: true, // Defaults to storageaccounts.BypassAzureServices in the API, but schema does not support defaults for lists/sets.
 				Elem: &pluginsdk.Schema{
-					Type: pluginsdk.TypeString,
-					ValidateFunc: validation.StringInSlice([]string{
-						string(storageaccounts.BypassAzureServices),
-						string(storageaccounts.BypassLogging),
-						string(storageaccounts.BypassMetrics),
-						string(storageaccounts.BypassNone),
-					}, false),
+					Type:         pluginsdk.TypeString,
+					ValidateFunc: validation.StringInSlice(storageaccounts.PossibleValuesForBypass(), false),
 				},
 				Set: pluginsdk.HashString,
 			},
@@ -91,12 +86,9 @@ func resourceStorageAccountNetworkRules() *pluginsdk.Resource {
 			},
 
 			"default_action": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(storageaccounts.DefaultActionAllow),
-					string(storageaccounts.DefaultActionDeny),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(storageaccounts.PossibleValuesForDefaultAction(), false),
 			},
 
 			"private_link_access": {

--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -345,14 +345,11 @@ func resourceStorageAccount() *pluginsdk.Resource {
 			},
 
 			"dns_endpoint_type": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Default:  string(storageaccounts.DnsEndpointTypeStandard),
-				ValidateFunc: validation.StringInSlice([]string{
-					string(storageaccounts.DnsEndpointTypeStandard),
-					string(storageaccounts.DnsEndpointTypeAzureDnsZone),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Default:      string(storageaccounts.DnsEndpointTypeStandard),
+				ValidateFunc: validation.StringInSlice(storageaccounts.PossibleValuesForDnsEndpointType(), false),
 			},
 
 			"default_to_oauth_authentication": {

--- a/internal/services/storage/storage_blob_inventory_policy_resource.go
+++ b/internal/services/storage/storage_blob_inventory_policy_resource.go
@@ -72,30 +72,21 @@ func resourceStorageBlobInventoryPolicy() *pluginsdk.Resource {
 						},
 
 						"format": {
-							Type:     pluginsdk.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(blobinventorypolicies.FormatCsv),
-								string(blobinventorypolicies.FormatParquet),
-							}, false),
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(blobinventorypolicies.PossibleValuesForFormat(), false),
 						},
 
 						"schedule": {
-							Type:     pluginsdk.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(blobinventorypolicies.ScheduleDaily),
-								string(blobinventorypolicies.ScheduleWeekly),
-							}, false),
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(blobinventorypolicies.PossibleValuesForSchedule(), false),
 						},
 
 						"scope": {
-							Type:     pluginsdk.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(blobinventorypolicies.ObjectTypeBlob),
-								string(blobinventorypolicies.ObjectTypeContainer),
-							}, false),
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(blobinventorypolicies.PossibleValuesForObjectType(), false),
 						},
 
 						"schema_fields": {

--- a/internal/services/storage/storage_encryption_scope_resource.go
+++ b/internal/services/storage/storage_encryption_scope_resource.go
@@ -60,12 +60,9 @@ func resourceStorageEncryptionScope() *pluginsdk.Resource {
 			},
 
 			"source": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(encryptionscopes.EncryptionScopeSourceMicrosoftPointKeyVault),
-					string(encryptionscopes.EncryptionScopeSourceMicrosoftPointStorage),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(encryptionscopes.PossibleValuesForEncryptionScopeSource(), false),
 			},
 
 			"key_vault_key_id": {

--- a/internal/services/storage/storage_sync_resource.go
+++ b/internal/services/storage/storage_sync_resource.go
@@ -63,13 +63,10 @@ func resourceStorageSync() *pluginsdk.Resource {
 			"location": commonschema.Location(),
 
 			"incoming_traffic_policy": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				Default:  string(storagesyncservicesresource.IncomingTrafficPolicyAllowAllTraffic),
-				ValidateFunc: validation.StringInSlice([]string{
-					string(storagesyncservicesresource.IncomingTrafficPolicyAllowAllTraffic),
-					string(storagesyncservicesresource.IncomingTrafficPolicyAllowVirtualNetworksOnly),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				Default:      string(storagesyncservicesresource.IncomingTrafficPolicyAllowAllTraffic),
+				ValidateFunc: validation.StringInSlice(storagesyncservicesresource.PossibleValuesForIncomingTrafficPolicy(), false),
 			},
 
 			"registered_servers": {

--- a/internal/services/storagemover/storage_mover_job_definition_resource.go
+++ b/internal/services/storagemover/storage_mover_job_definition_resource.go
@@ -90,12 +90,9 @@ func (r StorageMoverJobDefinitionResource) Arguments() map[string]*pluginsdk.Sch
 		},
 
 		"copy_mode": {
-			Type:     pluginsdk.TypeString,
-			Required: true,
-			ValidateFunc: validation.StringInSlice([]string{
-				string(jobdefinitions.CopyModeMirror),
-				string(jobdefinitions.CopyModeAdditive),
-			}, false),
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: validation.StringInSlice(jobdefinitions.PossibleValuesForCopyMode(), false),
 		},
 
 		"source_sub_path": {

--- a/internal/services/storagemover/storage_mover_source_endpoint_resource.go
+++ b/internal/services/storagemover/storage_mover_source_endpoint_resource.go
@@ -87,15 +87,11 @@ func (r StorageMoverSourceEndpointResource) Arguments() map[string]*pluginsdk.Sc
 		},
 
 		"nfs_version": {
-			Type:     pluginsdk.TypeString,
-			Optional: true,
-			ForceNew: true,
-			Default:  string(endpoints.NfsVersionNFSauto),
-			ValidateFunc: validation.StringInSlice([]string{
-				string(endpoints.NfsVersionNFSauto),
-				string(endpoints.NfsVersionNFSvFour),
-				string(endpoints.NfsVersionNFSvThree),
-			}, false),
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ForceNew:     true,
+			Default:      string(endpoints.NfsVersionNFSauto),
+			ValidateFunc: validation.StringInSlice(endpoints.PossibleValuesForNfsVersion(), false),
 		},
 
 		"description": {

--- a/internal/services/streamanalytics/helpers_input.go
+++ b/internal/services/streamanalytics/helpers_input.go
@@ -42,11 +42,9 @@ func schemaStreamAnalyticsStreamInputSerialization() *pluginsdk.Schema {
 				},
 
 				"encoding": {
-					Type:     pluginsdk.TypeString,
-					Optional: true,
-					ValidateFunc: validation.StringInSlice([]string{
-						string(inputs.EncodingUTFEight),
-					}, false),
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringInSlice(inputs.PossibleValuesForEncoding(), false),
 				},
 			},
 		},

--- a/internal/services/streamanalytics/helpers_output.go
+++ b/internal/services/streamanalytics/helpers_output.go
@@ -43,20 +43,15 @@ func schemaStreamAnalyticsOutputSerialization() *pluginsdk.Schema {
 				},
 
 				"encoding": {
-					Type:     pluginsdk.TypeString,
-					Optional: true,
-					ValidateFunc: validation.StringInSlice([]string{
-						string(outputs.EncodingUTFEight),
-					}, false),
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringInSlice(outputs.PossibleValuesForEncoding(), false),
 				},
 
 				"format": {
-					Type:     pluginsdk.TypeString,
-					Optional: true,
-					ValidateFunc: validation.StringInSlice([]string{
-						string(outputs.JsonOutputSerializationFormatArray),
-						string(outputs.JsonOutputSerializationFormatLineSeparated),
-					}, false),
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringInSlice(outputs.PossibleValuesForJsonOutputSerializationFormat(), false),
 				},
 			},
 		},

--- a/internal/services/streamanalytics/stream_analytics_job_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_job_resource.go
@@ -188,10 +188,13 @@ func resourceStreamAnalyticsJob() *pluginsdk.Resource {
 			},
 
 			"sku_name": {
-				Type:         pluginsdk.TypeString,
-				Optional:     true,
-				Default:      string(streamingjobs.SkuNameStandard),
-				ValidateFunc: validation.StringInSlice(streamingjobs.PossibleValuesForSkuName(), false),
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				Default:  string(streamingjobs.SkuNameStandard),
+				ValidateFunc: validation.StringInSlice([]string{
+					string(streamingjobs.SkuNameStandard),
+					"StandardV2", // missing from swagger as described here https://github.com/Azure/azure-rest-api-specs/issues/27506
+				}, false),
 			},
 
 			"tags": commonschema.Tags(),

--- a/internal/services/streamanalytics/stream_analytics_job_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_job_resource.go
@@ -75,8 +75,13 @@ func resourceStreamAnalyticsJob() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
 				// NOTE: O+C Best Practice from MSFT is to use the latest version 1.2, but API uses 1.0 as the default
-				Computed:     true,
-				ValidateFunc: validation.StringInSlice(streamingjobs.PossibleValuesForCompatibilityLevel(), false),
+				Computed: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					// values found in the other API the portal uses
+					string(streamingjobs.CompatibilityLevelOnePointZero),
+					"1.1",
+					string(streamingjobs.CompatibilityLevelOnePointTwo),
+				}, false),
 			},
 
 			"data_locale": {

--- a/internal/services/streamanalytics/stream_analytics_job_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_job_resource.go
@@ -75,13 +75,8 @@ func resourceStreamAnalyticsJob() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
 				// NOTE: O+C Best Practice from MSFT is to use the latest version 1.2, but API uses 1.0 as the default
-				Computed: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					// values found in the other API the portal uses
-					string(streamingjobs.CompatibilityLevelOnePointZero),
-					"1.1",
-					string(streamingjobs.CompatibilityLevelOnePointTwo),
-				}, false),
+				Computed:     true,
+				ValidateFunc: validation.StringInSlice(streamingjobs.PossibleValuesForCompatibilityLevel(), false),
 			},
 
 			"data_locale": {
@@ -108,34 +103,25 @@ func resourceStreamAnalyticsJob() *pluginsdk.Resource {
 			},
 
 			"events_out_of_order_policy": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(streamingjobs.EventsOutOfOrderPolicyAdjust),
-					string(streamingjobs.EventsOutOfOrderPolicyDrop),
-				}, false),
-				Default: string(streamingjobs.EventsOutOfOrderPolicyAdjust),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(streamingjobs.PossibleValuesForEventsOutOfOrderPolicy(), false),
+				Default:      string(streamingjobs.EventsOutOfOrderPolicyAdjust),
 			},
 
 			"type": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(streamingjobs.JobTypeCloud),
-					string(streamingjobs.JobTypeEdge),
-				}, false),
-				Default: string(streamingjobs.JobTypeCloud),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(streamingjobs.PossibleValuesForJobType(), false),
+				Default:      string(streamingjobs.JobTypeCloud),
 			},
 
 			"output_error_policy": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(streamingjobs.OutputErrorPolicyDrop),
-					string(streamingjobs.OutputErrorPolicyStop),
-				}, false),
-				Default: string(streamingjobs.OutputErrorPolicyDrop),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(streamingjobs.PossibleValuesForOutputErrorPolicy(), false),
+				Default:      string(streamingjobs.OutputErrorPolicyDrop),
 			},
 
 			"streaming_units": {
@@ -145,13 +131,10 @@ func resourceStreamAnalyticsJob() *pluginsdk.Resource {
 			},
 
 			"content_storage_policy": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				Default:  string(streamingjobs.ContentStoragePolicySystemAccount),
-				ValidateFunc: validation.StringInSlice([]string{
-					string(streamingjobs.ContentStoragePolicySystemAccount),
-					string(streamingjobs.ContentStoragePolicyJobStorageAccount),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				Default:      string(streamingjobs.ContentStoragePolicySystemAccount),
+				ValidateFunc: validation.StringInSlice(streamingjobs.PossibleValuesForContentStoragePolicy(), false),
 			},
 
 			"job_storage_account": {
@@ -200,13 +183,10 @@ func resourceStreamAnalyticsJob() *pluginsdk.Resource {
 			},
 
 			"sku_name": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				Default:  string(streamingjobs.SkuNameStandard),
-				ValidateFunc: validation.StringInSlice([]string{
-					string(streamingjobs.SkuNameStandard),
-					"StandardV2", // missing from swagger as described here https://github.com/Azure/azure-rest-api-specs/issues/27506
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				Default:      string(streamingjobs.SkuNameStandard),
+				ValidateFunc: validation.StringInSlice(streamingjobs.PossibleValuesForSkuName(), false),
 			},
 
 			"tags": commonschema.Tags(),

--- a/internal/services/streamanalytics/stream_analytics_job_schedule_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_job_schedule_resource.go
@@ -43,13 +43,9 @@ func (r JobScheduleResource) Arguments() map[string]*pluginsdk.Schema {
 		},
 
 		"start_mode": {
-			Type:     pluginsdk.TypeString,
-			Required: true,
-			ValidateFunc: validation.StringInSlice([]string{
-				string(streamingjobs.OutputStartModeCustomTime),
-				string(streamingjobs.OutputStartModeJobStartTime),
-				string(streamingjobs.OutputStartModeLastOutputEventTime),
-			}, false),
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: validation.StringInSlice(streamingjobs.PossibleValuesForOutputStartMode(), false),
 		},
 
 		"start_time": {

--- a/internal/services/subscription/subscription_resource.go
+++ b/internal/services/subscription/subscription_resource.go
@@ -88,10 +88,7 @@ func resourceSubscription() *pluginsdk.Resource {
 				ForceNew:    true,
 				Description: "The workload type for the Subscription. Possible values are `Production` (default) and `DevTest`.",
 				// Other RP's have updated Constants with contextual prefixes so these are likely to change
-				ValidateFunc: validation.StringInSlice([]string{
-					string(subscriptionAlias.WorkloadProduction),
-					string(subscriptionAlias.WorkloadDevTest),
-				}, false),
+				ValidateFunc: validation.StringInSlice(subscriptionAlias.PossibleValuesForWorkload(), false),
 				// Workload is not exposed in any way, so must be ignored if the resource is imported.
 				DiffSuppressFunc: func(k, old, new string, d *pluginsdk.ResourceData) bool {
 					return new == ""

--- a/internal/services/trafficmanager/traffic_manager_profile_resource.go
+++ b/internal/services/trafficmanager/traffic_manager_profile_resource.go
@@ -61,16 +61,9 @@ func resourceArmTrafficManagerProfile() *pluginsdk.Resource {
 			"resource_group_name": azure.SchemaResourceGroupNameDiffSuppress(),
 
 			"traffic_routing_method": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(profiles.TrafficRoutingMethodGeographic),
-					string(profiles.TrafficRoutingMethodWeighted),
-					string(profiles.TrafficRoutingMethodPerformance),
-					string(profiles.TrafficRoutingMethodPriority),
-					string(profiles.TrafficRoutingMethodSubnet),
-					string(profiles.TrafficRoutingMethodMultiValue),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(profiles.PossibleValuesForTrafficRoutingMethod(), false),
 			},
 
 			"dns_config": {
@@ -127,13 +120,9 @@ func resourceArmTrafficManagerProfile() *pluginsdk.Resource {
 						},
 
 						"protocol": {
-							Type:     pluginsdk.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(profiles.MonitorProtocolHTTP),
-								string(profiles.MonitorProtocolHTTPS),
-								string(profiles.MonitorProtocolTCP),
-							}, false),
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(profiles.PossibleValuesForMonitorProtocol(), false),
 						},
 
 						"port": {
@@ -172,13 +161,10 @@ func resourceArmTrafficManagerProfile() *pluginsdk.Resource {
 			},
 
 			"profile_status": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				Default:  string(profiles.ProfileStatusEnabled),
-				ValidateFunc: validation.StringInSlice([]string{
-					string(profiles.ProfileStatusEnabled),
-					string(profiles.ProfileStatusDisabled),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				Default:      string(profiles.ProfileStatusEnabled),
+				ValidateFunc: validation.StringInSlice(profiles.PossibleValuesForProfileStatus(), false),
 			},
 
 			"max_return": {


### PR DESCRIPTION
Part 4/4 of splitting #33162 (services newrelic through trafficmanager, 49 files, plus the .golangci.yml AZS004 comment update).

Converts complete hand-written `validation.StringInSlice` enum value lists to the generated `PossibleValuesFor<Enum>()` helpers, so new enum values are picked up automatically on SDK upgrades. No validation behavior changes - only lists proven complete by the AZS004 check are converted.

Deliberately left as-is across the series: 235 lists missing values from their enum (accepting new values is a behavior change needing per-case review) and 69 lists referencing track-1 SDK enums whose `Possible<Enum>Values()` helpers return typed slices rather than `[]string`. AZS004 stays disabled in .golangci.yml until these are resolved; this part updates the comment to reflect the remaining findings.