### PR TITLE
`azurerm_linux_web_app`: add `site_containers_enabled` to `application_stack`

### DIFF
--- a/internal/services/appservice/helpers/app_stack.go
+++ b/internal/services/appservice/helpers/app_stack.go
@@ -334,6 +334,8 @@ type ApplicationStackLinux struct {
 	DockerRegistryUsername string `tfschema:"docker_registry_username"`
 	DockerRegistryPassword string `tfschema:"docker_registry_password"`
 	DockerImageName        string `tfschema:"docker_image_name"`
+
+	SiteContainersEnabled bool `tfschema:"site_containers_enabled"`
 }
 
 var linuxApplicationStackConstraint = []string{
@@ -344,6 +346,7 @@ var linuxApplicationStackConstraint = []string{
 	"site_config.0.application_stack.0.php_version",
 	"site_config.0.application_stack.0.python_version",
 	"site_config.0.application_stack.0.go_version",
+	"site_config.0.application_stack.0.site_containers_enabled",
 }
 
 func linuxApplicationStackSchema() *pluginsdk.Schema {
@@ -487,6 +490,13 @@ func linuxApplicationStackSchema() *pluginsdk.Schema {
 					Optional:  true,
 					Sensitive: true,
 				},
+
+				"site_containers_enabled": {
+					Type:         pluginsdk.TypeBool,
+					Optional:     true,
+					Default:      false,
+					ExactlyOneOf: linuxApplicationStackConstraint,
+				},
 			},
 		},
 	}
@@ -557,6 +567,11 @@ func linuxApplicationStackSchemaComputed() *pluginsdk.Schema {
 					Type:      pluginsdk.TypeString,
 					Computed:  true,
 					Sensitive: true,
+				},
+
+				"site_containers_enabled": {
+					Type:     pluginsdk.TypeBool,
+					Computed: true,
 				},
 			},
 		},

--- a/internal/services/appservice/helpers/fx_strings.go
+++ b/internal/services/appservice/helpers/fx_strings.go
@@ -25,6 +25,8 @@ const (
 	FxStringPrefixTomcat         FxStringPrefix = "TOMCAT"
 )
 
+const LinuxFxVersionSiteContainers = "sitecontainers"
+
 type FxStringPrefix string
 
 var urlSchemes = []string{
@@ -33,8 +35,13 @@ var urlSchemes = []string{
 }
 
 func decodeApplicationStackLinux(fxString string) ApplicationStackLinux {
-	parts := strings.Split(fxString, "|")
 	result := ApplicationStackLinux{}
+	if strings.EqualFold(fxString, LinuxFxVersionSiteContainers) {
+		result.SiteContainersEnabled = true
+		return result
+	}
+
+	parts := strings.Split(fxString, "|")
 	if len(parts) != 2 {
 		return result
 	}

--- a/internal/services/appservice/helpers/linux_web_app_schema.go
+++ b/internal/services/appservice/helpers/linux_web_app_schema.go
@@ -824,6 +824,10 @@ func (s *SiteConfigLinux) ExpandForCreate(appSettings map[string]string) (*webap
 
 	if len(s.ApplicationStack) == 1 {
 		linuxAppStack := s.ApplicationStack[0]
+		if linuxAppStack.SiteContainersEnabled {
+			expanded.LinuxFxVersion = pointer.To(LinuxFxVersionSiteContainers)
+		}
+
 		if linuxAppStack.NetFrameworkVersion != "" {
 			expanded.LinuxFxVersion = pointer.To(fmt.Sprintf("%s|%s", FxStringPrefixDotNetCore, linuxAppStack.NetFrameworkVersion))
 		}
@@ -946,6 +950,10 @@ func (s *SiteConfigLinux) ExpandForUpdate(metadata sdk.ResourceMetaData, existin
 
 	if len(s.ApplicationStack) == 1 {
 		linuxAppStack := s.ApplicationStack[0]
+		if linuxAppStack.SiteContainersEnabled {
+			expanded.LinuxFxVersion = pointer.To(LinuxFxVersionSiteContainers)
+		}
+
 		if linuxAppStack.NetFrameworkVersion != "" {
 			expanded.LinuxFxVersion = pointer.To(fmt.Sprintf("DOTNETCORE|%s", linuxAppStack.NetFrameworkVersion))
 		}

--- a/internal/services/appservice/helpers/web_app_slot_schema.go
+++ b/internal/services/appservice/helpers/web_app_slot_schema.go
@@ -570,6 +570,10 @@ func (s *SiteConfigLinuxWebAppSlot) ExpandForCreate(appSettings map[string]strin
 
 	if len(s.ApplicationStack) == 1 {
 		linuxAppStack := s.ApplicationStack[0]
+		if linuxAppStack.SiteContainersEnabled {
+			expanded.LinuxFxVersion = pointer.To(LinuxFxVersionSiteContainers)
+		}
+
 		if linuxAppStack.NetFrameworkVersion != "" {
 			expanded.LinuxFxVersion = pointer.To(fmt.Sprintf("DOTNETCORE|%s", linuxAppStack.NetFrameworkVersion))
 		}
@@ -698,6 +702,10 @@ func (s *SiteConfigLinuxWebAppSlot) ExpandForUpdate(metadata sdk.ResourceMetaDat
 
 	if len(s.ApplicationStack) == 1 {
 		linuxAppStack := s.ApplicationStack[0]
+		if linuxAppStack.SiteContainersEnabled {
+			expanded.LinuxFxVersion = pointer.To(LinuxFxVersionSiteContainers)
+		}
+
 		if linuxAppStack.NetFrameworkVersion != "" {
 			expanded.LinuxFxVersion = pointer.To(fmt.Sprintf("DOTNETCORE|%s", linuxAppStack.NetFrameworkVersion))
 		}

--- a/website/docs/d/linux_web_app.html.markdown
+++ b/website/docs/d/linux_web_app.html.markdown
@@ -163,6 +163,8 @@ An `application_stack` block exports the following:
 
 * `python_version` - The version of Python in use.
 
+* `site_containers_enabled` - Whether the Linux Web App uses site containers (sidecars) defined via `azurerm_linux_web_app_site_container` resources.
+
 ---
 
 A `auth_settings` block exports the following:

--- a/website/docs/r/linux_web_app.html.markdown
+++ b/website/docs/r/linux_web_app.html.markdown
@@ -153,6 +153,7 @@ An `application_logs` block supports the following:
 
 An `application_stack` block supports the following:
 
+~> **Note:** When an `application_stack` block is specified, exactly one of `docker_image_name`, `dotnet_version`, `go_version`, `java_version`, `node_version`, `php_version`, `python_version`, or `site_containers_enabled` must be set.
 
 * `docker_image_name` - (Optional) The docker image, including tag, to be used. e.g. `appsvc/staticsite:latest`.
 
@@ -189,6 +190,8 @@ An `application_stack` block supports the following:
 ~> **Note:** version `7.4` is deprecated and will be removed from the provider in a future version.
 
 * `python_version` - (Optional) The version of Python to run. Possible values include `3.14`, `3.13`, `3.12`, `3.11`, `3.10`, `3.9`, `3.8` and `3.7`.
+
+* `site_containers_enabled` - (Optional) Should the Web App use the multi-container (sidecar) runtime stack? When set to `true` the `linuxFxVersion` is set to `sitecontainers` and container definitions are managed via the [`azurerm_linux_web_app_site_container`](linux_web_app_site_container.html) resource. Defaults to `false`.
 
 ---
 

--- a/website/docs/r/linux_web_app_slot.html.markdown
+++ b/website/docs/r/linux_web_app_slot.html.markdown
@@ -158,6 +158,8 @@ An `application_logs` block supports the following:
 
 An `application_stack` block supports the following:
 
+~> **Note:** When an `application_stack` block is specified, exactly one of `docker_image_name`, `dotnet_version`, `go_version`, `java_version`, `node_version`, `php_version`, `python_version`, or `site_containers_enabled` must be set.
+
 * `docker_image_name` - (Optional) The docker image, including tag, to be used. e.g. `appsvc/staticsite:latest`.
 
 * `docker_registry_url` - (Optional) The URL of the container registry where the `docker_image_name` is located. e.g. `https://index.docker.io` or `https://mcr.microsoft.com`. This value is required with `docker_image_name`.
@@ -191,6 +193,8 @@ An `application_stack` block supports the following:
 ~> **Note:** version `7.4` is deprecated and will be removed from the provider in a future version.
 
 * `python_version` - (Optional) The version of Python to run. Possible values include `3.14`, `3.13`, `3.12`, `3.11`, `3.10`, `3.9`, `3.8` and `3.7`.
+
+* `site_containers_enabled` - (Optional) Should the Web App Slot use the multi-container (sidecar) runtime stack? When set to `true` the `linuxFxVersion` is set to `sitecontainers`. Defaults to `false`.
 
 ---
 


### PR DESCRIPTION
### Community Note

<!-- Please leave the community note as is. -->

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* Please do not leave _+1_ or _me too_ comments, they generate extra noise for issue followers and do not help prioritize the request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

---

This PR splits the parent-side **enabler** out of #31320 per review feedback.

It adds a `site_containers_enabled` argument to the `application_stack` block of `azurerm_linux_web_app` and `azurerm_linux_web_app_slot`, plus the matching computed attribute on the `azurerm_linux_web_app` data source. When enabled, the app''s `linuxFxVersion` is set to `sitecontainers`, which is the mode required to manage sidecar containers.

**This PR should merge first.** The child-resource PR (#31320, scoped to just `azurerm_linux_web_app_site_container`) depends on this argument being present — its acceptance tests configure `site_containers_enabled = true` on the parent web app.

### Changes

- `site_containers_enabled` on `azurerm_linux_web_app` `application_stack` (Optional, part of the exactly-one application-stack set)
- Same argument on `azurerm_linux_web_app_slot`
- Computed `site_containers_enabled` on the `azurerm_linux_web_app` data source
- `sitecontainers` LinuxFxVersion encode/decode handling
- Documentation updates for the resource, slot, and data source
