### PR TITLE
`azurerm_public_ip` - add support for setting `ip_address`

### DIFF
--- a/internal/services/network/public_ip_resource.go
+++ b/internal/services/network/public_ip_resource.go
@@ -141,8 +141,9 @@ func resourcePublicIp() *pluginsdk.Resource {
 			},
 
 			"ip_address": {
-				Type:         pluginsdk.TypeString,
-				Optional:     true,
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				// NOTE: O+C Azure assigns an IP address when one is not specified
 				Computed:     true,
 				ForceNew:     true,
 				ValidateFunc: validation.IsIPAddress,
@@ -152,6 +153,7 @@ func resourcePublicIp() *pluginsdk.Resource {
 				Type:         pluginsdk.TypeString,
 				Optional:     true,
 				ForceNew:     true,
+				RequiredWith: []string{"ip_address"},
 				ValidateFunc: publicipprefixes.ValidatePublicIPPrefixID,
 			},
 
@@ -178,6 +180,7 @@ func resourcePublicIp() *pluginsdk.Resource {
 					"location",
 					"allocation_method",
 					"edge_zone",
+					"ip_address",
 					"ip_version",
 					"sku",
 					"sku_tier",

--- a/internal/services/network/public_ip_resource.go
+++ b/internal/services/network/public_ip_resource.go
@@ -141,8 +141,11 @@ func resourcePublicIp() *pluginsdk.Resource {
 			},
 
 			"ip_address": {
-				Type:     pluginsdk.TypeString,
-				Computed: true,
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IsIPAddress,
 			},
 
 			"public_ip_prefix_id": {
@@ -298,6 +301,10 @@ func resourcePublicIpCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 		}
 
 		publicIp.Properties.DnsSettings = &dnsSettings
+	}
+
+	if ipAddress, ipAddressOk := d.GetOk("ip_address"); ipAddressOk {
+		publicIp.Properties.IPAddress = pointer.To(ipAddress.(string))
 	}
 
 	if v, ok := d.GetOk("ip_tags"); ok {

--- a/internal/services/network/public_ip_resource.go
+++ b/internal/services/network/public_ip_resource.go
@@ -303,8 +303,8 @@ func resourcePublicIpCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 		publicIp.Properties.DnsSettings = &dnsSettings
 	}
 
-	if ipAddress, ipAddressOk := d.GetOk("ip_address"); ipAddressOk {
-		publicIp.Properties.IPAddress = pointer.To(ipAddress.(string))
+	if v, ok := d.GetOk("ip_address"); ok {
+		publicIp.Properties.IPAddress = pointer.To(v.(string))
 	}
 
 	if v, ok := d.GetOk("ip_tags"); ok {

--- a/internal/services/network/public_ip_resource_test.go
+++ b/internal/services/network/public_ip_resource_test.go
@@ -450,6 +450,21 @@ func TestAccPublicIp_edgeZone(t *testing.T) {
 	})
 }
 
+func TestAccPublicIp_ipAddress(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_public_ip", "test")
+	r := PublicIpResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.ipAddress(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (t PublicIpResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := commonids.ParsePublicIPAddressID(state.ID)
 	if err != nil {
@@ -985,4 +1000,33 @@ resource "azurerm_public_ip" "test" {
   edge_zone           = data.azurerm_extended_locations.test.extended_locations[0]
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (PublicIpResource) ipAddress(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_public_ip_prefix" "test" {
+  name                = "acctestpublicipprefix-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_public_ip" "test" {
+  name                = "acctestpublicip-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+  public_ip_prefix_id = azurerm_public_ip_prefix.test.id
+  ip_address          = cidrhost(azurerm_public_ip_prefix.test.ip_prefix, 0)
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }

--- a/website/docs/r/public_ip.html.markdown
+++ b/website/docs/r/public_ip.html.markdown
@@ -76,6 +76,10 @@ The following arguments are supported:
 
 -> **Note:** Only `Static` IP address allocation is supported for IPv6.
 
+* `ip_address` - (Optional) The IP address associated with the public IP address resource. Changing this forces a new resource to be created.
+
+~> **Note:** `Dynamic` Public IP Addresses aren't allocated until they're attached to a device (e.g. a Virtual Machine/Load Balancer). Instead you can obtain the IP Address once the Public IP has been assigned via the [`azurerm_public_ip` Data Source](../d/public_ip.html).
+
 * `public_ip_prefix_id` - (Optional) If specified then public IP address allocated will be provided from the public IP prefix resource. Changing this forces a new resource to be created.
 
 * `reverse_fqdn` - (Optional) A fully qualified domain name that resolves to this public IP address. If the reverseFqdn is specified, then a PTR DNS record is created pointing from the IP address in the in-addr.arpa domain to the reverse FQDN.
@@ -97,10 +101,6 @@ The following arguments are supported:
 In addition to the Arguments listed above - the following Attributes are exported:
 
 * `id` - The ID of this Public IP.
-
-* `ip_address` - The IP address value that was allocated.
-
-~> **Note:** `Dynamic` Public IP Addresses aren't allocated until they're attached to a device (e.g. a Virtual Machine/Load Balancer). Instead you can obtain the IP Address once the Public IP has been assigned via the [`azurerm_public_ip` Data Source](../d/public_ip.html).
 
 * `fqdn` - Fully qualified domain name of the A DNS record associated with the public IP. `domain_name_label` must be specified to get the `fqdn`. This is the concatenation of the `domain_name_label` and the regionalized DNS zone
 

--- a/website/docs/r/public_ip.html.markdown
+++ b/website/docs/r/public_ip.html.markdown
@@ -68,6 +68,10 @@ The following arguments are supported:
 
 * `idle_timeout_in_minutes` - (Optional) Specifies the timeout for the TCP idle connection. The value can be set between 4 and 30 minutes.
 
+* `ip_address` - (Optional) The IP address associated with the public IP address resource. `public_ip_prefix_id` must be specified when setting this property. Changing this forces a new resource to be created.
+
+~> **Note:** `Dynamic` Public IP Addresses aren't allocated until they're attached to a device (e.g. a Virtual Machine/Load Balancer). Instead you can obtain the IP Address once the Public IP has been assigned via the [`azurerm_public_ip` Data Source](../d/public_ip.html).
+
 * `ip_tags` - (Optional) A mapping of IP tags to assign to the public IP. Changing this forces a new resource to be created.
 
 -> **Note:** IP Tag `RoutingPreference` requires multiple `zones` and `Standard` SKU to be set.
@@ -75,10 +79,6 @@ The following arguments are supported:
 * `ip_version` - (Optional) The IP Version to use, IPv6 or IPv4. Changing this forces a new resource to be created. Defaults to `IPv4`.
 
 -> **Note:** Only `Static` IP address allocation is supported for IPv6.
-
-* `ip_address` - (Optional) The IP address associated with the public IP address resource. Changing this forces a new resource to be created.
-
-~> **Note:** `Dynamic` Public IP Addresses aren't allocated until they're attached to a device (e.g. a Virtual Machine/Load Balancer). Instead you can obtain the IP Address once the Public IP has been assigned via the [`azurerm_public_ip` Data Source](../d/public_ip.html).
 
 * `public_ip_prefix_id` - (Optional) If specified then public IP address allocated will be provided from the public IP prefix resource. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests/issues/comments/) to the original PR to help the community and maintainers prioritise for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritise for review

## Description

This PR builds on #32355 by @aqche. I cannot update the branch used by that PR, so this branch cherry-picks its two original commits, preserving their authorship, and addresses all five outstanding review comments.

The change allows `ip_address` to be configured on `azurerm_public_ip` when used with `public_ip_prefix_id`. It also adds the required schema constraint, preserves the Basic SKU plan-time rejection, documents the Optional+Computed behaviour, and updates the argument documentation and ordering.

Fixes #30806
Fixes #16310

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked for other open pull requests for the same change. This PR intentionally builds on #32355.
- [x] I have checked if my changes close any open issues and included the appropriate closing keywords.
- [x] I have updated the documentation as required.
- [x] I have used a meaningful PR title.

## Changes to existing Resource / Data Source

- [x] I have explained what the changes do and why they should be included.
- [x] The change includes dedicated acceptance-test coverage and updated documentation.
- [ ] I have successfully rerun the Azure acceptance test with these review changes locally.

## Testing

- [x] `make website-lint`
- [x] Network package compilation and targeted test selection
- [x] `make pr-check`
- [ ] `make acctests SERVICE=network TESTARGS='-run=TestAccPublicIp_ipAddress' TESTTIMEOUT=60m`

The original PR reports `TestAccPublicIp_ipAddress` passing before the review-feedback changes. The Azure acceptance test has not yet been rerun on this branch.

`make document-lint` reports existing repository-wide documentation issues, with no findings for `azurerm_public_ip`.

## Change Log

* `azurerm_public_ip` - support setting the `ip_address` property

This is a:

- [x] Enhancement

## Related Issue(s)

Fixes #30806
Fixes #16310

## AI Assistance Disclosure

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

GitHub Copilot was used to inspect repository guidance, implement the requested review changes, and draft this PR description. The original feature commits remain authored by @aqche.

## Rollback Plan

Revert this PR to remove configurable `ip_address` support and restore the previous schema and documentation behaviour.

## Changes to Security Controls

No.