### PR TITLE
Attributes added `azurerm_signalr_service ` - add support for `connectivity_logs_enabled + 9 attributes`

### DIFF
--- a/internal/services/signalr/signalr_service_data_source.go
+++ b/internal/services/signalr/signalr_service_data_source.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
@@ -334,15 +335,8 @@ func dataSourceArmSignalRServiceRead(d *pluginsdk.ResourceData, meta interface{}
 
 			if props.ResourceLogConfiguration != nil && props.ResourceLogConfiguration.Categories != nil {
 				for _, item := range *props.ResourceLogConfiguration.Categories {
-					name := ""
-					if item.Name != nil {
-						name = *item.Name
-					}
-
-					enabled := ""
-					if item.Enabled != nil {
-						enabled = *item.Enabled
-					}
+					name := pointer.From(item.Name)
+					enabled := pointer.From(item.Enabled)
 
 					switch name {
 					case "MessagingLogs":

--- a/internal/services/signalr/signalr_service_data_source.go
+++ b/internal/services/signalr/signalr_service_data_source.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/signalr/2024-03-01/signalr"
@@ -49,6 +50,24 @@ func dataSourceArmSignalRService() *pluginsdk.Resource {
 				Computed: true,
 			},
 
+			"sku": {
+				Type:     pluginsdk.TypeList,
+				Computed: true,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"name": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+
+						"capacity": {
+							Type:     pluginsdk.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+
 			"public_port": {
 				Type:     pluginsdk.TypeInt,
 				Computed: true,
@@ -79,10 +98,118 @@ func dataSourceArmSignalRService() *pluginsdk.Resource {
 				Computed: true,
 			},
 
+			"connectivity_logs_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Computed: true,
+			},
+
+			"messaging_logs_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Computed: true,
+			},
+
+			"http_request_logs_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Computed: true,
+			},
+
+			"live_trace": {
+				Type:     pluginsdk.TypeList,
+				Computed: true,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"enabled": {
+							Type:     pluginsdk.TypeBool,
+							Computed: true,
+						},
+
+						"connectivity_logs_enabled": {
+							Type:     pluginsdk.TypeBool,
+							Computed: true,
+						},
+
+						"messaging_logs_enabled": {
+							Type:     pluginsdk.TypeBool,
+							Computed: true,
+						},
+
+						"http_request_logs_enabled": {
+							Type:     pluginsdk.TypeBool,
+							Computed: true,
+						},
+					},
+				},
+			},
+
+			"service_mode": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
 			"serverless_connection_timeout_in_seconds": {
 				Type:     pluginsdk.TypeInt,
 				Computed: true,
 			},
+
+			"upstream_endpoint": {
+				Type:     pluginsdk.TypeSet,
+				Computed: true,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"category_pattern": {
+							Type:     pluginsdk.TypeList,
+							Computed: true,
+							Elem: &pluginsdk.Schema{
+								Type: pluginsdk.TypeString,
+							},
+						},
+
+						"event_pattern": {
+							Type:     pluginsdk.TypeList,
+							Computed: true,
+							Elem: &pluginsdk.Schema{
+								Type: pluginsdk.TypeString,
+							},
+						},
+
+						"hub_pattern": {
+							Type:     pluginsdk.TypeList,
+							Computed: true,
+							Elem: &pluginsdk.Schema{
+								Type: pluginsdk.TypeString,
+							},
+						},
+
+						"url_template": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+
+						"user_assigned_identity_id": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+
+			"cors": {
+				Type:     pluginsdk.TypeList,
+				Computed: true,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"allowed_origins": {
+							Type:     pluginsdk.TypeSet,
+							Computed: true,
+							Elem: &pluginsdk.Schema{
+								Type: pluginsdk.TypeString,
+							},
+						},
+					},
+				},
+			},
+
+			"identity": commonschema.SystemOrUserAssignedIdentityComputed(),
 
 			"primary_access_key": {
 				Type:      pluginsdk.TypeString,
@@ -141,11 +268,29 @@ func dataSourceArmSignalRServiceRead(d *pluginsdk.ResourceData, meta interface{}
 	if model := resp.Model; model != nil {
 		d.Set("location", location.Normalize(model.Location))
 
+		if err := d.Set("sku", flattenSignalRServiceSku(model.Sku)); err != nil {
+			return fmt.Errorf("setting `sku`: %+v", err)
+		}
+
 		if props := model.Properties; props != nil {
 			d.Set("hostname", props.HostName)
 			d.Set("ip_address", props.ExternalIP)
 			d.Set("public_port", props.PublicPort)
 			d.Set("server_port", props.ServerPort)
+
+			connectivityLogsEnabled := false
+			messagingLogsEnabled := false
+			httpLogsEnabled := false
+			serviceMode := "Default"
+			if props.Features != nil {
+				for _, feature := range *props.Features {
+					if feature.Flag == signalr.FeatureFlagsServiceMode {
+						serviceMode = feature.Value
+					}
+				}
+			}
+
+			d.Set("service_mode", serviceMode)
 
 			aadAuthEnabled := true
 			if props.DisableAadAuth != nil {
@@ -174,6 +319,52 @@ func dataSourceArmSignalRServiceRead(d *pluginsdk.ResourceData, meta interface{}
 			if props.Serverless != nil && props.Serverless.ConnectionTimeoutInSeconds != nil {
 				d.Set("serverless_connection_timeout_in_seconds", int(*props.Serverless.ConnectionTimeoutInSeconds))
 			}
+
+			if err := d.Set("cors", flattenSignalRCors(props.Cors)); err != nil {
+				return fmt.Errorf("setting `cors`: %+v", err)
+			}
+
+			if err := d.Set("upstream_endpoint", flattenUpstreamSettings(props.Upstream)); err != nil {
+				return fmt.Errorf("setting `upstream_endpoint`: %+v", err)
+			}
+
+			if err := d.Set("live_trace", flattenSignalRLiveTraceConfig(props.LiveTraceConfiguration)); err != nil {
+				return fmt.Errorf("setting `live_trace`: %+v", err)
+			}
+
+			if props.ResourceLogConfiguration != nil && props.ResourceLogConfiguration.Categories != nil {
+				for _, item := range *props.ResourceLogConfiguration.Categories {
+					name := ""
+					if item.Name != nil {
+						name = *item.Name
+					}
+
+					enabled := ""
+					if item.Enabled != nil {
+						enabled = *item.Enabled
+					}
+
+					switch name {
+					case "MessagingLogs":
+						messagingLogsEnabled = strings.EqualFold(enabled, "true")
+					case "ConnectivityLogs":
+						connectivityLogsEnabled = strings.EqualFold(enabled, "true")
+					case "HttpRequestLogs":
+						httpLogsEnabled = strings.EqualFold(enabled, "true")
+					}
+				}
+			}
+			d.Set("connectivity_logs_enabled", connectivityLogsEnabled)
+			d.Set("messaging_logs_enabled", messagingLogsEnabled)
+			d.Set("http_request_logs_enabled", httpLogsEnabled)
+		}
+
+		identityValue, err := identity.FlattenSystemOrUserAssignedMap(model.Identity)
+		if err != nil {
+			return fmt.Errorf("flattening `identity`: %+v", err)
+		}
+		if err := d.Set("identity", identityValue); err != nil {
+			return fmt.Errorf("setting `identity`: %+v", err)
 		}
 
 		if err := tags.FlattenAndSet(d, model.Tags); err != nil {

--- a/internal/services/signalr/signalr_service_data_source_test.go
+++ b/internal/services/signalr/signalr_service_data_source_test.go
@@ -25,6 +25,13 @@ func TestAccDataSourceSignalRService_basic(t *testing.T) {
 				check.That(data.ResourceName).Key("ip_address").Exists(),
 				check.That(data.ResourceName).Key("public_port").Exists(),
 				check.That(data.ResourceName).Key("server_port").Exists(),
+				check.That(data.ResourceName).Key("sku.#").HasValue("1"),
+				check.That(data.ResourceName).Key("sku.0.name").HasValue("Standard_S1"),
+				check.That(data.ResourceName).Key("sku.0.capacity").HasValue("1"),
+				check.That(data.ResourceName).Key("connectivity_logs_enabled").HasValue("false"),
+				check.That(data.ResourceName).Key("messaging_logs_enabled").HasValue("false"),
+				check.That(data.ResourceName).Key("http_request_logs_enabled").HasValue("false"),
+				check.That(data.ResourceName).Key("service_mode").HasValue("Default"),
 				check.That(data.ResourceName).Key("primary_access_key").Exists(),
 				check.That(data.ResourceName).Key("primary_connection_string").Exists(),
 				check.That(data.ResourceName).Key("secondary_access_key").Exists(),
@@ -34,8 +41,167 @@ func TestAccDataSourceSignalRService_basic(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceSignalRService_cors(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_signalr_service", "test")
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: SignalRServiceDataSource{}.cors(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("cors.#").HasValue("1"),
+				check.That(data.ResourceName).Key("cors.0.allowed_origins.#").HasValue("2"),
+			),
+		},
+	})
+}
+
+func TestAccDataSourceSignalRService_identity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_signalr_service", "test")
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: SignalRServiceDataSource{}.identity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("identity.#").HasValue("1"),
+				check.That(data.ResourceName).Key("identity.0.type").HasValue("SystemAssigned"),
+				check.That(data.ResourceName).Key("identity.0.principal_id").IsUUID(),
+				check.That(data.ResourceName).Key("identity.0.tenant_id").IsUUID(),
+			),
+		},
+	})
+}
+
+func TestAccDataSourceSignalRService_liveTrace(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_signalr_service", "test")
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: SignalRServiceDataSource{}.liveTrace(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("live_trace.#").HasValue("1"),
+				check.That(data.ResourceName).Key("live_trace.0.enabled").HasValue("true"),
+				check.That(data.ResourceName).Key("live_trace.0.connectivity_logs_enabled").HasValue("true"),
+				check.That(data.ResourceName).Key("live_trace.0.messaging_logs_enabled").HasValue("false"),
+			),
+		},
+	})
+}
+
+func TestAccDataSourceSignalRService_resourceLogs(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_signalr_service", "test")
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: SignalRServiceDataSource{}.resourceLogs(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("connectivity_logs_enabled").HasValue("true"),
+				check.That(data.ResourceName).Key("messaging_logs_enabled").HasValue("false"),
+				check.That(data.ResourceName).Key("http_request_logs_enabled").HasValue("false"),
+			),
+		},
+	})
+}
+
+func TestAccDataSourceSignalRService_serviceMode(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_signalr_service", "test")
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: SignalRServiceDataSource{}.serviceMode(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("service_mode").HasValue("Serverless"),
+			),
+		},
+	})
+}
+
+func TestAccDataSourceSignalRService_upstreamEndpoint(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_signalr_service", "test")
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: SignalRServiceDataSource{}.upstreamEndpoint(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("upstream_endpoint.#").HasValue("4"),
+			),
+		},
+	})
+}
+
 func (r SignalRServiceDataSource) basic(data acceptance.TestData) string {
 	template := SignalRServiceResource{}.basic(data)
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_signalr_service" "test" {
+  name                = azurerm_signalr_service.test.name
+  resource_group_name = azurerm_resource_group.test.name
+}
+`, template)
+}
+
+func (r SignalRServiceDataSource) cors(data acceptance.TestData) string {
+	template := SignalRServiceResource{}.withCors(data)
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_signalr_service" "test" {
+  name                = azurerm_signalr_service.test.name
+  resource_group_name = azurerm_resource_group.test.name
+}
+`, template)
+}
+
+func (r SignalRServiceDataSource) identity(data acceptance.TestData) string {
+	template := SignalRServiceResource{}.systemAssignedIdentity(data)
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_signalr_service" "test" {
+  name                = azurerm_signalr_service.test.name
+  resource_group_name = azurerm_resource_group.test.name
+}
+`, template)
+}
+
+func (r SignalRServiceDataSource) liveTrace(data acceptance.TestData) string {
+	template := SignalRServiceResource{}.liveTrace(data)
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_signalr_service" "test" {
+  name                = azurerm_signalr_service.test.name
+  resource_group_name = azurerm_resource_group.test.name
+}
+`, template)
+}
+
+func (r SignalRServiceDataSource) resourceLogs(data acceptance.TestData) string {
+	template := SignalRServiceResource{}.resourceLogs(data)
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_signalr_service" "test" {
+  name                = azurerm_signalr_service.test.name
+  resource_group_name = azurerm_resource_group.test.name
+}
+`, template)
+}
+
+func (r SignalRServiceDataSource) serviceMode(data acceptance.TestData) string {
+	template := SignalRServiceResource{}.withServiceMode(data, "Serverless")
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_signalr_service" "test" {
+  name                = azurerm_signalr_service.test.name
+  resource_group_name = azurerm_resource_group.test.name
+}
+`, template)
+}
+
+func (r SignalRServiceDataSource) upstreamEndpoint(data acceptance.TestData) string {
+	template := SignalRServiceResource{}.withUpstreamEndpoints(data)
 	return fmt.Sprintf(`
 %s
 

--- a/internal/services/signalr/signalr_service_resource.go
+++ b/internal/services/signalr/signalr_service_resource.go
@@ -873,7 +873,7 @@ func resourceArmSignalRServiceSchema() map[string]*pluginsdk.Schema {
 			Default:  false,
 		},
 
-		"live_trace_enabled": {
+		"live_trace_enabled": { // azignore:AZS006 - deprecated in favor of `live_trace` and not added to the data source
 			Type:       pluginsdk.TypeBool,
 			Optional:   true,
 			Default:    false,

--- a/website/docs/d/signalr_service.html.markdown
+++ b/website/docs/d/signalr_service.html.markdown
@@ -39,8 +39,6 @@ The following attributes are exported:
 
 * `location` - Specifies the supported Azure location where the SignalR service exists.
 
-* `sku` - A `sku` block as documented below.
-
 * `public_port` - The publicly accessible port of the SignalR service which is designed for browser/client use.
 
 * `server_port` - The publicly accessible port of the SignalR service which is designed for customer server side use.
@@ -61,6 +59,8 @@ The following attributes are exported:
 
 * `secondary_connection_string` - The secondary connection string of the SignalR service.
 
+* `sku` - A `sku` block as documented below.
+
 * `public_network_access_enabled` - Is public network access enabled for this SignalR service?
 
 * `local_auth_enabled` - Is local auth enable for this SignalR serviced?
@@ -71,7 +71,7 @@ The following attributes are exported:
 
 * `serverless_connection_timeout_in_seconds` - The serverless connection timeout of this SignalR service.
 
-* `service_mode` - Specifies the service mode. Possible values are `Classic`, `Default` and `Serverless`.
+* `service_mode` - Specifies the service mode.
 
 * `upstream_endpoint` - One or more `upstream_endpoint` blocks as documented below.
 

--- a/website/docs/d/signalr_service.html.markdown
+++ b/website/docs/d/signalr_service.html.markdown
@@ -39,9 +39,19 @@ The following attributes are exported:
 
 * `location` - Specifies the supported Azure location where the SignalR service exists.
 
+* `sku` - A `sku` block as documented below.
+
 * `public_port` - The publicly accessible port of the SignalR service which is designed for browser/client use.
 
 * `server_port` - The publicly accessible port of the SignalR service which is designed for customer server side use.
+
+* `cors` - A `cors` block as documented below.
+
+* `connectivity_logs_enabled` - Specifies if Connectivity Logs are enabled or not.
+
+* `messaging_logs_enabled` - Specifies if Messaging Logs are enabled or not.
+
+* `http_request_logs_enabled` - Specifies if Http Request Logs are enabled or not.
 
 * `primary_access_key` - The primary access key of the SignalR service.
 
@@ -61,7 +71,53 @@ The following attributes are exported:
 
 * `serverless_connection_timeout_in_seconds` - The serverless connection timeout of this SignalR service.
 
+* `service_mode` - Specifies the service mode. Possible values are `Classic`, `Default` and `Serverless`.
+
+* `upstream_endpoint` - One or more `upstream_endpoint` blocks as documented below.
+
+* `live_trace` - A `live_trace` block as defined below.
+
 * `identity` - An `identity` block as documented below.
+
+---
+
+The `sku` block exports the following:
+
+* `name` - The name of the SKU.
+
+* `capacity` - The capacity of the SKU.
+
+---
+
+A `cors` block exports the following:
+
+* `allowed_origins` - A list of origins which should be able to make cross-origin calls.
+
+---
+
+An `upstream_endpoint` block exports the following:
+
+* `url_template` - The upstream URL Template.
+
+* `category_pattern` - The categories to match on, or `*` for all.
+
+* `event_pattern` - The events to match on, or `*` for all.
+
+* `hub_pattern` - The hubs to match on, or `*` for all.
+
+* `user_assigned_identity_id` - The Managed Identity ID assigned to this SignalR upstream setting.
+
+---
+
+A `live_trace` block exports the following:
+
+* `enabled` - Whether live trace is enabled.
+
+* `messaging_logs_enabled` - Whether the log category `MessagingLogs` is enabled.
+
+* `connectivity_logs_enabled` - Whether the log category `ConnectivityLogs` is enabled.
+
+* `http_request_logs_enabled` - Whether the log category `HttpRequestLogs` is enabled.
 
 ---
 
@@ -69,7 +125,7 @@ The `identity` block exports the following:
 
 * `type` - The type of identity used for the signalR service.
 
-* `user_assigned_identity_id` - The ID of the User Assigned Identity. This value will be empty when using system assigned identity.
+* `identity_ids` - The list of User Assigned Managed Identity IDs assigned to the SignalR service.
 
 * `principal_id` - The principal id of the system assigned identity.
 


### PR DESCRIPTION
<!-- markdownlint-disable-file first-line-heading -->
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 
--- PASS: TestAccDataSourceSignalRService_basic (188.76s)
--- PASS: TestAccDataSourceSignalRService_liveTrace (188.76s)
--- PASS: TestAccDataSourceSignalRService_identity (189.55s)
--- PASS: TestAccDataSourceSignalRService_cors (338.35s)
--- PASS: TestAccDataSourceSignalRService_upstreamEndpoint (341.34s)
--- PASS: TestAccDataSourceSignalRService_resourceLogs (360.12s)
--- PASS: TestAccDataSourceSignalRService_serviceMode (404.64s)

data source "azurerm_signalr_service" is missing resource properties: "connectivity_logs_enabled", "cors", "http_request_logs_enabled", "identity", "live_trace", "live_trace_enabled", "messaging_logs_enabled", "service_mode", "sku", "upstream_endpoint"

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”

<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->

## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.

## Testing

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [x] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change

## Related Issue(s)

Fixes #0000

## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE]
> If this PR changes meaningfully during the course of review please update the title and description as required.
