### PR TITLE
`postgresql_flexible_server_firewall_rule` - add List Resource support

### DIFF
--- a/internal/services/postgres/postgresql_flexible_server_firewall_rule_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_firewall_rule_resource.go
@@ -23,6 +23,8 @@ import (
 
 //go:generate go run ../../tools/generator-tests resourceidentity -resource-name postgresql_flexible_server_firewall_rule -service-package-name postgres -properties "name" -compare-values "subscription_id:server_id,resource_group_name:server_id,flexible_server_name:server_id"
 
+const azurePostgresqlFlexibleServerFirewallRuleResourceName = "azurerm_postgresql_flexible_server_firewall_rule"
+
 func resourcePostgresqlFlexibleServerFirewallRule() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
 		Create: resourcePostgresqlFlexibleServerFirewallRuleCreateUpdate,
@@ -98,7 +100,7 @@ func resourcePostgresqlFlexibleServerFirewallRuleCreateUpdate(d *pluginsdk.Resou
 				}
 			}
 			if !response.WasNotFound(existing.HttpResponse) {
-				return tf.ImportAsExistsError("azurerm_postgresql_flexible_server_firewall_rule", id.ID())
+				return tf.ImportAsExistsError(azurePostgresqlFlexibleServerFirewallRuleResourceName, id.ID())
 			}
 		}
 	}
@@ -111,7 +113,7 @@ func resourcePostgresqlFlexibleServerFirewallRuleCreateUpdate(d *pluginsdk.Resou
 	}
 
 	if d.IsNewResource() {
-		if err := client.CreateOrUpdateCallbackThenPoll(ctx, id, properties, sdk.SetIDCallback(meta, &id, d)); err != nil {
+		if err := client.CreateOrUpdateCallbackThenPoll(ctx, id, properties, sdk.SetIDAndIdentityCallback(meta, &id, d)); err != nil {
 			return fmt.Errorf("creating %s: %+v", id, err)
 		}
 		d.SetId(id.ID())
@@ -128,7 +130,6 @@ func resourcePostgresqlFlexibleServerFirewallRuleCreateUpdate(d *pluginsdk.Resou
 }
 
 func resourcePostgresqlFlexibleServerFirewallRuleRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	client := meta.(*clients.Client).Postgres.FlexibleServerFirewallRuleClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -147,10 +148,14 @@ func resourcePostgresqlFlexibleServerFirewallRuleRead(d *pluginsdk.ResourceData,
 		}
 		return fmt.Errorf("retrieving %q: %+v", id, err)
 	}
-	d.Set("name", id.FirewallRuleName)
-	d.Set("server_id", firewallrules.NewFlexibleServerID(subscriptionId, id.ResourceGroupName, id.FlexibleServerName).ID())
+	return resourcePostgresqlFlexibleServerFirewallRuleFlatten(d, id, resp.Model)
+}
 
-	if model := resp.Model; model != nil {
+func resourcePostgresqlFlexibleServerFirewallRuleFlatten(d *pluginsdk.ResourceData, id *firewallrules.FirewallRuleId, model *firewallrules.FirewallRule) error {
+	d.Set("name", id.FirewallRuleName)
+	d.Set("server_id", firewallrules.NewFlexibleServerID(id.SubscriptionId, id.ResourceGroupName, id.FlexibleServerName).ID())
+
+	if model != nil {
 		d.Set("end_ip_address", model.Properties.EndIPAddress)
 		d.Set("start_ip_address", model.Properties.StartIPAddress)
 	}

--- a/internal/services/postgres/postgresql_flexible_server_firewall_rule_resource_list.go
+++ b/internal/services/postgres/postgresql_flexible_server_firewall_rule_resource_list.go
@@ -20,7 +20,7 @@ import (
 type PostgresqlFlexibleServerFirewallRuleListResource struct{}
 
 type PostgresqlFlexibleServerFirewallRuleListModel struct {
-	FlexibleServerId types.String `tfsdk:"server_id"`
+	FlexibleServerId types.String `tfsdk:"postgresql_flexible_server_id"`
 }
 
 var _ sdk.FrameworkListWrappedResource = new(PostgresqlFlexibleServerFirewallRuleListResource)
@@ -36,7 +36,7 @@ func (PostgresqlFlexibleServerFirewallRuleListResource) ResourceFunc() *pluginsd
 func (PostgresqlFlexibleServerFirewallRuleListResource) ListResourceConfigSchema(_ context.Context, _ list.ListResourceSchemaRequest, response *list.ListResourceSchemaResponse) {
 	response.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
-			"server_id": schema.StringAttribute{
+			"postgresql_flexible_server_id": schema.StringAttribute{
 				Required: true,
 				Validators: []validator.String{
 					typehelpers.WrappedStringValidator{Func: firewallrules.ValidateFlexibleServerID},

--- a/internal/services/postgres/postgresql_flexible_server_firewall_rule_resource_list.go
+++ b/internal/services/postgres/postgresql_flexible_server_firewall_rule_resource_list.go
@@ -1,0 +1,99 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-azure-helpers/framework/typehelpers"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2025-08-01/firewallrules"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-framework/list/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type PostgresqlFlexibleServerFirewallRuleListResource struct{}
+
+type PostgresqlFlexibleServerFirewallRuleListModel struct {
+	FlexibleServerId types.String `tfsdk:"server_id"`
+}
+
+var _ sdk.FrameworkListWrappedResource = new(PostgresqlFlexibleServerFirewallRuleListResource)
+
+func (PostgresqlFlexibleServerFirewallRuleListResource) Metadata(_ context.Context, _ resource.MetadataRequest, response *resource.MetadataResponse) {
+	response.TypeName = azurePostgresqlFlexibleServerFirewallRuleResourceName
+}
+
+func (PostgresqlFlexibleServerFirewallRuleListResource) ResourceFunc() *pluginsdk.Resource {
+	return resourcePostgresqlFlexibleServerFirewallRule()
+}
+
+func (PostgresqlFlexibleServerFirewallRuleListResource) ListResourceConfigSchema(_ context.Context, _ list.ListResourceSchemaRequest, response *list.ListResourceSchemaResponse) {
+	response.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"server_id": schema.StringAttribute{
+				Required: true,
+				Validators: []validator.String{
+					typehelpers.WrappedStringValidator{Func: firewallrules.ValidateFlexibleServerID},
+				},
+			},
+		},
+	}
+}
+
+func (PostgresqlFlexibleServerFirewallRuleListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream, metadata sdk.ResourceMetadata) {
+	client := metadata.Client.Postgres.FlexibleServerFirewallRuleClient
+
+	var data PostgresqlFlexibleServerFirewallRuleListModel
+	diags := request.Config.Get(ctx, &data)
+	if diags.HasError() {
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+
+	parentID, err := firewallrules.ParseFlexibleServerID(data.FlexibleServerId.ValueString())
+	if err != nil {
+		sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("parsing Flexible Server ID for `%s`", azurePostgresqlFlexibleServerFirewallRuleResourceName), err)
+		return
+	}
+
+	resp, err := client.ListByServerComplete(ctx, *parentID)
+	if err != nil {
+		sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("listing `%s`", azurePostgresqlFlexibleServerFirewallRuleResourceName), err)
+		return
+	}
+
+	stream.Results = func(push func(list.ListResult) bool) {
+		for _, item := range resp.Items {
+			result := request.NewListResult(ctx)
+			result.DisplayName = pointer.From(item.Name)
+
+			rd := resourcePostgresqlFlexibleServerFirewallRule().Data(&terraform.InstanceState{})
+			id, err := firewallrules.ParseFirewallRuleIDInsensitively(pointer.From(item.Id))
+			if err != nil {
+				sdk.SetErrorDiagnosticAndPushListResult(result, push, fmt.Sprintf("parsing ID for `%s`", azurePostgresqlFlexibleServerFirewallRuleResourceName), err)
+				return
+			}
+			rd.SetId(id.ID())
+
+			if err := resourcePostgresqlFlexibleServerFirewallRuleFlatten(rd, id, &item); err != nil {
+				sdk.SetErrorDiagnosticAndPushListResult(result, push, fmt.Sprintf("encoding `%s` resource data", azurePostgresqlFlexibleServerFirewallRuleResourceName), err)
+				return
+			}
+
+			sdk.EncodeListResult(ctx, rd, &result)
+			if result.Diagnostics.HasError() {
+				push(result)
+				return
+			}
+			if !push(result) {
+				return
+			}
+		}
+	}
+}

--- a/internal/services/postgres/postgresql_flexible_server_firewall_rule_resource_list_test.go
+++ b/internal/services/postgres/postgresql_flexible_server_firewall_rule_resource_list_test.go
@@ -1,0 +1,74 @@
+package postgres_test
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
+)
+
+func TestAccPostgresqlFlexibleServerFirewallRule_listByFlexibleServerID(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_postgresql_flexible_server_firewall_rule", "testlist1")
+	r := PostgresqlFlexibleServerFirewallRuleResource{}
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []resource.TestStep{
+			{
+				Config: r.basicList(data),
+			},
+			{
+				Query:  true,
+				Config: r.basicQuery(),
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectLengthAtLeast("azurerm_postgresql_flexible_server_firewall_rule.list", 3),
+					querycheck.ExpectIdentity(
+						"azurerm_postgresql_flexible_server_firewall_rule.list",
+						map[string]knownvalue.Check{
+							"name":                 knownvalue.StringRegexp(regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
+							"resource_group_name":  knownvalue.StringRegexp(regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
+							"flexible_server_name": knownvalue.StringRegexp(regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
+							"subscription_id":      knownvalue.StringExact(data.Subscriptions.Primary),
+						},
+					),
+				},
+			},
+		},
+	})
+}
+
+func (PostgresqlFlexibleServerFirewallRuleResource) basicList(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_postgresql_flexible_server_firewall_rule" "test" {
+  count            = 3
+  name             = "acctest-FSFR-%d${count.index}"
+  server_id        = azurerm_postgresql_flexible_server.test.id
+  start_ip_address = "122.122.0.${count.index}"
+  end_ip_address   = "122.122.0.${count.index}"
+}
+`, PostgresqlFlexibleServerResource{}.basic(data), data.RandomInteger)
+}
+
+func (r PostgresqlFlexibleServerFirewallRuleResource) basicQuery() string {
+	return `
+list "azurerm_postgresql_flexible_server_firewall_rule" "list" {
+  provider = azurerm
+  config {
+    server_id = azurerm_postgresql_flexible_server.test.id
+  }
+}
+`
+}

--- a/internal/services/postgres/postgresql_flexible_server_firewall_rule_resource_list_test.go
+++ b/internal/services/postgres/postgresql_flexible_server_firewall_rule_resource_list_test.go
@@ -67,7 +67,7 @@ func (r PostgresqlFlexibleServerFirewallRuleResource) basicQuery() string {
 list "azurerm_postgresql_flexible_server_firewall_rule" "list" {
   provider = azurerm
   config {
-    server_id = azurerm_postgresql_flexible_server.test.id
+    postgresql_flexible_server_id = azurerm_postgresql_flexible_server.test.id
   }
 }
 `

--- a/internal/services/postgres/registration.go
+++ b/internal/services/postgres/registration.go
@@ -80,5 +80,7 @@ func (r Registration) EphemeralResources() []func() ephemeral.EphemeralResource 
 }
 
 func (r Registration) ListResources() []sdk.FrameworkListWrappedResource {
-	return []sdk.FrameworkListWrappedResource{}
+	return []sdk.FrameworkListWrappedResource{
+		PostgresqlFlexibleServerFirewallRuleListResource{},
+	}
 }

--- a/website/docs/list-resources/postgresql_flexible_server_firewall_rule.html.markdown
+++ b/website/docs/list-resources/postgresql_flexible_server_firewall_rule.html.markdown
@@ -1,0 +1,30 @@
+---
+subcategory: "Database"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_postgresql_flexible_server_firewall_rule"
+description: |-
+    Lists Postgresql Flexible Server Firewall Rule resources.
+---
+
+# List resource: azurerm_postgresql_flexible_server_firewall_rule
+
+Lists Postgresql Flexible Server Firewall Rule resources.
+
+## Example Usage
+
+### List Postgresql Flexible Server Firewall Rules in a Server
+
+```hcl
+list "azurerm_postgresql_flexible_server_firewall_rule" "example" {
+  provider = azurerm
+  config {
+    server_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example-rg/providers/Microsoft.DBforPostgreSQL/flexibleServers/example-server"
+  }
+}
+```
+
+## Argument Reference
+
+This list resource supports the following arguments:
+
+* `server_id` - (Required) The ID of the PostgreSQL Flexible Server to query.

--- a/website/docs/list-resources/postgresql_flexible_server_firewall_rule.html.markdown
+++ b/website/docs/list-resources/postgresql_flexible_server_firewall_rule.html.markdown
@@ -18,7 +18,7 @@ Lists Postgresql Flexible Server Firewall Rule resources.
 list "azurerm_postgresql_flexible_server_firewall_rule" "example" {
   provider = azurerm
   config {
-    server_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example-rg/providers/Microsoft.DBforPostgreSQL/flexibleServers/example-server"
+    postgresql_flexible_server_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example-rg/providers/Microsoft.DBforPostgreSQL/flexibleServers/example-server"
   }
 }
 ```
@@ -27,4 +27,4 @@ list "azurerm_postgresql_flexible_server_firewall_rule" "example" {
 
 This list resource supports the following arguments:
 
-* `server_id` - (Required) The ID of the PostgreSQL Flexible Server to query.
+* `postgresql_flexible_server_id` - (Required) The ID of the PostgreSQL Flexible Server to query.


### PR DESCRIPTION
<!-- markdownlint-disable-file first-line-heading -->
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”

<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->

## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.

## Testing

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change

## Related Issue(s)

Fixes #0000

## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE]
> If this PR changes meaningfully during the course of review please update the title and description as required.
