### PR TITLE
`dns_a_record` - add List Resource support

### DIFF
--- a/internal/services/dns/dns_a_record_data_source_test.go
+++ b/internal/services/dns/dns_a_record_data_source_test.go
@@ -43,5 +43,5 @@ data "azurerm_dns_a_record" "test" {
   resource_group_name = azurerm_resource_group.test.name
   zone_name           = azurerm_dns_zone.test.name
 }
-`, TestAccDnsARecordResource{}.basic(data))
+`, DnsARecordResource{}.basic(data))
 }

--- a/internal/services/dns/dns_a_record_resource.go
+++ b/internal/services/dns/dns_a_record_resource.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/dns/2018-05-01/recordsets"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -20,6 +21,10 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
+
+//go:generate go run ../../tools/generator-tests resourceidentity -parent-id dns_zone_id
+
+const azurermDnsARecordResourceName = "azurerm_dns_a_record"
 
 func resourceDnsARecord() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
@@ -34,16 +39,11 @@ func resourceDnsARecord() *pluginsdk.Resource {
 			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
-		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
-			parsed, err := recordsets.ParseRecordTypeID(id)
-			if err != nil {
-				return err
-			}
-			if parsed.RecordType != recordsets.RecordTypeA {
-				return fmt.Errorf("this resource only supports 'A' records")
-			}
-			return nil
-		}),
+		Identity: &schema.ResourceIdentity{
+			SchemaFunc: pluginsdk.GenerateIdentitySchema(&recordsets.RecordTypeId{}),
+		},
+
+		Importer: pluginsdk.ImporterValidatingIdentity(&recordsets.RecordTypeId{}),
 
 		SchemaVersion: 1,
 		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
@@ -152,6 +152,9 @@ func resourceDnsARecordCreateUpdate(d *pluginsdk.ResourceData, meta interface{})
 	}
 
 	d.SetId(id.ID())
+	if err := pluginsdk.SetResourceIdentityData(d, &id); err != nil {
+		return err
+	}
 
 	return resourceDnsARecordRead(d, meta)
 }
@@ -175,11 +178,15 @@ func resourceDnsARecordRead(d *pluginsdk.ResourceData, meta interface{}) error {
 		return fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
+	return resourceDnsARecordFlatten(d, id, resp.Model)
+}
+
+func resourceDnsARecordFlatten(d *pluginsdk.ResourceData, id *recordsets.RecordTypeId, model *recordsets.RecordSet) error {
 	d.Set("name", id.RelativeRecordSetName)
 	d.Set("resource_group_name", id.ResourceGroupName)
 	d.Set("zone_name", id.DnsZoneName)
 
-	if model := resp.Model; model != nil {
+	if model != nil {
 		if props := model.Properties; props != nil {
 			d.Set("fqdn", props.Fqdn)
 			d.Set("ttl", props.TTL)
@@ -200,7 +207,7 @@ func resourceDnsARecordRead(d *pluginsdk.ResourceData, meta interface{}) error {
 		}
 	}
 
-	return nil
+	return pluginsdk.SetResourceIdentityData(d, id)
 }
 
 func resourceDnsARecordDelete(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/dns/dns_a_record_resource.go
+++ b/internal/services/dns/dns_a_record_resource.go
@@ -4,6 +4,7 @@
 package dns
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -22,7 +23,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
 
-//go:generate go run ../../tools/generator-tests resourceidentity -parent-id dns_zone_id
+//go:generate go run ../../tools/generator-tests resourceidentity -properties "dns_zone_name:zone_name,resource_group_name,name" -known-values "record_type:A"
 
 const azurermDnsARecordResourceName = "azurerm_dns_a_record"
 
@@ -43,7 +44,7 @@ func resourceDnsARecord() *pluginsdk.Resource {
 			SchemaFunc: pluginsdk.GenerateIdentitySchema(&recordsets.RecordTypeId{}),
 		},
 
-		Importer: pluginsdk.ImporterValidatingIdentity(&recordsets.RecordTypeId{}),
+		Importer: pluginsdk.ImporterValidatingIdentityThen(&recordsets.RecordTypeId{}, resourceDnsARecordImporter),
 
 		SchemaVersion: 1,
 		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
@@ -95,6 +96,17 @@ func resourceDnsARecord() *pluginsdk.Resource {
 			"tags": commonschema.Tags(),
 		},
 	}
+}
+
+func resourceDnsARecordImporter(_ context.Context, d *pluginsdk.ResourceData, _ interface{}) ([]*pluginsdk.ResourceData, error) {
+	resourceId, err := recordsets.ParseRecordTypeID(d.Id())
+	if err != nil {
+		return []*pluginsdk.ResourceData{d}, err
+	}
+	if resourceId.RecordType != recordsets.RecordTypeA {
+		return []*pluginsdk.ResourceData{d}, fmt.Errorf("importing %s wrong type received: expected %s received %s", resourceId, recordsets.RecordTypeA, resourceId.RecordType)
+	}
+	return []*pluginsdk.ResourceData{d}, nil
 }
 
 func resourceDnsARecordCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/dns/dns_a_record_resource_identity_gen_test.go
+++ b/internal/services/dns/dns_a_record_resource_identity_gen_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestAccDnsARecord_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_dns_a_record", "test")
-	r := TestAccDnsARecordResource{}
+	r := DnsARecordResource{}
 
 	checkedFields := map[string]struct{}{
 		"dns_zone_name":       {},
@@ -29,11 +29,11 @@ func TestAccDnsARecord_resourceIdentity(t *testing.T) {
 			Config: r.basic(data),
 			ConfigStateChecks: []statecheck.StateCheck{
 				customstatecheck.ExpectAllIdentityFieldsAreChecked("azurerm_dns_a_record.test", checkedFields),
-				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_dns_a_record.test", tfjsonpath.New("dns_zone_name"), tfjsonpath.New("zone_name")),
-				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_dns_a_record.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_dns_a_record.test", tfjsonpath.New("record_type"), tfjsonpath.New("id")),
-				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_dns_a_record.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_dns_a_record.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_dns_a_record.test", tfjsonpath.New("dns_zone_name"), tfjsonpath.New("dns_zone_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_dns_a_record.test", tfjsonpath.New("name"), tfjsonpath.New("dns_zone_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_dns_a_record.test", tfjsonpath.New("record_type"), tfjsonpath.New("dns_zone_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_dns_a_record.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("dns_zone_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_dns_a_record.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("dns_zone_id")),
 			},
 		},
 		data.ImportBlockWithResourceIdentityStep(false),

--- a/internal/services/dns/dns_a_record_resource_identity_gen_test.go
+++ b/internal/services/dns/dns_a_record_resource_identity_gen_test.go
@@ -6,6 +6,7 @@ package dns_test
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
@@ -17,11 +18,11 @@ func TestAccDnsARecord_resourceIdentity(t *testing.T) {
 	r := DnsARecordResource{}
 
 	checkedFields := map[string]struct{}{
+		"subscription_id":     {},
+		"record_type":         {},
 		"dns_zone_name":       {},
 		"name":                {},
-		"record_type":         {},
 		"resource_group_name": {},
-		"subscription_id":     {},
 	}
 
 	data.ResourceIdentityTest(t, []acceptance.TestStep{
@@ -29,11 +30,11 @@ func TestAccDnsARecord_resourceIdentity(t *testing.T) {
 			Config: r.basic(data),
 			ConfigStateChecks: []statecheck.StateCheck{
 				customstatecheck.ExpectAllIdentityFieldsAreChecked("azurerm_dns_a_record.test", checkedFields),
-				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_dns_a_record.test", tfjsonpath.New("dns_zone_name"), tfjsonpath.New("dns_zone_id")),
-				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_dns_a_record.test", tfjsonpath.New("name"), tfjsonpath.New("dns_zone_id")),
-				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_dns_a_record.test", tfjsonpath.New("record_type"), tfjsonpath.New("dns_zone_id")),
-				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_dns_a_record.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("dns_zone_id")),
-				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_dns_a_record.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("dns_zone_id")),
+				statecheck.ExpectIdentityValue("azurerm_dns_a_record.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValue("azurerm_dns_a_record.test", tfjsonpath.New("record_type"), knownvalue.StringExact("A")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_dns_a_record.test", tfjsonpath.New("dns_zone_name"), tfjsonpath.New("zone_name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_dns_a_record.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_dns_a_record.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 			},
 		},
 		data.ImportBlockWithResourceIdentityStep(false),

--- a/internal/services/dns/dns_a_record_resource_identity_gen_test.go
+++ b/internal/services/dns/dns_a_record_resource_identity_gen_test.go
@@ -1,0 +1,42 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package dns_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
+)
+
+func TestAccDnsARecord_resourceIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_dns_a_record", "test")
+	r := TestAccDnsARecordResource{}
+
+	checkedFields := map[string]struct{}{
+		"dns_zone_name":       {},
+		"name":                {},
+		"record_type":         {},
+		"resource_group_name": {},
+		"subscription_id":     {},
+	}
+
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				customstatecheck.ExpectAllIdentityFieldsAreChecked("azurerm_dns_a_record.test", checkedFields),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_dns_a_record.test", tfjsonpath.New("dns_zone_name"), tfjsonpath.New("zone_name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_dns_a_record.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_dns_a_record.test", tfjsonpath.New("record_type"), tfjsonpath.New("id")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_dns_a_record.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_dns_a_record.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("id")),
+			},
+		},
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
+}

--- a/internal/services/dns/dns_a_record_resource_list.go
+++ b/internal/services/dns/dns_a_record_resource_list.go
@@ -1,0 +1,100 @@
+package dns
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-azure-helpers/framework/typehelpers"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/dns/2018-05-01/recordsets"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-framework/list/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type DnsARecordListResource struct{}
+
+type DnsARecordListModel struct {
+	DnsZoneId types.String `tfsdk:"dns_zone_id"`
+}
+
+var _ sdk.FrameworkListWrappedResource = new(DnsARecordListResource)
+
+func (DnsARecordListResource) Metadata(_ context.Context, _ resource.MetadataRequest, response *resource.MetadataResponse) {
+	response.TypeName = azurermDnsARecordResourceName
+}
+
+func (DnsARecordListResource) ResourceFunc() *pluginsdk.Resource {
+	return resourceDnsARecord()
+}
+
+func (DnsARecordListResource) ListResourceConfigSchema(_ context.Context, _ list.ListResourceSchemaRequest, response *list.ListResourceSchemaResponse) {
+	response.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"dns_zone_id": schema.StringAttribute{
+				Required: true,
+				Validators: []validator.String{
+					typehelpers.WrappedStringValidator{Func: recordsets.ValidateDnsZoneID},
+				},
+			},
+		},
+	}
+}
+
+func (DnsARecordListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream, metadata sdk.ResourceMetadata) {
+	client := metadata.Client.Dns.RecordSets
+
+	var data DnsARecordListModel
+	diags := request.Config.Get(ctx, &data)
+	if diags.HasError() {
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+
+	parentID, err := recordsets.ParseDnsZoneID(data.DnsZoneId.ValueString())
+	if err != nil {
+		sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("parsing parent ID for `%s`", azurermDnsARecordResourceName), err)
+		return
+	}
+
+	resp, err := client.ListAllByDnsZoneComplete(ctx, *parentID, recordsets.DefaultListAllByDnsZoneOperationOptions())
+	if err != nil {
+		sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("listing `%s`", azurermDnsARecordResourceName), err)
+		return
+	}
+
+	stream.Results = func(push func(list.ListResult) bool) {
+		for _, item := range resp.Items {
+			result := request.NewListResult(ctx)
+			result.DisplayName = pointer.From(item.Name)
+
+			rd := resourceDnsARecord().Data(&terraform.InstanceState{})
+
+			id, err := recordsets.ParseRecordTypeIDInsensitively(pointer.From(item.Id))
+			if err != nil {
+				sdk.SetErrorDiagnosticAndPushListResult(result, push, fmt.Sprintf("parsing `%s` ID", azurermDnsARecordResourceName), err)
+				return
+			}
+			rd.SetId(id.ID())
+
+			if err := resourceDnsARecordFlatten(rd, id, &item); err != nil {
+				sdk.SetErrorDiagnosticAndPushListResult(result, push, fmt.Sprintf("encoding `%s` resource data", azurermDnsARecordResourceName), err)
+				return
+			}
+
+			sdk.EncodeListResult(ctx, rd, &result)
+			if result.Diagnostics.HasError() {
+				push(result)
+				return
+			}
+			if !push(result) {
+				return
+			}
+		}
+	}
+}

--- a/internal/services/dns/dns_a_record_resource_list_test.go
+++ b/internal/services/dns/dns_a_record_resource_list_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestAccDnsARecord_listByDnsZoneID(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_dns_a_record", "testlist1")
-	r := TestAccDnsARecordResource{}
+	r := DnsARecordResource{}
 
 	resource.Test(t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -29,7 +29,7 @@ func TestAccDnsARecord_listByDnsZoneID(t *testing.T) {
 			},
 			{
 				Query:  true,
-				Config: r.basicQuery(data),
+				Config: r.basicQuery(),
 				QueryResultChecks: []querycheck.QueryResultCheck{
 					querycheck.ExpectLengthAtLeast("azurerm_dns_a_record.list", 1),
 					querycheck.ExpectIdentity(
@@ -48,7 +48,7 @@ func TestAccDnsARecord_listByDnsZoneID(t *testing.T) {
 	})
 }
 
-func (r TestAccDnsARecordResource) basicQuery(data acceptance.TestData) string {
+func (r DnsARecordResource) basicQuery() string {
 	return `
 list "azurerm_dns_a_record" "list" {
   provider = azurerm

--- a/internal/services/dns/dns_a_record_resource_list_test.go
+++ b/internal/services/dns/dns_a_record_resource_list_test.go
@@ -1,0 +1,60 @@
+package dns_test
+
+import (
+	"context"
+	"regexp"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
+)
+
+func TestAccDnsARecord_listByDnsZoneID(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_dns_a_record", "testlist1")
+	r := TestAccDnsARecordResource{}
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []resource.TestStep{
+			{
+				Config: r.basic(data),
+			},
+			{
+				Query:  true,
+				Config: r.basicQuery(data),
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectLengthAtLeast("azurerm_dns_a_record.list", 1),
+					querycheck.ExpectIdentity(
+						"azurerm_dns_a_record.list",
+					map[string]knownvalue.Check{
+						"name":                  knownvalue.StringRegexp(regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
+						"resource_group_name":   knownvalue.StringRegexp(regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
+						"dns_zone_name":         knownvalue.StringRegexp(regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
+						"subscription_id":       knownvalue.StringExact(data.Subscriptions.Primary),
+						"record_type":           knownvalue.StringExact("A"),
+					},
+					),
+				},
+			},
+		},
+	})
+}
+
+func (r TestAccDnsARecordResource) basicQuery(data acceptance.TestData) string {
+	return `
+list "azurerm_dns_a_record" "list" {
+  provider = azurerm
+  config {
+    dns_zone_id = azurerm_dns_zone.test.id
+  }
+}
+`
+}

--- a/internal/services/dns/dns_a_record_resource_list_test.go
+++ b/internal/services/dns/dns_a_record_resource_list_test.go
@@ -34,13 +34,13 @@ func TestAccDnsARecord_listByDnsZoneID(t *testing.T) {
 					querycheck.ExpectLengthAtLeast("azurerm_dns_a_record.list", 1),
 					querycheck.ExpectIdentity(
 						"azurerm_dns_a_record.list",
-					map[string]knownvalue.Check{
-						"name":                  knownvalue.StringRegexp(regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
-						"resource_group_name":   knownvalue.StringRegexp(regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
-						"dns_zone_name":         knownvalue.StringRegexp(regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
-						"subscription_id":       knownvalue.StringExact(data.Subscriptions.Primary),
-						"record_type":           knownvalue.StringExact("A"),
-					},
+						map[string]knownvalue.Check{
+							"name":                knownvalue.StringRegexp(regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
+							"resource_group_name": knownvalue.StringRegexp(regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
+							"dns_zone_name":       knownvalue.StringRegexp(regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
+							"subscription_id":     knownvalue.StringExact(data.Subscriptions.Primary),
+							"record_type":         knownvalue.StringExact("A"),
+						},
 					),
 				},
 			},

--- a/internal/services/dns/dns_a_record_resource_test.go
+++ b/internal/services/dns/dns_a_record_resource_test.go
@@ -16,11 +16,11 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
-type TestAccDnsARecordResource struct{}
+type DnsARecordResource struct{}
 
 func TestAccDnsARecord_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_dns_a_record", "test")
-	r := TestAccDnsARecordResource{}
+	r := DnsARecordResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -36,7 +36,7 @@ func TestAccDnsARecord_basic(t *testing.T) {
 
 func TestAccDnsARecord_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_dns_a_record", "test")
-	r := TestAccDnsARecordResource{}
+	r := DnsARecordResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -54,7 +54,7 @@ func TestAccDnsARecord_requiresImport(t *testing.T) {
 
 func TestAccDnsARecord_updateRecords(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_dns_a_record", "test")
-	r := TestAccDnsARecordResource{}
+	r := DnsARecordResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -76,7 +76,7 @@ func TestAccDnsARecord_updateRecords(t *testing.T) {
 
 func TestAccDnsARecord_withTags(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_dns_a_record", "test")
-	r := TestAccDnsARecordResource{}
+	r := DnsARecordResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -99,7 +99,7 @@ func TestAccDnsARecord_withTags(t *testing.T) {
 
 func TestAccDnsARecord_withAlias(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_dns_a_record", "test")
-	r := TestAccDnsARecordResource{}
+	r := DnsARecordResource{}
 	targetResourceName := "azurerm_public_ip.test"
 	targetResourceName2 := "azurerm_public_ip.test2"
 
@@ -124,7 +124,7 @@ func TestAccDnsARecord_withAlias(t *testing.T) {
 
 func TestAccDnsARecord_RecordsToAlias(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_dns_a_record", "test")
-	r := TestAccDnsARecordResource{}
+	r := DnsARecordResource{}
 	targetResourceName := "azurerm_public_ip.test"
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -149,7 +149,7 @@ func TestAccDnsARecord_RecordsToAlias(t *testing.T) {
 
 func TestAccDnsARecord_AliasToRecords(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_dns_a_record", "test")
-	r := TestAccDnsARecordResource{}
+	r := DnsARecordResource{}
 	targetResourceName := "azurerm_public_ip.test"
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -172,7 +172,7 @@ func TestAccDnsARecord_AliasToRecords(t *testing.T) {
 	})
 }
 
-func (TestAccDnsARecordResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+func (DnsARecordResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := recordsets.ParseRecordTypeID(state.ID)
 	if err != nil {
 		return nil, err
@@ -186,7 +186,7 @@ func (TestAccDnsARecordResource) Exists(ctx context.Context, clients *clients.Cl
 	return pointer.To(resp.Model != nil), nil
 }
 
-func (TestAccDnsARecordResource) basic(data acceptance.TestData) string {
+func (DnsARecordResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -212,7 +212,7 @@ resource "azurerm_dns_a_record" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
 
-func (r TestAccDnsARecordResource) requiresImport(data acceptance.TestData) string {
+func (r DnsARecordResource) requiresImport(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -226,7 +226,7 @@ resource "azurerm_dns_a_record" "import" {
 `, r.basic(data))
 }
 
-func (TestAccDnsARecordResource) updateRecords(data acceptance.TestData) string {
+func (DnsARecordResource) updateRecords(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -252,7 +252,7 @@ resource "azurerm_dns_a_record" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
 
-func (TestAccDnsARecordResource) withTags(data acceptance.TestData) string {
+func (DnsARecordResource) withTags(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -283,7 +283,7 @@ resource "azurerm_dns_a_record" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
 
-func (TestAccDnsARecordResource) withTagsUpdate(data acceptance.TestData) string {
+func (DnsARecordResource) withTagsUpdate(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -313,7 +313,7 @@ resource "azurerm_dns_a_record" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
 
-func (TestAccDnsARecordResource) withAlias(data acceptance.TestData) string {
+func (DnsARecordResource) withAlias(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -347,7 +347,7 @@ resource "azurerm_dns_a_record" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
-func (TestAccDnsARecordResource) withAliasUpdate(data acceptance.TestData) string {
+func (DnsARecordResource) withAliasUpdate(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -381,7 +381,7 @@ resource "azurerm_dns_a_record" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
-func (TestAccDnsARecordResource) AliasToRecords(data acceptance.TestData) string {
+func (DnsARecordResource) AliasToRecords(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -415,7 +415,7 @@ resource "azurerm_dns_a_record" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
-func (TestAccDnsARecordResource) AliasToRecordsUpdate(data acceptance.TestData) string {
+func (DnsARecordResource) AliasToRecordsUpdate(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}

--- a/internal/services/dns/registration.go
+++ b/internal/services/dns/registration.go
@@ -96,5 +96,7 @@ func (r Registration) EphemeralResources() []func() ephemeral.EphemeralResource 
 }
 
 func (r Registration) ListResources() []sdk.FrameworkListWrappedResource {
-	return []sdk.FrameworkListWrappedResource{}
+	return []sdk.FrameworkListWrappedResource{
+		DnsARecordListResource{},
+	}
 }

--- a/website/docs/list-resources/dns_a_record.html.markdown
+++ b/website/docs/list-resources/dns_a_record.html.markdown
@@ -1,0 +1,30 @@
+---
+subcategory: "DNS"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_dns_a_record"
+description: |-
+    Lists DNS A Record resources.
+---
+
+# List resource: azurerm_dns_a_record
+
+Lists DNS A Record resources.
+
+## Example Usage
+
+### List DNS A Records in a DNS Zone
+
+```hcl
+list "azurerm_dns_a_record" "example" {
+  provider = azurerm
+  config {
+    dns_zone_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/dnsZones/zone1"
+  }
+}
+```
+
+## Argument Reference
+
+This list resource supports the following arguments:
+
+* `dns_zone_id` - (Required) The ID of the DNS Zone to query.


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
