### PR TITLE
feat(enhancement): update ampls linked service arguments

### DIFF
--- a/internal/services/monitor/monitor_private_link_scoped_service_resource.go
+++ b/internal/services/monitor/monitor_private_link_scoped_service_resource.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	components "github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2020-02-02/componentsapis"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/insights/2019-10-17-preview/privatelinkscopedresources"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/insights/2021-07-01-preview/privatelinkscopesapis"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/insights/2023-03-11/datacollectionendpoints"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/workspaces"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
@@ -50,13 +51,37 @@ func resourceMonitorPrivateLinkScopedService() *pluginsdk.Resource {
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
 
-			"resource_group_name": commonschema.ResourceGroupName(),
+			"resource_group_name": commonschema.ResourceGroupNameOptional(),
+
+			"scope_resource_group_name": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				AtLeastOneOf: []string{"resource_group_name", "scope_resource_group_name", "scope_resource_id"},
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"scope_subscription_id": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IsUUID,
+			},
 
 			"scope_name": {
 				Type:         pluginsdk.TypeString,
-				Required:     true,
+				Optional:     true,
 				ForceNew:     true,
+				AtLeastOneOf: []string{"scope_name", "scope_resource_id"},
 				ValidateFunc: validate.PrivateLinkScopeName,
+			},
+
+			"scope_resource_id": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				AtLeastOneOf: []string{"scope_name", "scope_resource_id"},
+				ValidateFunc: privatelinkscopesapis.ValidatePrivateLinkScopeID,
 			},
 
 			"linked_resource_id": {
@@ -76,11 +101,30 @@ func resourceMonitorPrivateLinkScopedService() *pluginsdk.Resource {
 
 func resourceMonitorPrivateLinkScopedServiceCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+	resourceGroupName := d.Get("resource_group_name").(string)
+	scopeName := d.Get("scope_name").(string)
+	if scopeResourceGroupName, ok := d.GetOk("scope_resource_group_name"); ok {
+		resourceGroupName = scopeResourceGroupName.(string)
+	}
+	if scopeSubscriptionId, ok := d.GetOk("scope_subscription_id"); ok {
+		subscriptionId = scopeSubscriptionId.(string)
+	}
 	client := meta.(*clients.Client).Monitor.PrivateLinkScopedResourcesClient
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id := privatelinkscopedresources.NewScopedResourceID(subscriptionId, d.Get("resource_group_name").(string), d.Get("scope_name").(string), d.Get("name").(string))
+	if scopeIdRaw, ok := d.GetOk("scope_resource_id"); ok {
+		scopeId, err := privatelinkscopesapis.ParsePrivateLinkScopeID(scopeIdRaw.(string))
+		if err != nil {
+			return fmt.Errorf("parsing scope ID: %+v", err)
+		}
+
+		subscriptionId = scopeId.SubscriptionId
+		resourceGroupName = scopeId.ResourceGroupName
+		scopeName = scopeId.PrivateLinkScopeName
+	}
+
+	id := privatelinkscopedresources.NewScopedResourceID(subscriptionId, resourceGroupName, scopeName, d.Get("name").(string))
 
 	if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
 		existing, err := client.Get(ctx, id)
@@ -129,8 +173,23 @@ func resourceMonitorPrivateLinkScopedServiceRead(d *pluginsdk.ResourceData, meta
 	}
 
 	d.Set("name", id.ScopedResourceName)
-	d.Set("resource_group_name", id.ResourceGroupName)
-	d.Set("scope_name", id.PrivateLinkScopeName)
+	if scopeIdRaw, ok := d.GetOk("scope_resource_id"); ok {
+		scopeId, err := privatelinkscopesapis.ParsePrivateLinkScopeID(scopeIdRaw.(string))
+		if err != nil {
+			return fmt.Errorf("parsing scope ID: %+v", err)
+		}
+		d.Set("scope_resource_id", scopeId.ID())
+	} else {
+		d.Set("scope_name", id.PrivateLinkScopeName)
+		if _, ok := d.GetOk("scope_resource_group_name"); ok {
+			d.Set("scope_resource_group_name", id.ResourceGroupName)
+		} else {
+			d.Set("resource_group_name", id.ResourceGroupName)
+		}
+		if _, ok := d.GetOk("scope_subscription_id"); ok {
+			d.Set("scope_subscription_id", id.SubscriptionId)
+		}
+	}
 
 	if model := resp.Model; model != nil {
 		if props := model.Properties; props != nil {

--- a/internal/services/monitor/monitor_private_link_scoped_service_resource_test.go
+++ b/internal/services/monitor/monitor_private_link_scoped_service_resource_test.go
@@ -107,7 +107,7 @@ resource "azurerm_application_insights" "test" {
 resource "azurerm_monitor_private_link_scoped_service" "test" {
   name                = "acctest-plss-%d"
   resource_group_name = azurerm_resource_group.test.name
-  scope_name          = azurerm_monitor_private_link_scope.test.name
+	scope_name          = azurerm_monitor_private_link_scope.test.name
   linked_resource_id  = azurerm_application_insights.test.id
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
@@ -120,7 +120,7 @@ func (r MonitorPrivateLinkScopedServiceResource) requiresImport(data acceptance.
 resource "azurerm_monitor_private_link_scoped_service" "import" {
   name                = azurerm_monitor_private_link_scoped_service.test.name
   resource_group_name = azurerm_monitor_private_link_scoped_service.test.resource_group_name
-  scope_name          = azurerm_monitor_private_link_scoped_service.test.scope_name
+	scope_name          = azurerm_monitor_private_link_scoped_service.test.scope_name
   linked_resource_id  = azurerm_monitor_private_link_scoped_service.test.linked_resource_id
 }
 `, r.basic(data))
@@ -152,8 +152,9 @@ resource "azurerm_monitor_private_link_scope" "test" {
 resource "azurerm_monitor_private_link_scoped_service" "test" {
   name                = "acctest-plss-%d"
   resource_group_name = azurerm_resource_group.test.name
-  scope_name          = azurerm_monitor_private_link_scope.test.name
+	scope_name          = "acctest-unused-pls-%d"
+	scope_resource_id   = azurerm_monitor_private_link_scope.test.id
   linked_resource_id  = azurerm_monitor_data_collection_endpoint.test.id
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }

--- a/website/docs/r/monitor_private_link_scoped_service.html.markdown
+++ b/website/docs/r/monitor_private_link_scoped_service.html.markdown
@@ -33,7 +33,7 @@ resource "azurerm_monitor_private_link_scope" "example" {
 resource "azurerm_monitor_private_link_scoped_service" "example" {
   name                = "example-amplsservice"
   resource_group_name = azurerm_resource_group.example.name
-  scope_name          = azurerm_monitor_private_link_scope.example.name
+  scope_resource_id   = azurerm_monitor_private_link_scope.example.id
   linked_resource_id  = azurerm_application_insights.example.id
 }
 ```
@@ -42,27 +42,33 @@ resource "azurerm_monitor_private_link_scoped_service" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the Azure Monitor Private Link Scoped Service. Changing this forces a new resource to be created.
+- `name` - (Required) The name of the Azure Monitor Private Link Scoped Service. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the Resource Group where the Azure Monitor Private Link Scoped Service should exist. Changing this forces a new resource to be created.
+- `resource_group_name` - (Optional) The name of the Resource Group containing the Azure Monitor Private Link Scope. One of `resource_group_name`, `scope_resource_group_name`, or `scope_resource_id` must be specified. Changing this forces a new resource to be created.
 
-* `scope_name` - (Required) The name of the Azure Monitor Private Link Scope. Changing this forces a new resource to be created.
+- `scope_resource_group_name` - (Optional) The name of the Resource Group containing the Azure Monitor Private Link Scope. One of `resource_group_name`, `scope_resource_group_name`, or `scope_resource_id` must be specified. Changing this forces a new resource to be created.
 
-* `linked_resource_id` - (Required) The ID of the linked resource. It must be the Log Analytics workspace or the Application Insights component or the Data Collection endpoint. Changing this forces a new resource to be created.
+- `scope_subscription_id` - (Optional) The subscription ID containing the Azure Monitor Private Link Scope. Changing this forces a new resource to be created.
+
+- `scope_name` - (Optional) The name of the Azure Monitor Private Link Scope. One of `scope_name` or `scope_resource_id` must be specified. Changing this forces a new resource to be created.
+
+- `scope_resource_id` - (Optional) The resource ID of the Azure Monitor Private Link Scope. One of `scope_name` or `scope_resource_id` must be specified. Changing this forces a new resource to be created. When both are specified, `scope_resource_id` takes precedence.
+
+- `linked_resource_id` - (Required) The ID of the linked resource. It must be the Log Analytics workspace or the Application Insights component or the Data Collection endpoint. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 
 In addition to the Arguments listed above - the following Attributes are exported:
 
-* `id` - The ID of the Azure Monitor Private Link Scoped Service.
+- `id` - The ID of the Azure Monitor Private Link Scoped Service.
 
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/configure#define-operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the Azure Monitor Private Link Scope.
-* `read` - (Defaults to 5 minutes) Used when retrieving the Azure Monitor Private Link Scope.
-* `delete` - (Defaults to 30 minutes) Used when deleting the Azure Monitor Private Link Scope.
+- `create` - (Defaults to 30 minutes) Used when creating the Azure Monitor Private Link Scope.
+- `read` - (Defaults to 5 minutes) Used when retrieving the Azure Monitor Private Link Scope.
+- `delete` - (Defaults to 30 minutes) Used when deleting the Azure Monitor Private Link Scope.
 
 ## Import
 
@@ -73,7 +79,9 @@ terraform import azurerm_monitor_private_link_scoped_service.example /subscripti
 ```
 
 ## API Providers
+
 <!-- This section is generated, changes will be overwritten -->
+
 This resource uses the following Azure API Providers:
 
-* `Microsoft.Insights` - 2019-10-17-preview
+- `Microsoft.Insights` - 2019-10-17-preview


### PR DESCRIPTION
<!-- markdownlint-disable-file first-line-heading -->
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This MR is to address issue #33359. The current resource assumed the AMPLS resource is in the same subscription used by provider/client-config. The changes in this pull request  make it easier to set the associated AMPLS resource when it is not in the same subscription as the linked_resource_id. 

With this change all arguments are optional with the exception of `name` and `linked_resource_id`

Introduces the optional argument of `scope_resource_group_name` which is alias to `resource_group_name` now. 

Introduces an optional `scope_subscription_id` argument that allows for referencing the Subscription where the AMPLS is located. If not provided, then fallback to  the Client-Config/Provider Subscription-Id.

The new optional argument of `scope_resource_id` takes precedence over the other optional argument when provided. It is the full Azure Resource-Id of the AMPLS



## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”

<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->

## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.

## Testing

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_monitor_private_link_scoped_service` - Introduces `scope_subscription_id` and `scope_resource_id` as new optional arguments. Also, makes existing `scope_name` and `resource_group_name` optional. If the `scope_resource_id` is provided, then it takes precedence over all other optional arguments. Lastly, the `resource_group_name` argument and `scope_resource_group_name` become aliases for one another.

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change

## Related Issue(s)

Fixes #33359

## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE]
> If this PR changes meaningfully during the course of review please update the title and description as required.
