### PR TITLE
`postgresql_flexible_server_configuration` - add List Resource support

### DIFF
--- a/internal/services/postgres/postgresql_flexible_server_configuration_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_configuration_resource.go
@@ -21,7 +21,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
 
-//go:generate go run ../../tools/generator-tests resourceidentity -parent-id server_id -test-params "backslash_quote,on"
+//go:generate go run ../../tools/generator-tests resourceidentity -properties "name" -compare-values "flexible_server_name:server_id,resource_group_name:server_id" -test-params "backslash_quote,on"
 
 const azurePostgresqlFlexibleServerConfigurationResourceName = "azurerm_postgresql_flexible_server_configuration"
 

--- a/internal/services/postgres/postgresql_flexible_server_configuration_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_configuration_resource.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2025-08-01/configurations"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2025-08-01/servers"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
@@ -19,6 +20,10 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
+
+//go:generate go run ../../tools/generator-tests resourceidentity -parent-id server_id -test-params "backslash_quote,on"
+
+const azurePostgresqlFlexibleServerConfigurationResourceName = "azurerm_postgresql_flexible_server_configuration"
 
 func resourcePostgresqlFlexibleServerConfiguration() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
@@ -34,10 +39,11 @@ func resourcePostgresqlFlexibleServerConfiguration() *pluginsdk.Resource {
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 
-		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
-			_, err := configurations.ParseConfigurationID(id)
-			return err
-		}),
+		Identity: &schema.ResourceIdentity{
+			SchemaFunc: pluginsdk.GenerateIdentitySchema(&configurations.ConfigurationId{}),
+		},
+
+		Importer: pluginsdk.ImporterValidatingIdentity(&configurations.ConfigurationId{}),
 
 		Schema: map[string]*pluginsdk.Schema{
 			"name": {
@@ -85,10 +91,13 @@ func resourceFlexibleServerConfigurationCreateUpdate(d *pluginsdk.ResourceData, 
 		},
 	}
 
-	if err := client.UpdateCallbackThenPoll(ctx, id, props, sdk.SetIDCallback(meta, &id, d)); err != nil {
+	if err := client.UpdateCallbackThenPoll(ctx, id, props, sdk.SetIDAndIdentityCallback(meta, &id, d)); err != nil {
 		return fmt.Errorf("updating %s: %+v", id, err)
 	}
 	d.SetId(id.ID())
+	if err := pluginsdk.SetResourceIdentityData(d, &id); err != nil {
+		return err
+	}
 
 	resp, err := client.Get(ctx, id)
 	if err != nil {
@@ -113,7 +122,6 @@ func resourceFlexibleServerConfigurationCreateUpdate(d *pluginsdk.ResourceData, 
 }
 
 func resourceFlexibleServerConfigurationRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	client := meta.(*clients.Client).Postgres.FlexibleServersConfigurationsClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -142,14 +150,20 @@ func resourceFlexibleServerConfigurationRead(d *pluginsdk.ResourceData, meta int
 		return fmt.Errorf("making Read request for %s: %+v", id, err)
 	}
 
-	d.Set("name", id.ConfigurationName)
-	d.Set("server_id", configurations.NewFlexibleServerID(subscriptionId, id.ResourceGroupName, id.FlexibleServerName).ID())
+	return resourcePostgresqlFlexibleServerConfigurationFlatten(d, id, resp.Model)
+}
 
-	if resp.Model != nil && resp.Model.Properties != nil {
-		d.Set("value", resp.Model.Properties.Value)
+func resourcePostgresqlFlexibleServerConfigurationFlatten(d *pluginsdk.ResourceData, id *configurations.ConfigurationId, model *configurations.Configuration) error {
+	d.Set("name", id.ConfigurationName)
+	d.Set("server_id", configurations.NewFlexibleServerID(id.SubscriptionId, id.ResourceGroupName, id.FlexibleServerName).ID())
+
+	if model != nil {
+		if props := model.Properties; props != nil {
+			d.Set("value", props.Value)
+		}
 	}
 
-	return nil
+	return pluginsdk.SetResourceIdentityData(d, id)
 }
 
 func resourceFlexibleServerConfigurationDelete(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/postgres/postgresql_flexible_server_configuration_resource_identity_gen_test.go
+++ b/internal/services/postgres/postgresql_flexible_server_configuration_resource_identity_gen_test.go
@@ -1,0 +1,40 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package postgres_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
+)
+
+func TestAccPostgresqlFlexibleServerConfiguration_resourceIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_postgresql_flexible_server_configuration", "test")
+	r := PostgresqlFlexibleServerConfigurationResource{}
+
+	checkedFields := map[string]struct{}{
+		"name":                 {},
+		"flexible_server_name": {},
+		"resource_group_name":  {},
+		"subscription_id":      {},
+	}
+
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data, "backslash_quote", "on"),
+			ConfigStateChecks: []statecheck.StateCheck{
+				customstatecheck.ExpectAllIdentityFieldsAreChecked("azurerm_postgresql_flexible_server_configuration.test", checkedFields),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_postgresql_flexible_server_configuration.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_postgresql_flexible_server_configuration.test", tfjsonpath.New("flexible_server_name"), tfjsonpath.New("server_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_postgresql_flexible_server_configuration.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("server_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_postgresql_flexible_server_configuration.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("server_id")),
+			},
+		},
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
+}

--- a/internal/services/postgres/postgresql_flexible_server_configuration_resource_identity_gen_test.go
+++ b/internal/services/postgres/postgresql_flexible_server_configuration_resource_identity_gen_test.go
@@ -6,6 +6,7 @@ package postgres_test
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
@@ -17,10 +18,10 @@ func TestAccPostgresqlFlexibleServerConfiguration_resourceIdentity(t *testing.T)
 	r := PostgresqlFlexibleServerConfigurationResource{}
 
 	checkedFields := map[string]struct{}{
+		"subscription_id":      {},
 		"name":                 {},
 		"flexible_server_name": {},
 		"resource_group_name":  {},
-		"subscription_id":      {},
 	}
 
 	data.ResourceIdentityTest(t, []acceptance.TestStep{
@@ -28,10 +29,10 @@ func TestAccPostgresqlFlexibleServerConfiguration_resourceIdentity(t *testing.T)
 			Config: r.basic(data, "backslash_quote", "on"),
 			ConfigStateChecks: []statecheck.StateCheck{
 				customstatecheck.ExpectAllIdentityFieldsAreChecked("azurerm_postgresql_flexible_server_configuration.test", checkedFields),
+				statecheck.ExpectIdentityValue("azurerm_postgresql_flexible_server_configuration.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
 				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_postgresql_flexible_server_configuration.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
 				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_postgresql_flexible_server_configuration.test", tfjsonpath.New("flexible_server_name"), tfjsonpath.New("server_id")),
 				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_postgresql_flexible_server_configuration.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("server_id")),
-				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_postgresql_flexible_server_configuration.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("server_id")),
 			},
 		},
 		data.ImportBlockWithResourceIdentityStep(false),

--- a/internal/services/postgres/postgresql_flexible_server_configuration_resource_list.go
+++ b/internal/services/postgres/postgresql_flexible_server_configuration_resource_list.go
@@ -1,0 +1,100 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-azure-helpers/framework/typehelpers"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2025-08-01/configurations"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2025-08-01/servers"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-framework/list/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type PostgresqlFlexibleServerConfigurationListResource struct{}
+
+type PostgresqlFlexibleServerConfigurationListModel struct {
+	FlexibleServerId types.String `tfsdk:"server_id"`
+}
+
+var _ sdk.FrameworkListWrappedResource = new(PostgresqlFlexibleServerConfigurationListResource)
+
+func (PostgresqlFlexibleServerConfigurationListResource) Metadata(_ context.Context, _ resource.MetadataRequest, response *resource.MetadataResponse) {
+	response.TypeName = azurePostgresqlFlexibleServerConfigurationResourceName
+}
+
+func (PostgresqlFlexibleServerConfigurationListResource) ResourceFunc() *pluginsdk.Resource {
+	return resourcePostgresqlFlexibleServerConfiguration()
+}
+
+func (PostgresqlFlexibleServerConfigurationListResource) ListResourceConfigSchema(_ context.Context, _ list.ListResourceSchemaRequest, response *list.ListResourceSchemaResponse) {
+	response.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"server_id": schema.StringAttribute{
+				Required: true,
+				Validators: []validator.String{
+					typehelpers.WrappedStringValidator{Func: servers.ValidateFlexibleServerID},
+				},
+			},
+		},
+	}
+}
+
+func (PostgresqlFlexibleServerConfigurationListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream, metadata sdk.ResourceMetadata) {
+	client := metadata.Client.Postgres.FlexibleServersConfigurationsClient
+
+	var data PostgresqlFlexibleServerConfigurationListModel
+	diags := request.Config.Get(ctx, &data)
+	if diags.HasError() {
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+
+	parentID, err := servers.ParseFlexibleServerID(data.FlexibleServerId.ValueString())
+	if err != nil {
+		sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("parsing Flexible Server ID for `%s`", azurePostgresqlFlexibleServerConfigurationResourceName), err)
+		return
+	}
+
+	resp, err := client.ListByServerComplete(ctx, configurations.NewFlexibleServerID(parentID.SubscriptionId, parentID.ResourceGroupName, parentID.FlexibleServerName))
+	if err != nil {
+		sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("listing `%s`", azurePostgresqlFlexibleServerConfigurationResourceName), err)
+		return
+	}
+
+	stream.Results = func(push func(list.ListResult) bool) {
+		for _, item := range resp.Items {
+			result := request.NewListResult(ctx)
+			result.DisplayName = pointer.From(item.Name)
+
+			rd := resourcePostgresqlFlexibleServerConfiguration().Data(&terraform.InstanceState{})
+			id, err := configurations.ParseConfigurationIDInsensitively(pointer.From(item.Id))
+			if err != nil {
+				sdk.SetErrorDiagnosticAndPushListResult(result, push, fmt.Sprintf("parsing ID for `%s`", azurePostgresqlFlexibleServerConfigurationResourceName), err)
+				return
+			}
+			rd.SetId(id.ID())
+
+			if err := resourcePostgresqlFlexibleServerConfigurationFlatten(rd, id, &item); err != nil {
+				sdk.SetErrorDiagnosticAndPushListResult(result, push, fmt.Sprintf("encoding `%s` resource data", azurePostgresqlFlexibleServerConfigurationResourceName), err)
+				return
+			}
+
+			sdk.EncodeListResult(ctx, rd, &result)
+			if result.Diagnostics.HasError() {
+				push(result)
+				return
+			}
+			if !push(result) {
+				return
+			}
+		}
+	}
+}

--- a/internal/services/postgres/postgresql_flexible_server_configuration_resource_list.go
+++ b/internal/services/postgres/postgresql_flexible_server_configuration_resource_list.go
@@ -21,7 +21,7 @@ import (
 type PostgresqlFlexibleServerConfigurationListResource struct{}
 
 type PostgresqlFlexibleServerConfigurationListModel struct {
-	FlexibleServerId types.String `tfsdk:"server_id"`
+	FlexibleServerId types.String `tfsdk:"postgresql_flexible_server_id"`
 }
 
 var _ sdk.FrameworkListWrappedResource = new(PostgresqlFlexibleServerConfigurationListResource)
@@ -37,7 +37,7 @@ func (PostgresqlFlexibleServerConfigurationListResource) ResourceFunc() *plugins
 func (PostgresqlFlexibleServerConfigurationListResource) ListResourceConfigSchema(_ context.Context, _ list.ListResourceSchemaRequest, response *list.ListResourceSchemaResponse) {
 	response.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
-			"server_id": schema.StringAttribute{
+			"postgresql_flexible_server_id": schema.StringAttribute{
 				Required: true,
 				Validators: []validator.String{
 					typehelpers.WrappedStringValidator{Func: servers.ValidateFlexibleServerID},

--- a/internal/services/postgres/postgresql_flexible_server_configuration_resource_list_test.go
+++ b/internal/services/postgres/postgresql_flexible_server_configuration_resource_list_test.go
@@ -52,7 +52,7 @@ func (r PostgresqlFlexibleServerConfigurationResource) basicQuery() string {
 list "azurerm_postgresql_flexible_server_configuration" "list" {
   provider = azurerm
   config {
-    server_id = azurerm_postgresql_flexible_server.test.id
+    postgresql_flexible_server_id = azurerm_postgresql_flexible_server.test.id
   }
 }
 `

--- a/internal/services/postgres/postgresql_flexible_server_configuration_resource_list_test.go
+++ b/internal/services/postgres/postgresql_flexible_server_configuration_resource_list_test.go
@@ -1,0 +1,59 @@
+package postgres_test
+
+import (
+	"context"
+	"regexp"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
+)
+
+func TestAccPostgresqlFlexibleServerConfiguration_listByFlexibleServerID(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_postgresql_flexible_server_configuration", "testlist1")
+	r := PostgresqlFlexibleServerConfigurationResource{}
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []resource.TestStep{
+			{
+				Config: r.basic(data, "backslash_quote", "on"),
+			},
+			{
+				Query:  true,
+				Config: r.basicQuery(),
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectLengthAtLeast("azurerm_postgresql_flexible_server_configuration.list", 1),
+					querycheck.ExpectIdentity(
+						"azurerm_postgresql_flexible_server_configuration.list",
+						map[string]knownvalue.Check{
+							"name":                 knownvalue.StringExact("backslash_quote"),
+							"resource_group_name":  knownvalue.StringRegexp(regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
+							"flexible_server_name": knownvalue.StringRegexp(regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
+							"subscription_id":      knownvalue.StringExact(data.Subscriptions.Primary),
+						},
+					),
+				},
+			},
+		},
+	})
+}
+
+func (r PostgresqlFlexibleServerConfigurationResource) basicQuery() string {
+	return `
+list "azurerm_postgresql_flexible_server_configuration" "list" {
+  provider = azurerm
+  config {
+    server_id = azurerm_postgresql_flexible_server.test.id
+  }
+}
+`
+}

--- a/internal/services/postgres/registration.go
+++ b/internal/services/postgres/registration.go
@@ -80,5 +80,7 @@ func (r Registration) EphemeralResources() []func() ephemeral.EphemeralResource 
 }
 
 func (r Registration) ListResources() []sdk.FrameworkListWrappedResource {
-	return []sdk.FrameworkListWrappedResource{}
+	return []sdk.FrameworkListWrappedResource{
+		PostgresqlFlexibleServerConfigurationListResource{},
+	}
 }

--- a/website/docs/list-resources/postgresql_flexible_server_configuration.html.markdown
+++ b/website/docs/list-resources/postgresql_flexible_server_configuration.html.markdown
@@ -18,7 +18,7 @@ Lists Postgresql Flexible Server Configuration resources.
 list "azurerm_postgresql_flexible_server_configuration" "example" {
   provider = azurerm
   config {
-    server_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example-rg/providers/Microsoft.DBforPostgreSQL/flexibleServers/example-server"
+    postgresql_flexible_server_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example-rg/providers/Microsoft.DBforPostgreSQL/flexibleServers/example-server"
   }
 }
 ```
@@ -27,4 +27,4 @@ list "azurerm_postgresql_flexible_server_configuration" "example" {
 
 This list resource supports the following arguments:
 
-* `server_id` - (Required) The ID of the PostgreSQL Flexible Server to query.
+* `postgresql_flexible_server_id` - (Required) The ID of the PostgreSQL Flexible Server to query.

--- a/website/docs/list-resources/postgresql_flexible_server_configuration.html.markdown
+++ b/website/docs/list-resources/postgresql_flexible_server_configuration.html.markdown
@@ -1,0 +1,30 @@
+---
+subcategory: "Database"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_postgresql_flexible_server_configuration"
+description: |-
+    Lists Postgresql Flexible Server Configuration resources.
+---
+
+# List resource: azurerm_postgresql_flexible_server_configuration
+
+Lists Postgresql Flexible Server Configuration resources.
+
+## Example Usage
+
+### List PostgreSQL Flexible Server Configurations in a Flexible Server
+
+```hcl
+list "azurerm_postgresql_flexible_server_configuration" "example" {
+  provider = azurerm
+  config {
+    server_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example-rg/providers/Microsoft.DBforPostgreSQL/flexibleServers/example-server"
+  }
+}
+```
+
+## Argument Reference
+
+This list resource supports the following arguments:
+
+* `server_id` - (Required) The ID of the PostgreSQL Flexible Server to query.


### PR DESCRIPTION
<!-- markdownlint-disable-file first-line-heading -->
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”

<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->

## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.

## Testing

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change

## Related Issue(s)

Fixes #0000

## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE]
> If this PR changes meaningfully during the course of review please update the title and description as required.
