### PR TITLE
add preflight to azurerm_virtual_machine_extension

### DIFF
--- a/internal/services/compute/virtual_machine_extension_resource.go
+++ b/internal/services/compute/virtual_machine_extension_resource.go
@@ -4,6 +4,7 @@
 package compute
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -19,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/preflight"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -45,6 +47,8 @@ func resourceVirtualMachineExtension() *pluginsdk.Resource {
 			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
+
+		CustomizeDiff: pluginsdk.CustomizeDiffShim(resourceVirtualMachineExtensionCustomizeDiff),
 
 		Schema: map[string]*pluginsdk.Schema{
 			"name": {
@@ -127,6 +131,149 @@ func resourceVirtualMachineExtension() *pluginsdk.Resource {
 			"tags": commonschema.Tags(),
 		},
 	}
+}
+
+// expandCreateForVirtualMachineExtension builds the full ARM PUT body for a VM extension from
+// a ResourceDiff at plan time. location must be resolved beforehand from the parent VM.
+func expandCreateForVirtualMachineExtension(d *schema.ResourceDiff, location string) (virtualmachineextensions.VirtualMachineExtension, error) {
+	publisher := d.Get("publisher").(string)
+	extensionType := d.Get("type").(string)
+	typeHandlerVersion := d.Get("type_handler_version").(string)
+	autoUpgradeMinor := d.Get("auto_upgrade_minor_version").(bool)
+	enableAutomaticUpgrade := d.Get("automatic_upgrade_enabled").(bool)
+	suppressFailure := d.Get("failure_suppression_enabled").(bool)
+
+	extension := virtualmachineextensions.VirtualMachineExtension{
+		Location: &location,
+		Properties: &virtualmachineextensions.VirtualMachineExtensionProperties{
+			Publisher:                     &publisher,
+			Type:                          &extensionType,
+			TypeHandlerVersion:            &typeHandlerVersion,
+			AutoUpgradeMinorVersion:       &autoUpgradeMinor,
+			EnableAutomaticUpgrade:        &enableAutomaticUpgrade,
+			ProtectedSettingsFromKeyVault: expandProtectedSettingsFromKeyVault(d.Get("protected_settings_from_key_vault").([]interface{})),
+			SuppressFailures:              &suppressFailure,
+		},
+		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
+	}
+
+	if settingsString := d.Get("settings").(string); settingsString != "" {
+		var result interface{}
+		if err := json.Unmarshal([]byte(settingsString), &result); err != nil {
+			return extension, fmt.Errorf("unmarshaling `settings`: %+v", err)
+		}
+		extension.Properties.Settings = pointer.To(result)
+	}
+
+	if protectedSettingsString := d.Get("protected_settings").(string); protectedSettingsString != "" {
+		var result interface{}
+		if err := json.Unmarshal([]byte(protectedSettingsString), &result); err != nil {
+			return extension, fmt.Errorf("unmarshaling `protected_settings`: %+v", err)
+		}
+		extension.Properties.ProtectedSettings = pointer.To(result)
+	}
+
+	if provisionAfterExtensionsValue, exists := d.GetOk("provision_after_extensions"); exists {
+		extension.Properties.ProvisionAfterExtensions = helpers.ExpandStringSlice(provisionAfterExtensionsValue.([]interface{}))
+	}
+
+	return extension, nil
+}
+
+// resolvePreflightVMLocation looks up the location of the parent VM for use in preflight
+// validation. Returns skip=true if the virtual_machine_id is not yet known (cross-resource
+// computed value) or if the VM cannot be found, so that validation is gracefully skipped
+// rather than failing the plan.
+func resolvePreflightVMLocation(ctx context.Context, client *clients.Client, d *schema.ResourceDiff) (loc string, skip bool) {
+	vmIdRaw := d.Get("virtual_machine_id").(string)
+	if vmIdRaw == "" {
+		// virtual_machine_id is (known after apply) — skip gracefully.
+		return "", true
+	}
+
+	vmId, err := virtualmachines.ParseVirtualMachineID(vmIdRaw)
+	if err != nil {
+		return "", true
+	}
+
+	vm, err := client.Compute.VirtualMachinesClient.Get(ctx, *vmId, virtualmachines.DefaultGetOperationOptions())
+	if err != nil {
+		if response.WasNotFound(vm.HttpResponse) {
+			// VM doesn't exist yet — gracefully skip.
+			return "", true
+		}
+		// For any other error also skip rather than failing plan.
+		return "", true
+	}
+
+	if vm.Model == nil || vm.Model.Location == "" {
+		return "", true
+	}
+
+	return vm.Model.Location, false
+}
+
+// resourceVirtualMachineExtensionCustomizeDiff implements preflight validation for
+// azurerm_virtual_machine_extension. It uses Pattern 2 (create and ForceNew replacement
+// only) because in-place updates do not change the extension type or its parent VM, so
+// running the full ARM PUT payload against the preflight API on every update would produce
+// false positives from immutable fields (publisher, virtual_machine_id) that cannot change
+// without a ForceNew destroy+create.
+func resourceVirtualMachineExtensionCustomizeDiff(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+	client := meta.(*clients.Client)
+
+	if !client.Features.EnhancedValidation.PreflightEnabled {
+		return nil
+	}
+
+	isNewResource := d.Id() == ""
+	isForceNewReplacement := false
+
+	if !isNewResource {
+		forceNewKeys := []string{"name", "virtual_machine_id", "publisher"}
+		for _, key := range forceNewKeys {
+			if d.HasChange(key) {
+				isForceNewReplacement = true
+				break
+			}
+		}
+	}
+
+	if !isNewResource && !isForceNewReplacement {
+		return nil
+	}
+
+	loc, skip := resolvePreflightVMLocation(ctx, client, d)
+	if skip {
+		return nil
+	}
+
+	vmIdRaw := d.Get("virtual_machine_id").(string)
+	vmId, err := virtualmachines.ParseVirtualMachineID(vmIdRaw)
+	if err != nil {
+		return nil
+	}
+
+	extensionName := d.Get("name").(string)
+	id := virtualmachineextensions.NewExtensionID(vmId.SubscriptionId, vmId.ResourceGroupName, vmId.VirtualMachineName, extensionName)
+
+	req, err := expandCreateForVirtualMachineExtension(d, loc)
+	if err != nil {
+		return err
+	}
+
+	preflightValidate, err := preflight.NewValidationRequest(pointer.To(loc), pointer.To(id), "2024-03-01", req)
+	if err != nil {
+		return fmt.Errorf("constructing preflight validation request: %w", err)
+	}
+
+	metadata := sdk.ResourceMetaData{
+		Client:       client,
+		ResourceDiff: d,
+		Logger:       sdk.ConsoleLogger{},
+	}
+
+	return preflightValidate.ValidateResource(ctx, metadata)
 }
 
 func resourceVirtualMachineExtensionsCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/compute/virtual_machine_extension_resource.go
+++ b/internal/services/compute/virtual_machine_extension_resource.go
@@ -181,69 +181,57 @@ func expandCreateForVirtualMachineExtension(d *schema.ResourceDiff, location str
 }
 
 // resolvePreflightVMLocation looks up the location of the parent VM for use in preflight
-// validation. Returns skip=true if the virtual_machine_id is not yet known (cross-resource
-// computed value) or if the VM cannot be found, so that validation is gracefully skipped
-// rather than failing the plan.
-func resolvePreflightVMLocation(ctx context.Context, client *clients.Client, d *schema.ResourceDiff) (loc string, skip bool) {
+// validation. Returns skip=true if the virtual_machine_id is not yet known or the VM does not
+// exist and no location fallback is configured.
+func resolvePreflightVMLocation(ctx context.Context, client *clients.Client, d *schema.ResourceDiff) (loc string, skip bool, err error) {
 	vmIdRaw := d.Get("virtual_machine_id").(string)
 	if vmIdRaw == "" {
-		// virtual_machine_id is (known after apply) — skip gracefully.
-		return "", true
+		return "", true, nil
 	}
 
 	vmId, err := virtualmachines.ParseVirtualMachineID(vmIdRaw)
 	if err != nil {
-		return "", true
+		return "", false, fmt.Errorf("parsing virtual_machine_id for preflight validation: %w", err)
 	}
 
 	vm, err := client.Compute.VirtualMachinesClient.Get(ctx, *vmId, virtualmachines.DefaultGetOperationOptions())
 	if err != nil {
 		if response.WasNotFound(vm.HttpResponse) {
-			// VM doesn't exist yet — gracefully skip.
-			return "", true
+			if fallback := client.Features.EnhancedValidation.LocationFallback; fallback != nil {
+				return *fallback, false, nil
+			}
+
+			return "", true, nil
 		}
-		// For any other error also skip rather than failing plan.
-		return "", true
+
+		return "", false, fmt.Errorf("retrieving %s for preflight validation: %+v", vmId, err)
 	}
 
 	if vm.Model == nil || vm.Model.Location == "" {
-		return "", true
+		return "", false, fmt.Errorf("determining location of %s for preflight validation: location was missing", vmId)
 	}
 
-	return vm.Model.Location, false
+	return vm.Model.Location, false, nil
 }
 
 // resourceVirtualMachineExtensionCustomizeDiff implements preflight validation for
-// azurerm_virtual_machine_extension. It uses Pattern 2 (create and ForceNew replacement
-// only) because in-place updates do not change the extension type or its parent VM, so
-// running the full ARM PUT payload against the preflight API on every update would produce
-// false positives from immutable fields (publisher, virtual_machine_id) that cannot change
-// without a ForceNew destroy+create.
+// azurerm_virtual_machine_extension. The resource uses the same complete PUT payload for
+// create and update, so validation can run for both operations.
 func resourceVirtualMachineExtensionCustomizeDiff(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
 	client := meta.(*clients.Client)
 
-	if !client.Features.EnhancedValidation.PreflightEnabled {
+	if d == nil || !client.Features.EnhancedValidation.PreflightEnabled {
 		return nil
 	}
 
-	isNewResource := d.Id() == ""
-	isForceNewReplacement := false
-
-	if !isNewResource {
-		forceNewKeys := []string{"name", "virtual_machine_id", "publisher"}
-		for _, key := range forceNewKeys {
-			if d.HasChange(key) {
-				isForceNewReplacement = true
-				break
-			}
-		}
-	}
-
-	if !isNewResource && !isForceNewReplacement {
+	if len(d.GetChangedKeysPrefix("")) == 0 && d.Id() != "" {
 		return nil
 	}
 
-	loc, skip := resolvePreflightVMLocation(ctx, client, d)
+	loc, skip, err := resolvePreflightVMLocation(ctx, client, d)
+	if err != nil {
+		return err
+	}
 	if skip {
 		return nil
 	}
@@ -251,7 +239,7 @@ func resourceVirtualMachineExtensionCustomizeDiff(ctx context.Context, d *schema
 	vmIdRaw := d.Get("virtual_machine_id").(string)
 	vmId, err := virtualmachines.ParseVirtualMachineID(vmIdRaw)
 	if err != nil {
-		return nil
+		return fmt.Errorf("parsing virtual_machine_id for preflight validation: %w", err)
 	}
 
 	extensionName := d.Get("name").(string)

--- a/internal/services/compute/virtual_machine_extension_resource_test.go
+++ b/internal/services/compute/virtual_machine_extension_resource_test.go
@@ -154,6 +154,104 @@ func (t VirtualMachineExtensionResource) Exists(ctx context.Context, clients *cl
 	return pointer.To(resp.Model != nil), nil
 }
 
+func TestAccVirtualMachineExtension_completePreflightPlan(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_virtual_machine_extension", "test")
+	r := VirtualMachineExtensionResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config:             r.completePreflightPlan(data),
+			PlanOnly:           true,
+			ExpectNonEmptyPlan: true,
+		},
+	})
+}
+
+func (r VirtualMachineExtensionResource) completePreflightPlan(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    enhanced_validation {
+      preflight_enabled = true
+    }
+  }
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctvn-%[1]d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctsub-%[1]d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.2.0/24"]
+}
+
+resource "azurerm_network_interface" "test" {
+  name                = "acctni-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  ip_configuration {
+    name                          = "testconfiguration1"
+    subnet_id                     = azurerm_subnet.test.id
+    private_ip_address_allocation = "Dynamic"
+  }
+}
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctvm-%[1]d"
+  location                        = azurerm_resource_group.test.location
+  resource_group_name             = azurerm_resource_group.test.name
+  network_interface_ids           = [azurerm_network_interface.test.id]
+  size                            = "Standard_F2"
+  computer_name                   = "hostname%[1]d"
+  admin_username                  = "testadmin"
+  admin_password                  = "Password1234!"
+  disable_password_authentication = false
+
+  os_disk {
+    name                 = "myosdisk1-%[1]d"
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "0001-com-ubuntu-server-jammy"
+    sku       = "22_04-lts"
+    version   = "latest"
+  }
+}
+
+resource "azurerm_virtual_machine_extension" "test" {
+  name                       = "acctvme-%[1]d"
+  virtual_machine_id         = azurerm_linux_virtual_machine.test.id
+  publisher                  = "Microsoft.Azure.Extensions"
+  type                       = "CustomScript"
+  type_handler_version       = "2.0"
+  auto_upgrade_minor_version = true
+
+  settings = jsonencode({
+    commandToExecute = "hostname"
+  })
+
+  tags = {
+    environment = "Production"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
 func (r VirtualMachineExtensionResource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {

--- a/internal/services/compute/virtual_machine_extension_resource_test.go
+++ b/internal/services/compute/virtual_machine_extension_resource_test.go
@@ -160,11 +160,78 @@ func TestAccVirtualMachineExtension_completePreflightPlan(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
+			Config: r.preflightVirtualMachine(data),
+		},
+		{
 			Config:             r.completePreflightPlan(data),
 			PlanOnly:           true,
 			ExpectNonEmptyPlan: true,
 		},
 	})
+}
+
+func (r VirtualMachineExtensionResource) preflightVirtualMachine(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctvn-%[1]d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctsub-%[1]d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.2.0/24"]
+}
+
+resource "azurerm_network_interface" "test" {
+  name                = "acctni-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  ip_configuration {
+    name                          = "testconfiguration1"
+    subnet_id                     = azurerm_subnet.test.id
+    private_ip_address_allocation = "Dynamic"
+  }
+}
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctvm-%[1]d"
+  location                        = azurerm_resource_group.test.location
+  resource_group_name             = azurerm_resource_group.test.name
+  network_interface_ids           = [azurerm_network_interface.test.id]
+  size                            = "Standard_F2"
+  computer_name                   = "hostname%[1]d"
+  admin_username                  = "testadmin"
+  admin_password                  = "Password1234!"
+  disable_password_authentication = false
+
+  os_disk {
+    name                 = "myosdisk1-%[1]d"
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "0001-com-ubuntu-server-jammy"
+    sku       = "22_04-lts"
+    version   = "latest"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func (r VirtualMachineExtensionResource) completePreflightPlan(data acceptance.TestData) string {
@@ -173,6 +240,7 @@ provider "azurerm" {
   features {
     enhanced_validation {
       preflight_enabled = true
+      preflight_location_fallback = "%[2]s"
     }
   }
 }

--- a/internal/services/compute/virtual_machine_extension_resource_test.go
+++ b/internal/services/compute/virtual_machine_extension_resource_test.go
@@ -239,7 +239,7 @@ func (r VirtualMachineExtensionResource) completePreflightPlan(data acceptance.T
 provider "azurerm" {
   features {
     enhanced_validation {
-      preflight_enabled = true
+      preflight_enabled           = true
       preflight_location_fallback = "%[2]s"
     }
   }

--- a/website/docs/guides/preflight_validation.html.markdown
+++ b/website/docs/guides/preflight_validation.html.markdown
@@ -29,8 +29,10 @@ Preflight Validation can also be enabled by setting the `ARM_PROVIDER_ENHANCED_V
 
 The following resources currently support Preflight Validation:
 
+* `azurerm_dashboard_grafana`
 * `azurerm_eventgrid_namespace`
 * `azurerm_managed_redis`
-* `azurerm_service_plan`
-* `azurerm_dashboard_grafana`
+* `azurerm_monitor_data_collection_endpoint`
 * `azurerm_nginx_deployment`
+* `azurerm_service_plan`
+* `azurerm_virtual_machine_extension`

--- a/website/docs/guides/preflight_validation.html.markdown
+++ b/website/docs/guides/preflight_validation.html.markdown
@@ -32,7 +32,6 @@ The following resources currently support Preflight Validation:
 * `azurerm_dashboard_grafana`
 * `azurerm_eventgrid_namespace`
 * `azurerm_managed_redis`
-* `azurerm_monitor_data_collection_endpoint`
 * `azurerm_nginx_deployment`
 * `azurerm_service_plan`
 * `azurerm_virtual_machine_extension`


### PR DESCRIPTION
<!-- markdownlint-disable-file first-line-heading -->
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

Added pre-flight validation for azurerm_virtual_machine_extension

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”

<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->

## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.

## Testing

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change

## Related Issue(s)

Fixes #0000

## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE]
> If this PR changes meaningfully during the course of review please update the title and description as required.
