### PR TITLE
`azurerm_storage_account` - add `encryption_in_transit_enabled` properties

### DIFF
--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -565,6 +565,12 @@ func resourceStorageAccount() *pluginsdk.Resource {
 					Schema: map[string]*pluginsdk.Schema{
 						"cors_rule": helpers.SchemaStorageAccountCorsRule(true),
 
+						"nfs_encryption_in_transit_enabled": {
+							Type:     pluginsdk.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
+
 						"retention_policy": {
 							Type:     pluginsdk.TypeList,
 							Optional: true,
@@ -610,6 +616,12 @@ func resourceStorageAccount() *pluginsdk.Resource {
 												"AES-256-GCM",
 											}, false),
 										},
+									},
+
+									"encryption_in_transit_enabled": {
+										Type:     pluginsdk.TypeBool,
+										Optional: true,
+										Default:  false,
 									},
 
 									"kerberos_ticket_encryption_type": {
@@ -1154,6 +1166,20 @@ func resourceStorageAccount() *pluginsdk.Resource {
 					keys := sortedKeysFromSlice(storageKindsSupportHns)
 					return fmt.Errorf("`is_hns_enabled` can only be used for accounts with `account_kind` set to one of: %+v", strings.Join(keys, " / "))
 				}
+
+				// Based on portal
+				accountTier := d.Get("account_tier").(string)
+				nfsEncryptionInTransitEnabled := d.Get("share_properties.0.nfs_encryption_in_transit_enabled").(bool)
+				if (accountKind != storageaccounts.KindFileStorage || accountTier != string(storageaccounts.SkuTierPremium)) && nfsEncryptionInTransitEnabled {
+					return fmt.Errorf("`share_properties.0.nfs_encryption_in_transit_enabled` can only be set to `true` when `account_kind` is `%s` and `account_tier` is `%s`", storageaccounts.KindFileStorage, storageaccounts.SkuTierPremium)
+				}
+
+				// Based on portal
+				smbEncryptionInTransitEnabled := d.Get("share_properties.0.smb.0.encryption_in_transit_enabled").(bool)
+				if accountKind == storageaccounts.KindBlockBlobStorage && accountTier == string(storageaccounts.SkuTierPremium) && smbEncryptionInTransitEnabled {
+					return fmt.Errorf("`share_properties.0.smb.0.encryption_in_transit_enabled` cannot be set to `true` when `account_kind` is `%s` and `account_tier` is `%s`", storageaccounts.KindBlockBlobStorage, storageaccounts.SkuTierPremium)
+				}
+
 				return nil
 			}),
 			pluginsdk.ForceNewIfChange("account_replication_type", func(ctx context.Context, old, new, meta interface{}) bool {
@@ -1429,7 +1455,7 @@ func resourceStorageAccountCreate(d *pluginsdk.ResourceData, meta interface{}) e
 			return fmt.Errorf("`share_properties` aren't supported for account kind %q in sku tier %q", accountKind, accountTier)
 		}
 
-		sharePayload := expandAccountShareProperties(val.([]interface{}))
+		sharePayload := expandAccountShareProperties(val.([]interface{}), accountTier)
 
 		// The API complains if any multichannel info is sent on non premium fileshares. Even if multichannel is set to false
 		if accountTier != storageaccounts.SkuTierPremium && sharePayload.Properties != nil && sharePayload.Properties.ProtocolSettings != nil {
@@ -1746,7 +1772,7 @@ func resourceStorageAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 			return fmt.Errorf("`share_properties` aren't supported for account kind %q in sku tier %q", accountKind, accountTier)
 		}
 
-		sharePayload := expandAccountShareProperties(d.Get("share_properties").([]interface{}))
+		sharePayload := expandAccountShareProperties(d.Get("share_properties").([]interface{}), accountTier)
 		// The API complains if any multichannel info is sent on non premium fileshares. Even if multichannel is set to false
 		if accountTier != storageaccounts.SkuTierPremium {
 			// Error if the user has tried to enable multichannel on a standard tier storage account
@@ -2712,7 +2738,7 @@ func flattenAccountBlobPropertiesCorsRule(input *blobservices.CorsRules) []inter
 	return corsRules
 }
 
-func expandAccountShareProperties(input []interface{}) fileservices.FileServiceProperties {
+func expandAccountShareProperties(input []interface{}, accountTier storageaccounts.SkuTier) fileservices.FileServiceProperties {
 	props := fileservices.FileServiceProperties{
 		Properties: &fileservices.FileServicePropertiesProperties{
 			Cors: &fileservices.CorsRules{
@@ -2734,6 +2760,14 @@ func expandAccountShareProperties(input []interface{}) fileservices.FileServiceP
 		props.Properties.ProtocolSettings = &fileservices.ProtocolSettings{
 			Smb: expandAccountSharePropertiesSMB(v["smb"].([]interface{})),
 		}
+		// REST API returns error for specifying `Nfs.EncryptionInTransit.Required` when `accountTier` is `SkuTierStandard`
+		if accountTier == storageaccounts.SkuTierPremium {
+			props.Properties.ProtocolSettings.Nfs = &fileservices.NfsSetting{
+				EncryptionInTransit: &fileservices.EncryptionInTransit{
+					Required: pointer.To(v["nfs_encryption_in_transit_enabled"].(bool)),
+				},
+			}
+		}
 	}
 
 	return props
@@ -2745,9 +2779,10 @@ func flattenAccountShareProperties(input *fileservices.FileServiceProperties) []
 	if input != nil {
 		if props := input.Properties; props != nil {
 			output = append(output, map[string]interface{}{
-				"cors_rule":        flattenAccountSharePropertiesCorsRule(props.Cors),
-				"retention_policy": flattenAccountShareDeleteRetentionPolicy(props.ShareDeleteRetentionPolicy),
-				"smb":              flattenAccountSharePropertiesSMB(props.ProtocolSettings),
+				"cors_rule":                         flattenAccountSharePropertiesCorsRule(props.Cors),
+				"nfs_encryption_in_transit_enabled": flattenAccountSharePropertiesNfsEncryptionInTransitEnabled(props.ProtocolSettings),
+				"retention_policy":                  flattenAccountShareDeleteRetentionPolicy(props.ShareDeleteRetentionPolicy),
+				"smb":                               flattenAccountSharePropertiesSMB(props.ProtocolSettings),
 			})
 		}
 	}
@@ -2800,6 +2835,14 @@ func flattenAccountSharePropertiesCorsRule(input *fileservices.CorsRules) []inte
 	return corsRules
 }
 
+func flattenAccountSharePropertiesNfsEncryptionInTransitEnabled(input *fileservices.ProtocolSettings) bool {
+	if input == nil || input.Nfs == nil || input.Nfs.EncryptionInTransit == nil {
+		return false
+	}
+
+	return pointer.From(input.Nfs.EncryptionInTransit.Required)
+}
+
 func expandAccountShareDeleteRetentionPolicy(input []interface{}) *fileservices.DeleteRetentionPolicy {
 	result := fileservices.DeleteRetentionPolicy{
 		Enabled: pointer.To(false),
@@ -2849,8 +2892,11 @@ func expandAccountSharePropertiesSMB(input []interface{}) *fileservices.SmbSetti
 	v := input[0].(map[string]interface{})
 
 	return &fileservices.SmbSetting{
-		AuthenticationMethods:    providerhelpers.ExpandStringSliceWithDelimiter(v["authentication_types"].(*pluginsdk.Set).List(), ";"),
-		ChannelEncryption:        providerhelpers.ExpandStringSliceWithDelimiter(v["channel_encryption_type"].(*pluginsdk.Set).List(), ";"),
+		AuthenticationMethods: providerhelpers.ExpandStringSliceWithDelimiter(v["authentication_types"].(*pluginsdk.Set).List(), ";"),
+		ChannelEncryption:     providerhelpers.ExpandStringSliceWithDelimiter(v["channel_encryption_type"].(*pluginsdk.Set).List(), ";"),
+		EncryptionInTransit: &fileservices.EncryptionInTransit{
+			Required: pointer.To(v["encryption_in_transit_enabled"].(bool)),
+		},
 		KerberosTicketEncryption: providerhelpers.ExpandStringSliceWithDelimiter(v["kerberos_ticket_encryption_type"].(*pluginsdk.Set).List(), ";"),
 		Versions:                 providerhelpers.ExpandStringSliceWithDelimiter(v["versions"].(*pluginsdk.Set).List(), ";"),
 		Multichannel: &fileservices.Multichannel{
@@ -2889,7 +2935,12 @@ func flattenAccountSharePropertiesSMB(input *fileservices.ProtocolSettings) []in
 		multichannelEnabled = *input.Smb.Multichannel.Enabled
 	}
 
-	if len(versions) == 0 && len(authenticationMethods) == 0 && len(kerberosTicketEncryption) == 0 && len(channelEncryption) == 0 && (input.Smb.Multichannel == nil || input.Smb.Multichannel.Enabled == nil) {
+	encryptionInTransitEnabled := false
+	if input.Smb.EncryptionInTransit != nil {
+		encryptionInTransitEnabled = pointer.From(input.Smb.EncryptionInTransit.Required)
+	}
+
+	if len(versions) == 0 && len(authenticationMethods) == 0 && len(kerberosTicketEncryption) == 0 && len(channelEncryption) == 0 && (input.Smb.Multichannel == nil || input.Smb.Multichannel.Enabled == nil) && (input.Smb.EncryptionInTransit == nil || input.Smb.EncryptionInTransit.Required == nil) {
 		return []interface{}{}
 	}
 
@@ -2897,6 +2948,7 @@ func flattenAccountSharePropertiesSMB(input *fileservices.ProtocolSettings) []in
 		map[string]interface{}{
 			"authentication_types":            authenticationMethods,
 			"channel_encryption_type":         channelEncryption,
+			"encryption_in_transit_enabled":   encryptionInTransitEnabled,
 			"kerberos_ticket_encryption_type": kerberosTicketEncryption,
 			"multichannel_enabled":            multichannelEnabled,
 			"versions":                        versions,

--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -2042,7 +2042,7 @@ func resourceStorageAccountFlatten(ctx context.Context, d *pluginsdk.ResourceDat
 			return fmt.Errorf("retrieving share properties for %s: %+v", id, err)
 		}
 
-		shareProperties = flattenAccountShareProperties(shareProps.Model)
+		shareProperties = flattenAccountShareProperties(shareProps.Model, d)
 	}
 	if err := d.Set("share_properties", shareProperties); err != nil {
 		return fmt.Errorf("setting `share_properties` for %s: %+v", id, err)
@@ -2773,7 +2773,7 @@ func expandAccountShareProperties(input []interface{}, accountTier storageaccoun
 	return props
 }
 
-func flattenAccountShareProperties(input *fileservices.FileServiceProperties) []interface{} {
+func flattenAccountShareProperties(input *fileservices.FileServiceProperties, d *pluginsdk.ResourceData) []interface{} {
 	output := make([]interface{}, 0)
 
 	if input != nil {
@@ -2782,7 +2782,7 @@ func flattenAccountShareProperties(input *fileservices.FileServiceProperties) []
 				"cors_rule":                         flattenAccountSharePropertiesCorsRule(props.Cors),
 				"nfs_encryption_in_transit_enabled": flattenAccountSharePropertiesNfsEncryptionInTransitEnabled(props.ProtocolSettings),
 				"retention_policy":                  flattenAccountShareDeleteRetentionPolicy(props.ShareDeleteRetentionPolicy),
-				"smb":                               flattenAccountSharePropertiesSMB(props.ProtocolSettings),
+				"smb":                               flattenAccountSharePropertiesSMB(props.ProtocolSettings, d),
 			})
 		}
 	}
@@ -2881,8 +2881,11 @@ func flattenAccountShareDeleteRetentionPolicy(input *fileservices.DeleteRetentio
 func expandAccountSharePropertiesSMB(input []interface{}) *fileservices.SmbSetting {
 	if len(input) == 0 || input[0] == nil {
 		return &fileservices.SmbSetting{
-			AuthenticationMethods:    pointer.To(""),
-			ChannelEncryption:        pointer.To(""),
+			AuthenticationMethods: pointer.To(""),
+			ChannelEncryption:     pointer.To(""),
+			EncryptionInTransit: &fileservices.EncryptionInTransit{
+				Required: pointer.To(false),
+			},
 			KerberosTicketEncryption: pointer.To(""),
 			Versions:                 pointer.To(""),
 			Multichannel:             nil,
@@ -2905,7 +2908,7 @@ func expandAccountSharePropertiesSMB(input []interface{}) *fileservices.SmbSetti
 	}
 }
 
-func flattenAccountSharePropertiesSMB(input *fileservices.ProtocolSettings) []interface{} {
+func flattenAccountSharePropertiesSMB(input *fileservices.ProtocolSettings, d *pluginsdk.ResourceData) []interface{} {
 	if input == nil || input.Smb == nil {
 		return []interface{}{}
 	}
@@ -2940,7 +2943,8 @@ func flattenAccountSharePropertiesSMB(input *fileservices.ProtocolSettings) []in
 		encryptionInTransitEnabled = pointer.From(input.Smb.EncryptionInTransit.Required)
 	}
 
-	if len(versions) == 0 && len(authenticationMethods) == 0 && len(kerberosTicketEncryption) == 0 && len(channelEncryption) == 0 && (input.Smb.Multichannel == nil || input.Smb.Multichannel.Enabled == nil) && (input.Smb.EncryptionInTransit == nil || input.Smb.EncryptionInTransit.Required == nil) {
+	_, smbOk := d.GetOk("share_properties.0.smb")
+	if len(versions) == 0 && len(authenticationMethods) == 0 && len(kerberosTicketEncryption) == 0 && len(channelEncryption) == 0 && (input.Smb.Multichannel == nil || input.Smb.Multichannel.Enabled == nil) && (input.Smb.EncryptionInTransit == nil || input.Smb.EncryptionInTransit.Required == nil || (pointer.From(input.Smb.EncryptionInTransit.Required) == false && !smbOk)) {
 		return []interface{}{}
 	}
 

--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -2944,7 +2944,7 @@ func flattenAccountSharePropertiesSMB(input *fileservices.ProtocolSettings, d *p
 	}
 
 	_, smbOk := d.GetOk("share_properties.0.smb")
-	if len(versions) == 0 && len(authenticationMethods) == 0 && len(kerberosTicketEncryption) == 0 && len(channelEncryption) == 0 && (input.Smb.Multichannel == nil || input.Smb.Multichannel.Enabled == nil) && (input.Smb.EncryptionInTransit == nil || input.Smb.EncryptionInTransit.Required == nil || (pointer.From(input.Smb.EncryptionInTransit.Required) == false && !smbOk)) {
+	if len(versions) == 0 && len(authenticationMethods) == 0 && len(kerberosTicketEncryption) == 0 && len(channelEncryption) == 0 && (input.Smb.Multichannel == nil || input.Smb.Multichannel.Enabled == nil) && (input.Smb.EncryptionInTransit == nil || input.Smb.EncryptionInTransit.Required == nil || (!pointer.From(input.Smb.EncryptionInTransit.Required) && !smbOk)) {
 		return []interface{}{}
 	}
 

--- a/internal/services/storage/storage_account_resource_test.go
+++ b/internal/services/storage/storage_account_resource_test.go
@@ -1746,6 +1746,30 @@ func TestAccStorageAccount_noDataPlane(t *testing.T) {
 	})
 }
 
+func TestAccStorageAccount_nfsEncryptionInTransitConfigError(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_account", "test")
+	r := StorageAccountResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config:      r.nfsEncryptionInTransitError(data),
+			ExpectError: regexp.MustCompile("`share_properties.0.nfs_encryption_in_transit_enabled` can only be set to `true` when `account_kind` is `FileStorage` and `account_tier` is `Premium`"),
+		},
+	})
+}
+
+func TestAccStorageAccount_smbEncryptionInTransitConfigError(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_account", "test")
+	r := StorageAccountResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config:      r.smbEncryptionInTransitConfigError(data),
+			ExpectError: regexp.MustCompile("`share_properties.0.smb.0.encryption_in_transit_enabled` cannot be set to `true` when `account_kind` is `BlockBlobStorage` and `account_tier` is `Premium`"),
+		},
+	})
+}
+
 func (r StorageAccountResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := commonids.ParseStorageAccountID(state.ID)
 	if err != nil {
@@ -3360,6 +3384,7 @@ resource "azurerm_storage_account" "test" {
       authentication_types            = ["NTLMv2", "Kerberos"]
       kerberos_ticket_encryption_type = ["AES-256", "RC4-HMAC"]
       channel_encryption_type         = ["AES-128-CCM", "AES-256-GCM"]
+      encryption_in_transit_enabled   = true
     }
   }
 }
@@ -3717,6 +3742,15 @@ resource "azurerm_storage_account" "test" {
   account_tier                      = "Premium"
   account_replication_type          = "LRS"
   infrastructure_encryption_enabled = true
+
+  share_properties {
+    nfs_encryption_in_transit_enabled = true
+  }
+
+  # Ignore changes based on https://github.com/hashicorp/terraform-provider-azurerm/pull/21226
+  lifecycle {
+    ignore_changes = [share_properties.0.smb]
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }
@@ -4860,6 +4894,65 @@ resource "azurerm_storage_account" "test" {
 
   tags = {
     environment = "production"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}
+
+func (r StorageAccountResource) nfsEncryptionInTransitError(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-storage-%d"
+  location = "%s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "unlikely23exst2acct%s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_kind             = "FileStorage"
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  share_properties {
+    nfs_encryption_in_transit_enabled = true
+  }
+
+  # Ignore changes based on https://github.com/hashicorp/terraform-provider-azurerm/pull/21226
+  lifecycle {
+    ignore_changes = [share_properties.0.smb]
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}
+
+func (r StorageAccountResource) smbEncryptionInTransitConfigError(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-storage-%d"
+  location = "%s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "unlikely23exst2acct%s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_kind             = "BlockBlobStorage"
+  account_tier             = "Premium"
+  account_replication_type = "LRS"
+
+  share_properties {
+    smb {
+      encryption_in_transit_enabled = true
+    }
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -379,6 +379,10 @@ A `share_properties` block supports the following:
 
 * `cors_rule` - (Optional) A `cors_rule` block as defined below.
 
+* `nfs_encryption_in_transit_enabled` - (Optional) Indicates whether encryption in transit is enabled for NFS. Defaults to `false`.
+
+~> **Note:** `nfs_encryption_in_transit_enabled` can only be set to `true` when `account_kind` is `FileStorage` and `account_tier` is `Premium`.
+
 * `retention_policy` - (Optional) A `retention_policy` block as defined below.
 
 * `smb` - (Optional) A `smb` block as defined below.
@@ -402,6 +406,10 @@ A `smb` block supports the following:
 * `channel_encryption_type` - (Optional) A set of SMB channel encryption. Possible values are `AES-128-CCM`, `AES-128-GCM`, and `AES-256-GCM`.
 
 * `multichannel_enabled` - (Optional) Indicates whether multichannel is enabled. Defaults to `false`. This is only supported on Premium storage accounts.
+
+* `encryption_in_transit_enabled` - (Optional) Indicates whether encryption in transit is enabled for SMB. Defaults to `false`.
+
+~> **Note:** `encryption_in_transit_enabled` cannot be set to `true` when `account_kind` is `BlockBlobStorage` and `account_tier` is `Premium`.
 
 ---
 


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

`encryption_in_transit_enabled` properties of NFS and SMB are added in this PR.

OpenAPI specification: https://github.com/Azure/azure-rest-api-specs/blob/main/specification/storage/resource-manager/Microsoft.Storage/stable/2025-08-01/openapi.json

Documentation:
* https://learn.microsoft.com/en-us/azure/storage/files/encryption-in-transit-for-nfs-shares?tabs=azure-portal%2CUbuntu
* https://learn.microsoft.com/en-us/azure/storage/files/files-smb-protocol?tabs=azure-portal#encryption-in-transit
* https://learn.microsoft.com/en-us/azure/storage/files/encryption-in-transit-for-nfs-shares?tabs=azure-portal%2CUbuntu


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] ~(For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.~


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_storage_account` - add `nfs_encryption_in_transit_enabled` and `smb.encryption_in_transit_enabled` properties


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #33093


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
