### PR TITLE
add preflight to azurerm_monitor_data_collection_endpoint

### DIFF
--- a/internal/services/monitor/monitor_data_collection_endpoint_resource.go
+++ b/internal/services/monitor/monitor_data_collection_endpoint_resource.go
@@ -14,14 +14,16 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/insights/2023-03-11/datacollectionendpoints"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/preflight"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 )
 
 var (
-	_ sdk.Resource           = DataCollectionEndpointResource{}
-	_ sdk.ResourceWithUpdate = DataCollectionEndpointResource{}
+	_ sdk.Resource                  = DataCollectionEndpointResource{}
+	_ sdk.ResourceWithUpdate        = DataCollectionEndpointResource{}
+	_ sdk.ResourceWithCustomizeDiff = DataCollectionEndpointResource{}
 )
 
 type DataCollectionEndpointResource struct{}
@@ -112,6 +114,58 @@ func (r DataCollectionEndpointResource) ModelObject() interface{} {
 	return &DataCollectionEndpoint{}
 }
 
+func expandCreateForDataCollectionEndpoint(state DataCollectionEndpoint) datacollectionendpoints.DataCollectionEndpointResource {
+	return datacollectionendpoints.DataCollectionEndpointResource{
+		Kind:     expandDataCollectionEndpointKind(state.Kind),
+		Location: location.Normalize(state.Location),
+		Name:     pointer.To(state.Name),
+		Properties: &datacollectionendpoints.DataCollectionEndpoint{
+			Description: pointer.To(state.Description),
+			NetworkAcls: &datacollectionendpoints.NetworkRuleSet{
+				PublicNetworkAccess: expandDataCollectionEndpointPublicNetworkAccess(state.PublicNetworkAccessEnabled),
+			},
+		},
+		Tags: tags.Expand(state.Tags),
+	}
+}
+
+func (r DataCollectionEndpointResource) CustomizeDiff() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			if metadata.ResourceDiff == nil {
+				return nil
+			}
+
+			if metadata.Client.Features.EnhancedValidation.PreflightEnabled {
+				// Only perform preflight validation if there are changes. This avoids validation failures and
+				// additional API calls for resources that are unchanged between plan invocations.
+				if len(metadata.ResourceDiff.GetChangedKeysPrefix("")) > 0 || metadata.ResourceDiff.Id() == "" {
+					var model DataCollectionEndpoint
+					if err := metadata.DecodeDiff(&model); err != nil {
+						return err
+					}
+
+					req := expandCreateForDataCollectionEndpoint(model)
+
+					id := datacollectionendpoints.NewDataCollectionEndpointID(metadata.Client.Account.SubscriptionId, model.ResourceGroupName, model.Name)
+
+					preflightValidate, err := preflight.NewValidationRequest(pointer.To(model.Location), pointer.To(id), "2023-03-11", req)
+					if err != nil {
+						return fmt.Errorf("constructing preflight validation request: %w", err)
+					}
+
+					if err = preflightValidate.ValidateResource(ctx, metadata); err != nil {
+						return err
+					}
+				}
+			}
+
+			return nil
+		},
+	}
+}
+
 func (r DataCollectionEndpointResource) Create() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
@@ -135,18 +189,7 @@ func (r DataCollectionEndpointResource) Create() sdk.ResourceFunc {
 				}
 			}
 
-			input := datacollectionendpoints.DataCollectionEndpointResource{
-				Kind:     expandDataCollectionEndpointKind(state.Kind),
-				Location: location.Normalize(state.Location),
-				Name:     pointer.To(state.Name),
-				Properties: &datacollectionendpoints.DataCollectionEndpoint{
-					Description: pointer.To(state.Description),
-					NetworkAcls: &datacollectionendpoints.NetworkRuleSet{
-						PublicNetworkAccess: expandDataCollectionEndpointPublicNetworkAccess(state.PublicNetworkAccessEnabled),
-					},
-				},
-				Tags: tags.Expand(state.Tags),
-			}
+			input := expandCreateForDataCollectionEndpoint(state)
 
 			if _, err := client.Create(ctx, id, input); err != nil {
 				return fmt.Errorf("creating %s: %+v", id, err)

--- a/internal/services/monitor/monitor_data_collection_endpoint_resource_test.go
+++ b/internal/services/monitor/monitor_data_collection_endpoint_resource_test.go
@@ -109,6 +109,19 @@ func TestAccMonitorDataCollectionEndpoint_complete(t *testing.T) {
 	})
 }
 
+func TestAccMonitorDataCollectionEndpoint_completePreflightPlan(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_monitor_data_collection_endpoint", "test")
+	r := MonitorDataCollectionEndpointResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config:             r.completePreflightPlan(data),
+			PlanOnly:           true,
+			ExpectNonEmptyPlan: true,
+		},
+	})
+}
+
 func (r MonitorDataCollectionEndpointResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %[1]s
@@ -146,6 +159,35 @@ resource "azurerm_monitor_data_collection_endpoint" "import" {
   location            = azurerm_monitor_data_collection_endpoint.test.location
 }
 `, r.basic(data))
+}
+
+func (r MonitorDataCollectionEndpointResource) completePreflightPlan(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    enhanced_validation {
+      preflight_enabled = true
+    }
+  }
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-DataCollectionEndpoint-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_monitor_data_collection_endpoint" "test" {
+  name                          = "acctestmdce-%[1]d"
+  resource_group_name           = azurerm_resource_group.test.name
+  location                      = azurerm_resource_group.test.location
+  kind                          = "Windows"
+  public_network_access_enabled = false
+  description                   = "acc test monitor_data_collection_endpoint preflight"
+  tags = {
+    ENV = "test"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func (r MonitorDataCollectionEndpointResource) template(data acceptance.TestData) string {

--- a/website/docs/guides/preflight_validation.html.markdown
+++ b/website/docs/guides/preflight_validation.html.markdown
@@ -29,8 +29,9 @@ Preflight Validation can also be enabled by setting the `ARM_PROVIDER_ENHANCED_V
 
 The following resources currently support Preflight Validation:
 
+* `azurerm_dashboard_grafana`
 * `azurerm_eventgrid_namespace`
 * `azurerm_managed_redis`
-* `azurerm_service_plan`
-* `azurerm_dashboard_grafana`
+* `azurerm_monitor_data_collection_endpoint`
 * `azurerm_nginx_deployment`
+* `azurerm_service_plan`


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Pre flight validation for azurerm_monitor_data_collection_endpoint

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
