### PR TITLE
`azurerm_eventhub_namespace` -  prevent `network_rulesets.x.default_action` being set to `Deny`  `ip_rule` or `virtual_network_rule` is not specified

### DIFF
--- a/internal/services/eventhub/eventhub_namespace_resource.go
+++ b/internal/services/eventhub/eventhub_namespace_resource.go
@@ -6,6 +6,7 @@ package eventhub
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -351,8 +352,12 @@ func resourceEventHubNamespaceCreate(d *pluginsdk.ResourceData, meta interface{}
 			return fmt.Errorf("network_rulesets cannot be used when the SKU is basic")
 		}
 
+		ruleSetProperties, err := expandEventHubNamespaceNetworkRuleset(ruleSets.([]interface{}))
+		if err != nil {
+			return err
+		}
 		rulesets := networkrulesets.NetworkRuleSet{
-			Properties: expandEventHubNamespaceNetworkRuleset(ruleSets.([]interface{})),
+			Properties: ruleSetProperties,
 		}
 
 		if !strings.EqualFold(string(*rulesets.Properties.PublicNetworkAccess), string(*parameters.Properties.PublicNetworkAccess)) {
@@ -463,8 +468,12 @@ func resourceEventHubNamespaceUpdate(d *pluginsdk.ResourceData, meta interface{}
 		}
 
 		ruleSets := d.Get("network_rulesets")
+		ruleSetProperties, err := expandEventHubNamespaceNetworkRuleset(ruleSets.([]interface{}))
+		if err != nil {
+			return err
+		}
 		rulesets := networkrulesets.NetworkRuleSet{
-			Properties: expandEventHubNamespaceNetworkRuleset(ruleSets.([]interface{})),
+			Properties: ruleSetProperties,
 		}
 
 		if !strings.EqualFold(string(*rulesets.Properties.PublicNetworkAccess), string(*parameters.Properties.PublicNetworkAccess)) {
@@ -594,9 +603,9 @@ func resourceEventHubNamespaceDelete(d *pluginsdk.ResourceData, meta interface{}
 	return nil
 }
 
-func expandEventHubNamespaceNetworkRuleset(input []interface{}) *networkrulesets.NetworkRuleSetProperties {
+func expandEventHubNamespaceNetworkRuleset(input []interface{}) (*networkrulesets.NetworkRuleSetProperties, error) {
 	if len(input) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	block := input[0].(map[string]interface{})
@@ -606,11 +615,9 @@ func expandEventHubNamespaceNetworkRuleset(input []interface{}) *networkrulesets
 		publicNetworkAccess = networkrulesets.PublicNetworkAccessFlagDisabled
 	}
 
+	defaultAction := networkrulesets.DefaultAction(block["default_action"].(string))
 	ruleset := networkrulesets.NetworkRuleSetProperties{
-		DefaultAction: func() *networkrulesets.DefaultAction {
-			v := networkrulesets.DefaultAction(block["default_action"].(string))
-			return &v
-		}(),
+		DefaultAction:       &defaultAction,
 		PublicNetworkAccess: &publicNetworkAccess,
 	}
 
@@ -654,7 +661,13 @@ func expandEventHubNamespaceNetworkRuleset(input []interface{}) *networkrulesets
 		}
 	}
 
-	return &ruleset
+	// the API silently keeps the effective `default_action` as `Allow` if `Deny` is sent with no `ip_rule` or
+	// `virtual_network_rule` defined, and returns no error - producing permanent plan drift on the next read
+	if defaultAction == networkrulesets.DefaultActionDeny && ruleset.VirtualNetworkRules == nil && ruleset.IPRules == nil {
+		return nil, errors.New("the `default_action` of `network_rulesets` can only be set to `Deny` when at least one `ip_rule` or `virtual_network_rule` block is specified")
+	}
+
+	return &ruleset, nil
 }
 
 func flattenEventHubNamespaceNetworkRuleset(ruleset networkrulesets.NamespacesGetNetworkRuleSetOperationResponse) ([]interface{}, error) {

--- a/internal/services/eventhub/eventhub_namespace_resource_test.go
+++ b/internal/services/eventhub/eventhub_namespace_resource_test.go
@@ -183,6 +183,18 @@ func TestAccEventHubNamespace_networkrule_publicNetworkAccessDiff(t *testing.T) 
 	})
 }
 
+func TestAccEventHubNamespace_networkrule_denyWithNoRules(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_eventhub_namespace", "test")
+	r := EventHubNamespaceResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config:      r.networkrule_denyWithNoRules(data),
+			ExpectError: regexp.MustCompile("the `default_action` of `network_rulesets` can only be set to `Deny` when at least one `ip_rule` or `virtual_network_rule` block is specified"),
+		},
+	})
+}
+
 func TestAccEventHubNamespace_networkrule_vnet(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_eventhub_namespace", "test")
 	r := EventHubNamespaceResource{}
@@ -729,6 +741,31 @@ resource "azurerm_eventhub_namespace" "test" {
       ip_mask = "10.0.0.0/16"
       action  = "Allow"
     }
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (EventHubNamespaceResource) networkrule_denyWithNoRules(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-eh-%d"
+  location = "%s"
+}
+
+resource "azurerm_eventhub_namespace" "test" {
+  name                = "acctesteventhubnamespace-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Standard"
+  capacity            = "2"
+
+  network_rulesets {
+    default_action = "Deny"
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)

--- a/website/docs/r/eventhub_namespace.html.markdown
+++ b/website/docs/r/eventhub_namespace.html.markdown
@@ -83,6 +83,8 @@ A `network_rulesets` block supports the following:
 
 * `default_action` - (Required) The default action to take when a rule is not matched. Possible values are `Allow` and `Deny`.
 
+~> **Note:** `default_action` can only be set to `Deny` when at least one `ip_rule` or `virtual_network_rule` block is specified, otherwise the Azure API will not honor the setting.
+
 * `public_network_access_enabled` - (Optional) Is public network access enabled for the EventHub Namespace? Defaults to `true`.
 
 ~> **Note:** The public network access setting at the network rule sets level should be the same as it's at the namespace level.


### PR DESCRIPTION
Adds validation to `azurerm_eventhub_namespace` so network_rulesets.default_action = "Deny" is rejected at apply-time unless at least one ip_rule or virtual_network_rule is configured, since Azure silently ignores Deny without an explicit allow rule.


<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #33100


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
