### PR TITLE
`azurerm_linux_function_app_slot` - strip the URL scheme from `registry_url` when building `linuxFxVersion`

### DIFF
--- a/internal/services/appservice/helpers/function_app_slot_schema.go
+++ b/internal/services/appservice/helpers/function_app_slot_schema.go
@@ -1113,7 +1113,18 @@ func ExpandSiteConfigLinuxFunctionAppSlot(siteConfig []SiteConfigLinuxFunctionAp
 				Name:  pointer.To("DOCKER_REGISTRY_SERVER_PASSWORD"),
 				Value: pointer.To(dockerConfig.RegistryPassword),
 			})
-			expanded.LinuxFxVersion = pointer.To(fmt.Sprintf("DOCKER|%s/%s:%s", dockerConfig.RegistryURL, dockerConfig.ImageName, dockerConfig.ImageTag))
+			// The registry URL is documented (and stored) with its scheme, e.g. `https://myregistry.azurecr.io`,
+			// but the image reference in `linuxFxVersion` must not contain it. Strip it the same way
+			// `ExpandSiteConfigLinuxFunctionApp` does, otherwise an update of an unrelated attribute (e.g. `app_settings`)
+			// rewrites `linuxFxVersion` as `DOCKER|https://myregistry.azurecr.io/image:tag` and the container can no longer start.
+			dockerUrl := dockerConfig.RegistryURL
+			for _, prefix := range urlSchemes {
+				if strings.HasPrefix(dockerConfig.RegistryURL, prefix) {
+					dockerUrl = strings.TrimPrefix(dockerConfig.RegistryURL, prefix)
+					continue
+				}
+			}
+			expanded.LinuxFxVersion = pointer.To(fmt.Sprintf("DOCKER|%s/%s:%s", dockerUrl, dockerConfig.ImageName, dockerConfig.ImageTag))
 		}
 	} else {
 		appSettings = append(appSettings, webapps.NameValuePair{


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

`ExpandSiteConfigLinuxFunctionAppSlot` builds `linuxFxVersion` with the docker `registry_url` verbatim. Because `registry_url` is documented and stored with its scheme (`https://myregistry.azurecr.io`), any update of the slot (for example an `app_settings` change) rewrites `linuxFxVersion` as `DOCKER|https://myregistry.azurecr.io/image:tag`, which App Service cannot pull, so the slot's container stops starting. Nothing about it is visible in `terraform plan` because `linux_fx_version` is computed.

The non-slot resource already strips `urlSchemes` before building the same string (`ExpandSiteConfigLinuxFunctionApp`, #18194). This PR applies the identical logic to the slot code path so both resources produce `DOCKER|myregistry.azurecr.io/image:tag`.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source. (no documentation change needed — behaviour now matches the documented `registry_url` format)
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.

## Changes to existing Resource / Data Source

- `azurerm_linux_function_app_slot` - `site_config.application_stack.docker.registry_url` no longer leaks its `https://` / `http://` scheme into `linuxFxVersion` on create/update. No schema change.

## Testing

- No new test added; the change mirrors the existing, tested scheme-stripping logic in `ExpandSiteConfigLinuxFunctionApp`.
- Reproduced the bug on v4.21.1 against a real Function App slot (see the linked issue for the exact malformed value and its effect) and confirmed the code path on `main` @ 2e9b8cc is unchanged.
- I was not able to run the `TestAccLinuxFunctionAppSlot_*` acceptance tests myself.

## Change Log

* `azurerm_linux_function_app_slot` - fix `linuxFxVersion` being written as `DOCKER|https://<registry>/<image>:<tag>` (URL scheme not stripped from `registry_url`) when the slot is updated [GH-33218]

## This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change

## Related Issue(s)
Fixes #33218

## Note

If this PR changes meaningfully during the course of review please update the title and description as required.
