### PR TITLE
`azurerm_storage_account` - add support for `public_network_access` and the `SecuredByPerimeter` value

### DIFF
--- a/internal/services/storage/storage_account_data_source.go
+++ b/internal/services/storage/storage_account_data_source.go
@@ -102,6 +102,11 @@ func dataSourceStorageAccount() *pluginsdk.Resource {
 				Computed: true,
 			},
 
+			"public_network_access": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
 			"primary_location": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
@@ -610,6 +615,7 @@ func dataSourceStorageAccountRead(d *pluginsdk.ResourceData, meta interface{}) e
 			d.Set("nfsv3_enabled", pointer.From(props.IsNfsV3Enabled))
 			d.Set("primary_location", location.NormalizeNilable(props.PrimaryLocation))
 			d.Set("secondary_location", location.NormalizeNilable(props.SecondaryLocation))
+			d.Set("public_network_access", pointer.FromEnum(props.PublicNetworkAccess))
 
 			// Setting the encryption key type to "Service" in PUT. The following GET will not return the queue/table in the service list of its response.
 			// So defaults to setting the encryption key type to "Service" if it is absent in the GET response. Also, define the default value as "Service" in the schema.

--- a/internal/services/storage/storage_account_data_source_test.go
+++ b/internal/services/storage/storage_account_data_source_test.go
@@ -27,6 +27,7 @@ func TestAccDataSourceStorageAccount_basic(t *testing.T) {
 				check.That(data.ResourceName).Key("account_replication_type").HasValue("LRS"),
 				check.That(data.ResourceName).Key("tags.%").HasValue("1"),
 				check.That(data.ResourceName).Key("tags.environment").HasValue("production"),
+				check.That(data.ResourceName).Key("public_network_access").HasValue("Enabled"),
 			),
 		},
 	})

--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -29,6 +29,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	keyVaultsClient "github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/client"
@@ -70,7 +71,7 @@ var (
 )
 
 func resourceStorageAccount() *pluginsdk.Resource {
-	return &pluginsdk.Resource{
+	r := &pluginsdk.Resource{
 		Create: resourceStorageAccountCreate,
 		Read:   resourceStorageAccountRead,
 		Update: resourceStorageAccountUpdate,
@@ -354,10 +355,11 @@ func resourceStorageAccount() *pluginsdk.Resource {
 				Default:  true,
 			},
 
-			"public_network_access_enabled": {
-				Type:     pluginsdk.TypeBool,
-				Optional: true,
-				Default:  true,
+			"public_network_access": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				Default:      string(storageaccounts.PublicNetworkAccessEnabled),
+				ValidateFunc: validation.StringInSlice(storageaccounts.PossibleValuesForPublicNetworkAccess(), false),
 			},
 
 			"dns_endpoint_type": {
@@ -1207,8 +1209,46 @@ func resourceStorageAccount() *pluginsdk.Resource {
 				}
 				return false
 			}),
+			pluginsdk.CustomizeDiffShim(func(ctx context.Context, d *pluginsdk.ResourceDiff, v interface{}) error {
+				if !features.SixPointOh() {
+					// If both are `null`/unset, set diff to return default of `true` / `Enabled`
+					// to ensure removal functions while O+C in 5.x
+					if rawConfig := d.GetRawConfig().AsValueMap(); rawConfig["public_network_access"].IsNull() && rawConfig["public_network_access_enabled"].IsNull() {
+						if err := d.SetNew("public_network_access", string(storageaccounts.PublicNetworkAccessEnabled)); err != nil {
+							return err
+						}
+						if err := d.SetNew("public_network_access_enabled", true); err != nil {
+							return err
+						}
+					}
+				}
+
+				return nil
+			}),
 		),
 	}
+
+	if !features.SixPointOh() {
+		r.Schema["public_network_access_enabled"] = &pluginsdk.Schema{
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			// Note: O+C because in 5.x this value may be affected by `public_network_access`
+			Computed:      true,
+			ConflictsWith: []string{"public_network_access"},
+			Deprecated:    "`public_network_access_enabled` has been deprecated in favour of `public_network_access` and will be removed in v6.0 of the AzureRM provider",
+		}
+
+		r.Schema["public_network_access"] = &pluginsdk.Schema{
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			// Note: O+C because in 5.x this value may be affected by `public_network_access_enabled`
+			Computed:      true,
+			ConflictsWith: []string{"public_network_access_enabled"},
+			ValidateFunc:  validation.StringInSlice(storageaccounts.PossibleValuesForPublicNetworkAccess(), false),
+		}
+	}
+
+	return r
 }
 
 func resourceStorageAccountCreate(d *pluginsdk.ResourceData, meta interface{}) error {
@@ -1242,10 +1282,18 @@ func resourceStorageAccountCreate(d *pluginsdk.ResourceData, meta interface{}) e
 	provisionedBillingModelVersion := d.Get("provisioned_billing_model_version").(string)
 	replicationType := d.Get("account_replication_type").(string)
 
-	publicNetworkAccess := storageaccounts.PublicNetworkAccessDisabled
-	if d.Get("public_network_access_enabled").(bool) {
-		publicNetworkAccess = storageaccounts.PublicNetworkAccessEnabled
+	publicNetworkAccess := storageaccounts.PublicNetworkAccessEnabled
+	if !pluginsdk.IsExplicitlyNullInConfig(d, "public_network_access") {
+		// (features.SixPointOh) In 6.0, the only line needed is the below, it can be inlined in the payload instantiation
+		publicNetworkAccess = storageaccounts.PublicNetworkAccess(d.Get("public_network_access").(string))
 	}
+
+	if !features.SixPointOh() {
+		if !pluginsdk.IsExplicitlyNullInConfig(d, "public_network_access_enabled") && !d.Get("public_network_access_enabled").(bool) {
+			publicNetworkAccess = storageaccounts.PublicNetworkAccessDisabled
+		}
+	}
+
 	expandedIdentity, err := identity.ExpandLegacySystemAndUserAssignedMap(d.Get("identity").([]interface{}))
 	if err != nil {
 		return fmt.Errorf("expanding `identity`: %+v", err)
@@ -1648,13 +1696,21 @@ func resourceStorageAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 	if d.HasChange("network_rules") {
 		props.NetworkAcls = expandAccountNetworkRules(d.Get("network_rules").([]interface{}), tenantId)
 	}
-	if d.HasChange("public_network_access_enabled") {
-		publicNetworkAccess := storageaccounts.PublicNetworkAccessDisabled
-		if d.Get("public_network_access_enabled").(bool) {
-			publicNetworkAccess = storageaccounts.PublicNetworkAccessEnabled
-		}
-		props.PublicNetworkAccess = pointer.To(publicNetworkAccess)
+
+	if d.HasChange("public_network_access") {
+		props.PublicNetworkAccess = pointer.ToEnum[storageaccounts.PublicNetworkAccess](d.Get("public_network_access").(string))
 	}
+
+	if !features.SixPointOh() {
+		if d.HasChange("public_network_access_enabled") {
+			publicNetworkAccess := storageaccounts.PublicNetworkAccessDisabled
+			if d.Get("public_network_access_enabled").(bool) {
+				publicNetworkAccess = storageaccounts.PublicNetworkAccessEnabled
+			}
+			props.PublicNetworkAccess = pointer.To(publicNetworkAccess)
+		}
+	}
+
 	if d.HasChange("routing") {
 		props.RoutingPreference = expandAccountRoutingPreference(d.Get("routing").([]interface{}))
 	}
@@ -1973,11 +2029,14 @@ func resourceStorageAccountFlatten(ctx context.Context, d *pluginsdk.ResourceDat
 		}
 		d.Set("min_tls_version", minTlsVersion)
 
-		publicNetworkAccessEnabled := true
-		if props.PublicNetworkAccess != nil && *props.PublicNetworkAccess == storageaccounts.PublicNetworkAccessDisabled {
-			publicNetworkAccessEnabled = false
+		if !features.SixPointOh() {
+			publicNetworkAccessEnabled := true
+			if props.PublicNetworkAccess != nil && *props.PublicNetworkAccess != storageaccounts.PublicNetworkAccessEnabled {
+				publicNetworkAccessEnabled = false
+			}
+			d.Set("public_network_access_enabled", publicNetworkAccessEnabled)
 		}
-		d.Set("public_network_access_enabled", publicNetworkAccessEnabled)
+		d.Set("public_network_access", pointer.FromEnum(props.PublicNetworkAccess))
 
 		allowSharedKeyAccess := true
 		if props.AllowSharedKeyAccess != nil {

--- a/internal/services/storage/storage_account_resource_test.go
+++ b/internal/services/storage/storage_account_resource_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
@@ -53,6 +54,20 @@ func TestAccStorageAccount_basic(t *testing.T) {
 		},
 		data.ImportStep(),
 	})
+}
+
+func TestAccStorageAccount_regression(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_account", "test")
+	r := StorageAccountResource{}
+
+	data.ResourceRegressionTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+	}, "")
 }
 
 func TestAccStorageAccount_requiresImport(t *testing.T) {
@@ -493,16 +508,117 @@ func TestAccStorageAccount_publicNetworkAccess(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.publicNetworkAccess(data, true),
+			Config: r.publicNetworkAccess(data, ""),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				// (features.SixPointOh) this check can be removed from each step in 6.0, only required in 5.0 as it's optional+computed argument
+				check.That(data.ResourceName).Key("public_network_access").HasValue("Enabled"),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config: r.publicNetworkAccess(data, false),
+			Config: r.publicNetworkAccess(data, "Disabled"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("public_network_access").HasValue("Disabled"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.publicNetworkAccess(data, "SecuredByPerimeter"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("public_network_access").HasValue("SecuredByPerimeter"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.publicNetworkAccess(data, ""),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("public_network_access").HasValue("Enabled"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccStorageAccount_publicNetworkAccessEnabledDeprecated(t *testing.T) {
+	if features.SixPointOh() {
+		t.Skip("This test is no longer valid in 6.0")
+	}
+
+	data := acceptance.BuildTestData(t, "azurerm_storage_account", "test")
+	r := StorageAccountResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.publicNetworkAccessEnabled(data, true, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("public_network_access_enabled").HasValue("true"),
+				check.That(data.ResourceName).Key("public_network_access").HasValue("Enabled"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.publicNetworkAccessEnabled(data, false, false),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("public_network_access_enabled").HasValue("false"),
+				check.That(data.ResourceName).Key("public_network_access").HasValue("Disabled"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.publicNetworkAccessEnabled(data, true, false),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("public_network_access_enabled").HasValue("true"),
+				check.That(data.ResourceName).Key("public_network_access").HasValue("Enabled"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.publicNetworkAccess(data, "Enabled"),
+			ConfigPlanChecks: resource.ConfigPlanChecks{
+				PreApply: []plancheck.PlanCheck{
+					// Switching from deprecated to new argument should not trigger any action
+					plancheck.ExpectResourceAction(data.ResourceName, plancheck.ResourceActionNoop),
+				},
+			},
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("public_network_access_enabled").HasValue("true"),
+				check.That(data.ResourceName).Key("public_network_access").HasValue("Enabled"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.publicNetworkAccess(data, "Disabled"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("public_network_access_enabled").HasValue("false"),
+				check.That(data.ResourceName).Key("public_network_access").HasValue("Disabled"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.publicNetworkAccess(data, "SecuredByPerimeter"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("public_network_access_enabled").HasValue("false"),
+				check.That(data.ResourceName).Key("public_network_access").HasValue("SecuredByPerimeter"),
+			),
+		},
+		data.ImportStep(),
+		{
+			// Omitting the argument should reset to the default of true/Enabled
+			Config: r.publicNetworkAccess(data, ""),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("public_network_access_enabled").HasValue("true"),
+				check.That(data.ResourceName).Key("public_network_access").HasValue("Enabled"),
 			),
 		},
 		data.ImportStep(),
@@ -1839,7 +1955,12 @@ resource "azurerm_storage_account" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }
 
-func (r StorageAccountResource) publicNetworkAccess(data acceptance.TestData, enabled bool) string {
+func (r StorageAccountResource) publicNetworkAccess(data acceptance.TestData, v string) string {
+	pna := fmt.Sprintf("public_network_access = %q", v)
+	if v == "" {
+		pna = ""
+	}
+
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -1854,12 +1975,40 @@ resource "azurerm_storage_account" "test" {
   name                = "unlikely23exst2acct%s"
   resource_group_name = azurerm_resource_group.test.name
 
-  location                      = azurerm_resource_group.test.location
-  account_tier                  = "Standard"
-  account_replication_type      = "LRS"
-  public_network_access_enabled = %t
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+  %s
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, enabled)
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, pna)
+}
+
+func (r StorageAccountResource) publicNetworkAccessEnabled(data acceptance.TestData, enabled, omitArgument bool) string {
+	pna := fmt.Sprintf("public_network_access_enabled = %t", enabled)
+	if omitArgument {
+		pna = ""
+	}
+
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-storage-%d"
+  location = "%s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                = "unlikely23exst2acct%s"
+  resource_group_name = azurerm_resource_group.test.name
+
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+  %s
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, pna)
 }
 
 func (r StorageAccountResource) noCrossTenantReplication(data acceptance.TestData) string {

--- a/website/docs/6.0-upgrade-guide.html.markdown
+++ b/website/docs/6.0-upgrade-guide.html.markdown
@@ -90,6 +90,10 @@ Please follow the format in the example below for listing breaking changes in re
 
 * The deprecated `key_vault_id` property has been removed.
 
+### `azurerm_storage_account`
+
+* The deprecated `public_network_access_enabled` property has been removed.
+
 ## Breaking Changes in Data Sources
 
 Please follow the format in the example below for listing breaking changes in data sources:

--- a/website/docs/d/storage_account.html.markdown
+++ b/website/docs/d/storage_account.html.markdown
@@ -27,6 +27,7 @@ output "storage_account_tier" {
 ## Arguments Reference
 
 * `name` - Specifies the name of the Storage Account
+
 * `resource_group_name` - Specifies the name of the resource group the Storage Account is located in.
 
 ## Attributes Reference
@@ -62,6 +63,8 @@ output "storage_account_tier" {
 * `tags` - A mapping of tags to assigned to the resource.
 
 * `primary_location` - The primary location of the Storage Account.
+
+* `public_network_access` - The public network access setting of the Storage Account.
 
 * `secondary_location` - The secondary location of the Storage Account.
 

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -128,7 +128,7 @@ The following arguments are supported:
 
 ~> **Note:** Terraform uses Shared Key Authorisation to provision Storage Containers, Blobs and other items - when Shared Key Access is disabled, you will need to enable [the `storage_use_azuread` flag in the Provider block](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs#storage_use_azuread) to use Azure AD for authentication, however not all Azure Storage services support Active Directory authentication.
 
-* `public_network_access_enabled` - (Optional) Whether the public network access is enabled? Defaults to `true`.
+* `public_network_access` - (Optional) The public network access setting. Possible values are `Disabled`, `Enabled`, and `SecuredByPerimeter`. Defaults to `Enabled`.
 
 * `default_to_oauth_authentication` - (Optional) Default to Azure Active Directory authorization in the Azure portal when accessing the Storage Account. The default value is `false`
 


### PR DESCRIPTION

<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

### azurerm_storage_account

- Adds support for the `public_network_access` argument
- Deprecates `public_network_access_enabled` in favour of `public_network_access`

### Data Source: azurerm_storage_account

- Adds support for the `public_network_access` attribute


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #33287


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
