### PR TITLE
`stream_analytics_output_cosmosdb_resource` - prevent database ID drift across resource groups

### DIFF
--- a/internal/services/streamanalytics/stream_analytics_output_cosmosdb_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_output_cosmosdb_resource.go
@@ -207,7 +207,17 @@ func (r OutputCosmosDBResource) Read() sdk.ResourceFunc {
 
 					state.AccountKey = metadata.ResourceData.Get("cosmosdb_account_key").(string)
 
-					databaseId := cosmosdb.NewSqlDatabaseID(id.SubscriptionId, id.ResourceGroupName, *output.Properties.AccountId, *output.Properties.Database)
+					// The Stream Analytics API does not return the Cosmos DB account's subscription or resource group, so preserve them from the existing state to avoid drift when the account is in a different subscription or resource group than the job
+					databaseSubscriptionId := id.SubscriptionId
+					databaseResourceGroupName := id.ResourceGroupName
+					if existing := metadata.ResourceData.Get("cosmosdb_sql_database_id").(string); existing != "" {
+						if existingDatabaseId, err := cosmosdb.ParseSqlDatabaseID(existing); err == nil {
+							databaseSubscriptionId = existingDatabaseId.SubscriptionId
+							databaseResourceGroupName = existingDatabaseId.ResourceGroupName
+						}
+					}
+
+					databaseId := cosmosdb.NewSqlDatabaseID(databaseSubscriptionId, databaseResourceGroupName, *output.Properties.AccountId, *output.Properties.Database)
 					state.Database = databaseId.ID()
 
 					state.ContainerName = pointer.From(output.Properties.CollectionNamePattern)

--- a/internal/services/streamanalytics/stream_analytics_output_cosmosdb_resource_test.go
+++ b/internal/services/streamanalytics/stream_analytics_output_cosmosdb_resource_test.go
@@ -34,6 +34,25 @@ func TestAccStreamAnalyticsOutputCosmosDB_basic(t *testing.T) {
 	})
 }
 
+func TestAccStreamAnalyticsOutputCosmosDB_crossResourceGroup(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_stream_analytics_output_cosmosdb", "test")
+	r := StreamAnalyticsOutputCosmosDBResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.crossResourceGroup(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("cosmosdb_sql_database_id").MatchesOtherKey(check.That("azurerm_cosmosdb_sql_database.test").Key("id")),
+			),
+		},
+		{
+			Config:   r.crossResourceGroup(data),
+			PlanOnly: true,
+		},
+	})
+}
+
 func TestAccStreamAnalyticsOutputCosmosDB_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_stream_analytics_output_cosmosdb", "test")
 	r := StreamAnalyticsOutputCosmosDBResource{}
@@ -115,6 +134,25 @@ resource "azurerm_stream_analytics_output_cosmosdb" "test" {
 `, r.template(data), data.RandomString, data.RandomInteger)
 }
 
+func (r StreamAnalyticsOutputCosmosDBResource) crossResourceGroup(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_resource_group" "cosmos" {
+  name     = "acctestRG-cosmos-%[2]d"
+  location = "%[3]s"
+}
+
+resource "azurerm_stream_analytics_output_cosmosdb" "test" {
+  name                     = "acctestoutput-%[2]d"
+  stream_analytics_job_id  = azurerm_stream_analytics_job.test.id
+  cosmosdb_account_key     = azurerm_cosmosdb_account.test.primary_key
+  cosmosdb_sql_database_id = azurerm_cosmosdb_sql_database.test.id
+  container_name           = azurerm_cosmosdb_sql_container.test.name
+}
+`, r.templateWithCosmosDBResourceGroup(data, "azurerm_resource_group.cosmos"), data.RandomInteger, data.Locations.Primary)
+}
+
 func (r StreamAnalyticsOutputCosmosDBResource) updated(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %[1]s
@@ -176,6 +214,10 @@ resource "azurerm_stream_analytics_output_cosmosdb" "import" {
 }
 
 func (r StreamAnalyticsOutputCosmosDBResource) template(data acceptance.TestData) string {
+	return r.templateWithCosmosDBResourceGroup(data, "azurerm_resource_group.test")
+}
+
+func (r StreamAnalyticsOutputCosmosDBResource) templateWithCosmosDBResourceGroup(data acceptance.TestData, cosmosDBResourceGroup string) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -188,8 +230,8 @@ resource "azurerm_resource_group" "test" {
 
 resource "azurerm_cosmosdb_account" "test" {
   name                = "acctestacc%[3]s"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
+  location            = %[4]s.location
+  resource_group_name = %[4]s.name
   offer_type          = "Standard"
   kind                = "GlobalDocumentDB"
 
@@ -200,7 +242,7 @@ resource "azurerm_cosmosdb_account" "test" {
   }
 
   geo_location {
-    location          = azurerm_resource_group.test.location
+    location          = %[4]s.location
     failover_priority = 0
   }
 }
@@ -239,5 +281,5 @@ resource "azurerm_stream_analytics_job" "test" {
 QUERY
 
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, cosmosDBResourceGroup)
 }

--- a/internal/services/streamanalytics/stream_analytics_output_cosmosdb_resource_test.go
+++ b/internal/services/streamanalytics/stream_analytics_output_cosmosdb_resource_test.go
@@ -200,7 +200,7 @@ resource "azurerm_cosmosdb_account" "test" {
   }
 
   geo_location {
-	location          = azurerm_resource_group.test.location
+    location          = azurerm_resource_group.test.location
     failover_priority = 0
   }
 }

--- a/internal/services/streamanalytics/stream_analytics_output_cosmosdb_resource_test.go
+++ b/internal/services/streamanalytics/stream_analytics_output_cosmosdb_resource_test.go
@@ -172,7 +172,7 @@ resource "azurerm_stream_analytics_output_cosmosdb" "import" {
   cosmosdb_sql_database_id = azurerm_stream_analytics_output_cosmosdb.test.cosmosdb_sql_database_id
   container_name           = azurerm_stream_analytics_output_cosmosdb.test.container_name
 }
-`, r.template(data))
+`, r.basic(data))
 }
 
 func (r StreamAnalyticsOutputCosmosDBResource) template(data acceptance.TestData) string {
@@ -200,7 +200,7 @@ resource "azurerm_cosmosdb_account" "test" {
   }
 
   geo_location {
-    location          = azurerm_resource_group.test.location
+	location          = azurerm_resource_group.test.location
     failover_priority = 0
   }
 }


### PR DESCRIPTION
<!-- markdownlint-disable-file first-line-heading -->
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

The Stream Analytics API returns only the Cosmos DB account name and database name for a Cosmos DB output. It does not return the Cosmos DB account's subscription or resource group.

Previously, the Read operation reconstructed `cosmosdb_sql_database_id` using the Stream Analytics job's subscription and resource group. When the Cosmos DB account was in a different resource group, this changed the ID stored in Terraform state and caused a persistent diff.

This change preserves the Cosmos DB subscription and resource group from the existing Terraform state while continuing to use the account and database names returned by Azure. It also adds acceptance coverage for a Stream Analytics job and Cosmos DB account in different resource groups.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”

<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->

## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.

## Testing

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_stream_analytics_output_cosmosdb` - prevent persistent differences for `cosmosdb_sql_database_id` when Cosmos DB and the Stream Analytics job use different resource groups [GH-33380]

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change

## Related Issue(s)

Fixes #33340 

## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE]
> If this PR changes meaningfully during the course of review please update the title and description as required.
