### PR TITLE
Attributes added `data.azurerm_storage_blob` - add missing attributes to match resource

### DIFF
--- a/internal/services/storage/storage_blob_data_source.go
+++ b/internal/services/storage/storage_blob_data_source.go
@@ -58,7 +58,17 @@ func dataSourceStorageBlob() *pluginsdk.Resource {
 				Computed: true,
 			},
 
+			"cache_control": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
 			"encryption_scope": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
+			"source_uri": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
 			},
@@ -135,6 +145,7 @@ func dataSourceStorageBlobRead(d *pluginsdk.ResourceData, meta interface{}) erro
 
 	d.Set("access_tier", string(props.AccessTier))
 	d.Set("content_type", props.ContentType)
+	d.Set("cache_control", props.CacheControl)
 
 	// Set the ContentMD5 value to md5 hash in hex
 	contentMD5 := ""
@@ -145,8 +156,11 @@ func dataSourceStorageBlobRead(d *pluginsdk.ResourceData, meta interface{}) erro
 		}
 	}
 	d.Set("content_md5", contentMD5)
-
 	d.Set("encryption_scope", props.EncryptionScope)
+
+	if props.CopySource != "" {
+		d.Set("source_uri", props.CopySource)
+	}
 
 	d.Set("type", strings.TrimSuffix(string(props.BlobType), "Blob"))
 

--- a/internal/services/storage/storage_blob_data_source.go
+++ b/internal/services/storage/storage_blob_data_source.go
@@ -157,10 +157,7 @@ func dataSourceStorageBlobRead(d *pluginsdk.ResourceData, meta interface{}) erro
 	}
 	d.Set("content_md5", contentMD5)
 	d.Set("encryption_scope", props.EncryptionScope)
-
-	if props.CopySource != "" {
-		d.Set("source_uri", props.CopySource)
-	}
+	d.Set("source_uri", props.CopySource)
 
 	d.Set("type", strings.TrimSuffix(string(props.BlobType), "Blob"))
 

--- a/internal/services/storage/storage_blob_data_source_test.go
+++ b/internal/services/storage/storage_blob_data_source_test.go
@@ -30,6 +30,7 @@ func TestAccDataSourceStorageBlob_basic(t *testing.T) {
 		{
 			Config: StorageBlobDataSource{}.basicWithDataSource(data, sourceBlob.Name()),
 			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("cache_control").HasValue("no-cache"),
 				check.That(data.ResourceName).Key("encryption_scope").HasValue(fmt.Sprintf("acctestEScontainer%d", data.RandomInteger)),
 				check.That(data.ResourceName).Key("type").HasValue("Block"),
 				check.That(data.ResourceName).Key("metadata.%").HasValue("2"),
@@ -77,6 +78,7 @@ resource "azurerm_storage_blob" "test" {
   storage_container_id = azurerm_storage_container.test.id
   encryption_scope     = azurerm_storage_encryption_scope.test.name
   type                 = "Block"
+  cache_control        = "no-cache"
   source               = "%[4]s"
 
   metadata = {

--- a/website/docs/d/storage_blob.html.markdown
+++ b/website/docs/d/storage_blob.html.markdown
@@ -41,7 +41,11 @@ The following arguments are supported:
 
 * `content_md5` - The MD5 sum of the blob contents.
 
+* `cache_control` - The cache control directive that is set on the blob.
+
 * `encryption_scope` - The encryption scope for this blob.
+
+* `source_uri` - The source URI used to copy the blob, if it was created from another blob.
 
 * `metadata` - A map of custom blob metadata.
 


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

--- PASS: TestAccDataSourceStorageBlob_basic (127.66s)
data source "azurerm_storage_blob" is missing resource properties: 
- 'cache_control', 
- 'source_uri'


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [x] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
