### PR TITLE
fix(postgres): administrator_password validation fails with ignore_changes

### DIFF
--- a/internal/services/postgres/postgresql_flexible_server_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_resource.go
@@ -984,6 +984,19 @@ func resourcePostgresqlFlexibleServerUpdate(d *pluginsdk.ResourceData, meta inte
 		_, adminLoginSet := d.GetOk("administrator_login")
 		_, adminPwdSet := d.GetOk("administrator_password")
 
+		// d.GetOk returns false for fields in lifecycle.ignore_changes, because
+		// Terraform strips ignored fields from the resource data before passing
+		// it to the provider. Fall back to the raw config to detect whether the
+		// field is actually declared.
+		if !adminPwdSet {
+			rawCfg := d.GetRawConfig()
+			if !rawCfg.IsNull() {
+				if v := rawCfg.GetAttr("administrator_password"); !v.IsNull() && v.IsKnown() {
+					adminPwdSet = true
+				}
+			}
+		}
+
 		pwdEnabled := true // it defaults to true
 		if authRaw, authExist := d.GetOk("authentication"); authExist {
 			authConfig := expandFlexibleServerAuthConfig(authRaw.([]interface{}))


### PR DESCRIPTION
Fixes #33389

### Description

`d.GetOk("administrator_password")` in `resourcePostgresqlFlexibleServerUpdate` returns `false` when the field is in `lifecycle { ignore_changes }`, because Terraform strips ignored fields from the resource data before passing it to the provider. This causes the validation to reject a config that has the password declared but ignored:

```
Error: `administrator_password` or `administrator_password_wo` is required when `authentication.password_auth_enabled` is set to `true`
```

`terraform plan` passes because it doesn't execute CRUD functions — only `apply` hits this path. The result is a config that plans cleanly but fails every apply.

### Fix

Fall back to `d.GetRawConfig()` when `d.GetOk` returns false. `GetRawConfig()` reads the HCL config before lifecycle processing, so a declared-but-ignored `administrator_password` satisfies the validation without being sent to the Azure API.

### Reproduction

```hcl
resource "azurerm_postgresql_flexible_server" "main" {
  name                   = "example-pg"
  location               = "eastus2"
  resource_group_name    = "example-rg"
  administrator_login    = "pgadmin"
  administrator_password = "initial-password"

  authentication {
    active_directory_auth_enabled = true
  }

  lifecycle {
    ignore_changes = [administrator_password]
  }
}
```

1. Create the server
2. Change any other field (e.g. `backup_retention_days`)
3. `terraform plan` — passes
4. `terraform apply` — fails with the error above

After this fix, step 4 succeeds.

### PR Checklist

- [x] I have followed the guidelines in our [Contributing](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/README.md) documentation
- [x] This is a bug fix and no breaking changes are introduced
- [ ] Tests added/updated (acceptance test needed)