### PR TITLE
`azurerm_private_endpoint` - lock on private service connection resource ids

### DIFF
--- a/internal/services/cognitive/cognitive_account_resource_test.go
+++ b/internal/services/cognitive/cognitive_account_resource_test.go
@@ -597,6 +597,21 @@ func TestAccCognitiveAccount_upgradeOpenAIToAIServicesAndRollback(t *testing.T) 
 	})
 }
 
+func TestAccCognitiveAccount_privateEndpoint(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cognitive_account", "test")
+	r := CognitiveAccountResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.privateEndpoint(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (t CognitiveAccountResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := cognitiveservicesaccounts.ParseAccountID(state.ID)
 	if err != nil {
@@ -1821,6 +1836,100 @@ resource "azurerm_cognitive_account" "test" {
   project_management_enabled = true
   identity {
     type = "SystemAssigned"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (CognitiveAccountResource) privateEndpoint(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_subscription" "current" {}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-cognitive-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvnet-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  address_space       = ["10.5.0.0/16"]
+}
+
+resource "azurerm_subnet" "endpoint" {
+  name                 = "acctestsnetendpoint-%[1]d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.5.2.0/24"]
+
+  private_endpoint_network_policies = "Disabled"
+}
+
+resource "azurerm_cognitive_account" "test" {
+  name                = "acctestcogacc-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  kind                = "AIServices"
+  sku_name            = "S0"
+
+  project_management_enabled         = true
+  custom_subdomain_name              = "testing-%[1]d"
+  public_network_access_enabled      = false
+  local_auth_enabled                 = false
+  outbound_network_access_restricted = true
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  network_acls {
+    default_action = "Deny"
+    bypass         = "None"
+  }
+}
+
+resource "azurerm_private_endpoint" "test" {
+  name                = "acctest-privatelink-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  subnet_id           = azurerm_subnet.endpoint.id
+
+  private_service_connection {
+    name                           = azurerm_cognitive_account.test.name
+    is_manual_connection           = false
+    private_connection_resource_id = azurerm_cognitive_account.test.id
+    subresource_names              = ["account"]
+  }
+}
+
+resource "azurerm_cognitive_account_project" "test" {
+  name                 = "acctest-%[1]d"
+  cognitive_account_id = azurerm_cognitive_account.test.id
+  location             = azurerm_resource_group.test.location
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+resource "azurerm_cognitive_deployment" "test" {
+  name                   = "acctest-cd-%[1]d"
+  cognitive_account_id   = azurerm_cognitive_account.test.id
+  version_upgrade_option = "OnceCurrentVersionExpired"
+
+  sku {
+    name     = "GlobalStandard"
+    capacity = 1
+  }
+
+  model {
+    format  = "OpenAI"
+    name    = "gpt-4.1"
+    version = "2025-04-14"
   }
 }
 `, data.RandomInteger, data.Locations.Primary)

--- a/internal/services/network/private_endpoint_resource.go
+++ b/internal/services/network/private_endpoint_resource.go
@@ -342,12 +342,20 @@ func resourcePrivateEndpointCreate(d *pluginsdk.ResourceData, meta interface{}) 
 
 	privateDnsZoneGroup := d.Get("private_dns_zone_group").([]interface{})
 
+	// Certain child resources like those for cognitive account lock the parent resource to make sure we don't try and update the parent when it's not ready.
+	// Due to that, we'll lock on that resource id to try and prevent those type of errors.
+	privateLinkServiceConnections, privateLinkServiceConnectionIds := expandPrivateLinkEndpointServiceConnection(d.Get("private_service_connection").([]interface{}), false)
+	manualPrivateLinkServiceConnections, manualPrivateLinkServiceConnectionIds := expandPrivateLinkEndpointServiceConnection(d.Get("private_service_connection").([]interface{}), true)
+	privateLinkServiceConnectionIds = append(privateLinkServiceConnectionIds, manualPrivateLinkServiceConnectionIds...)
+	locks.MultipleByID(pointer.To(privateLinkServiceConnectionIds))
+	defer locks.UnlockMultipleByID(pointer.To(privateLinkServiceConnectionIds))
+
 	parameters := privateendpoints.PrivateEndpoint{
 		Location:         pointer.To(location.Normalize(d.Get("location").(string))),
 		ExtendedLocation: expandEdgeZoneModel(d.Get("edge_zone").(string)),
 		Properties: &privateendpoints.PrivateEndpointProperties{
-			PrivateLinkServiceConnections:       expandPrivateLinkEndpointServiceConnection(d.Get("private_service_connection").([]interface{}), false),
-			ManualPrivateLinkServiceConnections: expandPrivateLinkEndpointServiceConnection(d.Get("private_service_connection").([]interface{}), true),
+			PrivateLinkServiceConnections:       privateLinkServiceConnections,
+			ManualPrivateLinkServiceConnections: manualPrivateLinkServiceConnections,
 			Subnet: &privateendpoints.Subnet{
 				Id: pointer.To(d.Get("subnet_id").(string)),
 			},
@@ -519,14 +527,22 @@ func resourcePrivateEndpointUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 	subnetId := d.Get("subnet_id").(string)
 	customNicName := d.Get("custom_network_interface_name").(string)
 
+	// Certain child resources like those for cognitive account lock the parent resource to make sure we don't try and update the parent when it's not ready.
+	// Due to that, we'll lock on that resource id to try and prevent those type of errors.
+	privateLinkServiceConnections, privateLinkServiceConnectionIds := expandPrivateLinkEndpointServiceConnection(privateServiceConnections, false)
+	manualPrivateLinkServiceConnections, manualPrivateLinkServiceConnectionIds := expandPrivateLinkEndpointServiceConnection(privateServiceConnections, true)
+	privateLinkServiceConnectionIds = append(privateLinkServiceConnectionIds, manualPrivateLinkServiceConnectionIds...)
+	locks.MultipleByID(pointer.To(privateLinkServiceConnectionIds))
+	defer locks.UnlockMultipleByID(pointer.To(privateLinkServiceConnectionIds))
+
 	// TODO: in future it'd be nice to support conditional updates here, but one problem at a time
 	parameters := privateendpoints.PrivateEndpoint{
 		Location:         pointer.To(location),
 		ExtendedLocation: expandEdgeZoneModel(d.Get("edge_zone").(string)),
 		Properties: &privateendpoints.PrivateEndpointProperties{
 			ApplicationSecurityGroups:           applicationSecurityGroupAssociation,
-			PrivateLinkServiceConnections:       expandPrivateLinkEndpointServiceConnection(privateServiceConnections, false),
-			ManualPrivateLinkServiceConnections: expandPrivateLinkEndpointServiceConnection(privateServiceConnections, true),
+			PrivateLinkServiceConnections:       privateLinkServiceConnections,
+			ManualPrivateLinkServiceConnections: manualPrivateLinkServiceConnections,
 			Subnet: &privateendpoints.Subnet{
 				Id: pointer.To(subnetId),
 			},
@@ -765,6 +781,27 @@ func resourcePrivateEndpointDelete(d *pluginsdk.ResourceData, meta interface{}) 
 			if subnet := props.Subnet; subnet != nil && subnet.Id != nil {
 				subnetId = *subnet.Id
 			}
+
+			// Certain child resources like those for cognitive account lock the parent resource to make sure we don't try and update the parent when it's not ready.
+			// Due to that, we'll lock on that resource id to try and prevent those type of errors.
+			privateLinkServiceConnectionIds := make([]string, 0)
+			if privateLinkServiceConnections := props.PrivateLinkServiceConnections; privateLinkServiceConnections != nil {
+				for _, connection := range *privateLinkServiceConnections {
+					if connectionProps := connection.Properties; connectionProps != nil {
+						privateLinkServiceConnectionIds = append(privateLinkServiceConnectionIds, pointer.From(connectionProps.PrivateLinkServiceId))
+					}
+				}
+			}
+			if manualPrivateLinkServiceConnections := props.ManualPrivateLinkServiceConnections; manualPrivateLinkServiceConnections != nil {
+				for _, connection := range *manualPrivateLinkServiceConnections {
+					if connectionProps := connection.Properties; connectionProps != nil {
+						privateLinkServiceConnectionIds = append(privateLinkServiceConnectionIds, pointer.From(connectionProps.PrivateLinkServiceId))
+					}
+				}
+			}
+
+			locks.MultipleByID(pointer.To(privateLinkServiceConnectionIds))
+			defer locks.UnlockMultipleByID(pointer.To(privateLinkServiceConnectionIds))
 		}
 	}
 	if subnetId == "" {
@@ -786,8 +823,9 @@ func resourcePrivateEndpointDelete(d *pluginsdk.ResourceData, meta interface{}) 
 	return nil
 }
 
-func expandPrivateLinkEndpointServiceConnection(input []interface{}, parseManual bool) *[]privateendpoints.PrivateLinkServiceConnection {
+func expandPrivateLinkEndpointServiceConnection(input []interface{}, parseManual bool) (*[]privateendpoints.PrivateLinkServiceConnection, []string) {
 	results := make([]privateendpoints.PrivateLinkServiceConnection, 0)
+	privateConnectionResourceIds := make([]string, 0)
 
 	for _, item := range input {
 		v := item.(map[string]interface{})
@@ -795,6 +833,8 @@ func expandPrivateLinkEndpointServiceConnection(input []interface{}, parseManual
 		if privateConnectionResourceId == "" {
 			privateConnectionResourceId = v["private_connection_resource_alias"].(string)
 		}
+		privateConnectionResourceIds = append(privateConnectionResourceIds, privateConnectionResourceId)
+
 		subresourceNames := v["subresource_names"].([]interface{})
 		requestMessage := v["request_message"].(string)
 		isManual := v["is_manual_connection"].(bool)
@@ -817,7 +857,7 @@ func expandPrivateLinkEndpointServiceConnection(input []interface{}, parseManual
 		}
 	}
 
-	return &results
+	return &results, privateConnectionResourceIds
 }
 
 func expandPrivateEndpointIPConfigurations(input []interface{}) *[]privateendpoints.PrivateEndpointIPConfiguration {


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Child resources of Cognitive Accounts force the Account into a non-ready state which can cause child resource creation to fail when created at the same time. All child resources of Cognitive Accounts lock the account so we'll check to see if the id for the private endpoint is a cognitive account and lock it if so.

We'll also parse cognitive account ids insensitively to make sure we lock regardless of casing differences.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #31712


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
