### PR TITLE
linters - AZR008 - returning empty slices from flatten functions

### DIFF
--- a/internal/services/appservice/helpers/auth_v2_schema.go
+++ b/internal/services/appservice/helpers/auth_v2_schema.go
@@ -2062,7 +2062,7 @@ func flattenTwitterAuthV2Settings(input *webapps.Twitter) []TwitterAuthV2Setting
 		return []TwitterAuthV2Settings{result}
 	}
 
-	return nil
+	return []TwitterAuthV2Settings{}
 }
 
 func ExpandAuthV2Settings(input []AuthV2Settings) *webapps.SiteAuthSettingsV2 {

--- a/internal/services/appservice/helpers/auto_heal.go
+++ b/internal/services/appservice/helpers/auto_heal.go
@@ -658,5 +658,5 @@ func flattenAutoHealSettingsWindows(autoHealRules *webapps.AutoHealRules) []Auto
 		return []AutoHealSettingWindows{result}
 	}
 
-	return nil
+	return []AutoHealSettingWindows{}
 }

--- a/internal/services/appservice/helpers/common_web_app_schema.go
+++ b/internal/services/appservice/helpers/common_web_app_schema.go
@@ -1177,7 +1177,7 @@ func FlattenLogsConfig(logsConfig *webapps.SiteLogsConfig) []LogsConfig {
 	}
 	props := *logsConfig.Properties
 	if onlyDefaultLoggingConfig(props) {
-		return nil
+		return []LogsConfig{}
 	}
 
 	logs := LogsConfig{}

--- a/internal/services/appservice/helpers/linux_web_app_schema.go
+++ b/internal/services/appservice/helpers/linux_web_app_schema.go
@@ -1360,5 +1360,5 @@ func flattenAutoHealSettingsLinux(autoHealRules *webapps.AutoHealRules) []AutoHe
 		return []AutoHealSettingLinux{result}
 	}
 
-	return nil
+	return []AutoHealSettingLinux{}
 }

--- a/internal/services/automanage/automanage_configuration_resource.go
+++ b/internal/services/automanage/automanage_configuration_resource.go
@@ -753,7 +753,7 @@ func expandConfigurationProfile(model ConfigurationModel) *interface{} {
 
 func flattenAntiMalwareConfig(configMap map[string]interface{}) []AntimalwareConfiguration {
 	if val, ok := configMap["Antimalware/Enable"]; !ok || (val == nil) {
-		return nil
+		return []AntimalwareConfiguration{}
 	}
 
 	antimalware := make([]AntimalwareConfiguration, 1)
@@ -806,7 +806,7 @@ func flattenAntiMalwareConfig(configMap map[string]interface{}) []AntimalwareCon
 
 func flattenAzureSecurityBaselineConfig(configMap map[string]interface{}) []AzureSecurityBaselineConfiguration {
 	if val, ok := configMap["AzureSecurityBaseline/Enable"]; !ok || (val == nil) {
-		return nil
+		return []AzureSecurityBaselineConfiguration{}
 	}
 
 	azureSecurityBaseline := make([]AzureSecurityBaselineConfiguration, 1)
@@ -821,7 +821,7 @@ func flattenAzureSecurityBaselineConfig(configMap map[string]interface{}) []Azur
 
 func flattenBackupConfig(configMap map[string]interface{}) []BackupConfiguration {
 	if val, ok := configMap["Backup/Enable"]; !ok || (val == nil) {
-		return nil
+		return []BackupConfiguration{}
 	}
 
 	backup := make([]BackupConfiguration, 1)

--- a/internal/services/cognitive/cognitive_deployment_resource.go
+++ b/internal/services/cognitive/cognitive_deployment_resource.go
@@ -448,7 +448,7 @@ func flattenDeploymentModelModel(input *deployments.DeploymentModel) []Deploymen
 
 func flattenDeploymentSkuModel(input *deployments.Sku) []DeploymentSkuModel {
 	if input == nil {
-		return nil
+		return []DeploymentSkuModel{}
 	}
 	output := DeploymentSkuModel{
 		Name: input.Name,

--- a/internal/services/compute/gallery_application_version_resource.go
+++ b/internal/services/compute/gallery_application_version_resource.go
@@ -497,7 +497,7 @@ func expandGalleryApplicationVersionManageAction(input []ManageAction) *gallerya
 
 func flattenGalleryApplicationVersionManageAction(input *galleryapplicationversions.UserArtifactManage) []ManageAction {
 	if input == nil {
-		return nil
+		return []ManageAction{}
 	}
 
 	output := make([]ManageAction, 0)

--- a/internal/services/compute/protected_settings_from_key_vault.go
+++ b/internal/services/compute/protected_settings_from_key_vault.go
@@ -116,7 +116,7 @@ func flattenProtectedSettingsFromKeyVaultVMSS(input *virtualmachinescalesets.Key
 
 func flattenProtectedSettingsFromKeyVaultOldVMSSExtension(input *virtualmachinescalesetextensions.KeyVaultSecretReference) []interface{} {
 	if input == nil {
-		return nil
+		return []interface{}{}
 	}
 
 	sourceVaultId := pointer.From(input.SourceVault.Id)

--- a/internal/services/compute/virtual_machine.go
+++ b/internal/services/compute/virtual_machine.go
@@ -476,7 +476,7 @@ func expandTerminateNotificationProfile(input []interface{}) *virtualmachines.Te
 
 func flattenOsImageNotificationProfile(input *virtualmachines.OSImageNotificationProfile) []interface{} {
 	if input == nil || !pointer.From(input.Enable) {
-		return nil
+		return []interface{}{}
 	}
 
 	timeout := "PT15M"
@@ -591,7 +591,7 @@ func expandVirtualMachineGalleryApplication(input []interface{}) *[]virtualmachi
 
 func flattenVirtualMachineGalleryApplication(input *[]virtualmachines.VMGalleryApplication) []interface{} {
 	if len(*input) == 0 {
-		return nil
+		return []interface{}{}
 	}
 
 	out := make([]interface{}, 0)

--- a/internal/services/compute/virtual_machine_scale_set.go
+++ b/internal/services/compute/virtual_machine_scale_set.go
@@ -207,7 +207,7 @@ func expandVirtualMachineScaleSetGalleryApplication(input []interface{}) *[]virt
 
 func flattenVirtualMachineScaleSetGalleryApplication(input *[]virtualmachinescalesets.VMGalleryApplication) []interface{} {
 	if len(*input) == 0 {
-		return nil
+		return []interface{}{}
 	}
 
 	out := make([]interface{}, 0)
@@ -345,7 +345,7 @@ func ExpandVirtualMachineScaleSetSpotRestorePolicy(input []interface{}) *virtual
 
 func FlattenVirtualMachineScaleSetSpotRestorePolicy(input *virtualmachinescalesets.SpotRestorePolicy) []interface{} {
 	if input == nil {
-		return nil
+		return []interface{}{}
 	}
 
 	return []interface{}{

--- a/internal/services/containers/container_group_resource.go
+++ b/internal/services/containers/container_group_resource.go
@@ -1563,7 +1563,7 @@ func flattenContainerProbeHttpHeaders(input *[]containerinstance.HTTPHeader) map
 
 func flattenContainerImageRegistryCredentials(d *pluginsdk.ResourceData, input *[]containerinstance.ImageRegistryCredential) []interface{} {
 	if input == nil {
-		return nil
+		return []interface{}{}
 	}
 	configsOld := d.Get("image_registry_credential").([]interface{})
 
@@ -1591,7 +1591,7 @@ func flattenContainerImageRegistryCredentials(d *pluginsdk.ResourceData, input *
 
 func flattenContainerGroupInitContainers(d *pluginsdk.ResourceData, initContainers *[]containerinstance.InitContainerDefinition, containerGroupVolumes *[]containerinstance.Volume) []interface{} {
 	if initContainers == nil {
-		return nil
+		return []interface{}{}
 	}
 	// map old container names to index so we can look up things up
 	nameIndexMap := map[string]int{}

--- a/internal/services/containers/container_registry_task_resource.go
+++ b/internal/services/containers/container_registry_task_resource.go
@@ -974,7 +974,7 @@ func expandRegistryTaskBaseImageTrigger(triggers []BaseImageTrigger) *tasks.Base
 
 func flattenRegistryTaskBaseImageTrigger(trigger *tasks.BaseImageTrigger, model ContainerRegistryTaskModel) []BaseImageTrigger {
 	if trigger == nil {
-		return nil
+		return []BaseImageTrigger{}
 	}
 
 	payloadType := ""
@@ -1035,7 +1035,7 @@ func expandRegistryTaskSourceTriggers(triggers []SourceTrigger) *[]tasks.SourceT
 
 func flattenRegistryTaskSourceTriggers(triggers *[]tasks.SourceTrigger, model ContainerRegistryTaskModel) []SourceTrigger {
 	if triggers == nil {
-		return nil
+		return []SourceTrigger{}
 	}
 	out := make([]SourceTrigger, 0, len(*triggers))
 	for i, trigger := range *triggers {
@@ -1107,7 +1107,7 @@ func expandRegistryTaskTimerTriggers(triggers []TimerTrigger) *[]tasks.TimerTrig
 
 func flattenRegistryTaskTimerTriggers(triggers *[]tasks.TimerTrigger) []TimerTrigger {
 	if triggers == nil {
-		return nil
+		return []TimerTrigger{}
 	}
 	out := make([]TimerTrigger, 0, len(*triggers))
 	for _, trigger := range *triggers {
@@ -1158,12 +1158,12 @@ func expandRegistryTaskDockerStep(step DockerStep) tasks.DockerBuildStep {
 
 func flattenRegistryTaskDockerStep(step tasks.TaskStepProperties, model ContainerRegistryTaskModel) []DockerStep {
 	if step == nil {
-		return nil
+		return []DockerStep{}
 	}
 
 	dockerStep, ok := step.(tasks.DockerBuildStep)
 	if !ok {
-		return nil
+		return []DockerStep{}
 	}
 
 	obj := DockerStep{
@@ -1218,12 +1218,12 @@ func expandRegistryTaskFileTaskStep(step FileTaskStep) tasks.FileTaskStep {
 
 func flattenRegistryTaskFileTaskStep(step tasks.TaskStepProperties, model ContainerRegistryTaskModel) []FileTaskStep {
 	if step == nil {
-		return nil
+		return []FileTaskStep{}
 	}
 
 	fileTaskStep, ok := step.(tasks.FileTaskStep)
 	if !ok {
-		return nil
+		return []FileTaskStep{}
 	}
 
 	obj := FileTaskStep{
@@ -1269,12 +1269,12 @@ func expandRegistryTaskEncodedTaskStep(step EncodedTaskStep) tasks.EncodedTaskSt
 
 func flattenRegistryTaskEncodedTaskStep(step tasks.TaskStepProperties, model ContainerRegistryTaskModel) []EncodedTaskStep {
 	if step == nil {
-		return nil
+		return []EncodedTaskStep{}
 	}
 
 	encodedTaskStep, ok := step.(tasks.EncodedTaskStep)
 	if !ok {
-		return nil
+		return []EncodedTaskStep{}
 	}
 
 	obj := EncodedTaskStep{
@@ -1426,7 +1426,7 @@ func expandRegistryTaskPlatform(input []Platform) *tasks.PlatformProperties {
 
 func flattenRegistryTaskPlatform(platform *tasks.PlatformProperties) []Platform {
 	if platform == nil {
-		return nil
+		return []Platform{}
 	}
 
 	architecture := ""
@@ -1459,7 +1459,7 @@ func expandRegistryTaskCredentials(input []RegistryCredential) *tasks.Credential
 
 func flattenRegistryTaskCredentials(input *tasks.Credentials, model ContainerRegistryTaskModel) []RegistryCredential {
 	if input == nil {
-		return nil
+		return []RegistryCredential{}
 	}
 
 	// The customRegistryCredentials is sensitive and won't return from API, setting it from the config.
@@ -1486,7 +1486,7 @@ func expandSourceRegistryCredential(input []SourceRegistryCredential) *tasks.Sou
 
 func flattenSourceRegistryCredential(input *tasks.SourceRegistryCredentials) []SourceRegistryCredential {
 	if input == nil || input.LoginMode == nil {
-		return nil
+		return []SourceRegistryCredential{}
 	}
 
 	return []SourceRegistryCredential{{LoginMode: string(*input.LoginMode)}}
@@ -1540,7 +1540,7 @@ func expandRegistryTaskAgentProperties(input []AgentConfig) *tasks.AgentProperti
 
 func flattenRegistryTaskAgentProperties(input *tasks.AgentProperties) []AgentConfig {
 	if input == nil {
-		return nil
+		return []AgentConfig{}
 	}
 
 	return []AgentConfig{{CPU: pointer.From(input.Cpu)}}

--- a/internal/services/containers/container_registry_token_password_resource.go
+++ b/internal/services/containers/container_registry_token_password_resource.go
@@ -352,7 +352,7 @@ func (r ContainerRegistryTokenPasswordResource) expandContainerRegistryTokenPass
 
 func (r ContainerRegistryTokenPasswordResource) flattenContainerRegistryTokenPassword(input *[]tokens.TokenPassword) (password1, password2 []ContainerRegistryTokenPassword) {
 	if input == nil {
-		return nil, nil
+		return []ContainerRegistryTokenPassword{}, []ContainerRegistryTokenPassword{}
 	}
 
 	for _, e := range *input {

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -4833,7 +4833,7 @@ func expandKubernetesClusterAzureMonitorProfile(input []interface{}) *managedclu
 
 func flattenKubernetesClusterAzureServiceMeshProfile(input *managedclusters.ServiceMeshProfile) []interface{} {
 	if input == nil || input.Mode != managedclusters.ServiceMeshModeIstio {
-		return nil
+		return []interface{}{}
 	}
 
 	returnMap := map[string]interface{}{
@@ -4886,7 +4886,7 @@ func flattenKubernetesClusterServiceMeshProfileCertificateAuthority(certificateA
 
 func flattenKubernetesClusterAzureMonitorProfile(input *managedclusters.ManagedClusterAzureMonitorProfile) []interface{} {
 	if input == nil || input.Metrics == nil || !input.Metrics.Enabled {
-		return nil
+		return []interface{}{}
 	}
 	if input.Metrics.KubeStateMetrics == nil {
 		return []interface{}{

--- a/internal/services/cosmos/common/indexing_policy.go
+++ b/internal/services/cosmos/common/indexing_policy.go
@@ -120,7 +120,7 @@ func ExpandAzureRmCosmosDbIndexingPolicy(d *pluginsdk.ResourceData) *cosmosdb.In
 
 func flattenCosmosDBIndexingPolicyExcludedPaths(input *[]cosmosdb.ExcludedPath) []interface{} {
 	if input == nil {
-		return nil
+		return []interface{}{}
 	}
 
 	excludedPaths := make([]interface{}, 0)
@@ -174,7 +174,7 @@ func FlattenCosmosDBIndexingPolicyCompositeIndexes(input *[][]cosmosdb.Composite
 
 func flattenCosmosDBIndexingPolicyIncludedPaths(input *[]cosmosdb.IncludedPath) []interface{} {
 	if input == nil {
-		return nil
+		return []interface{}{}
 	}
 
 	includedPaths := make([]interface{}, 0)
@@ -208,7 +208,7 @@ func FlattenCosmosDBIndexingPolicySpatialIndexes(input *[]cosmosdb.SpatialSpec) 
 
 func flattenCosmosDBIndexingPolicySpatialIndexesTypes(input *[]cosmosdb.SpatialType) []interface{} {
 	if input == nil {
-		return nil
+		return []interface{}{}
 	}
 
 	types := make([]interface{}, 0)

--- a/internal/services/cosmos/cosmosdb_cassandra_table_resource.go
+++ b/internal/services/cosmos/cosmosdb_cassandra_table_resource.go
@@ -362,7 +362,7 @@ func flattenTableSchema(input *cosmosdb.CassandraSchema) []interface{} {
 
 func flattenTableSchemaColumns(input *[]cosmosdb.Column) []interface{} {
 	if input == nil {
-		return nil
+		return []interface{}{}
 	}
 
 	columns := make([]interface{}, 0)
@@ -381,7 +381,7 @@ func flattenTableSchemaColumns(input *[]cosmosdb.Column) []interface{} {
 
 func flattenTableSchemaPartitionKeys(input *[]cosmosdb.CassandraPartitionKey) []interface{} {
 	if input == nil {
-		return nil
+		return []interface{}{}
 	}
 
 	keys := make([]interface{}, 0)
@@ -397,7 +397,7 @@ func flattenTableSchemaPartitionKeys(input *[]cosmosdb.CassandraPartitionKey) []
 
 func flattenTableSchemaClusterKeys(input *[]cosmosdb.ClusterKey) []interface{} {
 	if input == nil {
-		return nil
+		return []interface{}{}
 	}
 
 	keys := make([]interface{}, 0)

--- a/internal/services/cosmos/cosmosdb_postgresql_cluster_resource.go
+++ b/internal/services/cosmos/cosmosdb_postgresql_cluster_resource.go
@@ -663,7 +663,7 @@ func expandMaintenanceWindow(input []MaintenanceWindow) *clusters.MaintenanceWin
 
 func flattenMaintenanceWindow(input *clusters.MaintenanceWindow) []MaintenanceWindow {
 	if input == nil || input.CustomWindow == nil || *input.CustomWindow == "Disabled" {
-		return nil
+		return []MaintenanceWindow{}
 	}
 
 	return []MaintenanceWindow{

--- a/internal/services/databricks/databricks_workspace_data_source.go
+++ b/internal/services/databricks/databricks_workspace_data_source.go
@@ -186,7 +186,7 @@ func dataSourceDatabricksWorkspace() *pluginsdk.Resource {
 // It also omits the public and private subnet NSG association IDs since they are not available in API.
 func flattenWorkspaceCustomParametersForDataSource(input *workspaces.WorkspaceCustomParameters) []interface{} {
 	if input == nil {
-		return nil
+		return []interface{}{}
 	}
 
 	parameters := make(map[string]interface{})

--- a/internal/services/databricks/databricks_workspace_resource.go
+++ b/internal/services/databricks/databricks_workspace_resource.go
@@ -1106,7 +1106,7 @@ func expandDatabricksWorkspaceEncryption(d *pluginsdk.ResourceData) (*workspaces
 
 func flattenWorkspaceManagedIdentity(input *workspaces.ManagedIdentityConfiguration) []interface{} {
 	if input == nil {
-		return nil
+		return []interface{}{}
 	}
 
 	e := make(map[string]interface{})
@@ -1132,7 +1132,7 @@ func flattenWorkspaceManagedIdentity(input *workspaces.ManagedIdentityConfigurat
 
 func flattenWorkspaceCustomParameters(input *workspaces.WorkspaceCustomParameters, publicSubnetAssociation, privateSubnetAssociation *string) ([]interface{}, string) {
 	if input == nil {
-		return nil, ""
+		return []interface{}{}, ""
 	}
 
 	var backendAddressPoolId, backendName, loadBalancerId string

--- a/internal/services/datafactory/data_factory.go
+++ b/internal/services/datafactory/data_factory.go
@@ -249,7 +249,7 @@ func expandAzureKeyVaultSecretReference(input []interface{}) *datafactory.AzureK
 
 func flattenAzureKeyVaultConnectionString(input map[string]interface{}) []interface{} {
 	if input == nil {
-		return nil
+		return []interface{}{}
 	}
 
 	parameters := make(map[string]interface{})
@@ -267,7 +267,7 @@ func flattenAzureKeyVaultConnectionString(input map[string]interface{}) []interf
 
 func flattenAzureKeyVaultSecretReference(secretReference *datafactory.AzureKeyVaultSecretReference) []interface{} {
 	if secretReference == nil {
-		return nil
+		return []interface{}{}
 	}
 
 	parameters := make(map[string]interface{})
@@ -365,7 +365,7 @@ func expandDataFactoryDatasetAzureBlobFSLocation(d *pluginsdk.ResourceData) data
 
 func flattenDataFactoryDatasetHTTPServerLocation(input *datafactory.HTTPServerLocation) []interface{} {
 	if input == nil {
-		return nil
+		return []interface{}{}
 	}
 	result := make(map[string]interface{})
 
@@ -388,7 +388,7 @@ func flattenDataFactoryDatasetHTTPServerLocation(input *datafactory.HTTPServerLo
 
 func flattenDataFactoryDatasetAzureBlobStorageLocation(input *datafactory.AzureBlobStorageLocation) []interface{} {
 	if input == nil {
-		return nil
+		return []interface{}{}
 	}
 	result := make(map[string]interface{})
 
@@ -438,7 +438,7 @@ func flattenDataFactoryDatasetAzureBlobFSLocation(input *datafactory.AzureBlobFS
 
 func flattenDataFactoryDatasetSFTPLocation(input *datafactory.SftpLocation) []interface{} {
 	if input == nil {
-		return nil
+		return []interface{}{}
 	}
 	result := make(map[string]interface{})
 

--- a/internal/services/datafactory/data_factory_integration_runtime_azure_ssis_resource.go
+++ b/internal/services/datafactory/data_factory_integration_runtime_azure_ssis_resource.go
@@ -1158,7 +1158,7 @@ func flattenDataFactoryIntegrationRuntimeAzureSsisCustomSetupScript(customSetupS
 
 func flattenDataFactoryIntegrationRuntimeAzureSsisPackageStore(input *[]integrationruntimes.PackageStore) []interface{} {
 	if input == nil {
-		return nil
+		return []interface{}{}
 	}
 
 	result := make([]interface{}, 0)

--- a/internal/services/eventgrid/eventgrid_namespace_resource.go
+++ b/internal/services/eventgrid/eventgrid_namespace_resource.go
@@ -575,7 +575,7 @@ func expandStaticRoutingEnrichments(input []RoutingEnrichmentModel) *[]namespace
 func flattenTopicSpacesConfiguration(topicSpacesConfig *namespaces.TopicSpacesConfiguration) ([]TopicSpacesConfigurationModel, error) {
 	var output TopicSpacesConfigurationModel
 	if topicSpacesConfig == nil {
-		return nil, nil
+		return []TopicSpacesConfigurationModel{}, nil
 	}
 
 	output.MaximumSessionExpiryInHours = pointer.From(topicSpacesConfig.MaximumSessionExpiryInHours)

--- a/internal/services/eventhub/eventhub_namespace_resource.go
+++ b/internal/services/eventhub/eventhub_namespace_resource.go
@@ -663,7 +663,7 @@ func expandEventHubNamespaceNetworkRuleset(input []interface{}) (*networkruleset
 
 func flattenEventHubNamespaceNetworkRuleset(ruleset networkrulesets.NamespacesGetNetworkRuleSetOperationResponse) ([]interface{}, error) {
 	if ruleset.Model == nil || ruleset.Model.Properties == nil {
-		return nil, nil
+		return []interface{}{}, nil
 	}
 
 	vnetBlocks := make([]interface{}, 0)

--- a/internal/services/firewall/firewall_resource.go
+++ b/internal/services/firewall/firewall_resource.go
@@ -682,7 +682,7 @@ func expandFirewallAdditionalProperty(d *pluginsdk.ResourceData) map[string]stri
 
 func flattenFirewallAdditionalProperty(input *map[string]string) (enabled interface{}, servers []interface{}) {
 	if input == nil || len(*input) == 0 {
-		return nil, nil
+		return nil, []interface{}{}
 	}
 
 	if enabledPtr, ok := (*input)["Network.DNS.EnableProxy"]; ok {
@@ -715,7 +715,7 @@ func expandFirewallPrivateIpRange(input []interface{}) map[string]string {
 
 func flattenFirewallPrivateIpRange(input *map[string]string) []interface{} {
 	if input == nil || len(*input) == 0 {
-		return nil
+		return []interface{}{}
 	}
 
 	attrs := *input
@@ -777,7 +777,7 @@ func expandFirewallVirtualHubSetting(existing *azurefirewalls.AzureFirewall, inp
 
 func flattenFirewallVirtualHubSetting(props *azurefirewalls.AzureFirewallPropertiesFormat) []interface{} {
 	if props.VirtualHub == nil {
-		return nil
+		return []interface{}{}
 	}
 
 	var (

--- a/internal/services/hdinsight/schema.go
+++ b/internal/services/hdinsight/schema.go
@@ -1813,7 +1813,7 @@ func findHDInsightConnectivityEndpoint(name string, input *[]clusters.Connectivi
 
 func FlattenHDInsightNodeAutoscaleDefinition(input *clusters.Autoscale) []interface{} {
 	if input == nil {
-		return nil
+		return []interface{}{}
 	}
 
 	result := map[string]interface{}{}
@@ -1829,7 +1829,7 @@ func FlattenHDInsightNodeAutoscaleDefinition(input *clusters.Autoscale) []interf
 	if len(result) > 0 {
 		return []interface{}{result}
 	}
-	return nil
+	return []interface{}{}
 }
 
 func FlattenHDInsightAutoscaleCapacityDefinition(input *clusters.AutoscaleCapacity) []interface{} {

--- a/internal/services/iotcentral/iotcentral_application_network_rule_set_resource.go
+++ b/internal/services/iotcentral/iotcentral_application_network_rule_set_resource.go
@@ -295,7 +295,7 @@ func expandIotCentralApplicationNetworkRuleSetIPRule(input []IPRule) *[]apps.Net
 
 func flattenIotCentralApplicationNetworkRuleSetIPRule(input *[]apps.NetworkRuleSetIPRule) []IPRule {
 	if input == nil {
-		return nil
+		return []IPRule{}
 	}
 
 	results := make([]IPRule, 0)

--- a/internal/services/keyvault/key_vault_key_resource.go
+++ b/internal/services/keyvault/key_vault_key_resource.go
@@ -942,7 +942,7 @@ func expandKeyVaultKeyReleasePolicy(input []any) *keys.KeyReleasePolicy {
 
 func flattenKeyVaultKeyReleasePolicy(input *keys.KeyReleasePolicy) ([]any, error) {
 	if input == nil {
-		return nil, nil
+		return []any{}, nil
 	}
 
 	data := ""

--- a/internal/services/legacy/virtual_machine_scale_set_resource.go
+++ b/internal/services/legacy/virtual_machine_scale_set_resource.go
@@ -1457,7 +1457,7 @@ func flattenAzureRmVirtualMachineScaleSetSku(sku *virtualmachinescalesets.Sku) [
 
 func flattenAzureRmVirtualMachineScaleSetExtensionProfile(profile *virtualmachinescalesets.VirtualMachineScaleSetExtensionProfile) ([]map[string]interface{}, error) {
 	if profile.Extensions == nil {
-		return nil, nil
+		return []map[string]interface{}{}, nil
 	}
 
 	result := make([]map[string]interface{}, 0, len(*profile.Extensions))

--- a/internal/services/lighthouse/lighthouse_definition_resource.go
+++ b/internal/services/lighthouse/lighthouse_definition_resource.go
@@ -471,7 +471,7 @@ func expandLighthouseDefinitionApprover(input []interface{}) *[]registrationdefi
 
 func flattenLighthouseDefinitionEligibleAuthorization(input *[]registrationdefinitions.EligibleAuthorization) []interface{} {
 	if input == nil {
-		return nil
+		return []interface{}{}
 	}
 
 	results := make([]interface{}, 0, len(*input))
@@ -497,7 +497,7 @@ func flattenLighthouseDefinitionEligibleAuthorization(input *[]registrationdefin
 
 func flattenLighthouseDefinitionJustInTimeAccessPolicy(input *registrationdefinitions.JustInTimeAccessPolicy) []interface{} {
 	if input == nil {
-		return nil
+		return []interface{}{}
 	}
 
 	var results []interface{}
@@ -523,7 +523,7 @@ func flattenLighthouseDefinitionJustInTimeAccessPolicy(input *registrationdefini
 
 func flattenLighthouseDefinitionApprover(input *[]registrationdefinitions.EligibleApprover) []interface{} {
 	if input == nil {
-		return nil
+		return []interface{}{}
 	}
 
 	results := make([]interface{}, 0, len(*input))

--- a/internal/services/loganalytics/log_analytics_workspace_table.go
+++ b/internal/services/loganalytics/log_analytics_workspace_table.go
@@ -91,7 +91,7 @@ func expandWorkspaceTableColumns(columns []workspaceTableColumn) *[]tables.Colum
 
 func flattenWorkspaceTableColumns(columns *[]tables.Column) []workspaceTableColumn {
 	if columns == nil {
-		return nil
+		return []workspaceTableColumn{}
 	}
 	result := make([]workspaceTableColumn, 0, len(*columns))
 	for _, column := range *columns {

--- a/internal/services/loganalytics/log_analytics_workspace_table_microsoft_resource.go
+++ b/internal/services/loganalytics/log_analytics_workspace_table_microsoft_resource.go
@@ -491,7 +491,7 @@ func expandWorkspaceTableMicrosoftColumns(columns []Column) *[]tables.Column {
 
 func flattenWorkspaceTableMicrosoftColumns(columns *[]tables.Column) []Column {
 	if columns == nil {
-		return nil
+		return []Column{}
 	}
 	result := make([]Column, 0, len(*columns))
 	for _, column := range *columns {

--- a/internal/services/logic/logic_app_standard_resource.go
+++ b/internal/services/logic/logic_app_standard_resource.go
@@ -1010,7 +1010,7 @@ func flattenLogicAppStandardIpRestriction(input *[]webapps.IPSecurityRestriction
 	restrictions := make([]interface{}, 0)
 
 	if input == nil {
-		return nil
+		return []interface{}{}
 	}
 
 	for _, v := range *input {

--- a/internal/services/logic/logic_apps.go
+++ b/internal/services/logic/logic_apps.go
@@ -23,7 +23,7 @@ import (
 // NOTE: this file is not a recommended way of developing Terraform resources; this exists to work around the fact that this API is dynamic (by its nature)
 func flattenLogicAppActionRunAfter(input map[string]interface{}) []interface{} {
 	if len(input) == 0 {
-		return nil
+		return []interface{}{}
 	}
 	output := []interface{}{}
 	for k, v := range input {

--- a/internal/services/managedredis/managed_redis_geo_replication_resource.go
+++ b/internal/services/managedredis/managed_redis_geo_replication_resource.go
@@ -361,7 +361,7 @@ func toClusterId(dbIdStr string) (*redisenterprise.RedisEnterpriseId, error) {
 
 func flattenLinkedDatabases(dbs *[]databases.LinkedDatabase) []string {
 	if dbs == nil {
-		return nil
+		return []string{}
 	}
 
 	result := make([]string, 0, len(*dbs))

--- a/internal/services/monitor/monitor_metric_alert_resource.go
+++ b/internal/services/monitor/monitor_metric_alert_resource.go
@@ -733,13 +733,13 @@ func flattenMonitorMetricAlertCriteria(input metricalerts.MetricAlertCriteria) [
 	case metricalerts.WebtestLocationAvailabilityCriteria:
 		return flattenMonitorMetricAlertWebtestLocAvailCriteria(&criteria)
 	default:
-		return nil
+		return []interface{}{}
 	}
 }
 
 func flattenMonitorMetricAlertSingleResourceMultiMetricCriteria(input *[]metricalerts.MetricCriteria) []interface{} {
 	if input == nil || len(*input) == 0 {
-		return nil
+		return []interface{}{}
 	}
 	criteria := (*input)[0]
 	metricName := criteria.MetricName
@@ -777,7 +777,7 @@ func flattenMonitorMetricAlertSingleResourceMultiMetricCriteria(input *[]metrica
 
 func flattenMonitorMetricAlertMultiResourceMultiMetricCriteria(input *[]metricalerts.MultiMetricCriteria) []interface{} {
 	if input == nil {
-		return nil
+		return []interface{}{}
 	}
 	result := make([]interface{}, 0)
 
@@ -856,7 +856,7 @@ func flattenMonitorMetricAlertMultiResourceMultiMetricCriteria(input *[]metrical
 
 func flattenMonitorMetricAlertWebtestLocAvailCriteria(input *metricalerts.WebtestLocationAvailabilityCriteria) []interface{} {
 	if input == nil {
-		return nil
+		return []interface{}{}
 	}
 
 	return []interface{}{

--- a/internal/services/mssqlmanagedinstance/mssql_managed_instance_data_source.go
+++ b/internal/services/mssqlmanagedinstance/mssql_managed_instance_data_source.go
@@ -231,7 +231,7 @@ func (d MsSqlManagedInstanceDataSource) Read() sdk.ResourceFunc {
 
 func (d MsSqlManagedInstanceDataSource) flattenIdentity(input *identity.LegacySystemAndUserAssignedMap) []identity.SystemOrUserAssignedList {
 	if input == nil {
-		return nil
+		return []identity.SystemOrUserAssignedList{}
 	}
 
 	identityIds := make([]string, 0)

--- a/internal/services/mssqlmanagedinstance/mssql_managed_instance_resource.go
+++ b/internal/services/mssqlmanagedinstance/mssql_managed_instance_resource.go
@@ -860,7 +860,7 @@ func (r MsSqlManagedInstanceResource) expandIdentity(input []identity.SystemOrUs
 
 func (r MsSqlManagedInstanceResource) flattenIdentity(input *identity.LegacySystemAndUserAssignedMap) []identity.SystemOrUserAssignedList {
 	if input == nil {
-		return nil
+		return []identity.SystemOrUserAssignedList{}
 	}
 
 	identityIds := make([]string, 0)

--- a/internal/services/netapp/netapp_volume_bucket_helper.go
+++ b/internal/services/netapp/netapp_volume_bucket_helper.go
@@ -259,7 +259,7 @@ func expandNetAppBucketCifsUser(input string) *buckets.CifsUser {
 
 func flattenNetAppBucketNfsUser(input *buckets.NfsUser) []netAppModels.NetAppVolumeBucketNfsUser {
 	if input == nil {
-		return nil
+		return []netAppModels.NetAppVolumeBucketNfsUser{}
 	}
 
 	return []netAppModels.NetAppVolumeBucketNfsUser{

--- a/internal/services/network/application_gateway_resource.go
+++ b/internal/services/network/application_gateway_resource.go
@@ -3219,7 +3219,7 @@ func expandApplicationGatewayGlobalConfiguration(input []interface{}) *applicati
 
 func flattenApplicationGatewayGlobalConfiguration(input *applicationgateways.ApplicationGatewayGlobalConfiguration) []interface{} {
 	if input == nil {
-		return nil
+		return []interface{}{}
 	}
 
 	output := make(map[string]interface{})

--- a/internal/services/network/express_route_port_resource.go
+++ b/internal/services/network/express_route_port_resource.go
@@ -445,7 +445,7 @@ func expandExpressRoutePortLink(idx int, input []interface{}) *expressrouteports
 
 func flattenExpressRoutePortLinks(links *[]expressrouteports.ExpressRouteLink) ([]interface{}, []interface{}, error) {
 	if links == nil {
-		return nil, nil, nil
+		return []interface{}{}, []interface{}{}, nil
 	}
 	length := len(*links)
 	if length != 2 {

--- a/internal/services/network/network_security_perimeter_access_rule_resource.go
+++ b/internal/services/network/network_security_perimeter_access_rule_resource.go
@@ -336,7 +336,7 @@ func expandAccessRuleSubscriptionIDs(subscriptionIDs []string) *[]networksecurit
 
 func flattenAccessRuleSubscriptionIDs(subscriptions *[]networksecurityperimeteraccessrules.SubscriptionId) []string {
 	if subscriptions == nil || len(*subscriptions) == 0 {
-		return nil
+		return []string{}
 	}
 
 	result := make([]string, 0, len(*subscriptions))

--- a/internal/services/network/subnet_resource.go
+++ b/internal/services/network/subnet_resource.go
@@ -965,7 +965,7 @@ func expandSubnetServiceEndpointPolicies(input []interface{}) *[]subnets.Service
 
 func flattenSubnetServiceEndpointPolicies(input *[]subnets.ServiceEndpointPolicy) []interface{} {
 	if input == nil {
-		return nil
+		return []interface{}{}
 	}
 
 	output := make([]interface{}, 0, len(*input))

--- a/internal/services/recoveryservices/backup_policy_vm_resource.go
+++ b/internal/services/recoveryservices/backup_policy_vm_resource.go
@@ -760,7 +760,7 @@ func expandBackupProtectionPolicyVMArchivedRP(input []interface{}) protectionpol
 
 func flattenBackupProtectionPolicyVMResourceGroup(rpDetail protectionpolicies.InstantRPAdditionalDetails) []interface{} {
 	if rpDetail.AzureBackupRGNamePrefix == nil {
-		return nil
+		return []interface{}{}
 	}
 
 	block := map[string]interface{}{}

--- a/internal/services/recoveryservices/backup_policy_vm_workload_resource.go
+++ b/internal/services/recoveryservices/backup_policy_vm_workload_resource.go
@@ -734,7 +734,7 @@ func expandBackupProtectionPolicyVMWorkloadSchedulePolicy(input ProtectionPolicy
 
 func flattenBackupProtectionPolicyVMWorkloadSchedulePolicy(input protectionpolicies.SchedulePolicy, policyType protectionpolicies.PolicyType) []Backup {
 	if input == nil {
-		return nil
+		return []Backup{}
 	}
 
 	backupBlock := Backup{}
@@ -884,7 +884,7 @@ func expandBackupProtectionPolicyVMWorkloadRetentionPolicy(input ProtectionPolic
 
 func flattenBackupProtectionPolicyVMWorkloadRetentionDaily(input *protectionpolicies.DailyRetentionSchedule) []RetentionDaily {
 	if input == nil {
-		return nil
+		return []RetentionDaily{}
 	}
 
 	retentionDailyBlock := RetentionDaily{}
@@ -900,7 +900,7 @@ func flattenBackupProtectionPolicyVMWorkloadRetentionDaily(input *protectionpoli
 
 func flattenBackupProtectionPolicyVMWorkloadRetentionWeekly(input *protectionpolicies.WeeklyRetentionSchedule) []RetentionWeekly {
 	if input == nil {
-		return nil
+		return []RetentionWeekly{}
 	}
 
 	retentionWeeklyBlock := RetentionWeekly{}
@@ -924,7 +924,7 @@ func flattenBackupProtectionPolicyVMWorkloadRetentionWeekly(input *protectionpol
 
 func flattenBackupProtectionPolicyVMWorkloadRetentionMonthly(input *protectionpolicies.MonthlyRetentionSchedule) []RetentionMonthly {
 	if input == nil {
-		return nil
+		return []RetentionMonthly{}
 	}
 
 	retentionMonthlyBlock := RetentionMonthly{}
@@ -952,7 +952,7 @@ func flattenBackupProtectionPolicyVMWorkloadRetentionMonthly(input *protectionpo
 
 func flattenBackupProtectionPolicyVMWorkloadRetentionYearly(input *protectionpolicies.YearlyRetentionSchedule) []RetentionYearly {
 	if input == nil {
-		return nil
+		return []RetentionYearly{}
 	}
 
 	retentionYearlyBlock := RetentionYearly{}
@@ -988,7 +988,7 @@ func flattenBackupProtectionPolicyVMWorkloadRetentionYearly(input *protectionpol
 
 func flattenBackupProtectionPolicyVMWorkloadSimpleRetention(input *protectionpolicies.RetentionDuration) []SimpleRetention {
 	if input == nil {
-		return nil
+		return []SimpleRetention{}
 	}
 
 	simpleRetentionBlock := SimpleRetention{}

--- a/internal/services/securitycenter/iot_security_solution_resource.go
+++ b/internal/services/securitycenter/iot_security_solution_resource.go
@@ -530,7 +530,7 @@ func flattenIotSecuritySolutionAdditionalWorkspace(input *[]security.AdditionalW
 
 func flattenIotSecuritySolutionDisabledDataSources(input *[]security.DataSource) []interface{} {
 	if input == nil || len(*input) == 0 {
-		return nil
+		return []interface{}{}
 	}
 
 	results := make([]string, 0)

--- a/internal/services/springcloud/spring_cloud_api_portal_resource.go
+++ b/internal/services/springcloud/spring_cloud_api_portal_resource.go
@@ -420,7 +420,7 @@ func flattenAPIPortalSsoProperties(input *appplatform.SsoProperties, old []ApiPo
 
 func flattenSpringCloudAPIPortalGatewayIds(ids *[]string) []string {
 	if ids == nil || len(*ids) == 0 {
-		return nil
+		return []string{}
 	}
 	out := make([]string, 0)
 	for _, id := range *ids {

--- a/internal/services/springcloud/spring_cloud_container_deployment_resource.go
+++ b/internal/services/springcloud/spring_cloud_container_deployment_resource.go
@@ -368,7 +368,7 @@ func expandSpringCloudDeploymentApms(input []interface{}) *[]appplatform.ApmRefe
 
 func flattenSpringCloudDeploymentApms(input *[]appplatform.ApmReference) ([]interface{}, error) {
 	if input == nil {
-		return nil, nil
+		return []interface{}{}, nil
 	}
 	result := make([]interface{}, 0)
 	for _, v := range *input {

--- a/internal/services/springcloud/spring_cloud_gateway_resource.go
+++ b/internal/services/springcloud/spring_cloud_gateway_resource.go
@@ -874,7 +874,7 @@ func flattenGatewaySsoProperties(input *appplatform.SsoProperties, old []Gateway
 
 func flattenGatewayGatewayApmTypes(input *[]appplatform.ApmType) []string {
 	if input == nil {
-		return nil
+		return []string{}
 	}
 	out := make([]string, 0)
 	for _, v := range *input {

--- a/internal/services/storage/storage_account_local_user_resource.go
+++ b/internal/services/storage/storage_account_local_user_resource.go
@@ -504,7 +504,7 @@ func (r LocalUserResource) expandPermissionScopes(input []PermissionScopeModel) 
 
 func (r LocalUserResource) flattenPermissionScopes(input *[]localuseroperationgroup.PermissionScope) []PermissionScopeModel {
 	if input == nil {
-		return nil
+		return []PermissionScopeModel{}
 	}
 
 	output := make([]PermissionScopeModel, 0, len(*input))

--- a/internal/services/storagecache/managed_lustre_file_system_resource.go
+++ b/internal/services/storagecache/managed_lustre_file_system_resource.go
@@ -567,7 +567,7 @@ func expandRootSquashSettings(input []RootSquashSetting) *amlfilesystems.AmlFile
 func flattenRootSquashSettings(input *amlfilesystems.AmlFilesystemRootSquashSettings) []RootSquashSetting {
 	result := make([]RootSquashSetting, 0)
 	if input == nil || pointer.From(input.Mode) == amlfilesystems.AmlFilesystemSquashModeNone {
-		return nil
+		return []RootSquashSetting{}
 	}
 
 	rootSquashSetting := RootSquashSetting{


### PR DESCRIPTION
## Community Note

* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

This PR addresses the `AZR008` linter rule, which flags `flatten` functions that return `nil` instead of an empty slice.

`AZR008` prefers `flatten` functions to return an empty slice (`[]interface{}{}`) rather than `nil` for empty or absent input. This is a consistency and readability convention: the two are equivalent at the state level for this provider, but standardizing on an empty slice makes the intent explicit and keeps the flatten helpers uniform across the codebase.

The change is mechanical and behavior-preserving: each affected `flatten` function now returns `[]interface{}{}` in place of `nil` for its empty/nil-input guard and default branches. No schema, CRUD logic, or resource behavior is otherwise altered.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.

## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them.
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally.

## Testing

This is a mechanical, behavior-preserving change to `flatten` functions. It builds cleanly (`go build`) and existing acceptance tests for the affected resources continue to pass, as the flattened output for populated input is unchanged and empty input now yields an empty list rather than `nil`.

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

* No changelog entry required — this is an internal linter-compliance cleanup with no user-facing behavior change.

This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change

## Related Issue(s)

N/A

## AI Assistance Disclosure

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

There are no changes to security controls (access controls, encryption, logging) in this pull request.
