### PR TITLE
fix: Support for Allow patch configuration when using os_managed_disk_id with...

### DIFF
--- a/internal/services/compute/windows_virtual_machine_resource.go
+++ b/internal/services/compute/windows_virtual_machine_resource.go
@@ -301,9 +301,6 @@ func resourceWindowsVirtualMachine() *pluginsdk.Resource {
 				Optional:     true,
 				Computed:     true,
 				ValidateFunc: validation.StringInSlice(virtualmachines.PossibleValuesForWindowsVMGuestPatchMode(), false),
-				ConflictsWith: []string{
-					"os_managed_disk_id",
-				},
 			},
 
 			"patch_assessment_mode": {
@@ -311,9 +308,6 @@ func resourceWindowsVirtualMachine() *pluginsdk.Resource {
 				Optional:     true,
 				Computed:     true,
 				ValidateFunc: validation.StringInSlice(virtualmachines.PossibleValuesForWindowsPatchAssessmentMode(), false),
-				ConflictsWith: []string{
-					"os_managed_disk_id",
-				},
 			},
 
 			"hotpatching_enabled": {
@@ -876,6 +870,35 @@ func resourceWindowsVirtualMachineCreate(d *pluginsdk.ResourceData, meta interfa
 	}
 
 	d.SetId(id.ID())
+
+	if osDiskIsImported {
+		patchSettings := virtualmachines.PatchSettings{}
+		shouldUpdatePatchSettings := false
+		if !d.GetRawConfig().AsValueMap()["patch_mode"].IsNull() {
+			patchSettings.PatchMode = pointer.ToEnum[virtualmachines.WindowsVMGuestPatchMode](patchMode)
+			shouldUpdatePatchSettings = true
+		}
+		if !d.GetRawConfig().AsValueMap()["patch_assessment_mode"].IsNull() {
+			patchSettings.AssessmentMode = pointer.ToEnum[virtualmachines.WindowsPatchAssessmentMode](assessmentMode)
+			shouldUpdatePatchSettings = true
+		}
+
+		if shouldUpdatePatchSettings {
+			update := virtualmachines.VirtualMachineUpdate{
+				Properties: &virtualmachines.VirtualMachineProperties{
+					OsProfile: &virtualmachines.OSProfile{
+						WindowsConfiguration: &virtualmachines.WindowsConfiguration{
+							PatchSettings: &patchSettings,
+						},
+					},
+				},
+			}
+			if err := client.UpdateThenPoll(ctx, id, update, virtualmachines.DefaultUpdateOperationOptions()); err != nil {
+				return fmt.Errorf("updating patch settings for Windows %s: %+v", id, err)
+			}
+		}
+	}
+
 	return resourceWindowsVirtualMachineRead(d, meta)
 }
 

--- a/internal/services/compute/windows_virtual_machine_resource_disk_os_test.go
+++ b/internal/services/compute/windows_virtual_machine_resource_disk_os_test.go
@@ -405,15 +405,28 @@ func TestAccWindowsVirtualMachine_diskOSImportManagedDisk(t *testing.T) {
 			Config: r.diskOSImportManagedDisk(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("patch_mode").HasValue("AutomaticByPlatform"),
+				check.That(data.ResourceName).Key("patch_assessment_mode").HasValue("AutomaticByPlatform"),
 			),
 		},
 		data.ImportStep("bypass_platform_safety_checks_on_user_schedule_enabled"),
 		{
-			// This step does nothing except flip the delete OS disk with VM to true to avoid the RG preventing being deleted
+			Config:             r.diskOSImportManagedDisk(data),
+			PlanOnly:           true,
+			ExpectNonEmptyPlan: false,
+		},
+		{
 			Config: r.diskOSImportManagedDiskUpdate(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("patch_mode").HasValue("AutomaticByOS"),
+				check.That(data.ResourceName).Key("patch_assessment_mode").HasValue("ImageDefault"),
 			),
+		},
+		{
+			Config:             r.diskOSImportManagedDiskUpdate(data),
+			PlanOnly:           true,
+			ExpectNonEmptyPlan: false,
 		},
 		data.ImportStep(),
 	})
@@ -548,6 +561,9 @@ resource "azurerm_windows_virtual_machine" "test" {
 
   os_managed_disk_id = data.azurerm_managed_disks.test.disk.0.id
 
+  patch_mode            = "AutomaticByPlatform"
+  patch_assessment_mode = "AutomaticByPlatform"
+
   os_disk {
     caching = "ReadWrite"
   }
@@ -616,6 +632,9 @@ resource "azurerm_windows_virtual_machine" "test" {
   ]
 
   os_managed_disk_id = data.azurerm_managed_disks.test.disk.0.id
+
+  patch_mode            = "AutomaticByOS"
+  patch_assessment_mode = "ImageDefault"
 
   os_disk {
     caching = "ReadOnly"

--- a/website/docs/r/windows_virtual_machine.html.markdown
+++ b/website/docs/r/windows_virtual_machine.html.markdown
@@ -213,7 +213,7 @@ The following arguments are supported:
 
 * `os_managed_disk_id` - (Optional) The ID of an existing Managed Disk to use as the OS Disk for this Windows Virtual Machine. Changing this forces a new resource to be created.
 
-~> **Note:** When specifying an existing Managed Disk it is not currently possible to subsequently manage the Operating System Profile properties: `admin_username`, `admin_password`, `bypass_platform_safety_checks_on_user_schedule_enabled`, `computer_name`, `custom_data`, `provision_vm_agent`, `patch_mode`, `patch_assessment_mode`, or `reboot_setting`.
+~> **Note:** When specifying an existing Managed Disk it is not currently possible to subsequently manage the Operating System Profile properties: `admin_username`, `admin_password`, `bypass_platform_safety_checks_on_user_schedule_enabled`, `computer_name`, `custom_data`, `provision_vm_agent`, or `reboot_setting`.
 
 * `termination_notification` - (Optional) A `termination_notification` block as defined below.
 


### PR DESCRIPTION
Fixes #33187.

## Summary

Support for Allow patch configuration when using os_managed_disk_id with azurerm_windows_virtual_machine

## Validation

- Mechanical gate: +50/-8, tests passed
- Adversarial review: approved

---
🤖 AI-authored PR, operated by @yhay81. <!-- tsumugi-ai-disclosure -->