### PR TITLE
Attributes added `data.azurerm_storage_sync ` - add missing attributes to match resource

### DIFF
--- a/internal/services/storage/storage_sync_data_source.go
+++ b/internal/services/storage/storage_sync_data_source.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/registeredserverresource"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/storagesyncservicesresource"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/validate"
@@ -43,6 +44,14 @@ func dataSourceStorageSync() *pluginsdk.Resource {
 				Computed: true,
 			},
 
+			"registered_servers": {
+				Type:     pluginsdk.TypeList,
+				Computed: true,
+				Elem: &pluginsdk.Schema{
+					Type: pluginsdk.TypeString,
+				},
+			},
+
 			"tags": commonschema.TagsDataSource(),
 		},
 	}
@@ -50,6 +59,7 @@ func dataSourceStorageSync() *pluginsdk.Resource {
 
 func dataSourceStorageSyncRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Storage.SyncServiceClient
+	registeredServerClient := meta.(*clients.Client).Storage.SyncRegisteredServerClient
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -78,5 +88,27 @@ func dataSourceStorageSyncRead(d *pluginsdk.ResourceData, meta interface{}) erro
 			return fmt.Errorf("setting `tags`: %+v", err)
 		}
 	}
+
+	storageSyncId := registeredserverresource.NewStorageSyncServiceID(id.SubscriptionId, id.ResourceGroupName, id.StorageSyncServiceName)
+	registeredServersResp, err := registeredServerClient.RegisteredServersListByStorageSyncService(ctx, storageSyncId)
+	if err != nil {
+		if !response.WasNotFound(registeredServersResp.HttpResponse) {
+			return fmt.Errorf("retrieving registered servers for %s: %+v", id, err)
+		}
+	}
+
+	if serverModel := registeredServersResp.Model; serverModel != nil {
+		registeredServerValues := pointer.From(serverModel.Value)
+		registeredServers := make([]interface{}, 0, len(registeredServerValues))
+		for _, registeredServer := range registeredServerValues {
+			if serverId := pointer.From(registeredServer.Id); serverId != "" {
+				registeredServers = append(registeredServers, serverId)
+			}
+		}
+		if err := d.Set("registered_servers", registeredServers); err != nil {
+			return fmt.Errorf("setting `registered_servers`: %+v", err)
+		}
+	}
+
 	return nil
 }

--- a/internal/services/storage/storage_sync_data_source_test.go
+++ b/internal/services/storage/storage_sync_data_source_test.go
@@ -27,6 +27,19 @@ func TestAccDataSourceStorageSync_basic(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceStorageSync_registeredServers(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_storage_sync", "test")
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: StorageSyncDataSource{}.registeredServers(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("registered_servers.#").HasValue("1"),
+			),
+		},
+	})
+}
+
 func (d StorageSyncDataSource) basic(data acceptance.TestData) string {
 	basic := StorageSyncResource{}.basic(data)
 	return fmt.Sprintf(`
@@ -37,4 +50,21 @@ data "azurerm_storage_sync" "test" {
   resource_group_name = azurerm_storage_sync.test.resource_group_name
 }
 `, basic)
+}
+
+func (d StorageSyncDataSource) registeredServers(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+data "azurerm_storage_sync" "test" {
+  name                = azurerm_storage_sync.test.name
+  resource_group_name = azurerm_storage_sync.test.resource_group_name
+
+  depends_on = [terraform_data.afs_server_id]
+}
+`, StorageSyncServerEndpointResource{}.template(data))
 }

--- a/website/docs/d/storage_sync.html.markdown
+++ b/website/docs/d/storage_sync.html.markdown
@@ -41,6 +41,8 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `location` - The Azure Region where the Storage Sync exists.
 
+* `registered_servers` - A list of registered servers owned by this Storage Sync.
+
 * `tags` - A mapping of tags assigned to the Storage Sync.
 
 ## Timeouts


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

data source "azurerm_storage_sync" Added missing resource properties: 
- `registered_servers`


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [x] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
