### PR TITLE
azurerm_container_app_environment_storage - support for the `access_key_wo` write-only attribute

### DIFF
--- a/internal/services/containerapps/container_app_environment_storage_resource.go
+++ b/internal/services/containerapps/container_app_environment_storage_resource.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/managedenvironmentsstorages"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/containerapps/validate"
 	storageValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/validate"
@@ -25,6 +26,7 @@ type ContainerAppEnvironmentStorageModel struct {
 	ContainerAppEnvironmentId string `tfschema:"container_app_environment_id"`
 	AccountName               string `tfschema:"account_name"`
 	AccessKey                 string `tfschema:"access_key"`
+	AccessKeyWOVersion        int64  `tfschema:"access_key_wo_version"`
 	ShareName                 string `tfschema:"share_name"`
 	AccessMode                string `tfschema:"access_mode"`
 	NfsServer                 string `tfschema:"nfs_server_url"`
@@ -67,18 +69,38 @@ func (r ContainerAppEnvironmentStorageResource) Arguments() map[string]*pluginsd
 			Optional:      true,
 			ForceNew:      true,
 			ValidateFunc:  storageValidate.StorageAccountName,
-			RequiredWith:  []string{"access_key"},
 			ConflictsWith: []string{"nfs_server_url"},
 			Description:   "The Azure Storage Account in which the Share to be used is located.",
 		},
 
 		"access_key": {
-			Type:         pluginsdk.TypeString,
+			Type:          pluginsdk.TypeString,
+			Optional:      true,
+			Sensitive:     true,
+			ValidateFunc:  validation.StringIsNotEmpty,
+			RequiredWith:  []string{"account_name"},
+			AtLeastOneOf:  []string{"access_key", "access_key_wo", "nfs_server_url"},
+			ConflictsWith: []string{"access_key_wo", "nfs_server_url"},
+			Description:   "The Storage Account Access Key.",
+		},
+
+		"access_key_wo": {
+			Type:          pluginsdk.TypeString,
+			Optional:      true,
+			WriteOnly:     true,
+			ValidateFunc:  validation.StringIsNotEmpty,
+			RequiredWith:  []string{"account_name", "access_key_wo_version"},
+			AtLeastOneOf:  []string{"access_key", "access_key_wo", "nfs_server_url"},
+			ConflictsWith: []string{"access_key", "nfs_server_url"},
+			Description:   "The Storage Account Access Key.",
+		},
+
+		"access_key_wo_version": {
+			Type:         pluginsdk.TypeInt,
 			Optional:     true,
-			Sensitive:    true,
-			ValidateFunc: validation.StringIsNotEmpty,
-			RequiredWith: []string{"account_name"},
-			Description:  "The Storage Account Access Key.",
+			RequiredWith: []string{"access_key_wo"},
+			ValidateFunc: validation.IntAtLeast(1),
+			Description:  "An integer value used to trigger an update for `access_key_wo`. This property should be incremented when updating `access_key_wo`.",
 		},
 
 		"share_name": {
@@ -101,7 +123,8 @@ func (r ContainerAppEnvironmentStorageResource) Arguments() map[string]*pluginsd
 			Optional:      true,
 			ForceNew:      true,
 			ValidateFunc:  validation.StringIsNotEmpty,
-			ConflictsWith: []string{"account_name"},
+			AtLeastOneOf:  []string{"access_key", "access_key_wo", "nfs_server_url"},
+			ConflictsWith: []string{"account_name", "access_key", "access_key_wo"},
 		},
 	}
 }
@@ -153,6 +176,15 @@ func (r ContainerAppEnvironmentStorageResource) Create() sdk.ResourceFunc {
 					},
 				}
 			} else {
+				woAccessKey, err := pluginsdk.GetWriteOnly(metadata.ResourceData, "access_key_wo", cty.String)
+				if err != nil {
+					return err
+				}
+
+				if !woAccessKey.IsNull() {
+					storage.AccessKey = woAccessKey.AsString()
+				}
+
 				managedEnvironmentStorage.Properties = &managedenvironmentsstorages.ManagedEnvironmentStorageProperties{
 					AzureFile: &managedenvironmentsstorages.AzureFileProperties{
 						AccessMode:  &accessMode,
@@ -219,6 +251,8 @@ func (r ContainerAppEnvironmentStorageResource) Read() sdk.ResourceFunc {
 				state.AccessKey = keyFromConfig.(string)
 			}
 
+			state.AccessKeyWOVersion = int64(metadata.ResourceData.Get("access_key_wo_version").(int))
+
 			return metadata.Encode(&state)
 		},
 	}
@@ -269,8 +303,17 @@ func (r ContainerAppEnvironmentStorageResource) Update() sdk.ResourceFunc {
 				return fmt.Errorf("could not update %s: existing resource is missing `AzureFile` properties", *id)
 			}
 
+			woAccessKey, err := pluginsdk.GetWriteOnly(metadata.ResourceData, "access_key_wo", cty.String)
+			if err != nil {
+				return err
+			}
+
+			if !woAccessKey.IsNull() {
+				storage.AccessKey = woAccessKey.AsString()
+			}
+
 			// This *must* be sent, and is currently the only updatable property on the resource.
-			existing.Model.Properties.AzureFile.AccountKey = pointer.To(metadata.ResourceData.Get("access_key").(string))
+			existing.Model.Properties.AzureFile.AccountKey = pointer.To(storage.AccessKey)
 
 			if _, err := client.CreateOrUpdate(ctx, *id, *existing.Model); err != nil {
 				return fmt.Errorf("updating %s: %+v", id, err)

--- a/internal/services/containerapps/container_app_environment_storage_resource_test.go
+++ b/internal/services/containerapps/container_app_environment_storage_resource_test.go
@@ -11,9 +11,13 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/managedenvironmentsstorages"
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
@@ -68,6 +72,59 @@ func TestAccContainerAppEnvironmentStorage_update(t *testing.T) {
 			),
 		},
 		data.ImportStep("access_key"),
+	})
+}
+
+func TestAccContainerAppEnvironmentStorage_writeOnlyAccessKey(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_app_environment_storage", "test")
+	r := ContainerAppEnvironmentStorageResource{}
+
+	resource.ParallelTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.11.0"))),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []resource.TestStep{
+			{
+				Config: r.writeOnlyAccessKey(data, "primary_access_key", 1),
+				Check:  check.That(data.ResourceName).ExistsInAzure(r),
+			},
+			data.ImportStep("access_key_wo_version"),
+			{
+				Config: r.writeOnlyAccessKey(data, "secondary_access_key", 2),
+				Check:  check.That(data.ResourceName).ExistsInAzure(r),
+			},
+			data.ImportStep("access_key_wo_version"),
+		},
+	})
+}
+
+func TestAccContainerAppEnvironmentStorage_updateToWriteOnlyAccessKey(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_app_environment_storage", "test")
+	r := ContainerAppEnvironmentStorageResource{}
+
+	resource.ParallelTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.11.0"))),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []resource.TestStep{
+			{
+				Config: r.basic(data),
+				Check:  check.That(data.ResourceName).ExistsInAzure(r),
+			},
+			data.ImportStep("access_key"),
+			{
+				Config: r.writeOnlyAccessKey(data, "primary_access_key", 1),
+				Check:  check.That(data.ResourceName).ExistsInAzure(r),
+			},
+			data.ImportStep("access_key", "access_key_wo_version"),
+			{
+				Config: r.basic(data),
+				Check:  check.That(data.ResourceName).ExistsInAzure(r),
+			},
+			data.ImportStep("access_key"),
+		},
 	})
 }
 
@@ -160,6 +217,30 @@ resource "azurerm_container_app_environment_storage" "test" {
   access_mode                  = "ReadWrite"
 }
 `, r.template(data), data.RandomInteger)
+}
+
+func (r ContainerAppEnvironmentStorageResource) writeOnlyAccessKey(data acceptance.TestData, accessKeyProperty string, version int) string {
+	secret := fmt.Sprintf("${azurerm_storage_account.test.%s}", accessKeyProperty)
+
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+%[2]s
+
+resource "azurerm_container_app_environment_storage" "test" {
+  name                         = "testacc-caes-%[3]d"
+  container_app_environment_id = azurerm_container_app_environment.test.id
+  account_name                 = azurerm_storage_account.test.name
+  access_key_wo                = ephemeral.azurerm_key_vault_secret.test.value
+  access_key_wo_version        = %[4]d
+  share_name                   = azurerm_storage_share.test.name
+  access_mode                  = "ReadWrite"
+}
+`, r.template(data), acceptance.WriteOnlyKeyVaultSecretTemplate(data, secret), data.RandomInteger, version)
 }
 
 func (r ContainerAppEnvironmentStorageResource) requiresImport(data acceptance.TestData) string {

--- a/website/docs/r/container_app_environment_storage.html.markdown
+++ b/website/docs/r/container_app_environment_storage.html.markdown
@@ -67,7 +67,11 @@ The following arguments are supported:
 
 * `account_name` - (Optional) The Azure Storage Account in which the Share to be used is located. Changing this forces a new resource to be created.
 
-* `access_key` - (Optional) The Storage Account Access Key.
+* `access_key` - (Optional) The Storage Account Access Key. Conflicts with `access_key_wo`.
+
+* `access_key_wo` - (Optional, Write-Only) The Storage Account Access Key. Conflicts with `access_key`.
+
+* `access_key_wo_version` - (Optional) An integer value used to trigger an update for `access_key_wo`. This property should be incremented when updating `access_key_wo`.
 
 * `share_name` - (Required) The name of the Azure Storage Share to use. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
<!-- markdownlint-disable-file first-line-heading -->
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

Adds the `access_key_wo` write-only attribute to `azurerm_container_app_environment_storage` so the storage account key is never persisted in state.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.

<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->

## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.


## Testing

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass.


## Change Log

* `azurerm_container_app_environment_storage` - support for the `access_key_wo` [GH-33384]

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change

## Related Issue(s)

Fixes #33124 

## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

NA

## Changes to Security Controls

NA
