### PR TITLE
Tests: fix tests and expand identity test generator

### DIFF
--- a/internal/services/healthcare/healthcare_fhir_service_resource_test.go
+++ b/internal/services/healthcare/healthcare_fhir_service_resource_test.go
@@ -281,9 +281,10 @@ resource "azurerm_container_registry" "test" {
   admin_enabled       = false
 
   georeplications {
-    location                = "%s"
-    zone_redundancy_enabled = true
-    tags                    = {}
+    global_endpoint_routing_enabled = false
+    location                        = "%s"
+    tags                            = {}
+    zone_redundancy_enabled         = true
   }
 }
 

--- a/internal/services/signalr/signalr_service_custom_domain_resource.go
+++ b/internal/services/signalr/signalr_service_custom_domain_resource.go
@@ -3,7 +3,7 @@
 
 package signalr
 
-//go:generate go run ../../tools/generator-tests resourceidentity -resource-name signalr_service_custom_domain -service-package-name signalr -properties "name" -compare-values "subscription_id:signalr_service_id,resource_group_name:signalr_service_id,signalr_name:signalr_service_id"
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name signalr_service_custom_domain -service-package-name signalr -properties "name" -compare-values "subscription_id:signalr_service_id,resource_group_name:signalr_service_id,signalr_name:signalr_service_id" -test-env-vars "ARM_TEST_DNS_ZONE,ARM_TEST_DATA_RESOURCE_GROUP"
 
 import (
 	"context"

--- a/internal/services/signalr/signalr_service_custom_domain_resource_identity_gen_test.go
+++ b/internal/services/signalr/signalr_service_custom_domain_resource_identity_gen_test.go
@@ -4,6 +4,7 @@
 package signalr_test
 
 import (
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -13,6 +14,12 @@ import (
 )
 
 func TestAccSignalrServiceCustomDomain_resourceIdentity(t *testing.T) {
+	for _, v := range []string{"ARM_TEST_DNS_ZONE", "ARM_TEST_DATA_RESOURCE_GROUP"} {
+		if os.Getenv(v) == "" {
+			t.Skipf("Skipping as `%s` was not specified", v)
+		}
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_signalr_service_custom_domain", "test")
 	r := SignalrServiceCustomDomainResource{}
 

--- a/internal/services/signalr/web_pubsub_custom_domain_resource.go
+++ b/internal/services/signalr/web_pubsub_custom_domain_resource.go
@@ -3,7 +3,7 @@
 
 package signalr
 
-//go:generate go run ../../tools/generator-tests resourceidentity -resource-name web_pubsub_custom_domain -service-package-name signalr -properties "name" -compare-values "subscription_id:web_pubsub_id,resource_group_name:web_pubsub_id,web_pubsub_name:web_pubsub_id"
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name web_pubsub_custom_domain -service-package-name signalr -properties "name" -compare-values "subscription_id:web_pubsub_id,resource_group_name:web_pubsub_id,web_pubsub_name:web_pubsub_id" -test-env-vars "ARM_TEST_DNS_ZONE,ARM_TEST_DATA_RESOURCE_GROUP"
 
 import (
 	"context"

--- a/internal/services/signalr/web_pubsub_custom_domain_resource_identity_gen_test.go
+++ b/internal/services/signalr/web_pubsub_custom_domain_resource_identity_gen_test.go
@@ -4,6 +4,7 @@
 package signalr_test
 
 import (
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -13,6 +14,12 @@ import (
 )
 
 func TestAccWebPubsubCustomDomain_resourceIdentity(t *testing.T) {
+	for _, v := range []string{"ARM_TEST_DNS_ZONE", "ARM_TEST_DATA_RESOURCE_GROUP"} {
+		if os.Getenv(v) == "" {
+			t.Skipf("Skipping as `%s` was not specified", v)
+		}
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_web_pubsub_custom_domain", "test")
 	r := WebPubsubCustomDomainResource{}
 

--- a/internal/tools/generator-tests/generators/resource_identity.go
+++ b/internal/tools/generator-tests/generators/resource_identity.go
@@ -41,6 +41,8 @@ type resourceIdentityData struct {
 	CompareValueMap        map[string]string
 	NoSubscriptionID       bool
 	TestName               string
+	TestEnvVarsFlag        string
+	TestEnvVars            []string
 	TestExpectNonEmptyPlan bool
 	TestSequential         bool
 	RewriteTag             bool
@@ -72,6 +74,8 @@ Optional args:
 		- 'no-subscription-id' can be passed to omit the default subscription ID known value in the test if the resource's ID doesn't contain subscription ID. Defaults to 'false'.
 	- test-name [string]
 		'test-name' specifies the test config name that will be used to test Resource Identity. Defaults to 'basic'.
+	- test-env-vars [string]
+		- 'test-env-vars' specifies any environment variables that are required for the test to run, the test is skipped if specified env vars are not defined.
 	- test-expect-non-empty [bool]
 		'test-expect-non-empty' indicates whether the test should expect (and ignore) a non-empty plan, to be used when the API does not return certain values during import.
 	- test-sequential [bool]
@@ -120,6 +124,7 @@ func (d *resourceIdentityData) parseArgs(args []string) (errors []error) {
 	argSet.StringVar(&d.ParentID, "parent-id", "", "(Optional) for sub-resources with a virtual identity, specify the schema property name of the parent ID (e.g. `workspace_id`). This automatically expands into compare-values.")
 	argSet.StringVar(&d.ServicePackageName, "service-package-name", "", "(Optional) the path to the directory containing the service package to write the generated test to. For Go generate this will be picked up from $GOPACKAGE or current working directory.")
 	argSet.StringVar(&d.BasicTestParams, "test-params", "", "(Optional) comma separated list of additional properties that need to be passed to the basic test config for this resource.")
+	argSet.StringVar(&d.TestEnvVarsFlag, "test-env-vars", "", "(Optional) comma separated list of env vars that need to be passed to the basic test config for this resource, if any of the provided env vars are missing the test is skipped.")
 	argSet.StringVar(&d.KnownValues, "known-values", "", "(Optional) comma separated list of known (aka discriminated) value names and their values for this resource type, formatted as [attribute_name]:[attribute value]. e.g. `kind:linux;functionapp,foo:bar`")
 	argSet.StringVar(&d.CompareValues, "compare-values", "", "(Optional) comma separated list of resource identity names that are contained within a schema property value, formatted as [attribute_name]:[attribute value]. e.g. `parent_name:parent_resource_id;resource_group_name,parent_resource_id`")
 	argSet.BoolVar(&d.NoSubscriptionID, "no-subscription-id", false, "(Optional) 'no-subscription-id' can be passed to omit the default subscription ID known value in the test if the resource's ID doesn't contain subscription ID. Defaults to 'false'.")
@@ -343,6 +348,10 @@ func (d *resourceIdentityData) parseArgs(args []string) (errors []error) {
 
 	if len(d.BasicTestParams) > 0 {
 		d.TestParams = strings.Split(d.BasicTestParams, ",")
+	}
+
+	if len(d.TestEnvVarsFlag) > 0 {
+		d.TestEnvVars = strings.Split(d.TestEnvVarsFlag, ",")
 	}
 
 	if len(d.KnownValues) > 0 {

--- a/internal/tools/generator-tests/generators/templates/identity_test.gotpl
+++ b/internal/tools/generator-tests/generators/templates/identity_test.gotpl
@@ -21,6 +21,14 @@ func testAcc{{ToCamel .ResourceName}}_resourceIdentity(t *testing.T) {
 {{- else }}
 func TestAcc{{ToCamel .ResourceName}}_resourceIdentity(t *testing.T) {
 {{- end }}
+	{{- if (gt (.TestEnvVars | len) 0) }}
+	for _, v := range []string{{ "{" }}{{ ToQuotedCommaSeparated .TestEnvVars }}{{ "}" }} {
+		if os.Getenv(v) == "" {
+			t.Skipf("Skipping as `%s` was not specified", v)
+		}
+	}
+
+	{{ end }}
 	data := acceptance.BuildTestData(t, "azurerm_{{ ToSnake $resourceName }}", "test")
 	r := {{ ToCamel $resourceName }}Resource{}
 

--- a/internal/tools/templatehelpers/formatters.go
+++ b/internal/tools/templatehelpers/formatters.go
@@ -21,6 +21,7 @@ var TplFuncMap = template.FuncMap{
 	"ToLower":                        strings.ToLower,
 	"ToTitle":                        ToTitle,
 	"ToCamel":                        strcase.ToCamel,
+	"ToQuotedCommaSeparated":         ToQuotedCommaSeparated,
 	"ToSnake":                        pluginsdk.ToSnakeCase,
 	"TfName":                         TerraformResourceName,
 	"ToString":                       ToString,
@@ -147,4 +148,13 @@ func QuoteIfNeeded(input string) string {
 	}
 
 	return input
+}
+
+func ToQuotedCommaSeparated(input []string) string {
+	quoted := make([]string, 0, len(input))
+	for _, v := range input {
+		quoted = append(quoted, fmt.Sprintf("\"%s\"", v))
+	}
+
+	return strings.Join(quoted, ",")
 }


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

- Fixes a number of tests
- Enhances identity test generator to allow for checks ensuring required env vars are set


## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change



## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
