### PR TITLE
`azurerm_(windows|linux)_virtual_machine` - support for `size_properties` property 

### DIFF
--- a/internal/services/compute/linux_virtual_machine_resource.go
+++ b/internal/services/compute/linux_virtual_machine_resource.go
@@ -375,6 +375,8 @@ func resourceLinuxVirtualMachine() *pluginsdk.Resource {
 				ForceNew: true,
 			},
 
+			"size_properties": virtualMachineSizePropertiesSchema(),
+
 			"source_image_id": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
@@ -828,6 +830,10 @@ func resourceLinuxVirtualMachineCreate(d *pluginsdk.ResourceData, meta interface
 		}
 	}
 
+	if v, ok := d.GetOk("size_properties"); ok {
+		params.Properties.HardwareProfile.VMSizeProperties = expandVirtualMachineSizeProperties(v.([]interface{}))
+	}
+
 	if v, ok := d.GetOk("virtual_machine_scale_set_id"); ok {
 		params.Properties.VirtualMachineScaleSet = &virtualmachines.SubResource{
 			Id: pointer.To(v.(string)),
@@ -953,6 +959,7 @@ func resourceLinuxVirtualMachineFlatten(ctx context.Context, clientsClient *clie
 			d.Set("eviction_policy", pointer.From(props.EvictionPolicy))
 			if profile := props.HardwareProfile; profile != nil {
 				d.Set("size", pointer.From(profile.VMSize))
+				d.Set("size_properties", flattenVirtualMachineSizeProperties(profile.VMSizeProperties))
 			}
 
 			extensionsTimeBudget := "PT1H30M"
@@ -1607,6 +1614,14 @@ func resourceLinuxVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interface
 		update.Properties.SecurityProfile = &virtualmachines.SecurityProfile{
 			EncryptionAtHost: pointer.To(d.Get("encryption_at_host_enabled").(bool)),
 		}
+	}
+
+	if d.HasChange("size_properties") {
+		shouldUpdate = true
+		if update.Properties.HardwareProfile == nil {
+			update.Properties.HardwareProfile = &virtualmachines.HardwareProfile{}
+		}
+		update.Properties.HardwareProfile.VMSizeProperties = expandVirtualMachineSizeProperties(d.Get("size_properties").([]interface{}))
 	}
 
 	if d.HasChange("user_data") {

--- a/internal/services/compute/linux_virtual_machine_resource_other_test.go
+++ b/internal/services/compute/linux_virtual_machine_resource_other_test.go
@@ -970,6 +970,42 @@ func TestAccLinuxVirtualMachine_otherRebootSetting(t *testing.T) {
 	})
 }
 
+func TestAccLinuxVirtualMachine_otherSizeProperties(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+	r := LinuxVirtualMachineResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.otherSizeProperties(data, 0, 0),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.otherSizeProperties(data, 0, 2),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.otherSizeProperties(data, 1, 1),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.otherSizeProperties(data, 0, 0),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (r LinuxVirtualMachineResource) otherPatchMode(data acceptance.TestData, patchMode string) string {
 	return fmt.Sprintf(`
 %s
@@ -3046,4 +3082,58 @@ resource "azurerm_linux_virtual_machine" "test" {
   patch_mode = "ImageDefault"
 }
 `, r.template(data), data.RandomInteger)
+}
+
+func (r LinuxVirtualMachineResource) otherSizeProperties(data acceptance.TestData, available, percore int) string {
+	text, vCpuAvailable, vCPUsPerCore := "", "", ""
+
+	if available > 0 || percore > 0 {
+		if available > 0 {
+			vCpuAvailable = fmt.Sprintf(`vcpu_available = %[1]d`, available)
+		}
+		if percore > 0 {
+			vCPUsPerCore = fmt.Sprintf(`vcpu_per_core = %[1]d`, percore)
+		}
+
+		text = fmt.Sprintf(`
+  size_properties {
+    %[1]s
+    %[2]s
+  }`, vCpuAvailable, vCPUsPerCore)
+	}
+
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_D2s_v3"
+  admin_username      = "adminuser"
+
+  %[3]s
+
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "0001-com-ubuntu-server-jammy"
+    sku       = "22_04-lts"
+    version   = "latest"
+  }
+}
+`, r.template(data), data.RandomInteger, text)
 }

--- a/internal/services/compute/virtual_machine.go
+++ b/internal/services/compute/virtual_machine.go
@@ -635,3 +635,59 @@ func flattenVirtualMachineGalleryApplication(input *[]virtualmachines.VMGalleryA
 
 	return out
 }
+
+func virtualMachineSizePropertiesSchema() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		// NOTE: O+C the Azure API returns the effective vCPU values derived from the VM size even when these are not configured, and they cannot be unset once applied, so this block and its properties are Optional and Computed to avoid a persistent diff
+		Computed: true,
+		MaxItems: 1,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"vcpu_available": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: validation.IntPositive,
+				},
+
+				"vcpu_per_core": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: validation.IntPositive,
+				},
+			},
+		},
+	}
+}
+
+func expandVirtualMachineSizeProperties(input []interface{}) *virtualmachines.VMSizeProperties {
+	if len(input) == 0 {
+		return nil
+	}
+	sizeProps := input[0].(map[string]interface{})
+
+	out := &virtualmachines.VMSizeProperties{}
+	if v := sizeProps["vcpu_available"].(int); v > 0 {
+		out.VCPUsAvailable = pointer.To(int64(v))
+	}
+	if v := sizeProps["vcpu_per_core"].(int); v > 0 {
+		out.VCPUsPerCore = pointer.To(int64(v))
+	}
+	return out
+}
+
+func flattenVirtualMachineSizeProperties(input *virtualmachines.VMSizeProperties) []interface{} {
+	if input == nil {
+		return []interface{}{}
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"vcpu_available": pointer.From(input.VCPUsAvailable),
+			"vcpu_per_core":  pointer.From(input.VCPUsPerCore),
+		},
+	}
+}

--- a/internal/services/compute/windows_virtual_machine_resource.go
+++ b/internal/services/compute/windows_virtual_machine_resource.go
@@ -382,6 +382,8 @@ func resourceWindowsVirtualMachine() *pluginsdk.Resource {
 				ForceNew: true,
 			},
 
+			"size_properties": virtualMachineSizePropertiesSchema(),
+
 			"source_image_id": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
@@ -833,6 +835,10 @@ func resourceWindowsVirtualMachineCreate(d *pluginsdk.ResourceData, meta interfa
 		}
 	}
 
+	if v, ok := d.GetOk("size_properties"); ok {
+		params.Properties.HardwareProfile.VMSizeProperties = expandVirtualMachineSizeProperties(v.([]interface{}))
+	}
+
 	if v, ok := d.GetOk("virtual_machine_scale_set_id"); ok {
 		params.Properties.VirtualMachineScaleSet = &virtualmachines.SubResource{
 			Id: pointer.To(v.(string)),
@@ -958,6 +964,7 @@ func resourceWindowsVirtualMachineRead(d *pluginsdk.ResourceData, meta interface
 			d.Set("eviction_policy", pointer.From(props.EvictionPolicy))
 			if profile := props.HardwareProfile; profile != nil {
 				d.Set("size", pointer.From(profile.VMSize))
+				d.Set("size_properties", flattenVirtualMachineSizeProperties(profile.VMSizeProperties))
 			}
 			d.Set("license_type", props.LicenseType)
 
@@ -1558,6 +1565,14 @@ func resourceWindowsVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interfa
 		update.Properties.HardwareProfile = &virtualmachines.HardwareProfile{
 			VMSize: pointer.ToEnum[virtualmachines.VirtualMachineSizeTypes](vmSize),
 		}
+	}
+
+	if d.HasChange("size_properties") {
+		shouldUpdate = true
+		if update.Properties.HardwareProfile == nil {
+			update.Properties.HardwareProfile = &virtualmachines.HardwareProfile{}
+		}
+		update.Properties.HardwareProfile.VMSizeProperties = expandVirtualMachineSizeProperties(d.Get("size_properties").([]interface{}))
 	}
 
 	if d.HasChange("tags") {

--- a/internal/services/compute/windows_virtual_machine_resource_other_test.go
+++ b/internal/services/compute/windows_virtual_machine_resource_other_test.go
@@ -1185,6 +1185,42 @@ func TestAccWindowsVirtualMachine_otherRebootSetting(t *testing.T) {
 	})
 }
 
+func TestAccWindowsVirtualMachine_otherSizeProperties(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+	r := WindowsVirtualMachineResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.otherSizeProperties(data, 0, 0),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			Config: r.otherSizeProperties(data, 0, 2),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			Config: r.otherSizeProperties(data, 1, 1),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			Config: r.otherSizeProperties(data, 0, 0),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
 func (r WindowsVirtualMachineResource) otherHotpatching(data acceptance.TestData, hotPatch bool) string {
 	return fmt.Sprintf(`
 %s
@@ -3491,4 +3527,54 @@ resource "azurerm_windows_virtual_machine" "test" {
   patch_mode = "AutomaticByOS"
 }
 `, r.template(data))
+}
+
+func (r WindowsVirtualMachineResource) otherSizeProperties(data acceptance.TestData, available, percore int) string {
+	text, vCpuAvailable, vCPUsPerCore := "", "", ""
+
+	if available > 0 || percore > 0 {
+		if available > 0 {
+			vCpuAvailable = fmt.Sprintf(`vcpu_available = %[1]d`, available)
+		}
+		if percore > 0 {
+			vCPUsPerCore = fmt.Sprintf(`vcpu_per_core = %[1]d`, percore)
+		}
+
+		text = fmt.Sprintf(`
+  size_properties {
+    %[1]s
+    %[2]s
+  }`, vCpuAvailable, vCPUsPerCore)
+	}
+
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_D2s_v3"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
+
+  %[2]s
+
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, r.template(data), text)
 }

--- a/website/docs/r/linux_virtual_machine.html.markdown
+++ b/website/docs/r/linux_virtual_machine.html.markdown
@@ -202,6 +202,8 @@ The following arguments are supported:
 
 * `secure_boot_enabled` - (Optional) Specifies whether secure boot should be enabled on the virtual machine. Changing this forces a new resource to be created.
 
+* `size_properties` - (Optional) A `size_properties` block as defined below.
+
 * `source_image_id` - (Optional) The ID of the Image which this Virtual Machine should be created from. Changing this forces a new resource to be created. Possible Image ID types include `Image ID`s, `Shared Image ID`s, `Shared Image Version ID`s, `Community Gallery Image ID`s, `Community Gallery Image Version ID`s, `Shared Gallery Image ID`s and `Shared Gallery Image Version ID`s.
 
 -> **Note:** One of either `source_image_id` or `source_image_reference` must be set.
@@ -359,6 +361,14 @@ A `secret` block supports the following:
 * `certificate` - (Required) One or more `certificate` blocks as defined above.
 
 * `key_vault_id` - (Required) The ID of the Key Vault from which all Secrets should be sourced.
+
+---
+
+A `size_properties` block supports the following:
+
+* `vcpu_available` - (Optional) The number of vCPUs available for this Virtual Machine.
+
+* `vcpu_per_core` - (Optional) The number of vCPUs per physical core for this Virtual Machine.
 
 ---
 

--- a/website/docs/r/windows_virtual_machine.html.markdown
+++ b/website/docs/r/windows_virtual_machine.html.markdown
@@ -199,6 +199,8 @@ The following arguments are supported:
 
 * `secure_boot_enabled` - (Optional) Specifies if Secure Boot and Trusted Launch is enabled for the Virtual Machine. Changing this forces a new resource to be created.
 
+* `size_properties` - (Optional) A `size_properties` block as defined below.
+
 * `source_image_id` - (Optional) The ID of the Image which this Virtual Machine should be created from. Changing this forces a new resource to be created. Possible Image ID types include `Image ID`s, `Shared Image ID`s, `Shared Image Version ID`s, `Community Gallery Image ID`s, `Community Gallery Image Version ID`s, `Shared Gallery Image ID`s and `Shared Gallery Image Version ID`s.
 
 -> **Note:** One of either `source_image_id` or `source_image_reference` must be set.
@@ -363,6 +365,14 @@ A `secret` block supports the following:
 * `certificate` - (Required) One or more `certificate` blocks as defined above.
 
 * `key_vault_id` - (Required) The ID of the Key Vault from which all Secrets should be sourced.
+
+---
+
+A `size_properties` block supports the following:
+
+* `vcpu_available` - (Optional) The number of vCPUs available for this Virtual Machine.
+
+* `vcpu_per_core` - (Optional) The number of vCPUs per physical core for this Virtual Machine.
 
 ---
 


### PR DESCRIPTION
<!-- markdownlint-disable-file first-line-heading -->
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Support `size_properties` feature for configuring VM vCore Customization https://learn.microsoft.com/en-us/azure/virtual-machines/vm-customization

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”

<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->

## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.

## Testing

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

<img width="700" height="60" alt="image" src="https://github.com/user-attachments/assets/6cb1aba8-f230-43a1-bf1e-91e5a4e5af6e" />

<img width="705" height="59" alt="image" src="https://github.com/user-attachments/assets/c9f61c03-3a32-4026-a30b-8be3d5148c75" />

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* azurerm_(windows|linux)_virtual_machine - support for `size_properties` property [GH-33382]

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change

## Related Issue(s)

Fixes #33364

## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE]
> If this PR changes meaningfully during the course of review please update the title and description as required.
