### PR TITLE
Attributes added `data.azurerm_service_plan` - add missing attributes to match resource

### DIFF
--- a/internal/services/appservice/service_plan_data_source.go
+++ b/internal/services/appservice/service_plan_data_source.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appservice/helpers"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appservice/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
@@ -165,12 +166,14 @@ func (r ServicePlanDataSource) Read() sdk.ResourceFunc {
 						servicePlan.AppServiceEnvironmentId = pointer.From(props.HostingEnvironmentProfile.Id)
 					}
 
+					if pointer.From(props.ElasticScaleEnabled) && servicePlan.Sku != "" && helpers.PlanIsPremium(servicePlan.Sku) {
+						servicePlan.PremiumPlanAutoScaleEnabled = pointer.From(props.ElasticScaleEnabled)
+					}
+
 					servicePlan.PerSiteScaling = pointer.From(props.PerSiteScaling)
 					servicePlan.Reserved = pointer.From(props.Reserved)
 					servicePlan.ZoneBalancing = pointer.From(props.ZoneRedundant)
 					servicePlan.MaximumElasticWorkerCount = pointer.From(props.MaximumElasticWorkerCount)
-					servicePlan.PremiumPlanAutoScaleEnabled = pointer.From(props.ElasticScaleEnabled)
-
 				}
 				servicePlan.Tags = pointer.From(model.Tags)
 			}

--- a/internal/services/appservice/service_plan_data_source.go
+++ b/internal/services/appservice/service_plan_data_source.go
@@ -23,19 +23,20 @@ type ServicePlanDataSource struct{}
 var _ sdk.DataSource = ServicePlanDataSource{}
 
 type ServicePlanDataSourceModel struct {
-	Name                      string            `tfschema:"name"`
-	ResourceGroup             string            `tfschema:"resource_group_name"`
-	Location                  string            `tfschema:"location"`
-	Kind                      string            `tfschema:"kind"`
-	OSType                    OSType            `tfschema:"os_type"`
-	Sku                       string            `tfschema:"sku_name"`
-	AppServiceEnvironmentId   string            `tfschema:"app_service_environment_id"`
-	PerSiteScaling            bool              `tfschema:"per_site_scaling_enabled"`
-	Reserved                  bool              `tfschema:"reserved"`
-	WorkerCount               int64             `tfschema:"worker_count"`
-	MaximumElasticWorkerCount int64             `tfschema:"maximum_elastic_worker_count"`
-	ZoneBalancing             bool              `tfschema:"zone_balancing_enabled"`
-	Tags                      map[string]string `tfschema:"tags"`
+	Name                        string            `tfschema:"name"`
+	ResourceGroup               string            `tfschema:"resource_group_name"`
+	Location                    string            `tfschema:"location"`
+	Kind                        string            `tfschema:"kind"`
+	OSType                      OSType            `tfschema:"os_type"`
+	Sku                         string            `tfschema:"sku_name"`
+	AppServiceEnvironmentId     string            `tfschema:"app_service_environment_id"`
+	PerSiteScaling              bool              `tfschema:"per_site_scaling_enabled"`
+	PremiumPlanAutoScaleEnabled bool              `tfschema:"premium_plan_auto_scale_enabled"`
+	Reserved                    bool              `tfschema:"reserved"`
+	WorkerCount                 int64             `tfschema:"worker_count"`
+	MaximumElasticWorkerCount   int64             `tfschema:"maximum_elastic_worker_count"`
+	ZoneBalancing               bool              `tfschema:"zone_balancing_enabled"`
+	Tags                        map[string]string `tfschema:"tags"`
 }
 
 func (r ServicePlanDataSource) ModelObject() interface{} {
@@ -78,6 +79,11 @@ func (r ServicePlanDataSource) Attributes() map[string]*pluginsdk.Schema {
 		},
 
 		"per_site_scaling_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Computed: true,
+		},
+
+		"premium_plan_auto_scale_enabled": {
 			Type:     pluginsdk.TypeBool,
 			Computed: true,
 		},
@@ -163,6 +169,8 @@ func (r ServicePlanDataSource) Read() sdk.ResourceFunc {
 					servicePlan.Reserved = pointer.From(props.Reserved)
 					servicePlan.ZoneBalancing = pointer.From(props.ZoneRedundant)
 					servicePlan.MaximumElasticWorkerCount = pointer.From(props.MaximumElasticWorkerCount)
+					servicePlan.PremiumPlanAutoScaleEnabled = pointer.From(props.ElasticScaleEnabled)
+
 				}
 				servicePlan.Tags = pointer.From(model.Tags)
 			}

--- a/internal/services/appservice/service_plan_data_source_test.go
+++ b/internal/services/appservice/service_plan_data_source_test.go
@@ -22,6 +22,7 @@ func TestAccServicePlanDataSource_complete(t *testing.T) {
 			Config: d.complete(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("location").HasValue("eastasia"),
+				check.That(data.ResourceName).Key("premium_plan_auto_scale_enabled").IsSet(),
 				// TODO - rest of the sane properties
 			),
 		},

--- a/internal/services/appservice/service_plan_data_source_test.go
+++ b/internal/services/appservice/service_plan_data_source_test.go
@@ -22,7 +22,6 @@ func TestAccServicePlanDataSource_complete(t *testing.T) {
 			Config: d.complete(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("location").HasValue("eastasia"),
-				check.That(data.ResourceName).Key("premium_plan_auto_scale_enabled").IsSet(),
 				// TODO - rest of the sane properties
 			),
 		},
@@ -38,4 +37,29 @@ data azurerm_service_plan test {
   resource_group_name = azurerm_service_plan.test.resource_group_name
 }
 `, ServicePlanResource{}.complete(data))
+}
+
+func TestAccServicePlanDataSource_premiumPlanAutoScale(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_service_plan", "test")
+	d := ServicePlanDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: d.premiumPlanAutoScale(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("premium_plan_auto_scale_enabled").HasValue("true"),
+			),
+		},
+	})
+}
+
+func (ServicePlanDataSource) premiumPlanAutoScale(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_service_plan" "test" {
+  name                = azurerm_service_plan.test.name
+  resource_group_name = azurerm_service_plan.test.resource_group_name
+}
+`, ServicePlanResource{}.linuxPremiumAutoScaleFeature(data))
 }

--- a/website/docs/d/service_plan.html.markdown
+++ b/website/docs/d/service_plan.html.markdown
@@ -51,6 +51,8 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `per_site_scaling_enabled` - Is Per Site Scaling be enabled?
 
+* `premium_plan_auto_scale_enabled` - Is premium plan autoscale enabled.
+
 * `reserved` - Whether this is a reserved Service Plan Type. `true` if `os_type` is `Linux`, otherwise `false`.
 
 * `sku_name` - The SKU for the Service Plan.


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description
--- PASS: TestAccServicePlanDataSource_complete (107.83s)
data source "azurerm_service_plan"  added missing resource properties: "premium_plan_auto_scale_enabled"


<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [x] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
