### PR TITLE
`azurerm_mssql_database` - derive `zone_redundant` from the elastic pool when not explicitly configured

### DIFF
--- a/internal/services/mssql/mssql_database_resource.go
+++ b/internal/services/mssql/mssql_database_resource.go
@@ -341,12 +341,18 @@ func resourceMsSqlDatabaseCreate(d *pluginsdk.ResourceData, meta interface{}) er
 			HighAvailabilityReplicaCount:     pointer.To(int64(d.Get("read_replica_count").(int))),
 			SampleName:                       pointer.ToEnum[databases.SampleName](d.Get("sample_name").(string)),
 			RequestedBackupStorageRedundancy: pointer.ToEnum[databases.BackupStorageRedundancy](d.Get("storage_account_type").(string)),
-			ZoneRedundant:                    pointer.To(d.Get("zone_redundant").(bool)),
 			IsLedgerOn:                       pointer.To(ledgerEnabled),
 			SecondaryType:                    pointer.ToEnum[databases.SecondaryType](d.Get("secondary_type").(string)),
 		},
 
 		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
+	}
+
+	// NOTE: 'zone_redundant' is only sent when it is explicitly set in the configuration - when omitted
+	// the service derives it, e.g. a database created in a zone redundant elastic pool must also be zone
+	// redundant, and explicitly sending 'false' in that case is rejected by the API...
+	if !d.GetRawConfig().AsValueMap()["zone_redundant"].IsNull() {
+		input.Properties.ZoneRedundant = pointer.To(d.Get("zone_redundant").(bool))
 	}
 
 	// NOTE: The 'PreferredEnclaveType' field cannot be passed to the APIs Create if the 'sku_name' is a DW or DC-series SKU...

--- a/internal/services/mssql/mssql_database_resource_test.go
+++ b/internal/services/mssql/mssql_database_resource_test.go
@@ -175,6 +175,23 @@ func TestAccMsSqlDatabase_elasticPool(t *testing.T) {
 	})
 }
 
+func TestAccMsSqlDatabase_elasticPoolZoneRedundantDerived(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_mssql_database", "test")
+	r := MssqlDatabaseResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			// `zone_redundant` is not set on the database and should be derived from the elastic pool
+			Config: r.elasticPoolZoneRedundant(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("zone_redundant").HasValue("true"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccMsSqlDatabase_gp(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_mssql_database", "test")
 	r := MssqlDatabaseResource{}
@@ -1466,6 +1483,40 @@ resource "azurerm_mssql_elasticpool" "test" {
   location            = azurerm_resource_group.test.location
   server_name         = azurerm_mssql_server.test.name
   max_size_gb         = 5
+
+  sku {
+    name     = "GP_Gen5"
+    tier     = "GeneralPurpose"
+    capacity = 4
+    family   = "Gen5"
+  }
+
+  per_database_settings {
+    min_capacity = 0.25
+    max_capacity = 4
+  }
+}
+
+resource "azurerm_mssql_database" "test" {
+  name            = "acctest-db-%[2]d"
+  server_id       = azurerm_mssql_server.test.id
+  elastic_pool_id = azurerm_mssql_elasticpool.test.id
+  sku_name        = "ElasticPool"
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r MssqlDatabaseResource) elasticPoolZoneRedundant(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_mssql_elasticpool" "test" {
+  name                = "acctest-pool-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  server_name         = azurerm_mssql_server.test.name
+  max_size_gb         = 5
+  zone_redundant      = true
 
   sku {
     name     = "GP_Gen5"

--- a/website/docs/r/mssql_database.html.markdown
+++ b/website/docs/r/mssql_database.html.markdown
@@ -251,7 +251,7 @@ The following arguments are supported:
 
 ~> **Note:** When the `sku_name` is `DW100c`, the `transparent_data_encryption_key_automatic_rotation_enabled` and the `transparent_data_encryption_key_vault_key_id` properties should not be specified, as database-level CMK is not supported for Data Warehouse SKUs.
 
-* `zone_redundant` - (Optional) Whether or not this database is zone redundant, which means the replicas of this database will be spread across multiple availability zones. This property is only settable for Premium and Business Critical databases.
+* `zone_redundant` - (Optional) Whether or not this database is zone redundant, which means the replicas of this database will be spread across multiple availability zones. This property is only settable for Premium and Business Critical databases. When omitted, the value is derived by the service - for example, a database created in a zone redundant elastic pool inherits the zone redundancy of the pool.
 
 * `secondary_type` - (Optional) How do you want your replica to be made? Valid values include `Geo`, `Named` and `Standby`. Defaults to `Geo`. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
<!-- markdownlint-disable-file first-line-heading -->

## Community Note
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

Creating an `azurerm_mssql_database` inside a zone redundant `azurerm_mssql_elasticpool` currently fails unless the database explicitly sets `zone_redundant = true` to match the pool. This is because the create path unconditionally sends `zoneRedundant` to the API — `d.Get("zone_redundant")` returns `false` when the attribute is omitted (the schema is `Optional` + `Computed` with no default), and the service rejects a non-zone-redundant database in a zone redundant pool.

Requiring users to duplicate the pool's setting on every pooled database is unnecessary: the service can derive the value itself. This PR only sends `zoneRedundant` on create when the attribute is explicitly present in the configuration (checked via `d.GetRawConfig()`, the same pattern already used in this service, e.g. for `high_availability_replica_count` in `mssql_elasticpool_resource.go`). When omitted:

* a database created in a zone redundant elastic pool now inherits the pool's zone redundancy instead of failing, and
* a non-pooled database keeps today's behavior — the API default is `false`, identical to the `false` the provider used to send — so this is not a breaking change.

The Update path is unchanged: it already only sends the property on `d.HasChange("zone_redundant")`, and Read stores the service-derived value in state (the attribute is `Computed`), so there is no perpetual diff.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.

## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.

## Testing

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

A new acceptance test `TestAccMsSqlDatabase_elasticPoolZoneRedundantDerived` creates a database with no `zone_redundant` attribute inside a zone redundant elastic pool and asserts the derived value is `true` — this exact configuration fails on `main` today. I was not able to run the acceptance tests against a live subscription (provisioning a zone redundant elastic pool was not possible in my environment); `go build`, `go vet` and compilation of the test package pass locally. Happy to iterate if CI surfaces anything.

## Change Log

* `azurerm_mssql_database` - `zone_redundant` is now derived by the service (e.g. from the elastic pool) when not explicitly configured [GH-00000]

This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change

## AI Assistance Disclosure

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

Code, acceptance test, documentation update and this PR description were authored with the assistance of Claude Code, directed and reviewed by the contributor. Responses to review feedback may also be AI-assisted.

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

No changes to security controls.