### PR TITLE
`azurerm_vpn_server_configuration` - fix persistent diff when the API returns an empty `radiusServerAddress`

### DIFF
--- a/internal/services/network/vpn_server_configuration_resource.go
+++ b/internal/services/network/vpn_server_configuration_resource.go
@@ -789,7 +789,7 @@ func expandVpnServerConfigurationRadius(input []interface{}) *vpnServerConfigura
 }
 
 func flattenVpnServerConfigurationRadius(input *virtualwans.VpnServerConfigurationProperties, d *pluginsdk.ResourceData) []interface{} {
-	if input == nil || (input.RadiusServerAddress == nil && (input.RadiusServers == nil || len(*input.RadiusServers) == 0)) {
+	if input == nil || (pointer.From(input.RadiusServerAddress) == "" && (input.RadiusServers == nil || len(*input.RadiusServers) == 0)) {
 		return []interface{}{}
 	}
 


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

With the current provider, when no `radius` block is configured, the provider never sends the radius properties, and the API returns `radiusServerAddress` as `null`. The current read has a condition that checks for that: `input.RadiusServerAddress == nil`.

However, some existing resources have an empty string returned by the API instead of `null`. This means that the current condition won't pass, and the read will flatten an empty element into `radius` even when the config omits the property, which leads into a diff on every plan.

This change aims to change the guard to check for both an empty string and for null values.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

This can't be covered by an acceptance test as the current API version returns null values instead of empty strings, which means it can't be replicated inside the acceptance tests.

<pre>
=== RUN   TestAccVPNServerConfiguration_azureAD
=== PAUSE TestAccVPNServerConfiguration_azureAD
=== RUN   TestAccVPNServerConfiguration_certificate
=== PAUSE TestAccVPNServerConfiguration_certificate
=== RUN   TestAccVPNServerConfiguration_requiresImport
=== PAUSE TestAccVPNServerConfiguration_requiresImport
=== RUN   TestAccVPNServerConfiguration_radius
=== PAUSE TestAccVPNServerConfiguration_radius
=== RUN   TestAccVPNServerConfiguration_multipleRadius
=== PAUSE TestAccVPNServerConfiguration_multipleRadius
=== RUN   TestAccVPNServerConfiguration_multipleAuth
=== PAUSE TestAccVPNServerConfiguration_multipleAuth
=== RUN   TestAccVPNServerConfiguration_tags
=== PAUSE TestAccVPNServerConfiguration_tags
=== RUN   TestAccVPNServerConfiguration_multipleAuthTypes
=== PAUSE TestAccVPNServerConfiguration_multipleAuthTypes
=== RUN   TestAccVPNServerConfiguration_withoutRadiusServerRootCertificate
=== PAUSE TestAccVPNServerConfiguration_withoutRadiusServerRootCertificate
=== CONT  TestAccVPNServerConfiguration_azureAD
=== CONT  TestAccVPNServerConfiguration_multipleAuth
=== CONT  TestAccVPNServerConfiguration_radius
=== CONT  TestAccVPNServerConfiguration_multipleAuthTypes
=== CONT  TestAccVPNServerConfiguration_withoutRadiusServerRootCertificate
=== CONT  TestAccVPNServerConfiguration_tags
=== CONT  TestAccVPNServerConfiguration_requiresImport
=== CONT  TestAccVPNServerConfiguration_certificate
=== CONT  TestAccVPNServerConfiguration_multipleRadius
--- PASS: TestAccVPNServerConfiguration_requiresImport (133.15s)
--- PASS: TestAccVPNServerConfiguration_withoutRadiusServerRootCertificate (136.80s)
--- PASS: TestAccVPNServerConfiguration_radius (140.60s)
--- PASS: TestAccVPNServerConfiguration_azureAD (141.28s)
--- PASS: TestAccVPNServerConfiguration_tags (141.91s)
--- PASS: TestAccVPNServerConfiguration_multipleAuthTypes (142.57s)
--- PASS: TestAccVPNServerConfiguration_certificate (175.94s)
--- PASS: TestAccVPNServerConfiguration_multipleAuth (203.29s)
--- PASS: TestAccVPNServerConfiguration_multipleRadius (235.76s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/network       235.815s
</pre>

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_vpn_server_configuration` - fix persistent diff when the API returns an empty `radiusServerAddress`


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #33203 


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
