### PR TITLE
azurerm_application_gateway - preserve unchanged nested blocks in plans

### DIFF
--- a/internal/provider/applicationgateway/blocks_test.go
+++ b/internal/provider/applicationgateway/blocks_test.go
@@ -1,0 +1,191 @@
+// Copyright IBM Corp. 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package applicationgateway
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network"
+)
+
+// Exercise every repeatable named block from the production gateway schema,
+// including nested lists/sets. Azure client configuration is deliberately not
+// needed to test how the SDK plans these blocks.
+func TestGatewayBlocks(t *testing.T) {
+	gateway := (network.Registration{}).SupportedResources()[resourceName]
+	for key, field := range gateway.Schema {
+		block, ok := field.Elem.(*schema.Resource)
+		if !ok || (field.Computed && !field.Optional) || (field.Type != schema.TypeSet && field.Type != schema.TypeList) || field.MaxItems == 1 || block.Schema["name"] == nil {
+			continue
+		}
+		actions := []string{"none", "rename", "add", "remove"}
+		editKey := map[string]string{"backend_http_settings": "request_timeout", "request_routing_rule": "priority"}[key]
+		if editKey != "" {
+			actions = append(actions, "edit")
+		}
+		for _, empty := range []bool{false, true} {
+			for _, action := range actions {
+				t.Run(fmt.Sprintf("%s/empty=%t/%s", key, empty, action), func(t *testing.T) {
+					t.Parallel()
+					resource := &schema.Resource{Schema: map[string]*schema.Schema{key: field}}
+					provider := &schema.Provider{ResourcesMap: map[string]*schema.Resource{resourceName: resource}}
+					typ := resource.CoreConfigSchema().ImpliedType().AttributeType(key)
+					before := []cty.Value{blockFixture(block, typ.ElementType(), "unchanged", empty), blockFixture(block, typ.ElementType(), "edited", empty)}
+					after := append([]cty.Value(nil), before...)
+					switch action {
+					case "edit":
+						attrs := after[1].AsValueMap()
+						attrs[editKey] = cty.NumberIntVal(121)
+						after[1] = cty.ObjectVal(attrs)
+					case "rename":
+						attrs := after[1].AsValueMap()
+						attrs["name"] = cty.StringVal("renamed")
+						after[1] = cty.ObjectVal(attrs)
+					case "add":
+						after = append(after, blockFixture(block, typ.ElementType(), "new", empty))
+					case "remove":
+						after = after[:1]
+					}
+					config, proposed := make([]cty.Value, len(after)), make([]cty.Value, len(after))
+					for i, value := range after {
+						config[i] = blockConfig(value, block)
+						proposed[i] = config[i]
+						for _, old := range before {
+							if value.RawEquals(old) {
+								proposed[i] = value
+							}
+						}
+					}
+					wrap := func(values []cty.Value, id cty.Value) *tfprotov5.DynamicValue {
+						return testDynamic(t, cty.ObjectVal(map[string]cty.Value{"id": id, key: collectionValue(typ, values)}))
+					}
+					response, err := Wrap(provider.GRPCProvider(), resource).PlanResourceChange(t.Context(), &tfprotov5.PlanResourceChangeRequest{
+						TypeName: resourceName, PriorState: wrap(before, cty.StringVal("gateway")), Config: wrap(config, cty.NullVal(cty.String)), ProposedNewState: wrap(proposed, cty.StringVal("gateway")),
+					})
+					planned := testPlanned(t, resource, response, err).GetAttr(key)
+					if planned.LengthInt() != len(after) {
+						t.Fatalf("got %d blocks, want %d", planned.LengthInt(), len(after))
+					}
+					for it := planned.ElementIterator(); it.Next(); {
+						_, got := it.Element()
+						name := got.GetAttr("name").AsString()
+						found := false
+						for _, want := range after {
+							if name != want.GetAttr("name").AsString() {
+								continue
+							}
+							found = true
+							if action == "edit" && name == "edited" && !got.GetAttr(editKey).RawEquals(want.GetAttr(editKey)) {
+								t.Errorf("lost configured %s change", editKey)
+							}
+							if name == "unchanged" || action == "none" || (name == "edited" && action == "add") {
+								for attr, value := range got.AsValueMap() {
+									if !value.RawEquals(want.GetAttr(attr)) {
+										t.Errorf("untouched %s.%s.%s differs", key, name, attr)
+									}
+								}
+							}
+						}
+						if !found {
+							t.Errorf("unexpected block name %q", name)
+						}
+					}
+				})
+			}
+		}
+	}
+}
+
+func blockFixture(resource *schema.Resource, typ cty.Type, name string, empty bool) cty.Value {
+	attrs := map[string]cty.Value{}
+	for key, field := range resource.Schema {
+		valueType := typ.AttributeType(key)
+		value := cty.NullVal(valueType)
+		if nested, ok := field.Elem.(*schema.Resource); ok && (field.Type == schema.TypeList || field.Type == schema.TypeSet) {
+			value = collectionValue(valueType, []cty.Value{blockFixture(nested, valueType.ElementType(), name+"-child", empty)})
+		} else if field.Default != nil {
+			switch v := field.Default.(type) {
+			case bool:
+				value = cty.BoolVal(v)
+			case int:
+				value = cty.NumberIntVal(int64(v))
+			case string:
+				value = cty.StringVal(v)
+			}
+		} else if field.Required {
+			switch field.Type {
+			case schema.TypeString:
+				if field.StateFunc != nil {
+					value = cty.StringVal(field.StateFunc("example"))
+				} else {
+					value = cty.StringVal("example")
+				}
+			case schema.TypeInt:
+				value = cty.NumberIntVal(1)
+			case schema.TypeBool:
+				value = cty.False
+			case schema.TypeList, schema.TypeSet:
+				if valueType.ElementType() == cty.String {
+					value = collectionValue(valueType, []cty.Value{cty.StringVal("example")})
+				}
+			}
+		}
+		if key == "name" {
+			value = cty.StringVal(name)
+		}
+		attrs[key] = value
+	}
+	for key, field := range resource.Schema {
+		if !field.Computed || field.Optional || field.Type != schema.TypeString {
+			continue
+		}
+		if empty {
+			attrs[key] = cty.StringVal("")
+		}
+		reference := strings.TrimSuffix(key, "_id") + "_name"
+		if key == "id" {
+			reference = "name"
+		}
+		if value, ok := attrs[reference]; ok && !absentString(value) {
+			attrs[key] = cty.StringVal("/fake/" + name + "/" + key)
+		}
+	}
+	return cty.ObjectVal(attrs)
+}
+
+func blockConfig(value cty.Value, resource *schema.Resource) cty.Value {
+	attrs := value.AsValueMap()
+	for key, field := range resource.Schema {
+		if field.Computed && !field.Optional {
+			attrs[key] = cty.NullVal(attrs[key].Type())
+			continue
+		}
+		if nested, ok := field.Elem.(*schema.Resource); ok && !attrs[key].IsNull() && (field.Type == schema.TypeSet || field.Type == schema.TypeList) {
+			values := attrs[key].AsValueSlice()
+			for i, v := range values {
+				values[i] = blockConfig(v, nested)
+			}
+			attrs[key] = collectionValue(attrs[key].Type(), values)
+		}
+	}
+	return cty.ObjectVal(attrs)
+}
+
+func collectionValue(typ cty.Type, values []cty.Value) cty.Value {
+	if typ.IsSetType() {
+		if len(values) == 0 {
+			return cty.SetValEmpty(typ.ElementType())
+		}
+		return cty.SetVal(values)
+	}
+	if len(values) == 0 {
+		return cty.ListValEmpty(typ.ElementType())
+	}
+	return cty.ListVal(values)
+}

--- a/internal/provider/applicationgateway/blocks_test.go
+++ b/internal/provider/applicationgateway/blocks_test.go
@@ -14,9 +14,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network"
 )
 
-// Exercise every repeatable named block from the production gateway schema,
-// including nested lists/sets. Azure client configuration is deliberately not
-// needed to test how the SDK plans these blocks.
 func TestGatewayBlocks(t *testing.T) {
 	gateway := (network.Registration{}).SupportedResources()[resourceName]
 	for key, field := range gateway.Schema {
@@ -65,7 +62,7 @@ func TestGatewayBlocks(t *testing.T) {
 					wrap := func(values []cty.Value, id cty.Value) *tfprotov5.DynamicValue {
 						return testDynamic(t, cty.ObjectVal(map[string]cty.Value{"id": id, key: collectionValue(typ, values)}))
 					}
-					response, err := Wrap(provider.GRPCProvider(), resource).PlanResourceChange(t.Context(), &tfprotov5.PlanResourceChangeRequest{
+					response, err := NewServerFactory(provider)().PlanResourceChange(t.Context(), &tfprotov5.PlanResourceChangeRequest{
 						TypeName: resourceName, PriorState: wrap(before, cty.StringVal("gateway")), Config: wrap(config, cty.NullVal(cty.String)), ProposedNewState: wrap(proposed, cty.StringVal("gateway")),
 					})
 					planned := testPlanned(t, resource, response, err).GetAttr(key)
@@ -152,7 +149,7 @@ func blockFixture(resource *schema.Resource, typ cty.Type, name string, empty bo
 		if key == "id" {
 			reference = "name"
 		}
-		if value, ok := attrs[reference]; ok && !absentString(value) {
+		if value, ok := attrs[reference]; ok && !isAbsentString(value) {
 			attrs[key] = cty.StringVal("/fake/" + name + "/" + key)
 		}
 	}

--- a/internal/provider/applicationgateway/fixture_test.go
+++ b/internal/provider/applicationgateway/fixture_test.go
@@ -8,8 +8,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network"
 )
 
-// Use the production listener schema and hash while exercising the planning
-// RPC without configuring an Azure client or provisioning a gateway.
 func testProvider() (*schema.Provider, *schema.Resource) {
 	gateway := (network.Registration{}).SupportedResources()[resourceName]
 	resource := &schema.Resource{Schema: map[string]*schema.Schema{"http_listener": gateway.Schema["http_listener"]}}

--- a/internal/provider/applicationgateway/fixture_test.go
+++ b/internal/provider/applicationgateway/fixture_test.go
@@ -1,0 +1,18 @@
+// Copyright IBM Corp. 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package applicationgateway
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network"
+)
+
+// Use the production listener schema and hash while exercising the planning
+// RPC without configuring an Azure client or provisioning a gateway.
+func testProvider() (*schema.Provider, *schema.Resource) {
+	gateway := (network.Registration{}).SupportedResources()[resourceName]
+	resource := &schema.Resource{Schema: map[string]*schema.Schema{"http_listener": gateway.Schema["http_listener"]}}
+	provider := &schema.Provider{ResourcesMap: map[string]*schema.Resource{resourceName: resource, "azurerm_other": resource}}
+	return provider, resource
+}

--- a/internal/provider/applicationgateway/plan.go
+++ b/internal/provider/applicationgateway/plan.go
@@ -1,0 +1,160 @@
+// Copyright IBM Corp. 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package applicationgateway
+
+import (
+	"strings"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func preserveUnchangedBlocks(prior, planned cty.Value, resource *schema.Resource) cty.Value {
+	attributes := planned.AsValueMap()
+	for name, field := range resource.Schema {
+		if field.Computed && !field.Optional {
+			continue
+		}
+		attributes[name] = preserveUnchangedCollection(prior.GetAttr(name), attributes[name], field)
+	}
+	return cty.ObjectVal(attributes)
+}
+
+func preserveUnchangedCollection(prior, planned cty.Value, field *schema.Schema) cty.Value {
+	if prior.IsNull() || planned.IsNull() || !prior.IsKnown() || !planned.IsKnown() || prior.RawEquals(planned) {
+		return planned
+	}
+	block, ok := field.Elem.(*schema.Resource)
+	if !ok {
+		return planned
+	}
+	switch field.Type {
+	case schema.TypeSet:
+		if block.Schema["name"] != nil {
+			return preserveSetBlocksByName(prior, planned, block)
+		}
+	case schema.TypeList:
+		return preserveListBlocksByPosition(prior, planned, block)
+	}
+	return planned
+}
+
+func preserveSetBlocksByName(prior, planned cty.Value, block *schema.Resource) cty.Value {
+	priorByName, valid := indexBlocksByName(prior)
+	if !valid {
+		return planned
+	}
+	if _, valid := indexBlocksByName(planned); !valid {
+		return planned
+	}
+
+	values := planned.AsValueSlice()
+	changed := false
+	for i, value := range values {
+		if previous, exists := priorByName[value.GetAttr("name").AsString()]; exists {
+			values[i] = preserveUnchangedBlock(previous, value, block)
+			changed = changed || !values[i].RawEquals(value)
+		}
+	}
+	if changed {
+		return cty.SetVal(values)
+	}
+	return planned
+}
+
+func preserveListBlocksByPosition(prior, planned cty.Value, block *schema.Resource) cty.Value {
+	values := planned.AsValueSlice()
+	previous := prior.AsValueSlice()
+	changed := false
+	for i := 0; i < min(len(values), len(previous)); i++ {
+		preserved := preserveUnchangedBlock(previous[i], values[i], block)
+		changed = changed || !preserved.RawEquals(values[i])
+		values[i] = preserved
+	}
+	if changed {
+		return cty.ListVal(values)
+	}
+	return planned
+}
+
+func indexBlocksByName(collection cty.Value) (map[string]cty.Value, bool) {
+	blocks := make(map[string]cty.Value)
+	for it := collection.ElementIterator(); it.Next(); {
+		_, value := it.Element()
+		if value.IsNull() || !value.IsKnown() {
+			return nil, false
+		}
+		name := value.GetAttr("name")
+		if name.IsNull() || !name.IsKnown() {
+			return nil, false
+		}
+		if _, duplicate := blocks[name.AsString()]; duplicate {
+			return nil, false
+		}
+		blocks[name.AsString()] = value
+	}
+	return blocks, true
+}
+
+func preserveUnchangedBlock(prior, planned cty.Value, block *schema.Resource) cty.Value {
+	if prior.IsNull() || planned.IsNull() || !prior.IsWhollyKnown() || !planned.IsKnown() || prior.RawEquals(planned) {
+		return planned
+	}
+	for name, field := range block.Schema {
+		previous, next := prior.GetAttr(name), planned.GetAttr(name)
+		switch {
+		case previous.RawEquals(next), equivalentEmptyValues(previous, next):
+			continue
+		case canPreserveAbsentComputedString(name, field, prior, next):
+			continue
+		}
+		if !preserveUnchangedCollection(previous, next, field).RawEquals(previous) {
+			return planned
+		}
+	}
+	return prior
+}
+
+func canPreserveAbsentComputedString(name string, field *schema.Schema, prior cty.Value, planned cty.Value) bool {
+	if !field.Computed || field.Optional || field.Type != schema.TypeString || planned.IsKnown() || !isAbsentString(prior.GetAttr(name)) {
+		return false
+	}
+	return !hasConfiguredReference(name, prior)
+}
+
+func hasConfiguredReference(attribute string, block cty.Value) bool {
+	reference := strings.TrimSuffix(attribute, "_id") + "_name"
+	if attribute == "id" {
+		reference = "name"
+	}
+	return block.Type().HasAttribute(reference) && !isAbsentString(block.GetAttr(reference))
+}
+
+func equivalentEmptyValues(prior, planned cty.Value) bool {
+	if !prior.IsKnown() || !planned.IsKnown() {
+		return false
+	}
+	return (prior.IsNull() && isZeroValue(planned)) || (planned.IsNull() && isZeroValue(prior))
+}
+
+func isZeroValue(value cty.Value) bool {
+	if value.IsNull() {
+		return true
+	}
+	switch {
+	case value.Type() == cty.String:
+		return value.RawEquals(cty.StringVal(""))
+	case value.Type() == cty.Bool:
+		return value.RawEquals(cty.False)
+	case value.Type() == cty.Number:
+		return value.RawEquals(cty.NumberIntVal(0))
+	case value.Type().IsCollectionType():
+		return value.LengthInt() == 0
+	}
+	return false
+}
+
+func isAbsentString(value cty.Value) bool {
+	return value.IsKnown() && (value.IsNull() || value.RawEquals(cty.StringVal("")))
+}

--- a/internal/provider/applicationgateway/server.go
+++ b/internal/provider/applicationgateway/server.go
@@ -1,0 +1,238 @@
+// Copyright IBM Corp. 2026
+// SPDX-License-Identifier: MPL-2.0
+
+// Package applicationgateway normalizes SDK plan artifacts for Application
+// Gateway nested blocks without changing planning for other AzureRM resources.
+package applicationgateway
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-cty/cty"
+	ctyjson "github.com/hashicorp/go-cty/cty/json"
+	"github.com/hashicorp/go-cty/cty/msgpack"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+const resourceName = "azurerm_application_gateway"
+
+// Wrap preserves absent computed outputs when the SDK changes only their
+// representation while reconstructing a set. All other RPCs are delegated.
+func Wrap(server tfprotov5.ProviderServer, resource *schema.Resource) tfprotov5.ProviderServer {
+	if resource == nil {
+		return server
+	}
+	return &planServer{ProviderServer: server, resourceType: resource.CoreConfigSchema().ImpliedType(), resource: resource}
+}
+
+type planServer struct {
+	tfprotov5.ProviderServer
+	resourceType cty.Type
+	resource     *schema.Resource
+}
+
+func (s *planServer) PlanResourceChange(ctx context.Context, req *tfprotov5.PlanResourceChangeRequest) (*tfprotov5.PlanResourceChangeResponse, error) {
+	resp, err := s.ProviderServer.PlanResourceChange(ctx, req)
+	if err != nil || resp == nil || req.TypeName != resourceName || req.PriorState == nil || resp.PlannedState == nil || len(resp.RequiresReplace) > 0 || resp.Deferred != nil {
+		return resp, err
+	}
+	for _, diagnostic := range resp.Diagnostics {
+		if diagnostic.Severity == tfprotov5.DiagnosticSeverityError {
+			return resp, nil
+		}
+	}
+	prior, err := decode(req.PriorState, s.resourceType)
+	if err != nil {
+		return nil, fmt.Errorf("decoding Application Gateway prior state: %w", err)
+	}
+	planned, err := decode(resp.PlannedState, s.resourceType)
+	if err != nil {
+		return nil, fmt.Errorf("decoding Application Gateway planned state: %w", err)
+	}
+	if prior.IsNull() || planned.IsNull() || !prior.IsKnown() || !planned.IsKnown() {
+		return resp, nil
+	}
+	// Restrict normalization to updates of the same gateway.
+	if !prior.GetAttr("id").IsKnown() || !prior.GetAttr("id").RawEquals(planned.GetAttr("id")) {
+		return resp, nil
+	}
+	attrs := planned.AsValueMap()
+	changed := false
+	for key, field := range s.resource.Schema {
+		if field.Computed && !field.Optional {
+			continue
+		}
+		if _, ok := field.Elem.(*schema.Resource); !ok || (field.Type != schema.TypeSet && field.Type != schema.TypeList) {
+			continue
+		}
+		value := normalizeCollection(prior.GetAttr(key), attrs[key], field)
+		if !value.RawEquals(attrs[key]) {
+			attrs[key] = value
+			changed = true
+		}
+	}
+	if !changed {
+		return resp, nil
+	}
+	encoded, err := msgpack.Marshal(cty.ObjectVal(attrs), s.resourceType)
+	if err != nil {
+		return nil, fmt.Errorf("encoding Application Gateway planned state: %w", err)
+	}
+	resp.PlannedState = &tfprotov5.DynamicValue{MsgPack: encoded}
+	return resp, nil
+}
+
+func decode(value *tfprotov5.DynamicValue, typ cty.Type) (cty.Value, error) {
+	if len(value.MsgPack) > 0 {
+		return msgpack.Unmarshal(value.MsgPack, typ)
+	}
+	return ctyjson.Unmarshal(value.JSON, typ)
+}
+
+// normalizeCollection matches named set members by name and list members by
+// position. The entire candidate block must match its prior value before any
+// computed output is restored; a matching name alone is never sufficient.
+func normalizeCollection(prior, planned cty.Value, field *schema.Schema) cty.Value {
+	if prior.IsNull() || planned.IsNull() || !prior.IsKnown() || !planned.IsKnown() || prior.RawEquals(planned) {
+		return planned
+	}
+	resource, ok := field.Elem.(*schema.Resource)
+	if !ok {
+		return planned
+	}
+	values := planned.AsValueSlice()
+	if len(values) == 0 {
+		return planned
+	}
+	changed := false
+	switch field.Type {
+	case schema.TypeSet:
+		if _, named := resource.Schema["name"]; !named {
+			return planned
+		}
+		before, valid := namedMembers(prior)
+		if !valid {
+			return planned
+		}
+		if _, valid := namedMembers(planned); !valid {
+			return planned
+		}
+		for i, value := range values {
+			if value.IsNull() || !value.IsKnown() {
+				continue
+			}
+			name := value.GetAttr("name")
+			if name.IsNull() || !name.IsKnown() {
+				continue
+			}
+			if old, exists := before[name.AsString()]; exists {
+				values[i] = normalizeBlock(old, value, resource)
+				changed = changed || !values[i].RawEquals(value)
+			}
+		}
+		if changed {
+			return cty.SetVal(values)
+		}
+	case schema.TypeList:
+		for i, value := range values {
+			if i >= prior.LengthInt() {
+				continue
+			}
+			values[i] = normalizeBlock(prior.Index(cty.NumberIntVal(int64(i))), value, resource)
+			changed = changed || !values[i].RawEquals(value)
+		}
+		if changed {
+			return cty.ListVal(values)
+		}
+	}
+	return planned
+}
+
+func namedMembers(collection cty.Value) (map[string]cty.Value, bool) {
+	result := map[string]cty.Value{}
+	for it := collection.ElementIterator(); it.Next(); {
+		_, value := it.Element()
+		if value.IsNull() || !value.IsKnown() {
+			return nil, false
+		}
+		name := value.GetAttr("name")
+		if name.IsNull() || !name.IsKnown() {
+			return nil, false
+		}
+		if _, duplicate := result[name.AsString()]; duplicate {
+			return nil, false
+		}
+		result[name.AsString()] = value
+	}
+	return result, true
+}
+
+func normalizeBlock(prior, planned cty.Value, resource *schema.Resource) cty.Value {
+	if prior.IsNull() || planned.IsNull() || !prior.IsWhollyKnown() || !planned.IsKnown() || prior.RawEquals(planned) {
+		return planned
+	}
+	candidate := planned.AsValueMap()
+	for key, field := range resource.Schema {
+		old, next := prior.GetAttr(key), candidate[key]
+		switch {
+		case equivalentEmpty(old, next):
+			// The legacy SDK treats null and zero values as equivalent, but the
+			// resulting set elements differ to Terraform Core.
+			candidate[key] = old
+		case field.Computed && !field.Optional && field.Type == schema.TypeString && absentString(old) && !next.IsKnown():
+			// Do not restore a missing ID when the corresponding named object is
+			// configured: that output is expected to become populated.
+			reference := strings.TrimSuffix(key, "_id") + "_name"
+			if key == "id" {
+				reference = "name"
+			}
+			if _, exists := resource.Schema[reference]; exists && !absentString(prior.GetAttr(reference)) {
+				continue
+			}
+			candidate[key] = old
+		case field.Type == schema.TypeSet || field.Type == schema.TypeList:
+			candidate[key] = normalizeCollection(old, next, field)
+		}
+	}
+	if cty.ObjectVal(candidate).RawEquals(prior) {
+		return prior
+	}
+	return planned
+}
+
+func equivalentEmpty(a, b cty.Value) bool {
+	if !a.IsKnown() || !b.IsKnown() || a.RawEquals(b) {
+		return false
+	}
+	if a.IsNull() {
+		return zeroValue(b)
+	}
+	if b.IsNull() {
+		return zeroValue(a)
+	}
+	return false
+}
+
+func zeroValue(value cty.Value) bool {
+	if value.IsNull() {
+		return true
+	}
+	switch {
+	case value.Type() == cty.String:
+		return value.RawEquals(cty.StringVal(""))
+	case value.Type() == cty.Bool:
+		return value.RawEquals(cty.False)
+	case value.Type() == cty.Number:
+		return value.RawEquals(cty.NumberIntVal(0))
+	case value.Type().IsCollectionType():
+		return value.LengthInt() == 0
+	}
+	return false
+}
+
+func absentString(value cty.Value) bool {
+	return value.IsKnown() && (value.IsNull() || value.RawEquals(cty.StringVal("")))
+}

--- a/internal/provider/applicationgateway/server.go
+++ b/internal/provider/applicationgateway/server.go
@@ -1,14 +1,11 @@
 // Copyright IBM Corp. 2026
 // SPDX-License-Identifier: MPL-2.0
 
-// Package applicationgateway normalizes SDK plan artifacts for Application
-// Gateway nested blocks without changing planning for other AzureRM resources.
 package applicationgateway
 
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/hashicorp/go-cty/cty"
 	ctyjson "github.com/hashicorp/go-cty/cty/json"
@@ -19,13 +16,23 @@ import (
 
 const resourceName = "azurerm_application_gateway"
 
-// Wrap preserves absent computed outputs when the SDK changes only their
-// representation while reconstructing a set. All other RPCs are delegated.
-func Wrap(server tfprotov5.ProviderServer, resource *schema.Resource) tfprotov5.ProviderServer {
+// NewServerFactory preserves unchanged Application Gateway blocks after the SDK
+// reconstructs the plan. CustomizeDiff runs before that reconstruction.
+func NewServerFactory(provider *schema.Provider) func() tfprotov5.ProviderServer {
+	return func() tfprotov5.ProviderServer {
+		return wrapServer(provider.GRPCProvider(), provider.ResourcesMap[resourceName])
+	}
+}
+
+func wrapServer(server tfprotov5.ProviderServer, resource *schema.Resource) tfprotov5.ProviderServer {
 	if resource == nil {
 		return server
 	}
-	return &planServer{ProviderServer: server, resourceType: resource.CoreConfigSchema().ImpliedType(), resource: resource}
+	return &planServer{
+		ProviderServer: server,
+		resourceType:   resource.CoreConfigSchema().ImpliedType(),
+		resource:       resource,
+	}
 }
 
 type planServer struct {
@@ -36,13 +43,8 @@ type planServer struct {
 
 func (s *planServer) PlanResourceChange(ctx context.Context, req *tfprotov5.PlanResourceChangeRequest) (*tfprotov5.PlanResourceChangeResponse, error) {
 	resp, err := s.ProviderServer.PlanResourceChange(ctx, req)
-	if err != nil || resp == nil || req.TypeName != resourceName || req.PriorState == nil || resp.PlannedState == nil || len(resp.RequiresReplace) > 0 || resp.Deferred != nil {
+	if err != nil || !canPreserveBlocks(req, resp) {
 		return resp, err
-	}
-	for _, diagnostic := range resp.Diagnostics {
-		if diagnostic.Severity == tfprotov5.DiagnosticSeverityError {
-			return resp, nil
-		}
 	}
 	prior, err := decode(req.PriorState, s.resourceType)
 	if err != nil {
@@ -52,32 +54,15 @@ func (s *planServer) PlanResourceChange(ctx context.Context, req *tfprotov5.Plan
 	if err != nil {
 		return nil, fmt.Errorf("decoding Application Gateway planned state: %w", err)
 	}
-	if prior.IsNull() || planned.IsNull() || !prior.IsKnown() || !planned.IsKnown() {
+	if !isExistingGatewayUpdate(prior, planned) {
 		return resp, nil
 	}
-	// Restrict normalization to updates of the same gateway.
-	if !prior.GetAttr("id").IsKnown() || !prior.GetAttr("id").RawEquals(planned.GetAttr("id")) {
+
+	preserved := preserveUnchangedBlocks(prior, planned, s.resource)
+	if preserved.RawEquals(planned) {
 		return resp, nil
 	}
-	attrs := planned.AsValueMap()
-	changed := false
-	for key, field := range s.resource.Schema {
-		if field.Computed && !field.Optional {
-			continue
-		}
-		if _, ok := field.Elem.(*schema.Resource); !ok || (field.Type != schema.TypeSet && field.Type != schema.TypeList) {
-			continue
-		}
-		value := normalizeCollection(prior.GetAttr(key), attrs[key], field)
-		if !value.RawEquals(attrs[key]) {
-			attrs[key] = value
-			changed = true
-		}
-	}
-	if !changed {
-		return resp, nil
-	}
-	encoded, err := msgpack.Marshal(cty.ObjectVal(attrs), s.resourceType)
+	encoded, err := msgpack.Marshal(preserved, s.resourceType)
 	if err != nil {
 		return nil, fmt.Errorf("encoding Application Gateway planned state: %w", err)
 	}
@@ -85,154 +70,32 @@ func (s *planServer) PlanResourceChange(ctx context.Context, req *tfprotov5.Plan
 	return resp, nil
 }
 
+func canPreserveBlocks(req *tfprotov5.PlanResourceChangeRequest, resp *tfprotov5.PlanResourceChangeResponse) bool {
+	if req.TypeName != resourceName || req.PriorState == nil || resp == nil || resp.PlannedState == nil {
+		return false
+	}
+	if len(resp.RequiresReplace) > 0 || resp.Deferred != nil {
+		return false
+	}
+	for _, diagnostic := range resp.Diagnostics {
+		if diagnostic.Severity == tfprotov5.DiagnosticSeverityError {
+			return false
+		}
+	}
+	return true
+}
+
+func isExistingGatewayUpdate(prior, planned cty.Value) bool {
+	if prior.IsNull() || planned.IsNull() || !prior.IsKnown() || !planned.IsKnown() {
+		return false
+	}
+	id := prior.GetAttr("id")
+	return id.IsKnown() && id.RawEquals(planned.GetAttr("id"))
+}
+
 func decode(value *tfprotov5.DynamicValue, typ cty.Type) (cty.Value, error) {
 	if len(value.MsgPack) > 0 {
 		return msgpack.Unmarshal(value.MsgPack, typ)
 	}
 	return ctyjson.Unmarshal(value.JSON, typ)
-}
-
-// normalizeCollection matches named set members by name and list members by
-// position. The entire candidate block must match its prior value before any
-// computed output is restored; a matching name alone is never sufficient.
-func normalizeCollection(prior, planned cty.Value, field *schema.Schema) cty.Value {
-	if prior.IsNull() || planned.IsNull() || !prior.IsKnown() || !planned.IsKnown() || prior.RawEquals(planned) {
-		return planned
-	}
-	resource, ok := field.Elem.(*schema.Resource)
-	if !ok {
-		return planned
-	}
-	values := planned.AsValueSlice()
-	if len(values) == 0 {
-		return planned
-	}
-	changed := false
-	switch field.Type {
-	case schema.TypeSet:
-		if _, named := resource.Schema["name"]; !named {
-			return planned
-		}
-		before, valid := namedMembers(prior)
-		if !valid {
-			return planned
-		}
-		if _, valid := namedMembers(planned); !valid {
-			return planned
-		}
-		for i, value := range values {
-			if value.IsNull() || !value.IsKnown() {
-				continue
-			}
-			name := value.GetAttr("name")
-			if name.IsNull() || !name.IsKnown() {
-				continue
-			}
-			if old, exists := before[name.AsString()]; exists {
-				values[i] = normalizeBlock(old, value, resource)
-				changed = changed || !values[i].RawEquals(value)
-			}
-		}
-		if changed {
-			return cty.SetVal(values)
-		}
-	case schema.TypeList:
-		for i, value := range values {
-			if i >= prior.LengthInt() {
-				continue
-			}
-			values[i] = normalizeBlock(prior.Index(cty.NumberIntVal(int64(i))), value, resource)
-			changed = changed || !values[i].RawEquals(value)
-		}
-		if changed {
-			return cty.ListVal(values)
-		}
-	}
-	return planned
-}
-
-func namedMembers(collection cty.Value) (map[string]cty.Value, bool) {
-	result := map[string]cty.Value{}
-	for it := collection.ElementIterator(); it.Next(); {
-		_, value := it.Element()
-		if value.IsNull() || !value.IsKnown() {
-			return nil, false
-		}
-		name := value.GetAttr("name")
-		if name.IsNull() || !name.IsKnown() {
-			return nil, false
-		}
-		if _, duplicate := result[name.AsString()]; duplicate {
-			return nil, false
-		}
-		result[name.AsString()] = value
-	}
-	return result, true
-}
-
-func normalizeBlock(prior, planned cty.Value, resource *schema.Resource) cty.Value {
-	if prior.IsNull() || planned.IsNull() || !prior.IsWhollyKnown() || !planned.IsKnown() || prior.RawEquals(planned) {
-		return planned
-	}
-	candidate := planned.AsValueMap()
-	for key, field := range resource.Schema {
-		old, next := prior.GetAttr(key), candidate[key]
-		switch {
-		case equivalentEmpty(old, next):
-			// The legacy SDK treats null and zero values as equivalent, but the
-			// resulting set elements differ to Terraform Core.
-			candidate[key] = old
-		case field.Computed && !field.Optional && field.Type == schema.TypeString && absentString(old) && !next.IsKnown():
-			// Do not restore a missing ID when the corresponding named object is
-			// configured: that output is expected to become populated.
-			reference := strings.TrimSuffix(key, "_id") + "_name"
-			if key == "id" {
-				reference = "name"
-			}
-			if _, exists := resource.Schema[reference]; exists && !absentString(prior.GetAttr(reference)) {
-				continue
-			}
-			candidate[key] = old
-		case field.Type == schema.TypeSet || field.Type == schema.TypeList:
-			candidate[key] = normalizeCollection(old, next, field)
-		}
-	}
-	if cty.ObjectVal(candidate).RawEquals(prior) {
-		return prior
-	}
-	return planned
-}
-
-func equivalentEmpty(a, b cty.Value) bool {
-	if !a.IsKnown() || !b.IsKnown() || a.RawEquals(b) {
-		return false
-	}
-	if a.IsNull() {
-		return zeroValue(b)
-	}
-	if b.IsNull() {
-		return zeroValue(a)
-	}
-	return false
-}
-
-func zeroValue(value cty.Value) bool {
-	if value.IsNull() {
-		return true
-	}
-	switch {
-	case value.Type() == cty.String:
-		return value.RawEquals(cty.StringVal(""))
-	case value.Type() == cty.Bool:
-		return value.RawEquals(cty.False)
-	case value.Type() == cty.Number:
-		return value.RawEquals(cty.NumberIntVal(0))
-	case value.Type().IsCollectionType():
-		return value.LengthInt() == 0
-	}
-	return false
-}
-
-func absentString(value cty.Value) bool {
-	return value.IsKnown() && (value.IsNull() || value.RawEquals(cty.StringVal("")))
 }

--- a/internal/provider/applicationgateway/server_test.go
+++ b/internal/provider/applicationgateway/server_test.go
@@ -1,0 +1,278 @@
+// Copyright IBM Corp. 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package applicationgateway
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/hashicorp/go-cty/cty"
+	ctyjson "github.com/hashicorp/go-cty/cty/json"
+	"github.com/hashicorp/go-cty/cty/msgpack"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestPlanResourceChange(t *testing.T) {
+	for _, profile := range []string{"null", "empty", "populated"} {
+		for _, action := range []string{"none", "edit", "add", "remove", "rename", "errors", "profile"} {
+			t.Run(profile+"/"+action, func(t *testing.T) {
+				t.Parallel()
+				p, resource := testProvider()
+				before := []cty.Value{testListener(t, resource, "private", profile), testListener(t, resource, "orbit", profile)}
+				after := append([]cty.Value(nil), before...)
+				switch action {
+				case "edit":
+					attrs := after[1].AsValueMap()
+					attrs["host_names"] = cty.SetVal([]cty.Value{cty.StringVal("*.orbit.example.com"), cty.StringVal("test.orbit.example.com")})
+					after[1] = cty.ObjectVal(attrs)
+				case "add":
+					after = append(after, testListener(t, resource, "new", profile))
+				case "remove":
+					after = after[:1]
+				case "rename":
+					attrs := after[1].AsValueMap()
+					attrs["name"] = cty.StringVal("renamed")
+					after[1] = cty.ObjectVal(attrs)
+				case "errors":
+					attrs := after[1].AsValueMap()
+					errors := attrs["custom_error_configuration"].AsValueSlice()
+					errorAttrs := errors[0].AsValueMap()
+					errorAttrs["custom_error_page_url"] = cty.StringVal("https://example.com/new-error.html")
+					attrs["custom_error_configuration"] = cty.ListVal([]cty.Value{cty.ObjectVal(errorAttrs)})
+					after[1] = cty.ObjectVal(attrs)
+				case "profile":
+					attrs := after[1].AsValueMap()
+					attrs["ssl_profile_name"] = cty.StringVal("new-profile")
+					after[1] = cty.ObjectVal(attrs)
+				}
+				req := testRequest(t, resource, before, after)
+				response, err := Wrap(p.GRPCProvider(), resource).PlanResourceChange(t.Context(), req)
+				planned := testPlanned(t, resource, response, err).GetAttr("http_listener")
+				if planned.LengthInt() != len(after) {
+					t.Fatalf("got %d listeners, want %d", planned.LengthInt(), len(after))
+				}
+				for it := planned.ElementIterator(); it.Next(); {
+					_, listener := it.Element()
+					name := listener.GetAttr("name").AsString()
+					var expected cty.Value
+					for _, want := range after {
+						if want.GetAttr("name").AsString() == name {
+							expected = want
+						}
+					}
+					if expected == cty.NilVal {
+						t.Fatalf("unexpected listener %q", name)
+					}
+					if name == "private" || action == "none" || (name == "orbit" && action == "add") {
+						if !listener.RawEquals(expected) {
+							t.Errorf("untouched listener %q changed:\n got: %#v\nwant: %#v", name, listener, expected)
+						}
+					} else {
+						for _, key := range []string{"host_names", "ssl_profile_name"} {
+							if !listener.GetAttr(key).RawEquals(expected.GetAttr(key)) && (!absentString(listener.GetAttr(key)) || !absentString(expected.GetAttr(key))) {
+								t.Errorf("lost configured %s change for %q", key, name)
+							}
+						}
+						if listener.GetAttr("id").IsKnown() {
+							t.Errorf("changed listener %q should still recompute its ID", name)
+						}
+						if action == "errors" && !listener.GetAttr("custom_error_configuration").Index(cty.NumberIntVal(0)).GetAttr("custom_error_page_url").RawEquals(expected.GetAttr("custom_error_configuration").Index(cty.NumberIntVal(0)).GetAttr("custom_error_page_url")) {
+							t.Error("lost custom error page edit")
+						}
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestOtherResourceUnchanged(t *testing.T) {
+	p, resource := testProvider()
+	before := []cty.Value{testListener(t, resource, "private", "empty"), testListener(t, resource, "orbit", "empty")}
+	after := before[:1]
+	req := testRequest(t, resource, before, after)
+	req.TypeName = "azurerm_other"
+	raw, err := p.GRPCProvider().PlanResourceChange(t.Context(), req)
+	want := testPlanned(t, resource, raw, err)
+	got, err := Wrap(p.GRPCProvider(), resource).PlanResourceChange(t.Context(), req)
+	if !testPlanned(t, resource, got, err).RawEquals(want) {
+		t.Fatal("changed another resource's plan")
+	}
+}
+
+func TestNormalizeListenersBoundaries(t *testing.T) {
+	_, resource := testProvider()
+	old := testListener(t, resource, "private", "empty")
+	for _, name := range []string{"absent_profile", "configured_profile", "known_profile", "configured_port", "unknown_existing_id", "new_profile_id", "unknown_set", "empty_set"} {
+		t.Run(name, func(t *testing.T) {
+			prior := old
+			attrs := old.AsValueMap()
+			attrs["ssl_profile_id"] = cty.UnknownVal(cty.String)
+			wantChanged := name == "absent_profile"
+			switch name {
+			case "configured_profile":
+				priorAttrs := old.AsValueMap()
+				priorAttrs["ssl_profile_name"] = cty.StringVal("profile")
+				prior = cty.ObjectVal(priorAttrs)
+				attrs["ssl_profile_name"] = cty.StringVal("profile")
+			case "known_profile":
+				prior = testListener(t, resource, "private", "populated")
+				attrs = prior.AsValueMap()
+				attrs["ssl_profile_id"] = cty.UnknownVal(cty.String)
+			case "configured_port":
+				attrs["frontend_port_name"] = cty.StringVal("other-port")
+			case "unknown_existing_id":
+				attrs["frontend_port_id"] = cty.UnknownVal(cty.String)
+			case "new_profile_id":
+				attrs["ssl_profile_id"] = cty.StringVal("/new/profile")
+			}
+			before := cty.SetVal([]cty.Value{prior})
+			planned := cty.SetVal([]cty.Value{cty.ObjectVal(attrs)})
+			switch name {
+			case "unknown_set":
+				planned = cty.UnknownVal(before.Type())
+			case "empty_set":
+				planned = cty.SetValEmpty(prior.Type())
+			}
+			got := normalizeCollection(before, planned, resource.Schema["http_listener"])
+			changed := !got.RawEquals(planned)
+			if changed != wantChanged {
+				t.Fatalf("changed = %t, want %t", changed, wantChanged)
+			}
+			want := planned
+			if wantChanged {
+				want = before
+			}
+			if !got.RawEquals(want) {
+				t.Fatalf("unexpected plan: %#v", got)
+			}
+		})
+	}
+}
+
+func TestKnownComputedChangePreserved(t *testing.T) {
+	p, resource := testProvider()
+	before := []cty.Value{testListener(t, resource, "private", "empty")}
+	req := testRequest(t, resource, before, before)
+	delegate := &testServer{ProviderServer: p.GRPCProvider(), change: func(response *tfprotov5.PlanResourceChangeResponse) {
+		planned := testPlanned(t, resource, response, nil)
+		attrs := planned.AsValueMap()
+		listener := before[0].AsValueMap()
+		listener["frontend_port_id"] = cty.UnknownVal(cty.String)
+		listener["ssl_profile_id"] = cty.UnknownVal(cty.String)
+		attrs["http_listener"] = cty.SetVal([]cty.Value{cty.ObjectVal(listener)})
+		response.PlannedState = testDynamic(t, cty.ObjectVal(attrs))
+	}}
+	response, err := Wrap(delegate, resource).PlanResourceChange(t.Context(), req)
+	planned := testPlanned(t, resource, response, err).GetAttr("http_listener").AsValueSlice()[0]
+	if planned.GetAttr("frontend_port_id").IsKnown() || planned.GetAttr("ssl_profile_id").IsKnown() {
+		t.Fatal("normalized a listener with a real computed change")
+	}
+}
+
+type testServer struct {
+	tfprotov5.ProviderServer
+	change func(*tfprotov5.PlanResourceChangeResponse)
+}
+
+func (s *testServer) PlanResourceChange(ctx context.Context, req *tfprotov5.PlanResourceChangeRequest) (*tfprotov5.PlanResourceChangeResponse, error) {
+	response, err := s.ProviderServer.PlanResourceChange(ctx, req)
+	if err == nil {
+		s.change(response)
+	}
+	return response, err
+}
+
+func testListener(t *testing.T, resource *schema.Resource, name, profile string) cty.Value {
+	t.Helper()
+	fields := resource.Schema["http_listener"].Elem.(*schema.Resource).Schema
+	attrs := map[string]interface{}{}
+	for key := range fields {
+		attrs[key] = nil
+	}
+	attrs["name"] = name
+	attrs["frontend_ip_configuration_name"] = "private"
+	attrs["frontend_port_name"] = "https"
+	attrs["protocol"] = "Https"
+	attrs["require_sni"] = true
+	attrs["ssl_certificate_name"] = "cert"
+	attrs["host_names"] = []string{"*." + name + ".example.com"}
+	for _, key := range []string{"id", "frontend_ip_configuration_id", "frontend_port_id", "ssl_certificate_id"} {
+		attrs[key] = "/fake/" + name + "/" + key
+	}
+	switch profile {
+	case "empty":
+		attrs["ssl_profile_id"] = ""
+	case "populated":
+		attrs["ssl_profile_id"] = "/fake/profile"
+		attrs["ssl_profile_name"] = "profile"
+	}
+	attrs["custom_error_configuration"] = []interface{}{map[string]interface{}{"status_code": "HttpStatus403", "custom_error_page_url": "https://example.com/403.html", "id": attrs["ssl_profile_id"]}}
+	encoded, err := json.Marshal(attrs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	typ := resource.CoreConfigSchema().ImpliedType().AttributeType("http_listener").ElementType()
+	value, err := ctyjson.Unmarshal(encoded, typ)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return value
+}
+
+func testRequest(t *testing.T, resource *schema.Resource, before, after []cty.Value) *tfprotov5.PlanResourceChangeRequest {
+	t.Helper()
+	config := make([]cty.Value, len(after))
+	proposed := make([]cty.Value, len(after))
+	for i, listener := range after {
+		attrs := listener.AsValueMap()
+		for key, field := range resource.Schema["http_listener"].Elem.(*schema.Resource).Schema {
+			if field.Computed {
+				attrs[key] = cty.NullVal(cty.String)
+			}
+		}
+		errorAttrs := attrs["custom_error_configuration"].Index(cty.NumberIntVal(0)).AsValueMap()
+		errorAttrs["id"] = cty.NullVal(cty.String)
+		attrs["custom_error_configuration"] = cty.ListVal([]cty.Value{cty.ObjectVal(errorAttrs)})
+		config[i] = cty.ObjectVal(attrs)
+		proposed[i] = config[i]
+		for _, old := range before {
+			if listener.RawEquals(old) {
+				proposed[i] = listener
+			}
+		}
+	}
+	wrap := func(members []cty.Value, id cty.Value) *tfprotov5.DynamicValue {
+		return testDynamic(t, cty.ObjectVal(map[string]cty.Value{"id": id, "http_listener": cty.SetVal(members)}))
+	}
+	return &tfprotov5.PlanResourceChangeRequest{TypeName: resourceName, PriorState: wrap(before, cty.StringVal("gateway")), Config: wrap(config, cty.NullVal(cty.String)), ProposedNewState: wrap(proposed, cty.StringVal("gateway"))}
+}
+
+func testDynamic(t *testing.T, value cty.Value) *tfprotov5.DynamicValue {
+	t.Helper()
+	encoded, err := msgpack.Marshal(value, value.Type())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &tfprotov5.DynamicValue{MsgPack: encoded}
+}
+
+func testPlanned(t *testing.T, resource *schema.Resource, response *tfprotov5.PlanResourceChangeResponse, err error) cty.Value {
+	t.Helper()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, diagnostic := range response.Diagnostics {
+		if diagnostic.Severity == tfprotov5.DiagnosticSeverityError {
+			t.Fatalf("%s: %s", diagnostic.Summary, diagnostic.Detail)
+		}
+	}
+	value, err := decode(response.PlannedState, resource.CoreConfigSchema().ImpliedType())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return value
+}

--- a/internal/provider/applicationgateway/server_test.go
+++ b/internal/provider/applicationgateway/server_test.go
@@ -6,12 +6,14 @@ package applicationgateway
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/hashicorp/go-cty/cty"
 	ctyjson "github.com/hashicorp/go-cty/cty/json"
 	"github.com/hashicorp/go-cty/cty/msgpack"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -49,7 +51,7 @@ func TestPlanResourceChange(t *testing.T) {
 					after[1] = cty.ObjectVal(attrs)
 				}
 				req := testRequest(t, resource, before, after)
-				response, err := Wrap(p.GRPCProvider(), resource).PlanResourceChange(t.Context(), req)
+				response, err := NewServerFactory(p)().PlanResourceChange(t.Context(), req)
 				planned := testPlanned(t, resource, response, err).GetAttr("http_listener")
 				if planned.LengthInt() != len(after) {
 					t.Fatalf("got %d listeners, want %d", planned.LengthInt(), len(after))
@@ -72,7 +74,7 @@ func TestPlanResourceChange(t *testing.T) {
 						}
 					} else {
 						for _, key := range []string{"host_names", "ssl_profile_name"} {
-							if !listener.GetAttr(key).RawEquals(expected.GetAttr(key)) && (!absentString(listener.GetAttr(key)) || !absentString(expected.GetAttr(key))) {
+							if !listener.GetAttr(key).RawEquals(expected.GetAttr(key)) && (!isAbsentString(listener.GetAttr(key)) || !isAbsentString(expected.GetAttr(key))) {
 								t.Errorf("lost configured %s change for %q", key, name)
 							}
 						}
@@ -97,13 +99,13 @@ func TestOtherResourceUnchanged(t *testing.T) {
 	req.TypeName = "azurerm_other"
 	raw, err := p.GRPCProvider().PlanResourceChange(t.Context(), req)
 	want := testPlanned(t, resource, raw, err)
-	got, err := Wrap(p.GRPCProvider(), resource).PlanResourceChange(t.Context(), req)
+	got, err := NewServerFactory(p)().PlanResourceChange(t.Context(), req)
 	if !testPlanned(t, resource, got, err).RawEquals(want) {
 		t.Fatal("changed another resource's plan")
 	}
 }
 
-func TestNormalizeListenersBoundaries(t *testing.T) {
+func TestPreserveUnchangedListeners(t *testing.T) {
 	_, resource := testProvider()
 	old := testListener(t, resource, "private", "empty")
 	for _, name := range []string{"absent_profile", "configured_profile", "known_profile", "configured_port", "unknown_existing_id", "new_profile_id", "unknown_set", "empty_set"} {
@@ -137,7 +139,7 @@ func TestNormalizeListenersBoundaries(t *testing.T) {
 			case "empty_set":
 				planned = cty.SetValEmpty(prior.Type())
 			}
-			got := normalizeCollection(before, planned, resource.Schema["http_listener"])
+			got := preserveUnchangedCollection(before, planned, resource.Schema["http_listener"])
 			changed := !got.RawEquals(planned)
 			if changed != wantChanged {
 				t.Fatalf("changed = %t, want %t", changed, wantChanged)
@@ -153,6 +155,83 @@ func TestNormalizeListenersBoundaries(t *testing.T) {
 	}
 }
 
+func TestPlanResourceChangePreservationBoundaries(t *testing.T) {
+	for _, action := range []string{"update", "create", "destroy", "replacement", "different_id", "unknown_id", "unknown_state", "deferred", "diagnostic_error", "rpc_error", "missing_prior", "missing_plan", "missing_response"} {
+		t.Run(action, func(t *testing.T) {
+			_, resource := testProvider()
+			listener := testListener(t, resource, "private", "empty")
+			req := testRequest(t, resource, []cty.Value{listener}, []cty.Value{listener})
+			planned, err := decode(req.PriorState, resource.CoreConfigSchema().ImpliedType())
+			if err != nil {
+				t.Fatal(err)
+			}
+			attributes := planned.AsValueMap()
+			listenerAttributes := listener.AsValueMap()
+			listenerAttributes["ssl_profile_id"] = cty.UnknownVal(cty.String)
+			attributes["http_listener"] = cty.SetVal([]cty.Value{cty.ObjectVal(listenerAttributes)})
+			planned = cty.ObjectVal(attributes)
+			response := &tfprotov5.PlanResourceChangeResponse{PlannedState: testDynamic(t, planned)}
+			var rpcError error
+			switch action {
+			case "create":
+				req.PriorState = testDynamic(t, cty.NullVal(planned.Type()))
+			case "destroy":
+				response.PlannedState = testDynamic(t, cty.NullVal(planned.Type()))
+			case "replacement":
+				response.RequiresReplace = []*tftypes.AttributePath{tftypes.NewAttributePath().WithAttributeName("id")}
+			case "different_id":
+				attributes["id"] = cty.StringVal("another-gateway")
+				response.PlannedState = testDynamic(t, cty.ObjectVal(attributes))
+			case "unknown_id":
+				attributes["id"] = cty.UnknownVal(cty.String)
+				response.PlannedState = testDynamic(t, cty.ObjectVal(attributes))
+			case "unknown_state":
+				response.PlannedState = testDynamic(t, cty.UnknownVal(planned.Type()))
+			case "deferred":
+				response.Deferred = &tfprotov5.Deferred{Reason: tfprotov5.DeferredReasonProviderConfigUnknown}
+			case "diagnostic_error":
+				response.Diagnostics = []*tfprotov5.Diagnostic{{Severity: tfprotov5.DiagnosticSeverityError, Summary: "planning failed"}}
+			case "rpc_error":
+				rpcError = errors.New("planning failed")
+			case "missing_prior":
+				req.PriorState = nil
+			case "missing_plan":
+				response.PlannedState = nil
+			case "missing_response":
+				response = nil
+			}
+
+			var originalPlan *tfprotov5.DynamicValue
+			if response != nil {
+				originalPlan = response.PlannedState
+			}
+			server := &staticPlanServer{response: response, err: rpcError}
+			got, err := wrapServer(server, resource).PlanResourceChange(t.Context(), req)
+			if got != response || err != rpcError {
+				t.Fatalf("did not preserve the delegated response and error: %v", err)
+			}
+			if action == "update" {
+				preserved := testPlanned(t, resource, got, err).GetAttr("http_listener")
+				if !preserved.RawEquals(cty.SetVal([]cty.Value{listener})) {
+					t.Fatal("did not preserve the unchanged listener")
+				}
+			} else if got != nil && got.PlannedState != originalPlan {
+				t.Fatal("rewrote a plan that should have been passed through")
+			}
+		})
+	}
+}
+
+type staticPlanServer struct {
+	tfprotov5.ProviderServer
+	response *tfprotov5.PlanResourceChangeResponse
+	err      error
+}
+
+func (s *staticPlanServer) PlanResourceChange(context.Context, *tfprotov5.PlanResourceChangeRequest) (*tfprotov5.PlanResourceChangeResponse, error) {
+	return s.response, s.err
+}
+
 func TestKnownComputedChangePreserved(t *testing.T) {
 	p, resource := testProvider()
 	before := []cty.Value{testListener(t, resource, "private", "empty")}
@@ -166,7 +245,7 @@ func TestKnownComputedChangePreserved(t *testing.T) {
 		attrs["http_listener"] = cty.SetVal([]cty.Value{cty.ObjectVal(listener)})
 		response.PlannedState = testDynamic(t, cty.ObjectVal(attrs))
 	}}
-	response, err := Wrap(delegate, resource).PlanResourceChange(t.Context(), req)
+	response, err := wrapServer(delegate, resource).PlanResourceChange(t.Context(), req)
 	planned := testPlanned(t, resource, response, err).GetAttr("http_listener").AsValueSlice()[0]
 	if planned.GetAttr("frontend_port_id").IsKnown() || planned.GetAttr("ssl_profile_id").IsKnown() {
 		t.Fatal("normalized a listener with a real computed change")

--- a/internal/provider/framework/factory_builder.go
+++ b/internal/provider/framework/factory_builder.go
@@ -54,7 +54,7 @@ func ProtoV5ProviderServerFactory(ctx context.Context) (func() tfprotov5.Provide
 	v2Provider := provider.AzureProvider()
 
 	providers := []func() tfprotov5.ProviderServer{
-		sdkProviderServer(v2Provider),
+		applicationgateway.NewServerFactory(v2Provider),
 		providerserver.NewProtocol5(NewFrameworkProvider(v2Provider)),
 	}
 
@@ -88,7 +88,7 @@ func ProtoV5ProviderServerFactoryWithTestName(ctx context.Context, testName stri
 	v2Provider := provider.AzureProviderWithTestName(testName)
 
 	providers := []func() tfprotov5.ProviderServer{
-		sdkProviderServer(v2Provider),
+		applicationgateway.NewServerFactory(v2Provider),
 		providerserver.NewProtocol5(NewFrameworkProvider(v2Provider)),
 	}
 
@@ -102,12 +102,4 @@ func ProtoV5ProviderServerFactoryWithTestName(ctx context.Context, testName stri
 
 func V5ProviderWithoutPluginSDK() func() tfprotov5.ProviderServer {
 	return providerserver.NewProtocol5(NewFrameworkV5Provider())
-}
-
-// sdkProviderServer applies Application Gateway nested block plan normalization to
-// both the production server and the acceptance-test server.
-func sdkProviderServer(provider *schema.Provider) func() tfprotov5.ProviderServer {
-	return func() tfprotov5.ProviderServer {
-		return applicationgateway.Wrap(provider.GRPCProvider(), provider.ResourcesMap["azurerm_application_gateway"])
-	}
 }

--- a/internal/provider/framework/factory_builder.go
+++ b/internal/provider/framework/factory_builder.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-testing/echoprovider"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/provider"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/applicationgateway"
 )
 
 func ProtoV6ProviderFactoriesInit(_ context.Context, providerNames ...string) map[string]func() (tfprotov6.ProviderServer, error) {
@@ -53,7 +54,7 @@ func ProtoV5ProviderServerFactory(ctx context.Context) (func() tfprotov5.Provide
 	v2Provider := provider.AzureProvider()
 
 	providers := []func() tfprotov5.ProviderServer{
-		v2Provider.GRPCProvider,
+		sdkProviderServer(v2Provider),
 		providerserver.NewProtocol5(NewFrameworkProvider(v2Provider)),
 	}
 
@@ -87,7 +88,7 @@ func ProtoV5ProviderServerFactoryWithTestName(ctx context.Context, testName stri
 	v2Provider := provider.AzureProviderWithTestName(testName)
 
 	providers := []func() tfprotov5.ProviderServer{
-		v2Provider.GRPCProvider,
+		sdkProviderServer(v2Provider),
 		providerserver.NewProtocol5(NewFrameworkProvider(v2Provider)),
 	}
 
@@ -101,4 +102,12 @@ func ProtoV5ProviderServerFactoryWithTestName(ctx context.Context, testName stri
 
 func V5ProviderWithoutPluginSDK() func() tfprotov5.ProviderServer {
 	return providerserver.NewProtocol5(NewFrameworkV5Provider())
+}
+
+// sdkProviderServer applies Application Gateway nested block plan normalization to
+// both the production server and the acceptance-test server.
+func sdkProviderServer(provider *schema.Provider) func() tfprotov5.ProviderServer {
+	return func() tfprotov5.ProviderServer {
+		return applicationgateway.Wrap(provider.GRPCProvider(), provider.ResourcesMap["azurerm_application_gateway"])
+	}
 }

--- a/website/docs/r/application_gateway.html.markdown
+++ b/website/docs/r/application_gateway.html.markdown
@@ -11,9 +11,7 @@ description: |-
 Manages an Application Gateway.
 
 ~> **Note:** The `backend_address_pool`, `backend_http_settings`, `http_listener`, `private_link_configuration`, `request_routing_rule`, `redirect_configuration`, `probe`, `ssl_certificate`,
-and `frontend_port` properties are Sets as the service API returns these lists of objects in a different order from how the provider sends them. As Sets are stored using a hash, if one 
-value is added or removed from the Set, Terraform considers the entire list of objects changed and the plan shows that it is removing every value in the list and re-adding it with the 
-new information. Though Terraform is showing all the values being removed and re-added, we are not actually removing anything unless the user specifies a removal in the configfile.
+and `frontend_port` properties are Sets as the service API returns these lists of objects in a different order from how the provider sends them. A changed set member may appear as a removed block followed by an added block in the plan. This does not imply replacement of the Application Gateway; check the resource-level action in the plan. Unchanged blocks are preserved when their only differences are absent-value representations introduced during planning.
 
 ## Example Usage
 


### PR DESCRIPTION
## Description

A small change to an Application Gateway nested block can cause unrelated blocks to appear removed and re-added in the Terraform plan. For example, adding a hostname to one HTTP listener also shows unchanged listeners as modified.

The legacy SDK can change absent values between null, empty, and unknown representations when rebuilding nested collections. This PR adds an Application Gateway-specific planning adapter that preserves an existing block when its complete planned value matches prior state after normalizing those representations.

The change covers nested blocks throughout Application Gateway, including listeners, backend settings, and routing rules. Actual configuration changes remain visible. A modified set member can still appear as a removed block followed by an added block.

The adapter is used by both production and acceptance-test provider factories. No SDK dependency, resource schema, or state migration changes are included.

## PR Checklist

  - [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
  - [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
  - [ ] I have checked if my changes close any open issues.
  - [x] I have updated/added Documentation as required.
  - [x] I have used a meaningful PR title.

## Changes to existing Resource / Data Source

  - [x] I have explained what my changes do and why they should be included.
  - [x] I have written new tests and updated relevant documentation.
  - [x] I have successfully run tests with my changes locally.

## Testing
Local planning tests pass, including:

  - 156 scenarios across 19 repeatable named block types from the production Application Gateway schema.
  - Listener hostname, SSL profile, and custom error page changes.
  - Backend timeout and routing-priority changes.
  - Additions, removals, renames, and unchanged configurations.
  - Preservation of meaningful computed-value changes and pass-through for other resource types.
  - Provider factory schema-equivalence validation.

An isolated Terraform CLI reproduction using synthetic state shows both listeners changing before the fix. With the adapter enabled, only the edited listener is displayed; the unrelated listener is hidden as unchanged.

Standard lint checks pass. The repository's custom provider lint plugins were not run.

Azure acceptance tests have not been run. Validation used local planning without provisioning Azure resources.

## Change Log

  * `azurerm_application_gateway` - prevent absent-value planning differences from making unchanged nested blocks appear modified.

This is a:
  - [x] Bug Fix
  - [ ] New Feature
  - [ ] Enhancement
  - [ ] Breaking Change

## Related Issue(s)
    No linked issue yet.

## AI Assistance Disclosure

  - [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs AI assistance was used for investigation, implementation, regression tests, local validation and documentation.

## Rollback Plan
  If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

  No changes to access controls, encryption, or logging. This change is limited to Application Gateway plan normalization.