### PR TITLE
`network_watcher` - add List Resource support

### DIFF
--- a/internal/services/network/network_watcher_resource.go
+++ b/internal/services/network/network_watcher_resource.go
@@ -13,11 +13,16 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/networkwatchers"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
+
+//go:generate go run ../../tools/generator-tests resourceidentity
+
+var azureNetworkWatcherResourceName = "azurerm_network_watcher"
 
 func resourceNetworkWatcher() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
@@ -25,10 +30,11 @@ func resourceNetworkWatcher() *pluginsdk.Resource {
 		Read:   resourceNetworkWatcherRead,
 		Update: resourceNetworkWatcherUpdate,
 		Delete: resourceNetworkWatcherDelete,
-		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
-			_, err := networkwatchers.ParseNetworkWatcherID(id)
-			return err
-		}),
+		Identity: &schema.ResourceIdentity{
+			SchemaFunc: pluginsdk.GenerateIdentitySchema(&networkwatchers.NetworkWatcherId{}),
+		},
+
+		Importer: pluginsdk.ImporterValidatingIdentity(&networkwatchers.NetworkWatcherId{}),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
@@ -84,6 +90,9 @@ func resourceNetworkWatcherCreate(d *pluginsdk.ResourceData, meta interface{}) e
 	}
 
 	d.SetId(id.ID())
+	if err := pluginsdk.SetResourceIdentityData(d, &id); err != nil {
+		return err
+	}
 
 	return resourceNetworkWatcherRead(d, meta)
 }
@@ -140,10 +149,14 @@ func resourceNetworkWatcherRead(d *pluginsdk.ResourceData, meta interface{}) err
 		return fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
+	return resourceNetworkWatcherFlatten(d, id, resp.Model)
+}
+
+func resourceNetworkWatcherFlatten(d *pluginsdk.ResourceData, id *networkwatchers.NetworkWatcherId, model *networkwatchers.NetworkWatcher) error {
 	d.Set("name", id.NetworkWatcherName)
 	d.Set("resource_group_name", id.ResourceGroupName)
 
-	if model := resp.Model; model != nil {
+	if model != nil {
 		d.Set("location", location.NormalizeNilable(model.Location))
 
 		if err := tags.FlattenAndSet(d, model.Tags); err != nil {
@@ -151,7 +164,7 @@ func resourceNetworkWatcherRead(d *pluginsdk.ResourceData, meta interface{}) err
 		}
 	}
 
-	return nil
+	return pluginsdk.SetResourceIdentityData(d, id)
 }
 
 func resourceNetworkWatcherDelete(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/network/network_watcher_resource.go
+++ b/internal/services/network/network_watcher_resource.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
 
-//go:generate go run ../../tools/generator-tests resourceidentity
+//go:generate go run ../../tools/generator-tests resourceidentity -test-name basicConfig
 
 var azureNetworkWatcherResourceName = "azurerm_network_watcher"
 

--- a/internal/services/network/network_watcher_resource.go
+++ b/internal/services/network/network_watcher_resource.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
 
-//go:generate go run ../../tools/generator-tests resourceidentity -test-name basicConfig
+//go:generate go run ../../tools/generator-tests resourceidentity -test-name basicConfig -test-sequential true
 
 var azureNetworkWatcherResourceName = "azurerm_network_watcher"
 

--- a/internal/services/network/network_watcher_resource_identity_gen_test.go
+++ b/internal/services/network/network_watcher_resource_identity_gen_test.go
@@ -1,0 +1,39 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package network_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
+)
+
+func TestAccNetworkWatcher_resourceIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_network_watcher", "test")
+	r := NetworkWatcherResource{}
+
+	checkedFields := map[string]struct{}{
+		"subscription_id":     {},
+		"name":                {},
+		"resource_group_name": {},
+	}
+
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basicConfig(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				customstatecheck.ExpectAllIdentityFieldsAreChecked("azurerm_network_watcher.test", checkedFields),
+				statecheck.ExpectIdentityValue("azurerm_network_watcher.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_network_watcher.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_network_watcher.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
+			},
+		},
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
+}

--- a/internal/services/network/network_watcher_resource_identity_gen_test.go
+++ b/internal/services/network/network_watcher_resource_identity_gen_test.go
@@ -13,7 +13,7 @@ import (
 	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
 )
 
-func TestAccNetworkWatcher_resourceIdentity(t *testing.T) {
+func testAccNetworkWatcher_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_network_watcher", "test")
 	r := NetworkWatcherResource{}
 
@@ -35,5 +35,5 @@ func TestAccNetworkWatcher_resourceIdentity(t *testing.T) {
 		},
 		data.ImportBlockWithResourceIdentityStep(false),
 		data.ImportBlockWithIDStep(false),
-	}, false)
+	}, true)
 }

--- a/internal/services/network/network_watcher_resource_list.go
+++ b/internal/services/network/network_watcher_resource_list.go
@@ -1,0 +1,94 @@
+package network
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/networkwatchers"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type NetworkWatcherListResource struct{}
+
+var _ sdk.FrameworkListWrappedResource = new(NetworkWatcherListResource)
+
+func (NetworkWatcherListResource) Metadata(_ context.Context, _ resource.MetadataRequest, response *resource.MetadataResponse) {
+	response.TypeName = azureNetworkWatcherResourceName
+}
+
+func (NetworkWatcherListResource) ResourceFunc() *pluginsdk.Resource {
+	return resourceNetworkWatcher()
+}
+
+func (NetworkWatcherListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream, metadata sdk.ResourceMetadata) {
+	client := metadata.Client.Network.NetworkWatchers
+
+	var data sdk.DefaultListModel
+	diags := request.Config.Get(ctx, &data)
+	if diags.HasError() {
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+
+	var results []networkwatchers.NetworkWatcher
+	subscriptionID := metadata.SubscriptionId
+	if !data.SubscriptionId.IsNull() {
+		subscriptionID = data.SubscriptionId.ValueString()
+	}
+
+	switch {
+	case !data.ResourceGroupName.IsNull():
+		resp, err := client.List(ctx, commonids.NewResourceGroupID(subscriptionID, data.ResourceGroupName.ValueString()))
+		if err != nil {
+			sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("listing `%s`", azureNetworkWatcherResourceName), err)
+			return
+		}
+		if resp.Model != nil && resp.Model.Value != nil {
+			results = *resp.Model.Value
+		}
+	default:
+		resp, err := client.ListAll(ctx, commonids.NewSubscriptionID(subscriptionID))
+		if err != nil {
+			sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("listing `%s`", azureNetworkWatcherResourceName), err)
+			return
+		}
+		if resp.Model != nil && resp.Model.Value != nil {
+			results = *resp.Model.Value
+		}
+	}
+
+	stream.Results = func(push func(list.ListResult) bool) {
+		for _, item := range results {
+			result := request.NewListResult(ctx)
+			result.DisplayName = pointer.From(item.Name)
+
+			rd := resourceNetworkWatcher().Data(&terraform.InstanceState{})
+			id, err := networkwatchers.ParseNetworkWatcherIDInsensitively(pointer.From(item.Id))
+			if err != nil {
+				sdk.SetErrorDiagnosticAndPushListResult(result, push, fmt.Sprintf("parsing %s ID", azureNetworkWatcherResourceName), err)
+				return
+			}
+			rd.SetId(id.ID())
+
+			if err := resourceNetworkWatcherFlatten(rd, id, &item); err != nil {
+				sdk.SetErrorDiagnosticAndPushListResult(result, push, fmt.Sprintf("encoding `%s` resource data", azureNetworkWatcherResourceName), err)
+				return
+			}
+
+			sdk.EncodeListResult(ctx, rd, &result)
+			if result.Diagnostics.HasError() {
+				push(result)
+				return
+			}
+			if !push(result) {
+				return
+			}
+		}
+	}
+}

--- a/internal/services/network/network_watcher_resource_list_test.go
+++ b/internal/services/network/network_watcher_resource_list_test.go
@@ -1,0 +1,95 @@
+package network_test
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
+)
+
+func TestAccNetworkWatcher_listBySubscriptionAndRG(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_network_watcher", "testlist1")
+	r := NetworkWatcherResource{}
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []resource.TestStep{
+			{
+				Config: r.basicList(data),
+			},
+			{
+				Query:  true,
+				Config: r.basicQuery(),
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectLengthAtLeast("azurerm_network_watcher.list", 3),
+					querycheck.ExpectIdentity(
+						"azurerm_network_watcher.list",
+						map[string]knownvalue.Check{
+						"name":                knownvalue.StringRegexp(regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
+						"resource_group_name": knownvalue.StringRegexp(regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
+						"subscription_id":     knownvalue.StringExact(data.Subscriptions.Primary),
+						},
+					),
+				},
+			},
+			{
+				Query:  true,
+				Config: r.basicQueryByResourceGroupName(),
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectLength("azurerm_network_watcher.list", 3),
+				},
+			},
+		},
+	})
+}
+
+func (NetworkWatcherResource) basicList(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-watcher-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_network_watcher" "test" {
+  count               = 3
+  name                = "acctestNW${count.index}-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (NetworkWatcherResource) basicQuery() string {
+	return `
+list "azurerm_network_watcher" "list" {
+  provider = azurerm
+  config {}
+}
+`
+}
+
+func (NetworkWatcherResource) basicQueryByResourceGroupName() string {
+	return `
+list "azurerm_network_watcher" "list" {
+  provider = azurerm
+  config {
+    resource_group_name = azurerm_resource_group.test.name
+  }
+}
+`
+}

--- a/internal/services/network/network_watcher_resource_list_test.go
+++ b/internal/services/network/network_watcher_resource_list_test.go
@@ -36,9 +36,9 @@ func TestAccNetworkWatcher_listBySubscriptionAndRG(t *testing.T) {
 					querycheck.ExpectIdentity(
 						"azurerm_network_watcher.list",
 						map[string]knownvalue.Check{
-						"name":                knownvalue.StringRegexp(regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
-						"resource_group_name": knownvalue.StringRegexp(regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
-						"subscription_id":     knownvalue.StringExact(data.Subscriptions.Primary),
+							"name":                knownvalue.StringRegexp(regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
+							"resource_group_name": knownvalue.StringRegexp(regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
+							"subscription_id":     knownvalue.StringExact(data.Subscriptions.Primary),
 						},
 					),
 				},

--- a/internal/services/network/network_watcher_resource_list_test.go
+++ b/internal/services/network/network_watcher_resource_list_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
-func TestAccNetworkWatcher_listBySubscriptionAndRG(t *testing.T) {
+func testAccNetworkWatcher_listBySubscriptionAndRG(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_network_watcher", "testlist1")
 	r := NetworkWatcherResource{}
 

--- a/internal/services/network/network_watcher_resource_test.go
+++ b/internal/services/network/network_watcher_resource_test.go
@@ -34,6 +34,8 @@ func TestAccNetworkWatcher_sequential(t *testing.T) {
 			"complete":       testAccNetworkWatcher_complete,
 			"update":         testAccNetworkWatcher_update,
 			"disappears":     testAccNetworkWatcher_disappears,
+			"list":           testAccNetworkWatcher_listBySubscriptionAndRG,
+			"identity":       testAccNetworkWatcher_resourceIdentity,
 		},
 		"DataSource": {
 			"basic": testAccDataSourceNetworkWatcher_basic,

--- a/internal/services/network/registration.go
+++ b/internal/services/network/registration.go
@@ -207,6 +207,7 @@ func (r Registration) ListResources() []sdk.FrameworkListWrappedResource {
 		NetworkProfileListResource{},
 		NetworkSecurityGroupListResource{},
 		NetworkSecurityRuleListResource{},
+		NetworkWatcherListResource{},
 		PrivateEndpointListResource{},
 		PublicIpListResource{},
 		RouteListResource{},

--- a/website/docs/list-resources/network_watcher.html.markdown
+++ b/website/docs/list-resources/network_watcher.html.markdown
@@ -1,0 +1,41 @@
+---
+subcategory: "Network"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_network_watcher"
+description: |-
+    Lists Network Watcher resources.
+---
+
+# List resource: azurerm_network_watcher
+
+Lists Network Watcher resources.
+
+## Example Usage
+
+### List all Network Watchers in the subscription
+
+```hcl
+list "azurerm_network_watcher" "example" {
+  provider = azurerm
+  config {}
+}
+```
+
+### List all Network Watchers in a specific resource group
+
+```hcl
+list "azurerm_network_watcher" "example" {
+  provider = azurerm
+  config {
+    resource_group_name = "example-rg"
+  }
+}
+```
+
+## Argument Reference
+
+This list resource supports the following arguments:
+
+* `resource_group_name` - (Optional) The name of the resource group to query.
+
+* `subscription_id` - (Optional) The Subscription ID to query. Defaults to the value specified in the Provider Configuration.


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
