### PR TITLE
`data.api_management_subscription` - add support for `"api_management_name", "resource_group_name"`

### DIFF
--- a/internal/services/apimanagement/api_management_subscription_data_source.go
+++ b/internal/services/apimanagement/api_management_subscription_data_source.go
@@ -25,16 +25,18 @@ var _ sdk.DataSource = ApiManagementSubscriptionDataSource{}
 type ApiManagementSubscriptionDataSource struct{}
 
 type ApiManagementSubscriptionDataSourceModel struct {
-	ApiManagementId string `tfschema:"api_management_id"`
-	SubscriptionId  string `tfschema:"subscription_id"`
-	AllowTracing    bool   `tfschema:"allow_tracing"`
-	ApiId           string `tfschema:"api_id"`
-	DisplayName     string `tfschema:"display_name"`
-	PrimaryKey      string `tfschema:"primary_key"`
-	ProductId       string `tfschema:"product_id"`
-	SecondaryKey    string `tfschema:"secondary_key"`
-	State           string `tfschema:"state"`
-	UserId          string `tfschema:"user_id"`
+	ApiManagementId   string `tfschema:"api_management_id"`
+	ApiManagementName string `tfschema:"api_management_name"`
+	ResourceGroupName string `tfschema:"resource_group_name"`
+	SubscriptionId    string `tfschema:"subscription_id"`
+	AllowTracing      bool   `tfschema:"allow_tracing"`
+	ApiId             string `tfschema:"api_id"`
+	DisplayName       string `tfschema:"display_name"`
+	PrimaryKey        string `tfschema:"primary_key"`
+	ProductId         string `tfschema:"product_id"`
+	SecondaryKey      string `tfschema:"secondary_key"`
+	State             string `tfschema:"state"`
+	UserId            string `tfschema:"user_id"`
 }
 
 func (ApiManagementSubscriptionDataSource) Arguments() map[string]*pluginsdk.Schema {
@@ -62,6 +64,11 @@ func (ApiManagementSubscriptionDataSource) Attributes() map[string]*pluginsdk.Sc
 			Computed: true,
 		},
 
+		"api_management_name": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
 		"display_name": {
 			Type:     pluginsdk.TypeString,
 			Computed: true,
@@ -74,6 +81,11 @@ func (ApiManagementSubscriptionDataSource) Attributes() map[string]*pluginsdk.Sc
 		},
 
 		"product_id": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"resource_group_name": {
 			Type:     pluginsdk.TypeString,
 			Computed: true,
 		},
@@ -119,6 +131,9 @@ func (ApiManagementSubscriptionDataSource) Read() sdk.ResourceFunc {
 			if err != nil {
 				return fmt.Errorf("parsing: %+v", err)
 			}
+
+			state.ApiManagementName = api_management_id.ServiceName
+			state.ResourceGroupName = api_management_id.ResourceGroupName
 
 			id := subscription.NewSubscriptions2ID(api_management_id.SubscriptionId, api_management_id.ResourceGroupName, api_management_id.ServiceName, state.SubscriptionId)
 

--- a/internal/services/apimanagement/api_management_subscription_data_source_test.go
+++ b/internal/services/apimanagement/api_management_subscription_data_source_test.go
@@ -25,6 +25,8 @@ func TestAccDataSourceApiManagementSubscription_basic(t *testing.T) {
 				check.That(data.ResourceName).Key("display_name").HasValue("Test Subscription"),
 				check.That(data.ResourceName).Key("allow_tracing").HasValue("true"),
 				check.That(data.ResourceName).Key("state").HasValue("active"),
+				check.That(data.ResourceName).Key("api_management_name").IsSet(),
+				check.That(data.ResourceName).Key("resource_group_name").IsSet(),
 			),
 		},
 	})

--- a/internal/services/apimanagement/api_management_subscription_data_source_test.go
+++ b/internal/services/apimanagement/api_management_subscription_data_source_test.go
@@ -25,8 +25,8 @@ func TestAccDataSourceApiManagementSubscription_basic(t *testing.T) {
 				check.That(data.ResourceName).Key("display_name").HasValue("Test Subscription"),
 				check.That(data.ResourceName).Key("allow_tracing").HasValue("true"),
 				check.That(data.ResourceName).Key("state").HasValue("active"),
-				check.That(data.ResourceName).Key("api_management_name").IsSet(),
-				check.That(data.ResourceName).Key("resource_group_name").IsSet(),
+				check.That(data.ResourceName).Key("api_management_name").MatchesOtherKey(check.That("azurerm_api_management.test").Key("name")),
+				check.That(data.ResourceName).Key("resource_group_name").MatchesOtherKey(check.That("azurerm_resource_group.test").Key("name")),
 			),
 		},
 	})

--- a/internal/services/apimanagement/api_management_workspace_data_source_test.go
+++ b/internal/services/apimanagement/api_management_workspace_data_source_test.go
@@ -19,6 +19,7 @@ func TestAccDataSourceApiManagementWorkspace_basic(t *testing.T) {
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("display_name").Exists(),
+				check.That(data.ResourceName).Key("description").HasValue("example workspace description"),
 			),
 		},
 	})
@@ -59,6 +60,7 @@ resource "azurerm_api_management_workspace" "test" {
   name              = "acctestws%d"
   api_management_id = azurerm_api_management.test.id
   display_name      = "acctest-workspace-%d"
+  description       = "example workspace description"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }

--- a/website/docs/d/api_management_subscription.html.markdown
+++ b/website/docs/d/api_management_subscription.html.markdown
@@ -41,11 +41,15 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `api_id` - The ID of the API assigned to this Subscription.
 
+* `api_management_name` - The name of the API Management Service.
+
 * `display_name` - The display name of this Subscription.
 
 * `primary_key` - The primary key for this subscription.
 
 * `product_id` - The ID of the Product assigned to this Subscription.
+
+* `resource_group_name` - The name of the Resource Group where the API Management Service exists.
 
 * `secondary_key` - The secondary key for this subscription.
 


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know.

--- PASS: TestAccDataSourceApiManagementSubscription_basic (378.59s)
data source "azurerm_api_management_subscription"  added missing resource properties: "api_management_name", "resource_group_name"


If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [x] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
