### PR TITLE
`azurerm_storage_account` - add support for migrating `account_replication_type` between zonal & non-zonal types

### DIFF
--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2025-08-01/blobservices"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2025-08-01/fileservices"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2025-08-01/storageaccountmigrations"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2025-08-01/storageaccounts"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	providerhelpers "github.com/hashicorp/terraform-provider-azurerm/helpers"
@@ -134,6 +135,13 @@ func resourceStorageAccount() *pluginsdk.Resource {
 			"account_replication_type": {
 				Type:     pluginsdk.TypeString,
 				Required: true,
+				DiffSuppressFunc: func(_, _, _ string, d *schema.ResourceData) bool {
+					// Migration of a storage account to/from zonal can take days
+					// so the provider doesn't poll and wait for it to complete.
+					// While in queue for migration/actively migrating, the Storage Account will return the old `account_replication_type`
+					// which we'll suppress here.
+					return d.Get("migration_in_progress").(bool)
+				},
 				ValidateFunc: validation.StringInSlice([]string{
 					"LRS",
 					"ZRS",
@@ -718,6 +726,11 @@ func resourceStorageAccount() *pluginsdk.Resource {
 				Default:  true,
 			},
 
+			"migration_in_progress": {
+				Type:     pluginsdk.TypeBool,
+				Computed: true,
+			},
+
 			"primary_location": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
@@ -1156,21 +1169,21 @@ func resourceStorageAccount() *pluginsdk.Resource {
 				}
 				return nil
 			}),
-			pluginsdk.ForceNewIfChange("account_replication_type", func(ctx context.Context, old, new, meta interface{}) bool {
-				newAccRep := strings.ToUpper(new.(string))
-
-				switch strings.ToUpper(old.(string)) {
-				case "LRS", "GRS", "RAGRS":
-					if newAccRep == "GZRS" || newAccRep == "RAGZRS" || newAccRep == "ZRS" {
-						return true
-					}
-				case "ZRS", "GZRS", "RAGZRS":
-					if newAccRep == "LRS" || newAccRep == "GRS" || newAccRep == "RAGRS" {
-						return true
-					}
-				}
-				return false
-			}),
+			//pluginsdk.ForceNewIfChange("account_replication_type", func(ctx context.Context, old, new, meta interface{}) bool {
+			//	newAccRep := strings.ToUpper(new.(string))
+			//
+			//	switch strings.ToUpper(old.(string)) {
+			//	case "LRS", "GRS", "RAGRS":
+			//		if newAccRep == "GZRS" || newAccRep == "RAGZRS" || newAccRep == "ZRS" {
+			//			return true
+			//		}
+			//	case "ZRS", "GZRS", "RAGZRS":
+			//		if newAccRep == "LRS" || newAccRep == "GRS" || newAccRep == "RAGRS" {
+			//			return true
+			//		}
+			//	}
+			//	return false
+			//}),
 		),
 	}
 }
@@ -1646,10 +1659,28 @@ func resourceStorageAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 	if d.HasChange("account_kind") {
 		payload.Kind = accountKind
 	}
+
+	migrationRequired := false
 	if d.HasChange("account_replication_type") {
-		// storageType is derived from "account_replication_type", "account_tier" (force-new) and "provisioned_billing_model_version" (force-new)
-		payload.Sku = storageaccounts.Sku{
-			Name: storageaccounts.SkuName(storageType),
+		// certain changes to `account_replication_type` require a storage migration, in this scenario we'll omit the updated SKU and trigger a migration instead
+		o, n := d.GetChange("account_replication_type")
+		newReplicationType := strings.ToUpper(n.(string))
+		switch strings.ToUpper(o.(string)) {
+		case "LRS", "GRS", "RAGRS":
+			if newReplicationType == "GZRS" || newReplicationType == "RAGZRS" || newReplicationType == "ZRS" {
+				migrationRequired = true
+			}
+		case "ZRS", "GZRS", "RAGZRS":
+			if newReplicationType == "LRS" || newReplicationType == "GRS" || newReplicationType == "RAGRS" {
+				migrationRequired = true
+			}
+		}
+
+		if !migrationRequired {
+			payload.Sku = storageaccounts.Sku{
+				// storageType is derived from "account_replication_type", "account_tier" (force-new) and "provisioned_billing_model_version" (force-new)
+				Name: storageaccounts.SkuName(storageType),
+			}
 		}
 	}
 	if d.HasChange("identity") {
@@ -1762,6 +1793,19 @@ func resourceStorageAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 		if _, err = storageClient.FileServices.SetServiceProperties(ctx, *id, sharePayload); err != nil {
 			return fmt.Errorf("updating File Share Properties for %s: %+v", *id, err)
 		}
+	}
+
+	if migrationRequired {
+		migrationPayload := storageaccounts.StorageAccountMigration{
+			Properties: storageaccounts.StorageAccountMigrationProperties{
+				TargetSkuName: storageaccounts.SkuName(storageType),
+			},
+		}
+
+		if _, err := client.CustomerInitiatedMigration(ctx, *id, migrationPayload); err != nil {
+			return fmt.Errorf("triggering account migration for %s: %+v", id, err)
+		}
+		d.Set("migration_in_progress", true)
 	}
 
 	return resourceStorageAccountRead(d, meta)

--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -59,6 +59,14 @@ var (
 		storageaccounts.KindFileStorage: {},
 		storageaccounts.KindStorageVTwo: {},
 	}
+	storageReplicationZonalMigrationPairs = map[string]string{
+		"LRS":    "ZRS",
+		"GRS":    "GZRS",
+		"RAGRS":  "RAGZRS",
+		"ZRS":    "LRS",
+		"GZRS":   "GRS",
+		"RAGZRS": "RAGRS",
+	}
 )
 
 func resourceStorageAccount() *pluginsdk.Resource {
@@ -135,12 +143,12 @@ func resourceStorageAccount() *pluginsdk.Resource {
 			"account_replication_type": {
 				Type:     pluginsdk.TypeString,
 				Required: true,
-				DiffSuppressFunc: func(_, _, _ string, d *schema.ResourceData) bool {
+				DiffSuppressFunc: func(_, _, n string, d *schema.ResourceData) bool {
 					// Migration of a storage account to/from zonal can take days
 					// so the provider doesn't poll and wait for it to complete.
 					// While in queue for migration/actively migrating, the Storage Account will return the old `account_replication_type`
-					// which we'll suppress here.
-					return d.Get("migration_in_progress").(bool)
+					// which we'll suppress here if the configured type matches the target migration type.
+					return d.Get("account_replication_type_migration_in_progress").(bool) && n == d.Get("account_replication_type_migrating_to").(string)
 				},
 				ValidateFunc: validation.StringInSlice([]string{
 					"LRS",
@@ -726,8 +734,13 @@ func resourceStorageAccount() *pluginsdk.Resource {
 				Default:  true,
 			},
 
-			"migration_in_progress": {
+			"account_replication_type_migration_in_progress": {
 				Type:     pluginsdk.TypeBool,
+				Computed: true,
+			},
+
+			"account_replication_type_migrating_to": {
+				Type:     pluginsdk.TypeString,
 				Computed: true,
 			},
 
@@ -1169,21 +1182,34 @@ func resourceStorageAccount() *pluginsdk.Resource {
 				}
 				return nil
 			}),
-			//pluginsdk.ForceNewIfChange("account_replication_type", func(ctx context.Context, old, new, meta interface{}) bool {
-			//	newAccRep := strings.ToUpper(new.(string))
-			//
-			//	switch strings.ToUpper(old.(string)) {
-			//	case "LRS", "GRS", "RAGRS":
-			//		if newAccRep == "GZRS" || newAccRep == "RAGZRS" || newAccRep == "ZRS" {
-			//			return true
-			//		}
-			//	case "ZRS", "GZRS", "RAGZRS":
-			//		if newAccRep == "LRS" || newAccRep == "GRS" || newAccRep == "RAGRS" {
-			//			return true
-			//		}
-			//	}
-			//	return false
-			//}),
+			pluginsdk.CustomizeDiffShim(func(ctx context.Context, d *pluginsdk.ResourceDiff, v interface{}) error {
+				if d.Get("account_replication_type_migration_in_progress").(bool) {
+					o, n := d.GetChange("account_replication_type")
+					migratingTo := d.Get("account_replication_type_migrating_to").(string)
+
+					oldType, newType := o.(string), n.(string)
+					if newType != migratingTo {
+						return fmt.Errorf("a migration from `%s` to `%s` is in progress, please wait until this operation has completed before changing `account_replication_type` (configured type: `%s`)", oldType, migratingTo, newType)
+					}
+				}
+
+				return nil
+			}),
+			pluginsdk.ForceNewIfChange("account_replication_type", func(ctx context.Context, old, new, meta interface{}) bool {
+				n := strings.ToUpper(new.(string))
+
+				switch o := strings.ToUpper(old.(string)); o {
+				case "LRS", "GRS", "RAGRS":
+					if n == "GZRS" || n == "RAGZRS" || n == "ZRS" {
+						return storageReplicationZonalMigrationPairs[o] != n
+					}
+				case "ZRS", "GZRS", "RAGZRS":
+					if n == "LRS" || n == "GRS" || n == "RAGRS" {
+						return storageReplicationZonalMigrationPairs[o] != n
+					}
+				}
+				return false
+			}),
 		),
 	}
 }
@@ -1384,6 +1410,7 @@ func resourceStorageAccountCreate(d *pluginsdk.ResourceData, meta interface{}) e
 	}
 
 	supportLevel := availableFunctionalityForAccount(accountKind, accountTier, replicationType)
+
 	if val, ok := d.GetOk("blob_properties"); ok {
 		if !supportLevel.supportBlob {
 			return fmt.Errorf("`blob_properties` aren't supported for account kind %q in sku tier %q", accountKind, accountTier)
@@ -1660,20 +1687,18 @@ func resourceStorageAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 		payload.Kind = accountKind
 	}
 
+	// avoid triggering an unnecessary update (`PUT`) API request if there are no other changes besides the below items
+	// `account_replication_type` may only require a migration request without the main `PUT` request
+	// `azure_files_authentication`, `blob_properties`, and `share_properties` ecah use their own API requests
+	updateRequired := d.HasChangesExcept("account_replication_type", "azure_files_authentication", "blob_properties", "share_properties")
+
 	migrationRequired := false
 	if d.HasChange("account_replication_type") {
 		// certain changes to `account_replication_type` require a storage migration, in this scenario we'll omit the updated SKU and trigger a migration instead
 		o, n := d.GetChange("account_replication_type")
-		newReplicationType := strings.ToUpper(n.(string))
-		switch strings.ToUpper(o.(string)) {
-		case "LRS", "GRS", "RAGRS":
-			if newReplicationType == "GZRS" || newReplicationType == "RAGZRS" || newReplicationType == "ZRS" {
-				migrationRequired = true
-			}
-		case "ZRS", "GZRS", "RAGZRS":
-			if newReplicationType == "LRS" || newReplicationType == "GRS" || newReplicationType == "RAGRS" {
-				migrationRequired = true
-			}
+		oRT, nRT := o.(string), n.(string)
+		if storageReplicationZonalMigrationPairs[oRT] == nRT {
+			migrationRequired = true
 		}
 
 		if !migrationRequired {
@@ -1681,6 +1706,7 @@ func resourceStorageAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 				// storageType is derived from "account_replication_type", "account_tier" (force-new) and "provisioned_billing_model_version" (force-new)
 				Name: storageaccounts.SkuName(storageType),
 			}
+			updateRequired = true
 		}
 	}
 	if d.HasChange("identity") {
@@ -1690,8 +1716,10 @@ func resourceStorageAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 		payload.Tags = tags.Expand(d.Get("tags").(map[string]interface{}))
 	}
 
-	if err := client.CreateCallbackThenPoll(ctx, *id, payload, sdk.SetIDCallback(meta, id, d)); err != nil {
-		return fmt.Errorf("updating %s: %+v", id, err)
+	if updateRequired {
+		if err := client.CreateThenPoll(ctx, *id, payload); err != nil {
+			return fmt.Errorf("updating %s: %+v", id, err)
+		}
 	}
 
 	// azure_files_authentication must be the last to be updated, cause it'll occupy the storage account for several minutes after receiving the response 200 OK. Issue: https://github.com/Azure/azure-rest-api-specs/issues/11272
@@ -1805,7 +1833,8 @@ func resourceStorageAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 		if _, err := client.CustomerInitiatedMigration(ctx, *id, migrationPayload); err != nil {
 			return fmt.Errorf("triggering account migration for %s: %+v", id, err)
 		}
-		d.Set("migration_in_progress", true)
+		d.Set("account_replication_type_migration_in_progress", true)
+		d.Set("account_replication_type_migrating_to", replicationType)
 	}
 
 	return resourceStorageAccountRead(d, meta)
@@ -1920,11 +1949,7 @@ func resourceStorageAccountFlatten(ctx context.Context, d *pluginsdk.ResourceDat
 		}
 		d.Set("secondary_location", pointer.From(props.SecondaryLocation))
 		d.Set("sftp_enabled", pointer.From(props.IsSftpEnabled))
-
-		// NOTE: The Storage API returns `null` rather than the default value in the API response for existing
-		// resources when a new field gets added - meaning we need to default the values below.
 		d.Set("allow_nested_items_to_be_public", pointer.From(props.AllowBlobPublicAccess))
-
 		d.Set("default_to_oauth_authentication", pointer.From(props.DefaultToOAuthAuthentication))
 
 		dnsEndpointType := storageaccounts.DnsEndpointTypeStandard
@@ -2065,6 +2090,24 @@ func resourceStorageAccountFlatten(ctx context.Context, d *pluginsdk.ResourceDat
 	if err := d.Set("share_properties", shareProperties); err != nil {
 		return fmt.Errorf("setting `share_properties` for %s: %+v", id, err)
 	}
+
+	resp, err := storageClient.StorageAccountMigrations.StorageAccountsGetCustomerInitiatedMigration(ctx, id)
+	if err != nil {
+		return fmt.Errorf("retrieving migration status for %s: %+v", id, err)
+	}
+
+	migrationInProgress, migratingTo := false, ""
+	if resp.Model != nil {
+		props := resp.Model.Properties
+		migrationInProgress = pointer.From(props.MigrationStatus) == storageaccountmigrations.MigrationStatusInProgress || pointer.From(props.MigrationStatus) == storageaccountmigrations.MigrationStatusSubmittedForConversion
+		if migrationInProgress {
+			if splitSKU := strings.Split(string(props.TargetSkuName), "_"); len(splitSKU) == 2 {
+				migratingTo = splitSKU[1]
+			}
+		}
+	}
+	d.Set("account_replication_type_migration_in_progress", migrationInProgress)
+	d.Set("account_replication_type_migrating_to", migratingTo)
 
 	return nil
 }
@@ -2226,7 +2269,7 @@ func expandAccountCustomerManagedKey(ctx context.Context, keyVaultClient *keyVau
 		}
 	}
 
-	encryption := &storageaccounts.Encryption{
+	return &storageaccounts.Encryption{
 		Services: &storageaccounts.EncryptionServices{
 			Blob: &storageaccounts.EncryptionService{
 				Enabled: pointer.To(true),
@@ -2252,9 +2295,7 @@ func expandAccountCustomerManagedKey(ctx context.Context, keyVaultClient *keyVau
 			Keyversion:  pointer.To(keyID.Version),
 			Keyvaulturi: pointer.To(keyID.KeyVaultBaseURL),
 		},
-	}
-
-	return encryption, nil
+	}, nil
 }
 
 func flattenAccountCustomerManagedKey(input *storageaccounts.Encryption) ([]any, error) {

--- a/internal/services/storage/storage_account_resource_test.go
+++ b/internal/services/storage/storage_account_resource_test.go
@@ -737,6 +737,62 @@ func TestAccStorageAccount_replicationTypeGZRS(t *testing.T) {
 	})
 }
 
+func TestAccStorageAccount_zonalMigration(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_account", "test")
+	r := StorageAccountResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.zonalMigration(data, "LRS", false),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("account_replication_type").HasValue("LRS"),
+				check.That(data.ResourceName).Key("account_replication_type_migration_in_progress").HasValue("false"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.zonalMigration(data, "ZRS", false),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("account_replication_type_migration_in_progress").HasValue("true"),
+			),
+		},
+		{
+			Config: r.zonalMigration(data, "ZRS", true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("account_replication_type_migration_in_progress").HasValue("true"),
+			),
+		},
+	})
+}
+
+func TestAccStorageAccount_zonalMigrationInProgressBlocksReplicationTypeChange(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_account", "test")
+	r := StorageAccountResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.zonalMigration(data, "LRS", false),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		{
+			Config: r.zonalMigration(data, "ZRS", false),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("account_replication_type_migration_in_progress").HasValue("true"),
+			),
+		},
+		{
+			Config:      r.zonalMigration(data, "GRS", false),
+			ExpectError: regexp.MustCompile("a migration from `LRS` to `ZRS` is in progress"),
+		},
+	})
+}
+
 func TestAccStorageAccount_largeFileShare(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_account", "test")
 	r := StorageAccountResource{}
@@ -2989,6 +3045,39 @@ resource "azurerm_storage_account" "test" {
   account_replication_type = "RAGZRS"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}
+
+func (r StorageAccountResource) zonalMigration(data acceptance.TestData, replicationType string, includeTags bool) string {
+	tags := ""
+	if includeTags {
+		tags = `
+tags = {
+  hello = "world"
+}
+`
+	}
+
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-storage-%d"
+  location = "%s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                = "unlikely23exst2acct%s"
+  resource_group_name = azurerm_resource_group.test.name
+
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "%s"
+
+  %s
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, replicationType, tags)
 }
 
 func (r StorageAccountResource) largeFileShareDisabled(data acceptance.TestData) string {

--- a/internal/services/storage/storage_account_resource_test.go
+++ b/internal/services/storage/storage_account_resource_test.go
@@ -755,37 +755,22 @@ func TestAccStorageAccount_zonalMigration(t *testing.T) {
 			Config: r.zonalMigration(data, "ZRS", false),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("account_replication_type").HasValue("LRS"),
 				check.That(data.ResourceName).Key("account_replication_type_migration_in_progress").HasValue("true"),
+				check.That(data.ResourceName).Key("account_replication_type_migrating_to").HasValue("ZRS"),
 			),
 		},
+		data.ImportStep(),
 		{
 			Config: r.zonalMigration(data, "ZRS", true),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("account_replication_type").HasValue("LRS"),
 				check.That(data.ResourceName).Key("account_replication_type_migration_in_progress").HasValue("true"),
+				check.That(data.ResourceName).Key("account_replication_type_migrating_to").HasValue("ZRS"),
 			),
 		},
-	})
-}
-
-func TestAccStorageAccount_zonalMigrationInProgressBlocksReplicationTypeChange(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_storage_account", "test")
-	r := StorageAccountResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.zonalMigration(data, "LRS", false),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		{
-			Config: r.zonalMigration(data, "ZRS", false),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("account_replication_type_migration_in_progress").HasValue("true"),
-			),
-		},
+		data.ImportStep(),
 		{
 			Config:      r.zonalMigration(data, "GRS", false),
 			ExpectError: regexp.MustCompile("a migration from `LRS` to `ZRS` is in progress"),

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -415,7 +415,7 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `id` - The ID of the Storage Account.
 
-* `account_replication_type_migration_in_progress` - Whether a replication tier migration is in progress.
+* `account_replication_type_migration_in_progress` - Whether a replication type migration is in progress.
 
 * `account_replication_type_migrating_to` - The `account_replication_type` that the Storage Account is migrating to.
 

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -100,7 +100,7 @@ The following arguments are supported:
 
 * `account_replication_type` - (Required) Defines the type of replication to use for this storage account. Possible values are `LRS`, `GRS`, `RAGRS`, `ZRS`, `GZRS`, and `RAGZRS`.
 
-~> **Note:**: Changing `account_replication_type` between non-zonal (`LRS`, `GRS`, `RAGRS`) and zonal (`ZRS`, `GZRS`, `RAGZRS`) types forces a new resource to be created, except for the equivalent tier pairs (`LRS` <-> `ZRS`, `GRS` <-> `GZRS`, and `RAGRS` <-> `RAGZRS`). For those pairs, the provider triggers a customer-initiated migration instead. This migration can take days to complete and the provider does not wait for it to finish. While a migration is in progress, plan time diffs on `account_replication_type` that match the type of the migration request will be suppressed.
+~> **Note:** Changing `account_replication_type` between non-zonal (`LRS`, `GRS`, `RAGRS`) and zonal (`ZRS`, `GZRS`, `RAGZRS`) types forces a new resource to be created, except for the equivalent tier pairs (`LRS` <-> `ZRS`, `GRS` <-> `GZRS`, and `RAGRS` <-> `RAGZRS`). For those pairs, the provider triggers a customer-initiated migration instead. This migration can take days to complete and the provider does not wait for it to finish. While a migration is in progress, plan time diffs on `account_replication_type` that match the type of the migration request will be suppressed.
 
 -> **Note:** For more information on `account_replication_type` migrations, including certain timing limitations, see [Change how a storage account is replicated](https://learn.microsoft.com/azure/storage/common/redundancy-migration?tabs=portal)
 

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -102,7 +102,7 @@ The following arguments are supported:
 
 ~> **Note:**: Changing `account_replication_type` between non-zonal (`LRS`, `GRS`, `RAGRS`) and zonal (`ZRS`, `GZRS`, `RAGZRS`) types forces a new resource to be created, except for the equivalent tier pairs (`LRS` <-> `ZRS`, `GRS` <-> `GZRS`, and `RAGRS` <-> `RAGZRS`). For those pairs, the provider triggers a customer-initiated migration instead. This migration can take days to complete and the provider does not wait for it to finish. While a migration is in progress, plan time diffs on `account_replication_type` that match the type of the migration request will be suppressed.
 
--> **Note:** For more information on `account_replication_type` migrations, including certain timing limitations, see [Change how a storage account is replicated](https://learn.microsoft.com/azure/storage/common/redundancy-migration?tabs=portal) 
+-> **Note:** For more information on `account_replication_type` migrations, including certain timing limitations, see [Change how a storage account is replicated](https://learn.microsoft.com/azure/storage/common/redundancy-migration?tabs=portal)
 
 * `provisioned_billing_model_version` - (Optional) Specifies the version of the **provisioned** billing model (e.g. when `account_kind = "FileStorage"` for Storage File). Possible value is `V2`. Changing this forces a new resource to be created.
 

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -98,7 +98,11 @@ The following arguments are supported:
 
 -> **Note:** Blobs with a tier of `Premium` are of account kind `StorageV2`.
 
-* `account_replication_type` - (Required) Defines the type of replication to use for this storage account. Valid options are `LRS`, `GRS`, `RAGRS`, `ZRS`, `GZRS` and `RAGZRS`. Changing this forces a new resource to be created when types `LRS`, `GRS` and `RAGRS` are changed to `ZRS`, `GZRS` or `RAGZRS` and vice versa.
+* `account_replication_type` - (Required) Defines the type of replication to use for this storage account. Possible values are `LRS`, `GRS`, `RAGRS`, `ZRS`, `GZRS`, and `RAGZRS`.
+
+~> **Note:**: Changing `account_replication_type` between non-zonal (`LRS`, `GRS`, `RAGRS`) and zonal (`ZRS`, `GZRS`, `RAGZRS`) types forces a new resource to be created, except for the equivalent tier pairs (`LRS` <-> `ZRS`, `GRS` <-> `GZRS`, and `RAGRS` <-> `RAGZRS`). For those pairs, the provider triggers a customer-initiated migration instead. This migration can take days to complete and the provider does not wait for it to finish. While a migration is in progress, plan time diffs on `account_replication_type` that match the type of the migration request will be suppressed.
+
+-> **Note:** For more information on `account_replication_type` migrations, including certain timing limitations, see [Change how a storage account is replicated](https://learn.microsoft.com/azure/storage/common/redundancy-migration?tabs=portal) 
 
 * `provisioned_billing_model_version` - (Optional) Specifies the version of the **provisioned** billing model (e.g. when `account_kind = "FileStorage"` for Storage File). Possible value is `V2`. Changing this forces a new resource to be created.
 
@@ -410,6 +414,10 @@ A `smb` block supports the following:
 In addition to the Arguments listed above - the following Attributes are exported:
 
 * `id` - The ID of the Storage Account.
+
+* `account_replication_type_migration_in_progress` - Whether a replication tier migration is in progress.
+
+* `account_replication_type_migrating_to` - The `account_replication_type` that the Storage Account is migrating to.
 
 * `primary_location` - The primary location of the storage account.
 


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Adds support for migrating `account_replication_type` between zonal & non-zonal types using the Customer Initiated Migration API

While this does deviate from the usual practice of a Terraform operation not returning until it's entirely finished, this case is added as an exception to avoid dataloss due to storage account recreations. Implementation of this functionality was prompted by a request from the Azure Storage service team as storage accounts are being converted to zonal types outside of Terraform, and there have been instances of unintentional data deletion because of it.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #32049


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
