### PR TITLE
golangci-lint: enable modernize

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,6 +34,7 @@ linters:
     - makezero                  # finds slices created with non-zero length that are later appended to (leaving zero-value elements)
     - mirror                    # reports mismatched bytes/strings function pairs causing needless conversions
     - misspell                  # finds commonly misspelled English words
+    - modernize                 # suggests modern Go idioms (range-over-int, slices/maps/strings helpers), autofixable - see settings below
     - nilerr                    # finds code that returns nil after it checks that the error is not nil
     - nilnesserr                # finds code that checks one error but mistakenly returns a different nil error
     - noctx                     # finds http requests and exec commands made without a context.Context
@@ -79,6 +80,10 @@ linters:
       ignore-rules:
         - hdinsight
         - exportfs
+    modernize:
+      disable:
+        - any # interface{} -> any: ~15k findings across ~2500 files, to be flipped on in a dedicated mechanical pr
+        - newexpr # flags pointer.To(x) -> new(x), azurerm standardises on pointer.To (see AZG002 below)
     predeclared:
       ignore: # widely used as ordinary variable/parameter names across the provider (old/new in diffs, min/max in validation)
         - new

--- a/helpers/common_marshal.go
+++ b/helpers/common_marshal.go
@@ -193,8 +193,8 @@ func ExpandIntSliceWithDelimiter(input []interface{}, delimiter string) *string 
 func FlattenStringSliceWithDelimiter(input *string, delimiter string) []interface{} {
 	result := make([]interface{}, 0)
 	if input != nil {
-		inputStrings := strings.Split(*input, delimiter)
-		for _, item := range inputStrings {
+		inputStrings := strings.SplitSeq(*input, delimiter)
+		for item := range inputStrings {
 			result = append(result, item)
 		}
 	}

--- a/internal/acceptance/data.go
+++ b/internal/acceptance/data.go
@@ -188,7 +188,7 @@ func randString(strlen int) string {
 // the charset provided
 func randStringFromCharSet(strlen int, charSet string) string {
 	result := make([]byte, strlen)
-	for i := 0; i < strlen; i++ {
+	for i := range strlen {
 		result[i] = charSet[rand.Intn(len(charSet))]
 	}
 	return string(result)

--- a/internal/preflight/validate.go
+++ b/internal/preflight/validate.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
 	"strings"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -167,8 +168,8 @@ func parseResourceId(id resourceids.ResourceId) (scope, provider, resourceType, 
 	var scopeSegments []string
 	cutOffIndex := providerIdx - 1
 	if len(typeSegs) > 1 {
-		for i := len(segments) - 1; i >= 0; i-- {
-			if segments[i].Type == resourceids.ConstantSegmentType || segments[i].Type == resourceids.StaticSegmentType {
+		for i, segment := range slices.Backward(segments) {
+			if segment.Type == resourceids.ConstantSegmentType || segment.Type == resourceids.StaticSegmentType {
 				cutOffIndex = i
 				break
 			}

--- a/internal/provider/services_test.go
+++ b/internal/provider/services_test.go
@@ -154,8 +154,7 @@ func TestTypedResourcesUsePointersForOptionalProperties(t *testing.T) {
 
 			var walkModel func(reflect.Type, map[string]*pluginsdk.Schema)
 			walkModel = func(modelType reflect.Type, schema map[string]*pluginsdk.Schema) {
-				for i := 0; i < modelType.NumField(); i++ {
-					field := modelType.Field(i)
+				for field := range modelType.Fields() {
 					property, ok := field.Tag.Lookup("tfschema")
 					if !ok || property == "" {
 						// This is tested for elsewhere, so we can ignore it here

--- a/internal/resourceproviders/required.go
+++ b/internal/resourceproviders/required.go
@@ -5,6 +5,7 @@ package resourceproviders
 
 import (
 	"fmt"
+	"maps"
 	"strings"
 )
 
@@ -36,9 +37,7 @@ func (r ResourceProviders) Add(providers ...string) {
 }
 
 func (r ResourceProviders) Merge(a ResourceProviders) ResourceProviders {
-	for k, v := range a {
-		r[k] = v
-	}
+	maps.Copy(r, a)
 	return r
 }
 

--- a/internal/services/appconfiguration/migration/feature_resource_v0_to_v1.go
+++ b/internal/services/appconfiguration/migration/feature_resource_v0_to_v1.go
@@ -33,12 +33,12 @@ func (FeatureResourceV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
 		oldId := rawState["id"].(string)
 		fixedId := oldId
 
-		if strings.HasSuffix(fixedId, "/Label/\000") {
-			fixedId = strings.TrimSuffix(fixedId, "/Label/\000") + "/Label/%00"
+		if before, ok := strings.CutSuffix(fixedId, "/Label/\000"); ok {
+			fixedId = before + "/Label/%00"
 		}
 
-		if strings.HasSuffix(fixedId, "/Label/") {
-			fixedId = strings.TrimSuffix(fixedId, "/Label/") + "/Label/%00"
+		if before, ok := strings.CutSuffix(fixedId, "/Label/"); ok {
+			fixedId = before + "/Label/%00"
 		}
 
 		parsedOldId, err := parse.FeatureId(fixedId)

--- a/internal/services/appconfiguration/migration/key_resource_v1_to_v2.go
+++ b/internal/services/appconfiguration/migration/key_resource_v1_to_v2.go
@@ -34,12 +34,12 @@ func (KeyResourceV1ToV2) UpgradeFunc() pluginsdk.StateUpgraderFunc {
 			fixedId = fixedId[:index2]
 		}
 
-		if strings.HasSuffix(fixedId, "/Label/\000") {
-			fixedId = strings.TrimSuffix(fixedId, "/Label/\000") + "/Label/%00"
+		if before, ok := strings.CutSuffix(fixedId, "/Label/\000"); ok {
+			fixedId = before + "/Label/%00"
 		}
 
-		if strings.HasSuffix(fixedId, "/Label/") {
-			fixedId = strings.TrimSuffix(fixedId, "/Label/") + "/Label/%00"
+		if before, ok := strings.CutSuffix(fixedId, "/Label/"); ok {
+			fixedId = before + "/Label/%00"
 		}
 
 		parsedOldId, err := parse.KeyId(fixedId)

--- a/internal/services/appconfiguration/validate/app_configuration_feature_name.go
+++ b/internal/services/appconfiguration/validate/app_configuration_feature_name.go
@@ -16,11 +16,11 @@ func AppConfigurationFeatureName(input interface{}, key string) ([]string, []err
 		return nil, []error{fmt.Errorf("expected type of %q to be string", key)}
 	}
 
-	if idx := strings.Index(v, "%"); idx != -1 {
+	if found := strings.Contains(v, "%"); found {
 		return nil, []error{fmt.Errorf(`character "%%" is not allowed in %q`, key)}
 	}
 
-	if idx := strings.Index(v, ":"); idx != -1 {
+	if found := strings.Contains(v, ":"); found {
 		return nil, []error{fmt.Errorf(`character ":" is not allowed in %q`, key)}
 	}
 
@@ -33,7 +33,7 @@ func AppConfigurationFeatureKey(input interface{}, key string) ([]string, []erro
 		return nil, []error{fmt.Errorf("expected type of %q to be string", key)}
 	}
 
-	if idx := strings.Index(v, "%"); idx != -1 {
+	if found := strings.Contains(v, "%"); found {
 		return nil, []error{fmt.Errorf(`character "%%" is not allowed in %q`, key)}
 	}
 

--- a/internal/services/appservice/function_app_flex_consumption_resource.go
+++ b/internal/services/appservice/function_app_flex_consumption_resource.go
@@ -424,10 +424,8 @@ func (r FunctionAppFlexConsumptionResource) Create() sdk.ResourceFunc {
 				},
 			}
 			storageConnStringForFCApp := "DEPLOYMENT_STORAGE_CONNECTION_STRING"
-			endpoint := strings.TrimPrefix(functionAppFlexConsumption.StorageContainerEndpoint, "https://")
 			var storageString string
-			if storageNameIndex := strings.Index(endpoint, "."); storageNameIndex != -1 {
-				storageName := endpoint[:storageNameIndex]
+			if storageName, _, ok := strings.Cut(strings.TrimPrefix(functionAppFlexConsumption.StorageContainerEndpoint, "https://"), "."); ok {
 				storageString = fmt.Sprintf(StorageStringFmt, storageName, functionAppFlexConsumption.StorageAccessKey, *storageDomainSuffix)
 			} else {
 				return fmt.Errorf("retrieving storage container endpoint error, the expected format is https://storagename.blob.core.windows.net/containername, the received value is %s", functionAppFlexConsumption.StorageContainerEndpoint)
@@ -852,10 +850,8 @@ func (r FunctionAppFlexConsumptionResource) Update() sdk.ResourceFunc {
 
 			var storageString string
 			if state.StorageContainerEndpoint != "" || metadata.ResourceData.HasChange("storage_container_endpoint") {
-				endpoint := strings.TrimPrefix(state.StorageContainerEndpoint, "https://")
 				model.Properties.FunctionAppConfig.Deployment.Storage.Value = pointer.To(state.StorageContainerEndpoint)
-				if storageNameIndex := strings.Index(endpoint, "."); storageNameIndex != -1 {
-					storageName := endpoint[:storageNameIndex]
+				if storageName, _, ok := strings.Cut(strings.TrimPrefix(state.StorageContainerEndpoint, "https://"), "."); ok {
 					storageString = fmt.Sprintf(StorageStringFmt, storageName, state.StorageAccessKey, *storageDomainSuffix)
 				} else {
 					return fmt.Errorf("retrieving storage container endpoint error, the expected format is https://storagename.blob.core.windows.net/containername, the received value is %s", state.StorageContainerEndpoint)

--- a/internal/services/appservice/helpers/function_app_schema.go
+++ b/internal/services/appservice/helpers/function_app_schema.go
@@ -1938,8 +1938,8 @@ func ExpandSiteConfigLinuxFunctionApp(siteConfig []SiteConfigLinuxFunctionApp, e
 			appSettings = updateOrAppendAppSettings(appSettings, "DOCKER_REGISTRY_SERVER_PASSWORD", dockerConfig.RegistryPassword, false)
 			dockerUrl := dockerConfig.RegistryURL
 			for _, prefix := range urlSchemes {
-				if strings.HasPrefix(dockerConfig.RegistryURL, prefix) {
-					dockerUrl = strings.TrimPrefix(dockerConfig.RegistryURL, prefix)
+				if after, ok := strings.CutPrefix(dockerConfig.RegistryURL, prefix); ok {
+					dockerUrl = after
 					continue
 				}
 			}
@@ -2672,8 +2672,8 @@ func ParseWebJobsStorageString(input string) (name, key string) {
 		return
 	}
 
-	parts := strings.Split(input, ";")
-	for _, part := range parts {
+	parts := strings.SplitSeq(input, ";")
+	for part := range parts {
 		if strings.HasPrefix(part, "AccountName") {
 			name = strings.TrimPrefix(part, "AccountName=")
 		}

--- a/internal/services/appservice/helpers/fx_strings.go
+++ b/internal/services/appservice/helpers/fx_strings.go
@@ -211,8 +211,8 @@ func DecodeFunctionAppDockerFxString(input string, partial ApplicationStackDocke
 
 	dockerUrl := partial.RegistryURL
 	for _, prefix := range urlSchemes {
-		if strings.HasPrefix(dockerUrl, prefix) {
-			dockerUrl = strings.TrimPrefix(dockerUrl, prefix)
+		if after, ok := strings.CutPrefix(dockerUrl, prefix); ok {
+			dockerUrl = after
 			continue
 		}
 	}

--- a/internal/services/appservice/helpers/shared_schema.go
+++ b/internal/services/appservice/helpers/shared_schema.go
@@ -5,6 +5,7 @@ package helpers
 
 import (
 	"fmt"
+	"maps"
 	"math"
 	"strings"
 
@@ -1608,9 +1609,7 @@ func flattenIpRestrictionHeaders(headers map[string][]string) []IpRestrictionHea
 func FlattenWebStringDictionary(input *webapps.StringDictionary) map[string]string {
 	result := make(map[string]string)
 	if input != nil && input.Properties != nil {
-		for k, v := range *input.Properties {
-			result[k] = v
-		}
+		maps.Copy(result, *input.Properties)
 	}
 	return result
 }

--- a/internal/services/appservice/validate/function_ip_address.go
+++ b/internal/services/appservice/validate/function_ip_address.go
@@ -20,7 +20,7 @@ func IsIpOrCIDRRangeList(i interface{}, k string) ([]string, []error) {
 		return allWarnings, allErrors
 	}
 	validator := validation.Any(validation.IsCIDR, validation.IsIPAddress)
-	for _, elem := range strings.Split(v, ",") {
+	for elem := range strings.SplitSeq(v, ",") {
 		warnings, errors := validator(elem, k)
 		if len(warnings) > 0 {
 			allWarnings = append(allWarnings, warnings...)

--- a/internal/services/cdn/cdn_frontdoor_helpers.go
+++ b/internal/services/cdn/cdn_frontdoor_helpers.go
@@ -130,9 +130,9 @@ func flattenCsvToStringSlice(input *string) []interface{} {
 		return results
 	}
 
-	v := strings.Split(*input, ",")
+	v := strings.SplitSeq(*input, ",")
 
-	for _, s := range v {
+	for s := range v {
 		results = append(results, s)
 	}
 

--- a/internal/services/cdn/validate/cdn.go
+++ b/internal/services/cdn/validate/cdn.go
@@ -44,8 +44,8 @@ func RuleActionUrlRedirectQueryString() pluginsdk.SchemaValidateFunc {
 		}
 
 		kvre := regexp.MustCompile("^[^?&]+=[^?&]+$")
-		kvs := strings.Split(querystring, "&")
-		for _, kv := range kvs {
+		kvs := strings.SplitSeq(querystring, "&")
+		for kv := range kvs {
 			if len(kv) > 0 && !kvre.MatchString(kv) {
 				return nil, []error{errors.New("the Url Query String must be in <key>=<value> format and separated by an ampersand")}
 			}

--- a/internal/services/cognitive/cognitive_account_rai_policy_resource.go
+++ b/internal/services/cognitive/cognitive_account_rai_policy_resource.go
@@ -6,6 +6,7 @@ package cognitive
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -85,10 +86,8 @@ func (r CognitiveAccountRaiPolicyResource) CustomizeDiff() sdk.ResourceFunc {
 					continue
 				}
 
-				for _, notApplicable := range severityThresholdNotApplicableFilterNames {
-					if name == notApplicable {
-						return fmt.Errorf("`severity_threshold` is not applicable for `content_filter[%d]` with name %q", i, name)
-					}
+				if slices.Contains(severityThresholdNotApplicableFilterNames, name) {
+					return fmt.Errorf("`severity_threshold` is not applicable for `content_filter[%d]` with name %q", i, name)
 				}
 			}
 

--- a/internal/services/compute/linux_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"slices"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -68,13 +69,7 @@ func resourceLinuxVirtualMachineScaleSet() *pluginsdk.Resource {
 				newZones := zones.ExpandUntyped(new.(*schema.Set).List())
 
 				for _, ov := range oldZones {
-					found := false
-					for _, nv := range newZones {
-						if ov == nv {
-							found = true
-							break
-						}
-					}
+					found := slices.Contains(newZones, ov)
 
 					if !found {
 						return true

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"slices"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
@@ -829,11 +830,9 @@ func validatePasswordComplexity(input interface{}, key string, min int, max int)
 		"abc@123", "P@$$w0rd", "P@ssw0rd", "P@ssword123", "Pa$$word", "pass@word1", "Password!", "Password1", "Password22", "iloveyou!",
 	}
 
-	for _, str := range disallowedValues {
-		if password == str {
-			errors = append(errors, fmt.Errorf("%q can not be one of %s, got %q", key, azure.QuotedStringSlice(disallowedValues), password))
-			return warnings, errors
-		}
+	if slices.Contains(disallowedValues, password) {
+		errors = append(errors, fmt.Errorf("%q can not be one of %s, got %q", key, azure.QuotedStringSlice(disallowedValues), password))
+		return warnings, errors
 	}
 
 	return warnings, errors

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -338,13 +339,7 @@ func resourceOrchestratedVirtualMachineScaleSet() *pluginsdk.Resource {
 				newZones := zones.ExpandUntyped(new.(*schema.Set).List())
 
 				for _, ov := range oldZones {
-					found := false
-					for _, nv := range newZones {
-						if ov == nv {
-							found = true
-							break
-						}
-					}
+					found := slices.Contains(newZones, ov)
 
 					if !found {
 						return true

--- a/internal/services/compute/windows_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"slices"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -68,13 +69,7 @@ func resourceWindowsVirtualMachineScaleSet() *pluginsdk.Resource {
 				newZones := zones.ExpandUntyped(new.(*schema.Set).List())
 
 				for _, ov := range oldZones {
-					found := false
-					for _, nv := range newZones {
-						if ov == nv {
-							found = true
-							break
-						}
-					}
+					found := slices.Contains(newZones, ov)
 
 					if !found {
 						return true

--- a/internal/services/consumption/consumption_budget_base.go
+++ b/internal/services/consumption/consumption_budget_base.go
@@ -6,6 +6,7 @@ package consumption
 import (
 	"context"
 	"fmt"
+	"maps"
 	"time"
 
 	"github.com/Azure/go-autorest/autorest/date"
@@ -263,9 +264,7 @@ func (br consumptionBudgetBaseResource) arguments(fields map[string]*pluginsdk.S
 
 	// Consumption Budgets for Management Groups have a different notification schema,
 	// here we override the notification schema in the base resource
-	for k, v := range fields {
-		output[k] = v
-	}
+	maps.Copy(output, fields)
 
 	return output
 }

--- a/internal/services/containers/container_registry_resource.go
+++ b/internal/services/containers/container_registry_resource.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -285,10 +286,8 @@ func resourceContainerRegistry() *pluginsdk.Resource {
 				geoReplicationLocations = append(geoReplicationLocations, location.Normalize(v["location"].(string)))
 			}
 			location := location.Normalize(d.Get("location").(string))
-			for _, loc := range geoReplicationLocations {
-				if loc == location {
-					return errors.New("the `georeplications` list cannot contain the location where the Container Registry exists")
-				}
+			if slices.Contains(geoReplicationLocations, location) {
+				return errors.New("the `georeplications` list cannot contain the location where the Container Registry exists")
 			}
 
 			quarantinePolicyEnabled := d.Get("quarantine_policy_enabled").(bool)

--- a/internal/services/containers/container_registry_webhook_resource.go
+++ b/internal/services/containers/container_registry_webhook_resource.go
@@ -6,6 +6,7 @@ package containers
 import (
 	"fmt"
 	"log"
+	"maps"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -226,9 +227,7 @@ func resourceContainerRegistryWebhookRead(d *pluginsdk.ResourceData, meta interf
 
 		customHeaders := make(map[string]string)
 		if callbackModel.CustomHeaders != nil {
-			for k, v := range *callbackModel.CustomHeaders {
-				customHeaders[k] = v
-			}
+			maps.Copy(customHeaders, *callbackModel.CustomHeaders)
 		}
 		d.Set("custom_headers", customHeaders)
 	}

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"log"
+	"maps"
 	"strconv"
 	"strings"
 	"time"
@@ -1699,9 +1700,7 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 		},
 	}
 
-	for k, v := range schemaKubernetesAddOns() {
-		resource.Schema[k] = v
-	}
+	maps.Copy(resource.Schema, schemaKubernetesAddOns())
 
 	return resource
 }
@@ -4392,9 +4391,7 @@ func flattenKubernetesClusterMaintenanceConfiguration(input *maintenanceconfigur
 		"utc_offset":  utcOfset,
 	}
 	// Add flattened schedule properties
-	for k, v := range flattenKubernetesClusterMaintenanceConfigurationSchedule(input.Schedule) {
-		windowProperties[k] = v
-	}
+	maps.Copy(windowProperties, flattenKubernetesClusterMaintenanceConfigurationSchedule(input.Schedule))
 
 	return append(results, windowProperties)
 }
@@ -4902,7 +4899,7 @@ func flattenKubernetesClusterMetricsProfile(input *managedclusters.ManagedCluste
 func retryNodePoolCreation(ctx context.Context, client *agentpools.AgentPoolsClient, id agentpools.AgentPoolId, profile agentpools.AgentPool) error {
 	// retries the creation of a node pool 3 times
 	var err error
-	for attempt := 0; attempt < 3; attempt++ {
+	for range 3 {
 		if err = client.CreateOrUpdateThenPoll(ctx, id, profile, agentpools.DefaultCreateOrUpdateOperationOptions()); err == nil {
 			return nil
 		}

--- a/internal/services/containers/kubernetes_nodepool.go
+++ b/internal/services/containers/kubernetes_nodepool.go
@@ -5,6 +5,7 @@ package containers
 
 import (
 	"fmt"
+	"maps"
 	"regexp"
 	"strconv"
 	"strings"
@@ -1225,9 +1226,7 @@ func FlattenDefaultNodePool(input *[]managedclusters.ManagedClusterAgentPoolProf
 	var nodeLabels map[string]string
 	if agentPool.NodeLabels != nil {
 		nodeLabels = make(map[string]string)
-		for k, v := range *agentPool.NodeLabels {
-			nodeLabels[k] = v
-		}
+		maps.Copy(nodeLabels, *agentPool.NodeLabels)
 	}
 
 	nodePublicIPPrefixID := pointer.From(agentPool.NodePublicIPPrefixID)

--- a/internal/services/containers/parse/repo_notification.go
+++ b/internal/services/containers/parse/repo_notification.go
@@ -5,6 +5,7 @@ package parse
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 )
 
@@ -46,13 +47,7 @@ func ParseRepositoryNotification(v string) (*RepositoryNotification, error) {
 		return nil, fmt.Errorf("parsing artifact %q: %w", v[:idx], err)
 	}
 	action := RepositoryNotificationAction(v[idx+1:])
-	isAllowedAction := false
-	for _, a := range allowedRepositoryNotificationActions {
-		if a == action {
-			isAllowedAction = true
-			break
-		}
-	}
+	isAllowedAction := slices.Contains(allowedRepositoryNotificationActions, action)
 	if !isAllowedAction {
 		return nil, fmt.Errorf("invalid action %q found", action)
 	}

--- a/internal/services/cosmos/common/cors_rule.go
+++ b/internal/services/cosmos/common/cors_rule.go
@@ -143,8 +143,8 @@ func flattenCorsProperty(input *string) []interface{} {
 
 	results := make([]interface{}, 0, len(*input))
 
-	origins := strings.Split(*input, ",")
-	for _, origin := range origins {
+	origins := strings.SplitSeq(*input, ",")
+	for origin := range origins {
 		results = append(results, origin)
 	}
 

--- a/internal/services/costmanagement/export_resource_base.go
+++ b/internal/services/costmanagement/export_resource_base.go
@@ -6,6 +6,7 @@ package costmanagement
 import (
 	"context"
 	"fmt"
+	"maps"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -116,9 +117,7 @@ func (br costManagementExportBaseResource) arguments(fields map[string]*pluginsd
 		},
 	}
 
-	for k, v := range fields {
-		output[k] = v
-	}
+	maps.Copy(output, fields)
 
 	return output
 }

--- a/internal/services/costmanagement/view_resource_base.go
+++ b/internal/services/costmanagement/view_resource_base.go
@@ -6,6 +6,7 @@ package costmanagement
 import (
 	"context"
 	"fmt"
+	"maps"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -184,9 +185,7 @@ func (br costManagementViewBaseResource) arguments(fields map[string]*pluginsdk.
 		},
 	}
 
-	for k, v := range fields {
-		output[k] = v
-	}
+	maps.Copy(output, fields)
 
 	return output
 }

--- a/internal/services/databoxedge/validate/databox_edge_device_sku_name.go
+++ b/internal/services/databoxedge/validate/databox_edge_device_sku_name.go
@@ -5,6 +5,7 @@ package validate
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/hashicorp/go-azure-sdk/resource-manager/databoxedge/2022-03-01/devices"
@@ -26,20 +27,14 @@ func DataboxEdgeDeviceSkuName(v interface{}, k string) (warnings []string, error
 	validTiers := devices.PossibleValuesForSkuTier()
 
 	// Validate the SKU Name section
-	for _, str := range validSkus {
-		if skuParts[0] == str {
-			validSku = true
-			break
-		}
+	if slices.Contains(validSkus, skuParts[0]) {
+		validSku = true
 	}
 
 	if len(skuParts) > 1 {
 		// Validate the SKU Tier section
-		for _, str := range validTiers {
-			if skuParts[1] == str {
-				validTier = true
-				break
-			}
+		if slices.Contains(validTiers, skuParts[1]) {
+			validTier = true
 		}
 	}
 

--- a/internal/services/datafactory/data_factory_custom_dataset_resource.go
+++ b/internal/services/datafactory/data_factory_custom_dataset_resource.go
@@ -6,6 +6,7 @@ package datafactory
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -175,9 +176,7 @@ func resourceDataFactoryCustomDatasetCreateUpdate(d *pluginsdk.ResourceData, met
 	}
 
 	additionalProperties := d.Get("additional_properties").(map[string]interface{})
-	for k, v := range additionalProperties {
-		props[k] = v
-	}
+	maps.Copy(props, additionalProperties)
 
 	if v, ok := d.GetOk("annotations"); ok {
 		props["annotations"] = v.([]interface{})

--- a/internal/services/datafactory/data_factory_linked_custom_service_resource.go
+++ b/internal/services/datafactory/data_factory_linked_custom_service_resource.go
@@ -6,6 +6,7 @@ package datafactory
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -174,9 +175,7 @@ func resourceDataFactoryLinkedCustomServiceCreateUpdate(d *pluginsdk.ResourceDat
 	}
 
 	additionalProperties := d.Get("additional_properties").(map[string]interface{})
-	for k, v := range additionalProperties {
-		props[k] = v
-	}
+	maps.Copy(props, additionalProperties)
 
 	jsonData, err := json.Marshal(map[string]interface{}{
 		"properties": props,

--- a/internal/services/firewall/firewall_resource.go
+++ b/internal/services/firewall/firewall_resource.go
@@ -690,7 +690,7 @@ func flattenFirewallAdditionalProperty(input *map[string]string) (enabled interf
 	}
 
 	if serversPtr, ok := (*input)["Network.DNS.Servers"]; ok {
-		for _, val := range strings.Split(serversPtr, ",") {
+		for val := range strings.SplitSeq(serversPtr, ",") {
 			servers = append(servers, val)
 		}
 	}
@@ -753,7 +753,7 @@ func expandFirewallVirtualHubSetting(existing *azurefirewalls.AzureFirewall, inp
 						// In case of scale down, keep the first new "Count" addresses.
 						if oldCount > newCount {
 							keptAddresses := make([]azurefirewalls.AzureFirewallPublicIPAddress, newCount)
-							for i := 0; i < newCount; i++ {
+							for i := range newCount {
 								keptAddresses[i] = (*addresses)[i]
 							}
 							addresses = &keptAddresses

--- a/internal/services/hdinsight/common_hdinsight.go
+++ b/internal/services/hdinsight/common_hdinsight.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"maps"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -325,21 +326,15 @@ func expandHDInsightsMetastore(input []interface{}) map[string]interface{} {
 	config := map[string]interface{}{}
 
 	if hiveRaw, ok := v["hive"]; ok {
-		for k, val := range ExpandHDInsightsHiveMetastore(hiveRaw.([]interface{})) {
-			config[k] = val
-		}
+		maps.Copy(config, ExpandHDInsightsHiveMetastore(hiveRaw.([]interface{})))
 	}
 
 	if oozieRaw, ok := v["oozie"]; ok {
-		for k, val := range ExpandHDInsightsOozieMetastore(oozieRaw.([]interface{})) {
-			config[k] = val
-		}
+		maps.Copy(config, ExpandHDInsightsOozieMetastore(oozieRaw.([]interface{})))
 	}
 
 	if ambariRaw, ok := v["ambari"]; ok {
-		for k, val := range ExpandHDInsightsAmbariMetastore(ambariRaw.([]interface{})) {
-			config[k] = val
-		}
+		maps.Copy(config, ExpandHDInsightsAmbariMetastore(ambariRaw.([]interface{})))
 	}
 
 	return config

--- a/internal/services/hdinsight/hdinsight_cluster_data_source.go
+++ b/internal/services/hdinsight/hdinsight_cluster_data_source.go
@@ -5,6 +5,7 @@ package hdinsight
 
 import (
 	"fmt"
+	"maps"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -184,9 +185,7 @@ func flattenHDInsightsDataSourceComponentVersions(input *map[string]string) map[
 	output := make(map[string]string)
 
 	if input != nil {
-		for k, v := range *input {
-			output[k] = v
-		}
+		maps.Copy(output, *input)
 	}
 
 	return output

--- a/internal/services/hdinsight/hdinsight_hadoop_cluster_resource.go
+++ b/internal/services/hdinsight/hdinsight_hadoop_cluster_resource.go
@@ -6,6 +6,7 @@ package hdinsight
 import (
 	"fmt"
 	"log"
+	"maps"
 	"strings"
 	"time"
 
@@ -228,9 +229,7 @@ func resourceHDInsightHadoopClusterCreate(d *pluginsdk.ResourceData, meta interf
 
 	metastoresRaw := d.Get("metastores").([]interface{})
 	metastores := expandHDInsightsMetastore(metastoresRaw)
-	for k, v := range metastores {
-		configurations[k] = v
-	}
+	maps.Copy(configurations, metastores)
 
 	networkPropertiesRaw := d.Get("network").([]interface{})
 	networkProperties := ExpandHDInsightsNetwork(networkPropertiesRaw)

--- a/internal/services/hdinsight/hdinsight_hbase_cluster_resource.go
+++ b/internal/services/hdinsight/hdinsight_hbase_cluster_resource.go
@@ -6,6 +6,7 @@ package hdinsight
 import (
 	"fmt"
 	"log"
+	"maps"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -169,9 +170,7 @@ func resourceHDInsightHBaseClusterCreate(d *pluginsdk.ResourceData, meta interfa
 
 	metastoresRaw := d.Get("metastores").([]interface{})
 	metastores := expandHDInsightsMetastore(metastoresRaw)
-	for k, v := range metastores {
-		configurations[k] = v
-	}
+	maps.Copy(configurations, metastores)
 
 	storageAccountsRaw := d.Get("storage_account").([]interface{})
 	storageAccountsGen2Raw := d.Get("storage_account_gen2").([]interface{})

--- a/internal/services/hdinsight/hdinsight_interactive_query_cluster_resource.go
+++ b/internal/services/hdinsight/hdinsight_interactive_query_cluster_resource.go
@@ -6,6 +6,7 @@ package hdinsight
 import (
 	"fmt"
 	"log"
+	"maps"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -177,9 +178,7 @@ func resourceHDInsightInteractiveQueryClusterCreate(d *pluginsdk.ResourceData, m
 
 	metastoresRaw := d.Get("metastores").([]interface{})
 	metastores := expandHDInsightsMetastore(metastoresRaw)
-	for k, v := range metastores {
-		configurations[k] = v
-	}
+	maps.Copy(configurations, metastores)
 
 	networkPropertiesRaw := d.Get("network").([]interface{})
 	networkProperties := ExpandHDInsightsNetwork(networkPropertiesRaw)

--- a/internal/services/hdinsight/hdinsight_kafka_cluster_resource.go
+++ b/internal/services/hdinsight/hdinsight_kafka_cluster_resource.go
@@ -6,6 +6,7 @@ package hdinsight
 import (
 	"fmt"
 	"log"
+	"maps"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -215,9 +216,7 @@ func resourceHDInsightKafkaClusterCreate(d *pluginsdk.ResourceData, meta interfa
 
 	metastoresRaw := d.Get("metastores").([]interface{})
 	metastores := expandHDInsightsMetastore(metastoresRaw)
-	for k, v := range metastores {
-		configurations[k] = v
-	}
+	maps.Copy(configurations, metastores)
 
 	storageAccountsRaw := d.Get("storage_account").([]interface{})
 	storageAccountsGen2Raw := d.Get("storage_account_gen2").([]interface{})

--- a/internal/services/hdinsight/hdinsight_spark_cluster_resource.go
+++ b/internal/services/hdinsight/hdinsight_spark_cluster_resource.go
@@ -6,6 +6,7 @@ package hdinsight
 import (
 	"fmt"
 	"log"
+	"maps"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -181,9 +182,7 @@ func resourceHDInsightSparkClusterCreate(d *pluginsdk.ResourceData, meta interfa
 
 	metastoresRaw := d.Get("metastores").([]interface{})
 	metastores := expandHDInsightsMetastore(metastoresRaw)
-	for k, v := range metastores {
-		configurations[k] = v
-	}
+	maps.Copy(configurations, metastores)
 
 	storageAccountsRaw := d.Get("storage_account").([]interface{})
 	storageAccountsGen2Raw := d.Get("storage_account_gen2").([]interface{})

--- a/internal/services/iothub/iothub_dps_shared_access_policy_resource.go
+++ b/internal/services/iothub/iothub_dps_shared_access_policy_resource.go
@@ -375,9 +375,9 @@ func flattenDpsAccessRights(r iotdpsresource.AccessRightsDescription) dpsAccessR
 		serviceConfig:     false,
 	}
 
-	actualAccessRights := strings.Split(string(r), ",")
+	actualAccessRights := strings.SplitSeq(string(r), ",")
 
-	for _, right := range actualAccessRights {
+	for right := range actualAccessRights {
 		switch strings.ToLower(strings.Trim(right, " ")) {
 		case "enrollmentread":
 			rights.enrollmentRead = true

--- a/internal/services/iothub/iothub_resource.go
+++ b/internal/services/iothub/iothub_resource.go
@@ -1907,8 +1907,8 @@ func IothubConnectionStringSuppress(k, old, new string, d *pluginsdk.ResourceDat
 
 func connectionStringToMap(connectionStr string) map[string]string {
 	m := make(map[string]string)
-	split := strings.Split(connectionStr, ";")
-	for _, v := range split {
+	split := strings.SplitSeq(connectionStr, ";")
+	for v := range split {
 		// The connection string might contain `=`
 		kv := strings.SplitN(v, "=", 2)
 		if len(kv) != 2 {

--- a/internal/services/iothub/iothub_shared_access_policy_resource.go
+++ b/internal/services/iothub/iothub_shared_access_policy_resource.go
@@ -349,9 +349,9 @@ func flattenAccessRights(r devices.AccessRights) accessRights {
 		serviceConnect: false,
 	}
 
-	actualAccessRights := strings.Split(string(r), ",")
+	actualAccessRights := strings.SplitSeq(string(r), ",")
 
-	for _, right := range actualAccessRights {
+	for right := range actualAccessRights {
 		switch strings.ToLower(strings.Trim(right, " ")) {
 		case "registrywrite":
 			rights.registryWrite = true

--- a/internal/services/keyvault/key_vault_certificate_data_data_source.go
+++ b/internal/services/keyvault/key_vault_certificate_data_data_source.go
@@ -257,7 +257,7 @@ func dataSourceArmKeyVaultCertificateDataRead(d *pluginsdk.ResourceData, meta in
 		return fmt.Errorf("encoding Key Vault Certificate Key: %+v", err)
 	}
 
-	certs := ""
+	var certs strings.Builder
 
 	for _, pemCert := range pemCerts {
 		certBlock := &pem.Block{
@@ -269,10 +269,10 @@ func dataSourceArmKeyVaultCertificateDataRead(d *pluginsdk.ResourceData, meta in
 		if err = pem.Encode(&certPEM, certBlock); err != nil {
 			return fmt.Errorf("encoding Key Vault Certificate PEM: %+v", err)
 		}
-		certs += certPEM.String()
+		certs.WriteString(certPEM.String())
 	}
 
-	d.Set("pem", certs)
+	d.Set("pem", certs.String())
 	d.Set("key", keyPEM.String())
 	d.Set("certificates_count", len(pemCerts))
 

--- a/internal/services/keyvault/key_vault_certificate_ephemeral.go
+++ b/internal/services/keyvault/key_vault_certificate_ephemeral.go
@@ -277,7 +277,7 @@ func (e *KeyVaultCertificateEphemeralResource) Open(ctx context.Context, req eph
 		return
 	}
 
-	certs := ""
+	var certs strings.Builder
 
 	for _, pemCert := range pemCerts {
 		certBlock := &pem.Block{
@@ -290,10 +290,10 @@ func (e *KeyVaultCertificateEphemeralResource) Open(ctx context.Context, req eph
 			sdk.SetResponseErrorDiagnostic(resp, fmt.Sprintf("encoding PEM for %q", id.Name), err)
 			return
 		}
-		certs += certPEM.String()
+		certs.WriteString(certPEM.String())
 	}
 
-	data.Pem = types.StringValue(certs)
+	data.Pem = types.StringValue(certs.String())
 	data.Key = types.StringValue(keyPEM.String())
 	data.CertificateCount = types.Int64Value(int64(len(pemCerts)))
 

--- a/internal/services/kusto/kusto_cluster_resource.go
+++ b/internal/services/kusto/kusto_cluster_resource.go
@@ -626,7 +626,7 @@ func expandKustoClusterSku(input []interface{}) (*clusters.AzureSku, error) {
 		"Standard":    "Standard",
 	}
 
-	skuNamePrefix := strings.Split(sku["name"].(string), "_")[0]
+	skuNamePrefix, _, _ := strings.Cut(sku["name"].(string), "_")
 	tier, ok := skuNamePrefixToTier[skuNamePrefix]
 	if !ok {
 		return nil, fmt.Errorf("sku name begins with invalid tier, possible are Dev(No SLA) and Standard but is: %q", skuNamePrefix)

--- a/internal/services/loadtestservice/load_test_resource.go
+++ b/internal/services/loadtestservice/load_test_resource.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -280,13 +281,7 @@ func (r LoadTestResource) EnsureEncryptionIdentityIDExistsInIdentity(model LoadT
 			return errors.New(msg)
 		}
 
-		existsInIdentity := false
-		for _, id := range model.Identity[0].IdentityIds {
-			if id == model.Encryption[0].Identity[0].IdentityID {
-				existsInIdentity = true
-				break
-			}
-		}
+		existsInIdentity := slices.Contains(model.Identity[0].IdentityIds, model.Encryption[0].Identity[0].IdentityID)
 
 		if !existsInIdentity {
 			return errors.New(msg)

--- a/internal/services/logic/logic_app_standard_resource.go
+++ b/internal/services/logic/logic_app_standard_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"maps"
 	"strconv"
 	"strings"
 	"time"
@@ -1305,17 +1306,13 @@ func mergeAppSettings(existing []webapps.NameValuePair, old, new map[string]inte
 		addOrUpdate[k] = v
 	}
 
-	for k, v := range cMap {
-		addOrUpdate[k] = v
-	}
+	maps.Copy(addOrUpdate, cMap)
 
 	for k := range remove {
 		delete(eMap, k)
 	}
 
-	for k, v := range addOrUpdate {
-		eMap[k] = v
-	}
+	maps.Copy(eMap, addOrUpdate)
 
 	return pointer.To(expandAppSettings(eMap))
 }

--- a/internal/services/manageddevopspools/validate/agent_lifetime.go
+++ b/internal/services/manageddevopspools/validate/agent_lifetime.go
@@ -45,13 +45,13 @@ func parseTimeSpan(s string) (days, hours, minutes, seconds int, err error) {
 	timePart := s
 
 	// Check for "dd.hh:mm:ss" format
-	if dotIdx := strings.IndexByte(s, '.'); dotIdx >= 0 {
-		days, err = strconv.Atoi(s[:dotIdx])
+	if before, after, ok := strings.Cut(s, "."); ok {
+		days, err = strconv.Atoi(before)
 		if err != nil || days < 0 {
 			err = fmt.Errorf("value %q has invalid days component", s)
 			return
 		}
-		timePart = s[dotIdx+1:]
+		timePart = after
 	}
 
 	parts := strings.Split(timePart, ":")

--- a/internal/services/managementgroup/management_group_resource.go
+++ b/internal/services/managementgroup/management_group_resource.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"slices"
 	"time"
 
 	"github.com/google/uuid"
@@ -413,13 +414,7 @@ func determineManagementGroupSubscriptionsIdsToRemove(existing *[]managementgrou
 			continue
 		}
 
-		found := false
-		for _, subId := range updated {
-			if id.SubscriptionId == subId {
-				found = true
-				break
-			}
-		}
+		found := slices.Contains(updated, id.SubscriptionId)
 
 		if !found {
 			subscriptionIdsToRemove = append(subscriptionIdsToRemove, id.SubscriptionId)

--- a/internal/services/monitor/monitor_autoscale_setting_resource.go
+++ b/internal/services/monitor/monitor_autoscale_setting_resource.go
@@ -6,6 +6,7 @@ package monitor
 import (
 	"fmt"
 	"log"
+	"maps"
 	"strconv"
 	"time"
 
@@ -1038,9 +1039,7 @@ func flattenAzureRmMonitorAutoScaleSettingNotification(notifications *[]autoscal
 
 				props := make(map[string]string)
 				if webHookProps := v.Properties; webHookProps != nil {
-					for key, value := range *v.Properties {
-						props[key] = value
-					}
+					maps.Copy(props, *v.Properties)
 					hook["properties"] = props
 					webhooks = append(webhooks, hook)
 				}

--- a/internal/services/monitor/monitor_metric_alert_resource.go
+++ b/internal/services/monitor/monitor_metric_alert_resource.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"maps"
 	"net/http"
 	"time"
 
@@ -882,9 +883,7 @@ func flattenMonitorMetricAlertAction(input *[]metricalerts.MetricAlertAction) (r
 
 		props := make(map[string]string)
 		if action.WebHookProperties != nil {
-			for pk, pv := range *action.WebHookProperties {
-				props[pk] = pv
-			}
+			maps.Copy(props, *action.WebHookProperties)
 		}
 		v["webhook_properties"] = props
 

--- a/internal/services/mssql/mssql_virtual_machine_resource.go
+++ b/internal/services/mssql/mssql_virtual_machine_resource.go
@@ -1179,8 +1179,8 @@ func flattenSqlVirtualMachineKeyVaultCredential(keyVault *sqlvirtualmachines.Key
 }
 
 func mssqlVMCredentialNameDiffSuppressFunc(_, old, new string, _ *pluginsdk.ResourceData) bool {
-	oldNamelist := strings.Split(old, ",")
-	for _, n := range oldNamelist {
+	oldNamelist := strings.SplitSeq(old, ",")
+	for n := range oldNamelist {
 		cur := strings.Split(n, ":")
 		if len(cur) > 1 && cur[1] == new {
 			return true

--- a/internal/services/netapp/netapp_backup_vault_resource.go
+++ b/internal/services/netapp/netapp_backup_vault_resource.go
@@ -210,7 +210,7 @@ func (r NetAppBackupVaultResource) Delete() sdk.ResourceFunc {
 			}
 
 			// Attempt to delete backup vault with retries
-			for retries := 0; retries < 5; retries++ {
+			for range 5 {
 				// Delete backups
 				if err := deleteBackupsFromVault(ctx, id, backupClient, metadata.Client.Features.NetApp.DeleteBackupsOnBackupVaultDestroy); err != nil {
 					return err
@@ -329,7 +329,7 @@ func deleteBackupsFromVault(ctx context.Context, id *backupvaults.BackupVaultId,
 
 func retryBackupDelete(ctx context.Context, client *backups.BackupsClient, id backups.BackupId, retryAttempts, retryIntervalSec int) error {
 	var lastErr error
-	for attempt := 0; attempt < retryAttempts; attempt++ {
+	for range retryAttempts {
 		if err := client.DeleteThenPoll(ctx, id); err == nil {
 			if err := waitForBackupDeletion(ctx, client, id); err != nil {
 				return fmt.Errorf("waiting for deletion of %s: %w", id.ID(), err)

--- a/internal/services/netapp/netapp_snapshot_policy_resource.go
+++ b/internal/services/netapp/netapp_snapshot_policy_resource.go
@@ -585,7 +585,7 @@ func flattenNetAppVolumeSnapshotPolicyWeeklySchedule(input *snapshotpolicies.Wee
 
 	weekDays := make([]interface{}, 0)
 	if input.Day != nil {
-		for _, day := range strings.Split(*input.Day, ",") {
+		for day := range strings.SplitSeq(*input.Day, ",") {
 			weekDays = append(weekDays, day)
 		}
 	}
@@ -607,7 +607,7 @@ func flattenNetAppVolumeSnapshotPolicyMonthlySchedule(input *snapshotpolicies.Mo
 
 	daysOfMonth := make([]interface{}, 0)
 	if input.DaysOfMonth != nil {
-		for _, day := range strings.Split(*input.DaysOfMonth, ",") {
+		for day := range strings.SplitSeq(*input.DaysOfMonth, ",") {
 			intDay, _ := strconv.Atoi(day)
 			daysOfMonth = append(daysOfMonth, intDay)
 		}

--- a/internal/services/network/custom_ip_prefix_resource.go
+++ b/internal/services/network/custom_ip_prefix_resource.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"slices"
 	"strings"
 	"time"
 
@@ -405,12 +406,7 @@ func (r CustomIpPrefixResource) Delete() sdk.ResourceFunc {
 type commissionedStates []customipprefixes.CommissionedState
 
 func (t commissionedStates) contains(i customipprefixes.CommissionedState) bool {
-	for _, s := range t {
-		if i == s {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(t, i)
 }
 
 func (t commissionedStates) strings() (out []string) {

--- a/internal/services/network/private_endpoint_resource.go
+++ b/internal/services/network/private_endpoint_resource.go
@@ -392,8 +392,7 @@ func resourcePrivateEndpointCreate(d *pluginsdk.ResourceData, meta interface{}) 
 		}
 
 		if err := result.Poller.PollUntilDone(ctx); err != nil {
-			var lroFailError pollers.PollingFailedError
-			if errors.As(err, &lroFailError) {
+			if lroFailError, ok := errors.AsType[pollers.PollingFailedError](err); ok {
 				type lroErrorType struct {
 					Error struct {
 						Code    string `json:"code"`

--- a/internal/services/network/private_endpoint_resource_test.go
+++ b/internal/services/network/private_endpoint_resource_test.go
@@ -348,7 +348,7 @@ func TestAccPrivateEndpoint_multipleInstances(t *testing.T) {
 
 	instanceCount := 5
 	var checks []pluginsdk.TestCheckFunc
-	for i := 0; i < instanceCount; i++ {
+	for i := range instanceCount {
 		checks = append(checks, check.That(fmt.Sprintf("%s.%d", data.ResourceName, i)).ExistsInAzure(r))
 	}
 
@@ -367,7 +367,7 @@ func TestAccPrivateEndpoint_multipleInstancesWithLinkAlias(t *testing.T) {
 
 	instanceCount := 5
 	var checks []pluginsdk.TestCheckFunc
-	for i := 0; i < instanceCount; i++ {
+	for i := range instanceCount {
 		checks = append(checks, check.That(fmt.Sprintf("%s.%d", data.ResourceName, i)).ExistsInAzure(r))
 	}
 

--- a/internal/services/network/route_map_resource_test.go
+++ b/internal/services/network/route_map_resource_test.go
@@ -119,7 +119,7 @@ func randString() string {
 	charSet := "abcdefghijklmnopqrstuvwxyz"
 	strlen := 5
 	result := make([]byte, strlen)
-	for i := 0; i < strlen; i++ {
+	for i := range strlen {
 		result[i] = charSet[rand.Intn(len(charSet))]
 	}
 	return string(result)

--- a/internal/services/network/virtual_network_resource_test.go
+++ b/internal/services/network/virtual_network_resource_test.go
@@ -530,7 +530,7 @@ resource "azurerm_virtual_network" "test" {
 
 func (r VirtualNetworkResource) tagCount(data acceptance.TestData) string {
 	tags := ""
-	for i := 0; i < 50; i++ {
+	for i := range 50 {
 		tags += fmt.Sprintf("t%d = \"v%d\"\n", i, i)
 	}
 

--- a/internal/services/oracle/oracle_autonomous_database_clone_from_database_resource.go
+++ b/internal/services/oracle/oracle_autonomous_database_clone_from_database_resource.go
@@ -6,6 +6,7 @@ package oracle
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -451,10 +452,8 @@ func (AutonomousDatabaseCloneFromDatabaseResource) CustomizeDiff() sdk.ResourceF
 				return fmt.Errorf("unsupported source workload: %s", sourceWorkload)
 			}
 
-			for _, target := range targets {
-				if dbWorkload == target {
-					return nil
-				}
+			if slices.Contains(targets, dbWorkload) {
+				return nil
 			}
 
 			return fmt.Errorf("invalid workload: %s->%s not allowed", sourceWorkload, dbWorkload)

--- a/internal/services/paloalto/validate/country_code.go
+++ b/internal/services/paloalto/validate/country_code.go
@@ -3,7 +3,10 @@
 
 package validate
 
-import "fmt"
+import (
+	"fmt"
+	"slices"
+)
 
 var ISO3166_1_alpha2 = []string{
 	"AF",
@@ -267,10 +270,8 @@ func ISO3361CountryCode(input interface{}, k string) (warnings []string, errors 
 		return
 	}
 
-	for _, a := range ISO3166_1_alpha2 {
-		if a == v {
-			return
-		}
+	if slices.Contains(ISO3166_1_alpha2, v) {
+		return
 	}
 	errors = append(errors, fmt.Errorf("%s (%q) is not a valid ISO3361-1 Alpha-2 country code, see the official Palo Alto supported list at https://knowledgebase.paloaltonetworks.com/KCSArticleDetail?id=kA10g000000ClFFCA0 for more information", k, v))
 

--- a/internal/services/policy/assignment_resource_base.go
+++ b/internal/services/policy/assignment_resource_base.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"maps"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -556,9 +557,7 @@ func (br assignmentBaseResource) arguments(fields map[string]*pluginsdk.Schema) 
 		},
 	}
 
-	for k, v := range fields {
-		output[k] = v
-	}
+	maps.Copy(output, fields)
 
 	return output
 }

--- a/internal/services/postgres/postgresql_flexible_server_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_resource.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -466,11 +467,8 @@ func resourcePostgresqlFlexibleServer() *pluginsdk.Resource {
 
 				// verify that the storage_tier is valid
 				// for the given storage_mb...
-				for _, tier := range *storageTiers.ValidTiers {
-					if newTier == tier {
-						isValid = true
-						break
-					}
+				if slices.Contains(*storageTiers.ValidTiers, newTier) {
+					isValid = true
 				}
 
 				if !isValid {

--- a/internal/services/redis/redis_cache_resource.go
+++ b/internal/services/redis/redis_cache_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"maps"
 	"slices"
 	"strconv"
 	"strings"
@@ -1011,9 +1012,7 @@ func flattenTenantSettings(input *map[string]string) map[string]string {
 	output := make(map[string]string)
 
 	if input != nil {
-		for k, v := range *input {
-			output[k] = v
-		}
+		maps.Copy(output, *input)
 	}
 
 	return output

--- a/internal/services/sentinel/sentinel_threat_intelligence_indicator_resource.go
+++ b/internal/services/sentinel/sentinel_threat_intelligence_indicator_resource.go
@@ -6,6 +6,7 @@ package sentinel
 import (
 	"context"
 	"fmt"
+	"maps"
 	"regexp"
 	"time"
 
@@ -811,9 +812,7 @@ func expandThreatIntelligenceExternalReferenceModel(inputList []externalReferenc
 	for _, v := range inputList {
 		input := v
 		hashesValue := make(map[string]string)
-		for k, hash := range input.Hashes {
-			hashesValue[k] = hash
-		}
+		maps.Copy(hashesValue, input.Hashes)
 
 		outputList = append(outputList, threatintelligence.ThreatIntelligenceExternalReference{
 			Hashes:      &hashesValue,
@@ -841,9 +840,7 @@ func flattenThreatIntelligenceExternalReferenceModel(input *[]threatintelligence
 		}
 		if len(pointer.From(v.Hashes)) > 0 {
 			o.Hashes = make(map[string]string)
-			for k, hash := range pointer.From(v.Hashes) {
-				o.Hashes[k] = hash
-			}
+			maps.Copy(o.Hashes, pointer.From(v.Hashes))
 		}
 		output = append(output, o)
 	}

--- a/internal/services/servicefabricmanaged/service_fabric_managed_cluster_resource.go
+++ b/internal/services/servicefabricmanaged/service_fabric_managed_cluster_resource.go
@@ -6,6 +6,7 @@ package servicefabricmanaged
 import (
 	"context"
 	"fmt"
+	"maps"
 	"reflect"
 	"regexp"
 	"strconv"
@@ -698,9 +699,7 @@ func flattenNodetypeProperties(nt nodetype.NodeType) NodeType {
 
 	if capacities := props.Capacities; capacities != nil {
 		caps := make(map[string]string)
-		for k, v := range *capacities {
-			caps[k] = v
-		}
+		maps.Copy(caps, *capacities)
 		out.Capacities = caps
 	}
 
@@ -710,9 +709,7 @@ func flattenNodetypeProperties(nt nodetype.NodeType) NodeType {
 
 	if placementProps := props.PlacementProperties; placementProps != nil {
 		placements := make(map[string]string)
-		for k, v := range *placementProps {
-			placements[k] = v
-		}
+		maps.Copy(placements, *placementProps)
 		out.PlacementProperties = placements
 	}
 

--- a/internal/services/signalr/web_pubsub_hub_resource.go
+++ b/internal/services/signalr/web_pubsub_hub_resource.go
@@ -393,8 +393,8 @@ func flattenEventListener(listener *[]webpubsub.EventListener) []interface{} {
 				listenerBlock["system_event_name_filter"] = helpers.FlattenStringSlice(eventNameFilter.SystemEvents)
 			}
 			if eventNameFilter.UserEventPattern != nil && *eventNameFilter.UserEventPattern != "" {
-				v := strings.Split(*eventNameFilter.UserEventPattern, ",")
-				for _, s := range v {
+				v := strings.SplitSeq(*eventNameFilter.UserEventPattern, ",")
+				for s := range v {
 					userNameFilterList = append(userNameFilterList, s)
 				}
 				listenerBlock["user_event_name_filter"] = userNameFilterList

--- a/internal/services/springcloud/spring_cloud_new_relic_application_performance_monitoring_resource.go
+++ b/internal/services/springcloud/spring_cloud_new_relic_application_performance_monitoring_resource.go
@@ -421,7 +421,7 @@ func flattenNewRelicLabels(input string) map[string]string {
 	if input == "" {
 		return labels
 	}
-	for _, label := range strings.Split(input, ";") {
+	for label := range strings.SplitSeq(input, ";") {
 		parts := strings.Split(label, ":")
 		if len(parts) == 2 {
 			labels[parts[0]] = parts[1]

--- a/internal/services/storage/blobs.go
+++ b/internal/services/storage/blobs.go
@@ -285,7 +285,7 @@ func (sbu BlobUpload) pageUploadFromSource(ctx context.Context, file io.ReaderAt
 	}
 	close(pages)
 
-	for i := 0; i < workerCount; i++ {
+	for range workerCount {
 		go sbu.blobPageUploadWorker(ctx, blobPageUploadContext{
 			blobSize: fileSize,
 			pages:    pages,
@@ -371,10 +371,7 @@ type blobPageUploadContext struct {
 func (sbu BlobUpload) blobPageUploadWorker(ctx context.Context, uploadCtx blobPageUploadContext) {
 	for page := range uploadCtx.pages {
 		start := page.offset
-		end := page.offset + page.section.Size() - 1
-		if end > uploadCtx.blobSize-1 {
-			end = uploadCtx.blobSize - 1
-		}
+		end := min(page.offset+page.section.Size()-1, uploadCtx.blobSize-1)
 		size := end - start + 1
 
 		chunk := make([]byte, size)

--- a/internal/services/storage/storage_account_blob_container_sas_data_source.go
+++ b/internal/services/storage/storage_account_blob_container_sas_data_source.go
@@ -6,6 +6,7 @@ package storage
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/storage"
@@ -247,13 +248,13 @@ func BuildContainerPermissionsString(perms map[string]interface{}) string {
 		{"set_immutability_policy", "i"},
 	}
 
-	retVal := ""
+	var retVal strings.Builder
 
 	for _, perm := range orderedPermissions {
 		if val, pres := perms[perm.name].(bool); pres && val {
-			retVal += perm.letter
+			retVal.WriteString(perm.letter)
 		}
 	}
 
-	return retVal
+	return retVal.String()
 }

--- a/internal/services/storage/storage_account_resource_test.go
+++ b/internal/services/storage/storage_account_resource_test.go
@@ -2040,7 +2040,7 @@ resource "azurerm_storage_account" "test" {
 
 func (r StorageAccountResource) tagCount(data acceptance.TestData) string {
 	tags := ""
-	for i := 0; i < 50; i++ {
+	for i := range 50 {
 		tags += fmt.Sprintf("t%d = \"v%d\"\n", i, i)
 	}
 

--- a/internal/services/storage/storage_filesystem_ace.go
+++ b/internal/services/storage/storage_filesystem_ace.go
@@ -15,7 +15,7 @@ func ExpandDataLakeGen2AceList(input []interface{}) (*accesscontrol.ACL, error) 
 	}
 	aceList := make([]accesscontrol.ACE, len(input))
 
-	for i := 0; i < len(input); i++ {
+	for i := range input {
 		v := input[i].(map[string]interface{})
 
 		isDefault := false

--- a/internal/services/synapse/synapse_linked_service_resource.go
+++ b/internal/services/synapse/synapse_linked_service_resource.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"maps"
 	"net/http"
 	"time"
 
@@ -193,9 +194,7 @@ func resourceSynapseLinkedServiceCreateUpdate(d *pluginsdk.ResourceData, meta in
 	}
 
 	additionalProperties := d.Get("additional_properties").(map[string]interface{})
-	for k, v := range additionalProperties {
-		props[k] = v
-	}
+	maps.Copy(props, additionalProperties)
 
 	jsonData, err := json.Marshal(map[string]interface{}{
 		"properties": props,

--- a/internal/services/systemcentervirtualmachinemanager/system_center_virtual_machine_manager_server_resource.go
+++ b/internal/services/systemcentervirtualmachinemanager/system_center_virtual_machine_manager_server_resource.go
@@ -300,7 +300,7 @@ func systemCenterVirtualMachineManagerServerStateRefreshFunc(ctx context.Context
 		checkTimes := 10
 		lastInventoryItemCount := 0
 
-		for i := 0; i < checkTimes; i++ {
+		for i := range checkTimes {
 			resp, err := client.ListByVMmServer(ctx, scvmmServerId)
 			if err != nil {
 				return nil, "", fmt.Errorf("polling for %s: %+v", id, err)

--- a/internal/tf/suppress/ssh_keys.go
+++ b/internal/tf/suppress/ssh_keys.go
@@ -47,7 +47,7 @@ func NormalizeSSHKey(input string) (*string, error) {
 	output = strings.ReplaceAll(output, "\r", "")
 
 	lines := make([]string, 0)
-	for _, line := range strings.Split(output, "\n") {
+	for line := range strings.SplitSeq(output, "\n") {
 		lines = append(lines, strings.TrimSpace(line))
 	}
 

--- a/internal/tf/validation/pluginsdk.go
+++ b/internal/tf/validation/pluginsdk.go
@@ -8,6 +8,7 @@ import (
 	"net/mail"
 	"net/url"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -54,10 +55,8 @@ func FloatInSlice(valid []float64) func(interface{}, string) ([]string, []error)
 			return warnings, errors
 		}
 
-		for _, validFloat := range valid {
-			if v == validFloat {
-				return warnings, errors
-			}
+		if slices.Contains(valid, v) {
+			return warnings, errors
 		}
 
 		errors = append(errors, fmt.Errorf("expected %s to be one of %v, got %f", k, valid, v))

--- a/internal/tools/document-lint/md/normalize.go
+++ b/internal/tools/document-lint/md/normalize.go
@@ -41,8 +41,8 @@ func tryBlockHeadDetect(line string) bool {
 }
 
 func tryFixBlockHead(line string) string {
-	if strings.HasPrefix(line, "*") {
-		line = strings.TrimSpace(strings.TrimPrefix(line, "*"))
+	if after, ok := strings.CutPrefix(line, "*"); ok {
+		line = strings.TrimSpace(after)
 	}
 
 	if strings.HasPrefix(line, "`") {

--- a/internal/tools/document-lint/md/resource_doc.go
+++ b/internal/tools/document-lint/md/resource_doc.go
@@ -158,8 +158,8 @@ func extractFieldFromLine(line string) (field *model.Field) {
 
 func extractBlockNames(line string) (res []string) {
 	if blockHeadReg.MatchString(line) {
-		idx := strings.Index(line, "block")
-		names := codeReg.FindAllString(line[:idx], -1)
+		before, _, _ := strings.Cut(line, "block")
+		names := codeReg.FindAllString(before, -1)
 		for idx, val := range names {
 			names[idx] = strings.Trim(val, "`'")
 		}

--- a/internal/tools/document-lint/model/resource_doc.go
+++ b/internal/tools/document-lint/model/resource_doc.go
@@ -5,6 +5,7 @@ package model
 
 import (
 	"log"
+	"maps"
 	"strconv"
 	"strings"
 
@@ -290,9 +291,7 @@ func (r *ResourceDoc) SetTimeout(lineNum int, line string) {
 
 func (r *ResourceDoc) AllProp() Properties {
 	res := Properties{}
-	for k, v := range r.Args {
-		res[k] = v
-	}
+	maps.Copy(res, r.Args)
 	for k, v := range r.Attr {
 		// merge back to args if exists in both arg and attr
 		if arg, ok := res[k]; ok {

--- a/internal/tools/generator-resource-id/main.go
+++ b/internal/tools/generator-resource-id/main.go
@@ -253,8 +253,8 @@ func NewResourceID(typeName, servicePackageName, resourceId string) (*ResourceId
 				// TODO: in time this could be worth a series of overrides
 
 				// handles "GallerieName" and `DataFactoriesName`
-				if strings.HasSuffix(key, "ies") {
-					key = strings.TrimSuffix(key, "ies")
+				if before, ok := strings.CutSuffix(key, "ies"); ok {
+					key = before
 					key = fmt.Sprintf("%sy", key)
 				}
 				switch {

--- a/internal/tools/generator-services/main.go
+++ b/internal/tools/generator-services/main.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 
@@ -130,7 +131,8 @@ func (githubLabelsGenerator) run(outputFileName string, _ map[string]struct{}) e
 	}
 	sort.Strings(sortedLabels)
 
-	output := strings.TrimSpace(githubLabelsTemplate)
+	var output strings.Builder
+	output.WriteString(strings.TrimSpace(githubLabelsTemplate))
 	for _, labelName := range sortedLabels {
 		pkgs := labelsToPackages[labelName]
 
@@ -148,10 +150,10 @@ func (githubLabelsGenerator) run(outputFileName string, _ map[string]struct{}) e
 		}
 
 		out = append(out, "")
-		output += fmt.Sprintf("\n%s", strings.Join(out, "\n"))
+		fmt.Fprintf(&output, "\n%s", strings.Join(out, "\n"))
 	}
 
-	return writeToFile(outputFileName, output)
+	return writeToFile(outputFileName, output.String())
 }
 
 type teamCityServicesListGenerator struct{}
@@ -327,7 +329,8 @@ func (githubIssueLabelsGenerator) run(outputFileName string, _ map[string]struct
 	}
 	sort.Strings(sortedLabels)
 
-	output := strings.TrimSpace(githubIssueLabelsTemplate)
+	var output strings.Builder
+	output.WriteString(strings.TrimSpace(githubIssueLabelsTemplate))
 
 	labelToPrefixes := make(map[string][]Prefix)
 
@@ -383,11 +386,11 @@ func (githubIssueLabelsGenerator) run(outputFileName string, _ map[string]struct
 				out = append(out, fmt.Sprintf("  - '### (|New or )Affected Resource\\(s\\)\\/Data Source\\(s\\)((.|\\n)*)azurerm_%s((.|\\n)*)###'", prefixes[0]))
 			}
 			out = append(out, "")
-			output += fmt.Sprintf("\n%s", strings.Join(out, "\n"))
+			fmt.Fprintf(&output, "\n%s", strings.Join(out, "\n"))
 		}
 	}
 
-	return writeToFile(outputFileName, output)
+	return writeToFile(outputFileName, output.String())
 }
 
 func writeToFile(filePath string, contents string) error {
@@ -416,13 +419,7 @@ func writeToFile(filePath string, contents string) error {
 }
 
 func contains(input []string, value string) bool {
-	for _, v := range input {
-		if v == value {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(input, value)
 }
 
 func appendToSliceWithinMap(sliceMap map[string][]string, slice []string, key string) map[string][]string {
@@ -435,7 +432,7 @@ func appendToSliceWithinMap(sliceMap map[string][]string, slice []string, key st
 }
 
 func longestCommonPrefix(names []string) string {
-	longestPrefix := ""
+	var longestPrefix strings.Builder
 	end := false
 
 	if len(names) > 0 {
@@ -445,14 +442,14 @@ func longestCommonPrefix(names []string) string {
 
 		for i := 0; i < len(first); i++ {
 			if !end && string(last[i]) == string(first[i]) {
-				longestPrefix += string(last[i])
+				longestPrefix.WriteString(string(last[i]))
 			} else {
 				end = true
 			}
 		}
 	}
 
-	return longestPrefix
+	return longestPrefix.String()
 }
 
 func commonPrefixGroups(names []string) [][]string {

--- a/internal/tools/generator-tests/generators/ast_parser.go
+++ b/internal/tools/generator-tests/generators/ast_parser.go
@@ -126,8 +126,8 @@ func resolveIdentityStruct(pkgName, typeName string, importsMap map[string]strin
 	var pkgPath string
 
 	if importPath, ok := importsMap[pkgName]; ok {
-		if strings.HasPrefix(importPath, "github.com/hashicorp/terraform-provider-azurerm/") {
-			pkgPath = filepath.Join(providerRoot, strings.TrimPrefix(importPath, "github.com/hashicorp/terraform-provider-azurerm/"))
+		if after, ok0 := strings.CutPrefix(importPath, "github.com/hashicorp/terraform-provider-azurerm/"); ok0 {
+			pkgPath = filepath.Join(providerRoot, after)
 		} else {
 			pkgPath = filepath.Join(providerRoot, "vendor", importPath)
 		}

--- a/internal/tools/generator-tests/generators/resource_identity.go
+++ b/internal/tools/generator-tests/generators/resource_identity.go
@@ -186,8 +186,8 @@ func (d *resourceIdentityData) parseArgs(args []string) (errors []error) {
 		}
 	} else if len(d.IdentityProperties) > 0 {
 		d.PropertyNameMap = map[string]string{}
-		propertiesList := strings.Split(d.IdentityProperties, ",")
-		for _, property := range propertiesList {
+		propertiesList := strings.SplitSeq(d.IdentityProperties, ",")
+		for property := range propertiesList {
 			v := strings.Split(property, ":")
 			switch len(v) {
 			case 1:
@@ -203,9 +203,9 @@ func (d *resourceIdentityData) parseArgs(args []string) (errors []error) {
 
 	if len(d.CompareValues) > 0 {
 		d.CompareValueMap = make(map[string]string)
-		kv := strings.Split(d.CompareValues, ",")
+		kv := strings.SplitSeq(d.CompareValues, ",")
 
-		for _, v := range kv {
+		for v := range kv {
 			vParts := strings.Split(v, ":")
 			if len(vParts) != 2 {
 				errors = append(errors, fmt.Errorf("invalid property format in compare-values: '%s'", v))
@@ -357,9 +357,9 @@ func (d *resourceIdentityData) parseArgs(args []string) (errors []error) {
 
 	if len(d.KnownValues) > 0 {
 		d.KnownValueMap = make(map[string]string)
-		kv := strings.Split(d.KnownValues, ",")
+		kv := strings.SplitSeq(d.KnownValues, ",")
 
-		for _, v := range kv {
+		for v := range kv {
 			vParts := strings.Split(v, ":")
 			if len(vParts) != 2 {
 				errors = append(errors, fmt.Errorf("invalid property format in known-values: '%s'", v))

--- a/internal/tools/generator-typed-model/main.go
+++ b/internal/tools/generator-typed-model/main.go
@@ -39,14 +39,14 @@ func main() {
 
 func snake2Camel(input string) string {
 	segs := strings.Split(input, "_")
-	var out string
+	var out strings.Builder
 	for _, seg := range segs {
 		if seg == "" {
 			continue
 		}
-		out += strings.ToUpper(string(seg[0])) + seg[1:]
+		out.WriteString(strings.ToUpper(string(seg[0])) + seg[1:])
 	}
-	return out
+	return out.String()
 }
 
 func modelForSchemaMap(name string, sm map[string]*schema.Schema) []jen.Statement {

--- a/internal/tools/pr-guide-suggestions/lint/gitdiff.go
+++ b/internal/tools/pr-guide-suggestions/lint/gitdiff.go
@@ -144,11 +144,10 @@ func parseDiffPath(root, p string) string {
 // parseHunkNewStart extracts the new-side start line from a hunk header such as
 // "@@ -1,0 +23,4 @@".
 func parseHunkNewStart(line string) (int, bool) {
-	plus := strings.IndexByte(line, '+')
-	if plus < 0 {
+	_, rest, ok := strings.Cut(line, "+")
+	if !ok {
 		return 0, false
 	}
-	rest := line[plus+1:]
 	end := strings.IndexAny(rest, ", ")
 	if end >= 0 {
 		rest = rest[:end]

--- a/internal/tools/pr-guide-suggestions/main.go
+++ b/internal/tools/pr-guide-suggestions/main.go
@@ -167,7 +167,7 @@ func splitSet(s string) map[string]bool {
 		return nil
 	}
 	out := map[string]bool{}
-	for _, part := range strings.Split(s, ",") {
+	for part := range strings.SplitSeq(s, ",") {
 		if p := strings.ToUpper(strings.TrimSpace(part)); p != "" {
 			out[p] = true
 		}

--- a/internal/tools/schema-api/providerjson/handlers.go
+++ b/internal/tools/schema-api/providerjson/handlers.go
@@ -23,7 +23,7 @@ func (p *ProviderJSON) DataSourcesHandler(w http.ResponseWriter, req *http.Reque
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 
 	dsRaw := strings.Split(req.URL.RequestURI(), DataSourcesPath)
-	ds := strings.Split(dsRaw[1], "/")[0]
+	ds, _, _ := strings.Cut(dsRaw[1], "/")
 	data, err := resourceFromRaw(p.DataSourcesMap[ds])
 	if err != nil {
 		w.WriteHeader(http.StatusNotFound)
@@ -38,7 +38,7 @@ func (p *ProviderJSON) ResourcesHandler(w http.ResponseWriter, req *http.Request
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 
 	dsRaw := strings.Split(req.URL.RequestURI(), ResourcesPath)
-	ds := strings.Split(dsRaw[1], "/")[0]
+	ds, _, _ := strings.Cut(dsRaw[1], "/")
 	data, err := resourceFromRaw(p.ResourcesMap[ds])
 	if err != nil {
 		w.WriteHeader(http.StatusNotFound)

--- a/internal/tools/website-scaffold/main.go
+++ b/internal/tools/website-scaffold/main.go
@@ -259,7 +259,7 @@ func (gen documentationGenerator) generate() string {
 // blocks
 func (gen documentationGenerator) argumentsBlock() string {
 	documentationForArguments := func(input map[string]*schema.Schema, onlyRequired, onlyOptional bool, blockName string) string {
-		fields := ""
+		var fields strings.Builder
 
 		for _, fieldName := range gen.sortFields(input) {
 			field := input[fieldName]
@@ -299,10 +299,10 @@ func (gen documentationGenerator) argumentsBlock() string {
 			if field.ForceNew {
 				value += " Changing this forces a new resource to be created."
 			}
-			fields += fmt.Sprintf("* `%s` - (%s) %s\n\n", fieldName, status, value)
+			fmt.Fprintf(&fields, "* `%s` - (%s) %s\n\n", fieldName, status, value)
 		}
 
-		return fields
+		return fields.String()
 	}
 
 	// first output the Required fields
@@ -343,7 +343,7 @@ The following arguments are supported:
 
 func (gen documentationGenerator) attributesBlock() string {
 	documentationForAttributes := func(input map[string]*schema.Schema, onlyComputed bool, blockName string) string {
-		fields := ""
+		var fields strings.Builder
 
 		// now list all of the top-level fields / blocks alphabetically
 		for _, fieldName := range gen.sortFields(input) {
@@ -357,10 +357,10 @@ func (gen documentationGenerator) attributesBlock() string {
 			}
 
 			value := gen.buildDescriptionForAttribute(fieldName, field, blockName)
-			fields += fmt.Sprintf("* `%s` - %s\n\n", fieldName, value)
+			fmt.Fprintf(&fields, "* `%s` - %s\n\n", fieldName, value)
 		}
 
-		return fields
+		return fields.String()
 	}
 
 	// present in everything
@@ -556,11 +556,11 @@ func (gen documentationGenerator) blockIsBefore(name string, blockName string) b
 }
 
 func (gen documentationGenerator) buildIndentForExample(level int) string {
-	out := ""
-	for i := 0; i < level; i++ {
-		out += "  "
+	var out strings.Builder
+	for range level {
+		out.WriteString("  ")
 	}
-	return out
+	return out.String()
 }
 
 func (gen documentationGenerator) buildDescriptionForArgument(name string, field *schema.Schema, blockName string) string {
@@ -777,7 +777,7 @@ func (gen documentationGenerator) processElementForExample(field string, indentL
 
 func (gen documentationGenerator) requiredFieldsForExampleBlock(fields map[string]*schema.Schema, indentLevel int) string {
 	indent := gen.buildIndentForExample(indentLevel)
-	output := ""
+	var output strings.Builder
 
 	processField := func(name string, field *schema.Schema) string {
 		value := gen.determineDefaultValueForExample(name, field)
@@ -786,13 +786,13 @@ func (gen documentationGenerator) requiredFieldsForExampleBlock(fields map[strin
 
 	// if we have a "name", "location" "resource_group_name" field output those first as per convention
 	if v, ok := fields["name"]; ok && v.Required {
-		output += processField("name", v)
+		output.WriteString(processField("name", v))
 	}
 	if v, ok := fields["resource_group_name"]; ok && v.Required {
-		output += processField("resource_group_name", v)
+		output.WriteString(processField("resource_group_name", v))
 	}
 	if v, ok := fields["location"]; ok && v.Required {
-		output += processField("location", v)
+		output.WriteString(processField("location", v))
 	}
 
 	for field, v := range fields {
@@ -805,13 +805,13 @@ func (gen documentationGenerator) requiredFieldsForExampleBlock(fields map[strin
 
 		if v.Elem != nil {
 			isAttribute := v.ConfigMode == schema.SchemaConfigModeAttr
-			output += gen.processElementForExample(field, indentLevel, v.Elem, isAttribute)
+			output.WriteString(gen.processElementForExample(field, indentLevel, v.Elem, isAttribute))
 			continue
 		}
 
-		output += processField(field, v)
+		output.WriteString(processField(field, v))
 	}
-	return strings.TrimSuffix(output, "\n")
+	return strings.TrimSuffix(output.String(), "\n")
 }
 
 func (gen documentationGenerator) sortFields(input map[string]*schema.Schema) []string {


### PR DESCRIPTION
Enables the `modernize` linter (bundled in golangci-lint v2.12.2, so no extra workflow/tooling) and applies its autofixes.

Disabled analyzers:
- `newexpr` - wants `pointer.To(x)` -> `new(x)`, conflicts with AZG002
- `any` - `interface{}` -> `any`, ~15k findings across ~2500 files, separate mechanical PR
