### PR TITLE
CI: bump TeamCity DSL to 2026.3-dsl3 & Java to 21 to fix `teamcity-test`

### DIFF
--- a/.github/workflows/main-checks.yaml
+++ b/.github/workflows/main-checks.yaml
@@ -169,7 +169,7 @@ jobs:
       - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
           distribution: zulu
-          java-version: 17
+          java-version: 21
           java-package: jdk
       - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:

--- a/.github/workflows/teamcity-test.yaml
+++ b/.github/workflows/teamcity-test.yaml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
           distribution: zulu
-          java-version: 17
+          java-version: 21
           java-package: jdk
       - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:

--- a/.teamcity/pom.xml
+++ b/.teamcity/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <kotlin.version>2.0.21</kotlin.version>
-    <teamcity.dsl.version>2025.11.3-1</teamcity.dsl.version>
+    <teamcity.dsl.version>2026.3-dsl3</teamcity.dsl.version>
   </properties>
 
   <parent>


### PR DESCRIPTION
hashicorp.teamcity.com was upgraded to 2026.3; its regenerated `1.0-SNAPSHOT` DSL plugin jars (refetched every run via `mvn -U`) are now binary-incompatible with the pinned `2025.11.3-1` core, so every `teamcity-test` run fails with `NoSuchMethodError` in `ScriptBuildStep.<init>`.

- bump `teamcity.dsl.version` → `2026.3-dsl3` (`-dsl4` lacks a published `server-api`)
- bump setup-java 17 → 21 in both workflows (new maven plugin requires Java ≥ 21)

Verified locally and CI is green. Note: the `.teamcity/tests/` suite silently runs 0 tests in CI (surefire bound to `process-sources`, before test-compile) and has 6 real failures when actually run — pre-existing, follow-up material.