### PR TITLE
containers: correct AKS acceptance configuration and assertions

### DIFF
--- a/internal/services/containers/kubernetes_automatic_cluster_data_source_test.go
+++ b/internal/services/containers/kubernetes_automatic_cluster_data_source_test.go
@@ -40,7 +40,7 @@ func TestAccDataSourceKubernetesAutomaticCluster_serviceMesh(t *testing.T) {
 		{
 			Config: r.serviceMesh(data),
 			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).Key("service_mesh.0.mode").HasValue("Istio"),
+				check.That(data.ResourceName).Key("service_mesh.#").HasValue("1"),
 				check.That(data.ResourceName).Key("service_mesh.0.internal_ingress_gateway_enabled").HasValue("true"),
 				check.That(data.ResourceName).Key("service_mesh.0.external_ingress_gateway_enabled").HasValue("true"),
 				check.That(data.ResourceName).Key("service_mesh.0.revisions.0").HasValue("asm-1-28"),
@@ -57,7 +57,8 @@ func TestAccDataSourceKubernetesAutomaticCluster_apiServerAuthorizedIPRanges(t *
 		{
 			Config: r.apiServerAuthorizedIPRanges(data),
 			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).Key("api_server_authorized_ip_ranges.#").HasValue("2"),
+				check.That(data.ResourceName).Key("api_server_access.#").HasValue("1"),
+				check.That(data.ResourceName).Key("api_server_access.0.authorized_ip_ranges.#").HasValue("2"),
 			),
 		},
 	})

--- a/internal/services/containers/kubernetes_automatic_cluster_data_source_test.go
+++ b/internal/services/containers/kubernetes_automatic_cluster_data_source_test.go
@@ -71,7 +71,8 @@ func TestAccDataSourceKubernetesAutomaticCluster_privateClusterEnabled(t *testin
 		{
 			Config: r.privateClusterEnabled(data),
 			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).Key("private_cluster_enabled").HasValue("true"),
+				check.That(data.ResourceName).Key("private_cluster.#").HasValue("1"),
+				check.That(data.ResourceName).Key("private_cluster.0.public_fully_qualified_domain_name_enabled").HasValue("true"),
 			),
 		},
 	})

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -1658,6 +1658,10 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   vm_size               = "Standard_DS2_v2"
   node_count            = 1
 
+  upgrade_settings {
+    max_surge = "10%%"
+  }
+
   kubelet_config {
     cpu_manager_policy    = "static"
     cpu_cfs_quota_enabled = true


### PR DESCRIPTION
## Community Note
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

Corrects AKS acceptance-test assertions and a node-pool fixture without changing production code or the public schema:

- The automatic-cluster data-source test now checks the existing `private_cluster` block and its public FQDN flag instead of the nonexistent `private_cluster_enabled` attribute.
- The service-mesh test checks the `service_mesh` block instead of a `mode` field that the data source does not expose. Existing ingress and revision checks remain.
- The API-server test checks `api_server_access.0.authorized_ip_ranges` instead of the nonexistent top-level `api_server_authorized_ip_ranges` attribute.
- The partial kubelet/Linux OS node-pool fixture now specifies `upgrade_settings.max_surge = "10%"`.

These test-only fixes are separate from the feature PRs so their scope and acceptance results remain clear.

## Testing

Passed locally:

```text
go test -mod=vendor -p=1 -count=1 -run '^$' ./internal/services/containers
```

This verifies test-package compilation only; it does not execute acceptance tests. Manual `azurerm-linter`, the repository-pinned custom `golangci-with-modules`, and the existing Terraform formatting checks passed.

An offline check against the actual data-source schema reproduced the two additional missing-field assertions. After correcting them, all 14 assertion paths in the data-source test file matched the schema. Both linters and test-package compilation passed again for the complete updated PR.

All four affected Azure acceptance cases passed in the [final TeamCity run](https://hashicorp.teamcity.com/viewLog.html?buildId=740161), whose tested merge contains the current PR head:

```text
TestAccDataSourceKubernetesAutomaticCluster_privateClusterEnabled
TestAccDataSourceKubernetesAutomaticCluster_serviceMesh
TestAccDataSourceKubernetesAutomaticCluster_apiServerAuthorizedIPRanges
TestAccKubernetesClusterNodePool_kubeletAndLinuxOSConfigPartial
```

The full result is **68 passed and 1 failed**. The remaining failure is `TestAccKubernetesClusterNodePool_virtualNetworkOwnershipRaceCondition`: Azure returned `ReferencedResourceNotProvisioned` while creating an agent pool because its shared subnet was still `Updating` under `PutSubnetOperation`.

The [same substantive failure occurs on main](https://hashicorp.teamcity.com/viewLog.html?buildId=715959): the same test, agent-pool creation stage, `ReferencedResourceNotProvisioned` error, `Updating` subnet state and `PutSubnetOperation`. The complete test and fixture are identical, and this PR changes no production code. This establishes that the failure predates these corrections; the subnet race is not fixed here and the broader suite is not green. The earlier optional beta request was unavailable; the results above are from the standard build.

## PR Checklist

- [x] Kept unrelated feature work out of this PR.
- [x] Verified the assertions against the existing data-source schema.
- [x] Checked for a duplicate PR from this fix branch.
- [x] Compiled the service test package and ran the relevant lint/format checks.
- [x] Verified all four affected acceptance tests against Azure; the separate subnet-race failure is disclosed above.

## Change Log

No user-facing change; acceptance-test corrections only.

## AI Assistance Disclosure

- [x] AI Assisted - AI tools assisted with the test corrections, review and this description. The changes and local verification results were reviewed before submission.

## Rollback Plan

Revert the test-only change if it causes an acceptance regression.

## Changes to Security Controls

None.
