### PR TITLE
Attributes added `azurerm_servicebus` - add support for `max_message_size_in_kilobytes in 2 files`

### DIFF
--- a/internal/services/servicebus/servicebus_queue_data_source.go
+++ b/internal/services/servicebus/servicebus_queue_data_source.go
@@ -93,6 +93,11 @@ func dataSourceServiceBusQueue() *pluginsdk.Resource {
 				Computed: true,
 			},
 
+			"maximum_message_size_in_kb": {
+				Type:     pluginsdk.TypeInt,
+				Computed: true,
+			},
+
 			"max_size_in_megabytes": {
 				Type:     pluginsdk.TypeInt,
 				Computed: true,
@@ -158,6 +163,7 @@ func dataSourceServiceBusQueueRead(d *pluginsdk.ResourceData, meta interface{}) 
 			d.Set("forward_to", props.ForwardTo)
 			d.Set("lock_duration", props.LockDuration)
 			d.Set("max_delivery_count", props.MaxDeliveryCount)
+			d.Set("maximum_message_size_in_kb", props.MaxMessageSizeInKilobytes)
 			d.Set("requires_duplicate_detection", props.RequiresDuplicateDetection)
 			d.Set("requires_session", props.RequiresSession)
 			d.Set("status", string(pointer.From(props.Status)))

--- a/internal/services/servicebus/servicebus_queue_data_source_test.go
+++ b/internal/services/servicebus/servicebus_queue_data_source_test.go
@@ -31,6 +31,7 @@ func TestAccDataSourceServiceBusQueue_basic(t *testing.T) {
 				check.That(data.ResourceName).Key("partitioning_enabled").Exists(),
 				check.That(data.ResourceName).Key("lock_duration").Exists(),
 				check.That(data.ResourceName).Key("max_delivery_count").Exists(),
+				check.That(data.ResourceName).Key("maximum_message_size_in_kb").Exists(),
 				check.That(data.ResourceName).Key("max_size_in_megabytes").Exists(),
 				check.That(data.ResourceName).Key("requires_duplicate_detection").Exists(),
 				check.That(data.ResourceName).Key("requires_session").Exists(),

--- a/internal/services/servicebus/servicebus_queue_resource.go
+++ b/internal/services/servicebus/servicebus_queue_resource.go
@@ -135,7 +135,7 @@ func resourceServicebusQueueSchema() map[string]*pluginsdk.Schema {
 			ValidateFunc: validation.IntAtLeast(1),
 		},
 
-		"max_message_size_in_kilobytes": { //azignore:AZS006 - named `maximum_message_size_in_kb` in the data source to follow new naming conventions
+		"max_message_size_in_kilobytes": { // azignore:AZS006 - named `maximum_message_size_in_kb` in the data source to follow new naming conventions
 			Type:     pluginsdk.TypeInt,
 			Optional: true,
 			// NOTE: O+C this gets a variable default based on the sku and can be updated without issues

--- a/internal/services/servicebus/servicebus_queue_resource.go
+++ b/internal/services/servicebus/servicebus_queue_resource.go
@@ -135,7 +135,7 @@ func resourceServicebusQueueSchema() map[string]*pluginsdk.Schema {
 			ValidateFunc: validation.IntAtLeast(1),
 		},
 
-		"max_message_size_in_kilobytes": {
+		"max_message_size_in_kilobytes": { //azignore:AZS006 - named `maximum_message_size_in_kb` in the data source to follow new naming conventions
 			Type:     pluginsdk.TypeInt,
 			Optional: true,
 			// NOTE: O+C this gets a variable default based on the sku and can be updated without issues

--- a/internal/services/servicebus/servicebus_topic_data_source.go
+++ b/internal/services/servicebus/servicebus_topic_data_source.go
@@ -67,6 +67,11 @@ func dataSourceServiceBusTopic() *pluginsdk.Resource {
 				Computed: true,
 			},
 
+			"maximum_message_size_in_kb": {
+				Type:     pluginsdk.TypeInt,
+				Computed: true,
+			},
+
 			"max_size_in_megabytes": {
 				Type:     pluginsdk.TypeInt,
 				Computed: true,
@@ -129,6 +134,7 @@ func dataSourceServiceBusTopicRead(d *pluginsdk.ResourceData, meta interface{}) 
 			d.Set("batched_operations_enabled", props.EnableBatchedOperations)
 			d.Set("express_enabled", props.EnableExpress)
 			d.Set("partitioning_enabled", props.EnablePartitioning)
+			d.Set("maximum_message_size_in_kb", props.MaxMessageSizeInKilobytes)
 			d.Set("requires_duplicate_detection", props.RequiresDuplicateDetection)
 			d.Set("support_ordering", props.SupportOrdering)
 

--- a/internal/services/servicebus/servicebus_topic_data_source_test.go
+++ b/internal/services/servicebus/servicebus_topic_data_source_test.go
@@ -28,6 +28,7 @@ func TestAccDataSourceServiceBusTopic_basic(t *testing.T) {
 				check.That(data.ResourceName).Key("batched_operations_enabled").Exists(),
 				check.That(data.ResourceName).Key("express_enabled").Exists(),
 				check.That(data.ResourceName).Key("partitioning_enabled").Exists(),
+				check.That(data.ResourceName).Key("maximum_message_size_in_kb").Exists(),
 				check.That(data.ResourceName).Key("max_size_in_megabytes").Exists(),
 				check.That(data.ResourceName).Key("requires_duplicate_detection").Exists(),
 				check.That(data.ResourceName).Key("status").Exists(),

--- a/internal/services/servicebus/servicebus_topic_resource.go
+++ b/internal/services/servicebus/servicebus_topic_resource.go
@@ -107,7 +107,7 @@ func resourceServiceBusTopicSchema() map[string]*pluginsdk.Schema {
 			ForceNew: true,
 		},
 
-		"max_message_size_in_kilobytes": { //azignore:AZS006 - named `maximum_message_size_in_kb` in the data source to follow new naming conventions
+		"max_message_size_in_kilobytes": { // azignore:AZS006 - named `maximum_message_size_in_kb` in the data source to follow new naming conventions
 			Type:     pluginsdk.TypeInt,
 			Optional: true,
 			// NOTE: O+C this gets a variable default based on the sku and can be updated without issues

--- a/internal/services/servicebus/servicebus_topic_resource.go
+++ b/internal/services/servicebus/servicebus_topic_resource.go
@@ -107,7 +107,7 @@ func resourceServiceBusTopicSchema() map[string]*pluginsdk.Schema {
 			ForceNew: true,
 		},
 
-		"max_message_size_in_kilobytes": {
+		"max_message_size_in_kilobytes": { //azignore:AZS006 - named `maximum_message_size_in_kb` in the data source to follow new naming conventions
 			Type:     pluginsdk.TypeInt,
 			Optional: true,
 			// NOTE: O+C this gets a variable default based on the sku and can be updated without issues

--- a/website/docs/d/servicebus_queue.html.markdown
+++ b/website/docs/d/servicebus_queue.html.markdown
@@ -59,6 +59,8 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `max_delivery_count` - Integer value which controls when a message is automatically dead lettered.
 
+* `maximum_message_size_in_kb` - Integer value which controls the maximum size of a message allowed on the queue for Premium SKU.
+
 * `max_size_in_megabytes` - Integer value which controls the size of memory allocated for the queue. For supported values see the "Queue or topic size" section of [Service Bus Quotas](https://docs.microsoft.com/azure/service-bus-messaging/service-bus-quotas).
 
 * `requires_duplicate_detection` - Boolean flag which controls whether the Queue requires duplicate detection.

--- a/website/docs/d/servicebus_topic.html.markdown
+++ b/website/docs/d/servicebus_topic.html.markdown
@@ -49,6 +49,8 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `partitioning_enabled` - Boolean flag which controls whether to enable the topic to be partitioned across multiple message brokers.
 
+* `maximum_message_size_in_kb` - Integer value which controls the maximum size of a message allowed on the topic for Premium SKU.
+
 * `max_size_in_megabytes` - Integer value which controls the size of memory allocated for the topic. For supported values see the "Queue/topic size" section of [this document](https://docs.microsoft.com/azure/service-bus-messaging/service-bus-quotas).
 
 * `requires_duplicate_detection` - Boolean flag which controls whether the Topic requires duplicate detection.


### PR DESCRIPTION
<!-- markdownlint-disable-file first-line-heading -->
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 
--- PASS: TestAccDataSourceServiceBusTopic_basic (161.06s)
--- PASS: TestAccDataSourceServiceBusQueue_basic (163.37s)

data source "azurerm_servicebus_topic" Added missing resource properties: "max_message_size_in_kilobytes"
data source "azurerm_servicebus_queue" Added missing resource properties: "max_message_size_in_kilobytes"

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”

<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->

## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.

## Testing

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [x] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change

## Related Issue(s)

Fixes #0000

## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE]
> If this PR changes meaningfully during the course of review please update the title and description as required.
