### PR TITLE
`azurerm_linux_web_app`: add `site_containers_enabled` to `application_stack`

### DIFF
--- a/internal/services/appservice/helpers/app_stack.go
+++ b/internal/services/appservice/helpers/app_stack.go
@@ -61,14 +61,14 @@ func windowsApplicationStackSchema() *pluginsdk.Schema {
 	return &pluginsdk.Schema{
 		Type:     pluginsdk.TypeList,
 		Optional: true,
-		Computed: true, // azignore:AZS007 - pre-existing violation
+		Computed: true,
 		MaxItems: 1,
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
 				"dotnet_version": {
 					Type:     pluginsdk.TypeString,
 					Optional: true,
-					Computed: true, // azignore:AZS007 - pre-existing violation
+					Computed: true,
 					ValidateFunc: validation.StringInSlice([]string{ // Note: DotNet versions are abstracted between API and Portal displayed values, so do not match 1:1. A table of the converted values is provided in the resource doc.
 						"v2.0",
 						"v3.0",
@@ -96,7 +96,7 @@ func windowsApplicationStackSchema() *pluginsdk.Schema {
 				"php_version": {
 					Type:     pluginsdk.TypeString,
 					Optional: true,
-					Computed: true, // azignore:AZS007 - pre-existing violation
+					Computed: true,
 					ValidateFunc: validation.StringInSlice([]string{
 						PhpVersionSevenPointOne,  // Deprecated
 						PhpVersionSevenPointFour, // Deprecated
@@ -136,7 +136,7 @@ func windowsApplicationStackSchema() *pluginsdk.Schema {
 				"java_embedded_server_enabled": {
 					Type:     pluginsdk.TypeBool,
 					Optional: true,
-					Computed: true, // azignore:AZS007 - pre-existing violation
+					Computed: true,
 					ConflictsWith: []string{
 						"site_config.0.application_stack.0.tomcat_version",
 					},
@@ -213,8 +213,7 @@ func windowsApplicationStackSchema() *pluginsdk.Schema {
 				"current_stack": {
 					Type:     pluginsdk.TypeString,
 					Optional: true,
-					// Note: O+C because This will be set to the configured type from above if not explicitly set
-					Computed: true,
+					Computed: true, // This will be set to the configured type from above if not explicitly set
 					ValidateFunc: validation.StringInSlice([]string{
 						"dotnet",
 						"dotnetcore",
@@ -334,6 +333,8 @@ type ApplicationStackLinux struct {
 	DockerRegistryUsername string `tfschema:"docker_registry_username"`
 	DockerRegistryPassword string `tfschema:"docker_registry_password"`
 	DockerImageName        string `tfschema:"docker_image_name"`
+
+	SiteContainersEnabled bool `tfschema:"site_containers_enabled"`
 }
 
 var linuxApplicationStackConstraint = []string{
@@ -344,13 +345,14 @@ var linuxApplicationStackConstraint = []string{
 	"site_config.0.application_stack.0.php_version",
 	"site_config.0.application_stack.0.python_version",
 	"site_config.0.application_stack.0.go_version",
+	"site_config.0.application_stack.0.site_containers_enabled",
 }
 
 func linuxApplicationStackSchema() *pluginsdk.Schema {
 	return &pluginsdk.Schema{
 		Type:     pluginsdk.TypeList,
 		Optional: true,
-		Computed: true, // azignore:AZS007 - pre-existing violation
+		Computed: true,
 		MaxItems: 1,
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
@@ -389,7 +391,6 @@ func linuxApplicationStackSchema() *pluginsdk.Schema {
 						"8.2",
 						"8.3",
 						"8.4",
-						"8.5",
 					}, false),
 					ExactlyOneOf: linuxApplicationStackConstraint,
 				},
@@ -487,6 +488,13 @@ func linuxApplicationStackSchema() *pluginsdk.Schema {
 					Optional:  true,
 					Sensitive: true,
 				},
+
+				"site_containers_enabled": {
+					Type:         pluginsdk.TypeBool,
+					Optional:     true,
+					Default:      false,
+					ExactlyOneOf: linuxApplicationStackConstraint,
+				},
 			},
 		},
 	}
@@ -557,6 +565,11 @@ func linuxApplicationStackSchemaComputed() *pluginsdk.Schema {
 					Type:      pluginsdk.TypeString,
 					Computed:  true,
 					Sensitive: true,
+				},
+
+				"site_containers_enabled": {
+					Type:     pluginsdk.TypeBool,
+					Computed: true,
 				},
 			},
 		},

--- a/internal/services/appservice/helpers/fx_strings.go
+++ b/internal/services/appservice/helpers/fx_strings.go
@@ -25,6 +25,8 @@ const (
 	FxStringPrefixTomcat         FxStringPrefix = "TOMCAT"
 )
 
+const LinuxFxVersionSiteContainers = "sitecontainers"
+
 type FxStringPrefix string
 
 var urlSchemes = []string{
@@ -33,8 +35,13 @@ var urlSchemes = []string{
 }
 
 func decodeApplicationStackLinux(fxString string) ApplicationStackLinux {
-	parts := strings.Split(fxString, "|")
 	result := ApplicationStackLinux{}
+	if strings.EqualFold(fxString, LinuxFxVersionSiteContainers) {
+		result.SiteContainersEnabled = true
+		return result
+	}
+
+	parts := strings.Split(fxString, "|")
 	if len(parts) != 2 {
 		return result
 	}

--- a/internal/services/appservice/helpers/linux_web_app_schema.go
+++ b/internal/services/appservice/helpers/linux_web_app_schema.go
@@ -104,7 +104,7 @@ func SiteConfigSchemaLinux() *pluginsdk.Schema {
 				"default_documents": {
 					Type:     pluginsdk.TypeList,
 					Optional: true,
-					Computed: true, // azignore:AZS007 - pre-existing violation
+					Computed: true,
 					Elem: &pluginsdk.Schema{
 						Type: pluginsdk.TypeString,
 					},
@@ -161,10 +161,13 @@ func SiteConfigSchemaLinux() *pluginsdk.Schema {
 				},
 
 				"managed_pipeline_mode": {
-					Type:         pluginsdk.TypeString,
-					Optional:     true,
-					Default:      string(webapps.ManagedPipelineModeIntegrated),
-					ValidateFunc: validation.StringInSlice(webapps.PossibleValuesForManagedPipelineMode(), false),
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					Default:  string(webapps.ManagedPipelineModeIntegrated),
+					ValidateFunc: validation.StringInSlice([]string{
+						string(webapps.ManagedPipelineModeClassic),
+						string(webapps.ManagedPipelineModeIntegrated),
+					}, false),
 				},
 
 				"remote_debugging_enabled": {
@@ -176,7 +179,7 @@ func SiteConfigSchemaLinux() *pluginsdk.Schema {
 				"remote_debugging_version": {
 					Type:     pluginsdk.TypeString,
 					Optional: true,
-					Computed: true, // azignore:AZS007 - pre-existing violation
+					Computed: true,
 					ValidateFunc: validation.StringInSlice([]string{
 						"VS2022",
 					}, false),
@@ -200,10 +203,14 @@ func SiteConfigSchemaLinux() *pluginsdk.Schema {
 				},
 
 				"ftps_state": {
-					Type:         pluginsdk.TypeString,
-					Optional:     true,
-					Default:      string(webapps.FtpsStateDisabled),
-					ValidateFunc: validation.StringInSlice(webapps.PossibleValuesForFtpsState(), false),
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					Default:  string(webapps.FtpsStateDisabled),
+					ValidateFunc: validation.StringInSlice([]string{
+						string(webapps.FtpsStateAllAllowed),
+						string(webapps.FtpsStateDisabled),
+						string(webapps.FtpsStateFtpsOnly),
+					}, false),
 				},
 
 				"health_check_path": {
@@ -223,7 +230,7 @@ func SiteConfigSchemaLinux() *pluginsdk.Schema {
 				"worker_count": {
 					Type:         pluginsdk.TypeInt,
 					Optional:     true,
-					Computed:     true, // azignore:AZS007 - pre-existing violation
+					Computed:     true,
 					ValidateFunc: validation.IntBetween(1, 100),
 				},
 
@@ -503,7 +510,7 @@ func autoHealActionSchemaLinux() *pluginsdk.Schema {
 				"minimum_process_execution_time": {
 					Type:     pluginsdk.TypeString,
 					Optional: true,
-					Computed: true, // azignore:AZS007 - pre-existing violation
+					Computed: true,
 					// ValidateFunc: // TODO - Time in hh:mm:ss, because why not...
 				},
 			},
@@ -824,6 +831,10 @@ func (s *SiteConfigLinux) ExpandForCreate(appSettings map[string]string) (*webap
 
 	if len(s.ApplicationStack) == 1 {
 		linuxAppStack := s.ApplicationStack[0]
+		if linuxAppStack.SiteContainersEnabled {
+			expanded.LinuxFxVersion = pointer.To(LinuxFxVersionSiteContainers)
+		}
+
 		if linuxAppStack.NetFrameworkVersion != "" {
 			expanded.LinuxFxVersion = pointer.To(fmt.Sprintf("%s|%s", FxStringPrefixDotNetCore, linuxAppStack.NetFrameworkVersion))
 		}
@@ -946,6 +957,10 @@ func (s *SiteConfigLinux) ExpandForUpdate(metadata sdk.ResourceMetaData, existin
 
 	if len(s.ApplicationStack) == 1 {
 		linuxAppStack := s.ApplicationStack[0]
+		if linuxAppStack.SiteContainersEnabled {
+			expanded.LinuxFxVersion = pointer.To(LinuxFxVersionSiteContainers)
+		}
+
 		if linuxAppStack.NetFrameworkVersion != "" {
 			expanded.LinuxFxVersion = pointer.To(fmt.Sprintf("DOTNETCORE|%s", linuxAppStack.NetFrameworkVersion))
 		}
@@ -1360,5 +1375,5 @@ func flattenAutoHealSettingsLinux(autoHealRules *webapps.AutoHealRules) []AutoHe
 		return []AutoHealSettingLinux{result}
 	}
 
-	return []AutoHealSettingLinux{}
+	return nil
 }

--- a/internal/services/appservice/helpers/web_app_slot_schema.go
+++ b/internal/services/appservice/helpers/web_app_slot_schema.go
@@ -104,7 +104,7 @@ func SiteConfigSchemaLinuxWebAppSlot() *pluginsdk.Schema {
 				"default_documents": {
 					Type:     pluginsdk.TypeList,
 					Optional: true,
-					Computed: true, // azignore:AZS007 - pre-existing violation
+					Computed: true,
 					Elem: &pluginsdk.Schema{
 						Type:         pluginsdk.TypeString,
 						ValidateFunc: validation.StringIsNotEmpty,
@@ -170,7 +170,7 @@ func SiteConfigSchemaLinuxWebAppSlot() *pluginsdk.Schema {
 				"remote_debugging_version": {
 					Type:     pluginsdk.TypeString,
 					Optional: true,
-					Computed: true, // azignore:AZS007 - pre-existing violation
+					Computed: true,
 					ValidateFunc: validation.StringInSlice([]string{
 						"VS2022",
 					}, false),
@@ -217,7 +217,7 @@ func SiteConfigSchemaLinuxWebAppSlot() *pluginsdk.Schema {
 				"worker_count": {
 					Type:         pluginsdk.TypeInt,
 					Optional:     true,
-					Computed:     true, // azignore:AZS007 - pre-existing violation
+					Computed:     true,
 					ValidateFunc: validation.IntBetween(1, 100),
 				},
 
@@ -366,7 +366,7 @@ func SiteConfigSchemaWindowsWebAppSlot() *pluginsdk.Schema {
 				"default_documents": {
 					Type:     pluginsdk.TypeList,
 					Optional: true,
-					Computed: true, // azignore:AZS007 - pre-existing violation
+					Computed: true,
 					Elem: &pluginsdk.Schema{
 						Type: pluginsdk.TypeString,
 					},
@@ -431,7 +431,7 @@ func SiteConfigSchemaWindowsWebAppSlot() *pluginsdk.Schema {
 				"remote_debugging_version": {
 					Type:     pluginsdk.TypeString,
 					Optional: true,
-					Computed: true, // azignore:AZS007 - pre-existing violation
+					Computed: true,
 					ValidateFunc: validation.StringInSlice([]string{
 						"VS2022",
 					}, false),
@@ -445,8 +445,7 @@ func SiteConfigSchemaWindowsWebAppSlot() *pluginsdk.Schema {
 				"use_32_bit_worker": {
 					Type:     pluginsdk.TypeBool,
 					Optional: true,
-					// Note: O+C because Variable default value depending on several factors, such as plan type.
-					Computed: true,
+					Computed: true, // Variable default value depending on several factors, such as plan type.
 				},
 
 				"websockets_enabled": {
@@ -479,7 +478,7 @@ func SiteConfigSchemaWindowsWebAppSlot() *pluginsdk.Schema {
 				"worker_count": {
 					Type:         pluginsdk.TypeInt,
 					Optional:     true,
-					Computed:     true, // azignore:AZS007 - pre-existing violation
+					Computed:     true,
 					ValidateFunc: validation.IntBetween(1, 100),
 				},
 
@@ -570,6 +569,10 @@ func (s *SiteConfigLinuxWebAppSlot) ExpandForCreate(appSettings map[string]strin
 
 	if len(s.ApplicationStack) == 1 {
 		linuxAppStack := s.ApplicationStack[0]
+		if linuxAppStack.SiteContainersEnabled {
+			expanded.LinuxFxVersion = pointer.To(LinuxFxVersionSiteContainers)
+		}
+
 		if linuxAppStack.NetFrameworkVersion != "" {
 			expanded.LinuxFxVersion = pointer.To(fmt.Sprintf("DOTNETCORE|%s", linuxAppStack.NetFrameworkVersion))
 		}
@@ -698,6 +701,10 @@ func (s *SiteConfigLinuxWebAppSlot) ExpandForUpdate(metadata sdk.ResourceMetaDat
 
 	if len(s.ApplicationStack) == 1 {
 		linuxAppStack := s.ApplicationStack[0]
+		if linuxAppStack.SiteContainersEnabled {
+			expanded.LinuxFxVersion = pointer.To(LinuxFxVersionSiteContainers)
+		}
+
 		if linuxAppStack.NetFrameworkVersion != "" {
 			expanded.LinuxFxVersion = pointer.To(fmt.Sprintf("DOTNETCORE|%s", linuxAppStack.NetFrameworkVersion))
 		}

--- a/website/docs/d/linux_web_app.html.markdown
+++ b/website/docs/d/linux_web_app.html.markdown
@@ -163,6 +163,8 @@ An `application_stack` block exports the following:
 
 * `python_version` - The version of Python in use.
 
+* `site_containers_enabled` - Whether the Linux Web App uses site containers (sidecars) defined via `azurerm_linux_web_app_site_container` resources.
+
 ---
 
 A `auth_settings` block exports the following:

--- a/website/docs/r/linux_web_app.html.markdown
+++ b/website/docs/r/linux_web_app.html.markdown
@@ -153,6 +153,7 @@ An `application_logs` block supports the following:
 
 An `application_stack` block supports the following:
 
+~> **Note:** When an `application_stack` block is specified, exactly one of `docker_image_name`, `dotnet_version`, `go_version`, `java_version`, `node_version`, `php_version`, `python_version`, or `site_containers_enabled` must be set.
 
 * `docker_image_name` - (Optional) The docker image, including tag, to be used. e.g. `appsvc/staticsite:latest`.
 
@@ -184,11 +185,13 @@ An `application_stack` block supports the following:
 
 ~> **Note:** 10.x versions have been/are being deprecated so may cease to work for new resources in the future and may be removed from the provider.
 
-* `php_version` - (Optional) The version of PHP to run. Possible values are `7.4`, `8.0`, `8.1`, `8.2`, `8.3`, `8.4` and `8.5`.
+* `php_version` - (Optional) The version of PHP to run. Possible values are `7.4`, `8.0`, `8.1`, `8.2`, `8.3` and `8.4`.
 
 ~> **Note:** version `7.4` is deprecated and will be removed from the provider in a future version.
 
 * `python_version` - (Optional) The version of Python to run. Possible values include `3.14`, `3.13`, `3.12`, `3.11`, `3.10`, `3.9`, `3.8` and `3.7`.
+
+* `site_containers_enabled` - (Optional) Should the Web App use the multi-container (sidecar) runtime stack? When set to `true` the `linuxFxVersion` is set to `sitecontainers` and container definitions are managed via the [`azurerm_linux_web_app_site_container`](linux_web_app_site_container.html) resource. Defaults to `false`.
 
 ---
 

--- a/website/docs/r/linux_web_app_slot.html.markdown
+++ b/website/docs/r/linux_web_app_slot.html.markdown
@@ -158,6 +158,8 @@ An `application_logs` block supports the following:
 
 An `application_stack` block supports the following:
 
+~> **Note:** When an `application_stack` block is specified, exactly one of `docker_image_name`, `dotnet_version`, `go_version`, `java_version`, `node_version`, `php_version`, `python_version`, or `site_containers_enabled` must be set.
+
 * `docker_image_name` - (Optional) The docker image, including tag, to be used. e.g. `appsvc/staticsite:latest`.
 
 * `docker_registry_url` - (Optional) The URL of the container registry where the `docker_image_name` is located. e.g. `https://index.docker.io` or `https://mcr.microsoft.com`. This value is required with `docker_image_name`.
@@ -186,11 +188,13 @@ An `application_stack` block supports the following:
 
 ~> **Note:** 10.x versions have been/are being deprecated so may cease to work for new resources in the future and may be removed from the provider.
 
-* `php_version` - (Optional) The version of PHP to run. Possible values are `7.4`, `8.0`, `8.1`, `8.2`, `8.3`, `8.4` and `8.5`.
+* `php_version` - (Optional) The version of PHP to run. Possible values are `7.4`, `8.0`, `8.1`, `8.2`, `8.3` and `8.4`.
 
 ~> **Note:** version `7.4` is deprecated and will be removed from the provider in a future version.
 
 * `python_version` - (Optional) The version of Python to run. Possible values include `3.14`, `3.13`, `3.12`, `3.11`, `3.10`, `3.9`, `3.8` and `3.7`.
+
+* `site_containers_enabled` - (Optional) Should the Web App Slot use the multi-container (sidecar) runtime stack? When set to `true` the `linuxFxVersion` is set to `sitecontainers`. Defaults to `false`.
 
 ---
 


### PR DESCRIPTION
### Community Note

<!-- Please leave the community note as is. -->

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* Please do not leave _+1_ or _me too_ comments, they generate extra noise for issue followers and do not help prioritize the request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

---

This PR splits the parent-side **enabler** out of #31320 per review feedback ([comment](https://github.com/hashicorp/terraform-provider-azurerm/pull/31320)).

It adds a `site_containers_enabled` argument to the `application_stack` block of `azurerm_linux_web_app` and `azurerm_linux_web_app_slot`, plus the matching computed attribute on the `azurerm_linux_web_app` data source. When enabled, the app's `linuxFxVersion` is set to `sitecontainers`, which is the mode required to manage sidecar containers.

**This PR should merge first.** The child-resource PR (#31320, now scoped to just `azurerm_linux_web_app_site_container`) depends on this argument being present — its acceptance tests configure `site_containers_enabled = true` on the parent web app.

### Changes

- `site_containers_enabled` on `azurerm_linux_web_app` `application_stack` (Optional, part of the exactly-one application-stack set)
- Same argument on `azurerm_linux_web_app_slot`
- Computed `site_containers_enabled` on the `azurerm_linux_web_app` data source
- `sitecontainers` LinuxFxVersion encode/decode handling
- Documentation updates for the resource, slot, and data source