### PR TITLE
`azurerm_eventgrid_namespace_topic_id_association` - add resource

### DIFF
--- a/internal/services/eventgrid/client/client.go
+++ b/internal/services/eventgrid/client/client.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2023-12-15-preview/namespaces"
 	eventgrid_v2025_02_15 "github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2025-02-15"
+	namespaces_v2025_02_15 "github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2025-02-15/namespaces"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2025-02-15/namespacetopics"
 	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/common"
@@ -16,8 +17,9 @@ import (
 type Client struct {
 	*eventgrid_v2025_02_15.Client
 
-	NamespacesClient      *namespaces.NamespacesClient
-	NamespaceTopicsClient *namespacetopics.NamespaceTopicsClient
+	NamespacesClient             *namespaces.NamespacesClient
+	NamespacesClient_v2025_02_15 *namespaces_v2025_02_15.NamespacesClient
+	NamespaceTopicsClient        *namespacetopics.NamespaceTopicsClient
 }
 
 func NewClient(o *common.ClientOptions) (*Client, error) {
@@ -26,6 +28,12 @@ func NewClient(o *common.ClientOptions) (*Client, error) {
 		return nil, fmt.Errorf("building Namespaces Client: %+v", err)
 	}
 	o.Configure(NamespacesClient.Client, o.Authorizers.ResourceManager)
+
+	NamespacesClient_v2025_02_15, err := namespaces_v2025_02_15.NewNamespacesClientWithBaseURI(o.Environment.ResourceManager)
+	if err != nil {
+		return nil, fmt.Errorf("building Namespaces v2025-02-15 Client: %+v", err)
+	}
+	o.Configure(NamespacesClient_v2025_02_15.Client, o.Authorizers.ResourceManager)
 
 	NamespaceTopicsClient, err := namespacetopics.NewNamespaceTopicsClientWithBaseURI(o.Environment.ResourceManager)
 	if err != nil {
@@ -40,8 +48,9 @@ func NewClient(o *common.ClientOptions) (*Client, error) {
 		return nil, fmt.Errorf("building EventGrid client: %+v", err)
 	}
 	return &Client{
-		NamespacesClient:      NamespacesClient,
-		NamespaceTopicsClient: NamespaceTopicsClient,
-		Client:                client,
+		NamespacesClient:             NamespacesClient,
+		NamespacesClient_v2025_02_15: NamespacesClient_v2025_02_15,
+		NamespaceTopicsClient:        NamespaceTopicsClient,
+		Client:                       client,
 	}, nil
 }

--- a/internal/services/eventgrid/eventgrid_namespace_resource.go
+++ b/internal/services/eventgrid/eventgrid_namespace_resource.go
@@ -14,7 +14,9 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2023-12-15-preview/namespaces"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2025-02-15/namespacetopics"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2025-02-15/topics"
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/preflight"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
@@ -119,8 +121,11 @@ func (r EventGridNamespaceResource) Arguments() map[string]*pluginsdk.Schema {
 		},
 
 		"topic_spaces_configuration": {
-			Type:     pluginsdk.TypeList,
-			Optional: true,
+			Type:       pluginsdk.TypeList,
+			ConfigMode: pluginsdk.SchemaConfigModeAttr,
+			Optional:   true,
+			// NOTE: O+C - `route_topic_id` property value is computed when `azurerm_eventgrid_namespace_topic_id_association` resource is created
+			Computed: true,
 			ForceNew: true,
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
@@ -148,14 +153,18 @@ func (r EventGridNamespaceResource) Arguments() map[string]*pluginsdk.Schema {
 					},
 
 					"route_topic_id": {
-						Type:         pluginsdk.TypeString,
-						Optional:     true,
-						ValidateFunc: topics.ValidateTopicID,
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						ValidateFunc: validation.Any(
+							topics.ValidateTopicID,
+							namespacetopics.ValidateNamespaceTopicID,
+						),
 					},
 
 					"dynamic_routing_enrichment": {
-						Type:     pluginsdk.TypeList,
-						Optional: true,
+						Type:       pluginsdk.TypeList,
+						ConfigMode: pluginsdk.SchemaConfigModeAttr,
+						Optional:   true,
 						Elem: &pluginsdk.Resource{
 							Schema: map[string]*pluginsdk.Schema{
 								"key": {
@@ -174,8 +183,9 @@ func (r EventGridNamespaceResource) Arguments() map[string]*pluginsdk.Schema {
 					},
 
 					"static_routing_enrichment": {
-						Type:     pluginsdk.TypeList,
-						Optional: true,
+						Type:       pluginsdk.TypeList,
+						ConfigMode: pluginsdk.SchemaConfigModeAttr,
+						Optional:   true,
 						Elem: &pluginsdk.Resource{
 							Schema: map[string]*pluginsdk.Schema{
 								"key": {
@@ -575,18 +585,27 @@ func expandStaticRoutingEnrichments(input []RoutingEnrichmentModel) *[]namespace
 func flattenTopicSpacesConfiguration(topicSpacesConfig *namespaces.TopicSpacesConfiguration) ([]TopicSpacesConfigurationModel, error) {
 	var output TopicSpacesConfigurationModel
 	if topicSpacesConfig == nil {
-		return nil, nil
+		return []TopicSpacesConfigurationModel{}, nil
 	}
 
 	output.MaximumSessionExpiryInHours = pointer.From(topicSpacesConfig.MaximumSessionExpiryInHours)
 	output.MaximumClientSessionsPerAuthenticationName = pointer.From(topicSpacesConfig.MaximumClientSessionsPerAuthenticationName)
 	var routeId string
+	var err error
 	if topicSpacesConfig.RouteTopicResourceId != nil && *topicSpacesConfig.RouteTopicResourceId != "" {
-		id, err := topics.ParseTopicID(*topicSpacesConfig.RouteTopicResourceId)
-		if err != nil {
-			return nil, err
+		topicId, topicIdErr := topics.ParseTopicID(*topicSpacesConfig.RouteTopicResourceId)
+		if topicIdErr != nil {
+			err = multierror.Append(err, topicIdErr)
+			namespaceTopicId, namespaceTopicIdErr := namespacetopics.ParseNamespaceTopicID(*topicSpacesConfig.RouteTopicResourceId)
+			if namespaceTopicIdErr != nil {
+				err = multierror.Append(err, namespaceTopicIdErr)
+				return []TopicSpacesConfigurationModel{}, err
+			}
+
+			routeId = namespaceTopicId.ID()
+		} else {
+			routeId = topicId.ID()
 		}
-		routeId = id.ID()
 	}
 	output.RouteTopicResourceId = routeId
 

--- a/internal/services/eventgrid/eventgrid_namespace_topic_id_association_resource.go
+++ b/internal/services/eventgrid/eventgrid_namespace_topic_id_association_resource.go
@@ -1,0 +1,213 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package eventgrid
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2025-02-15/namespaces"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2025-02-15/namespacetopics"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+//go:generate go run ../../tools/generator-tests resourceidentity -parent-id "eventgrid_namespace_id"
+
+type EventGridNamespaceTopicIdAssociationResource struct{}
+
+var _ sdk.ResourceWithIdentity = EventGridNamespaceTopicIdAssociationResource{}
+
+type EventGridNamespaceTopicIdAssociationModel struct {
+	EventGridNamespaceId      string `tfschema:"eventgrid_namespace_id"`
+	EventGridNamespaceTopicId string `tfschema:"eventgrid_namespace_topic_id"`
+}
+
+func (EventGridNamespaceTopicIdAssociationResource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"eventgrid_namespace_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: namespaces.ValidateNamespaceID,
+		},
+
+		"eventgrid_namespace_topic_id": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			// `ForceNew` as `eventgrid_namespace_topic_id` can only be assigned to `eventgrid_namespace_id` of same namespace and `eventgrid_namespace_topic_id` is unique for each namespace, changing `eventgrid_namespace_topic_id` means that `eventgrid_namespace_id` is changed too
+			ForceNew:     true,
+			ValidateFunc: namespacetopics.ValidateNamespaceTopicID,
+		},
+	}
+}
+
+func (EventGridNamespaceTopicIdAssociationResource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{}
+}
+
+func (EventGridNamespaceTopicIdAssociationResource) ModelObject() interface{} {
+	return &EventGridNamespaceTopicIdAssociationModel{}
+}
+
+func (EventGridNamespaceTopicIdAssociationResource) ResourceType() string {
+	return "azurerm_eventgrid_namespace_topic_id_association"
+}
+
+func (EventGridNamespaceTopicIdAssociationResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return namespaces.ValidateNamespaceID
+}
+
+func (EventGridNamespaceTopicIdAssociationResource) Identity() resourceids.ResourceId {
+	return &namespaces.NamespaceId{}
+}
+
+func (EventGridNamespaceTopicIdAssociationResource) IdentityType() pluginsdk.ResourceTypeForIdentity {
+	return pluginsdk.ResourceTypeForIdentityVirtual
+}
+
+func (EventGridNamespaceTopicIdAssociationResource) Create() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.EventGrid.NamespacesClient_v2025_02_15
+			var config EventGridNamespaceTopicIdAssociationModel
+			if err := metadata.Decode(&config); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			id, err := namespaces.ParseNamespaceID(config.EventGridNamespaceId)
+			if err != nil {
+				return err
+			}
+
+			existing, err := client.Get(ctx, *id)
+			if err != nil {
+				return fmt.Errorf("retrieving %s: %+v", *id, err)
+			}
+
+			if existing.Model == nil {
+				return fmt.Errorf("retrieving %s: `model` was nil", *id)
+			}
+			if existing.Model.Properties == nil {
+				return fmt.Errorf("retrieving %s: `properties` was nil", *id)
+			}
+
+			if existing.Model.Properties.TopicSpacesConfiguration == nil {
+				existing.Model.Properties.TopicSpacesConfiguration = &namespaces.TopicSpacesConfiguration{}
+			} else if rawRouteTopicResourceId := existing.Model.Properties.TopicSpacesConfiguration.RouteTopicResourceId; rawRouteTopicResourceId != nil && !metadata.Client.Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+				routeTopicResourceId := pointer.From(rawRouteTopicResourceId)
+				if _, err := namespacetopics.ParseNamespaceTopicID(routeTopicResourceId); err == nil {
+					return tf.ImportAsExistsAssociationError("azurerm_eventgrid_namespace_topic_id_association", config.EventGridNamespaceId, routeTopicResourceId)
+				}
+			}
+
+			existing.Model.Properties.TopicSpacesConfiguration.RouteTopicResourceId = pointer.To(config.EventGridNamespaceTopicId)
+
+			if err := client.CreateOrUpdateCallbackThenPoll(ctx, *id, *existing.Model, metadata.SetIDAndIdentityCallback(id)); err != nil {
+				return fmt.Errorf("updating Namespace Topic ID for %s: %+v", *id, err)
+			}
+
+			metadata.SetID(id)
+			return pluginsdk.SetResourceIdentityData(metadata.ResourceData, id, pluginsdk.ResourceTypeForIdentityVirtual)
+		},
+	}
+}
+
+func (EventGridNamespaceTopicIdAssociationResource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.EventGrid.NamespacesClient_v2025_02_15
+			var config EventGridNamespaceTopicIdAssociationModel
+			if err := metadata.Decode(&config); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			id, err := namespaces.ParseNamespaceID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.Get(ctx, *id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return metadata.MarkAsGone(id)
+				}
+				return fmt.Errorf("retrieving %s: %+v", id, err)
+			}
+
+			state := EventGridNamespaceTopicIdAssociationModel{}
+			topicSpacesConfigurationExisted := false
+
+			if model := resp.Model; model != nil {
+				state.EventGridNamespaceId = pointer.From(model.Id)
+
+				if props := model.Properties; props != nil {
+					if topicSpacesConfiguration := props.TopicSpacesConfiguration; topicSpacesConfiguration != nil {
+						if routeTopicResourceId := pointer.From(topicSpacesConfiguration.RouteTopicResourceId); routeTopicResourceId != "" {
+							state.EventGridNamespaceTopicId = routeTopicResourceId
+							topicSpacesConfigurationExisted = true
+						}
+					}
+				}
+			}
+
+			if !topicSpacesConfigurationExisted {
+				return metadata.MarkAsGone(id)
+			}
+
+			if err := pluginsdk.SetResourceIdentityData(metadata.ResourceData, id, pluginsdk.ResourceTypeForIdentityVirtual); err != nil {
+				return err
+			}
+
+			return metadata.Encode(&state)
+		},
+	}
+}
+
+func (EventGridNamespaceTopicIdAssociationResource) Delete() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.EventGrid.NamespacesClient_v2025_02_15
+			id, err := namespaces.ParseNamespaceID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			// If parent resource is not found or `TopicSpacesConfiguration` property cannot be accessed, assume that `RouteTopicResourceId` is already unset and continue to remove this resource from state
+			resp, err := client.Get(ctx, *id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return nil
+				}
+				return fmt.Errorf("retrieving %s: %+v", id, err)
+			}
+
+			if resp.Model == nil {
+				return nil
+			}
+			if resp.Model.Properties == nil {
+				return nil
+			}
+
+			if resp.Model.Properties.TopicSpacesConfiguration == nil {
+				return nil
+			}
+
+			resp.Model.Properties.TopicSpacesConfiguration.RouteTopicResourceId = nil
+			if err := client.CreateOrUpdateThenPoll(ctx, *id, *resp.Model); err != nil {
+				return fmt.Errorf("removing Namespace Topic ID from %s: %+v", *id, err)
+			}
+
+			return nil
+		},
+	}
+}

--- a/internal/services/eventgrid/eventgrid_namespace_topic_id_association_resource_identity_gen_test.go
+++ b/internal/services/eventgrid/eventgrid_namespace_topic_id_association_resource_identity_gen_test.go
@@ -1,0 +1,38 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package eventgrid_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
+)
+
+func TestAccEventgridNamespaceTopicIdAssociation_resourceIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_eventgrid_namespace_topic_id_association", "test")
+	r := EventgridNamespaceTopicIdAssociationResource{}
+
+	checkedFields := map[string]struct{}{
+		"namespace_name":      {},
+		"resource_group_name": {},
+		"subscription_id":     {},
+	}
+
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				customstatecheck.ExpectAllIdentityFieldsAreChecked("azurerm_eventgrid_namespace_topic_id_association.test", checkedFields),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_eventgrid_namespace_topic_id_association.test", tfjsonpath.New("namespace_name"), tfjsonpath.New("eventgrid_namespace_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_eventgrid_namespace_topic_id_association.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("eventgrid_namespace_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_eventgrid_namespace_topic_id_association.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("eventgrid_namespace_id")),
+			},
+		},
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
+}

--- a/internal/services/eventgrid/eventgrid_namespace_topic_id_association_resource_test.go
+++ b/internal/services/eventgrid/eventgrid_namespace_topic_id_association_resource_test.go
@@ -1,0 +1,119 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package eventgrid_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2025-02-15/namespaces"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type EventgridNamespaceTopicIdAssociationResource struct{}
+
+func TestAccEventgridNamespaceTopicIdAssociation_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_eventgrid_namespace_topic_id_association", "test")
+	r := EventgridNamespaceTopicIdAssociationResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccEventgridNamespaceTopicIdAssociation_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_eventgrid_namespace_topic_id_association", "test")
+	r := EventgridNamespaceTopicIdAssociationResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportAssociationErrorStep(r.requiresImport),
+	})
+}
+
+func (EventgridNamespaceTopicIdAssociationResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := namespaces.ParseNamespaceID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.EventGrid.NamespacesClient_v2025_02_15.Get(ctx, *id)
+	if err != nil {
+		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
+	}
+
+	model := resp.Model
+	if model == nil {
+		return nil, fmt.Errorf("model was nil for %s", *id)
+	}
+
+	props := model.Properties
+	if props == nil || props.TopicSpacesConfiguration == nil {
+		return nil, fmt.Errorf("properties was nil for %s", *id)
+	}
+
+	return pointer.To(props.TopicSpacesConfiguration.RouteTopicResourceId != nil), nil
+}
+
+func (r EventgridNamespaceTopicIdAssociationResource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_eventgrid_namespace_topic_id_association" test {
+  eventgrid_namespace_id       = azurerm_eventgrid_namespace.test.id
+  eventgrid_namespace_topic_id = azurerm_eventgrid_namespace_topic.test.id
+}
+`, r.template(data))
+}
+
+func (r EventgridNamespaceTopicIdAssociationResource) requiresImport(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_eventgrid_namespace_topic_id_association" import {
+  eventgrid_namespace_id       = azurerm_eventgrid_namespace_topic_id_association.test.eventgrid_namespace_id
+  eventgrid_namespace_topic_id = azurerm_eventgrid_namespace_topic_id_association.test.eventgrid_namespace_topic_id
+}
+`, r.basic(data))
+}
+
+func (r EventgridNamespaceTopicIdAssociationResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctest-evg-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_eventgrid_namespace" "test" {
+  name                = "acctest-evgns-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_eventgrid_namespace_topic" "test" {
+  name                   = "acctest-evgnst-%[1]d"
+  eventgrid_namespace_id = azurerm_eventgrid_namespace.test.id
+}
+`, data.RandomInteger, data.Locations.Primary)
+}

--- a/internal/services/eventgrid/registration.go
+++ b/internal/services/eventgrid/registration.go
@@ -43,6 +43,7 @@ func (r Registration) DataSources() []sdk.DataSource {
 func (r Registration) Resources() []sdk.Resource {
 	return []sdk.Resource{
 		EventGridNamespaceResource{},
+		EventGridNamespaceTopicIdAssociationResource{},
 		EventGridNamespaceTopicResource{},
 		EventGridPartnerConfigurationResource{},
 		EventGridPartnerNamespaceResource{},

--- a/website/docs/r/eventgrid_namespace.html.markdown
+++ b/website/docs/r/eventgrid_namespace.html.markdown
@@ -84,6 +84,8 @@ A `topic_spaces_configuration` block supports the following:
 
 * `route_topic_id` - (Optional) Specifies the Event Grid topic resource ID to route messages to.
 
+~> **Note:** `azurerm_eventgrid_namespace_topic_id_association` should not be created at the same time with `route_topic_id` being set to avoid perpetual change due to different topic ID set via the two methods.
+
 * `dynamic_routing_enrichment` - (Optional) One or more `dynamic_routing_enrichment` blocks as defined below.
 
 * `static_routing_enrichment` - (Optional) One or more `static_routing_enrichment` blocks as defined below.

--- a/website/docs/r/eventgrid_namespace_topic_id_association.html.markdown
+++ b/website/docs/r/eventgrid_namespace_topic_id_association.html.markdown
@@ -1,0 +1,74 @@
+---
+subcategory: "Messaging"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_eventgrid_namespace_topic_id_association"
+description: |-
+  Manages an Event Grid Namespace Topic ID Association.
+---
+
+# azurerm_eventgrid_namespace_topic_id_association
+
+Manages an Event Grid Namespace Topic ID Association.
+
+~> **Note:** `azurerm_eventgrid_namespace_topic_id_association` should not be created at the same time with `topic_spaces_configuration.0.route_topic_id` of `azurerm_eventgrid_namespace` resource being set to avoid perpetual change due to different topic ID set via the two methods.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example"
+  location = "southeastasia"
+}
+
+resource "azurerm_eventgrid_namespace" "example" {
+  name                = "example"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+}
+
+resource "azurerm_eventgrid_namespace_topic" "example" {
+  name                   = "example"
+  eventgrid_namespace_id = azurerm_eventgrid_namespace.example.id
+}
+
+resource "azurerm_eventgrid_namespace_topic_id_association" example {
+  eventgrid_namespace_id       = azurerm_eventgrid_namespace.example.id
+  eventgrid_namespace_topic_id = azurerm_eventgrid_namespace_topic.example.id
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `eventgrid_namespace_id` - (Required) The Event Grid Namespace ID. Changing this forces a new resource to be created.
+
+* `eventgrid_namespace_topic_id` - (Required) The ID of Event Grid Namespace Topic which is associated with the Event Grid Namespace. Changing this forces a new resource to be created.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The Event Grid Namespace ID.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/configure#define-operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Event Grid Namespace Topic ID Association.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Event Grid Namespace Topic ID Association.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Event Grid Namespace Topic ID Association.
+
+## Import
+
+Event Grid Namespace Topic ID Association can be imported using the `resource id` of Event Grid Namespace, e.g.
+
+```shell
+terraform import azurerm_eventgrid_namespace_topic_id_association.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1/providers/Microsoft.EventGrid/namespaces/namespace1
+```
+
+## API Providers
+<!-- This section is generated, changes will be overwritten -->
+This resource uses the following Azure API Providers:
+
+* `Microsoft.EventGrid` - 2025-02-15


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

There is an issue where `azurerm_eventgrid_namespace` and `azurerm_eventgrid_namespace_topic` resources refer each other's ID as shown in the example below. This causes cyclic dependency which is not allowed in Terraform.

```hcl
resource "azurerm_eventgrid_namespace" "example" {
  name                = "REDACTED"
  resource_group_name = azurerm_resource_group.example.name
  location            = azurerm_resource_group.example.location
  sku                 = "Standard"

  identity {
    type = "SystemAssigned"
  }

  topic_spaces_configuration {
    maximum_session_expiry_in_hours                 = 8
    maximum_client_sessions_per_authentication_name = 1
    route_topic_id                                  = azurerm_eventgrid_namespace_topic.example.id
  }
}

resource "azurerm_eventgrid_namespace_topic" "example" {
  name                   = "REDACTED"
  eventgrid_namespace_id = azurerm_eventgrid_namespace.example.id
}
```

To break the cycle, new `azurerm_eventgrid_namespace_topic_id_association` resource is added in this PR. Several notes regarding the resource are listed below:

* This resource is developed according to `azurerm_subnet_network_security_group_association` resource.
* `azurerm_eventgrid_namespace_topic_id_association` should not be created at the same time with `topic_spaces_configuration.0.route_topic_id` of `azurerm_eventgrid_namespace` resource being set to avoid perpetual change due to different topic ID set via the two methods.
* `Update` method is not defined as all properties have `ForceNew` behavior.
* `eventgrid_namespace_topic_id` property can only be assigned to `eventgrid_namespace_id` of same namespace and `eventgrid_namespace_topic_id` is unique for each namespace. Therefore, changing `eventgrid_namespace_topic_id` means that `eventgrid_namespace_id` which has `ForceNew` behavior is changed too. Thus, `eventgrid_namespace_topic_id` is added `ForceNew` behavior.

Apart from this, several changes are made to accommodate the new resource:

* `topic_spaces_configuration` property of `azurerm_eventgrid_namespace` resource is added `Computed` behavior to avoid difference due to change in `topic_spaces_configuration.0.route_topic_id` property when `azurerm_eventgrid_namespace_topic_id_association` is created.
* `topic_spaces_configuration` and other child properties which have nested `Schema` are added `pluginsdk.SchemaConfigModeAttr` behavior so that `Computed` behavior can be used to provide default elements when the argument is not set.
* `namespacetopics.ValidateNamespaceTopicID` validation method is added to `topic_spaces_configuration.0.route_topic_id` as the property can accept namespace topic ID too.
* In `flattenTopicSpacesConfiguration` method, namespace topic ID is parsed too.

This resource does not support listing as it is a virtual resource without its own API. This work is the continuation of #30320.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] ~(For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.~


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_eventgrid_namespace_topic_id_association` - add resource
* `azurerm_eventgrid_namespace` - perform modifications to accommodate `azurerm_eventgrid_namespace_topic_id_association`


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [x] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #33030


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
