### PR TITLE
`servicebus_subscription` - add List Resource support

### DIFF
--- a/internal/services/servicebus/registration.go
+++ b/internal/services/servicebus/registration.go
@@ -96,5 +96,6 @@ func (r Registration) ListResources() []sdk.FrameworkListWrappedResource {
 	return []sdk.FrameworkListWrappedResource{
 		ServiceBusNamespaceCustomerManagedKeyListResource{},
 		ServiceBusNamespaceListResource{},
+		ServiceBusSubscriptionListResource{},
 	}
 }

--- a/internal/services/servicebus/servicebus_subscription_resource.go
+++ b/internal/services/servicebus/servicebus_subscription_resource.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2024-01-01/rules"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2024-01-01/subscriptions"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2024-01-01/topics"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/servicebus/migration"
@@ -21,6 +22,10 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
+
+//go:generate go run ../../tools/generator-tests resourceidentity -properties "name" -compare-values "subscription_id:topic_id,resource_group_name:topic_id,namespace_name:topic_id,topic_name:topic_id"
+
+var serviceBusSubscriptionResourceName = "azurerm_servicebus_subscription"
 
 func resourceServiceBusSubscription() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
@@ -34,10 +39,11 @@ func resourceServiceBusSubscription() *pluginsdk.Resource {
 			0: migration.ServiceBusSubscriptionV0ToV1{},
 		}),
 
-		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
-			_, err := subscriptions.ParseSubscriptions2ID(id)
-			return err
-		}),
+		Identity: &schema.ResourceIdentity{
+			SchemaFunc: pluginsdk.GenerateIdentitySchema(&subscriptions.Subscriptions2Id{}),
+		},
+
+		Importer: pluginsdk.ImporterValidatingIdentity(&subscriptions.Subscriptions2Id{}),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
@@ -207,7 +213,7 @@ func resourceServiceBusSubscriptionCreateUpdate(d *pluginsdk.ResourceData, meta 
 			}
 
 			if !response.WasNotFound(existing.HttpResponse) {
-				return tf.ImportAsExistsError("azurerm_servicebus_subscription", id.ID())
+				return tf.ImportAsExistsError(serviceBusSubscriptionResourceName, id.ID())
 			}
 		}
 	}
@@ -259,6 +265,9 @@ func resourceServiceBusSubscriptionCreateUpdate(d *pluginsdk.ResourceData, meta 
 
 	if d.IsNewResource() {
 		d.SetId(id.ID())
+		if err := pluginsdk.SetResourceIdentityData(d, &id); err != nil {
+			return err
+		}
 	}
 
 	if d.IsNewResource() && meta.(*clients.Client).Features.ServiceBus.AutoDeleteSubscriptionDefaultRule {
@@ -294,13 +303,17 @@ func resourceServiceBusSubscriptionRead(d *pluginsdk.ResourceData, meta interfac
 		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
+	return resourceServiceBusSubscriptionFlatten(d, id, resp.Model)
+}
+
+func resourceServiceBusSubscriptionFlatten(d *pluginsdk.ResourceData, id *subscriptions.Subscriptions2Id, model *subscriptions.SBSubscription) error {
 	d.Set("topic_id", subscriptions.NewTopicID(id.SubscriptionId, id.ResourceGroupName, id.NamespaceName, id.TopicName).ID())
 
 	clientScopedEnabled := false
 	userAssignedName := id.SubscriptionName
 	clientId := ""
 
-	if model := resp.Model; model != nil {
+	if model != nil {
 		if props := model.Properties; props != nil {
 			d.Set("auto_delete_on_idle", props.AutoDeleteOnIdle)
 			d.Set("default_message_ttl", props.DefaultMessageTimeToLive)
@@ -310,7 +323,7 @@ func resourceServiceBusSubscriptionRead(d *pluginsdk.ResourceData, meta interfac
 			d.Set("requires_session", props.RequiresSession)
 			d.Set("forward_to", props.ForwardTo)
 			d.Set("forward_dead_lettered_messages_to", props.ForwardDeadLetteredMessagesTo)
-			d.Set("status", pointer.To(string(*props.Status)))
+			d.Set("status", pointer.To(string(pointer.From(props.Status))))
 			d.Set("client_scoped_subscription_enabled", props.IsClientAffine)
 			d.Set("batched_operations_enabled", props.EnableBatchedOperations)
 
@@ -318,7 +331,7 @@ func resourceServiceBusSubscriptionRead(d *pluginsdk.ResourceData, meta interfac
 				d.Set("max_delivery_count", int(*count))
 			}
 			if props.IsClientAffine != nil && *props.IsClientAffine {
-				if props.ClientAffineProperties.ClientId != nil {
+				if props.ClientAffineProperties != nil && props.ClientAffineProperties.ClientId != nil {
 					clientId = *props.ClientAffineProperties.ClientId
 				}
 				clientScopedEnabled = true
@@ -333,7 +346,7 @@ func resourceServiceBusSubscriptionRead(d *pluginsdk.ResourceData, meta interfac
 	}
 	d.Set("name", userAssignedName)
 
-	return nil
+	return pluginsdk.SetResourceIdentityData(d, id)
 }
 
 func resourceServiceBusSubscriptionDelete(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/servicebus/servicebus_subscription_resource.go
+++ b/internal/services/servicebus/servicebus_subscription_resource.go
@@ -323,7 +323,7 @@ func resourceServiceBusSubscriptionFlatten(d *pluginsdk.ResourceData, id *subscr
 			d.Set("requires_session", props.RequiresSession)
 			d.Set("forward_to", props.ForwardTo)
 			d.Set("forward_dead_lettered_messages_to", props.ForwardDeadLetteredMessagesTo)
-			d.Set("status", pointer.To(string(pointer.From(props.Status))))
+			d.Set("status", pointer.To(string(*props.Status)))
 			d.Set("client_scoped_subscription_enabled", props.IsClientAffine)
 			d.Set("batched_operations_enabled", props.EnableBatchedOperations)
 

--- a/internal/services/servicebus/servicebus_subscription_resource_identity_gen_test.go
+++ b/internal/services/servicebus/servicebus_subscription_resource_identity_gen_test.go
@@ -1,0 +1,42 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package servicebus_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
+)
+
+func TestAccServicebusSubscription_resourceIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_servicebus_subscription", "test")
+	r := ServicebusSubscriptionResource{}
+
+	checkedFields := map[string]struct{}{
+		"name":                {},
+		"namespace_name":      {},
+		"resource_group_name": {},
+		"subscription_id":     {},
+		"topic_name":          {},
+	}
+
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				customstatecheck.ExpectAllIdentityFieldsAreChecked("azurerm_servicebus_subscription.test", checkedFields),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_servicebus_subscription.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_servicebus_subscription.test", tfjsonpath.New("namespace_name"), tfjsonpath.New("topic_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_servicebus_subscription.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("topic_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_servicebus_subscription.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("topic_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_servicebus_subscription.test", tfjsonpath.New("topic_name"), tfjsonpath.New("topic_id")),
+			},
+		},
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
+}

--- a/internal/services/servicebus/servicebus_subscription_resource_list.go
+++ b/internal/services/servicebus/servicebus_subscription_resource_list.go
@@ -1,0 +1,100 @@
+package servicebus
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-azure-helpers/framework/typehelpers"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2024-01-01/subscriptions"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-framework/list/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type ServiceBusSubscriptionListResource struct{}
+
+type ServiceBusSubscriptionListModel struct {
+	TopicId types.String `tfsdk:"topic_id"`
+}
+
+var _ sdk.FrameworkListWrappedResource = new(ServiceBusSubscriptionListResource)
+
+func (ServiceBusSubscriptionListResource) Metadata(_ context.Context, _ resource.MetadataRequest, response *resource.MetadataResponse) {
+	response.TypeName = serviceBusSubscriptionResourceName
+}
+
+func (ServiceBusSubscriptionListResource) ResourceFunc() *pluginsdk.Resource {
+	return resourceServiceBusSubscription()
+}
+
+func (ServiceBusSubscriptionListResource) ListResourceConfigSchema(_ context.Context, _ list.ListResourceSchemaRequest, response *list.ListResourceSchemaResponse) {
+	response.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"topic_id": schema.StringAttribute{
+				Required: true,
+				Validators: []validator.String{
+					typehelpers.WrappedStringValidator{Func: subscriptions.ValidateTopicID},
+				},
+			},
+		},
+	}
+}
+
+func (ServiceBusSubscriptionListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream, metadata sdk.ResourceMetadata) {
+	client := metadata.Client.ServiceBus.SubscriptionsClient
+
+	var data ServiceBusSubscriptionListModel
+	diags := request.Config.Get(ctx, &data)
+	if diags.HasError() {
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+
+	parentID, err := subscriptions.ParseTopicID(data.TopicId.ValueString())
+	if err != nil {
+		sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("parsing Topic ID for `%s`", serviceBusSubscriptionResourceName), err)
+		return
+	}
+
+	resp, err := client.ListByTopicComplete(ctx, *parentID, subscriptions.DefaultListByTopicOperationOptions())
+	if err != nil {
+		sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("listing `%s`", serviceBusSubscriptionResourceName), err)
+		return
+	}
+
+	stream.Results = func(push func(list.ListResult) bool) {
+		for _, item := range resp.Items {
+			result := request.NewListResult(ctx)
+			result.DisplayName = pointer.From(item.Name)
+
+			rd := resourceServiceBusSubscription().Data(&terraform.InstanceState{})
+
+			id, err := subscriptions.ParseSubscriptions2IDInsensitively(pointer.From(item.Id))
+			if err != nil {
+				sdk.SetErrorDiagnosticAndPushListResult(result, push, fmt.Sprintf("parsing ID for `%s`", serviceBusSubscriptionResourceName), err)
+				return
+			}
+			rd.SetId(id.ID())
+
+			if err := resourceServiceBusSubscriptionFlatten(rd, id, &item); err != nil {
+				sdk.SetErrorDiagnosticAndPushListResult(result, push, fmt.Sprintf("encoding `%s` resource data", serviceBusSubscriptionResourceName), err)
+				return
+			}
+
+			sdk.EncodeListResult(ctx, rd, &result)
+			if result.Diagnostics.HasError() {
+				push(result)
+				return
+			}
+			if !push(result) {
+				return
+			}
+		}
+	}
+}

--- a/internal/services/servicebus/servicebus_subscription_resource_list_test.go
+++ b/internal/services/servicebus/servicebus_subscription_resource_list_test.go
@@ -2,6 +2,7 @@ package servicebus_test
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"strconv"
 	"testing"
@@ -16,7 +17,7 @@ import (
 
 func TestAccServiceBusSubscription_listByTopicID(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_servicebus_subscription", "testlist1")
-	r := ServiceBusSubscriptionResource{}
+	r := ServicebusSubscriptionResource{}
 
 	resource.Test(t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -25,13 +26,13 @@ func TestAccServiceBusSubscription_listByTopicID(t *testing.T) {
 		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
 		Steps: []resource.TestStep{
 			{
-				Config: r.basic(data),
+				Config: r.basicList(data),
 			},
 			{
 				Query:  true,
 				Config: r.basicQuery(),
 				QueryResultChecks: []querycheck.QueryResultCheck{
-					querycheck.ExpectLengthAtLeast("azurerm_servicebus_subscription.list", 1),
+					querycheck.ExpectLengthAtLeast("azurerm_servicebus_subscription.list", 3),
 					querycheck.ExpectIdentity(
 						"azurerm_servicebus_subscription.list",
 						map[string]knownvalue.Check{
@@ -48,7 +49,39 @@ func TestAccServiceBusSubscription_listByTopicID(t *testing.T) {
 	})
 }
 
-func (ServiceBusSubscriptionResource) basicQuery() string {
+func (ServicebusSubscriptionResource) basicList(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_servicebus_namespace" "test" {
+  name                = "acctestservicebusnamespace-%[1]d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  sku                 = "Standard"
+}
+
+resource "azurerm_servicebus_topic" "test" {
+  name         = "acctestservicebustopic-%[1]d"
+  namespace_id = azurerm_servicebus_namespace.test.id
+}
+
+resource "azurerm_servicebus_subscription" "test" {
+  count              = 3
+  name               = "_acctestservicebussubscription-%[1]d-${count.index}_"
+  topic_id           = azurerm_servicebus_topic.test.id
+  max_delivery_count = 10
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (ServicebusSubscriptionResource) basicQuery() string {
 	return `
 list "azurerm_servicebus_subscription" "list" {
   provider = azurerm

--- a/internal/services/servicebus/servicebus_subscription_resource_list_test.go
+++ b/internal/services/servicebus/servicebus_subscription_resource_list_test.go
@@ -1,0 +1,60 @@
+package servicebus_test
+
+import (
+	"context"
+	"regexp"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
+)
+
+func TestAccServiceBusSubscription_listByTopicID(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_servicebus_subscription", "testlist1")
+	r := ServiceBusSubscriptionResource{}
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []resource.TestStep{
+			{
+				Config: r.basic(data),
+			},
+			{
+				Query:  true,
+				Config: r.basicQuery(),
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectLengthAtLeast("azurerm_servicebus_subscription.list", 1),
+					querycheck.ExpectIdentity(
+						"azurerm_servicebus_subscription.list",
+						map[string]knownvalue.Check{
+							"name":                knownvalue.StringRegexp(regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
+							"resource_group_name": knownvalue.StringRegexp(regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
+							"namespace_name":      knownvalue.StringRegexp(regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
+							"topic_name":          knownvalue.StringRegexp(regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
+							"subscription_id":     knownvalue.StringExact(data.Subscriptions.Primary),
+						},
+					),
+				},
+			},
+		},
+	})
+}
+
+func (ServiceBusSubscriptionResource) basicQuery() string {
+	return `
+list "azurerm_servicebus_subscription" "list" {
+  provider = azurerm
+  config {
+    topic_id = azurerm_servicebus_topic.test.id
+  }
+}
+`
+}

--- a/internal/services/servicebus/servicebus_subscription_resource_list_test.go
+++ b/internal/services/servicebus/servicebus_subscription_resource_list_test.go
@@ -74,7 +74,7 @@ resource "azurerm_servicebus_topic" "test" {
 
 resource "azurerm_servicebus_subscription" "test" {
   count              = 3
-  name               = "_acctestservicebussubscription-%[1]d-${count.index}_"
+  name               = "_acctestsbsubscription-%[1]d-${count.index}_"
   topic_id           = azurerm_servicebus_topic.test.id
   max_delivery_count = 10
 }

--- a/internal/services/servicebus/servicebus_subscription_resource_test.go
+++ b/internal/services/servicebus/servicebus_subscription_resource_test.go
@@ -20,6 +20,9 @@ import (
 
 type ServiceBusSubscriptionResource struct{}
 
+// ServicebusSubscriptionResource is an alias used by the generated resource identity test.
+type ServicebusSubscriptionResource = ServiceBusSubscriptionResource
+
 func TestAccServiceBusSubscription_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_servicebus_subscription", "test")
 	r := ServiceBusSubscriptionResource{}

--- a/internal/services/servicebus/servicebus_subscription_resource_test.go
+++ b/internal/services/servicebus/servicebus_subscription_resource_test.go
@@ -18,14 +18,11 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
-type ServiceBusSubscriptionResource struct{}
-
-// ServicebusSubscriptionResource is an alias used by the generated resource identity test.
-type ServicebusSubscriptionResource = ServiceBusSubscriptionResource
+type ServicebusSubscriptionResource struct{}
 
 func TestAccServiceBusSubscription_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_servicebus_subscription", "test")
-	r := ServiceBusSubscriptionResource{}
+	r := ServicebusSubscriptionResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -40,7 +37,7 @@ func TestAccServiceBusSubscription_basic(t *testing.T) {
 
 func TestAccServiceBusSubscription_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_servicebus_subscription", "test")
-	r := ServiceBusSubscriptionResource{}
+	r := ServicebusSubscriptionResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -55,7 +52,7 @@ func TestAccServiceBusSubscription_complete(t *testing.T) {
 
 func TestAccServiceBusSubscription_clientScopedEnabled(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_servicebus_subscription", "test")
-	r := ServiceBusSubscriptionResource{}
+	r := ServicebusSubscriptionResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -70,7 +67,7 @@ func TestAccServiceBusSubscription_clientScopedEnabled(t *testing.T) {
 
 func TestAccServiceBusSubscription_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_servicebus_subscription", "test")
-	r := ServiceBusSubscriptionResource{}
+	r := ServicebusSubscriptionResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -85,7 +82,7 @@ func TestAccServiceBusSubscription_requiresImport(t *testing.T) {
 
 func TestAccServiceBusSubscription_defaultTtl(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_servicebus_subscription", "test")
-	r := ServiceBusSubscriptionResource{}
+	r := ServicebusSubscriptionResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -101,7 +98,7 @@ func TestAccServiceBusSubscription_defaultTtl(t *testing.T) {
 
 func TestAccServiceBusSubscription_updateEnableBatched(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_servicebus_subscription", "test")
-	r := ServiceBusSubscriptionResource{}
+	r := ServicebusSubscriptionResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -122,7 +119,7 @@ func TestAccServiceBusSubscription_updateEnableBatched(t *testing.T) {
 
 func TestAccServiceBusSubscription_requiresSession(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_servicebus_subscription", "test")
-	r := ServiceBusSubscriptionResource{}
+	r := ServicebusSubscriptionResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -137,7 +134,7 @@ func TestAccServiceBusSubscription_requiresSession(t *testing.T) {
 
 func TestAccServiceBusSubscription_updateForwardTo(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_servicebus_subscription", "test")
-	r := ServiceBusSubscriptionResource{}
+	r := ServicebusSubscriptionResource{}
 
 	expectedValue := fmt.Sprintf("acctestservicebustopic-forward_to-%d", data.RandomInteger)
 
@@ -160,7 +157,7 @@ func TestAccServiceBusSubscription_updateForwardTo(t *testing.T) {
 
 func TestAccServiceBusSubscription_updateForwardDeadLetteredMessagesTo(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_servicebus_subscription", "test")
-	r := ServiceBusSubscriptionResource{}
+	r := ServicebusSubscriptionResource{}
 
 	expectedValue := fmt.Sprintf("acctestservicebustopic-forward_dl_messages_to-%d", data.RandomInteger)
 
@@ -183,7 +180,7 @@ func TestAccServiceBusSubscription_updateForwardDeadLetteredMessagesTo(t *testin
 
 func TestAccServiceBusSubscription_updateDeadLetteringOnFilterEvaluationExceptions(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_servicebus_subscription", "test")
-	r := ServiceBusSubscriptionResource{}
+	r := ServicebusSubscriptionResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -204,7 +201,7 @@ func TestAccServiceBusSubscription_updateDeadLetteringOnFilterEvaluationExceptio
 
 func TestAccServiceBusSubscription_status(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_servicebus_subscription", "test")
-	r := ServiceBusSubscriptionResource{}
+	r := ServicebusSubscriptionResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -235,7 +232,7 @@ func TestAccServiceBusSubscription_status(t *testing.T) {
 	})
 }
 
-func (t ServiceBusSubscriptionResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+func (t ServicebusSubscriptionResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := subscriptions.ParseSubscriptions2ID(state.ID)
 	if err != nil {
 		return nil, err
@@ -279,11 +276,11 @@ resource "azurerm_servicebus_subscription" "test" {
 }
 `
 
-func (ServiceBusSubscriptionResource) basic(data acceptance.TestData) string {
+func (ServicebusSubscriptionResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(testAccServiceBusSubscription_tfTemplate, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, "")
 }
 
-func (ServiceBusSubscriptionResource) complete(data acceptance.TestData) string {
+func (ServicebusSubscriptionResource) complete(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -320,7 +317,7 @@ resource "azurerm_servicebus_subscription" "test" {
 `, data.RandomInteger, data.Locations.Primary, "")
 }
 
-func (r ServiceBusSubscriptionResource) requiresImport(data acceptance.TestData) string {
+func (r ServicebusSubscriptionResource) requiresImport(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -332,22 +329,22 @@ resource "azurerm_servicebus_subscription" "import" {
 `, r.basic(data))
 }
 
-func (ServiceBusSubscriptionResource) withDefaultTtl(data acceptance.TestData) string {
+func (ServicebusSubscriptionResource) withDefaultTtl(data acceptance.TestData) string {
 	return fmt.Sprintf(testAccServiceBusSubscription_tfTemplate, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger,
 		"default_message_ttl = \"PT1H\"\n")
 }
 
-func (ServiceBusSubscriptionResource) updateEnableBatched(data acceptance.TestData) string {
+func (ServicebusSubscriptionResource) updateEnableBatched(data acceptance.TestData) string {
 	return fmt.Sprintf(testAccServiceBusSubscription_tfTemplate, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger,
 		"batched_operations_enabled = true\n")
 }
 
-func (ServiceBusSubscriptionResource) requiresSession(data acceptance.TestData) string {
+func (ServicebusSubscriptionResource) requiresSession(data acceptance.TestData) string {
 	return fmt.Sprintf(testAccServiceBusSubscription_tfTemplate, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger,
 		"requires_session = true\n")
 }
 
-func (ServiceBusSubscriptionResource) updateForwardTo(data acceptance.TestData) string {
+func (ServicebusSubscriptionResource) updateForwardTo(data acceptance.TestData) string {
 	forwardToTf := testAccServiceBusSubscription_tfTemplate + `
 
 
@@ -366,7 +363,7 @@ resource "azurerm_servicebus_topic" "forward_to" {
 		"forward_to = \"${azurerm_servicebus_topic.forward_to.name}\"\n", data.RandomInteger)
 }
 
-func (ServiceBusSubscriptionResource) updateForwardDeadLetteredMessagesTo(data acceptance.TestData) string {
+func (ServicebusSubscriptionResource) updateForwardDeadLetteredMessagesTo(data acceptance.TestData) string {
 	forwardToTf := testAccServiceBusSubscription_tfTemplate + `
 
 
@@ -385,19 +382,19 @@ resource "azurerm_servicebus_topic" "forward_dl_messages_to" {
 		"forward_dead_lettered_messages_to = \"${azurerm_servicebus_topic.forward_dl_messages_to.name}\"\n", data.RandomInteger)
 }
 
-func (ServiceBusSubscriptionResource) status(data acceptance.TestData, status string) string {
+func (ServicebusSubscriptionResource) status(data acceptance.TestData, status string) string {
 	return fmt.Sprintf(testAccServiceBusSubscription_tfTemplate, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger,
 		fmt.Sprintf("status = \"%s\"", status))
 }
 
-func (ServiceBusSubscriptionResource) updateDeadLetteringOnFilterEvaluationExceptions(data acceptance.TestData) string {
+func (ServicebusSubscriptionResource) updateDeadLetteringOnFilterEvaluationExceptions(data acceptance.TestData) string {
 	return fmt.Sprintf(testAccServiceBusSubscription_tfTemplate, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger,
 		"dead_lettering_on_filter_evaluation_error = false\n")
 }
 
 func TestAccServiceBusSubscription_defaultRuleFeatureFlagEnabled(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_servicebus_subscription", "test")
-	r := ServiceBusSubscriptionResource{}
+	r := ServicebusSubscriptionResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -413,7 +410,7 @@ func TestAccServiceBusSubscription_defaultRuleFeatureFlagEnabled(t *testing.T) {
 
 func TestAccServiceBusSubscription_defaultRuleFeatureFlagDisabled(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_servicebus_subscription", "test")
-	r := ServiceBusSubscriptionResource{}
+	r := ServicebusSubscriptionResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -427,7 +424,7 @@ func TestAccServiceBusSubscription_defaultRuleFeatureFlagDisabled(t *testing.T) 
 	})
 }
 
-func (r ServiceBusSubscriptionResource) defaultRuleAbsent(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) error {
+func (r ServicebusSubscriptionResource) defaultRuleAbsent(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) error {
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
 	defer cancel()
 
@@ -453,7 +450,7 @@ func (r ServiceBusSubscriptionResource) defaultRuleAbsent(ctx context.Context, c
 	return nil
 }
 
-func (r ServiceBusSubscriptionResource) defaultRuleExists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) error {
+func (r ServicebusSubscriptionResource) defaultRuleExists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) error {
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
 	defer cancel()
 
@@ -479,7 +476,7 @@ func (r ServiceBusSubscriptionResource) defaultRuleExists(ctx context.Context, c
 	return fmt.Errorf("expected $Default rule to exist for %s, but it was not found", id)
 }
 
-func (ServiceBusSubscriptionResource) defaultRuleFeatureFlagEnabled(data acceptance.TestData) string {
+func (ServicebusSubscriptionResource) defaultRuleFeatureFlagEnabled(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {
@@ -514,7 +511,7 @@ resource "azurerm_servicebus_subscription" "test" {
 `, data.RandomInteger, data.Locations.Primary)
 }
 
-func (ServiceBusSubscriptionResource) defaultRuleFeatureFlagDisabled(data acceptance.TestData) string {
+func (ServicebusSubscriptionResource) defaultRuleFeatureFlagDisabled(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -545,7 +542,7 @@ resource "azurerm_servicebus_subscription" "test" {
 `, data.RandomInteger, data.Locations.Primary)
 }
 
-func (ServiceBusSubscriptionResource) clientScopedSubscriptionEnabled(data acceptance.TestData) string {
+func (ServicebusSubscriptionResource) clientScopedSubscriptionEnabled(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}

--- a/website/docs/list-resources/servicebus_subscription.html.markdown
+++ b/website/docs/list-resources/servicebus_subscription.html.markdown
@@ -1,0 +1,30 @@
+---
+subcategory: "Messaging"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_servicebus_subscription"
+description: |-
+    Lists ServiceBus Subscription resources.
+---
+
+# List resource: azurerm_servicebus_subscription
+
+Lists ServiceBus Subscription resources.
+
+## Example Usage
+
+### List all ServiceBus Subscriptions in a ServiceBus Topic
+
+```hcl
+list "azurerm_servicebus_subscription" "example" {
+  provider = azurerm
+  config {
+    topic_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example-rg/providers/Microsoft.ServiceBus/namespaces/example-namespace/topics/example-topic"
+  }
+}
+```
+
+## Argument Reference
+
+This list resource supports the following arguments:
+
+* `topic_id` - (Required) The ID of the ServiceBus Topic to query.


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
