### PR TITLE
azurerm_orchestrated_virtual_machine_scale_set: support for secure_boot_enabled and vtpm_enabled

### DIFF
--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
@@ -179,6 +179,18 @@ func resourceOrchestratedVirtualMachineScaleSet() *pluginsdk.Resource {
 				Optional: true,
 			},
 
+			"secure_boot_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"vtpm_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				ForceNew: true,
+			},
+
 			"eviction_policy": {
 				// only applicable when `priority` is set to `Spot`
 				Type:     pluginsdk.TypeString,
@@ -784,9 +796,33 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 	}
 
 	if v, ok := d.GetOk("encryption_at_host_enabled"); ok {
-		virtualMachineProfile.SecurityProfile = &virtualmachinescalesets.SecurityProfile{
-			EncryptionAtHost: pointer.To(v.(bool)),
+		if virtualMachineProfile.SecurityProfile == nil {
+			virtualMachineProfile.SecurityProfile = &virtualmachinescalesets.SecurityProfile{}
 		}
+		virtualMachineProfile.SecurityProfile.EncryptionAtHost = pointer.To(v.(bool))
+	}
+
+	secureBootEnabled := d.Get("secure_boot_enabled").(bool)
+	vtpmEnabled := d.Get("vtpm_enabled").(bool)
+	if secureBootEnabled {
+		if virtualMachineProfile.SecurityProfile == nil {
+			virtualMachineProfile.SecurityProfile = &virtualmachinescalesets.SecurityProfile{}
+		}
+		if virtualMachineProfile.SecurityProfile.UefiSettings == nil {
+			virtualMachineProfile.SecurityProfile.UefiSettings = &virtualmachinescalesets.UefiSettings{}
+		}
+		virtualMachineProfile.SecurityProfile.SecurityType = pointer.To(virtualmachinescalesets.SecurityTypesTrustedLaunch)
+		virtualMachineProfile.SecurityProfile.UefiSettings.SecureBootEnabled = pointer.To(secureBootEnabled)
+	}
+	if vtpmEnabled {
+		if virtualMachineProfile.SecurityProfile == nil {
+			virtualMachineProfile.SecurityProfile = &virtualmachinescalesets.SecurityProfile{}
+		}
+		if virtualMachineProfile.SecurityProfile.UefiSettings == nil {
+			virtualMachineProfile.SecurityProfile.UefiSettings = &virtualmachinescalesets.UefiSettings{}
+		}
+		virtualMachineProfile.SecurityProfile.SecurityType = pointer.To(virtualmachinescalesets.SecurityTypesTrustedLaunch)
+		virtualMachineProfile.SecurityProfile.UefiSettings.VTpmEnabled = pointer.To(vtpmEnabled)
 	}
 
 	if v, ok := d.GetOk("eviction_policy"); ok {
@@ -1531,10 +1567,24 @@ func resourceOrchestratedVirtualMachineScaleSetRead(d *pluginsdk.ResourceData, m
 				d.Set("extensions_time_budget", extensionsTimeBudget)
 
 				encryptionAtHostEnabled := false
-				if profile.SecurityProfile != nil && profile.SecurityProfile.EncryptionAtHost != nil {
-					encryptionAtHostEnabled = *profile.SecurityProfile.EncryptionAtHost
+				secureBootEnabled := false
+				vtpmEnabled := false
+				if secProfile := profile.SecurityProfile; secProfile != nil {
+					if secProfile.EncryptionAtHost != nil {
+						encryptionAtHostEnabled = *secProfile.EncryptionAtHost
+					}
+					if uefi := secProfile.UefiSettings; uefi != nil {
+						if uefi.SecureBootEnabled != nil {
+							secureBootEnabled = *uefi.SecureBootEnabled
+						}
+						if uefi.VTpmEnabled != nil {
+							vtpmEnabled = *uefi.VTpmEnabled
+						}
+					}
 				}
 				d.Set("encryption_at_host_enabled", encryptionAtHostEnabled)
+				d.Set("secure_boot_enabled", secureBootEnabled)
+				d.Set("vtpm_enabled", vtpmEnabled)
 				d.Set("user_data_base64", profile.UserData)
 
 				if policy := props.UpgradePolicy; policy != nil {

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_other_test.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_other_test.go
@@ -2410,3 +2410,157 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "test" {
 }
 `, data.RandomInteger, data.Locations.Primary, r.natgateway_template(data), data.RandomString, vmSku)
 }
+
+func TestAccOrchestratedVirtualMachineScaleSet_otherSecureBootEnabled(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_orchestrated_virtual_machine_scale_set", "test")
+	r := OrchestratedVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.otherSecureBootEnabled(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("os_profile.0.linux_configuration.0.admin_password"),
+	})
+}
+
+func TestAccOrchestratedVirtualMachineScaleSet_otherVTpmEnabled(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_orchestrated_virtual_machine_scale_set", "test")
+	r := OrchestratedVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.otherVTpmEnabled(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("os_profile.0.linux_configuration.0.admin_password"),
+	})
+}
+
+func (OrchestratedVirtualMachineScaleSetResource) otherSecureBootEnabled(data acceptance.TestData) string {
+	r := OrchestratedVirtualMachineScaleSetResource{}
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-OVMSS-%[1]d"
+  location = "%[2]s"
+}
+
+%[3]s
+
+resource "azurerm_orchestrated_virtual_machine_scale_set" "test" {
+  name                = "acctestOVMSS-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  sku_name  = "Standard_B1ls"
+  instances = 1
+
+  platform_fault_domain_count = 2
+
+  os_profile {
+    linux_configuration {
+      computer_name_prefix = "testvm-%[1]d"
+      admin_username       = "myadmin"
+      admin_password       = "Passwword1234"
+
+      disable_password_authentication = false
+    }
+  }
+
+  network_interface {
+    name    = "TestNetworkProfile-%[1]d"
+    primary = true
+
+    ip_configuration {
+      name      = "TestIPConfiguration"
+      primary   = true
+      subnet_id = azurerm_subnet.test.id
+    }
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "0001-com-ubuntu-server-jammy"
+    sku       = "22_04-lts-gen2"
+    version   = "latest"
+  }
+
+  secure_boot_enabled = true
+}
+`, data.RandomInteger, data.Locations.Primary, r.natgateway_template(data))
+}
+
+func (OrchestratedVirtualMachineScaleSetResource) otherVTpmEnabled(data acceptance.TestData) string {
+	r := OrchestratedVirtualMachineScaleSetResource{}
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-OVMSS-%[1]d"
+  location = "%[2]s"
+}
+
+%[3]s
+
+resource "azurerm_orchestrated_virtual_machine_scale_set" "test" {
+  name                = "acctestOVMSS-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  sku_name  = "Standard_B1ls"
+  instances = 1
+
+  platform_fault_domain_count = 2
+
+  os_profile {
+    linux_configuration {
+      computer_name_prefix = "testvm-%[1]d"
+      admin_username       = "myadmin"
+      admin_password       = "Passwword1234"
+
+      disable_password_authentication = false
+    }
+  }
+
+  network_interface {
+    name    = "TestNetworkProfile-%[1]d"
+    primary = true
+
+    ip_configuration {
+      name      = "TestIPConfiguration"
+      primary   = true
+      subnet_id = azurerm_subnet.test.id
+    }
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "0001-com-ubuntu-server-jammy"
+    sku       = "22_04-lts-gen2"
+    version   = "latest"
+  }
+
+  vtpm_enabled = true
+}
+`, data.RandomInteger, data.Locations.Primary, r.natgateway_template(data))
+}

--- a/website/docs/r/orchestrated_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/orchestrated_virtual_machine_scale_set.html.markdown
@@ -108,6 +108,8 @@ The following arguments are supported:
 
 ~> **Note:** `rolling_upgrade_policy` is required when `upgrade_mode` is set to `Rolling`, cannot be specified when `upgrade_mode` is set to `Manual`, and requires a valid application health extension when `upgrade_mode` is set to `Rolling`.
 
+* `secure_boot_enabled` - (Optional) Specifies whether secure boot should be enabled on the Virtual Machine Scale Set. Changing this forces a new resource to be created.
+
 * `single_placement_group` - (Optional) Should this Virtual Machine Scale Set be limited to a Single Placement Group, which means the number of instances will be capped at 100 Virtual Machines. Possible values are `true` or `false`.
 
 -> **Note:** `single_placement_group` behaves differently for Flexible orchestration Virtual Machine Scale Sets than it does for Uniform orchestration Virtual Machine Scale Sets. It is recommended that you do not define the `single_placement_group` field in your configuration file as the service will determine what this value should be based off of the value contained within the `sku_name` field of your configuration file. You may set the `single_placement_group` field to `true`, however once you set it to `false` you will not be able to revert it back to `true`.
@@ -137,6 +139,8 @@ The following arguments are supported:
 * `zone_balance` - (Optional) Should the Virtual Machines in this Scale Set be strictly evenly distributed across Availability Zones? Defaults to `false`. Changing this forces a new resource to be created.
 
 ~> **Note:** This can only be set to `true` when one or more `zones` are configured.
+
+* `vtpm_enabled` - (Optional) Specifies whether vTPM should be enabled on the Virtual Machine Scale Set. Changing this forces a new resource to be created.
 
 * `zones` - (Optional) Specifies a list of Availability Zones across which the Virtual Machine Scale Set will create instances.
 


### PR DESCRIPTION
## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This PR adds Trusted Launch support to the `azurerm_orchestrated_virtual_machine_scale_set` resource by introducing the `secure_boot_enabled` and `vtpm_enabled` properties.

The orchestrated (ie Flexible) VMSS resource previously had no way to configure Trusted Launch, even though:

* The underlying `Microsoft.Compute/virtualMachineScaleSets` API supports Trusted Launch for Flexible orchestration scale sets (`securityProfile.securityType = "TrustedLaunch"` with `uefiSettings`), and
* The sibling `azurerm_linux_virtual_machine_scale_set` / `azurerm_windows_virtual_machine_scale_set` and the `azurerm_linux_virtual_machine` / `azurerm_windows_virtual_machine` resources already expose `secure_boot_enabled` and `vtpm_enabled`.

As a result, a Shared Image Gallery image published with a `TrustedLaunch` security type could not be consumed by this resource: Creating a scale set from such an image fails with `The provided gallery image only supports creation of VMs and VM Scale Sets with 'TrustedLaunch' security type.`

This change wires the two new properties through to the virtual machine profile's `securityProfile.uefiSettings`, setting `securityType` to `TrustedLaunch` when either property is set. The implementation mirrors the existing behaviour in `azurerm_linux_virtual_machine_scale_set` (including the `SecurityProfile` nil-guard so it composes with `encryption_at_host_enabled`). Both properties are `Optional` + `ForceNew`, consistent with the other compute resources.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.

> Testing note: I was not able to run the acceptance tests end-to-end against a live Azure subscription in my environment, so I cannot yet confirm a green acceptance run. The tests are included and compile/skip locally. Please run the acceptance suite as part of review, or let me know and I can provide a run once I have subscription access.


## Testing

New acceptance tests were added mirroring the equivalent `azurerm_linux_virtual_machine_scale_set` tests:

* `TestAccOrchestratedVirtualMachineScaleSet_otherSecureBootEnabled`
* `TestAccOrchestratedVirtualMachineScaleSet_otherVTpmEnabled`

The package builds cleanly and `gofmt`/`go vet` pass. The compute package unit tests pass, and both new acceptance tests compile and are recognised (they `SKIP` without `TF_ACC`).

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

> Testing note: I was not able to run the acceptance tests end-to-end against a live Azure subscription in my environment, so I cannot yet confirm a green acceptance run. The tests are included and compile/skip locally. Please run the acceptance suite as part of review, or let me know and I can provide a run once I have subscription access.


## Change Log

* `azurerm_orchestrated_virtual_machine_scale_set` - support for the `secure_boot_enabled` and `vtpm_enabled` properties [GH-00000]


This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/31410 and https://github.com/hashicorp/terraform-provider-azurerm/issues/19339

_Expands_ https://github.com/hashicorp/terraform-provider-azurerm/issues/25808 (though that already needs to expand to cover `azurerm_linux_virtual_machine_scale_set` and `azurerm_windows_virtual_machine_scale_set` anyway)


## AI Assistance Disclosure

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

The implementation, documentation, acceptance tests, and this pull request description were produced with the assistance of an AI coding agent, reviewed and directed by the author. The approach mirrors the existing `secure_boot_enabled` / `vtpm_enabled` handling in the sibling VM and Uniform VMSS resources.


## Changes to Security Controls

This change lets users opt in to Azure Trusted Launch (Secure Boot and vTPM) on the orchestrated VMSS resource. It only adds the ability to configure these guest-security features; it does not alter any provider access controls, encryption, or logging behaviour, and the properties default to disabled/unset.
