### PR TITLE
`azurerm_managed_redis` - allow updating `clustering_policy` in place

### DIFF
--- a/internal/services/managedredis/managed_redis_resource.go
+++ b/internal/services/managedredis/managed_redis_resource.go
@@ -552,9 +552,13 @@ func (r ManagedRedisResource) Update() sdk.ResourceFunc {
 						return fmt.Errorf("creating %s: %+v", dbId, err)
 					}
 				default:
+					oldClusteringPolicyValue, newClusteringPolicyValue := metadata.ResourceData.GetChange("default_database.0.clustering_policy")
+					oldClusteringPolicy, oldClusteringPolicyOk := oldClusteringPolicyValue.(string)
+					newClusteringPolicy, newClusteringPolicyOk := newClusteringPolicyValue.(string)
+					clusteringPolicyRequiresRecreation := oldClusteringPolicyOk && newClusteringPolicyOk && clusteringPolicyRequiresDatabaseRecreation(oldClusteringPolicy, newClusteringPolicy)
+
 					// lintignore:R019 // deliberate subsets: the first branch lists fields requiring database re-creation, the second lists fields updatable in place
-					if metadata.ResourceData.HasChanges(
-						"default_database.0.clustering_policy",
+					if clusteringPolicyRequiresRecreation || metadata.ResourceData.HasChanges(
 						"default_database.0.geo_replication_group_name",
 						"default_database.0.module",
 					) {
@@ -567,22 +571,13 @@ func (r ManagedRedisResource) Update() sdk.ResourceFunc {
 					} else if metadata.ResourceData.HasChanges(
 						"default_database.0.access_keys_authentication_enabled",
 						"default_database.0.client_protocol",
+						"default_database.0.clustering_policy",
 						"default_database.0.eviction_policy",
 						"default_database.0.persistence_append_only_file_backup_frequency",
 						"default_database.0.persistence_redis_database_backup_frequency",
 					) {
-						existingDb, err := dbClient.Get(ctx, dbId)
-						if err != nil {
-							return fmt.Errorf("retrieving existing %s: %+v", dbId, err)
-						}
-
-						dbParams := existingDb.Model
-
-						if dbParams == nil {
-							return fmt.Errorf("retrieving existing %s: `model` was nil", dbId)
-						}
-						if dbParams.Properties == nil {
-							return fmt.Errorf("retrieving existing %s: `properties` was nil", dbId)
+						dbParams := databases.DatabaseUpdate{
+							Properties: &databases.DatabaseUpdateProperties{},
 						}
 
 						if metadata.ResourceData.HasChange("default_database.0.access_keys_authentication_enabled") {
@@ -590,6 +585,9 @@ func (r ManagedRedisResource) Update() sdk.ResourceFunc {
 						}
 						if metadata.ResourceData.HasChange("default_database.0.client_protocol") {
 							dbParams.Properties.ClientProtocol = pointer.ToEnum[databases.Protocol](state.DefaultDatabase[0].ClientProtocol)
+						}
+						if metadata.ResourceData.HasChange("default_database.0.clustering_policy") {
+							dbParams.Properties.ClusteringPolicy = pointer.ToEnum[databases.ClusteringPolicy](state.DefaultDatabase[0].ClusteringPolicy)
 						}
 						if metadata.ResourceData.HasChange("default_database.0.eviction_policy") {
 							dbParams.Properties.EvictionPolicy = pointer.ToEnum[databases.EvictionPolicy](state.DefaultDatabase[0].EvictionPolicy)
@@ -604,9 +602,7 @@ func (r ManagedRedisResource) Update() sdk.ResourceFunc {
 							)
 						}
 
-						// Despite the method name, Create uses PUT (create-or-update behaviour), which is preferred to Update (PATCH)
-						// to simplify 'omitempty' / empty values handling on expand functions
-						if err := dbClient.CreateThenPoll(ctx, dbId, *dbParams); err != nil {
+						if err := dbClient.UpdateThenPoll(ctx, dbId, dbParams); err != nil {
 							return fmt.Errorf("updating %s: %+v", dbId, err)
 						}
 
@@ -735,6 +731,10 @@ func (r ManagedRedisResource) CustomizeDiff() sdk.ResourceFunc {
 			return nil
 		},
 	}
+}
+
+func clusteringPolicyRequiresDatabaseRecreation(oldPolicy, newPolicy string) bool {
+	return oldPolicy != newPolicy && oldPolicy != string(redisenterprise.ClusteringPolicyNoCluster)
 }
 
 func createDb(ctx context.Context, dbClient *databases.DatabasesClient, dbId databases.DatabaseId, dbModel DefaultDatabaseModel) error {

--- a/internal/services/managedredis/managed_redis_resource_test.go
+++ b/internal/services/managedredis/managed_redis_resource_test.go
@@ -103,6 +103,26 @@ func TestAccManagedRedis_updateSku(t *testing.T) {
 	})
 }
 
+func TestAccManagedRedis_updateClusteringPolicyFromNoCluster(t *testing.T) {
+  data := acceptance.BuildTestData(t, "azurerm_managed_redis", "test")
+  r := ManagedRedisResource{}
+  data.ResourceTest(t, r, []acceptance.TestStep{
+    {
+      Config: r.clusteringPolicy(data, "NoCluster"),
+      Check: acceptance.ComposeTestCheckFunc(
+        check.That(data.ResourceName).Key("default_database.0.clustering_policy").HasValue("NoCluster"),
+      ),
+    },
+    {
+      Config: r.clusteringPolicy(data, "EnterpriseCluster"),
+      Check: acceptance.ComposeTestCheckFunc(
+        check.That(data.ResourceName).Key("default_database.0.clustering_policy").HasValue("EnterpriseCluster"),
+      ),
+    },
+    data.ImportStep(),
+  })
+}
+
 func TestAccManagedRedis_withPrivateEndpoint(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_managed_redis", "test")
 	r := ManagedRedisResource{}
@@ -337,6 +357,31 @@ resource "azurerm_managed_redis" "test" {
   default_database {}
 }
 `, data.RandomInteger, data.Locations.Primary)
+}
+
+func (r ManagedRedisResource) clusteringPolicy(data acceptance.TestData, clusteringPolicy string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-managedRedis-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_managed_redis" "test" {
+  name                = "acctest-amr-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+
+  location = "%[2]s"
+  sku_name = "Balanced_B0"
+
+  default_database {
+    clustering_policy = "%[3]s"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, clusteringPolicy)
 }
 
 func (r ManagedRedisResource) requiresImport(data acceptance.TestData) string {

--- a/internal/services/managedredis/managed_redis_resource_unit_test.go
+++ b/internal/services/managedredis/managed_redis_resource_unit_test.go
@@ -1,0 +1,57 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package managedredis
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/redisenterprise/2025-07-01/redisenterprise"
+)
+
+func TestClusteringPolicyRequiresDatabaseRecreation(t *testing.T) {
+	testCases := []struct {
+		name           string
+		oldPolicy      redisenterprise.ClusteringPolicy
+		newPolicy      redisenterprise.ClusteringPolicy
+		expectedResult bool
+	}{
+		{
+			name:      "NoCluster to OSSCluster",
+			oldPolicy: redisenterprise.ClusteringPolicyNoCluster,
+			newPolicy: redisenterprise.ClusteringPolicyOSSCluster,
+		},
+		{
+			name:      "NoCluster to EnterpriseCluster",
+			oldPolicy: redisenterprise.ClusteringPolicyNoCluster,
+			newPolicy: redisenterprise.ClusteringPolicyEnterpriseCluster,
+		},
+		{
+			name:           "OSSCluster to NoCluster",
+			oldPolicy:      redisenterprise.ClusteringPolicyOSSCluster,
+			newPolicy:      redisenterprise.ClusteringPolicyNoCluster,
+			expectedResult: true,
+		},
+		{
+			name:           "EnterpriseCluster to NoCluster",
+			oldPolicy:      redisenterprise.ClusteringPolicyEnterpriseCluster,
+			newPolicy:      redisenterprise.ClusteringPolicyNoCluster,
+			expectedResult: true,
+		},
+		{
+			name:           "OSSCluster to EnterpriseCluster",
+			oldPolicy:      redisenterprise.ClusteringPolicyOSSCluster,
+			newPolicy:      redisenterprise.ClusteringPolicyEnterpriseCluster,
+			expectedResult: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			actualResult := clusteringPolicyRequiresDatabaseRecreation(string(testCase.oldPolicy), string(testCase.newPolicy))
+			if actualResult != testCase.expectedResult {
+				t.Fatalf("expected %t, got %t", testCase.expectedResult, actualResult)
+			}
+		})
+	}
+}

--- a/website/docs/r/managed_redis.html.markdown
+++ b/website/docs/r/managed_redis.html.markdown
@@ -153,7 +153,7 @@ The following arguments are supported:
 
 A `default_database` block supports the following:
 
-~> **Note:** Updating the following properties will force a new database to be created, data will be lost and Managed Redis will be unavailable during the operation: `clustering_policy`, `geo_replication_group_name`, and `module`
+~> **Note:** Updating `geo_replication_group_name` or `module` will force a new database to be created. Updating `clustering_policy` will also force a new database unless its current value is `NoCluster`. Data will be lost and Managed Redis will be unavailable when the database is recreated.
 
 * `access_keys_authentication_enabled` - (Optional) Whether access key authentication is enabled for the database. Defaults to `false`.
 
@@ -161,7 +161,7 @@ A `default_database` block supports the following:
 
 * `clustering_policy` - (Optional) Clustering policy specified at create time. Possible values are `EnterpriseCluster`, `OSSCluster` and `NoCluster`. Defaults to `OSSCluster`.
 
-!> **Note:** Changing `clustering_policy` forces database recreation. Data will be lost and Managed Redis will be unavailable during the operation.
+!> **Note:** `clustering_policy` can be updated in place when its current value is `NoCluster`. Changing it from `OSSCluster` or `EnterpriseCluster` forces database recreation. Data will be lost and Managed Redis will be unavailable during database recreation.
 
 * `eviction_policy` - (Optional) Specifies the Redis eviction policy. Possible values are `AllKeysLFU`, `AllKeysLRU`, `AllKeysRandom`, `VolatileLRU`, `VolatileLFU`, `VolatileTTL`, `VolatileRandom` and `NoEviction`. Defaults to `VolatileLRU`.
 


### PR DESCRIPTION
## Community Note
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

Allows `azurerm_managed_redis` to update `default_database.clustering_policy` in place when its current value is `NoCluster`, matching the Azure Managed Redis API's supported transition behavior.

Transitions from `OSSCluster` or `EnterpriseCluster` continue to recreate the database. The documentation now distinguishes the in-place and recreation paths.

## Documentation
 - https://learn.microsoft.com/en-us/azure/redis/how-to-scale#can-the-clustering-policy-be-changed-after-selecting-oss-or-enterprise-cluster
 - https://learn.microsoft.com/en-us/rest/api/redis/redisenterprisecache/databases/update?view=rest-redis-redisenterprisecache-2025-07-01&tabs=HTTP#request-body 
 

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.

## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them.
- [x] I have written new tests for my resource or datasource changes and updated relevant documentation.
- [ ] I have successfully run tests with my changes locally. The focused unit test is being run; the Azure acceptance test requires acceptance-test credentials and infrastructure.
- [ ] (For changes that include a **state migration only**). Not applicable; this change does not include a state migration.

## Testing

- [x] My submission includes test coverage as described in the Contribution Guide.

Added table-driven unit coverage for clustering-policy transition behavior and an acceptance test covering `NoCluster` to `EnterpriseCluster`, followed by import.

## Change Log

* `azurerm_managed_redis` - support updating `clustering_policy` in place when its current value is `NoCluster`

This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change

## AI Assistance Disclosure

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

AI assistance was used for code development, tests, documentation, validation, and pull request preparation.

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

There are no changes to security controls in this pull request.

> [!NOTE]
> If this PR changes meaningfully during the course of review please update the title and description as required.