### PR TITLE
Attributes added `data.azurerm_storage_encryption_scope` - add missing attributes to match resource

### DIFF
--- a/internal/services/storage/storage_encryption_scope_data_source.go
+++ b/internal/services/storage/storage_encryption_scope_data_source.go
@@ -47,6 +47,11 @@ func dataSourceStorageEncryptionScope() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
 			},
+
+			"infrastructure_encryption_required": {
+				Type:     pluginsdk.TypeBool,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -81,6 +86,7 @@ func dataSourceStorageEncryptionScopeRead(d *pluginsdk.ResourceData, meta interf
 			}
 			d.Set("key_vault_key_id", keyVaultKeyUri)
 
+			d.Set("infrastructure_encryption_required", props.RequireInfrastructureEncryption)
 			d.Set("source", string(pointer.From(props.Source)))
 		}
 	}

--- a/internal/services/storage/storage_encryption_scope_data_source_test.go
+++ b/internal/services/storage/storage_encryption_scope_data_source_test.go
@@ -38,6 +38,20 @@ func TestAccDataSourceStorageEncryptionScope_microsoftManagedKey(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceStorageEncryptionScope_microsoftManagedKeyRequireInfrastructureEncryption(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_storage_encryption_scope", "test")
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: StorageEncryptionScopeDataSource{}.microsoftManagedKeyRequireInfrastructureEncryption(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("source").HasValue("Microsoft.Storage"),
+				check.That(data.ResourceName).Key("infrastructure_encryption_required").HasValue("true"),
+				check.That(data.ResourceName).Key("key_vault_key_id").IsEmpty(),
+			),
+		},
+	})
+}
+
 func (StorageEncryptionScopeDataSource) keyVaultKey(data acceptance.TestData) string {
 	basic := StorageEncryptionScopeResource{}.keyVaultKey(data)
 	return fmt.Sprintf(`
@@ -52,6 +66,18 @@ data "azurerm_storage_encryption_scope" "test" {
 
 func (StorageEncryptionScopeDataSource) microsoftManagedKey(data acceptance.TestData) string {
 	basic := StorageEncryptionScopeResource{}.microsoftManagedKey(data)
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_storage_encryption_scope" "test" {
+  name               = azurerm_storage_encryption_scope.test.name
+  storage_account_id = azurerm_storage_encryption_scope.test.storage_account_id
+}
+`, basic)
+}
+
+func (StorageEncryptionScopeDataSource) microsoftManagedKeyRequireInfrastructureEncryption(data acceptance.TestData) string {
+	basic := StorageEncryptionScopeResource{}.microsoftManagedKeyRequireInfrastructureEncryption(data)
 	return fmt.Sprintf(`
 %s
 

--- a/website/docs/d/storage_encryption_scope.html.markdown
+++ b/website/docs/d/storage_encryption_scope.html.markdown
@@ -44,6 +44,8 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `key_vault_key_id` - The ID of the Key Vault Key.
 
+* `infrastructure_encryption_required` - Is a secondary layer of encryption with Platform Managed Keys for data applied?
+
 * `source` - The source of the Storage Encryption Scope.
 
 ## Timeouts


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

--- PASS: TestAccDataSourceStorageEncryptionScope_microsoftManagedKeyRequireInfrastructureEncryption (271.15s)
data source "azurerm_storage_encryption_scope"  Added missing resource properties: "infrastructure_encryption_required"



## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [x] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
