### PR TITLE
`azurerm_mongo_cluster` - let the service select `storage_type` and stop replacements from changing it silently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 BUG FIXES:
 
 * `azurerm_mongo_cluster` - the `storage_type` property is now `Computed` and no longer defaults to `PremiumSSD`, so omitting it no longer plans a destructive replacement of an existing cluster that uses `PremiumSSDv2`, and allows the service to select the storage type
+* `azurerm_mongo_cluster` - a change that replaces the cluster is now rejected when `storage_type` is not set in the configuration, since the replacement would otherwise be created with a service-selected storage type that may differ from the one the cluster currently uses
 
 ## 5.4.0 (September 03, 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 5.5.0 (Unreleased)
+
+BUG FIXES:
+
+* `azurerm_mongo_cluster` - the `storage_type` property is now `Computed` and no longer defaults to `PremiumSSD`, so omitting it no longer plans a destructive replacement of an existing cluster that uses `PremiumSSDv2`, and allows the service to select the storage type
+
 ## 5.4.0 (September 03, 2026)
 
 FEATURES:

--- a/internal/services/mongocluster/mongo_cluster_resource.go
+++ b/internal/services/mongocluster/mongo_cluster_resource.go
@@ -269,12 +269,16 @@ func (r MongoClusterResource) Arguments() map[string]*pluginsdk.Schema {
 		},
 
 		"storage_type": {
-			Type:         pluginsdk.TypeString,
-			Optional:     true,
-			ForceNew:     true,
-			Default:      string(mongoclusters.StorageTypePremiumSSD),
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Computed: true,
+			ForceNew: true,
+			// No `Default` here on purpose. A static default would be sent to the service
+			// even when the practitioner never configured `storage_type`, which prevents the
+			// service from applying its own contextual default. `Computed` lets the service
+			// supply the value and keeps existing resources (which already have a concrete
+			// type in state) from generating a spurious ForceNew diff.
 			ValidateFunc: validation.StringInSlice(mongoclusters.PossibleValuesForStorageType(), false),
-			RequiredWith: []string{"storage_size_in_gb"},
 		},
 
 		"tags": commonschema.Tags(),
@@ -410,10 +414,18 @@ func (r MongoClusterResource) Create() sdk.ResourceFunc {
 			parameter.Properties.PublicNetworkAccess = pointer.ToEnum[mongoclusters.PublicNetworkAccess](state.PublicNetworkAccess)
 
 			if state.StorageSizeInGb != 0 {
-				parameter.Properties.Storage = &mongoclusters.StorageProperties{
+				storage := &mongoclusters.StorageProperties{
 					SizeGb: pointer.To(state.StorageSizeInGb),
-					Type:   pointer.ToEnum[mongoclusters.StorageType](state.StorageType),
 				}
+				// Send `type` only when a value is actually known at this point. It is empty
+				// exactly when the practitioner left `storage_type` unset and the service is
+				// therefore the one choosing, which covers both a brand new cluster and a
+				// cluster being recreated by a replacement. An explicitly configured value is
+				// populated here and must be sent.
+				if state.StorageType != "" {
+					storage.Type = pointer.ToEnum[mongoclusters.StorageType](state.StorageType)
+				}
+				parameter.Properties.Storage = storage
 			}
 
 			if state.Tags != nil {

--- a/internal/services/mongocluster/mongo_cluster_resource.go
+++ b/internal/services/mongocluster/mongo_cluster_resource.go
@@ -725,6 +725,10 @@ func (r MongoClusterResource) CustomizeDiff() sdk.ResourceFunc {
 				return fmt.Errorf("DecodeDiff: %+v", err)
 			}
 
+			// Tracks the ForceNew calls made below. Those are decided here rather than by the
+			// schema, so they are invisible to replacementPlanned.
+			replacementForced := false
+
 			switch state.CreateMode {
 			case string(mongoclusters.CreateModeDefault):
 				if isNativeAuthRequired(metadata) && state.AdministratorUserName == "" {
@@ -782,6 +786,7 @@ func (r MongoClusterResource) CustomizeDiff() sdk.ResourceFunc {
 
 			// Since the API doesn't return the value of create_mode, when importing `azurerm_mongo_cluster`, it will cause replacement.
 			if oldVal, newVal := metadata.ResourceDiff.GetChange("create_mode"); oldVal.(string) != "" && oldVal.(string) != newVal.(string) {
+				replacementForced = true
 				if err := metadata.ResourceDiff.ForceNew("create_mode"); err != nil {
 					return err
 				}
@@ -793,6 +798,7 @@ func (r MongoClusterResource) CustomizeDiff() sdk.ResourceFunc {
 
 			// Service team confirmed that `data_api_mode_enabled` can only be updated to `Enabled` after the cluster has been created
 			if oldVal, newVal := metadata.ResourceDiff.GetChange("data_api_mode_enabled"); oldVal.(bool) && !newVal.(bool) && state.CreateMode == string(mongoclusters.CreateModeDefault) {
+				replacementForced = true
 				if err := metadata.ResourceDiff.ForceNew("data_api_mode_enabled"); err != nil {
 					return err
 				}
@@ -804,14 +810,69 @@ func (r MongoClusterResource) CustomizeDiff() sdk.ResourceFunc {
 			// otherwise it will throw a schema validation error, Terraform can only dynamically treat this change as forceNew.
 			// 2. Service API will fail when identity type is changed from `None` to `UserAssigned`.
 			if oldVal, newVal := metadata.ResourceDiff.GetChange("identity"); (len(oldVal.([]interface{})) > 0 && len(newVal.([]interface{})) == 0) || (len(oldVal.([]interface{})) == 0 && len(newVal.([]interface{})) > 0) {
+				replacementForced = true
 				if err := metadata.ResourceDiff.ForceNew("identity"); err != nil {
 					return err
+				}
+			}
+
+			// A replacement recreates the cluster, and the storage type of the new cluster is
+			// decided by the service when `storage_type` is absent from the request. The provider
+			// cannot carry the existing type across a replacement: when a diff requires a new
+			// resource, helper/schema discards the state and re-runs this function with no access
+			// to the previous value, so anything set here on the first pass is thrown away.
+			//
+			// That makes a replacement of a cluster whose configuration omits `storage_type` a
+			// silent storage migration. It has been observed downgrading a PremiumSSDv2 cluster
+			// to PremiumSSD, taking the provisioned IOPS and throughput that only PremiumSSDv2
+			// supports with it, off the back of an unrelated `identity` change. The plan gives no
+			// warning, because the value simply shows as "known after apply".
+			//
+			// helper/schema has no way to raise a warning from CustomizeDiff, so the only way to
+			// stop that happening by accident is to refuse the plan and ask for the storage type
+			// to be stated. Setting it explicitly also makes the plan show the concrete type
+			// instead of an unknown, so the outcome is visible before apply.
+			if metadata.ResourceDiff.Id() != "" {
+				if rawConfig := metadata.ResourceDiff.GetRawConfig(); !rawConfig.IsNull() {
+					if rawConfig.AsValueMap()["storage_type"].IsNull() {
+						if existing, _ := metadata.ResourceDiff.GetChange("storage_type"); existing.(string) != "" {
+							if replacementForced || r.replacementPlanned(metadata) {
+								return fmt.Errorf("this change requires %s to be replaced, and `storage_type` is not set in the configuration. "+
+									"The replacement would be created with the storage type the service selects rather than the %[2]q it uses today, "+
+									"which can silently change the storage type of the cluster. "+
+									"Set `storage_type = %[2]q` to keep the current storage type, or set `storage_type` to the type the replacement should use, then plan again",
+									metadata.ResourceDiff.Id(), existing.(string))
+							}
+						}
+					}
 				}
 			}
 
 			return nil
 		},
 	}
+}
+
+// replacementPlanned reports whether any attribute the schema marks ForceNew has changed,
+// which is how a replacement gets triggered for everything except the handful of cases
+// CustomizeDiff decides for itself.
+//
+// helper/schema does not expose "this diff requires a new resource" while the diff is being
+// customised, so the condition has to be reconstructed. Deriving the attribute list from
+// the schema rather than hard-coding it means an attribute that becomes ForceNew later is
+// picked up automatically.
+func (r MongoClusterResource) replacementPlanned(metadata sdk.ResourceMetaData) bool {
+	for name, field := range r.Arguments() {
+		if !field.ForceNew {
+			continue
+		}
+
+		if metadata.ResourceDiff.HasChange(name) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func expandPreviewFeatures(input []string) *[]mongoclusters.PreviewFeature {

--- a/internal/services/mongocluster/mongo_cluster_resource_storage_type_test.go
+++ b/internal/services/mongocluster/mongo_cluster_resource_storage_type_test.go
@@ -1,0 +1,252 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package mongocluster_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/mongocluster"
+)
+
+// These tests exercise the `storage_type` schema behaviour offline, using the plugin
+// SDK's diff machinery directly. They require neither Azure credentials nor TF_ACC.
+//
+// Background: `storage_type` previously carried a static `Default` of "PremiumSSD",
+// which meant the provider transmitted an explicit storage type even when the
+// practitioner never configured one, preventing the service from applying its own
+// contextual default. Removing that `Default` is only safe if `Computed` is added at
+// the same time -- `storage_type` is `ForceNew`, so a configuration that omits it must
+// not be seen as "changed to empty", which would plan a destroy-and-recreate of an
+// existing cluster.
+//
+// TestAccMongoCluster_storageTypeOmittedNoReplacementOnUpgrade is therefore the
+// regression guard for the single highest-risk scenario: upgrading the provider with
+// no configuration change at all must not replace existing clusters.
+
+// priorStateForExistingCluster models the state an existing cluster would have on disk,
+// as written by a provider version that applied the static "PremiumSSD" default.
+func priorStateForExistingCluster(storageType string) *terraform.InstanceState {
+	attributes := map[string]string{
+		"id":                     "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example/providers/Microsoft.DocumentDB/mongoClusters/example",
+		"name":                   "example",
+		"resource_group_name":    "example",
+		"location":               "westeurope",
+		"compute_tier":           "M30",
+		"high_availability_mode": "Disabled",
+		"shard_count":            "1",
+		"storage_size_in_gb":     "64",
+		"version":                "7.0",
+		"create_mode":            "Default",
+		"public_network_access":  "Enabled",
+	}
+	if storageType != "" {
+		attributes["storage_type"] = storageType
+	}
+
+	return &terraform.InstanceState{
+		ID:         attributes["id"],
+		Attributes: attributes,
+	}
+}
+
+// configForExistingCluster mirrors the practitioner's HCL. `storage_type` is only
+// present when explicitlySetStorageType is non-empty, which is what lets these tests
+// distinguish "omitted in configuration" from "explicitly configured".
+func configForExistingCluster(explicitlySetStorageType string) *terraform.ResourceConfig {
+	raw := map[string]interface{}{
+		"name":                   "example",
+		"resource_group_name":    "example",
+		"location":               "westeurope",
+		"compute_tier":           "M30",
+		"high_availability_mode": "Disabled",
+		"shard_count":            1,
+		"storage_size_in_gb":     64,
+		"version":                "7.0",
+		"create_mode":            "Default",
+		"public_network_access":  "Enabled",
+	}
+	if explicitlySetStorageType != "" {
+		raw["storage_type"] = explicitlySetStorageType
+	}
+
+	return terraform.NewResourceConfigRaw(raw)
+}
+
+func diffForMongoCluster(t *testing.T, state *terraform.InstanceState, config *terraform.ResourceConfig) *terraform.InstanceDiff {
+	t.Helper()
+
+	// Diff against the resource's schema only. The typed wrapper's CustomizeDiff
+	// requires a fully constructed *clients.Client, which would turn this into an
+	// integration test; the behaviour under test here (`storage_type` being
+	// Optional+Computed+ForceNew with no static default) is decided entirely by the
+	// schema, so a bare schema.Resource isolates it precisely.
+	wrapped := sdk.WrappedResource(mongocluster.MongoClusterResource{})
+	resource := &schema.Resource{Schema: wrapped.Schema}
+
+	diff, err := resource.Diff(context.Background(), state, config, nil)
+	if err != nil {
+		t.Fatalf("generating diff: %+v", err)
+	}
+
+	return diff
+}
+
+// assertNoStorageTypeReplacement fails the test when the generated diff would destroy
+// and recreate the cluster because of `storage_type`.
+func assertNoStorageTypeReplacement(t *testing.T, diff *terraform.InstanceDiff) {
+	t.Helper()
+
+	if diff == nil {
+		return
+	}
+
+	if diff.RequiresNew() {
+		t.Fatalf("expected no replacement, but the diff requires the resource to be recreated: %#v", diff.Attributes)
+	}
+
+	if attr, ok := diff.Attributes["storage_type"]; ok && attr.RequiresNew {
+		t.Fatalf("expected no replacement, but `storage_type` is marked ForceNew (old: %q, new: %q)", attr.Old, attr.New)
+	}
+}
+
+// Scenario A1 (release blocking): an existing cluster created while the static default
+// was in place holds "PremiumSSD" in state, and the configuration never mentioned
+// `storage_type`. Upgrading the provider must not plan a replacement.
+func TestMongoClusterStorageType_omittedInConfigDoesNotReplaceExistingCluster(t *testing.T) {
+	state := priorStateForExistingCluster("PremiumSSD")
+	config := configForExistingCluster("")
+
+	diff := diffForMongoCluster(t, state, config)
+
+	assertNoStorageTypeReplacement(t, diff)
+
+	if diff != nil {
+		if attr, ok := diff.Attributes["storage_type"]; ok && attr.New != "" && attr.New != "PremiumSSD" {
+			t.Fatalf("expected `storage_type` to stay PremiumSSD, got %q", attr.New)
+		}
+	}
+}
+
+// Scenario A5: the same guarantee must hold for a cluster that was explicitly created
+// as PremiumSSDv2. Adding `Computed` must not drag it back to a default.
+func TestMongoClusterStorageType_omittedInConfigDoesNotReplaceExistingSSDv2Cluster(t *testing.T) {
+	state := priorStateForExistingCluster("PremiumSSDv2")
+	config := configForExistingCluster("")
+
+	diff := diffForMongoCluster(t, state, config)
+
+	assertNoStorageTypeReplacement(t, diff)
+
+	if diff != nil {
+		if attr, ok := diff.Attributes["storage_type"]; ok && attr.New != "" && attr.New != "PremiumSSDv2" {
+			t.Fatalf("expected `storage_type` to stay PremiumSSDv2, got %q", attr.New)
+		}
+	}
+}
+
+// Scenario A2: a configuration that explicitly pins PremiumSSD must remain stable --
+// no diff and no replacement -- across the provider upgrade.
+func TestMongoClusterStorageType_explicitlyConfiguredValueIsStable(t *testing.T) {
+	state := priorStateForExistingCluster("PremiumSSD")
+	config := configForExistingCluster("PremiumSSD")
+
+	diff := diffForMongoCluster(t, state, config)
+
+	assertNoStorageTypeReplacement(t, diff)
+}
+
+// Scenario C2: removing an explicitly configured `storage_type` from the configuration
+// must be a no-op rather than a replacement. `Computed` should retain the value that is
+// already in state.
+func TestMongoClusterStorageType_removingExplicitValueFromConfigDoesNotReplace(t *testing.T) {
+	state := priorStateForExistingCluster("PremiumSSD")
+	config := configForExistingCluster("")
+
+	diff := diffForMongoCluster(t, state, config)
+
+	assertNoStorageTypeReplacement(t, diff)
+}
+
+// Scenario C1: changing `storage_type` explicitly is a genuine storage migration, which
+// the service cannot perform in place. That must still be surfaced as a replacement --
+// this asserts the safety property that only an explicit change is destructive.
+func TestMongoClusterStorageType_explicitChangeStillForcesReplacement(t *testing.T) {
+	state := priorStateForExistingCluster("PremiumSSD")
+	config := configForExistingCluster("PremiumSSDv2")
+
+	diff := diffForMongoCluster(t, state, config)
+
+	if diff == nil {
+		t.Fatal("expected a diff when `storage_type` is explicitly changed, got none")
+	}
+
+	attr, ok := diff.Attributes["storage_type"]
+	if !ok {
+		t.Fatalf("expected `storage_type` in the diff, got: %#v", diff.Attributes)
+	}
+
+	if !attr.RequiresNew {
+		t.Fatalf("expected an explicit `storage_type` change to force replacement, got: %#v", attr)
+	}
+}
+
+// A fresh resource with no `storage_type` in configuration must leave the value unknown
+// so the service can decide it, rather than baking a client-side default into the plan.
+func TestMongoClusterStorageType_newResourceOmittedTypeIsNotDefaultedClientSide(t *testing.T) {
+	config := configForExistingCluster("")
+
+	diff := diffForMongoCluster(t, nil, config)
+
+	if diff == nil {
+		t.Fatal("expected a diff for a new resource, got none")
+	}
+
+	attr, ok := diff.Attributes["storage_type"]
+	if !ok {
+		// Not present in the diff at all is also acceptable: nothing is being asserted
+		// about the storage type, so the service remains free to choose it.
+		return
+	}
+
+	if attr.New == "PremiumSSD" && !attr.NewComputed {
+		t.Fatal("expected `storage_type` to be service-determined for a new resource, but the provider planned a client-side PremiumSSD default")
+	}
+}
+
+// An in-place update must not disturb the storage type, whichever type the cluster has.
+//
+// Note what this does *not* cover: a replacement. When a diff requires a new resource,
+// helper/schema discards the state and re-runs the diff and CustomizeDiff from scratch,
+// and the prior value is unreachable at that point — both the state and the raw state are
+// gone. So the recreated cluster is planned with `storage_type` unknown and takes whatever
+// the service chooses. That is verified harmless today (live run R1: the cluster came back
+// PremiumSSD), but it means the storage type cannot be carried across a replacement from
+// within the provider. See docs in the Marlin repo for the Phase 2 implications.
+func TestMongoClusterStorageType_inPlaceUpdateDoesNotDisturbExistingType(t *testing.T) {
+	for _, storageType := range []string{"PremiumSSD", "PremiumSSDv2"} {
+		t.Run(storageType, func(t *testing.T) {
+			state := priorStateForExistingCluster(storageType)
+			config := configForExistingCluster("")
+
+			diff := diffForMongoCluster(t, state, config)
+
+			assertNoStorageTypeReplacement(t, diff)
+
+			if diff != nil {
+				if attr, ok := diff.Attributes["storage_type"]; ok {
+					if attr.New != "" && attr.New != storageType {
+						t.Fatalf("expected `storage_type` to stay %q, got %q", storageType, attr.New)
+					}
+					if attr.NewRemoved {
+						t.Fatalf("expected `storage_type` to be retained, but it was marked removed")
+					}
+				}
+			}
+		})
+	}
+}

--- a/internal/services/mongocluster/mongo_cluster_resource_test.go
+++ b/internal/services/mongocluster/mongo_cluster_resource_test.go
@@ -205,6 +205,85 @@ func TestAccMongoCluster_authenticationMethodsValidation(t *testing.T) {
 	})
 }
 
+// TestAccMongoCluster_storageType covers the storage type being selected by the service
+// when it is not configured, and the guard that stops a replacement from silently changing
+// it. Sequential because each step provisions a cluster.
+func TestAccMongoCluster_storageType(t *testing.T) {
+	acceptance.RunTestsInSequence(t, map[string]map[string]func(t *testing.T){
+		"storageType": {
+			"omitted":                     testAccMongoCluster_storageTypeOmitted,
+			"explicit":                    testAccMongoCluster_storageTypeExplicit,
+			"replacementRequiresExplicit": testAccMongoCluster_storageTypeReplacementRequiresExplicit,
+		},
+	})
+}
+
+// Omitting `storage_type` must leave the choice to the service, and the value it returns
+// must settle into state without producing a follow-up diff.
+func testAccMongoCluster_storageTypeOmitted(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_mongo_cluster", "test")
+	r := MongoClusterResource{}
+
+	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.storageTypeOmitted(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("storage_type").Exists(),
+			),
+		},
+		data.ImportStep("administrator_password", "create_mode", "connection_strings.0.value", "connection_strings.1.value"),
+	})
+}
+
+// An explicitly configured storage type must be sent and honoured unchanged.
+func testAccMongoCluster_storageTypeExplicit(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_mongo_cluster", "test")
+	r := MongoClusterResource{}
+
+	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.storageTypeExplicit(data, "PremiumSSD"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("storage_type").HasValue("PremiumSSD"),
+			),
+		},
+		data.ImportStep("administrator_password", "create_mode", "connection_strings.0.value", "connection_strings.1.value"),
+	})
+}
+
+// A replacement recreates the cluster, and the storage type of the replacement is chosen by
+// the service when `storage_type` is absent, which can silently change the storage type of
+// the cluster. The plan must be rejected until the practitioner states which type they want.
+func testAccMongoCluster_storageTypeReplacementRequiresExplicit(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_mongo_cluster", "test")
+	r := MongoClusterResource{}
+
+	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.storageTypeOmitted(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		{
+			// Adding an identity forces a replacement, which must be refused while
+			// `storage_type` is unset.
+			Config:      r.storageTypeOmittedWithIdentity(data),
+			ExpectError: regexp.MustCompile("`storage_type` is not set in the configuration"),
+		},
+		{
+			// Stating the storage type explicitly allows the same replacement to proceed.
+			Config: r.storageTypeExplicitWithIdentity(data, "PremiumSSD"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("storage_type").HasValue("PremiumSSD"),
+			),
+		},
+	})
+}
+
 func (r MongoClusterResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := mongoclusters.ParseMongoClusterID(state.ID)
 	if err != nil {
@@ -530,4 +609,57 @@ resource "azurerm_resource_group" "test" {
   location = "%s"
 }
 `, data.RandomInteger, location)
+}
+
+const mongoClusterIdentityBlock = `  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.test.id]
+  }`
+
+func (r MongoClusterResource) storageTypeTemplate(data acceptance.TestData, storageType string, identity string) string {
+	storageTypeLine := ""
+	if storageType != "" {
+		storageTypeLine = fmt.Sprintf("  storage_type           = %q", storageType)
+	}
+
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acctest-uai-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_mongo_cluster" "test" {
+  name                   = "acctest-mc%[2]d"
+  resource_group_name    = azurerm_resource_group.test.name
+  location               = azurerm_resource_group.test.location
+  administrator_username = "adminTerraform"
+  administrator_password = "QAZwsx123basic"
+  shard_count            = "1"
+  compute_tier           = "M30"
+  high_availability_mode = "Disabled"
+  storage_size_in_gb     = "64"
+  version                = "7.0"
+%[3]s
+%[4]s
+}
+`, r.template(data, data.Locations.Primary), data.RandomInteger, storageTypeLine, identity)
+}
+
+func (r MongoClusterResource) storageTypeOmitted(data acceptance.TestData) string {
+	return r.storageTypeTemplate(data, "", "")
+}
+
+func (r MongoClusterResource) storageTypeExplicit(data acceptance.TestData, storageType string) string {
+	return r.storageTypeTemplate(data, storageType, "")
+}
+
+func (r MongoClusterResource) storageTypeOmittedWithIdentity(data acceptance.TestData) string {
+	return r.storageTypeTemplate(data, "", mongoClusterIdentityBlock)
+}
+
+func (r MongoClusterResource) storageTypeExplicitWithIdentity(data acceptance.TestData, storageType string) string {
+	return r.storageTypeTemplate(data, storageType, mongoClusterIdentityBlock)
 }

--- a/website/docs/r/mongo_cluster.html.markdown
+++ b/website/docs/r/mongo_cluster.html.markdown
@@ -87,6 +87,8 @@ The following arguments are supported:
 
 ~> **Note:** When `storage_type` is omitted, the storage type is selected by the service and exported back into state. Omitting this property does not modify the storage type of an existing MongoDB Cluster.
 
+~> **Note:** If a change would replace an existing MongoDB Cluster and `storage_type` is not set, the plan is rejected. A replacement is created with the storage type the service selects, which is not necessarily the type the cluster uses today, so `storage_type` must be set explicitly to confirm which storage type the replacement should have.
+
 * `version` - (Optional) The version for the MongoDB Cluster. Possibles values are `5.0`, `6.0`, `7.0` and `8.0`.
 
 ~> **Note:** `version` is required when `create_mode` is `Default`.

--- a/website/docs/r/mongo_cluster.html.markdown
+++ b/website/docs/r/mongo_cluster.html.markdown
@@ -83,7 +83,9 @@ The following arguments are supported:
 
 * `storage_size_in_gb` - (Optional) The size of the data disk space for the MongoDB Cluster.
 
-* `storage_type` - (Optional) The storage type for the MongoDB Cluster. Possible values are `PremiumSSD` and `PremiumSSDv2`. Defaults to `PremiumSSD`. Changing this forces a new resource to be created.
+* `storage_type` - (Optional) The storage type for the MongoDB Cluster. Possible values are `PremiumSSD` and `PremiumSSDv2`. Changing this forces a new resource to be created.
+
+~> **Note:** When `storage_type` is omitted, the storage type is selected by the service and exported back into state. Omitting this property does not modify the storage type of an existing MongoDB Cluster.
 
 * `version` - (Optional) The version for the MongoDB Cluster. Possibles values are `5.0`, `6.0`, `7.0` and `8.0`.
 


### PR DESCRIPTION
## Community Note

* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

`storage_type` on `azurerm_mongo_cluster` carries a static `Default` of `PremiumSSD`, so the provider sends an explicit storage type on every create even when the practitioner never configured one. The service selects a storage type contextually when the property is absent, and the static default prevents that from ever happening through Terraform.

Because `storage_type` is `ForceNew`, dropping the default on its own would make an omitted configuration read as "changed to empty" and plan a destroy-and-recreate of existing clusters. `Computed` is added at the same time, so an omitted value is retained from state on existing resources and resolved by the service on new ones.

### This also fixes an existing destructive-plan bug

With the static default in place, an existing `PremiumSSDv2` cluster whose configuration omits `storage_type` plans a downgrade:

```
# azurerm_mongo_cluster.example must be replaced
~ storage_type = "PremiumSSDv2" -> "PremiumSSD" # forces replacement
Plan: 1 to add, 0 to change, 1 to destroy.
```

The practitioner never asked for `PremiumSSD`; the schema default supplied it. Reproduced against `v5.3.0`.

`RequiredWith: storage_size_in_gb` is also removed, so the size can be set while leaving the type to the service. The underlying requirement that a `Default` cluster has a size is still enforced by `CustomizeDiff`, which now reports a clearer resource-specific error instead of a `RequiredWith` violation.

### Second commit: refusing a replacement when `storage_type` is unset

A replacement recreates the cluster, and the storage type of the new cluster is chosen by the service when `storage_type` is absent from the request. The existing type cannot be carried across: when a diff requires a new resource, `helper/schema` discards the state, re-diffs from scratch and re-runs `CustomizeDiff` with no access to the previous value, so anything set on the first pass is discarded. Confirmed with provider debug logging on a real plan:

```
pass 1: rawState.IsNull=false  existing="PremiumSSD"  SetNew applied
pass 2: rawState.IsNull=true   id=""  existing=""     skipped
```

That makes a replacement of a cluster whose configuration omits `storage_type` a silent storage migration. I observed it downgrading a `PremiumSSDv2` cluster to `PremiumSSD` — taking the provisioned IOPS and throughput that only `PremiumSSDv2` supports with it — off the back of an unrelated `identity` change. The plan gave no indication, because the value showed as `(known after apply)`.

`CustomizeDiffFunc` returns `error` only, so there is no way to warn. The plan is refused instead:

```
Error: this change requires <id> to be replaced, and `storage_type` is not set in the
configuration. The replacement would be created with the storage type the service selects
rather than the "PremiumSSDv2" it uses today, which can silently change the storage type of
the cluster. Set `storage_type = "PremiumSSDv2"` to keep the current storage type, or set
`storage_type` to the type the replacement should use, then plan again
```

Setting the property explicitly also makes the plan show the concrete type rather than an unknown, so the outcome is visible before apply. The check applies only to an existing cluster whose configuration omits the property when the change requires replacement, so it is silent for new clusters, refreshes, no-op plans and in-place updates.

`ResourceDiff` does not expose whether a diff requires a new resource, so the condition is rebuilt from the `ForceNew` attributes. That list is derived from the schema at runtime rather than hard-coded, so an attribute that becomes `ForceNew` later is covered automatically; the three `ForceNew` calls made by `CustomizeDiff` itself are tracked separately, since they are invisible to the schema.

I am happy to split the two commits into separate PRs if you would prefer to review them independently.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.

## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them.
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.

## Testing

Unit-level, requiring neither Azure credentials nor `TF_ACC`. `mongo_cluster_resource_storage_type_test.go` drives the plugin SDK's diff machinery directly:

```
$ go test ./internal/services/mongocluster/ -run TestMongoClusterStorageType -v
--- PASS: TestMongoClusterStorageType_omittedInConfigDoesNotReplaceExistingCluster
--- PASS: TestMongoClusterStorageType_omittedInConfigDoesNotReplaceExistingSSDv2Cluster
--- PASS: TestMongoClusterStorageType_explicitlyConfiguredValueIsStable
--- PASS: TestMongoClusterStorageType_removingExplicitValueFromConfigDoesNotReplace
--- PASS: TestMongoClusterStorageType_explicitChangeStillForcesReplacement
--- PASS: TestMongoClusterStorageType_newResourceOmittedTypeIsNotDefaultedClientSide
--- PASS: TestMongoClusterStorageType_inPlaceUpdateDoesNotDisturbExistingType
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/mongocluster

$ go test ./internal/provider/ -run TestProvider   # schema InternalValidate
ok      github.com/hashicorp/terraform-provider-azurerm/internal/provider
```

`go build`, `go vet` and `gofmt` are clean.

To check the tests are not vacuous I ran them against deliberately broken variants of the schema:

| Schema variant | Result |
|---|---|
| As submitted | all pass |
| `Default` removed but `Computed` not added | 3 fail, with `storage_type: Old:"PremiumSSD", New:"", RequiresNew:true` — i.e. every existing cluster replaced |
| Current shipping schema | the `PremiumSSDv2` and no-client-side-default tests fail |

Manual end-to-end testing against a real subscription, roughly ten clusters created and destroyed, including a genuine `5.3.0` to patched-build provider upgrade performed through a local filesystem mirror so `terraform init -upgrade` exercised the real upgrade path:

- existing cluster written by released `5.3.0`, upgraded with **zero configuration change** — `No changes`, no replacement
- `storage_size_in_gb` 64 to 128 in place, storage type unchanged, for both `PremiumSSD` and `PremiumSSDv2`
- `compute_tier` change, tag change and refresh — all in place, storage type untouched
- new cluster with the type omitted — service returned `PremiumSSD`, clean re-plan, no perpetual diff
- explicit `PremiumSSD` and explicit `PremiumSSDv2` creates both honoured
- `terraform import` with and without the type configured, for both types — no `storage_type` drift. The residual `administrator_password` and `create_mode` diff reproduces identically on `5.3.0`, so it is pre-existing and unrelated
- explicit type change still forces replacement
- Free tier with the type omitted — `PremiumSSD`
- the guard — silent on no-ops, blocks the replacement that previously downgraded a `PremiumSSDv2` cluster, and allows it once the type is stated, at which point the planned type is concrete rather than unknown

`TestAccMongoCluster_storageType` has been added covering omitted and explicit types and the replacement guard. I was not able to execute the acceptance tests themselves, as the subscription available to me is a canary environment rather than one set up for the provider's acceptance suite; the same scenarios were covered by the manual runs above.

## Change Log

* `azurerm_mongo_cluster` - the `storage_type` property is now `Computed` and no longer defaults to `PremiumSSD`, so omitting it no longer plans a destructive replacement of an existing cluster that uses `PremiumSSDv2`, and allows the service to select the storage type [GH-00000]
* `azurerm_mongo_cluster` - a change that replaces the cluster is now rejected when `storage_type` is not set in the configuration, since the replacement would otherwise be created with a service-selected storage type that may differ from the one the cluster currently uses [GH-00000]

This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change

Not marked as a breaking change, but two behaviour changes are worth calling out for the release notes:

1. An omitted `storage_type` now renders as `(known after apply)` in plans rather than `PremiumSSD`. The resulting cluster is unchanged.
2. A replacement of a cluster whose configuration omits `storage_type` is now refused until the type is stated. This is deliberate — that path silently changed storage type before.

## Related Issue(s)

None found. I searched open and closed issues for `mongo_cluster` and `storage_type` and did not find an existing report.

## AI Assistance Disclosure

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

This contribution was made with AI assistance covering the code, tests, documentation and this pull request description. The work was directed and reviewed by me throughout, and every behavioural claim above was verified by running it: the unit tests and their negative controls, the provider debug logging that established the `helper/schema` state-reset behaviour, and the manual end-to-end runs against a real subscription. Responses to review feedback on this PR may also be AI assisted.

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

None.
