### PR TITLE
`azurerm_public_ip_prefix` - support for the `edge_zone` property

### DIFF
--- a/internal/services/network/public_ip_prefix_resource.go
+++ b/internal/services/network/public_ip_prefix_resource.go
@@ -67,6 +67,8 @@ func resourcePublicIpPrefix() *pluginsdk.Resource {
 				ValidateFunc: customipprefixes.ValidateCustomIPPrefixID,
 			},
 
+			"edge_zone": commonschema.EdgeZoneOptionalForceNew(),
+
 			"sku": {
 				Type:         pluginsdk.TypeString,
 				Optional:     true,
@@ -143,7 +145,8 @@ func resourcePublicIpPrefixCreate(d *pluginsdk.ResourceData, meta interface{}) e
 	}
 
 	publicIpPrefix := publicipprefixes.PublicIPPrefix{
-		Location: pointer.To(location.Normalize(d.Get("location").(string))),
+		Location:         pointer.To(location.Normalize(d.Get("location").(string))),
+		ExtendedLocation: expandEdgeZoneModel(d.Get("edge_zone").(string)),
 		Sku: &publicipprefixes.PublicIPPrefixSku{
 			Name: pointer.ToEnum[publicipprefixes.PublicIPPrefixSkuName](d.Get("sku").(string)),
 			Tier: pointer.ToEnum[publicipprefixes.PublicIPPrefixSkuTier](d.Get("sku_tier").(string)),
@@ -226,6 +229,7 @@ func resourcePublicIpPrefixRead(d *pluginsdk.ResourceData, meta interface{}) err
 
 	if model := resp.Model; model != nil {
 		d.Set("location", location.NormalizeNilable(model.Location))
+		d.Set("edge_zone", flattenEdgeZoneModel(model.ExtendedLocation))
 		d.Set("zones", zones.FlattenUntyped(model.Zones))
 		if sku := model.Sku; sku != nil {
 			d.Set("sku", string(pointer.From(sku.Name)))

--- a/internal/services/network/public_ip_prefix_resource_test.go
+++ b/internal/services/network/public_ip_prefix_resource_test.go
@@ -262,7 +262,6 @@ func TestAccPublicIpPrefix_edgeZone(t *testing.T) {
 			Config: r.edgeZone(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("edge_zone").Exists(),
 			),
 		},
 		data.ImportStep(),

--- a/internal/services/network/public_ip_prefix_resource_test.go
+++ b/internal/services/network/public_ip_prefix_resource_test.go
@@ -253,6 +253,22 @@ func TestAccPublicIpPrefix_zonesMultiple(t *testing.T) {
 	})
 }
 
+func TestAccPublicIpPrefix_edgeZone(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_public_ip_prefix", "test")
+	r := PublicIpPrefixResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.edgeZone(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("edge_zone").Exists(),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (PublicIpPrefixResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -268,6 +284,33 @@ resource "azurerm_public_ip_prefix" "test" {
   name                = "acctestpublicipprefix-%d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (PublicIpPrefixResource) edgeZone(data acceptance.TestData) string {
+	// @tombuildsstuff: WestUS has an edge zone available - so hard-code to that for now
+	data.Locations.Primary = "westus"
+
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+data "azurerm_extended_locations" "test" {
+  location = azurerm_resource_group.test.location
+}
+
+resource "azurerm_public_ip_prefix" "test" {
+  name                = "acctestpublicipprefix-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  edge_zone           = data.azurerm_extended_locations.test.extended_locations[0]
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/website/docs/r/public_ip_prefix.html.markdown
+++ b/website/docs/r/public_ip_prefix.html.markdown
@@ -45,6 +45,8 @@ The following arguments are supported:
 
 -> **Note:** When `ip_version` is set to `IPv6`, `custom_ip_prefix_id` must reference a regional (child) range rather than a global (parent) range. For more details on creating a Public IP Prefix from a custom IP prefix, see [here](https://learn.microsoft.com/en-us/azure/virtual-network/ip-services/manage-custom-ip-address-prefix#create-a-public-ip-prefix-from-a-custom-ip-prefix).
 
+* `edge_zone` - (Optional) Specifies the Edge Zone within the Azure Region where this Public IP Prefix should exist. Changing this forces a new Public IP Prefix to be created.
+
 * `sku` - (Optional) The SKU of the Public IP Prefix. Possible values are `Standard` and `StandardV2`. Defaults to `Standard`. Changing this forces a new resource to be created.
 
 * `sku_tier` - (Optional) The SKU Tier that should be used for the Public IP Prefix. Possible values are `Regional` and `Global`. Defaults to `Regional`. Changing this forces a new resource to be created.


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Adds support for the `edge_zone` property to `azurerm_public_ip_prefix`, allowing a Public IP Prefix to be created in an [Azure Extended Zone](https://learn.microsoft.com/azure/extended-zones/overview) by mapping the property to `extendedLocation` on the underlying resource.

The property is optional and ForceNew, and reuses the existing `expandEdgeZoneModel`/`flattenEdgeZoneModel` helpers in the `network` service package. This brings `azurerm_public_ip_prefix` in line with `azurerm_public_ip`, which already supports `edge_zone`, so a prefix can be allocated in the same Extended Zone as the addresses drawn from it.

> [!NOTE]
> This PR is the second half of the split requested by @magodo and @liuwuliuyun on #32803, which originally covered both resources in a single PR. #32803 now contains the `azurerm_firewall` change only; this PR contains the `azurerm_public_ip_prefix` change only. The two are independent and can be reviewed and merged separately.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.


## Testing

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

Adds `TestAccPublicIpPrefix_edgeZone`, which follows the existing edge zone acceptance test pattern used elsewhere in the provider (pinned to `westus` and sourcing the zone from the `azurerm_extended_locations` data source).


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

* `azurerm_public_ip_prefix` - support for the `edge_zone` property


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #33271

Split from #32803


## AI Assistance Disclosure

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

No

> [!NOTE]
> If this PR changes meaningfully during the course of review please update the title and description as required.
