### PR TITLE
`azurerm_virtual_network` - add `summarized_gateway_prefixes` property

### DIFF
--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -424,7 +424,7 @@ func resourceKubernetesClusterNodePoolCreate(d *pluginsdk.ResourceData, meta int
 	clustersClient := containersClient.KubernetesClustersClient
 	poolsClient := containersClient.AgentPoolsClient
 	subnetClient := meta.(*clients.Client).Network.Subnets
-	vnetClient := meta.(*clients.Client).Network.VirtualNetworks
+	vnetClient := meta.(*clients.Client).Network.VirtualNetworksClient
 
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()

--- a/internal/services/network/client/client.go
+++ b/internal/services/network/client/client.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/networksecurityperimeterassociations"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/networksecurityperimeterprofiles"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/networksecurityperimeters"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks"
 	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/common"
 )
@@ -28,6 +29,7 @@ type Client struct {
 	NetworkSecurityPerimeterAssociationsClient *networksecurityperimeterassociations.NetworkSecurityPerimeterAssociationsClient
 	NetworkSecurityPerimeterProfilesClient     *networksecurityperimeterprofiles.NetworkSecurityPerimeterProfilesClient
 	NetworkSecurityPerimetersClient            *networksecurityperimeters.NetworkSecurityPerimetersClient
+	VirtualNetworksClient                      *virtualnetworks.VirtualNetworksClient
 	VMSSPublicIPAddressesClient                *vmsspublicipaddresses.VMSSPublicIPAddressesClient
 }
 
@@ -68,6 +70,12 @@ func NewClient(o *common.ClientOptions) (*Client, error) {
 	}
 	o.Configure(NetworkSecurityPerimetersClient.Client, o.Authorizers.ResourceManager)
 
+	VirtualNetworksClient, err := virtualnetworks.NewVirtualNetworksClientWithBaseURI(o.Environment.ResourceManager)
+	if err != nil {
+		return nil, fmt.Errorf("building Virtual Networks Client: %+v", err)
+	}
+	o.Configure(VirtualNetworksClient.Client, o.Authorizers.ResourceManager)
+
 	VMSSPublicIPAddressesClient, err := vmsspublicipaddresses.NewVMSSPublicIPAddressesClientWithBaseURI(o.Environment.ResourceManager)
 	if err != nil {
 		return nil, fmt.Errorf("building VMSS Public IP Addresses Client: %+v", err)
@@ -88,6 +96,7 @@ func NewClient(o *common.ClientOptions) (*Client, error) {
 		NetworkSecurityPerimeterAssociationsClient: NetworkSecurityPerimeterAssociationsClient,
 		NetworkSecurityPerimeterProfilesClient:     NetworkSecurityPerimeterProfilesClient,
 		NetworkSecurityPerimetersClient:            NetworkSecurityPerimetersClient,
+		VirtualNetworksClient:                      VirtualNetworksClient,
 		VMSSPublicIPAddressesClient:                VMSSPublicIPAddressesClient,
 		Client:                                     client,
 	}, nil

--- a/internal/services/network/helpers.go
+++ b/internal/services/network/helpers.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/subnets"
-	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/virtualnetworks"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 

--- a/internal/services/network/subnet_nat_gateway_association_resource.go
+++ b/internal/services/network/subnet_nat_gateway_association_resource.go
@@ -58,7 +58,7 @@ func resourceSubnetNatGatewayAssociation() *pluginsdk.Resource {
 
 func resourceSubnetNatGatewayAssociationCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Network.Subnets
-	vnetClient := meta.(*clients.Client).Network.VirtualNetworks
+	vnetClient := meta.(*clients.Client).Network.VirtualNetworksClient
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 

--- a/internal/services/network/subnet_network_security_group_association_resource.go
+++ b/internal/services/network/subnet_network_security_group_association_resource.go
@@ -59,7 +59,7 @@ func resourceSubnetNetworkSecurityGroupAssociation() *pluginsdk.Resource {
 
 func resourceSubnetNetworkSecurityGroupAssociationCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Network.Subnets
-	vnetClient := meta.(*clients.Client).Network.VirtualNetworks
+	vnetClient := meta.(*clients.Client).Network.VirtualNetworksClient
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 

--- a/internal/services/network/subnet_resource.go
+++ b/internal/services/network/subnet_resource.go
@@ -355,7 +355,7 @@ func resourceSubnet() *pluginsdk.Resource {
 
 func resourceSubnetCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Network.Subnets
-	vnetClient := meta.(*clients.Client).Network.VirtualNetworks
+	vnetClient := meta.(*clients.Client).Network.VirtualNetworksClient
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -462,7 +462,7 @@ func resourceSubnetCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 
 func resourceSubnetUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Network.Subnets
-	vnetClient := meta.(*clients.Client).Network.VirtualNetworks
+	vnetClient := meta.(*clients.Client).Network.VirtualNetworksClient
 
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()

--- a/internal/services/network/subnet_route_table_association_resource.go
+++ b/internal/services/network/subnet_route_table_association_resource.go
@@ -59,7 +59,7 @@ func resourceSubnetRouteTableAssociation() *pluginsdk.Resource {
 
 func resourceSubnetRouteTableAssociationCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Network.Subnets
-	vnetClient := meta.(*clients.Client).Network.VirtualNetworks
+	vnetClient := meta.(*clients.Client).Network.VirtualNetworksClient
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 

--- a/internal/services/network/virtual_network_dns_servers_resource.go
+++ b/internal/services/network/virtual_network_dns_servers_resource.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
-	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/virtualnetworks"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
@@ -60,7 +60,7 @@ func resourceVirtualNetworkDnsServers() *pluginsdk.Resource {
 }
 
 func resourceVirtualNetworkDnsServersCreate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.VirtualNetworks
+	client := meta.(*clients.Client).Network.VirtualNetworksClient
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -119,7 +119,7 @@ func resourceVirtualNetworkDnsServersCreate(d *pluginsdk.ResourceData, meta inte
 }
 
 func resourceVirtualNetworkDnsServersRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.VirtualNetworks
+	client := meta.(*clients.Client).Network.VirtualNetworksClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -153,7 +153,7 @@ func resourceVirtualNetworkDnsServersRead(d *pluginsdk.ResourceData, meta interf
 }
 
 func resourceVirtualNetworkDnsServersUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.VirtualNetworks
+	client := meta.(*clients.Client).Network.VirtualNetworksClient
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -213,7 +213,7 @@ func resourceVirtualNetworkDnsServersUpdate(d *pluginsdk.ResourceData, meta inte
 }
 
 func resourceVirtualNetworkDnsServersDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.VirtualNetworks
+	client := meta.(*clients.Client).Network.VirtualNetworksClient
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 

--- a/internal/services/network/virtual_network_resource.go
+++ b/internal/services/network/virtual_network_resource.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log"
 	"math/big"
+	"net/netip"
 	"regexp"
 	"strings"
 	"time"
@@ -25,7 +26,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-11-01/serviceendpointpolicies"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-11-01/subnets"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/ipampools"
-	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/virtualnetworks"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
@@ -63,6 +64,8 @@ func resourceVirtualNetwork() *pluginsdk.Resource {
 		Identity: &schema.ResourceIdentity{
 			SchemaFunc: pluginsdk.GenerateIdentitySchema(&commonids.VirtualNetworkId{}),
 		},
+
+		CustomizeDiff: pluginsdk.CustomizeDiffShim(virtualNetworkCustomizeDiff),
 	}
 }
 
@@ -339,12 +342,22 @@ func resourceVirtualNetworkSchema() map[string]*pluginsdk.Schema {
 			ValidateFunc: validation.StringInSlice(virtualnetworks.PossibleValuesForPrivateEndpointVNetPolicies(), false),
 		},
 
+		"summarized_gateway_prefixes": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			MinItems: 1,
+			Elem: &pluginsdk.Schema{
+				Type:         pluginsdk.TypeString,
+				ValidateFunc: validation.IsCIDR,
+			},
+		},
+
 		"tags": commonschema.Tags(),
 	}
 }
 
 func resourceVirtualNetworkCreate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.VirtualNetworks
+	client := meta.(*clients.Client).Network.VirtualNetworksClient
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -424,7 +437,7 @@ func resourceVirtualNetworkCreate(d *pluginsdk.ResourceData, meta interface{}) e
 }
 
 func resourceVirtualNetworkRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.VirtualNetworks
+	client := meta.(*clients.Client).Network.VirtualNetworksClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -499,6 +512,14 @@ func resourceVirtualNetworkFlatten(d *pluginsdk.ResourceData, id commonids.Virtu
 			if err := d.Set("bgp_community", bgpCommunity); err != nil {
 				return fmt.Errorf("setting `bgp_community`: %+v", err)
 			}
+
+			if summarizedGatewayPrefixes := props.SummarizedGatewayPrefixes; summarizedGatewayPrefixes != nil {
+				if addressPrefixes := summarizedGatewayPrefixes.AddressPrefixes; addressPrefixes != nil {
+					if err := d.Set("summarized_gateway_prefixes", addressPrefixes); err != nil {
+						return fmt.Errorf("setting `summarized_gateway_prefixes`: %+v", err)
+					}
+				}
+			}
 		}
 
 		if err := tags.FlattenAndSet(d, vnet.Tags); err != nil {
@@ -510,7 +531,7 @@ func resourceVirtualNetworkFlatten(d *pluginsdk.ResourceData, id commonids.Virtu
 }
 
 func resourceVirtualNetworkUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.VirtualNetworks
+	client := meta.(*clients.Client).Network.VirtualNetworksClient
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -625,6 +646,16 @@ func resourceVirtualNetworkUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 		payload.Properties.PrivateEndpointVNetPolicies = pointer.ToEnum[virtualnetworks.PrivateEndpointVNetPolicies](d.Get("private_endpoint_vnet_policies").(string))
 	}
 
+	if d.HasChange("summarized_gateway_prefixes") {
+		if summarizedGatewayPrefixes, ok := d.GetOk("summarized_gateway_prefixes"); ok {
+			payload.Properties.SummarizedGatewayPrefixes = &virtualnetworks.AddressSpace{
+				AddressPrefixes: pointer.To(expandVirtualNetworkSummarizedGatewayAddressPrefixes(summarizedGatewayPrefixes.([]interface{}))),
+			}
+		} else {
+			payload.Properties.SummarizedGatewayPrefixes = nil
+		}
+	}
+
 	if d.HasChange("tags") {
 		payload.Tags = tags.Expand(d.Get("tags").(map[string]interface{}))
 	}
@@ -659,7 +690,7 @@ func resourceVirtualNetworkUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 	stateConf := &pluginsdk.StateChangeConf{
 		Pending:    []string{string(virtualnetworks.ProvisioningStateUpdating)},
 		Target:     []string{string(virtualnetworks.ProvisioningStateSucceeded)},
-		Refresh:    VirtualNetworkProvisioningStateRefreshFunc(ctx, meta.(*clients.Client).Network.VirtualNetworks, *id),
+		Refresh:    VirtualNetworkProvisioningStateRefreshFunc(ctx, meta.(*clients.Client).Network.VirtualNetworksClient, *id),
 		MinTimeout: 1 * time.Minute,
 		Timeout:    time.Until(timeout),
 	}
@@ -672,7 +703,7 @@ func resourceVirtualNetworkUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 }
 
 func resourceVirtualNetworkDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.VirtualNetworks
+	client := meta.(*clients.Client).Network.VirtualNetworksClient
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -935,6 +966,12 @@ func expandVirtualNetworkProperties(ctx context.Context, client virtualnetworks.
 		properties.BgpCommunities = &virtualnetworks.VirtualNetworkBgpCommunities{VirtualNetworkCommunity: v.(string)}
 	}
 
+	if summarizedGatewayPrefixes, ok := d.GetOk("summarized_gateway_prefixes"); ok {
+		properties.SummarizedGatewayPrefixes = &virtualnetworks.AddressSpace{
+			AddressPrefixes: pointer.To(expandVirtualNetworkSummarizedGatewayAddressPrefixes(summarizedGatewayPrefixes.([]interface{}))),
+		}
+	}
+
 	return properties, &routeTables, nil
 }
 
@@ -962,6 +999,15 @@ func expandVirtualNetworkIPAddressPool(input []interface{}) *[]virtualnetworks.I
 	}
 
 	return &outputs
+}
+
+func expandVirtualNetworkSummarizedGatewayAddressPrefixes(inputs []interface{}) []string {
+	addressPrefixes := make([]string, 0)
+	for _, input := range inputs {
+		addressPrefixes = append(addressPrefixes, input.(string))
+	}
+
+	return addressPrefixes
 }
 
 func flattenVirtualNetworkIPAddressPool(input *[]virtualnetworks.IPamPoolPrefixAllocation) []interface{} {
@@ -1304,4 +1350,43 @@ func VirtualNetworkProvisioningStateRefreshFunc(ctx context.Context, client *vir
 		}
 		return res, "", fmt.Errorf("polling for %s: %+v", id, err)
 	}
+}
+
+func checkPrefixOverlap(prefixes []netip.Prefix) error {
+	for i := 0; i < len(prefixes)-1; i++ {
+		for j := i + 1; j < len(prefixes); j++ {
+			if prefixes[i].Overlaps(prefixes[j]) {
+				return fmt.Errorf("address space of `summarized_gateway_prefixes` property, `%s` overlaps with `%s`, address space overlapping is not allowed", prefixes[i], prefixes[j])
+			}
+		}
+	}
+
+	return nil
+}
+
+func virtualNetworkCustomizeDiff(ctx context.Context, d *pluginsdk.ResourceDiff, _ interface{}) error {
+	if rawSummarizedGatewayPrefixes, ok := d.GetOk("summarized_gateway_prefixes"); ok {
+		summarizedGatewayPrefixes := rawSummarizedGatewayPrefixes.([]interface{})
+		ipv4Prefixes := make([]netip.Prefix, 0)
+		ipv6Prefixes := make([]netip.Prefix, 0)
+
+		for _, summarizedGatewayPrefix := range summarizedGatewayPrefixes {
+			prefix, _ := netip.ParsePrefix(summarizedGatewayPrefix.(string))
+			if prefix.Addr().Is4() {
+				ipv4Prefixes = append(ipv4Prefixes, prefix)
+			} else {
+				ipv6Prefixes = append(ipv6Prefixes, prefix)
+			}
+		}
+
+		if err := checkPrefixOverlap(ipv4Prefixes); err != nil {
+			return err
+		}
+
+		if err := checkPrefixOverlap(ipv6Prefixes); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/internal/services/network/virtual_network_resource.go
+++ b/internal/services/network/virtual_network_resource.go
@@ -1366,6 +1366,7 @@ func checkPrefixOverlap(prefixes []netip.Prefix) error {
 
 func virtualNetworkCustomizeDiff(ctx context.Context, d *pluginsdk.ResourceDiff, _ interface{}) error {
 	if rawSummarizedGatewayPrefixes, ok := d.GetOk("summarized_gateway_prefixes"); ok {
+		// Check if `summarized_gateway_prefixes` list of prefixes overlap with each other according to portal
 		summarizedGatewayPrefixes := rawSummarizedGatewayPrefixes.([]interface{})
 		ipv4Prefixes := make([]netip.Prefix, 0)
 		ipv6Prefixes := make([]netip.Prefix, 0)

--- a/internal/services/network/virtual_network_resource_list.go
+++ b/internal/services/network/virtual_network_resource_list.go
@@ -53,7 +53,7 @@ func (r VirtualNetworkListResource) ListResourceConfigSchema(_ context.Context, 
 }
 
 func (r VirtualNetworkListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream, metadata sdk.ResourceMetadata) {
-	client := metadata.Client.Network.VirtualNetworks
+	client := metadata.Client.Network.VirtualNetworksClient
 
 	var data VirtualNetworkListModel
 

--- a/internal/services/network/virtual_network_resource_test.go
+++ b/internal/services/network/virtual_network_resource_test.go
@@ -473,7 +473,7 @@ func TestVirtualNetworkResource_tagCount(t *testing.T) {
 	})
 }
 
-func TestAccVirtualNetworkResource_overlappedSummarizedGatewayPrefixesError(t *testing.T) {
+func TestAccVirtualNetwork_overlappedSummarizedGatewayPrefixesError(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_virtual_network", "test")
 	r := VirtualNetworkResource{}
 

--- a/internal/services/network/virtual_network_resource_test.go
+++ b/internal/services/network/virtual_network_resource_test.go
@@ -473,6 +473,18 @@ func TestVirtualNetworkResource_tagCount(t *testing.T) {
 	})
 }
 
+func TestAccVirtualNetworkResource_overlappedSummarizedGatewayPrefixesError(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_virtual_network", "test")
+	r := VirtualNetworkResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config:      r.overlappedSummarizedGatewayPrefixesError(data),
+			ExpectError: regexp.MustCompile("address space of `summarized_gateway_prefixes` property, `10.0.0.0/16` overlaps with `10.0.0.0/24`, address space overlapping is not allowed"),
+		},
+	})
+}
+
 func (r VirtualNetworkResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := commonids.ParseVirtualNetworkID(state.ID)
 	if err != nil {
@@ -579,6 +591,7 @@ resource "azurerm_virtual_network" "test" {
   resource_group_name            = azurerm_resource_group.test.name
   dns_servers                    = ["10.7.7.2", "10.7.7.7", "10.7.7.1", ]
   private_endpoint_vnet_policies = "Basic"
+  summarized_gateway_prefixes    = ["10.1.0.0/16", "10.128.0.0/9", "2001:db8:abcd:0012::/64"]
 
   encryption {
     enforcement = "AllowUnencrypted"
@@ -1324,4 +1337,30 @@ resource "azurerm_virtual_network" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func (VirtualNetworkResource) overlappedSummarizedGatewayPrefixesError(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                        = "acctestvirtnet%d"
+  address_space               = ["10.0.0.0/16"]
+  location                    = azurerm_resource_group.test.location
+  resource_group_name         = azurerm_resource_group.test.name
+  summarized_gateway_prefixes = ["10.0.0.0/16", "10.0.0.0/24"]
+
+  subnet {
+    name             = "subnet1"
+    address_prefixes = ["10.0.1.0/24"]
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/README.md
@@ -1,0 +1,490 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks` Documentation
+
+The `virtualnetworks` SDK allows for interaction with Azure Resource Manager `network` (API Version `2025-07-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks"
+```
+
+
+### Client Initialization
+
+```go
+client := virtualnetworks.NewVirtualNetworksClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `VirtualNetworksClient.AvailableDelegationsList`
+
+```go
+ctx := context.TODO()
+id := virtualnetworks.NewLocationID("12345678-1234-9876-4563-123456789012", "locationName")
+
+// alternatively `client.AvailableDelegationsList(ctx, id)` can be used to do batched pagination
+items, err := client.AvailableDelegationsListComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `VirtualNetworksClient.AvailableEndpointServicesList`
+
+```go
+ctx := context.TODO()
+id := virtualnetworks.NewLocationID("12345678-1234-9876-4563-123456789012", "locationName")
+
+// alternatively `client.AvailableEndpointServicesList(ctx, id)` can be used to do batched pagination
+items, err := client.AvailableEndpointServicesListComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `VirtualNetworksClient.AvailablePrivateEndpointTypesList`
+
+```go
+ctx := context.TODO()
+id := virtualnetworks.NewLocationID("12345678-1234-9876-4563-123456789012", "locationName")
+
+// alternatively `client.AvailablePrivateEndpointTypesList(ctx, id)` can be used to do batched pagination
+items, err := client.AvailablePrivateEndpointTypesListComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `VirtualNetworksClient.AvailablePrivateEndpointTypesListByResourceGroup`
+
+```go
+ctx := context.TODO()
+id := virtualnetworks.NewProviderLocationID("12345678-1234-9876-4563-123456789012", "example-resource-group", "locationName")
+
+// alternatively `client.AvailablePrivateEndpointTypesListByResourceGroup(ctx, id)` can be used to do batched pagination
+items, err := client.AvailablePrivateEndpointTypesListByResourceGroupComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `VirtualNetworksClient.AvailableResourceGroupDelegationsList`
+
+```go
+ctx := context.TODO()
+id := virtualnetworks.NewProviderLocationID("12345678-1234-9876-4563-123456789012", "example-resource-group", "locationName")
+
+// alternatively `client.AvailableResourceGroupDelegationsList(ctx, id)` can be used to do batched pagination
+items, err := client.AvailableResourceGroupDelegationsListComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `VirtualNetworksClient.AvailableServiceAliasesList`
+
+```go
+ctx := context.TODO()
+id := virtualnetworks.NewLocationID("12345678-1234-9876-4563-123456789012", "locationName")
+
+// alternatively `client.AvailableServiceAliasesList(ctx, id)` can be used to do batched pagination
+items, err := client.AvailableServiceAliasesListComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `VirtualNetworksClient.AvailableServiceAliasesListByResourceGroup`
+
+```go
+ctx := context.TODO()
+id := virtualnetworks.NewProviderLocationID("12345678-1234-9876-4563-123456789012", "example-resource-group", "locationName")
+
+// alternatively `client.AvailableServiceAliasesListByResourceGroup(ctx, id)` can be used to do batched pagination
+items, err := client.AvailableServiceAliasesListByResourceGroupComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `VirtualNetworksClient.CheckDnsNameAvailability`
+
+```go
+ctx := context.TODO()
+id := virtualnetworks.NewLocationID("12345678-1234-9876-4563-123456789012", "locationName")
+
+read, err := client.CheckDnsNameAvailability(ctx, id, virtualnetworks.DefaultCheckDnsNameAvailabilityOperationOptions())
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `VirtualNetworksClient.CreateOrUpdate`
+
+```go
+ctx := context.TODO()
+id := commonids.NewVirtualNetworkID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualNetworkName")
+
+payload := virtualnetworks.VirtualNetwork{
+	// ...
+}
+
+
+if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `VirtualNetworksClient.Delete`
+
+```go
+ctx := context.TODO()
+id := commonids.NewVirtualNetworkID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualNetworkName")
+
+if err := client.DeleteThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `VirtualNetworksClient.Get`
+
+```go
+ctx := context.TODO()
+id := commonids.NewVirtualNetworkID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualNetworkName")
+
+read, err := client.Get(ctx, id, virtualnetworks.DefaultGetOperationOptions())
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `VirtualNetworksClient.InboundSecurityRuleCreateOrUpdate`
+
+```go
+ctx := context.TODO()
+id := virtualnetworks.NewInboundSecurityRuleID("12345678-1234-9876-4563-123456789012", "example-resource-group", "networkVirtualApplianceName", "inboundSecurityRuleName")
+
+payload := virtualnetworks.InboundSecurityRule{
+	// ...
+}
+
+
+if err := client.InboundSecurityRuleCreateOrUpdateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `VirtualNetworksClient.InboundSecurityRuleGet`
+
+```go
+ctx := context.TODO()
+id := virtualnetworks.NewInboundSecurityRuleID("12345678-1234-9876-4563-123456789012", "example-resource-group", "networkVirtualApplianceName", "inboundSecurityRuleName")
+
+read, err := client.InboundSecurityRuleGet(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `VirtualNetworksClient.List`
+
+```go
+ctx := context.TODO()
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+
+// alternatively `client.List(ctx, id)` can be used to do batched pagination
+items, err := client.ListComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `VirtualNetworksClient.ListAll`
+
+```go
+ctx := context.TODO()
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+
+// alternatively `client.ListAll(ctx, id)` can be used to do batched pagination
+items, err := client.ListAllComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `VirtualNetworksClient.PublicIPAddressesGetCloudServicePublicIPAddress`
+
+```go
+ctx := context.TODO()
+id := commonids.NewCloudServicesPublicIPAddressID("12345678-1234-9876-4563-123456789012", "example-resource-group", "cloudServiceName", "roleInstanceName", "networkInterfaceName", "ipConfigurationName", "publicIPAddressName")
+
+read, err := client.PublicIPAddressesGetCloudServicePublicIPAddress(ctx, id, virtualnetworks.DefaultPublicIPAddressesGetCloudServicePublicIPAddressOperationOptions())
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `VirtualNetworksClient.PublicIPAddressesListCloudServicePublicIPAddresses`
+
+```go
+ctx := context.TODO()
+id := virtualnetworks.NewProviderCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "cloudServiceName")
+
+// alternatively `client.PublicIPAddressesListCloudServicePublicIPAddresses(ctx, id)` can be used to do batched pagination
+items, err := client.PublicIPAddressesListCloudServicePublicIPAddressesComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `VirtualNetworksClient.PublicIPAddressesListCloudServiceRoleInstancePublicIPAddresses`
+
+```go
+ctx := context.TODO()
+id := commonids.NewCloudServicesIPConfigurationID("12345678-1234-9876-4563-123456789012", "example-resource-group", "cloudServiceName", "roleInstanceName", "networkInterfaceName", "ipConfigurationName")
+
+// alternatively `client.PublicIPAddressesListCloudServiceRoleInstancePublicIPAddresses(ctx, id)` can be used to do batched pagination
+items, err := client.PublicIPAddressesListCloudServiceRoleInstancePublicIPAddressesComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `VirtualNetworksClient.ResourceNavigationLinksList`
+
+```go
+ctx := context.TODO()
+id := commonids.NewSubnetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualNetworkName", "subnetName")
+
+// alternatively `client.ResourceNavigationLinksList(ctx, id)` can be used to do batched pagination
+items, err := client.ResourceNavigationLinksListComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `VirtualNetworksClient.ServiceAssociationLinksList`
+
+```go
+ctx := context.TODO()
+id := commonids.NewSubnetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualNetworkName", "subnetName")
+
+// alternatively `client.ServiceAssociationLinksList(ctx, id)` can be used to do batched pagination
+items, err := client.ServiceAssociationLinksListComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `VirtualNetworksClient.ServiceTagInformationList`
+
+```go
+ctx := context.TODO()
+id := virtualnetworks.NewLocationID("12345678-1234-9876-4563-123456789012", "locationName")
+
+// alternatively `client.ServiceTagInformationList(ctx, id, virtualnetworks.DefaultServiceTagInformationListOperationOptions())` can be used to do batched pagination
+items, err := client.ServiceTagInformationListComplete(ctx, id, virtualnetworks.DefaultServiceTagInformationListOperationOptions())
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `VirtualNetworksClient.ServiceTagsList`
+
+```go
+ctx := context.TODO()
+id := virtualnetworks.NewLocationID("12345678-1234-9876-4563-123456789012", "locationName")
+
+read, err := client.ServiceTagsList(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `VirtualNetworksClient.SubnetsPrepareNetworkPolicies`
+
+```go
+ctx := context.TODO()
+id := commonids.NewSubnetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualNetworkName", "subnetName")
+
+payload := virtualnetworks.PrepareNetworkPoliciesRequest{
+	// ...
+}
+
+
+if err := client.SubnetsPrepareNetworkPoliciesThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `VirtualNetworksClient.SubnetsUnprepareNetworkPolicies`
+
+```go
+ctx := context.TODO()
+id := commonids.NewSubnetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualNetworkName", "subnetName")
+
+payload := virtualnetworks.UnprepareNetworkPoliciesRequest{
+	// ...
+}
+
+
+if err := client.SubnetsUnprepareNetworkPoliciesThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `VirtualNetworksClient.UpdateTags`
+
+```go
+ctx := context.TODO()
+id := commonids.NewVirtualNetworkID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualNetworkName")
+
+payload := virtualnetworks.TagsObject{
+	// ...
+}
+
+
+read, err := client.UpdateTags(ctx, id, payload)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `VirtualNetworksClient.VirtualNetworksCheckIPAddressAvailability`
+
+```go
+ctx := context.TODO()
+id := commonids.NewVirtualNetworkID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualNetworkName")
+
+read, err := client.VirtualNetworksCheckIPAddressAvailability(ctx, id, virtualnetworks.DefaultVirtualNetworksCheckIPAddressAvailabilityOperationOptions())
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `VirtualNetworksClient.VirtualNetworksListDdosProtectionStatus`
+
+```go
+ctx := context.TODO()
+id := commonids.NewVirtualNetworkID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualNetworkName")
+
+// alternatively `client.VirtualNetworksListDdosProtectionStatus(ctx, id, virtualnetworks.DefaultVirtualNetworksListDdosProtectionStatusOperationOptions())` can be used to do batched pagination
+items, err := client.VirtualNetworksListDdosProtectionStatusComplete(ctx, id, virtualnetworks.DefaultVirtualNetworksListDdosProtectionStatusOperationOptions())
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `VirtualNetworksClient.VirtualNetworksListUsage`
+
+```go
+ctx := context.TODO()
+id := commonids.NewVirtualNetworkID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualNetworkName")
+
+// alternatively `client.VirtualNetworksListUsage(ctx, id)` can be used to do batched pagination
+items, err := client.VirtualNetworksListUsageComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/client.go
@@ -1,0 +1,26 @@
+package virtualnetworks
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualNetworksClient struct {
+	Client *resourcemanager.Client
+}
+
+func NewVirtualNetworksClientWithBaseURI(sdkApi sdkEnv.Api) (*VirtualNetworksClient, error) {
+	client, err := resourcemanager.NewClient(sdkApi, "virtualnetworks", defaultApiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating VirtualNetworksClient: %+v", err)
+	}
+
+	return &VirtualNetworksClient{
+		Client: client,
+	}, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/constants.go
@@ -1,0 +1,1723 @@
+package virtualnetworks
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AccessMode string
+
+const (
+	AccessModeDefault    AccessMode = "Default"
+	AccessModeRestricted AccessMode = "Restricted"
+)
+
+func PossibleValuesForAccessMode() []string {
+	return []string{
+		string(AccessModeDefault),
+		string(AccessModeRestricted),
+	}
+}
+
+func (s *AccessMode) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseAccessMode(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseAccessMode(input string) (*AccessMode, error) {
+	vals := map[string]AccessMode{
+		"default":    AccessModeDefault,
+		"restricted": AccessModeRestricted,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := AccessMode(input)
+	return &out, nil
+}
+
+type DdosSettingsProtectionMode string
+
+const (
+	DdosSettingsProtectionModeDisabled                DdosSettingsProtectionMode = "Disabled"
+	DdosSettingsProtectionModeEnabled                 DdosSettingsProtectionMode = "Enabled"
+	DdosSettingsProtectionModeVirtualNetworkInherited DdosSettingsProtectionMode = "VirtualNetworkInherited"
+)
+
+func PossibleValuesForDdosSettingsProtectionMode() []string {
+	return []string{
+		string(DdosSettingsProtectionModeDisabled),
+		string(DdosSettingsProtectionModeEnabled),
+		string(DdosSettingsProtectionModeVirtualNetworkInherited),
+	}
+}
+
+func (s *DdosSettingsProtectionMode) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseDdosSettingsProtectionMode(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseDdosSettingsProtectionMode(input string) (*DdosSettingsProtectionMode, error) {
+	vals := map[string]DdosSettingsProtectionMode{
+		"disabled":                DdosSettingsProtectionModeDisabled,
+		"enabled":                 DdosSettingsProtectionModeEnabled,
+		"virtualnetworkinherited": DdosSettingsProtectionModeVirtualNetworkInherited,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := DdosSettingsProtectionMode(input)
+	return &out, nil
+}
+
+type DeleteOptions string
+
+const (
+	DeleteOptionsDelete DeleteOptions = "Delete"
+	DeleteOptionsDetach DeleteOptions = "Detach"
+)
+
+func PossibleValuesForDeleteOptions() []string {
+	return []string{
+		string(DeleteOptionsDelete),
+		string(DeleteOptionsDetach),
+	}
+}
+
+func (s *DeleteOptions) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseDeleteOptions(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseDeleteOptions(input string) (*DeleteOptions, error) {
+	vals := map[string]DeleteOptions{
+		"delete": DeleteOptionsDelete,
+		"detach": DeleteOptionsDetach,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := DeleteOptions(input)
+	return &out, nil
+}
+
+type DisablePeeringRoute string
+
+const (
+	DisablePeeringRouteAll  DisablePeeringRoute = "All"
+	DisablePeeringRouteNone DisablePeeringRoute = "None"
+)
+
+func PossibleValuesForDisablePeeringRoute() []string {
+	return []string{
+		string(DisablePeeringRouteAll),
+		string(DisablePeeringRouteNone),
+	}
+}
+
+func (s *DisablePeeringRoute) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseDisablePeeringRoute(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseDisablePeeringRoute(input string) (*DisablePeeringRoute, error) {
+	vals := map[string]DisablePeeringRoute{
+		"all":  DisablePeeringRouteAll,
+		"none": DisablePeeringRouteNone,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := DisablePeeringRoute(input)
+	return &out, nil
+}
+
+type FlowLogFormatType string
+
+const (
+	FlowLogFormatTypeJSON FlowLogFormatType = "JSON"
+)
+
+func PossibleValuesForFlowLogFormatType() []string {
+	return []string{
+		string(FlowLogFormatTypeJSON),
+	}
+}
+
+func (s *FlowLogFormatType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseFlowLogFormatType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseFlowLogFormatType(input string) (*FlowLogFormatType, error) {
+	vals := map[string]FlowLogFormatType{
+		"json": FlowLogFormatTypeJSON,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := FlowLogFormatType(input)
+	return &out, nil
+}
+
+type GatewayLoadBalancerTunnelInterfaceType string
+
+const (
+	GatewayLoadBalancerTunnelInterfaceTypeExternal GatewayLoadBalancerTunnelInterfaceType = "External"
+	GatewayLoadBalancerTunnelInterfaceTypeInternal GatewayLoadBalancerTunnelInterfaceType = "Internal"
+	GatewayLoadBalancerTunnelInterfaceTypeNone     GatewayLoadBalancerTunnelInterfaceType = "None"
+)
+
+func PossibleValuesForGatewayLoadBalancerTunnelInterfaceType() []string {
+	return []string{
+		string(GatewayLoadBalancerTunnelInterfaceTypeExternal),
+		string(GatewayLoadBalancerTunnelInterfaceTypeInternal),
+		string(GatewayLoadBalancerTunnelInterfaceTypeNone),
+	}
+}
+
+func (s *GatewayLoadBalancerTunnelInterfaceType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseGatewayLoadBalancerTunnelInterfaceType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseGatewayLoadBalancerTunnelInterfaceType(input string) (*GatewayLoadBalancerTunnelInterfaceType, error) {
+	vals := map[string]GatewayLoadBalancerTunnelInterfaceType{
+		"external": GatewayLoadBalancerTunnelInterfaceTypeExternal,
+		"internal": GatewayLoadBalancerTunnelInterfaceTypeInternal,
+		"none":     GatewayLoadBalancerTunnelInterfaceTypeNone,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := GatewayLoadBalancerTunnelInterfaceType(input)
+	return &out, nil
+}
+
+type GatewayLoadBalancerTunnelProtocol string
+
+const (
+	GatewayLoadBalancerTunnelProtocolNative GatewayLoadBalancerTunnelProtocol = "Native"
+	GatewayLoadBalancerTunnelProtocolNone   GatewayLoadBalancerTunnelProtocol = "None"
+	GatewayLoadBalancerTunnelProtocolVXLAN  GatewayLoadBalancerTunnelProtocol = "VXLAN"
+)
+
+func PossibleValuesForGatewayLoadBalancerTunnelProtocol() []string {
+	return []string{
+		string(GatewayLoadBalancerTunnelProtocolNative),
+		string(GatewayLoadBalancerTunnelProtocolNone),
+		string(GatewayLoadBalancerTunnelProtocolVXLAN),
+	}
+}
+
+func (s *GatewayLoadBalancerTunnelProtocol) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseGatewayLoadBalancerTunnelProtocol(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseGatewayLoadBalancerTunnelProtocol(input string) (*GatewayLoadBalancerTunnelProtocol, error) {
+	vals := map[string]GatewayLoadBalancerTunnelProtocol{
+		"native": GatewayLoadBalancerTunnelProtocolNative,
+		"none":   GatewayLoadBalancerTunnelProtocolNone,
+		"vxlan":  GatewayLoadBalancerTunnelProtocolVXLAN,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := GatewayLoadBalancerTunnelProtocol(input)
+	return &out, nil
+}
+
+type IPAllocationMethod string
+
+const (
+	IPAllocationMethodDynamic IPAllocationMethod = "Dynamic"
+	IPAllocationMethodStatic  IPAllocationMethod = "Static"
+)
+
+func PossibleValuesForIPAllocationMethod() []string {
+	return []string{
+		string(IPAllocationMethodDynamic),
+		string(IPAllocationMethodStatic),
+	}
+}
+
+func (s *IPAllocationMethod) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseIPAllocationMethod(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseIPAllocationMethod(input string) (*IPAllocationMethod, error) {
+	vals := map[string]IPAllocationMethod{
+		"dynamic": IPAllocationMethodDynamic,
+		"static":  IPAllocationMethodStatic,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := IPAllocationMethod(input)
+	return &out, nil
+}
+
+type IPVersion string
+
+const (
+	IPVersionIPvFour IPVersion = "IPv4"
+	IPVersionIPvSix  IPVersion = "IPv6"
+)
+
+func PossibleValuesForIPVersion() []string {
+	return []string{
+		string(IPVersionIPvFour),
+		string(IPVersionIPvSix),
+	}
+}
+
+func (s *IPVersion) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseIPVersion(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseIPVersion(input string) (*IPVersion, error) {
+	vals := map[string]IPVersion{
+		"ipv4": IPVersionIPvFour,
+		"ipv6": IPVersionIPvSix,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := IPVersion(input)
+	return &out, nil
+}
+
+type InboundSecurityRuleType string
+
+const (
+	InboundSecurityRuleTypeAutoExpire InboundSecurityRuleType = "AutoExpire"
+	InboundSecurityRuleTypePermanent  InboundSecurityRuleType = "Permanent"
+)
+
+func PossibleValuesForInboundSecurityRuleType() []string {
+	return []string{
+		string(InboundSecurityRuleTypeAutoExpire),
+		string(InboundSecurityRuleTypePermanent),
+	}
+}
+
+func (s *InboundSecurityRuleType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseInboundSecurityRuleType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseInboundSecurityRuleType(input string) (*InboundSecurityRuleType, error) {
+	vals := map[string]InboundSecurityRuleType{
+		"autoexpire": InboundSecurityRuleTypeAutoExpire,
+		"permanent":  InboundSecurityRuleTypePermanent,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := InboundSecurityRuleType(input)
+	return &out, nil
+}
+
+type InboundSecurityRulesProtocol string
+
+const (
+	InboundSecurityRulesProtocolTCP InboundSecurityRulesProtocol = "TCP"
+	InboundSecurityRulesProtocolUDP InboundSecurityRulesProtocol = "UDP"
+)
+
+func PossibleValuesForInboundSecurityRulesProtocol() []string {
+	return []string{
+		string(InboundSecurityRulesProtocolTCP),
+		string(InboundSecurityRulesProtocolUDP),
+	}
+}
+
+func (s *InboundSecurityRulesProtocol) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseInboundSecurityRulesProtocol(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseInboundSecurityRulesProtocol(input string) (*InboundSecurityRulesProtocol, error) {
+	vals := map[string]InboundSecurityRulesProtocol{
+		"tcp": InboundSecurityRulesProtocolTCP,
+		"udp": InboundSecurityRulesProtocolUDP,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := InboundSecurityRulesProtocol(input)
+	return &out, nil
+}
+
+type IsWorkloadProtected string
+
+const (
+	IsWorkloadProtectedFalse IsWorkloadProtected = "False"
+	IsWorkloadProtectedTrue  IsWorkloadProtected = "True"
+)
+
+func PossibleValuesForIsWorkloadProtected() []string {
+	return []string{
+		string(IsWorkloadProtectedFalse),
+		string(IsWorkloadProtectedTrue),
+	}
+}
+
+func (s *IsWorkloadProtected) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseIsWorkloadProtected(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseIsWorkloadProtected(input string) (*IsWorkloadProtected, error) {
+	vals := map[string]IsWorkloadProtected{
+		"false": IsWorkloadProtectedFalse,
+		"true":  IsWorkloadProtectedTrue,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := IsWorkloadProtected(input)
+	return &out, nil
+}
+
+type LoadBalancerBackendAddressAdminState string
+
+const (
+	LoadBalancerBackendAddressAdminStateDown LoadBalancerBackendAddressAdminState = "Down"
+	LoadBalancerBackendAddressAdminStateNone LoadBalancerBackendAddressAdminState = "None"
+	LoadBalancerBackendAddressAdminStateUp   LoadBalancerBackendAddressAdminState = "Up"
+)
+
+func PossibleValuesForLoadBalancerBackendAddressAdminState() []string {
+	return []string{
+		string(LoadBalancerBackendAddressAdminStateDown),
+		string(LoadBalancerBackendAddressAdminStateNone),
+		string(LoadBalancerBackendAddressAdminStateUp),
+	}
+}
+
+func (s *LoadBalancerBackendAddressAdminState) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseLoadBalancerBackendAddressAdminState(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseLoadBalancerBackendAddressAdminState(input string) (*LoadBalancerBackendAddressAdminState, error) {
+	vals := map[string]LoadBalancerBackendAddressAdminState{
+		"down": LoadBalancerBackendAddressAdminStateDown,
+		"none": LoadBalancerBackendAddressAdminStateNone,
+		"up":   LoadBalancerBackendAddressAdminStateUp,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := LoadBalancerBackendAddressAdminState(input)
+	return &out, nil
+}
+
+type Nat64State string
+
+const (
+	Nat64StateDisabled Nat64State = "Disabled"
+	Nat64StateEnabled  Nat64State = "Enabled"
+	Nat64StateNone     Nat64State = "None"
+)
+
+func PossibleValuesForNat64State() []string {
+	return []string{
+		string(Nat64StateDisabled),
+		string(Nat64StateEnabled),
+		string(Nat64StateNone),
+	}
+}
+
+func (s *Nat64State) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseNat64State(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseNat64State(input string) (*Nat64State, error) {
+	vals := map[string]Nat64State{
+		"disabled": Nat64StateDisabled,
+		"enabled":  Nat64StateEnabled,
+		"none":     Nat64StateNone,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := Nat64State(input)
+	return &out, nil
+}
+
+type NatGatewaySkuName string
+
+const (
+	NatGatewaySkuNameStandard     NatGatewaySkuName = "Standard"
+	NatGatewaySkuNameStandardVTwo NatGatewaySkuName = "StandardV2"
+)
+
+func PossibleValuesForNatGatewaySkuName() []string {
+	return []string{
+		string(NatGatewaySkuNameStandard),
+		string(NatGatewaySkuNameStandardVTwo),
+	}
+}
+
+func (s *NatGatewaySkuName) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseNatGatewaySkuName(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseNatGatewaySkuName(input string) (*NatGatewaySkuName, error) {
+	vals := map[string]NatGatewaySkuName{
+		"standard":   NatGatewaySkuNameStandard,
+		"standardv2": NatGatewaySkuNameStandardVTwo,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := NatGatewaySkuName(input)
+	return &out, nil
+}
+
+type NetworkInterfaceAuxiliaryMode string
+
+const (
+	NetworkInterfaceAuxiliaryModeAcceleratedConnections NetworkInterfaceAuxiliaryMode = "AcceleratedConnections"
+	NetworkInterfaceAuxiliaryModeFloating               NetworkInterfaceAuxiliaryMode = "Floating"
+	NetworkInterfaceAuxiliaryModeMaxConnections         NetworkInterfaceAuxiliaryMode = "MaxConnections"
+	NetworkInterfaceAuxiliaryModeNone                   NetworkInterfaceAuxiliaryMode = "None"
+)
+
+func PossibleValuesForNetworkInterfaceAuxiliaryMode() []string {
+	return []string{
+		string(NetworkInterfaceAuxiliaryModeAcceleratedConnections),
+		string(NetworkInterfaceAuxiliaryModeFloating),
+		string(NetworkInterfaceAuxiliaryModeMaxConnections),
+		string(NetworkInterfaceAuxiliaryModeNone),
+	}
+}
+
+func (s *NetworkInterfaceAuxiliaryMode) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseNetworkInterfaceAuxiliaryMode(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseNetworkInterfaceAuxiliaryMode(input string) (*NetworkInterfaceAuxiliaryMode, error) {
+	vals := map[string]NetworkInterfaceAuxiliaryMode{
+		"acceleratedconnections": NetworkInterfaceAuxiliaryModeAcceleratedConnections,
+		"floating":               NetworkInterfaceAuxiliaryModeFloating,
+		"maxconnections":         NetworkInterfaceAuxiliaryModeMaxConnections,
+		"none":                   NetworkInterfaceAuxiliaryModeNone,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := NetworkInterfaceAuxiliaryMode(input)
+	return &out, nil
+}
+
+type NetworkInterfaceAuxiliarySku string
+
+const (
+	NetworkInterfaceAuxiliarySkuAEight NetworkInterfaceAuxiliarySku = "A8"
+	NetworkInterfaceAuxiliarySkuAFour  NetworkInterfaceAuxiliarySku = "A4"
+	NetworkInterfaceAuxiliarySkuAOne   NetworkInterfaceAuxiliarySku = "A1"
+	NetworkInterfaceAuxiliarySkuATwo   NetworkInterfaceAuxiliarySku = "A2"
+	NetworkInterfaceAuxiliarySkuNone   NetworkInterfaceAuxiliarySku = "None"
+)
+
+func PossibleValuesForNetworkInterfaceAuxiliarySku() []string {
+	return []string{
+		string(NetworkInterfaceAuxiliarySkuAEight),
+		string(NetworkInterfaceAuxiliarySkuAFour),
+		string(NetworkInterfaceAuxiliarySkuAOne),
+		string(NetworkInterfaceAuxiliarySkuATwo),
+		string(NetworkInterfaceAuxiliarySkuNone),
+	}
+}
+
+func (s *NetworkInterfaceAuxiliarySku) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseNetworkInterfaceAuxiliarySku(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseNetworkInterfaceAuxiliarySku(input string) (*NetworkInterfaceAuxiliarySku, error) {
+	vals := map[string]NetworkInterfaceAuxiliarySku{
+		"a8":   NetworkInterfaceAuxiliarySkuAEight,
+		"a4":   NetworkInterfaceAuxiliarySkuAFour,
+		"a1":   NetworkInterfaceAuxiliarySkuAOne,
+		"a2":   NetworkInterfaceAuxiliarySkuATwo,
+		"none": NetworkInterfaceAuxiliarySkuNone,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := NetworkInterfaceAuxiliarySku(input)
+	return &out, nil
+}
+
+type NetworkInterfaceMigrationPhase string
+
+const (
+	NetworkInterfaceMigrationPhaseAbort     NetworkInterfaceMigrationPhase = "Abort"
+	NetworkInterfaceMigrationPhaseCommit    NetworkInterfaceMigrationPhase = "Commit"
+	NetworkInterfaceMigrationPhaseCommitted NetworkInterfaceMigrationPhase = "Committed"
+	NetworkInterfaceMigrationPhaseNone      NetworkInterfaceMigrationPhase = "None"
+	NetworkInterfaceMigrationPhasePrepare   NetworkInterfaceMigrationPhase = "Prepare"
+)
+
+func PossibleValuesForNetworkInterfaceMigrationPhase() []string {
+	return []string{
+		string(NetworkInterfaceMigrationPhaseAbort),
+		string(NetworkInterfaceMigrationPhaseCommit),
+		string(NetworkInterfaceMigrationPhaseCommitted),
+		string(NetworkInterfaceMigrationPhaseNone),
+		string(NetworkInterfaceMigrationPhasePrepare),
+	}
+}
+
+func (s *NetworkInterfaceMigrationPhase) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseNetworkInterfaceMigrationPhase(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseNetworkInterfaceMigrationPhase(input string) (*NetworkInterfaceMigrationPhase, error) {
+	vals := map[string]NetworkInterfaceMigrationPhase{
+		"abort":     NetworkInterfaceMigrationPhaseAbort,
+		"commit":    NetworkInterfaceMigrationPhaseCommit,
+		"committed": NetworkInterfaceMigrationPhaseCommitted,
+		"none":      NetworkInterfaceMigrationPhaseNone,
+		"prepare":   NetworkInterfaceMigrationPhasePrepare,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := NetworkInterfaceMigrationPhase(input)
+	return &out, nil
+}
+
+type NetworkInterfaceNicType string
+
+const (
+	NetworkInterfaceNicTypeElastic  NetworkInterfaceNicType = "Elastic"
+	NetworkInterfaceNicTypeStandard NetworkInterfaceNicType = "Standard"
+)
+
+func PossibleValuesForNetworkInterfaceNicType() []string {
+	return []string{
+		string(NetworkInterfaceNicTypeElastic),
+		string(NetworkInterfaceNicTypeStandard),
+	}
+}
+
+func (s *NetworkInterfaceNicType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseNetworkInterfaceNicType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseNetworkInterfaceNicType(input string) (*NetworkInterfaceNicType, error) {
+	vals := map[string]NetworkInterfaceNicType{
+		"elastic":  NetworkInterfaceNicTypeElastic,
+		"standard": NetworkInterfaceNicTypeStandard,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := NetworkInterfaceNicType(input)
+	return &out, nil
+}
+
+type PrivateEndpointBillingSku string
+
+const (
+	PrivateEndpointBillingSkuFixed      PrivateEndpointBillingSku = "Fixed"
+	PrivateEndpointBillingSkuPayAsYouGo PrivateEndpointBillingSku = "PayAsYouGo"
+)
+
+func PossibleValuesForPrivateEndpointBillingSku() []string {
+	return []string{
+		string(PrivateEndpointBillingSkuFixed),
+		string(PrivateEndpointBillingSkuPayAsYouGo),
+	}
+}
+
+func (s *PrivateEndpointBillingSku) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parsePrivateEndpointBillingSku(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parsePrivateEndpointBillingSku(input string) (*PrivateEndpointBillingSku, error) {
+	vals := map[string]PrivateEndpointBillingSku{
+		"fixed":      PrivateEndpointBillingSkuFixed,
+		"payasyougo": PrivateEndpointBillingSkuPayAsYouGo,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := PrivateEndpointBillingSku(input)
+	return &out, nil
+}
+
+type PrivateEndpointIPVersionType string
+
+const (
+	PrivateEndpointIPVersionTypeDualStack PrivateEndpointIPVersionType = "DualStack"
+	PrivateEndpointIPVersionTypeIPvFour   PrivateEndpointIPVersionType = "IPv4"
+	PrivateEndpointIPVersionTypeIPvSix    PrivateEndpointIPVersionType = "IPv6"
+)
+
+func PossibleValuesForPrivateEndpointIPVersionType() []string {
+	return []string{
+		string(PrivateEndpointIPVersionTypeDualStack),
+		string(PrivateEndpointIPVersionTypeIPvFour),
+		string(PrivateEndpointIPVersionTypeIPvSix),
+	}
+}
+
+func (s *PrivateEndpointIPVersionType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parsePrivateEndpointIPVersionType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parsePrivateEndpointIPVersionType(input string) (*PrivateEndpointIPVersionType, error) {
+	vals := map[string]PrivateEndpointIPVersionType{
+		"dualstack": PrivateEndpointIPVersionTypeDualStack,
+		"ipv4":      PrivateEndpointIPVersionTypeIPvFour,
+		"ipv6":      PrivateEndpointIPVersionTypeIPvSix,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := PrivateEndpointIPVersionType(input)
+	return &out, nil
+}
+
+type PrivateEndpointVNetPolicies string
+
+const (
+	PrivateEndpointVNetPoliciesBasic    PrivateEndpointVNetPolicies = "Basic"
+	PrivateEndpointVNetPoliciesDisabled PrivateEndpointVNetPolicies = "Disabled"
+)
+
+func PossibleValuesForPrivateEndpointVNetPolicies() []string {
+	return []string{
+		string(PrivateEndpointVNetPoliciesBasic),
+		string(PrivateEndpointVNetPoliciesDisabled),
+	}
+}
+
+func (s *PrivateEndpointVNetPolicies) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parsePrivateEndpointVNetPolicies(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parsePrivateEndpointVNetPolicies(input string) (*PrivateEndpointVNetPolicies, error) {
+	vals := map[string]PrivateEndpointVNetPolicies{
+		"basic":    PrivateEndpointVNetPoliciesBasic,
+		"disabled": PrivateEndpointVNetPoliciesDisabled,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := PrivateEndpointVNetPolicies(input)
+	return &out, nil
+}
+
+type ProvisioningState string
+
+const (
+	ProvisioningStateCanceled  ProvisioningState = "Canceled"
+	ProvisioningStateCreating  ProvisioningState = "Creating"
+	ProvisioningStateDeleting  ProvisioningState = "Deleting"
+	ProvisioningStateFailed    ProvisioningState = "Failed"
+	ProvisioningStateSucceeded ProvisioningState = "Succeeded"
+	ProvisioningStateUpdating  ProvisioningState = "Updating"
+)
+
+func PossibleValuesForProvisioningState() []string {
+	return []string{
+		string(ProvisioningStateCanceled),
+		string(ProvisioningStateCreating),
+		string(ProvisioningStateDeleting),
+		string(ProvisioningStateFailed),
+		string(ProvisioningStateSucceeded),
+		string(ProvisioningStateUpdating),
+	}
+}
+
+func (s *ProvisioningState) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseProvisioningState(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseProvisioningState(input string) (*ProvisioningState, error) {
+	vals := map[string]ProvisioningState{
+		"canceled":  ProvisioningStateCanceled,
+		"creating":  ProvisioningStateCreating,
+		"deleting":  ProvisioningStateDeleting,
+		"failed":    ProvisioningStateFailed,
+		"succeeded": ProvisioningStateSucceeded,
+		"updating":  ProvisioningStateUpdating,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ProvisioningState(input)
+	return &out, nil
+}
+
+type PublicIPAddressDnsSettingsDomainNameLabelScope string
+
+const (
+	PublicIPAddressDnsSettingsDomainNameLabelScopeNoReuse            PublicIPAddressDnsSettingsDomainNameLabelScope = "NoReuse"
+	PublicIPAddressDnsSettingsDomainNameLabelScopeResourceGroupReuse PublicIPAddressDnsSettingsDomainNameLabelScope = "ResourceGroupReuse"
+	PublicIPAddressDnsSettingsDomainNameLabelScopeSubscriptionReuse  PublicIPAddressDnsSettingsDomainNameLabelScope = "SubscriptionReuse"
+	PublicIPAddressDnsSettingsDomainNameLabelScopeTenantReuse        PublicIPAddressDnsSettingsDomainNameLabelScope = "TenantReuse"
+)
+
+func PossibleValuesForPublicIPAddressDnsSettingsDomainNameLabelScope() []string {
+	return []string{
+		string(PublicIPAddressDnsSettingsDomainNameLabelScopeNoReuse),
+		string(PublicIPAddressDnsSettingsDomainNameLabelScopeResourceGroupReuse),
+		string(PublicIPAddressDnsSettingsDomainNameLabelScopeSubscriptionReuse),
+		string(PublicIPAddressDnsSettingsDomainNameLabelScopeTenantReuse),
+	}
+}
+
+func (s *PublicIPAddressDnsSettingsDomainNameLabelScope) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parsePublicIPAddressDnsSettingsDomainNameLabelScope(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parsePublicIPAddressDnsSettingsDomainNameLabelScope(input string) (*PublicIPAddressDnsSettingsDomainNameLabelScope, error) {
+	vals := map[string]PublicIPAddressDnsSettingsDomainNameLabelScope{
+		"noreuse":            PublicIPAddressDnsSettingsDomainNameLabelScopeNoReuse,
+		"resourcegroupreuse": PublicIPAddressDnsSettingsDomainNameLabelScopeResourceGroupReuse,
+		"subscriptionreuse":  PublicIPAddressDnsSettingsDomainNameLabelScopeSubscriptionReuse,
+		"tenantreuse":        PublicIPAddressDnsSettingsDomainNameLabelScopeTenantReuse,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := PublicIPAddressDnsSettingsDomainNameLabelScope(input)
+	return &out, nil
+}
+
+type PublicIPAddressMigrationPhase string
+
+const (
+	PublicIPAddressMigrationPhaseAbort     PublicIPAddressMigrationPhase = "Abort"
+	PublicIPAddressMigrationPhaseCommit    PublicIPAddressMigrationPhase = "Commit"
+	PublicIPAddressMigrationPhaseCommitted PublicIPAddressMigrationPhase = "Committed"
+	PublicIPAddressMigrationPhaseNone      PublicIPAddressMigrationPhase = "None"
+	PublicIPAddressMigrationPhasePrepare   PublicIPAddressMigrationPhase = "Prepare"
+)
+
+func PossibleValuesForPublicIPAddressMigrationPhase() []string {
+	return []string{
+		string(PublicIPAddressMigrationPhaseAbort),
+		string(PublicIPAddressMigrationPhaseCommit),
+		string(PublicIPAddressMigrationPhaseCommitted),
+		string(PublicIPAddressMigrationPhaseNone),
+		string(PublicIPAddressMigrationPhasePrepare),
+	}
+}
+
+func (s *PublicIPAddressMigrationPhase) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parsePublicIPAddressMigrationPhase(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parsePublicIPAddressMigrationPhase(input string) (*PublicIPAddressMigrationPhase, error) {
+	vals := map[string]PublicIPAddressMigrationPhase{
+		"abort":     PublicIPAddressMigrationPhaseAbort,
+		"commit":    PublicIPAddressMigrationPhaseCommit,
+		"committed": PublicIPAddressMigrationPhaseCommitted,
+		"none":      PublicIPAddressMigrationPhaseNone,
+		"prepare":   PublicIPAddressMigrationPhasePrepare,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := PublicIPAddressMigrationPhase(input)
+	return &out, nil
+}
+
+type PublicIPAddressSkuName string
+
+const (
+	PublicIPAddressSkuNameBasic        PublicIPAddressSkuName = "Basic"
+	PublicIPAddressSkuNameStandard     PublicIPAddressSkuName = "Standard"
+	PublicIPAddressSkuNameStandardVTwo PublicIPAddressSkuName = "StandardV2"
+)
+
+func PossibleValuesForPublicIPAddressSkuName() []string {
+	return []string{
+		string(PublicIPAddressSkuNameBasic),
+		string(PublicIPAddressSkuNameStandard),
+		string(PublicIPAddressSkuNameStandardVTwo),
+	}
+}
+
+func (s *PublicIPAddressSkuName) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parsePublicIPAddressSkuName(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parsePublicIPAddressSkuName(input string) (*PublicIPAddressSkuName, error) {
+	vals := map[string]PublicIPAddressSkuName{
+		"basic":      PublicIPAddressSkuNameBasic,
+		"standard":   PublicIPAddressSkuNameStandard,
+		"standardv2": PublicIPAddressSkuNameStandardVTwo,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := PublicIPAddressSkuName(input)
+	return &out, nil
+}
+
+type PublicIPAddressSkuTier string
+
+const (
+	PublicIPAddressSkuTierGlobal   PublicIPAddressSkuTier = "Global"
+	PublicIPAddressSkuTierRegional PublicIPAddressSkuTier = "Regional"
+)
+
+func PossibleValuesForPublicIPAddressSkuTier() []string {
+	return []string{
+		string(PublicIPAddressSkuTierGlobal),
+		string(PublicIPAddressSkuTierRegional),
+	}
+}
+
+func (s *PublicIPAddressSkuTier) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parsePublicIPAddressSkuTier(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parsePublicIPAddressSkuTier(input string) (*PublicIPAddressSkuTier, error) {
+	vals := map[string]PublicIPAddressSkuTier{
+		"global":   PublicIPAddressSkuTierGlobal,
+		"regional": PublicIPAddressSkuTierRegional,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := PublicIPAddressSkuTier(input)
+	return &out, nil
+}
+
+type RouteNextHopType string
+
+const (
+	RouteNextHopTypeInternet              RouteNextHopType = "Internet"
+	RouteNextHopTypeNone                  RouteNextHopType = "None"
+	RouteNextHopTypeVirtualAppliance      RouteNextHopType = "VirtualAppliance"
+	RouteNextHopTypeVirtualApplianceEcmp  RouteNextHopType = "VirtualApplianceEcmp"
+	RouteNextHopTypeVirtualNetworkGateway RouteNextHopType = "VirtualNetworkGateway"
+	RouteNextHopTypeVnetLocal             RouteNextHopType = "VnetLocal"
+)
+
+func PossibleValuesForRouteNextHopType() []string {
+	return []string{
+		string(RouteNextHopTypeInternet),
+		string(RouteNextHopTypeNone),
+		string(RouteNextHopTypeVirtualAppliance),
+		string(RouteNextHopTypeVirtualApplianceEcmp),
+		string(RouteNextHopTypeVirtualNetworkGateway),
+		string(RouteNextHopTypeVnetLocal),
+	}
+}
+
+func (s *RouteNextHopType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseRouteNextHopType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseRouteNextHopType(input string) (*RouteNextHopType, error) {
+	vals := map[string]RouteNextHopType{
+		"internet":              RouteNextHopTypeInternet,
+		"none":                  RouteNextHopTypeNone,
+		"virtualappliance":      RouteNextHopTypeVirtualAppliance,
+		"virtualapplianceecmp":  RouteNextHopTypeVirtualApplianceEcmp,
+		"virtualnetworkgateway": RouteNextHopTypeVirtualNetworkGateway,
+		"vnetlocal":             RouteNextHopTypeVnetLocal,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := RouteNextHopType(input)
+	return &out, nil
+}
+
+type SecurityRuleAccess string
+
+const (
+	SecurityRuleAccessAllow SecurityRuleAccess = "Allow"
+	SecurityRuleAccessDeny  SecurityRuleAccess = "Deny"
+)
+
+func PossibleValuesForSecurityRuleAccess() []string {
+	return []string{
+		string(SecurityRuleAccessAllow),
+		string(SecurityRuleAccessDeny),
+	}
+}
+
+func (s *SecurityRuleAccess) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseSecurityRuleAccess(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseSecurityRuleAccess(input string) (*SecurityRuleAccess, error) {
+	vals := map[string]SecurityRuleAccess{
+		"allow": SecurityRuleAccessAllow,
+		"deny":  SecurityRuleAccessDeny,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := SecurityRuleAccess(input)
+	return &out, nil
+}
+
+type SecurityRuleDirection string
+
+const (
+	SecurityRuleDirectionInbound  SecurityRuleDirection = "Inbound"
+	SecurityRuleDirectionOutbound SecurityRuleDirection = "Outbound"
+)
+
+func PossibleValuesForSecurityRuleDirection() []string {
+	return []string{
+		string(SecurityRuleDirectionInbound),
+		string(SecurityRuleDirectionOutbound),
+	}
+}
+
+func (s *SecurityRuleDirection) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseSecurityRuleDirection(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseSecurityRuleDirection(input string) (*SecurityRuleDirection, error) {
+	vals := map[string]SecurityRuleDirection{
+		"inbound":  SecurityRuleDirectionInbound,
+		"outbound": SecurityRuleDirectionOutbound,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := SecurityRuleDirection(input)
+	return &out, nil
+}
+
+type SecurityRuleProtocol string
+
+const (
+	SecurityRuleProtocolAh   SecurityRuleProtocol = "Ah"
+	SecurityRuleProtocolAny  SecurityRuleProtocol = "*"
+	SecurityRuleProtocolEsp  SecurityRuleProtocol = "Esp"
+	SecurityRuleProtocolIcmp SecurityRuleProtocol = "Icmp"
+	SecurityRuleProtocolTcp  SecurityRuleProtocol = "Tcp"
+	SecurityRuleProtocolUdp  SecurityRuleProtocol = "Udp"
+)
+
+func PossibleValuesForSecurityRuleProtocol() []string {
+	return []string{
+		string(SecurityRuleProtocolAh),
+		string(SecurityRuleProtocolAny),
+		string(SecurityRuleProtocolEsp),
+		string(SecurityRuleProtocolIcmp),
+		string(SecurityRuleProtocolTcp),
+		string(SecurityRuleProtocolUdp),
+	}
+}
+
+func (s *SecurityRuleProtocol) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseSecurityRuleProtocol(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseSecurityRuleProtocol(input string) (*SecurityRuleProtocol, error) {
+	vals := map[string]SecurityRuleProtocol{
+		"ah":   SecurityRuleProtocolAh,
+		"*":    SecurityRuleProtocolAny,
+		"esp":  SecurityRuleProtocolEsp,
+		"icmp": SecurityRuleProtocolIcmp,
+		"tcp":  SecurityRuleProtocolTcp,
+		"udp":  SecurityRuleProtocolUdp,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := SecurityRuleProtocol(input)
+	return &out, nil
+}
+
+type SharingScope string
+
+const (
+	SharingScopeDelegatedServices SharingScope = "DelegatedServices"
+	SharingScopeTenant            SharingScope = "Tenant"
+)
+
+func PossibleValuesForSharingScope() []string {
+	return []string{
+		string(SharingScopeDelegatedServices),
+		string(SharingScopeTenant),
+	}
+}
+
+func (s *SharingScope) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseSharingScope(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseSharingScope(input string) (*SharingScope, error) {
+	vals := map[string]SharingScope{
+		"delegatedservices": SharingScopeDelegatedServices,
+		"tenant":            SharingScopeTenant,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := SharingScope(input)
+	return &out, nil
+}
+
+type SyncMode string
+
+const (
+	SyncModeAutomatic SyncMode = "Automatic"
+	SyncModeManual    SyncMode = "Manual"
+)
+
+func PossibleValuesForSyncMode() []string {
+	return []string{
+		string(SyncModeAutomatic),
+		string(SyncModeManual),
+	}
+}
+
+func (s *SyncMode) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseSyncMode(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseSyncMode(input string) (*SyncMode, error) {
+	vals := map[string]SyncMode{
+		"automatic": SyncModeAutomatic,
+		"manual":    SyncModeManual,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := SyncMode(input)
+	return &out, nil
+}
+
+type TransportProtocol string
+
+const (
+	TransportProtocolAll  TransportProtocol = "All"
+	TransportProtocolQuic TransportProtocol = "Quic"
+	TransportProtocolTcp  TransportProtocol = "Tcp"
+	TransportProtocolUdp  TransportProtocol = "Udp"
+)
+
+func PossibleValuesForTransportProtocol() []string {
+	return []string{
+		string(TransportProtocolAll),
+		string(TransportProtocolQuic),
+		string(TransportProtocolTcp),
+		string(TransportProtocolUdp),
+	}
+}
+
+func (s *TransportProtocol) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseTransportProtocol(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseTransportProtocol(input string) (*TransportProtocol, error) {
+	vals := map[string]TransportProtocol{
+		"all":  TransportProtocolAll,
+		"quic": TransportProtocolQuic,
+		"tcp":  TransportProtocolTcp,
+		"udp":  TransportProtocolUdp,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := TransportProtocol(input)
+	return &out, nil
+}
+
+type VirtualNetworkEncryptionEnforcement string
+
+const (
+	VirtualNetworkEncryptionEnforcementAllowUnencrypted VirtualNetworkEncryptionEnforcement = "AllowUnencrypted"
+	VirtualNetworkEncryptionEnforcementDropUnencrypted  VirtualNetworkEncryptionEnforcement = "DropUnencrypted"
+)
+
+func PossibleValuesForVirtualNetworkEncryptionEnforcement() []string {
+	return []string{
+		string(VirtualNetworkEncryptionEnforcementAllowUnencrypted),
+		string(VirtualNetworkEncryptionEnforcementDropUnencrypted),
+	}
+}
+
+func (s *VirtualNetworkEncryptionEnforcement) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseVirtualNetworkEncryptionEnforcement(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseVirtualNetworkEncryptionEnforcement(input string) (*VirtualNetworkEncryptionEnforcement, error) {
+	vals := map[string]VirtualNetworkEncryptionEnforcement{
+		"allowunencrypted": VirtualNetworkEncryptionEnforcementAllowUnencrypted,
+		"dropunencrypted":  VirtualNetworkEncryptionEnforcementDropUnencrypted,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := VirtualNetworkEncryptionEnforcement(input)
+	return &out, nil
+}
+
+type VirtualNetworkPeeringLevel string
+
+const (
+	VirtualNetworkPeeringLevelFullyInSync             VirtualNetworkPeeringLevel = "FullyInSync"
+	VirtualNetworkPeeringLevelLocalAndRemoteNotInSync VirtualNetworkPeeringLevel = "LocalAndRemoteNotInSync"
+	VirtualNetworkPeeringLevelLocalNotInSync          VirtualNetworkPeeringLevel = "LocalNotInSync"
+	VirtualNetworkPeeringLevelRemoteNotInSync         VirtualNetworkPeeringLevel = "RemoteNotInSync"
+)
+
+func PossibleValuesForVirtualNetworkPeeringLevel() []string {
+	return []string{
+		string(VirtualNetworkPeeringLevelFullyInSync),
+		string(VirtualNetworkPeeringLevelLocalAndRemoteNotInSync),
+		string(VirtualNetworkPeeringLevelLocalNotInSync),
+		string(VirtualNetworkPeeringLevelRemoteNotInSync),
+	}
+}
+
+func (s *VirtualNetworkPeeringLevel) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseVirtualNetworkPeeringLevel(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseVirtualNetworkPeeringLevel(input string) (*VirtualNetworkPeeringLevel, error) {
+	vals := map[string]VirtualNetworkPeeringLevel{
+		"fullyinsync":             VirtualNetworkPeeringLevelFullyInSync,
+		"localandremotenotinsync": VirtualNetworkPeeringLevelLocalAndRemoteNotInSync,
+		"localnotinsync":          VirtualNetworkPeeringLevelLocalNotInSync,
+		"remotenotinsync":         VirtualNetworkPeeringLevelRemoteNotInSync,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := VirtualNetworkPeeringLevel(input)
+	return &out, nil
+}
+
+type VirtualNetworkPeeringState string
+
+const (
+	VirtualNetworkPeeringStateConnected    VirtualNetworkPeeringState = "Connected"
+	VirtualNetworkPeeringStateDisconnected VirtualNetworkPeeringState = "Disconnected"
+	VirtualNetworkPeeringStateInitiated    VirtualNetworkPeeringState = "Initiated"
+)
+
+func PossibleValuesForVirtualNetworkPeeringState() []string {
+	return []string{
+		string(VirtualNetworkPeeringStateConnected),
+		string(VirtualNetworkPeeringStateDisconnected),
+		string(VirtualNetworkPeeringStateInitiated),
+	}
+}
+
+func (s *VirtualNetworkPeeringState) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseVirtualNetworkPeeringState(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseVirtualNetworkPeeringState(input string) (*VirtualNetworkPeeringState, error) {
+	vals := map[string]VirtualNetworkPeeringState{
+		"connected":    VirtualNetworkPeeringStateConnected,
+		"disconnected": VirtualNetworkPeeringStateDisconnected,
+		"initiated":    VirtualNetworkPeeringStateInitiated,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := VirtualNetworkPeeringState(input)
+	return &out, nil
+}
+
+type VirtualNetworkPrivateEndpointNetworkPolicies string
+
+const (
+	VirtualNetworkPrivateEndpointNetworkPoliciesDisabled                    VirtualNetworkPrivateEndpointNetworkPolicies = "Disabled"
+	VirtualNetworkPrivateEndpointNetworkPoliciesEnabled                     VirtualNetworkPrivateEndpointNetworkPolicies = "Enabled"
+	VirtualNetworkPrivateEndpointNetworkPoliciesNetworkSecurityGroupEnabled VirtualNetworkPrivateEndpointNetworkPolicies = "NetworkSecurityGroupEnabled"
+	VirtualNetworkPrivateEndpointNetworkPoliciesRouteTableEnabled           VirtualNetworkPrivateEndpointNetworkPolicies = "RouteTableEnabled"
+)
+
+func PossibleValuesForVirtualNetworkPrivateEndpointNetworkPolicies() []string {
+	return []string{
+		string(VirtualNetworkPrivateEndpointNetworkPoliciesDisabled),
+		string(VirtualNetworkPrivateEndpointNetworkPoliciesEnabled),
+		string(VirtualNetworkPrivateEndpointNetworkPoliciesNetworkSecurityGroupEnabled),
+		string(VirtualNetworkPrivateEndpointNetworkPoliciesRouteTableEnabled),
+	}
+}
+
+func (s *VirtualNetworkPrivateEndpointNetworkPolicies) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseVirtualNetworkPrivateEndpointNetworkPolicies(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseVirtualNetworkPrivateEndpointNetworkPolicies(input string) (*VirtualNetworkPrivateEndpointNetworkPolicies, error) {
+	vals := map[string]VirtualNetworkPrivateEndpointNetworkPolicies{
+		"disabled":                    VirtualNetworkPrivateEndpointNetworkPoliciesDisabled,
+		"enabled":                     VirtualNetworkPrivateEndpointNetworkPoliciesEnabled,
+		"networksecuritygroupenabled": VirtualNetworkPrivateEndpointNetworkPoliciesNetworkSecurityGroupEnabled,
+		"routetableenabled":           VirtualNetworkPrivateEndpointNetworkPoliciesRouteTableEnabled,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := VirtualNetworkPrivateEndpointNetworkPolicies(input)
+	return &out, nil
+}
+
+type VirtualNetworkPrivateLinkServiceNetworkPolicies string
+
+const (
+	VirtualNetworkPrivateLinkServiceNetworkPoliciesDisabled VirtualNetworkPrivateLinkServiceNetworkPolicies = "Disabled"
+	VirtualNetworkPrivateLinkServiceNetworkPoliciesEnabled  VirtualNetworkPrivateLinkServiceNetworkPolicies = "Enabled"
+)
+
+func PossibleValuesForVirtualNetworkPrivateLinkServiceNetworkPolicies() []string {
+	return []string{
+		string(VirtualNetworkPrivateLinkServiceNetworkPoliciesDisabled),
+		string(VirtualNetworkPrivateLinkServiceNetworkPoliciesEnabled),
+	}
+}
+
+func (s *VirtualNetworkPrivateLinkServiceNetworkPolicies) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseVirtualNetworkPrivateLinkServiceNetworkPolicies(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseVirtualNetworkPrivateLinkServiceNetworkPolicies(input string) (*VirtualNetworkPrivateLinkServiceNetworkPolicies, error) {
+	vals := map[string]VirtualNetworkPrivateLinkServiceNetworkPolicies{
+		"disabled": VirtualNetworkPrivateLinkServiceNetworkPoliciesDisabled,
+		"enabled":  VirtualNetworkPrivateLinkServiceNetworkPoliciesEnabled,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := VirtualNetworkPrivateLinkServiceNetworkPolicies(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/id_inboundsecurityrule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/id_inboundsecurityrule.go
@@ -1,0 +1,139 @@
+package virtualnetworks
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&InboundSecurityRuleId{})
+}
+
+var _ resourceids.ResourceId = &InboundSecurityRuleId{}
+
+// InboundSecurityRuleId is a struct representing the Resource ID for a Inbound Security Rule
+type InboundSecurityRuleId struct {
+	SubscriptionId              string
+	ResourceGroupName           string
+	NetworkVirtualApplianceName string
+	InboundSecurityRuleName     string
+}
+
+// NewInboundSecurityRuleID returns a new InboundSecurityRuleId struct
+func NewInboundSecurityRuleID(subscriptionId string, resourceGroupName string, networkVirtualApplianceName string, inboundSecurityRuleName string) InboundSecurityRuleId {
+	return InboundSecurityRuleId{
+		SubscriptionId:              subscriptionId,
+		ResourceGroupName:           resourceGroupName,
+		NetworkVirtualApplianceName: networkVirtualApplianceName,
+		InboundSecurityRuleName:     inboundSecurityRuleName,
+	}
+}
+
+// ParseInboundSecurityRuleID parses 'input' into a InboundSecurityRuleId
+func ParseInboundSecurityRuleID(input string) (*InboundSecurityRuleId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&InboundSecurityRuleId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := InboundSecurityRuleId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseInboundSecurityRuleIDInsensitively parses 'input' case-insensitively into a InboundSecurityRuleId
+// note: this method should only be used for API response data and not user input
+func ParseInboundSecurityRuleIDInsensitively(input string) (*InboundSecurityRuleId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&InboundSecurityRuleId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := InboundSecurityRuleId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *InboundSecurityRuleId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.NetworkVirtualApplianceName, ok = input.Parsed["networkVirtualApplianceName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "networkVirtualApplianceName", input)
+	}
+
+	if id.InboundSecurityRuleName, ok = input.Parsed["inboundSecurityRuleName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "inboundSecurityRuleName", input)
+	}
+
+	return nil
+}
+
+// ValidateInboundSecurityRuleID checks that 'input' can be parsed as a Inbound Security Rule ID
+func ValidateInboundSecurityRuleID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseInboundSecurityRuleID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Inbound Security Rule ID
+func (id InboundSecurityRuleId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/networkVirtualAppliances/%s/inboundSecurityRules/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.NetworkVirtualApplianceName, id.InboundSecurityRuleName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Inbound Security Rule ID
+func (id InboundSecurityRuleId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftNetwork", "Microsoft.Network", "Microsoft.Network"),
+		resourceids.StaticSegment("staticNetworkVirtualAppliances", "networkVirtualAppliances", "networkVirtualAppliances"),
+		resourceids.UserSpecifiedSegment("networkVirtualApplianceName", "networkVirtualApplianceName"),
+		resourceids.StaticSegment("staticInboundSecurityRules", "inboundSecurityRules", "inboundSecurityRules"),
+		resourceids.UserSpecifiedSegment("inboundSecurityRuleName", "inboundSecurityRuleName"),
+	}
+}
+
+// String returns a human-readable description of this Inbound Security Rule ID
+func (id InboundSecurityRuleId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Network Virtual Appliance Name: %q", id.NetworkVirtualApplianceName),
+		fmt.Sprintf("Inbound Security Rule Name: %q", id.InboundSecurityRuleName),
+	}
+	return fmt.Sprintf("Inbound Security Rule (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/id_location.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/id_location.go
@@ -1,0 +1,121 @@
+package virtualnetworks
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&LocationId{})
+}
+
+var _ resourceids.ResourceId = &LocationId{}
+
+// LocationId is a struct representing the Resource ID for a Location
+type LocationId struct {
+	SubscriptionId string
+	LocationName   string
+}
+
+// NewLocationID returns a new LocationId struct
+func NewLocationID(subscriptionId string, locationName string) LocationId {
+	return LocationId{
+		SubscriptionId: subscriptionId,
+		LocationName:   locationName,
+	}
+}
+
+// ParseLocationID parses 'input' into a LocationId
+func ParseLocationID(input string) (*LocationId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&LocationId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := LocationId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseLocationIDInsensitively parses 'input' case-insensitively into a LocationId
+// note: this method should only be used for API response data and not user input
+func ParseLocationIDInsensitively(input string) (*LocationId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&LocationId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := LocationId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *LocationId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.LocationName, ok = input.Parsed["locationName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "locationName", input)
+	}
+
+	return nil
+}
+
+// ValidateLocationID checks that 'input' can be parsed as a Location ID
+func ValidateLocationID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseLocationID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Location ID
+func (id LocationId) ID() string {
+	fmtString := "/subscriptions/%s/providers/Microsoft.Network/locations/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.LocationName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Location ID
+func (id LocationId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftNetwork", "Microsoft.Network", "Microsoft.Network"),
+		resourceids.StaticSegment("staticLocations", "locations", "locations"),
+		resourceids.UserSpecifiedSegment("locationName", "locationName"),
+	}
+}
+
+// String returns a human-readable description of this Location ID
+func (id LocationId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Location Name: %q", id.LocationName),
+	}
+	return fmt.Sprintf("Location (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/id_providercloudservice.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/id_providercloudservice.go
@@ -1,0 +1,130 @@
+package virtualnetworks
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&ProviderCloudServiceId{})
+}
+
+var _ resourceids.ResourceId = &ProviderCloudServiceId{}
+
+// ProviderCloudServiceId is a struct representing the Resource ID for a Provider Cloud Service
+type ProviderCloudServiceId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	CloudServiceName  string
+}
+
+// NewProviderCloudServiceID returns a new ProviderCloudServiceId struct
+func NewProviderCloudServiceID(subscriptionId string, resourceGroupName string, cloudServiceName string) ProviderCloudServiceId {
+	return ProviderCloudServiceId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		CloudServiceName:  cloudServiceName,
+	}
+}
+
+// ParseProviderCloudServiceID parses 'input' into a ProviderCloudServiceId
+func ParseProviderCloudServiceID(input string) (*ProviderCloudServiceId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&ProviderCloudServiceId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := ProviderCloudServiceId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseProviderCloudServiceIDInsensitively parses 'input' case-insensitively into a ProviderCloudServiceId
+// note: this method should only be used for API response data and not user input
+func ParseProviderCloudServiceIDInsensitively(input string) (*ProviderCloudServiceId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&ProviderCloudServiceId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := ProviderCloudServiceId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *ProviderCloudServiceId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.CloudServiceName, ok = input.Parsed["cloudServiceName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "cloudServiceName", input)
+	}
+
+	return nil
+}
+
+// ValidateProviderCloudServiceID checks that 'input' can be parsed as a Provider Cloud Service ID
+func ValidateProviderCloudServiceID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseProviderCloudServiceID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Provider Cloud Service ID
+func (id ProviderCloudServiceId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/cloudServices/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.CloudServiceName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Provider Cloud Service ID
+func (id ProviderCloudServiceId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftCompute", "Microsoft.Compute", "Microsoft.Compute"),
+		resourceids.StaticSegment("staticCloudServices", "cloudServices", "cloudServices"),
+		resourceids.UserSpecifiedSegment("cloudServiceName", "cloudServiceName"),
+	}
+}
+
+// String returns a human-readable description of this Provider Cloud Service ID
+func (id ProviderCloudServiceId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Cloud Service Name: %q", id.CloudServiceName),
+	}
+	return fmt.Sprintf("Provider Cloud Service (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/id_providerlocation.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/id_providerlocation.go
@@ -1,0 +1,130 @@
+package virtualnetworks
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&ProviderLocationId{})
+}
+
+var _ resourceids.ResourceId = &ProviderLocationId{}
+
+// ProviderLocationId is a struct representing the Resource ID for a Provider Location
+type ProviderLocationId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	LocationName      string
+}
+
+// NewProviderLocationID returns a new ProviderLocationId struct
+func NewProviderLocationID(subscriptionId string, resourceGroupName string, locationName string) ProviderLocationId {
+	return ProviderLocationId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		LocationName:      locationName,
+	}
+}
+
+// ParseProviderLocationID parses 'input' into a ProviderLocationId
+func ParseProviderLocationID(input string) (*ProviderLocationId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&ProviderLocationId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := ProviderLocationId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseProviderLocationIDInsensitively parses 'input' case-insensitively into a ProviderLocationId
+// note: this method should only be used for API response data and not user input
+func ParseProviderLocationIDInsensitively(input string) (*ProviderLocationId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&ProviderLocationId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := ProviderLocationId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *ProviderLocationId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.LocationName, ok = input.Parsed["locationName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "locationName", input)
+	}
+
+	return nil
+}
+
+// ValidateProviderLocationID checks that 'input' can be parsed as a Provider Location ID
+func ValidateProviderLocationID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseProviderLocationID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Provider Location ID
+func (id ProviderLocationId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/locations/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.LocationName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Provider Location ID
+func (id ProviderLocationId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftNetwork", "Microsoft.Network", "Microsoft.Network"),
+		resourceids.StaticSegment("staticLocations", "locations", "locations"),
+		resourceids.UserSpecifiedSegment("locationName", "locationName"),
+	}
+}
+
+// String returns a human-readable description of this Provider Location ID
+func (id ProviderLocationId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Location Name: %q", id.LocationName),
+	}
+	return fmt.Sprintf("Provider Location (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/method_availabledelegationslist.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/method_availabledelegationslist.go
@@ -1,0 +1,105 @@
+package virtualnetworks
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AvailableDelegationsListOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]AvailableDelegation
+}
+
+type AvailableDelegationsListCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []AvailableDelegation
+}
+
+type AvailableDelegationsListCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *AvailableDelegationsListCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// AvailableDelegationsList ...
+func (c VirtualNetworksClient) AvailableDelegationsList(ctx context.Context, id LocationId) (result AvailableDelegationsListOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Pager:      &AvailableDelegationsListCustomPager{},
+		Path:       fmt.Sprintf("%s/availableDelegations", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]AvailableDelegation `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// AvailableDelegationsListComplete retrieves all the results into a single object
+func (c VirtualNetworksClient) AvailableDelegationsListComplete(ctx context.Context, id LocationId) (AvailableDelegationsListCompleteResult, error) {
+	return c.AvailableDelegationsListCompleteMatchingPredicate(ctx, id, AvailableDelegationOperationPredicate{})
+}
+
+// AvailableDelegationsListCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c VirtualNetworksClient) AvailableDelegationsListCompleteMatchingPredicate(ctx context.Context, id LocationId, predicate AvailableDelegationOperationPredicate) (result AvailableDelegationsListCompleteResult, err error) {
+	items := make([]AvailableDelegation, 0)
+
+	resp, err := c.AvailableDelegationsList(ctx, id)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = AvailableDelegationsListCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/method_availableendpointserviceslist.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/method_availableendpointserviceslist.go
@@ -1,0 +1,105 @@
+package virtualnetworks
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AvailableEndpointServicesListOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]EndpointServiceResult
+}
+
+type AvailableEndpointServicesListCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []EndpointServiceResult
+}
+
+type AvailableEndpointServicesListCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *AvailableEndpointServicesListCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// AvailableEndpointServicesList ...
+func (c VirtualNetworksClient) AvailableEndpointServicesList(ctx context.Context, id LocationId) (result AvailableEndpointServicesListOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Pager:      &AvailableEndpointServicesListCustomPager{},
+		Path:       fmt.Sprintf("%s/virtualNetworkAvailableEndpointServices", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]EndpointServiceResult `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// AvailableEndpointServicesListComplete retrieves all the results into a single object
+func (c VirtualNetworksClient) AvailableEndpointServicesListComplete(ctx context.Context, id LocationId) (AvailableEndpointServicesListCompleteResult, error) {
+	return c.AvailableEndpointServicesListCompleteMatchingPredicate(ctx, id, EndpointServiceResultOperationPredicate{})
+}
+
+// AvailableEndpointServicesListCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c VirtualNetworksClient) AvailableEndpointServicesListCompleteMatchingPredicate(ctx context.Context, id LocationId, predicate EndpointServiceResultOperationPredicate) (result AvailableEndpointServicesListCompleteResult, err error) {
+	items := make([]EndpointServiceResult, 0)
+
+	resp, err := c.AvailableEndpointServicesList(ctx, id)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = AvailableEndpointServicesListCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/method_availableprivateendpointtypeslist.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/method_availableprivateendpointtypeslist.go
@@ -1,0 +1,105 @@
+package virtualnetworks
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AvailablePrivateEndpointTypesListOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]AvailablePrivateEndpointType
+}
+
+type AvailablePrivateEndpointTypesListCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []AvailablePrivateEndpointType
+}
+
+type AvailablePrivateEndpointTypesListCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *AvailablePrivateEndpointTypesListCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// AvailablePrivateEndpointTypesList ...
+func (c VirtualNetworksClient) AvailablePrivateEndpointTypesList(ctx context.Context, id LocationId) (result AvailablePrivateEndpointTypesListOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Pager:      &AvailablePrivateEndpointTypesListCustomPager{},
+		Path:       fmt.Sprintf("%s/availablePrivateEndpointTypes", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]AvailablePrivateEndpointType `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// AvailablePrivateEndpointTypesListComplete retrieves all the results into a single object
+func (c VirtualNetworksClient) AvailablePrivateEndpointTypesListComplete(ctx context.Context, id LocationId) (AvailablePrivateEndpointTypesListCompleteResult, error) {
+	return c.AvailablePrivateEndpointTypesListCompleteMatchingPredicate(ctx, id, AvailablePrivateEndpointTypeOperationPredicate{})
+}
+
+// AvailablePrivateEndpointTypesListCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c VirtualNetworksClient) AvailablePrivateEndpointTypesListCompleteMatchingPredicate(ctx context.Context, id LocationId, predicate AvailablePrivateEndpointTypeOperationPredicate) (result AvailablePrivateEndpointTypesListCompleteResult, err error) {
+	items := make([]AvailablePrivateEndpointType, 0)
+
+	resp, err := c.AvailablePrivateEndpointTypesList(ctx, id)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = AvailablePrivateEndpointTypesListCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/method_availableprivateendpointtypeslistbyresourcegroup.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/method_availableprivateendpointtypeslistbyresourcegroup.go
@@ -1,0 +1,105 @@
+package virtualnetworks
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AvailablePrivateEndpointTypesListByResourceGroupOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]AvailablePrivateEndpointType
+}
+
+type AvailablePrivateEndpointTypesListByResourceGroupCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []AvailablePrivateEndpointType
+}
+
+type AvailablePrivateEndpointTypesListByResourceGroupCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *AvailablePrivateEndpointTypesListByResourceGroupCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// AvailablePrivateEndpointTypesListByResourceGroup ...
+func (c VirtualNetworksClient) AvailablePrivateEndpointTypesListByResourceGroup(ctx context.Context, id ProviderLocationId) (result AvailablePrivateEndpointTypesListByResourceGroupOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Pager:      &AvailablePrivateEndpointTypesListByResourceGroupCustomPager{},
+		Path:       fmt.Sprintf("%s/availablePrivateEndpointTypes", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]AvailablePrivateEndpointType `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// AvailablePrivateEndpointTypesListByResourceGroupComplete retrieves all the results into a single object
+func (c VirtualNetworksClient) AvailablePrivateEndpointTypesListByResourceGroupComplete(ctx context.Context, id ProviderLocationId) (AvailablePrivateEndpointTypesListByResourceGroupCompleteResult, error) {
+	return c.AvailablePrivateEndpointTypesListByResourceGroupCompleteMatchingPredicate(ctx, id, AvailablePrivateEndpointTypeOperationPredicate{})
+}
+
+// AvailablePrivateEndpointTypesListByResourceGroupCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c VirtualNetworksClient) AvailablePrivateEndpointTypesListByResourceGroupCompleteMatchingPredicate(ctx context.Context, id ProviderLocationId, predicate AvailablePrivateEndpointTypeOperationPredicate) (result AvailablePrivateEndpointTypesListByResourceGroupCompleteResult, err error) {
+	items := make([]AvailablePrivateEndpointType, 0)
+
+	resp, err := c.AvailablePrivateEndpointTypesListByResourceGroup(ctx, id)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = AvailablePrivateEndpointTypesListByResourceGroupCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/method_availableresourcegroupdelegationslist.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/method_availableresourcegroupdelegationslist.go
@@ -1,0 +1,105 @@
+package virtualnetworks
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AvailableResourceGroupDelegationsListOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]AvailableDelegation
+}
+
+type AvailableResourceGroupDelegationsListCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []AvailableDelegation
+}
+
+type AvailableResourceGroupDelegationsListCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *AvailableResourceGroupDelegationsListCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// AvailableResourceGroupDelegationsList ...
+func (c VirtualNetworksClient) AvailableResourceGroupDelegationsList(ctx context.Context, id ProviderLocationId) (result AvailableResourceGroupDelegationsListOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Pager:      &AvailableResourceGroupDelegationsListCustomPager{},
+		Path:       fmt.Sprintf("%s/availableDelegations", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]AvailableDelegation `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// AvailableResourceGroupDelegationsListComplete retrieves all the results into a single object
+func (c VirtualNetworksClient) AvailableResourceGroupDelegationsListComplete(ctx context.Context, id ProviderLocationId) (AvailableResourceGroupDelegationsListCompleteResult, error) {
+	return c.AvailableResourceGroupDelegationsListCompleteMatchingPredicate(ctx, id, AvailableDelegationOperationPredicate{})
+}
+
+// AvailableResourceGroupDelegationsListCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c VirtualNetworksClient) AvailableResourceGroupDelegationsListCompleteMatchingPredicate(ctx context.Context, id ProviderLocationId, predicate AvailableDelegationOperationPredicate) (result AvailableResourceGroupDelegationsListCompleteResult, err error) {
+	items := make([]AvailableDelegation, 0)
+
+	resp, err := c.AvailableResourceGroupDelegationsList(ctx, id)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = AvailableResourceGroupDelegationsListCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/method_availableservicealiaseslist.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/method_availableservicealiaseslist.go
@@ -1,0 +1,105 @@
+package virtualnetworks
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AvailableServiceAliasesListOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]AvailableServiceAlias
+}
+
+type AvailableServiceAliasesListCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []AvailableServiceAlias
+}
+
+type AvailableServiceAliasesListCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *AvailableServiceAliasesListCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// AvailableServiceAliasesList ...
+func (c VirtualNetworksClient) AvailableServiceAliasesList(ctx context.Context, id LocationId) (result AvailableServiceAliasesListOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Pager:      &AvailableServiceAliasesListCustomPager{},
+		Path:       fmt.Sprintf("%s/availableServiceAliases", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]AvailableServiceAlias `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// AvailableServiceAliasesListComplete retrieves all the results into a single object
+func (c VirtualNetworksClient) AvailableServiceAliasesListComplete(ctx context.Context, id LocationId) (AvailableServiceAliasesListCompleteResult, error) {
+	return c.AvailableServiceAliasesListCompleteMatchingPredicate(ctx, id, AvailableServiceAliasOperationPredicate{})
+}
+
+// AvailableServiceAliasesListCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c VirtualNetworksClient) AvailableServiceAliasesListCompleteMatchingPredicate(ctx context.Context, id LocationId, predicate AvailableServiceAliasOperationPredicate) (result AvailableServiceAliasesListCompleteResult, err error) {
+	items := make([]AvailableServiceAlias, 0)
+
+	resp, err := c.AvailableServiceAliasesList(ctx, id)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = AvailableServiceAliasesListCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/method_availableservicealiaseslistbyresourcegroup.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/method_availableservicealiaseslistbyresourcegroup.go
@@ -1,0 +1,105 @@
+package virtualnetworks
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AvailableServiceAliasesListByResourceGroupOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]AvailableServiceAlias
+}
+
+type AvailableServiceAliasesListByResourceGroupCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []AvailableServiceAlias
+}
+
+type AvailableServiceAliasesListByResourceGroupCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *AvailableServiceAliasesListByResourceGroupCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// AvailableServiceAliasesListByResourceGroup ...
+func (c VirtualNetworksClient) AvailableServiceAliasesListByResourceGroup(ctx context.Context, id ProviderLocationId) (result AvailableServiceAliasesListByResourceGroupOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Pager:      &AvailableServiceAliasesListByResourceGroupCustomPager{},
+		Path:       fmt.Sprintf("%s/availableServiceAliases", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]AvailableServiceAlias `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// AvailableServiceAliasesListByResourceGroupComplete retrieves all the results into a single object
+func (c VirtualNetworksClient) AvailableServiceAliasesListByResourceGroupComplete(ctx context.Context, id ProviderLocationId) (AvailableServiceAliasesListByResourceGroupCompleteResult, error) {
+	return c.AvailableServiceAliasesListByResourceGroupCompleteMatchingPredicate(ctx, id, AvailableServiceAliasOperationPredicate{})
+}
+
+// AvailableServiceAliasesListByResourceGroupCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c VirtualNetworksClient) AvailableServiceAliasesListByResourceGroupCompleteMatchingPredicate(ctx context.Context, id ProviderLocationId, predicate AvailableServiceAliasOperationPredicate) (result AvailableServiceAliasesListByResourceGroupCompleteResult, err error) {
+	items := make([]AvailableServiceAlias, 0)
+
+	resp, err := c.AvailableServiceAliasesListByResourceGroup(ctx, id)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = AvailableServiceAliasesListByResourceGroupCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/method_checkdnsnameavailability.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/method_checkdnsnameavailability.go
@@ -1,0 +1,83 @@
+package virtualnetworks
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CheckDnsNameAvailabilityOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *DnsNameAvailabilityResult
+}
+
+type CheckDnsNameAvailabilityOperationOptions struct {
+	DomainNameLabel *string
+}
+
+func DefaultCheckDnsNameAvailabilityOperationOptions() CheckDnsNameAvailabilityOperationOptions {
+	return CheckDnsNameAvailabilityOperationOptions{}
+}
+
+func (o CheckDnsNameAvailabilityOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+
+	return &out
+}
+
+func (o CheckDnsNameAvailabilityOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+
+	return &out
+}
+
+func (o CheckDnsNameAvailabilityOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+	if o.DomainNameLabel != nil {
+		out.Append("domainNameLabel", fmt.Sprintf("%v", *o.DomainNameLabel))
+	}
+	return &out
+}
+
+// CheckDnsNameAvailability ...
+func (c VirtualNetworksClient) CheckDnsNameAvailability(ctx context.Context, id LocationId, options CheckDnsNameAvailabilityOperationOptions) (result CheckDnsNameAvailabilityOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodGet,
+		OptionsObject: options,
+		Path:          fmt.Sprintf("%s/checkDnsNameAvailability", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model DnsNameAvailabilityResult
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/method_createorupdate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/method_createorupdate.go
@@ -1,0 +1,87 @@
+package virtualnetworks
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateOrUpdateOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *VirtualNetwork
+}
+
+// CreateOrUpdate ...
+func (c VirtualNetworksClient) CreateOrUpdate(ctx context.Context, id commonids.VirtualNetworkId, input VirtualNetwork) (result CreateOrUpdateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPut,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// CreateOrUpdateThenPoll performs CreateOrUpdate then polls until it's completed
+func (c VirtualNetworksClient) CreateOrUpdateThenPoll(ctx context.Context, id commonids.VirtualNetworkId, input VirtualNetwork) error {
+	return c.CreateOrUpdateCallbackThenPoll(ctx, id, input, nil)
+}
+
+// CreateOrUpdateCallbackThenPoll performs CreateOrUpdate, runs the optional callback function, then polls until it's completed
+func (c VirtualNetworksClient) CreateOrUpdateCallbackThenPoll(ctx context.Context, id commonids.VirtualNetworkId, input VirtualNetwork, callback func() error) error {
+	result, err := c.CreateOrUpdate(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing CreateOrUpdate: %+v", err)
+	}
+
+	if callback != nil {
+		if err := callback(); err != nil {
+			return fmt.Errorf("executing callback function: %+v", err)
+		}
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after CreateOrUpdate: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/method_delete.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/method_delete.go
@@ -1,0 +1,72 @@
+package virtualnetworks
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeleteOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// Delete ...
+func (c VirtualNetworksClient) Delete(ctx context.Context, id commonids.VirtualNetworkId) (result DeleteOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusNoContent,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodDelete,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// DeleteThenPoll performs Delete then polls until it's completed
+func (c VirtualNetworksClient) DeleteThenPoll(ctx context.Context, id commonids.VirtualNetworkId) error {
+	result, err := c.Delete(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing Delete: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Delete: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/method_get.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/method_get.go
@@ -1,0 +1,84 @@
+package virtualnetworks
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *VirtualNetwork
+}
+
+type GetOperationOptions struct {
+	Expand *string
+}
+
+func DefaultGetOperationOptions() GetOperationOptions {
+	return GetOperationOptions{}
+}
+
+func (o GetOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+
+	return &out
+}
+
+func (o GetOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+
+	return &out
+}
+
+func (o GetOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+	if o.Expand != nil {
+		out.Append("$expand", fmt.Sprintf("%v", *o.Expand))
+	}
+	return &out
+}
+
+// Get ...
+func (c VirtualNetworksClient) Get(ctx context.Context, id commonids.VirtualNetworkId, options GetOperationOptions) (result GetOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodGet,
+		OptionsObject: options,
+		Path:          id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model VirtualNetwork
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/method_inboundsecurityrulecreateorupdate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/method_inboundsecurityrulecreateorupdate.go
@@ -1,0 +1,86 @@
+package virtualnetworks
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InboundSecurityRuleCreateOrUpdateOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *InboundSecurityRule
+}
+
+// InboundSecurityRuleCreateOrUpdate ...
+func (c VirtualNetworksClient) InboundSecurityRuleCreateOrUpdate(ctx context.Context, id InboundSecurityRuleId, input InboundSecurityRule) (result InboundSecurityRuleCreateOrUpdateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPut,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// InboundSecurityRuleCreateOrUpdateThenPoll performs InboundSecurityRuleCreateOrUpdate then polls until it's completed
+func (c VirtualNetworksClient) InboundSecurityRuleCreateOrUpdateThenPoll(ctx context.Context, id InboundSecurityRuleId, input InboundSecurityRule) error {
+	return c.InboundSecurityRuleCreateOrUpdateCallbackThenPoll(ctx, id, input, nil)
+}
+
+// InboundSecurityRuleCreateOrUpdateCallbackThenPoll performs InboundSecurityRuleCreateOrUpdate, runs the optional callback function, then polls until it's completed
+func (c VirtualNetworksClient) InboundSecurityRuleCreateOrUpdateCallbackThenPoll(ctx context.Context, id InboundSecurityRuleId, input InboundSecurityRule, callback func() error) error {
+	result, err := c.InboundSecurityRuleCreateOrUpdate(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing InboundSecurityRuleCreateOrUpdate: %+v", err)
+	}
+
+	if callback != nil {
+		if err := callback(); err != nil {
+			return fmt.Errorf("executing callback function: %+v", err)
+		}
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after InboundSecurityRuleCreateOrUpdate: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/method_inboundsecurityruleget.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/method_inboundsecurityruleget.go
@@ -1,0 +1,53 @@
+package virtualnetworks
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InboundSecurityRuleGetOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *InboundSecurityRule
+}
+
+// InboundSecurityRuleGet ...
+func (c VirtualNetworksClient) InboundSecurityRuleGet(ctx context.Context, id InboundSecurityRuleId) (result InboundSecurityRuleGetOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model InboundSecurityRule
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/method_list.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/method_list.go
@@ -1,0 +1,106 @@
+package virtualnetworks
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]VirtualNetwork
+}
+
+type ListCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []VirtualNetwork
+}
+
+type ListCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *ListCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// List ...
+func (c VirtualNetworksClient) List(ctx context.Context, id commonids.ResourceGroupId) (result ListOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Pager:      &ListCustomPager{},
+		Path:       fmt.Sprintf("%s/providers/Microsoft.Network/virtualNetworks", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]VirtualNetwork `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListComplete retrieves all the results into a single object
+func (c VirtualNetworksClient) ListComplete(ctx context.Context, id commonids.ResourceGroupId) (ListCompleteResult, error) {
+	return c.ListCompleteMatchingPredicate(ctx, id, VirtualNetworkOperationPredicate{})
+}
+
+// ListCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c VirtualNetworksClient) ListCompleteMatchingPredicate(ctx context.Context, id commonids.ResourceGroupId, predicate VirtualNetworkOperationPredicate) (result ListCompleteResult, err error) {
+	items := make([]VirtualNetwork, 0)
+
+	resp, err := c.List(ctx, id)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/method_listall.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/method_listall.go
@@ -1,0 +1,106 @@
+package virtualnetworks
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListAllOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]VirtualNetwork
+}
+
+type ListAllCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []VirtualNetwork
+}
+
+type ListAllCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *ListAllCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// ListAll ...
+func (c VirtualNetworksClient) ListAll(ctx context.Context, id commonids.SubscriptionId) (result ListAllOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Pager:      &ListAllCustomPager{},
+		Path:       fmt.Sprintf("%s/providers/Microsoft.Network/virtualNetworks", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]VirtualNetwork `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListAllComplete retrieves all the results into a single object
+func (c VirtualNetworksClient) ListAllComplete(ctx context.Context, id commonids.SubscriptionId) (ListAllCompleteResult, error) {
+	return c.ListAllCompleteMatchingPredicate(ctx, id, VirtualNetworkOperationPredicate{})
+}
+
+// ListAllCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c VirtualNetworksClient) ListAllCompleteMatchingPredicate(ctx context.Context, id commonids.SubscriptionId, predicate VirtualNetworkOperationPredicate) (result ListAllCompleteResult, err error) {
+	items := make([]VirtualNetwork, 0)
+
+	resp, err := c.ListAll(ctx, id)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListAllCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/method_publicipaddressesgetcloudservicepublicipaddress.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/method_publicipaddressesgetcloudservicepublicipaddress.go
@@ -1,0 +1,84 @@
+package virtualnetworks
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PublicIPAddressesGetCloudServicePublicIPAddressOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *PublicIPAddress
+}
+
+type PublicIPAddressesGetCloudServicePublicIPAddressOperationOptions struct {
+	Expand *string
+}
+
+func DefaultPublicIPAddressesGetCloudServicePublicIPAddressOperationOptions() PublicIPAddressesGetCloudServicePublicIPAddressOperationOptions {
+	return PublicIPAddressesGetCloudServicePublicIPAddressOperationOptions{}
+}
+
+func (o PublicIPAddressesGetCloudServicePublicIPAddressOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+
+	return &out
+}
+
+func (o PublicIPAddressesGetCloudServicePublicIPAddressOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+
+	return &out
+}
+
+func (o PublicIPAddressesGetCloudServicePublicIPAddressOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+	if o.Expand != nil {
+		out.Append("$expand", fmt.Sprintf("%v", *o.Expand))
+	}
+	return &out
+}
+
+// PublicIPAddressesGetCloudServicePublicIPAddress ...
+func (c VirtualNetworksClient) PublicIPAddressesGetCloudServicePublicIPAddress(ctx context.Context, id commonids.CloudServicesPublicIPAddressId, options PublicIPAddressesGetCloudServicePublicIPAddressOperationOptions) (result PublicIPAddressesGetCloudServicePublicIPAddressOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodGet,
+		OptionsObject: options,
+		Path:          id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model PublicIPAddress
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/method_publicipaddresseslistcloudservicepublicipaddresses.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/method_publicipaddresseslistcloudservicepublicipaddresses.go
@@ -1,0 +1,105 @@
+package virtualnetworks
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PublicIPAddressesListCloudServicePublicIPAddressesOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]PublicIPAddress
+}
+
+type PublicIPAddressesListCloudServicePublicIPAddressesCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []PublicIPAddress
+}
+
+type PublicIPAddressesListCloudServicePublicIPAddressesCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *PublicIPAddressesListCloudServicePublicIPAddressesCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// PublicIPAddressesListCloudServicePublicIPAddresses ...
+func (c VirtualNetworksClient) PublicIPAddressesListCloudServicePublicIPAddresses(ctx context.Context, id ProviderCloudServiceId) (result PublicIPAddressesListCloudServicePublicIPAddressesOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Pager:      &PublicIPAddressesListCloudServicePublicIPAddressesCustomPager{},
+		Path:       fmt.Sprintf("%s/publicIPAddresses", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]PublicIPAddress `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// PublicIPAddressesListCloudServicePublicIPAddressesComplete retrieves all the results into a single object
+func (c VirtualNetworksClient) PublicIPAddressesListCloudServicePublicIPAddressesComplete(ctx context.Context, id ProviderCloudServiceId) (PublicIPAddressesListCloudServicePublicIPAddressesCompleteResult, error) {
+	return c.PublicIPAddressesListCloudServicePublicIPAddressesCompleteMatchingPredicate(ctx, id, PublicIPAddressOperationPredicate{})
+}
+
+// PublicIPAddressesListCloudServicePublicIPAddressesCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c VirtualNetworksClient) PublicIPAddressesListCloudServicePublicIPAddressesCompleteMatchingPredicate(ctx context.Context, id ProviderCloudServiceId, predicate PublicIPAddressOperationPredicate) (result PublicIPAddressesListCloudServicePublicIPAddressesCompleteResult, err error) {
+	items := make([]PublicIPAddress, 0)
+
+	resp, err := c.PublicIPAddressesListCloudServicePublicIPAddresses(ctx, id)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = PublicIPAddressesListCloudServicePublicIPAddressesCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/method_publicipaddresseslistcloudserviceroleinstancepublicipaddresses.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/method_publicipaddresseslistcloudserviceroleinstancepublicipaddresses.go
@@ -1,0 +1,106 @@
+package virtualnetworks
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PublicIPAddressesListCloudServiceRoleInstancePublicIPAddressesOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]PublicIPAddress
+}
+
+type PublicIPAddressesListCloudServiceRoleInstancePublicIPAddressesCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []PublicIPAddress
+}
+
+type PublicIPAddressesListCloudServiceRoleInstancePublicIPAddressesCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *PublicIPAddressesListCloudServiceRoleInstancePublicIPAddressesCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// PublicIPAddressesListCloudServiceRoleInstancePublicIPAddresses ...
+func (c VirtualNetworksClient) PublicIPAddressesListCloudServiceRoleInstancePublicIPAddresses(ctx context.Context, id commonids.CloudServicesIPConfigurationId) (result PublicIPAddressesListCloudServiceRoleInstancePublicIPAddressesOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Pager:      &PublicIPAddressesListCloudServiceRoleInstancePublicIPAddressesCustomPager{},
+		Path:       fmt.Sprintf("%s/publicIPAddresses", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]PublicIPAddress `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// PublicIPAddressesListCloudServiceRoleInstancePublicIPAddressesComplete retrieves all the results into a single object
+func (c VirtualNetworksClient) PublicIPAddressesListCloudServiceRoleInstancePublicIPAddressesComplete(ctx context.Context, id commonids.CloudServicesIPConfigurationId) (PublicIPAddressesListCloudServiceRoleInstancePublicIPAddressesCompleteResult, error) {
+	return c.PublicIPAddressesListCloudServiceRoleInstancePublicIPAddressesCompleteMatchingPredicate(ctx, id, PublicIPAddressOperationPredicate{})
+}
+
+// PublicIPAddressesListCloudServiceRoleInstancePublicIPAddressesCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c VirtualNetworksClient) PublicIPAddressesListCloudServiceRoleInstancePublicIPAddressesCompleteMatchingPredicate(ctx context.Context, id commonids.CloudServicesIPConfigurationId, predicate PublicIPAddressOperationPredicate) (result PublicIPAddressesListCloudServiceRoleInstancePublicIPAddressesCompleteResult, err error) {
+	items := make([]PublicIPAddress, 0)
+
+	resp, err := c.PublicIPAddressesListCloudServiceRoleInstancePublicIPAddresses(ctx, id)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = PublicIPAddressesListCloudServiceRoleInstancePublicIPAddressesCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/method_resourcenavigationlinkslist.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/method_resourcenavigationlinkslist.go
@@ -1,0 +1,106 @@
+package virtualnetworks
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ResourceNavigationLinksListOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]ResourceNavigationLink
+}
+
+type ResourceNavigationLinksListCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []ResourceNavigationLink
+}
+
+type ResourceNavigationLinksListCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *ResourceNavigationLinksListCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// ResourceNavigationLinksList ...
+func (c VirtualNetworksClient) ResourceNavigationLinksList(ctx context.Context, id commonids.SubnetId) (result ResourceNavigationLinksListOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Pager:      &ResourceNavigationLinksListCustomPager{},
+		Path:       fmt.Sprintf("%s/resourceNavigationLinks", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]ResourceNavigationLink `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ResourceNavigationLinksListComplete retrieves all the results into a single object
+func (c VirtualNetworksClient) ResourceNavigationLinksListComplete(ctx context.Context, id commonids.SubnetId) (ResourceNavigationLinksListCompleteResult, error) {
+	return c.ResourceNavigationLinksListCompleteMatchingPredicate(ctx, id, ResourceNavigationLinkOperationPredicate{})
+}
+
+// ResourceNavigationLinksListCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c VirtualNetworksClient) ResourceNavigationLinksListCompleteMatchingPredicate(ctx context.Context, id commonids.SubnetId, predicate ResourceNavigationLinkOperationPredicate) (result ResourceNavigationLinksListCompleteResult, err error) {
+	items := make([]ResourceNavigationLink, 0)
+
+	resp, err := c.ResourceNavigationLinksList(ctx, id)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ResourceNavigationLinksListCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/method_serviceassociationlinkslist.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/method_serviceassociationlinkslist.go
@@ -1,0 +1,106 @@
+package virtualnetworks
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ServiceAssociationLinksListOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]ServiceAssociationLink
+}
+
+type ServiceAssociationLinksListCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []ServiceAssociationLink
+}
+
+type ServiceAssociationLinksListCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *ServiceAssociationLinksListCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// ServiceAssociationLinksList ...
+func (c VirtualNetworksClient) ServiceAssociationLinksList(ctx context.Context, id commonids.SubnetId) (result ServiceAssociationLinksListOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Pager:      &ServiceAssociationLinksListCustomPager{},
+		Path:       fmt.Sprintf("%s/serviceAssociationLinks", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]ServiceAssociationLink `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ServiceAssociationLinksListComplete retrieves all the results into a single object
+func (c VirtualNetworksClient) ServiceAssociationLinksListComplete(ctx context.Context, id commonids.SubnetId) (ServiceAssociationLinksListCompleteResult, error) {
+	return c.ServiceAssociationLinksListCompleteMatchingPredicate(ctx, id, ServiceAssociationLinkOperationPredicate{})
+}
+
+// ServiceAssociationLinksListCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c VirtualNetworksClient) ServiceAssociationLinksListCompleteMatchingPredicate(ctx context.Context, id commonids.SubnetId, predicate ServiceAssociationLinkOperationPredicate) (result ServiceAssociationLinksListCompleteResult, err error) {
+	items := make([]ServiceAssociationLink, 0)
+
+	resp, err := c.ServiceAssociationLinksList(ctx, id)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ServiceAssociationLinksListCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/method_servicetaginformationlist.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/method_servicetaginformationlist.go
@@ -1,0 +1,138 @@
+package virtualnetworks
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ServiceTagInformationListOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]ServiceTagInformation
+}
+
+type ServiceTagInformationListCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []ServiceTagInformation
+}
+
+type ServiceTagInformationListOperationOptions struct {
+	NoAddressPrefixes *bool
+	TagName           *string
+}
+
+func DefaultServiceTagInformationListOperationOptions() ServiceTagInformationListOperationOptions {
+	return ServiceTagInformationListOperationOptions{}
+}
+
+func (o ServiceTagInformationListOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+
+	return &out
+}
+
+func (o ServiceTagInformationListOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+
+	return &out
+}
+
+func (o ServiceTagInformationListOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+	if o.NoAddressPrefixes != nil {
+		out.Append("noAddressPrefixes", fmt.Sprintf("%v", *o.NoAddressPrefixes))
+	}
+	if o.TagName != nil {
+		out.Append("tagName", fmt.Sprintf("%v", *o.TagName))
+	}
+	return &out
+}
+
+type ServiceTagInformationListCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *ServiceTagInformationListCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// ServiceTagInformationList ...
+func (c VirtualNetworksClient) ServiceTagInformationList(ctx context.Context, id LocationId, options ServiceTagInformationListOperationOptions) (result ServiceTagInformationListOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodGet,
+		OptionsObject: options,
+		Pager:         &ServiceTagInformationListCustomPager{},
+		Path:          fmt.Sprintf("%s/serviceTagDetails", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]ServiceTagInformation `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ServiceTagInformationListComplete retrieves all the results into a single object
+func (c VirtualNetworksClient) ServiceTagInformationListComplete(ctx context.Context, id LocationId, options ServiceTagInformationListOperationOptions) (ServiceTagInformationListCompleteResult, error) {
+	return c.ServiceTagInformationListCompleteMatchingPredicate(ctx, id, options, ServiceTagInformationOperationPredicate{})
+}
+
+// ServiceTagInformationListCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c VirtualNetworksClient) ServiceTagInformationListCompleteMatchingPredicate(ctx context.Context, id LocationId, options ServiceTagInformationListOperationOptions, predicate ServiceTagInformationOperationPredicate) (result ServiceTagInformationListCompleteResult, err error) {
+	items := make([]ServiceTagInformation, 0)
+
+	resp, err := c.ServiceTagInformationList(ctx, id, options)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ServiceTagInformationListCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/method_servicetagslist.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/method_servicetagslist.go
@@ -1,0 +1,54 @@
+package virtualnetworks
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ServiceTagsListOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *ServiceTagsListResult
+}
+
+// ServiceTagsList ...
+func (c VirtualNetworksClient) ServiceTagsList(ctx context.Context, id LocationId) (result ServiceTagsListOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       fmt.Sprintf("%s/serviceTags", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model ServiceTagsListResult
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/method_subnetspreparenetworkpolicies.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/method_subnetspreparenetworkpolicies.go
@@ -1,0 +1,86 @@
+package virtualnetworks
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SubnetsPrepareNetworkPoliciesOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// SubnetsPrepareNetworkPolicies ...
+func (c VirtualNetworksClient) SubnetsPrepareNetworkPolicies(ctx context.Context, id commonids.SubnetId, input PrepareNetworkPoliciesRequest) (result SubnetsPrepareNetworkPoliciesOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/prepareNetworkPolicies", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// SubnetsPrepareNetworkPoliciesThenPoll performs SubnetsPrepareNetworkPolicies then polls until it's completed
+func (c VirtualNetworksClient) SubnetsPrepareNetworkPoliciesThenPoll(ctx context.Context, id commonids.SubnetId, input PrepareNetworkPoliciesRequest) error {
+	return c.SubnetsPrepareNetworkPoliciesCallbackThenPoll(ctx, id, input, nil)
+}
+
+// SubnetsPrepareNetworkPoliciesCallbackThenPoll performs SubnetsPrepareNetworkPolicies, runs the optional callback function, then polls until it's completed
+func (c VirtualNetworksClient) SubnetsPrepareNetworkPoliciesCallbackThenPoll(ctx context.Context, id commonids.SubnetId, input PrepareNetworkPoliciesRequest, callback func() error) error {
+	result, err := c.SubnetsPrepareNetworkPolicies(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing SubnetsPrepareNetworkPolicies: %+v", err)
+	}
+
+	if callback != nil {
+		if err := callback(); err != nil {
+			return fmt.Errorf("executing callback function: %+v", err)
+		}
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after SubnetsPrepareNetworkPolicies: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/method_subnetsunpreparenetworkpolicies.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/method_subnetsunpreparenetworkpolicies.go
@@ -1,0 +1,86 @@
+package virtualnetworks
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SubnetsUnprepareNetworkPoliciesOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// SubnetsUnprepareNetworkPolicies ...
+func (c VirtualNetworksClient) SubnetsUnprepareNetworkPolicies(ctx context.Context, id commonids.SubnetId, input UnprepareNetworkPoliciesRequest) (result SubnetsUnprepareNetworkPoliciesOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/unprepareNetworkPolicies", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// SubnetsUnprepareNetworkPoliciesThenPoll performs SubnetsUnprepareNetworkPolicies then polls until it's completed
+func (c VirtualNetworksClient) SubnetsUnprepareNetworkPoliciesThenPoll(ctx context.Context, id commonids.SubnetId, input UnprepareNetworkPoliciesRequest) error {
+	return c.SubnetsUnprepareNetworkPoliciesCallbackThenPoll(ctx, id, input, nil)
+}
+
+// SubnetsUnprepareNetworkPoliciesCallbackThenPoll performs SubnetsUnprepareNetworkPolicies, runs the optional callback function, then polls until it's completed
+func (c VirtualNetworksClient) SubnetsUnprepareNetworkPoliciesCallbackThenPoll(ctx context.Context, id commonids.SubnetId, input UnprepareNetworkPoliciesRequest, callback func() error) error {
+	result, err := c.SubnetsUnprepareNetworkPolicies(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing SubnetsUnprepareNetworkPolicies: %+v", err)
+	}
+
+	if callback != nil {
+		if err := callback(); err != nil {
+			return fmt.Errorf("executing callback function: %+v", err)
+		}
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after SubnetsUnprepareNetworkPolicies: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/method_updatetags.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/method_updatetags.go
@@ -1,0 +1,58 @@
+package virtualnetworks
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpdateTagsOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *VirtualNetwork
+}
+
+// UpdateTags ...
+func (c VirtualNetworksClient) UpdateTags(ctx context.Context, id commonids.VirtualNetworkId, input TagsObject) (result UpdateTagsOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPatch,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model VirtualNetwork
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/method_virtualnetworkscheckipaddressavailability.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/method_virtualnetworkscheckipaddressavailability.go
@@ -1,0 +1,84 @@
+package virtualnetworks
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualNetworksCheckIPAddressAvailabilityOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *IPAddressAvailabilityResult
+}
+
+type VirtualNetworksCheckIPAddressAvailabilityOperationOptions struct {
+	IPAddress *string
+}
+
+func DefaultVirtualNetworksCheckIPAddressAvailabilityOperationOptions() VirtualNetworksCheckIPAddressAvailabilityOperationOptions {
+	return VirtualNetworksCheckIPAddressAvailabilityOperationOptions{}
+}
+
+func (o VirtualNetworksCheckIPAddressAvailabilityOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+
+	return &out
+}
+
+func (o VirtualNetworksCheckIPAddressAvailabilityOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+
+	return &out
+}
+
+func (o VirtualNetworksCheckIPAddressAvailabilityOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+	if o.IPAddress != nil {
+		out.Append("ipAddress", fmt.Sprintf("%v", *o.IPAddress))
+	}
+	return &out
+}
+
+// VirtualNetworksCheckIPAddressAvailability ...
+func (c VirtualNetworksClient) VirtualNetworksCheckIPAddressAvailability(ctx context.Context, id commonids.VirtualNetworkId, options VirtualNetworksCheckIPAddressAvailabilityOperationOptions) (result VirtualNetworksCheckIPAddressAvailabilityOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodGet,
+		OptionsObject: options,
+		Path:          fmt.Sprintf("%s/checkIPAddressAvailability", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model IPAddressAvailabilityResult
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/method_virtualnetworkslistddosprotectionstatus.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/method_virtualnetworkslistddosprotectionstatus.go
@@ -1,0 +1,134 @@
+package virtualnetworks
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualNetworksListDdosProtectionStatusOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]PublicIPDdosProtectionStatusResult
+}
+
+type VirtualNetworksListDdosProtectionStatusCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []PublicIPDdosProtectionStatusResult
+}
+
+type VirtualNetworksListDdosProtectionStatusOperationOptions struct {
+	SkipToken *string
+	Top       *int64
+}
+
+func DefaultVirtualNetworksListDdosProtectionStatusOperationOptions() VirtualNetworksListDdosProtectionStatusOperationOptions {
+	return VirtualNetworksListDdosProtectionStatusOperationOptions{}
+}
+
+func (o VirtualNetworksListDdosProtectionStatusOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+
+	return &out
+}
+
+func (o VirtualNetworksListDdosProtectionStatusOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+
+	return &out
+}
+
+func (o VirtualNetworksListDdosProtectionStatusOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+	if o.SkipToken != nil {
+		out.Append("skipToken", fmt.Sprintf("%v", *o.SkipToken))
+	}
+	if o.Top != nil {
+		out.Append("top", fmt.Sprintf("%v", *o.Top))
+	}
+	return &out
+}
+
+type VirtualNetworksListDdosProtectionStatusCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *VirtualNetworksListDdosProtectionStatusCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// VirtualNetworksListDdosProtectionStatus ...
+func (c VirtualNetworksClient) VirtualNetworksListDdosProtectionStatus(ctx context.Context, id commonids.VirtualNetworkId, options VirtualNetworksListDdosProtectionStatusOperationOptions) (result VirtualNetworksListDdosProtectionStatusOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodPost,
+		OptionsObject: options,
+		Pager:         &VirtualNetworksListDdosProtectionStatusCustomPager{},
+		Path:          fmt.Sprintf("%s/ddosProtectionStatus", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// VirtualNetworksListDdosProtectionStatusThenPoll performs VirtualNetworksListDdosProtectionStatus then polls until it's completed
+func (c VirtualNetworksClient) VirtualNetworksListDdosProtectionStatusThenPoll(ctx context.Context, id commonids.VirtualNetworkId, options VirtualNetworksListDdosProtectionStatusOperationOptions) error {
+	return c.VirtualNetworksListDdosProtectionStatusCallbackThenPoll(ctx, id, options, nil)
+}
+
+// VirtualNetworksListDdosProtectionStatusCallbackThenPoll performs VirtualNetworksListDdosProtectionStatus, runs the optional callback function, then polls until it's completed
+func (c VirtualNetworksClient) VirtualNetworksListDdosProtectionStatusCallbackThenPoll(ctx context.Context, id commonids.VirtualNetworkId, options VirtualNetworksListDdosProtectionStatusOperationOptions, callback func() error) error {
+	result, err := c.VirtualNetworksListDdosProtectionStatus(ctx, id, options)
+	if err != nil {
+		return fmt.Errorf("performing VirtualNetworksListDdosProtectionStatus: %+v", err)
+	}
+
+	if callback != nil {
+		if err := callback(); err != nil {
+			return fmt.Errorf("executing callback function: %+v", err)
+		}
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after VirtualNetworksListDdosProtectionStatus: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/method_virtualnetworkslistusage.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/method_virtualnetworkslistusage.go
@@ -1,0 +1,106 @@
+package virtualnetworks
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualNetworksListUsageOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]VirtualNetworkUsage
+}
+
+type VirtualNetworksListUsageCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []VirtualNetworkUsage
+}
+
+type VirtualNetworksListUsageCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *VirtualNetworksListUsageCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// VirtualNetworksListUsage ...
+func (c VirtualNetworksClient) VirtualNetworksListUsage(ctx context.Context, id commonids.VirtualNetworkId) (result VirtualNetworksListUsageOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Pager:      &VirtualNetworksListUsageCustomPager{},
+		Path:       fmt.Sprintf("%s/usages", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]VirtualNetworkUsage `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// VirtualNetworksListUsageComplete retrieves all the results into a single object
+func (c VirtualNetworksClient) VirtualNetworksListUsageComplete(ctx context.Context, id commonids.VirtualNetworkId) (VirtualNetworksListUsageCompleteResult, error) {
+	return c.VirtualNetworksListUsageCompleteMatchingPredicate(ctx, id, VirtualNetworkUsageOperationPredicate{})
+}
+
+// VirtualNetworksListUsageCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c VirtualNetworksClient) VirtualNetworksListUsageCompleteMatchingPredicate(ctx context.Context, id commonids.VirtualNetworkId, predicate VirtualNetworkUsageOperationPredicate) (result VirtualNetworksListUsageCompleteResult, err error) {
+	items := make([]VirtualNetworkUsage, 0)
+
+	resp, err := c.VirtualNetworksListUsage(ctx, id)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = VirtualNetworksListUsageCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_addressspace.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_addressspace.go
@@ -1,0 +1,9 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AddressSpace struct {
+	AddressPrefixes           *[]string                   `json:"addressPrefixes,omitempty"`
+	IPamPoolPrefixAllocations *[]IPamPoolPrefixAllocation `json:"ipamPoolPrefixAllocations,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_applicationgatewaybackendaddress.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_applicationgatewaybackendaddress.go
@@ -1,0 +1,9 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ApplicationGatewayBackendAddress struct {
+	Fqdn      *string `json:"fqdn,omitempty"`
+	IPAddress *string `json:"ipAddress,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_applicationgatewaybackendaddresspool.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_applicationgatewaybackendaddresspool.go
@@ -1,0 +1,12 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ApplicationGatewayBackendAddressPool struct {
+	Etag       *string                                               `json:"etag,omitempty"`
+	Id         *string                                               `json:"id,omitempty"`
+	Name       *string                                               `json:"name,omitempty"`
+	Properties *ApplicationGatewayBackendAddressPoolPropertiesFormat `json:"properties,omitempty"`
+	Type       *string                                               `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_applicationgatewaybackendaddresspoolpropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_applicationgatewaybackendaddresspoolpropertiesformat.go
@@ -1,0 +1,10 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ApplicationGatewayBackendAddressPoolPropertiesFormat struct {
+	BackendAddresses        *[]ApplicationGatewayBackendAddress `json:"backendAddresses,omitempty"`
+	BackendIPConfigurations *[]NetworkInterfaceIPConfiguration  `json:"backendIPConfigurations,omitempty"`
+	ProvisioningState       *ProvisioningState                  `json:"provisioningState,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_applicationgatewayipconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_applicationgatewayipconfiguration.go
@@ -1,0 +1,12 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ApplicationGatewayIPConfiguration struct {
+	Etag       *string                                            `json:"etag,omitempty"`
+	Id         *string                                            `json:"id,omitempty"`
+	Name       *string                                            `json:"name,omitempty"`
+	Properties *ApplicationGatewayIPConfigurationPropertiesFormat `json:"properties,omitempty"`
+	Type       *string                                            `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_applicationgatewayipconfigurationpropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_applicationgatewayipconfigurationpropertiesformat.go
@@ -1,0 +1,9 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ApplicationGatewayIPConfigurationPropertiesFormat struct {
+	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty"`
+	Subnet            *SubResource       `json:"subnet,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_applicationsecuritygroup.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_applicationsecuritygroup.go
@@ -1,0 +1,14 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ApplicationSecurityGroup struct {
+	Etag       *string                                   `json:"etag,omitempty"`
+	Id         *string                                   `json:"id,omitempty"`
+	Location   *string                                   `json:"location,omitempty"`
+	Name       *string                                   `json:"name,omitempty"`
+	Properties *ApplicationSecurityGroupPropertiesFormat `json:"properties,omitempty"`
+	Tags       *map[string]string                        `json:"tags,omitempty"`
+	Type       *string                                   `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_applicationsecuritygrouppropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_applicationsecuritygrouppropertiesformat.go
@@ -1,0 +1,9 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ApplicationSecurityGroupPropertiesFormat struct {
+	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty"`
+	ResourceGuid      *string            `json:"resourceGuid,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_availabledelegation.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_availabledelegation.go
@@ -1,0 +1,12 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AvailableDelegation struct {
+	Actions     *[]string `json:"actions,omitempty"`
+	Id          *string   `json:"id,omitempty"`
+	Name        *string   `json:"name,omitempty"`
+	ServiceName *string   `json:"serviceName,omitempty"`
+	Type        *string   `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_availableprivateendpointtype.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_availableprivateendpointtype.go
@@ -1,0 +1,12 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AvailablePrivateEndpointType struct {
+	DisplayName  *string `json:"displayName,omitempty"`
+	Id           *string `json:"id,omitempty"`
+	Name         *string `json:"name,omitempty"`
+	ResourceName *string `json:"resourceName,omitempty"`
+	Type         *string `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_availableservicealias.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_availableservicealias.go
@@ -1,0 +1,11 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AvailableServiceAlias struct {
+	Id           *string `json:"id,omitempty"`
+	Name         *string `json:"name,omitempty"`
+	ResourceName *string `json:"resourceName,omitempty"`
+	Type         *string `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_backendaddresspool.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_backendaddresspool.go
@@ -1,0 +1,12 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type BackendAddressPool struct {
+	Etag       *string                             `json:"etag,omitempty"`
+	Id         *string                             `json:"id,omitempty"`
+	Name       *string                             `json:"name,omitempty"`
+	Properties *BackendAddressPoolPropertiesFormat `json:"properties,omitempty"`
+	Type       *string                             `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_backendaddresspoolpropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_backendaddresspoolpropertiesformat.go
@@ -1,0 +1,19 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type BackendAddressPoolPropertiesFormat struct {
+	BackendIPConfigurations      *[]NetworkInterfaceIPConfiguration    `json:"backendIPConfigurations,omitempty"`
+	DrainPeriodInSeconds         *int64                                `json:"drainPeriodInSeconds,omitempty"`
+	InboundNatRules              *[]SubResource                        `json:"inboundNatRules,omitempty"`
+	LoadBalancerBackendAddresses *[]LoadBalancerBackendAddress         `json:"loadBalancerBackendAddresses,omitempty"`
+	LoadBalancingRules           *[]SubResource                        `json:"loadBalancingRules,omitempty"`
+	Location                     *string                               `json:"location,omitempty"`
+	OutboundRule                 *SubResource                          `json:"outboundRule,omitempty"`
+	OutboundRules                *[]SubResource                        `json:"outboundRules,omitempty"`
+	ProvisioningState            *ProvisioningState                    `json:"provisioningState,omitempty"`
+	SyncMode                     *SyncMode                             `json:"syncMode,omitempty"`
+	TunnelInterfaces             *[]GatewayLoadBalancerTunnelInterface `json:"tunnelInterfaces,omitempty"`
+	VirtualNetwork               *SubResource                          `json:"virtualNetwork,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_customdnsconfigpropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_customdnsconfigpropertiesformat.go
@@ -1,0 +1,9 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CustomDnsConfigPropertiesFormat struct {
+	Fqdn        *string   `json:"fqdn,omitempty"`
+	IPAddresses *[]string `json:"ipAddresses,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_ddosfrontendipconfigurationsettings.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_ddosfrontendipconfigurationsettings.go
@@ -1,0 +1,8 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DdosFrontendIPConfigurationSettings struct {
+	DdosCustomPolicy *SubResource `json:"ddosCustomPolicy,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_ddossettings.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_ddossettings.go
@@ -1,0 +1,10 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DdosSettings struct {
+	DdosCustomPolicy   *SubResource                `json:"ddosCustomPolicy,omitempty"`
+	DdosProtectionPlan *SubResource                `json:"ddosProtectionPlan,omitempty"`
+	ProtectionMode     *DdosSettingsProtectionMode `json:"protectionMode,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_delegation.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_delegation.go
@@ -1,0 +1,12 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type Delegation struct {
+	Etag       *string                            `json:"etag,omitempty"`
+	Id         *string                            `json:"id,omitempty"`
+	Name       *string                            `json:"name,omitempty"`
+	Properties *ServiceDelegationPropertiesFormat `json:"properties,omitempty"`
+	Type       *string                            `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_dhcpoptions.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_dhcpoptions.go
@@ -1,0 +1,8 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DhcpOptions struct {
+	DnsServers *[]string `json:"dnsServers,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_dnsnameavailabilityresult.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_dnsnameavailabilityresult.go
@@ -1,0 +1,8 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DnsNameAvailabilityResult struct {
+	Available *bool `json:"available,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_endpointserviceresult.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_endpointserviceresult.go
@@ -1,0 +1,10 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type EndpointServiceResult struct {
+	Id   *string `json:"id,omitempty"`
+	Name *string `json:"name,omitempty"`
+	Type *string `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_flowlog.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_flowlog.go
@@ -1,0 +1,19 @@
+package virtualnetworks
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type FlowLog struct {
+	Etag       *string                            `json:"etag,omitempty"`
+	Id         *string                            `json:"id,omitempty"`
+	Identity   *identity.SystemAndUserAssignedMap `json:"identity,omitempty"`
+	Location   *string                            `json:"location,omitempty"`
+	Name       *string                            `json:"name,omitempty"`
+	Properties *FlowLogPropertiesFormat           `json:"properties,omitempty"`
+	Tags       *map[string]string                 `json:"tags,omitempty"`
+	Type       *string                            `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_flowlogformatparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_flowlogformatparameters.go
@@ -1,0 +1,9 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type FlowLogFormatParameters struct {
+	Type    *FlowLogFormatType `json:"type,omitempty"`
+	Version *int64             `json:"version,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_flowlogpropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_flowlogpropertiesformat.go
@@ -1,0 +1,17 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type FlowLogPropertiesFormat struct {
+	Enabled                    *bool                       `json:"enabled,omitempty"`
+	EnabledFilteringCriteria   *string                     `json:"enabledFilteringCriteria,omitempty"`
+	FlowAnalyticsConfiguration *TrafficAnalyticsProperties `json:"flowAnalyticsConfiguration,omitempty"`
+	Format                     *FlowLogFormatParameters    `json:"format,omitempty"`
+	ProvisioningState          *ProvisioningState          `json:"provisioningState,omitempty"`
+	RecordTypes                *string                     `json:"recordTypes,omitempty"`
+	RetentionPolicy            *RetentionPolicyParameters  `json:"retentionPolicy,omitempty"`
+	StorageId                  string                      `json:"storageId"`
+	TargetResourceGuid         *string                     `json:"targetResourceGuid,omitempty"`
+	TargetResourceId           string                      `json:"targetResourceId"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_frontendipconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_frontendipconfiguration.go
@@ -1,0 +1,17 @@
+package virtualnetworks
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/zones"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type FrontendIPConfiguration struct {
+	Etag       *string                                  `json:"etag,omitempty"`
+	Id         *string                                  `json:"id,omitempty"`
+	Name       *string                                  `json:"name,omitempty"`
+	Properties *FrontendIPConfigurationPropertiesFormat `json:"properties,omitempty"`
+	Type       *string                                  `json:"type,omitempty"`
+	Zones      *zones.Schema                            `json:"zones,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_frontendipconfigurationpropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_frontendipconfigurationpropertiesformat.go
@@ -1,0 +1,20 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type FrontendIPConfigurationPropertiesFormat struct {
+	DdosSettings              *DdosFrontendIPConfigurationSettings `json:"ddosSettings,omitempty"`
+	GatewayLoadBalancer       *SubResource                         `json:"gatewayLoadBalancer,omitempty"`
+	InboundNatPools           *[]SubResource                       `json:"inboundNatPools,omitempty"`
+	InboundNatRules           *[]SubResource                       `json:"inboundNatRules,omitempty"`
+	LoadBalancingRules        *[]SubResource                       `json:"loadBalancingRules,omitempty"`
+	OutboundRules             *[]SubResource                       `json:"outboundRules,omitempty"`
+	PrivateIPAddress          *string                              `json:"privateIPAddress,omitempty"`
+	PrivateIPAddressVersion   *IPVersion                           `json:"privateIPAddressVersion,omitempty"`
+	PrivateIPAllocationMethod *IPAllocationMethod                  `json:"privateIPAllocationMethod,omitempty"`
+	ProvisioningState         *ProvisioningState                   `json:"provisioningState,omitempty"`
+	PublicIPAddress           *PublicIPAddress                     `json:"publicIPAddress,omitempty"`
+	PublicIPPrefix            *SubResource                         `json:"publicIPPrefix,omitempty"`
+	Subnet                    *Subnet                              `json:"subnet,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_gatewayloadbalancertunnelinterface.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_gatewayloadbalancertunnelinterface.go
@@ -1,0 +1,11 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GatewayLoadBalancerTunnelInterface struct {
+	Identifier *int64                                  `json:"identifier,omitempty"`
+	Port       *int64                                  `json:"port,omitempty"`
+	Protocol   *GatewayLoadBalancerTunnelProtocol      `json:"protocol,omitempty"`
+	Type       *GatewayLoadBalancerTunnelInterfaceType `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_inboundnatrule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_inboundnatrule.go
@@ -1,0 +1,12 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InboundNatRule struct {
+	Etag       *string                         `json:"etag,omitempty"`
+	Id         *string                         `json:"id,omitempty"`
+	Name       *string                         `json:"name,omitempty"`
+	Properties *InboundNatRulePropertiesFormat `json:"properties,omitempty"`
+	Type       *string                         `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_inboundnatrulepropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_inboundnatrulepropertiesformat.go
@@ -1,0 +1,19 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InboundNatRulePropertiesFormat struct {
+	BackendAddressPool      *SubResource                     `json:"backendAddressPool,omitempty"`
+	BackendIPConfiguration  *NetworkInterfaceIPConfiguration `json:"backendIPConfiguration,omitempty"`
+	BackendPort             *int64                           `json:"backendPort,omitempty"`
+	EnableFloatingIP        *bool                            `json:"enableFloatingIP,omitempty"`
+	EnableTcpReset          *bool                            `json:"enableTcpReset,omitempty"`
+	FrontendIPConfiguration *SubResource                     `json:"frontendIPConfiguration,omitempty"`
+	FrontendPort            *int64                           `json:"frontendPort,omitempty"`
+	FrontendPortRangeEnd    *int64                           `json:"frontendPortRangeEnd,omitempty"`
+	FrontendPortRangeStart  *int64                           `json:"frontendPortRangeStart,omitempty"`
+	IdleTimeoutInMinutes    *int64                           `json:"idleTimeoutInMinutes,omitempty"`
+	Protocol                *TransportProtocol               `json:"protocol,omitempty"`
+	ProvisioningState       *ProvisioningState               `json:"provisioningState,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_inboundsecurityrule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_inboundsecurityrule.go
@@ -1,0 +1,12 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InboundSecurityRule struct {
+	Etag       *string                        `json:"etag,omitempty"`
+	Id         *string                        `json:"id,omitempty"`
+	Name       *string                        `json:"name,omitempty"`
+	Properties *InboundSecurityRuleProperties `json:"properties,omitempty"`
+	Type       *string                        `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_inboundsecurityruleproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_inboundsecurityruleproperties.go
@@ -1,0 +1,10 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InboundSecurityRuleProperties struct {
+	ProvisioningState *ProvisioningState       `json:"provisioningState,omitempty"`
+	RuleType          *InboundSecurityRuleType `json:"ruleType,omitempty"`
+	Rules             *[]InboundSecurityRules  `json:"rules,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_inboundsecurityrules.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_inboundsecurityrules.go
@@ -1,0 +1,13 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InboundSecurityRules struct {
+	AppliesOn             *[]string                     `json:"appliesOn,omitempty"`
+	DestinationPortRange  *int64                        `json:"destinationPortRange,omitempty"`
+	DestinationPortRanges *[]string                     `json:"destinationPortRanges,omitempty"`
+	Name                  *string                       `json:"name,omitempty"`
+	Protocol              *InboundSecurityRulesProtocol `json:"protocol,omitempty"`
+	SourceAddressPrefix   *string                       `json:"sourceAddressPrefix,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_ipaddressavailabilityresult.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_ipaddressavailabilityresult.go
@@ -1,0 +1,10 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type IPAddressAvailabilityResult struct {
+	Available            *bool     `json:"available,omitempty"`
+	AvailableIPAddresses *[]string `json:"availableIPAddresses,omitempty"`
+	IsPlatformReserved   *bool     `json:"isPlatformReserved,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_ipampoolprefixallocation.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_ipampoolprefixallocation.go
@@ -1,0 +1,10 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type IPamPoolPrefixAllocation struct {
+	AllocatedAddressPrefixes *[]string                     `json:"allocatedAddressPrefixes,omitempty"`
+	NumberOfIPAddresses      *string                       `json:"numberOfIpAddresses,omitempty"`
+	Pool                     *IPamPoolPrefixAllocationPool `json:"pool,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_ipampoolprefixallocationpool.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_ipampoolprefixallocationpool.go
@@ -1,0 +1,8 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type IPamPoolPrefixAllocationPool struct {
+	Id *string `json:"id,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_ipconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_ipconfiguration.go
@@ -1,0 +1,11 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type IPConfiguration struct {
+	Etag       *string                          `json:"etag,omitempty"`
+	Id         *string                          `json:"id,omitempty"`
+	Name       *string                          `json:"name,omitempty"`
+	Properties *IPConfigurationPropertiesFormat `json:"properties,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_ipconfigurationprofile.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_ipconfigurationprofile.go
@@ -1,0 +1,12 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type IPConfigurationProfile struct {
+	Etag       *string                                 `json:"etag,omitempty"`
+	Id         *string                                 `json:"id,omitempty"`
+	Name       *string                                 `json:"name,omitempty"`
+	Properties *IPConfigurationProfilePropertiesFormat `json:"properties,omitempty"`
+	Type       *string                                 `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_ipconfigurationprofilepropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_ipconfigurationprofilepropertiesformat.go
@@ -1,0 +1,9 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type IPConfigurationProfilePropertiesFormat struct {
+	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty"`
+	Subnet            *Subnet            `json:"subnet,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_ipconfigurationpropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_ipconfigurationpropertiesformat.go
@@ -1,0 +1,12 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type IPConfigurationPropertiesFormat struct {
+	PrivateIPAddress          *string             `json:"privateIPAddress,omitempty"`
+	PrivateIPAllocationMethod *IPAllocationMethod `json:"privateIPAllocationMethod,omitempty"`
+	ProvisioningState         *ProvisioningState  `json:"provisioningState,omitempty"`
+	PublicIPAddress           *PublicIPAddress    `json:"publicIPAddress,omitempty"`
+	Subnet                    *Subnet             `json:"subnet,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_iptag.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_iptag.go
@@ -1,0 +1,9 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type IPTag struct {
+	IPTagType *string `json:"ipTagType,omitempty"`
+	Tag       *string `json:"tag,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_loadbalancerbackendaddress.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_loadbalancerbackendaddress.go
@@ -1,0 +1,9 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type LoadBalancerBackendAddress struct {
+	Name       *string                                     `json:"name,omitempty"`
+	Properties *LoadBalancerBackendAddressPropertiesFormat `json:"properties,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_loadbalancerbackendaddresspropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_loadbalancerbackendaddresspropertiesformat.go
@@ -1,0 +1,14 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type LoadBalancerBackendAddressPropertiesFormat struct {
+	AdminState                          *LoadBalancerBackendAddressAdminState `json:"adminState,omitempty"`
+	IPAddress                           *string                               `json:"ipAddress,omitempty"`
+	InboundNatRulesPortMapping          *[]NatRulePortMapping                 `json:"inboundNatRulesPortMapping,omitempty"`
+	LoadBalancerFrontendIPConfiguration *SubResource                          `json:"loadBalancerFrontendIPConfiguration,omitempty"`
+	NetworkInterfaceIPConfiguration     *SubResource                          `json:"networkInterfaceIPConfiguration,omitempty"`
+	Subnet                              *SubResource                          `json:"subnet,omitempty"`
+	VirtualNetwork                      *SubResource                          `json:"virtualNetwork,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_natgateway.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_natgateway.go
@@ -1,0 +1,20 @@
+package virtualnetworks
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/zones"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NatGateway struct {
+	Etag       *string                     `json:"etag,omitempty"`
+	Id         *string                     `json:"id,omitempty"`
+	Location   *string                     `json:"location,omitempty"`
+	Name       *string                     `json:"name,omitempty"`
+	Properties *NatGatewayPropertiesFormat `json:"properties,omitempty"`
+	Sku        *NatGatewaySku              `json:"sku,omitempty"`
+	Tags       *map[string]string          `json:"tags,omitempty"`
+	Type       *string                     `json:"type,omitempty"`
+	Zones      *zones.Schema               `json:"zones,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_natgatewaypropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_natgatewaypropertiesformat.go
@@ -1,0 +1,18 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NatGatewayPropertiesFormat struct {
+	IdleTimeoutInMinutes *int64             `json:"idleTimeoutInMinutes,omitempty"`
+	Nat64                *Nat64State        `json:"nat64,omitempty"`
+	ProvisioningState    *ProvisioningState `json:"provisioningState,omitempty"`
+	PublicIPAddresses    *[]SubResource     `json:"publicIpAddresses,omitempty"`
+	PublicIPAddressesV6  *[]SubResource     `json:"publicIpAddressesV6,omitempty"`
+	PublicIPPrefixes     *[]SubResource     `json:"publicIpPrefixes,omitempty"`
+	PublicIPPrefixesV6   *[]SubResource     `json:"publicIpPrefixesV6,omitempty"`
+	ResourceGuid         *string            `json:"resourceGuid,omitempty"`
+	ServiceGateway       *SubResource       `json:"serviceGateway,omitempty"`
+	SourceVirtualNetwork *SubResource       `json:"sourceVirtualNetwork,omitempty"`
+	Subnets              *[]SubResource     `json:"subnets,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_natgatewaysku.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_natgatewaysku.go
@@ -1,0 +1,8 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NatGatewaySku struct {
+	Name *NatGatewaySkuName `json:"name,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_natruleportmapping.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_natruleportmapping.go
@@ -1,0 +1,10 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NatRulePortMapping struct {
+	BackendPort        *int64  `json:"backendPort,omitempty"`
+	FrontendPort       *int64  `json:"frontendPort,omitempty"`
+	InboundNatRuleName *string `json:"inboundNatRuleName,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_networkintentpolicy.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_networkintentpolicy.go
@@ -1,0 +1,13 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NetworkIntentPolicy struct {
+	Etag     *string            `json:"etag,omitempty"`
+	Id       *string            `json:"id,omitempty"`
+	Location *string            `json:"location,omitempty"`
+	Name     *string            `json:"name,omitempty"`
+	Tags     *map[string]string `json:"tags,omitempty"`
+	Type     *string            `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_networkintentpolicyconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_networkintentpolicyconfiguration.go
@@ -1,0 +1,9 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NetworkIntentPolicyConfiguration struct {
+	NetworkIntentPolicyName   *string              `json:"networkIntentPolicyName,omitempty"`
+	SourceNetworkIntentPolicy *NetworkIntentPolicy `json:"sourceNetworkIntentPolicy,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_networkinterface.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_networkinterface.go
@@ -1,0 +1,19 @@
+package virtualnetworks
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/edgezones"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NetworkInterface struct {
+	Etag             *string                           `json:"etag,omitempty"`
+	ExtendedLocation *edgezones.Model                  `json:"extendedLocation,omitempty"`
+	Id               *string                           `json:"id,omitempty"`
+	Location         *string                           `json:"location,omitempty"`
+	Name             *string                           `json:"name,omitempty"`
+	Properties       *NetworkInterfacePropertiesFormat `json:"properties,omitempty"`
+	Tags             *map[string]string                `json:"tags,omitempty"`
+	Type             *string                           `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_networkinterfacednssettings.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_networkinterfacednssettings.go
@@ -1,0 +1,12 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NetworkInterfaceDnsSettings struct {
+	AppliedDnsServers        *[]string `json:"appliedDnsServers,omitempty"`
+	DnsServers               *[]string `json:"dnsServers,omitempty"`
+	InternalDnsNameLabel     *string   `json:"internalDnsNameLabel,omitempty"`
+	InternalDomainNameSuffix *string   `json:"internalDomainNameSuffix,omitempty"`
+	InternalFqdn             *string   `json:"internalFqdn,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_networkinterfaceipconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_networkinterfaceipconfiguration.go
@@ -1,0 +1,12 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NetworkInterfaceIPConfiguration struct {
+	Etag       *string                                          `json:"etag,omitempty"`
+	Id         *string                                          `json:"id,omitempty"`
+	Name       *string                                          `json:"name,omitempty"`
+	Properties *NetworkInterfaceIPConfigurationPropertiesFormat `json:"properties,omitempty"`
+	Type       *string                                          `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_networkinterfaceipconfigurationprivatelinkconnectionproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_networkinterfaceipconfigurationprivatelinkconnectionproperties.go
@@ -1,0 +1,10 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NetworkInterfaceIPConfigurationPrivateLinkConnectionProperties struct {
+	Fqdns              *[]string `json:"fqdns,omitempty"`
+	GroupId            *string   `json:"groupId,omitempty"`
+	RequiredMemberName *string   `json:"requiredMemberName,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_networkinterfaceipconfigurationpropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_networkinterfaceipconfigurationpropertiesformat.go
@@ -1,0 +1,22 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NetworkInterfaceIPConfigurationPropertiesFormat struct {
+	ApplicationGatewayBackendAddressPools *[]ApplicationGatewayBackendAddressPool                         `json:"applicationGatewayBackendAddressPools,omitempty"`
+	ApplicationSecurityGroups             *[]ApplicationSecurityGroup                                     `json:"applicationSecurityGroups,omitempty"`
+	GatewayLoadBalancer                   *SubResource                                                    `json:"gatewayLoadBalancer,omitempty"`
+	LoadBalancerBackendAddressPools       *[]BackendAddressPool                                           `json:"loadBalancerBackendAddressPools,omitempty"`
+	LoadBalancerInboundNatRules           *[]InboundNatRule                                               `json:"loadBalancerInboundNatRules,omitempty"`
+	Primary                               *bool                                                           `json:"primary,omitempty"`
+	PrivateIPAddress                      *string                                                         `json:"privateIPAddress,omitempty"`
+	PrivateIPAddressPrefixLength          *int64                                                          `json:"privateIPAddressPrefixLength,omitempty"`
+	PrivateIPAddressVersion               *IPVersion                                                      `json:"privateIPAddressVersion,omitempty"`
+	PrivateIPAllocationMethod             *IPAllocationMethod                                             `json:"privateIPAllocationMethod,omitempty"`
+	PrivateLinkConnectionProperties       *NetworkInterfaceIPConfigurationPrivateLinkConnectionProperties `json:"privateLinkConnectionProperties,omitempty"`
+	ProvisioningState                     *ProvisioningState                                              `json:"provisioningState,omitempty"`
+	PublicIPAddress                       *PublicIPAddress                                                `json:"publicIPAddress,omitempty"`
+	Subnet                                *Subnet                                                         `json:"subnet,omitempty"`
+	VirtualNetworkTaps                    *[]VirtualNetworkTap                                            `json:"virtualNetworkTaps,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_networkinterfacepropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_networkinterfacepropertiesformat.go
@@ -1,0 +1,30 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NetworkInterfacePropertiesFormat struct {
+	AuxiliaryMode                      *NetworkInterfaceAuxiliaryMode      `json:"auxiliaryMode,omitempty"`
+	AuxiliarySku                       *NetworkInterfaceAuxiliarySku       `json:"auxiliarySku,omitempty"`
+	DefaultOutboundConnectivityEnabled *bool                               `json:"defaultOutboundConnectivityEnabled,omitempty"`
+	DisableTcpStateTracking            *bool                               `json:"disableTcpStateTracking,omitempty"`
+	DnsSettings                        *NetworkInterfaceDnsSettings        `json:"dnsSettings,omitempty"`
+	DscpConfiguration                  *SubResource                        `json:"dscpConfiguration,omitempty"`
+	EnableAcceleratedNetworking        *bool                               `json:"enableAcceleratedNetworking,omitempty"`
+	EnableIPForwarding                 *bool                               `json:"enableIPForwarding,omitempty"`
+	HostedWorkloads                    *[]string                           `json:"hostedWorkloads,omitempty"`
+	IPConfigurations                   *[]NetworkInterfaceIPConfiguration  `json:"ipConfigurations,omitempty"`
+	MacAddress                         *string                             `json:"macAddress,omitempty"`
+	MigrationPhase                     *NetworkInterfaceMigrationPhase     `json:"migrationPhase,omitempty"`
+	NetworkSecurityGroup               *NetworkSecurityGroup               `json:"networkSecurityGroup,omitempty"`
+	NicType                            *NetworkInterfaceNicType            `json:"nicType,omitempty"`
+	Primary                            *bool                               `json:"primary,omitempty"`
+	PrivateEndpoint                    *PrivateEndpoint                    `json:"privateEndpoint,omitempty"`
+	PrivateLinkService                 *PrivateLinkService                 `json:"privateLinkService,omitempty"`
+	ProvisioningState                  *ProvisioningState                  `json:"provisioningState,omitempty"`
+	ResourceGuid                       *string                             `json:"resourceGuid,omitempty"`
+	TapConfigurations                  *[]NetworkInterfaceTapConfiguration `json:"tapConfigurations,omitempty"`
+	VirtualMachine                     *SubResource                        `json:"virtualMachine,omitempty"`
+	VnetEncryptionSupported            *bool                               `json:"vnetEncryptionSupported,omitempty"`
+	WorkloadType                       *string                             `json:"workloadType,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_networkinterfacetapconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_networkinterfacetapconfiguration.go
@@ -1,0 +1,12 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NetworkInterfaceTapConfiguration struct {
+	Etag       *string                                           `json:"etag,omitempty"`
+	Id         *string                                           `json:"id,omitempty"`
+	Name       *string                                           `json:"name,omitempty"`
+	Properties *NetworkInterfaceTapConfigurationPropertiesFormat `json:"properties,omitempty"`
+	Type       *string                                           `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_networkinterfacetapconfigurationpropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_networkinterfacetapconfigurationpropertiesformat.go
@@ -1,0 +1,9 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NetworkInterfaceTapConfigurationPropertiesFormat struct {
+	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty"`
+	VirtualNetworkTap *VirtualNetworkTap `json:"virtualNetworkTap,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_networksecuritygroup.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_networksecuritygroup.go
@@ -1,0 +1,14 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NetworkSecurityGroup struct {
+	Etag       *string                               `json:"etag,omitempty"`
+	Id         *string                               `json:"id,omitempty"`
+	Location   *string                               `json:"location,omitempty"`
+	Name       *string                               `json:"name,omitempty"`
+	Properties *NetworkSecurityGroupPropertiesFormat `json:"properties,omitempty"`
+	Tags       *map[string]string                    `json:"tags,omitempty"`
+	Type       *string                               `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_networksecuritygrouppropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_networksecuritygrouppropertiesformat.go
@@ -1,0 +1,15 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NetworkSecurityGroupPropertiesFormat struct {
+	DefaultSecurityRules *[]SecurityRule     `json:"defaultSecurityRules,omitempty"`
+	FlowLogs             *[]FlowLog          `json:"flowLogs,omitempty"`
+	FlushConnection      *bool               `json:"flushConnection,omitempty"`
+	NetworkInterfaces    *[]NetworkInterface `json:"networkInterfaces,omitempty"`
+	ProvisioningState    *ProvisioningState  `json:"provisioningState,omitempty"`
+	ResourceGuid         *string             `json:"resourceGuid,omitempty"`
+	SecurityRules        *[]SecurityRule     `json:"securityRules,omitempty"`
+	Subnets              *[]Subnet           `json:"subnets,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_preparenetworkpoliciesrequest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_preparenetworkpoliciesrequest.go
@@ -1,0 +1,9 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrepareNetworkPoliciesRequest struct {
+	NetworkIntentPolicyConfigurations *[]NetworkIntentPolicyConfiguration `json:"networkIntentPolicyConfigurations,omitempty"`
+	ServiceName                       *string                             `json:"serviceName,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_privateendpoint.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_privateendpoint.go
@@ -1,0 +1,19 @@
+package virtualnetworks
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/edgezones"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateEndpoint struct {
+	Etag             *string                    `json:"etag,omitempty"`
+	ExtendedLocation *edgezones.Model           `json:"extendedLocation,omitempty"`
+	Id               *string                    `json:"id,omitempty"`
+	Location         *string                    `json:"location,omitempty"`
+	Name             *string                    `json:"name,omitempty"`
+	Properties       *PrivateEndpointProperties `json:"properties,omitempty"`
+	Tags             *map[string]string         `json:"tags,omitempty"`
+	Type             *string                    `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_privateendpointconnection.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_privateendpointconnection.go
@@ -1,0 +1,12 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateEndpointConnection struct {
+	Etag       *string                              `json:"etag,omitempty"`
+	Id         *string                              `json:"id,omitempty"`
+	Name       *string                              `json:"name,omitempty"`
+	Properties *PrivateEndpointConnectionProperties `json:"properties,omitempty"`
+	Type       *string                              `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_privateendpointconnectionproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_privateendpointconnectionproperties.go
@@ -1,0 +1,12 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateEndpointConnectionProperties struct {
+	LinkIdentifier                    *string                            `json:"linkIdentifier,omitempty"`
+	PrivateEndpoint                   *PrivateEndpoint                   `json:"privateEndpoint,omitempty"`
+	PrivateEndpointLocation           *string                            `json:"privateEndpointLocation,omitempty"`
+	PrivateLinkServiceConnectionState *PrivateLinkServiceConnectionState `json:"privateLinkServiceConnectionState,omitempty"`
+	ProvisioningState                 *ProvisioningState                 `json:"provisioningState,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_privateendpointipconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_privateendpointipconfiguration.go
@@ -1,0 +1,11 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateEndpointIPConfiguration struct {
+	Etag       *string                                   `json:"etag,omitempty"`
+	Name       *string                                   `json:"name,omitempty"`
+	Properties *PrivateEndpointIPConfigurationProperties `json:"properties,omitempty"`
+	Type       *string                                   `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_privateendpointipconfigurationproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_privateendpointipconfigurationproperties.go
@@ -1,0 +1,10 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateEndpointIPConfigurationProperties struct {
+	GroupId          *string `json:"groupId,omitempty"`
+	MemberName       *string `json:"memberName,omitempty"`
+	PrivateIPAddress *string `json:"privateIPAddress,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_privateendpointproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_privateendpointproperties.go
@@ -1,0 +1,18 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateEndpointProperties struct {
+	ApplicationSecurityGroups           *[]ApplicationSecurityGroup        `json:"applicationSecurityGroups,omitempty"`
+	BillingSku                          *PrivateEndpointBillingSku         `json:"billingSku,omitempty"`
+	CustomDnsConfigs                    *[]CustomDnsConfigPropertiesFormat `json:"customDnsConfigs,omitempty"`
+	CustomNetworkInterfaceName          *string                            `json:"customNetworkInterfaceName,omitempty"`
+	IPConfigurations                    *[]PrivateEndpointIPConfiguration  `json:"ipConfigurations,omitempty"`
+	IPVersionType                       *PrivateEndpointIPVersionType      `json:"ipVersionType,omitempty"`
+	ManualPrivateLinkServiceConnections *[]PrivateLinkServiceConnection    `json:"manualPrivateLinkServiceConnections,omitempty"`
+	NetworkInterfaces                   *[]NetworkInterface                `json:"networkInterfaces,omitempty"`
+	PrivateLinkServiceConnections       *[]PrivateLinkServiceConnection    `json:"privateLinkServiceConnections,omitempty"`
+	ProvisioningState                   *ProvisioningState                 `json:"provisioningState,omitempty"`
+	Subnet                              *Subnet                            `json:"subnet,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_privatelinkservice.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_privatelinkservice.go
@@ -1,0 +1,19 @@
+package virtualnetworks
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/edgezones"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateLinkService struct {
+	Etag             *string                       `json:"etag,omitempty"`
+	ExtendedLocation *edgezones.Model              `json:"extendedLocation,omitempty"`
+	Id               *string                       `json:"id,omitempty"`
+	Location         *string                       `json:"location,omitempty"`
+	Name             *string                       `json:"name,omitempty"`
+	Properties       *PrivateLinkServiceProperties `json:"properties,omitempty"`
+	Tags             *map[string]string            `json:"tags,omitempty"`
+	Type             *string                       `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_privatelinkserviceconnection.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_privatelinkserviceconnection.go
@@ -1,0 +1,12 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateLinkServiceConnection struct {
+	Etag       *string                                 `json:"etag,omitempty"`
+	Id         *string                                 `json:"id,omitempty"`
+	Name       *string                                 `json:"name,omitempty"`
+	Properties *PrivateLinkServiceConnectionProperties `json:"properties,omitempty"`
+	Type       *string                                 `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_privatelinkserviceconnectionproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_privatelinkserviceconnectionproperties.go
@@ -1,0 +1,12 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateLinkServiceConnectionProperties struct {
+	GroupIds                          *[]string                          `json:"groupIds,omitempty"`
+	PrivateLinkServiceConnectionState *PrivateLinkServiceConnectionState `json:"privateLinkServiceConnectionState,omitempty"`
+	PrivateLinkServiceId              *string                            `json:"privateLinkServiceId,omitempty"`
+	ProvisioningState                 *ProvisioningState                 `json:"provisioningState,omitempty"`
+	RequestMessage                    *string                            `json:"requestMessage,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_privatelinkserviceconnectionstate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_privatelinkserviceconnectionstate.go
@@ -1,0 +1,10 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateLinkServiceConnectionState struct {
+	ActionsRequired *string `json:"actionsRequired,omitempty"`
+	Description     *string `json:"description,omitempty"`
+	Status          *string `json:"status,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_privatelinkserviceipconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_privatelinkserviceipconfiguration.go
@@ -1,0 +1,12 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateLinkServiceIPConfiguration struct {
+	Etag       *string                                      `json:"etag,omitempty"`
+	Id         *string                                      `json:"id,omitempty"`
+	Name       *string                                      `json:"name,omitempty"`
+	Properties *PrivateLinkServiceIPConfigurationProperties `json:"properties,omitempty"`
+	Type       *string                                      `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_privatelinkserviceipconfigurationproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_privatelinkserviceipconfigurationproperties.go
@@ -1,0 +1,13 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateLinkServiceIPConfigurationProperties struct {
+	Primary                   *bool               `json:"primary,omitempty"`
+	PrivateIPAddress          *string             `json:"privateIPAddress,omitempty"`
+	PrivateIPAddressVersion   *IPVersion          `json:"privateIPAddressVersion,omitempty"`
+	PrivateIPAllocationMethod *IPAllocationMethod `json:"privateIPAllocationMethod,omitempty"`
+	ProvisioningState         *ProvisioningState  `json:"provisioningState,omitempty"`
+	Subnet                    *Subnet             `json:"subnet,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_privatelinkserviceproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_privatelinkserviceproperties.go
@@ -1,0 +1,19 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateLinkServiceProperties struct {
+	AccessMode                           *AccessMode                          `json:"accessMode,omitempty"`
+	Alias                                *string                              `json:"alias,omitempty"`
+	AutoApproval                         *ResourceSet                         `json:"autoApproval,omitempty"`
+	DestinationIPAddress                 *string                              `json:"destinationIPAddress,omitempty"`
+	EnableProxyProtocol                  *bool                                `json:"enableProxyProtocol,omitempty"`
+	Fqdns                                *[]string                            `json:"fqdns,omitempty"`
+	IPConfigurations                     *[]PrivateLinkServiceIPConfiguration `json:"ipConfigurations,omitempty"`
+	LoadBalancerFrontendIPConfigurations *[]FrontendIPConfiguration           `json:"loadBalancerFrontendIpConfigurations,omitempty"`
+	NetworkInterfaces                    *[]NetworkInterface                  `json:"networkInterfaces,omitempty"`
+	PrivateEndpointConnections           *[]PrivateEndpointConnection         `json:"privateEndpointConnections,omitempty"`
+	ProvisioningState                    *ProvisioningState                   `json:"provisioningState,omitempty"`
+	Visibility                           *ResourceSet                         `json:"visibility,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_publicipaddress.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_publicipaddress.go
@@ -1,0 +1,22 @@
+package virtualnetworks
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/edgezones"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/zones"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PublicIPAddress struct {
+	Etag             *string                          `json:"etag,omitempty"`
+	ExtendedLocation *edgezones.Model                 `json:"extendedLocation,omitempty"`
+	Id               *string                          `json:"id,omitempty"`
+	Location         *string                          `json:"location,omitempty"`
+	Name             *string                          `json:"name,omitempty"`
+	Properties       *PublicIPAddressPropertiesFormat `json:"properties,omitempty"`
+	Sku              *PublicIPAddressSku              `json:"sku,omitempty"`
+	Tags             *map[string]string               `json:"tags,omitempty"`
+	Type             *string                          `json:"type,omitempty"`
+	Zones            *zones.Schema                    `json:"zones,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_publicipaddressdnssettings.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_publicipaddressdnssettings.go
@@ -1,0 +1,11 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PublicIPAddressDnsSettings struct {
+	DomainNameLabel      *string                                         `json:"domainNameLabel,omitempty"`
+	DomainNameLabelScope *PublicIPAddressDnsSettingsDomainNameLabelScope `json:"domainNameLabelScope,omitempty"`
+	Fqdn                 *string                                         `json:"fqdn,omitempty"`
+	ReverseFqdn          *string                                         `json:"reverseFqdn,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_publicipaddresspropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_publicipaddresspropertiesformat.go
@@ -1,0 +1,23 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PublicIPAddressPropertiesFormat struct {
+	DdosSettings             *DdosSettings                  `json:"ddosSettings,omitempty"`
+	DeleteOption             *DeleteOptions                 `json:"deleteOption,omitempty"`
+	DnsSettings              *PublicIPAddressDnsSettings    `json:"dnsSettings,omitempty"`
+	IPAddress                *string                        `json:"ipAddress,omitempty"`
+	IPConfiguration          *IPConfiguration               `json:"ipConfiguration,omitempty"`
+	IPTags                   *[]IPTag                       `json:"ipTags,omitempty"`
+	IdleTimeoutInMinutes     *int64                         `json:"idleTimeoutInMinutes,omitempty"`
+	LinkedPublicIPAddress    *PublicIPAddress               `json:"linkedPublicIPAddress,omitempty"`
+	MigrationPhase           *PublicIPAddressMigrationPhase `json:"migrationPhase,omitempty"`
+	NatGateway               *NatGateway                    `json:"natGateway,omitempty"`
+	ProvisioningState        *ProvisioningState             `json:"provisioningState,omitempty"`
+	PublicIPAddressVersion   *IPVersion                     `json:"publicIPAddressVersion,omitempty"`
+	PublicIPAllocationMethod *IPAllocationMethod            `json:"publicIPAllocationMethod,omitempty"`
+	PublicIPPrefix           *SubResource                   `json:"publicIPPrefix,omitempty"`
+	ResourceGuid             *string                        `json:"resourceGuid,omitempty"`
+	ServicePublicIPAddress   *PublicIPAddress               `json:"servicePublicIPAddress,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_publicipaddresssku.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_publicipaddresssku.go
@@ -1,0 +1,9 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PublicIPAddressSku struct {
+	Name *PublicIPAddressSkuName `json:"name,omitempty"`
+	Tier *PublicIPAddressSkuTier `json:"tier,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_publicipddosprotectionstatusresult.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_publicipddosprotectionstatusresult.go
@@ -1,0 +1,11 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PublicIPDdosProtectionStatusResult struct {
+	DdosProtectionPlanId *string              `json:"ddosProtectionPlanId,omitempty"`
+	IsWorkloadProtected  *IsWorkloadProtected `json:"isWorkloadProtected,omitempty"`
+	PublicIPAddress      *string              `json:"publicIpAddress,omitempty"`
+	PublicIPAddressId    *string              `json:"publicIpAddressId,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_resourcenavigationlink.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_resourcenavigationlink.go
@@ -1,0 +1,12 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ResourceNavigationLink struct {
+	Etag       *string                       `json:"etag,omitempty"`
+	Id         *string                       `json:"id,omitempty"`
+	Name       *string                       `json:"name,omitempty"`
+	Properties *ResourceNavigationLinkFormat `json:"properties,omitempty"`
+	Type       *string                       `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_resourcenavigationlinkformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_resourcenavigationlinkformat.go
@@ -1,0 +1,10 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ResourceNavigationLinkFormat struct {
+	Link               *string            `json:"link,omitempty"`
+	LinkedResourceType *string            `json:"linkedResourceType,omitempty"`
+	ProvisioningState  *ProvisioningState `json:"provisioningState,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_resourceset.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_resourceset.go
@@ -1,0 +1,8 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ResourceSet struct {
+	Subscriptions *[]string `json:"subscriptions,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_retentionpolicyparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_retentionpolicyparameters.go
@@ -1,0 +1,9 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RetentionPolicyParameters struct {
+	Days    *int64 `json:"days,omitempty"`
+	Enabled *bool  `json:"enabled,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_route.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_route.go
@@ -1,0 +1,12 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type Route struct {
+	Etag       *string                `json:"etag,omitempty"`
+	Id         *string                `json:"id,omitempty"`
+	Name       *string                `json:"name,omitempty"`
+	Properties *RoutePropertiesFormat `json:"properties,omitempty"`
+	Type       *string                `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_routenexthopecmp.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_routenexthopecmp.go
@@ -1,0 +1,8 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RouteNextHopEcmp struct {
+	NextHopIPAddresses []string `json:"nextHopIpAddresses"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_routepropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_routepropertiesformat.go
@@ -1,0 +1,13 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RoutePropertiesFormat struct {
+	AddressPrefix     *string            `json:"addressPrefix,omitempty"`
+	HasBgpOverride    *bool              `json:"hasBgpOverride,omitempty"`
+	NextHop           *RouteNextHopEcmp  `json:"nextHop,omitempty"`
+	NextHopIPAddress  *string            `json:"nextHopIpAddress,omitempty"`
+	NextHopType       RouteNextHopType   `json:"nextHopType"`
+	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_routetable.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_routetable.go
@@ -1,0 +1,14 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RouteTable struct {
+	Etag       *string                     `json:"etag,omitempty"`
+	Id         *string                     `json:"id,omitempty"`
+	Location   *string                     `json:"location,omitempty"`
+	Name       *string                     `json:"name,omitempty"`
+	Properties *RouteTablePropertiesFormat `json:"properties,omitempty"`
+	Tags       *map[string]string          `json:"tags,omitempty"`
+	Type       *string                     `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_routetablepropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_routetablepropertiesformat.go
@@ -1,0 +1,13 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RouteTablePropertiesFormat struct {
+	DisableBgpRoutePropagation *bool                `json:"disableBgpRoutePropagation,omitempty"`
+	DisablePeeringRoute        *DisablePeeringRoute `json:"disablePeeringRoute,omitempty"`
+	ProvisioningState          *ProvisioningState   `json:"provisioningState,omitempty"`
+	ResourceGuid               *string              `json:"resourceGuid,omitempty"`
+	Routes                     *[]Route             `json:"routes,omitempty"`
+	Subnets                    *[]Subnet            `json:"subnets,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_securityrule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_securityrule.go
@@ -1,0 +1,12 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SecurityRule struct {
+	Etag       *string                       `json:"etag,omitempty"`
+	Id         *string                       `json:"id,omitempty"`
+	Name       *string                       `json:"name,omitempty"`
+	Properties *SecurityRulePropertiesFormat `json:"properties,omitempty"`
+	Type       *string                       `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_securityrulepropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_securityrulepropertiesformat.go
@@ -1,0 +1,23 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SecurityRulePropertiesFormat struct {
+	Access                               SecurityRuleAccess          `json:"access"`
+	Description                          *string                     `json:"description,omitempty"`
+	DestinationAddressPrefix             *string                     `json:"destinationAddressPrefix,omitempty"`
+	DestinationAddressPrefixes           *[]string                   `json:"destinationAddressPrefixes,omitempty"`
+	DestinationApplicationSecurityGroups *[]ApplicationSecurityGroup `json:"destinationApplicationSecurityGroups,omitempty"`
+	DestinationPortRange                 *string                     `json:"destinationPortRange,omitempty"`
+	DestinationPortRanges                *[]string                   `json:"destinationPortRanges,omitempty"`
+	Direction                            SecurityRuleDirection       `json:"direction"`
+	Priority                             int64                       `json:"priority"`
+	Protocol                             SecurityRuleProtocol        `json:"protocol"`
+	ProvisioningState                    *ProvisioningState          `json:"provisioningState,omitempty"`
+	SourceAddressPrefix                  *string                     `json:"sourceAddressPrefix,omitempty"`
+	SourceAddressPrefixes                *[]string                   `json:"sourceAddressPrefixes,omitempty"`
+	SourceApplicationSecurityGroups      *[]ApplicationSecurityGroup `json:"sourceApplicationSecurityGroups,omitempty"`
+	SourcePortRange                      *string                     `json:"sourcePortRange,omitempty"`
+	SourcePortRanges                     *[]string                   `json:"sourcePortRanges,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_serviceassociationlink.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_serviceassociationlink.go
@@ -1,0 +1,12 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ServiceAssociationLink struct {
+	Etag       *string                                 `json:"etag,omitempty"`
+	Id         *string                                 `json:"id,omitempty"`
+	Name       *string                                 `json:"name,omitempty"`
+	Properties *ServiceAssociationLinkPropertiesFormat `json:"properties,omitempty"`
+	Type       *string                                 `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_serviceassociationlinkpropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_serviceassociationlinkpropertiesformat.go
@@ -1,0 +1,12 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ServiceAssociationLinkPropertiesFormat struct {
+	AllowDelete        *bool              `json:"allowDelete,omitempty"`
+	Link               *string            `json:"link,omitempty"`
+	LinkedResourceType *string            `json:"linkedResourceType,omitempty"`
+	Locations          *[]string          `json:"locations,omitempty"`
+	ProvisioningState  *ProvisioningState `json:"provisioningState,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_servicedelegationpropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_servicedelegationpropertiesformat.go
@@ -1,0 +1,10 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ServiceDelegationPropertiesFormat struct {
+	Actions           *[]string          `json:"actions,omitempty"`
+	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty"`
+	ServiceName       *string            `json:"serviceName,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_serviceendpointpolicy.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_serviceendpointpolicy.go
@@ -1,0 +1,15 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ServiceEndpointPolicy struct {
+	Etag       *string                                `json:"etag,omitempty"`
+	Id         *string                                `json:"id,omitempty"`
+	Kind       *string                                `json:"kind,omitempty"`
+	Location   *string                                `json:"location,omitempty"`
+	Name       *string                                `json:"name,omitempty"`
+	Properties *ServiceEndpointPolicyPropertiesFormat `json:"properties,omitempty"`
+	Tags       *map[string]string                     `json:"tags,omitempty"`
+	Type       *string                                `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_serviceendpointpolicydefinition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_serviceendpointpolicydefinition.go
@@ -1,0 +1,12 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ServiceEndpointPolicyDefinition struct {
+	Etag       *string                                          `json:"etag,omitempty"`
+	Id         *string                                          `json:"id,omitempty"`
+	Name       *string                                          `json:"name,omitempty"`
+	Properties *ServiceEndpointPolicyDefinitionPropertiesFormat `json:"properties,omitempty"`
+	Type       *string                                          `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_serviceendpointpolicydefinitionpropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_serviceendpointpolicydefinitionpropertiesformat.go
@@ -1,0 +1,11 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ServiceEndpointPolicyDefinitionPropertiesFormat struct {
+	Description       *string            `json:"description,omitempty"`
+	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty"`
+	Service           *string            `json:"service,omitempty"`
+	ServiceResources  *[]string          `json:"serviceResources,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_serviceendpointpolicypropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_serviceendpointpolicypropertiesformat.go
@@ -1,0 +1,13 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ServiceEndpointPolicyPropertiesFormat struct {
+	ContextualServiceEndpointPolicies *[]string                          `json:"contextualServiceEndpointPolicies,omitempty"`
+	ProvisioningState                 *ProvisioningState                 `json:"provisioningState,omitempty"`
+	ResourceGuid                      *string                            `json:"resourceGuid,omitempty"`
+	ServiceAlias                      *string                            `json:"serviceAlias,omitempty"`
+	ServiceEndpointPolicyDefinitions  *[]ServiceEndpointPolicyDefinition `json:"serviceEndpointPolicyDefinitions,omitempty"`
+	Subnets                           *[]Subnet                          `json:"subnets,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_serviceendpointpropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_serviceendpointpropertiesformat.go
@@ -1,0 +1,11 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ServiceEndpointPropertiesFormat struct {
+	Locations         *[]string          `json:"locations,omitempty"`
+	NetworkIdentifier *SubResource       `json:"networkIdentifier,omitempty"`
+	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty"`
+	Service           *string            `json:"service,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_servicetaginformation.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_servicetaginformation.go
@@ -1,0 +1,11 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ServiceTagInformation struct {
+	Id                     *string                                `json:"id,omitempty"`
+	Name                   *string                                `json:"name,omitempty"`
+	Properties             *ServiceTagInformationPropertiesFormat `json:"properties,omitempty"`
+	ServiceTagChangeNumber *string                                `json:"serviceTagChangeNumber,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_servicetaginformationpropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_servicetaginformationpropertiesformat.go
@@ -1,0 +1,12 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ServiceTagInformationPropertiesFormat struct {
+	AddressPrefixes *[]string `json:"addressPrefixes,omitempty"`
+	ChangeNumber    *string   `json:"changeNumber,omitempty"`
+	Region          *string   `json:"region,omitempty"`
+	State           *string   `json:"state,omitempty"`
+	SystemService   *string   `json:"systemService,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_servicetagslistresult.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_servicetagslistresult.go
@@ -1,0 +1,14 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ServiceTagsListResult struct {
+	ChangeNumber *string                  `json:"changeNumber,omitempty"`
+	Cloud        *string                  `json:"cloud,omitempty"`
+	Id           *string                  `json:"id,omitempty"`
+	Name         *string                  `json:"name,omitempty"`
+	NextLink     *string                  `json:"nextLink,omitempty"`
+	Type         *string                  `json:"type,omitempty"`
+	Values       *[]ServiceTagInformation `json:"values,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_subnet.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_subnet.go
@@ -1,0 +1,12 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type Subnet struct {
+	Etag       *string                 `json:"etag,omitempty"`
+	Id         *string                 `json:"id,omitempty"`
+	Name       *string                 `json:"name,omitempty"`
+	Properties *SubnetPropertiesFormat `json:"properties,omitempty"`
+	Type       *string                 `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_subnetpropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_subnetpropertiesformat.go
@@ -1,0 +1,30 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SubnetPropertiesFormat struct {
+	AddressPrefix                      *string                                          `json:"addressPrefix,omitempty"`
+	AddressPrefixes                    *[]string                                        `json:"addressPrefixes,omitempty"`
+	ApplicationGatewayIPConfigurations *[]ApplicationGatewayIPConfiguration             `json:"applicationGatewayIPConfigurations,omitempty"`
+	DefaultOutboundAccess              *bool                                            `json:"defaultOutboundAccess,omitempty"`
+	Delegations                        *[]Delegation                                    `json:"delegations,omitempty"`
+	IPAllocations                      *[]SubResource                                   `json:"ipAllocations,omitempty"`
+	IPConfigurationProfiles            *[]IPConfigurationProfile                        `json:"ipConfigurationProfiles,omitempty"`
+	IPConfigurations                   *[]IPConfiguration                               `json:"ipConfigurations,omitempty"`
+	IPamPoolPrefixAllocations          *[]IPamPoolPrefixAllocation                      `json:"ipamPoolPrefixAllocations,omitempty"`
+	NatGateway                         *SubResource                                     `json:"natGateway,omitempty"`
+	NetworkSecurityGroup               *NetworkSecurityGroup                            `json:"networkSecurityGroup,omitempty"`
+	PrivateEndpointNetworkPolicies     *VirtualNetworkPrivateEndpointNetworkPolicies    `json:"privateEndpointNetworkPolicies,omitempty"`
+	PrivateEndpoints                   *[]PrivateEndpoint                               `json:"privateEndpoints,omitempty"`
+	PrivateLinkServiceNetworkPolicies  *VirtualNetworkPrivateLinkServiceNetworkPolicies `json:"privateLinkServiceNetworkPolicies,omitempty"`
+	ProvisioningState                  *ProvisioningState                               `json:"provisioningState,omitempty"`
+	Purpose                            *string                                          `json:"purpose,omitempty"`
+	ResourceNavigationLinks            *[]ResourceNavigationLink                        `json:"resourceNavigationLinks,omitempty"`
+	RouteTable                         *RouteTable                                      `json:"routeTable,omitempty"`
+	ServiceAssociationLinks            *[]ServiceAssociationLink                        `json:"serviceAssociationLinks,omitempty"`
+	ServiceEndpointPolicies            *[]ServiceEndpointPolicy                         `json:"serviceEndpointPolicies,omitempty"`
+	ServiceEndpoints                   *[]ServiceEndpointPropertiesFormat               `json:"serviceEndpoints,omitempty"`
+	ServiceGateway                     *SubResource                                     `json:"serviceGateway,omitempty"`
+	SharingScope                       *SharingScope                                    `json:"sharingScope,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_subresource.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_subresource.go
@@ -1,0 +1,8 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SubResource struct {
+	Id *string `json:"id,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_tagsobject.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_tagsobject.go
@@ -1,0 +1,8 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type TagsObject struct {
+	Tags *map[string]string `json:"tags,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_trafficanalyticsconfigurationproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_trafficanalyticsconfigurationproperties.go
@@ -1,0 +1,12 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type TrafficAnalyticsConfigurationProperties struct {
+	Enabled                  *bool   `json:"enabled,omitempty"`
+	TrafficAnalyticsInterval *int64  `json:"trafficAnalyticsInterval,omitempty"`
+	WorkspaceId              *string `json:"workspaceId,omitempty"`
+	WorkspaceRegion          *string `json:"workspaceRegion,omitempty"`
+	WorkspaceResourceId      *string `json:"workspaceResourceId,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_trafficanalyticsproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_trafficanalyticsproperties.go
@@ -1,0 +1,8 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type TrafficAnalyticsProperties struct {
+	NetworkWatcherFlowAnalyticsConfiguration *TrafficAnalyticsConfigurationProperties `json:"networkWatcherFlowAnalyticsConfiguration,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_unpreparenetworkpoliciesrequest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_unpreparenetworkpoliciesrequest.go
@@ -1,0 +1,8 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UnprepareNetworkPoliciesRequest struct {
+	ServiceName *string `json:"serviceName,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_virtualnetwork.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_virtualnetwork.go
@@ -1,0 +1,19 @@
+package virtualnetworks
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/edgezones"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualNetwork struct {
+	Etag             *string                         `json:"etag,omitempty"`
+	ExtendedLocation *edgezones.Model                `json:"extendedLocation,omitempty"`
+	Id               *string                         `json:"id,omitempty"`
+	Location         *string                         `json:"location,omitempty"`
+	Name             *string                         `json:"name,omitempty"`
+	Properties       *VirtualNetworkPropertiesFormat `json:"properties,omitempty"`
+	Tags             *map[string]string              `json:"tags,omitempty"`
+	Type             *string                         `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_virtualnetworkbgpcommunities.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_virtualnetworkbgpcommunities.go
@@ -1,0 +1,9 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualNetworkBgpCommunities struct {
+	RegionalCommunity       *string `json:"regionalCommunity,omitempty"`
+	VirtualNetworkCommunity string  `json:"virtualNetworkCommunity"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_virtualnetworkencryption.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_virtualnetworkencryption.go
@@ -1,0 +1,9 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualNetworkEncryption struct {
+	Enabled     bool                                 `json:"enabled"`
+	Enforcement *VirtualNetworkEncryptionEnforcement `json:"enforcement,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_virtualnetworkpeering.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_virtualnetworkpeering.go
@@ -1,0 +1,12 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualNetworkPeering struct {
+	Etag       *string                                `json:"etag,omitempty"`
+	Id         *string                                `json:"id,omitempty"`
+	Name       *string                                `json:"name,omitempty"`
+	Properties *VirtualNetworkPeeringPropertiesFormat `json:"properties,omitempty"`
+	Type       *string                                `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_virtualnetworkpeeringpropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_virtualnetworkpeeringpropertiesformat.go
@@ -1,0 +1,27 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualNetworkPeeringPropertiesFormat struct {
+	AllowForwardedTraffic            *bool                         `json:"allowForwardedTraffic,omitempty"`
+	AllowGatewayTransit              *bool                         `json:"allowGatewayTransit,omitempty"`
+	AllowVirtualNetworkAccess        *bool                         `json:"allowVirtualNetworkAccess,omitempty"`
+	DoNotVerifyRemoteGateways        *bool                         `json:"doNotVerifyRemoteGateways,omitempty"`
+	EnableOnlyIPv6Peering            *bool                         `json:"enableOnlyIPv6Peering,omitempty"`
+	LocalAddressSpace                *AddressSpace                 `json:"localAddressSpace,omitempty"`
+	LocalSubnetNames                 *[]string                     `json:"localSubnetNames,omitempty"`
+	LocalVirtualNetworkAddressSpace  *AddressSpace                 `json:"localVirtualNetworkAddressSpace,omitempty"`
+	PeerCompleteVnets                *bool                         `json:"peerCompleteVnets,omitempty"`
+	PeeringState                     *VirtualNetworkPeeringState   `json:"peeringState,omitempty"`
+	PeeringSyncLevel                 *VirtualNetworkPeeringLevel   `json:"peeringSyncLevel,omitempty"`
+	ProvisioningState                *ProvisioningState            `json:"provisioningState,omitempty"`
+	RemoteAddressSpace               *AddressSpace                 `json:"remoteAddressSpace,omitempty"`
+	RemoteBgpCommunities             *VirtualNetworkBgpCommunities `json:"remoteBgpCommunities,omitempty"`
+	RemoteSubnetNames                *[]string                     `json:"remoteSubnetNames,omitempty"`
+	RemoteVirtualNetwork             *SubResource                  `json:"remoteVirtualNetwork,omitempty"`
+	RemoteVirtualNetworkAddressSpace *AddressSpace                 `json:"remoteVirtualNetworkAddressSpace,omitempty"`
+	RemoteVirtualNetworkEncryption   *VirtualNetworkEncryption     `json:"remoteVirtualNetworkEncryption,omitempty"`
+	ResourceGuid                     *string                       `json:"resourceGuid,omitempty"`
+	UseRemoteGateways                *bool                         `json:"useRemoteGateways,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_virtualnetworkpropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_virtualnetworkpropertiesformat.go
@@ -1,0 +1,24 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualNetworkPropertiesFormat struct {
+	AddressSpace                *AddressSpace                 `json:"addressSpace,omitempty"`
+	BgpCommunities              *VirtualNetworkBgpCommunities `json:"bgpCommunities,omitempty"`
+	DdosProtectionPlan          *SubResource                  `json:"ddosProtectionPlan,omitempty"`
+	DefaultPublicNatGateway     *SubResource                  `json:"defaultPublicNatGateway,omitempty"`
+	DhcpOptions                 *DhcpOptions                  `json:"dhcpOptions,omitempty"`
+	EnableDdosProtection        *bool                         `json:"enableDdosProtection,omitempty"`
+	EnableVMProtection          *bool                         `json:"enableVmProtection,omitempty"`
+	Encryption                  *VirtualNetworkEncryption     `json:"encryption,omitempty"`
+	FlowLogs                    *[]FlowLog                    `json:"flowLogs,omitempty"`
+	FlowTimeoutInMinutes        *int64                        `json:"flowTimeoutInMinutes,omitempty"`
+	IPAllocations               *[]SubResource                `json:"ipAllocations,omitempty"`
+	PrivateEndpointVNetPolicies *PrivateEndpointVNetPolicies  `json:"privateEndpointVNetPolicies,omitempty"`
+	ProvisioningState           *ProvisioningState            `json:"provisioningState,omitempty"`
+	ResourceGuid                *string                       `json:"resourceGuid,omitempty"`
+	Subnets                     *[]Subnet                     `json:"subnets,omitempty"`
+	SummarizedGatewayPrefixes   *AddressSpace                 `json:"summarizedGatewayPrefixes,omitempty"`
+	VirtualNetworkPeerings      *[]VirtualNetworkPeering      `json:"virtualNetworkPeerings,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_virtualnetworktap.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_virtualnetworktap.go
@@ -1,0 +1,14 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualNetworkTap struct {
+	Etag       *string                            `json:"etag,omitempty"`
+	Id         *string                            `json:"id,omitempty"`
+	Location   *string                            `json:"location,omitempty"`
+	Name       *string                            `json:"name,omitempty"`
+	Properties *VirtualNetworkTapPropertiesFormat `json:"properties,omitempty"`
+	Tags       *map[string]string                 `json:"tags,omitempty"`
+	Type       *string                            `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_virtualnetworktappropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_virtualnetworktappropertiesformat.go
@@ -1,0 +1,13 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualNetworkTapPropertiesFormat struct {
+	DestinationLoadBalancerFrontEndIPConfiguration *FrontendIPConfiguration            `json:"destinationLoadBalancerFrontEndIPConfiguration,omitempty"`
+	DestinationNetworkInterfaceIPConfiguration     *NetworkInterfaceIPConfiguration    `json:"destinationNetworkInterfaceIPConfiguration,omitempty"`
+	DestinationPort                                *int64                              `json:"destinationPort,omitempty"`
+	NetworkInterfaceTapConfigurations              *[]NetworkInterfaceTapConfiguration `json:"networkInterfaceTapConfigurations,omitempty"`
+	ProvisioningState                              *ProvisioningState                  `json:"provisioningState,omitempty"`
+	ResourceGuid                                   *string                             `json:"resourceGuid,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_virtualnetworkusage.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_virtualnetworkusage.go
@@ -1,0 +1,12 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualNetworkUsage struct {
+	CurrentValue *float64                 `json:"currentValue,omitempty"`
+	Id           *string                  `json:"id,omitempty"`
+	Limit        *float64                 `json:"limit,omitempty"`
+	Name         *VirtualNetworkUsageName `json:"name,omitempty"`
+	Unit         *string                  `json:"unit,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_virtualnetworkusagename.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/model_virtualnetworkusagename.go
@@ -1,0 +1,9 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualNetworkUsageName struct {
+	LocalizedValue *string `json:"localizedValue,omitempty"`
+	Value          *string `json:"value,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/predicates.go
@@ -1,0 +1,312 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AvailableDelegationOperationPredicate struct {
+	Id          *string
+	Name        *string
+	ServiceName *string
+	Type        *string
+}
+
+func (p AvailableDelegationOperationPredicate) Matches(input AvailableDelegation) bool {
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.ServiceName != nil && (input.ServiceName == nil || *p.ServiceName != *input.ServiceName) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}
+
+type AvailablePrivateEndpointTypeOperationPredicate struct {
+	DisplayName  *string
+	Id           *string
+	Name         *string
+	ResourceName *string
+	Type         *string
+}
+
+func (p AvailablePrivateEndpointTypeOperationPredicate) Matches(input AvailablePrivateEndpointType) bool {
+
+	if p.DisplayName != nil && (input.DisplayName == nil || *p.DisplayName != *input.DisplayName) {
+		return false
+	}
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.ResourceName != nil && (input.ResourceName == nil || *p.ResourceName != *input.ResourceName) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}
+
+type AvailableServiceAliasOperationPredicate struct {
+	Id           *string
+	Name         *string
+	ResourceName *string
+	Type         *string
+}
+
+func (p AvailableServiceAliasOperationPredicate) Matches(input AvailableServiceAlias) bool {
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.ResourceName != nil && (input.ResourceName == nil || *p.ResourceName != *input.ResourceName) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}
+
+type EndpointServiceResultOperationPredicate struct {
+	Id   *string
+	Name *string
+	Type *string
+}
+
+func (p EndpointServiceResultOperationPredicate) Matches(input EndpointServiceResult) bool {
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}
+
+type PublicIPAddressOperationPredicate struct {
+	Etag     *string
+	Id       *string
+	Location *string
+	Name     *string
+	Type     *string
+}
+
+func (p PublicIPAddressOperationPredicate) Matches(input PublicIPAddress) bool {
+
+	if p.Etag != nil && (input.Etag == nil || *p.Etag != *input.Etag) {
+		return false
+	}
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Location != nil && (input.Location == nil || *p.Location != *input.Location) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}
+
+type PublicIPDdosProtectionStatusResultOperationPredicate struct {
+	DdosProtectionPlanId *string
+	PublicIPAddress      *string
+	PublicIPAddressId    *string
+}
+
+func (p PublicIPDdosProtectionStatusResultOperationPredicate) Matches(input PublicIPDdosProtectionStatusResult) bool {
+
+	if p.DdosProtectionPlanId != nil && (input.DdosProtectionPlanId == nil || *p.DdosProtectionPlanId != *input.DdosProtectionPlanId) {
+		return false
+	}
+
+	if p.PublicIPAddress != nil && (input.PublicIPAddress == nil || *p.PublicIPAddress != *input.PublicIPAddress) {
+		return false
+	}
+
+	if p.PublicIPAddressId != nil && (input.PublicIPAddressId == nil || *p.PublicIPAddressId != *input.PublicIPAddressId) {
+		return false
+	}
+
+	return true
+}
+
+type ResourceNavigationLinkOperationPredicate struct {
+	Etag *string
+	Id   *string
+	Name *string
+	Type *string
+}
+
+func (p ResourceNavigationLinkOperationPredicate) Matches(input ResourceNavigationLink) bool {
+
+	if p.Etag != nil && (input.Etag == nil || *p.Etag != *input.Etag) {
+		return false
+	}
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}
+
+type ServiceAssociationLinkOperationPredicate struct {
+	Etag *string
+	Id   *string
+	Name *string
+	Type *string
+}
+
+func (p ServiceAssociationLinkOperationPredicate) Matches(input ServiceAssociationLink) bool {
+
+	if p.Etag != nil && (input.Etag == nil || *p.Etag != *input.Etag) {
+		return false
+	}
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}
+
+type ServiceTagInformationOperationPredicate struct {
+	Id                     *string
+	Name                   *string
+	ServiceTagChangeNumber *string
+}
+
+func (p ServiceTagInformationOperationPredicate) Matches(input ServiceTagInformation) bool {
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.ServiceTagChangeNumber != nil && (input.ServiceTagChangeNumber == nil || *p.ServiceTagChangeNumber != *input.ServiceTagChangeNumber) {
+		return false
+	}
+
+	return true
+}
+
+type VirtualNetworkOperationPredicate struct {
+	Etag     *string
+	Id       *string
+	Location *string
+	Name     *string
+	Type     *string
+}
+
+func (p VirtualNetworkOperationPredicate) Matches(input VirtualNetwork) bool {
+
+	if p.Etag != nil && (input.Etag == nil || *p.Etag != *input.Etag) {
+		return false
+	}
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Location != nil && (input.Location == nil || *p.Location != *input.Location) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}
+
+type VirtualNetworkUsageOperationPredicate struct {
+	CurrentValue *float64
+	Id           *string
+	Limit        *float64
+	Unit         *string
+}
+
+func (p VirtualNetworkUsageOperationPredicate) Matches(input VirtualNetworkUsage) bool {
+
+	if p.CurrentValue != nil && (input.CurrentValue == nil || *p.CurrentValue != *input.CurrentValue) {
+		return false
+	}
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Limit != nil && (input.Limit == nil || *p.Limit != *input.Limit) {
+		return false
+	}
+
+	if p.Unit != nil && (input.Unit == nil || *p.Unit != *input.Unit) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks/version.go
@@ -1,0 +1,14 @@
+package virtualnetworks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2025-07-01"
+
+func userAgent() string {
+	return "hashicorp/go-azure-sdk/virtualnetworks/2025-07-01"
+}
+
+func AzureAPIVersion() string {
+	return defaultApiVersion
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -950,6 +950,7 @@ github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/vpnserverc
 github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/vpnsites
 github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/webapplicationfirewallpolicies
 github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/webcategories
+github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-07-01/virtualnetworks
 github.com/hashicorp/go-azure-sdk/resource-manager/networkfunction/2022-11-01/azuretrafficcollectors
 github.com/hashicorp/go-azure-sdk/resource-manager/networkfunction/2022-11-01/collectorpolicies
 github.com/hashicorp/go-azure-sdk/resource-manager/newrelic/2024-03-01/monitors

--- a/website/docs/r/virtual_network.html.markdown
+++ b/website/docs/r/virtual_network.html.markdown
@@ -97,6 +97,8 @@ The following arguments are supported:
 
 * `private_endpoint_vnet_policies` - (Optional) The Private Endpoint VNet Policies for the Virtual Network. Possible values are `Disabled` and `Basic`. Defaults to `Disabled`.
 
+* `summarized_gateway_prefixes` - (Optional) The list of summarized gateway prefixes advertised for the Virtual Network.
+
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ---
@@ -232,4 +234,4 @@ terraform import azurerm_virtual_network.exampleNetwork /subscriptions/00000000-
 <!-- This section is generated, changes will be overwritten -->
 This resource uses the following Azure API Providers:
 
-* `Microsoft.Network` - 2025-01-01
+* `Microsoft.Network` - 2025-07-01

--- a/website/docs/r/virtual_network_dns_servers.html.markdown
+++ b/website/docs/r/virtual_network_dns_servers.html.markdown
@@ -74,4 +74,4 @@ terraform import azurerm_virtual_network_dns_servers.exampleNetwork /subscriptio
 <!-- This section is generated, changes will be overwritten -->
 This resource uses the following Azure API Providers:
 
-* `Microsoft.Network` - 2025-01-01
+* `Microsoft.Network` - 2025-07-01


### PR DESCRIPTION
<!-- markdownlint-disable-file first-line-heading -->
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

`summarized_gateway_prefixes` property is added in `azurerm_virtual_network` resource. The related documentations are listed below.

* Documentation: https://learn.microsoft.com/en-us/azure/virtual-network/advertised-gateway-prefixes-overview
* API: https://learn.microsoft.com/en-us/rest/api/virtualnetwork/virtual-networks/create-or-update?view=rest-virtualnetwork-2025-07-01&tabs=HTTP#request-body

Files to be reviewed include:

```
internal/services/containers/kubernetes_cluster_node_pool_resource.go
internal/services/network/client/client.go
internal/services/network/helpers.go
internal/services/network/subnet_nat_gateway_association_resource.go
internal/services/network/subnet_network_security_group_association_resource.go
internal/services/network/subnet_resource.go
internal/services/network/subnet_route_table_association_resource.go
internal/services/network/virtual_network_dns_servers_resource.go
internal/services/network/virtual_network_resource.go
internal/services/network/virtual_network_resource_list.go
internal/services/network/virtual_network_resource_test.go
website/docs/r/virtual_network.html.markdown
```

This PR is in pending stage as current changes only involve partial API version bumping. Another PR will be opened specifically to update the API version before this PR can be reviewed.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”

<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->

## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] ~(For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.~

## Testing

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_virtual_network` - add `summarized_gateway_prefixes` property
* Network - bump some of virtual network API versions to 2025-07-01

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change

## Related Issue(s)

Fixes #33348 

> [!NOTE]
> If this PR changes meaningfully during the course of review please update the title and description as required.
