### PR TITLE
`virtual_hub_connection` - add List Resource support

### DIFF
--- a/internal/services/network/registration.go
+++ b/internal/services/network/registration.go
@@ -212,6 +212,7 @@ func (r Registration) ListResources() []sdk.FrameworkListWrappedResource {
 		RouteListResource{},
 		RouteTableListResource{},
 		SubnetListResource{},
+		VirtualHubConnectionListResource{},
 		VirtualNetworkListResource{},
 		VirtualNetworkPeeringListResource{},
 		WebApplicationFirewallPolicyListResource{},

--- a/internal/services/network/virtual_hub_connection_resource.go
+++ b/internal/services/network/virtual_hub_connection_resource.go
@@ -25,6 +25,8 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
 
+const azureVirtualHubConnectionResourceName = "azurerm_virtual_hub_connection"
+
 //go:generate go run ../../tools/generator-tests resourceidentity -resource-name virtual_hub_connection -service-package-name network -properties "name" -compare-values "subscription_id:virtual_hub_id,resource_group_name:virtual_hub_id,virtual_hub_name:virtual_hub_id"
 
 func resourceVirtualHubConnection() *pluginsdk.Resource {
@@ -218,7 +220,7 @@ func resourceVirtualHubConnectionCreateOrUpdate(d *pluginsdk.ResourceData, meta 
 				}
 			}
 			if !response.WasNotFound(existing.HttpResponse) {
-				return tf.ImportAsExistsError("azurerm_virtual_hub_connection", id.ID())
+				return tf.ImportAsExistsError(azureVirtualHubConnectionResourceName, id.ID())
 			}
 		}
 	}
@@ -281,10 +283,14 @@ func resourceVirtualHubConnectionRead(d *pluginsdk.ResourceData, meta interface{
 		return fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
+	return resourceVirtualHubConnectionFlatten(d, id, resp.Model)
+}
+
+func resourceVirtualHubConnectionFlatten(d *pluginsdk.ResourceData, id *virtualwans.HubVirtualNetworkConnectionId, model *virtualwans.HubVirtualNetworkConnection) error {
 	d.Set("name", id.HubVirtualNetworkConnectionName)
 	d.Set("virtual_hub_id", virtualwans.NewVirtualHubID(id.SubscriptionId, id.ResourceGroupName, id.VirtualHubName).ID())
 
-	if model := resp.Model; model != nil {
+	if model != nil {
 		if props := model.Properties; props != nil {
 			d.Set("internet_security_enabled", props.EnableInternetSecurity)
 			remoteVirtualNetworkId := ""

--- a/internal/services/network/virtual_hub_connection_resource_list.go
+++ b/internal/services/network/virtual_hub_connection_resource_list.go
@@ -1,0 +1,107 @@
+// Copyright IBM Corp.
+// SPDX-License-Identifier: MPL-2.0
+
+package network
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-azure-helpers/framework/typehelpers"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/virtualwans"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-framework/list/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type (
+	VirtualHubConnectionListResource struct{}
+	VirtualHubConnectionListModel    struct {
+		VirtualHubId types.String `tfsdk:"virtual_hub_id"`
+	}
+)
+
+var _ sdk.FrameworkListWrappedResource = new(VirtualHubConnectionListResource)
+
+func (r VirtualHubConnectionListResource) ResourceFunc() *pluginsdk.Resource {
+	return resourceVirtualHubConnection()
+}
+
+func (r VirtualHubConnectionListResource) Metadata(_ context.Context, _ resource.MetadataRequest, response *resource.MetadataResponse) {
+	response.TypeName = azureVirtualHubConnectionResourceName
+}
+
+func (r VirtualHubConnectionListResource) ListResourceConfigSchema(_ context.Context, _ list.ListResourceSchemaRequest, response *list.ListResourceSchemaResponse) {
+	response.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"virtual_hub_id": schema.StringAttribute{
+				Required: true,
+				Validators: []validator.String{
+					typehelpers.WrappedStringValidator{
+						Func: virtualwans.ValidateVirtualHubID,
+					},
+				},
+			},
+		},
+	}
+}
+
+func (r VirtualHubConnectionListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream, metadata sdk.ResourceMetadata) {
+	client := metadata.Client.Network.VirtualWANs
+
+	var data VirtualHubConnectionListModel
+	diags := request.Config.Get(ctx, &data)
+	if diags.HasError() {
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+
+	virtualHubId, err := virtualwans.ParseVirtualHubID(data.VirtualHubId.ValueString())
+	if err != nil {
+		sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("parsing Virtual Hub ID for `%s`", azureVirtualHubConnectionResourceName), err)
+		return
+	}
+
+	resp, err := client.HubVirtualNetworkConnectionsListComplete(ctx, *virtualHubId)
+	if err != nil {
+		sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("listing `%s`", azureVirtualHubConnectionResourceName), err)
+		return
+	}
+
+	stream.Results = func(push func(list.ListResult) bool) {
+		for _, item := range resp.Items {
+			result := request.NewListResult(ctx)
+			result.DisplayName = pointer.From(item.Name)
+
+			rd := resourceVirtualHubConnection().Data(&terraform.InstanceState{})
+
+			id, err := virtualwans.ParseHubVirtualNetworkConnectionIDInsensitively(pointer.From(item.Id))
+			if err != nil {
+				sdk.SetErrorDiagnosticAndPushListResult(result, push, "parsing Virtual Hub Connection ID", err)
+				return
+			}
+
+			rd.SetId(id.ID())
+
+			if err := resourceVirtualHubConnectionFlatten(rd, id, &item); err != nil {
+				sdk.SetErrorDiagnosticAndPushListResult(result, push, fmt.Sprintf("encoding `%s` resource data", azureVirtualHubConnectionResourceName), err)
+				return
+			}
+
+			sdk.EncodeListResult(ctx, rd, &result)
+			if result.Diagnostics.HasError() {
+				push(result)
+				return
+			}
+			if !push(result) {
+				return
+			}
+		}
+	}
+}

--- a/internal/services/network/virtual_hub_connection_resource_list_test.go
+++ b/internal/services/network/virtual_hub_connection_resource_list_test.go
@@ -1,0 +1,59 @@
+package network_test
+
+import (
+	"context"
+	"regexp"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
+)
+
+func TestAccVirtualHubConnection_listByVirtualHubID(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_virtual_hub_connection", "testlist1")
+	r := VirtualHubConnectionResource{}
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []resource.TestStep{
+			{
+				Config: r.basic(data),
+			},
+			{
+				Query:  true,
+				Config: r.basicQuery(data),
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectLengthAtLeast("azurerm_virtual_hub_connection.list", 1),
+					querycheck.ExpectIdentity(
+						"azurerm_virtual_hub_connection.list",
+						map[string]knownvalue.Check{
+							"name":                knownvalue.StringRegexp(regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
+							"resource_group_name": knownvalue.StringRegexp(regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
+							"virtual_hub_name":    knownvalue.StringRegexp(regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
+							"subscription_id":     knownvalue.StringExact(data.Subscriptions.Primary),
+						},
+					),
+				},
+			},
+		},
+	})
+}
+
+func (r VirtualHubConnectionResource) basicQuery(data acceptance.TestData) string {
+	return `
+list "azurerm_virtual_hub_connection" "list" {
+  provider = azurerm
+  config {
+    virtual_hub_id = azurerm_virtual_hub.test.id
+  }
+}
+`
+}

--- a/website/docs/list-resources/virtual_hub_connection.html.markdown
+++ b/website/docs/list-resources/virtual_hub_connection.html.markdown
@@ -1,0 +1,30 @@
+---
+subcategory: "Network"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_virtual_hub_connection"
+description: |-
+    Lists Virtual Hub Connection resources.
+---
+
+# List resource: azurerm_virtual_hub_connection
+
+Lists Virtual Hub Connection resources.
+
+## Example Usage
+
+### List Virtual Hub Connections in a Virtual Hub
+
+```hcl
+list "azurerm_virtual_hub_connection" "example" {
+  provider = azurerm
+  config {
+    virtual_hub_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Network/virtualHubs/hub1"
+  }
+}
+```
+
+## Argument Reference
+
+This list resource supports the following arguments:
+
+* `virtual_hub_id` - (Required) The ID of the Virtual Hub to query.


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
