### PR TITLE
`kubernetes_cluster_node_pool` - add List Resource support

### DIFF
--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -38,6 +38,10 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
 
+const azureKubernetesClusterNodePoolResourceName = "azurerm_kubernetes_cluster_node_pool"
+
+//go:generate go run ../../tools/generator-tests resourceidentity -parent-id "kubernetes_cluster_id" -test-name "manualScaleConfig"
+
 func resourceKubernetesClusterNodePool() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
 		Create: resourceKubernetesClusterNodePoolCreate,
@@ -45,10 +49,11 @@ func resourceKubernetesClusterNodePool() *pluginsdk.Resource {
 		Update: resourceKubernetesClusterNodePoolUpdate,
 		Delete: resourceKubernetesClusterNodePoolDelete,
 
-		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
-			_, err := agentpools.ParseAgentPoolID(id)
-			return err
-		}),
+		Identity: &schema.ResourceIdentity{
+			SchemaFunc: pluginsdk.GenerateIdentitySchema(&agentpools.AgentPoolId{}),
+		},
+
+		Importer: pluginsdk.ImporterValidatingIdentity(&agentpools.AgentPoolId{}),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(60 * time.Minute),
@@ -488,7 +493,7 @@ func resourceKubernetesClusterNodePoolCreate(d *pluginsdk.ResourceData, meta int
 		}
 
 		if !response.WasNotFound(existing.HttpResponse) {
-			return tf.ImportAsExistsError("azurerm_kubernetes_cluster_node_pool", id.ID())
+			return tf.ImportAsExistsError(azureKubernetesClusterNodePoolResourceName, id.ID())
 		}
 	}
 
@@ -683,10 +688,13 @@ func resourceKubernetesClusterNodePoolCreate(d *pluginsdk.ResourceData, meta int
 		Properties: &profile,
 	}
 
-	if err := poolsClient.CreateOrUpdateCallbackThenPoll(ctx, id, parameters, agentpools.DefaultCreateOrUpdateOperationOptions(), sdk.SetIDCallback(meta, &id, d)); err != nil {
+	if err := poolsClient.CreateOrUpdateCallbackThenPoll(ctx, id, parameters, agentpools.DefaultCreateOrUpdateOperationOptions(), sdk.SetIDAndIdentityCallback(meta, &id, d)); err != nil {
 		return fmt.Errorf("creating %s: %+v", id, err)
 	}
 	d.SetId(id.ID())
+	if err := pluginsdk.SetResourceIdentityData(d, &id); err != nil {
+		return err
+	}
 
 	// Wait for vnet and node subnet to come back to Succeeded before releasing any locks
 	timeout, ok := ctx.Deadline()
@@ -1030,8 +1038,6 @@ func resourceKubernetesClusterNodePoolRead(d *pluginsdk.ResourceData, meta inter
 		return err
 	}
 
-	clusterId := commonids.NewKubernetesClusterID(id.SubscriptionId, id.ResourceGroupName, id.ManagedClusterName)
-
 	resp, err := poolsClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
@@ -1043,10 +1049,16 @@ func resourceKubernetesClusterNodePoolRead(d *pluginsdk.ResourceData, meta inter
 		return fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
+	return resourceKubernetesClusterNodePoolFlatten(d, id, resp.Model)
+}
+
+func resourceKubernetesClusterNodePoolFlatten(d *pluginsdk.ResourceData, id *agentpools.AgentPoolId, model *agentpools.AgentPool) error {
+	clusterId := commonids.NewKubernetesClusterID(id.SubscriptionId, id.ResourceGroupName, id.ManagedClusterName)
+
 	d.Set("name", id.AgentPoolName)
 	d.Set("kubernetes_cluster_id", clusterId.ID())
 
-	if model := resp.Model; model != nil && model.Properties != nil {
+	if model != nil && model.Properties != nil {
 		props := model.Properties
 		d.Set("zones", zones.FlattenUntyped(props.AvailabilityZones))
 
@@ -1200,9 +1212,13 @@ func resourceKubernetesClusterNodePoolRead(d *pluginsdk.ResourceData, meta inter
 		if err := d.Set("node_network_profile", flattenAgentPoolNetworkProfile(props.NetworkProfile)); err != nil {
 			return fmt.Errorf("setting `node_network_profile`: %+v", err)
 		}
+
+		if err := tags.FlattenAndSet(d, props.Tags); err != nil {
+			return err
+		}
 	}
 
-	return tags.FlattenAndSet(d, resp.Model.Properties.Tags)
+	return pluginsdk.SetResourceIdentityData(d, id)
 }
 
 func resourceKubernetesClusterNodePoolDelete(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -40,7 +40,7 @@ import (
 
 const azureKubernetesClusterNodePoolResourceName = "azurerm_kubernetes_cluster_node_pool"
 
-//go:generate go run ../../tools/generator-tests resourceidentity -parent-id "kubernetes_cluster_id" -test-name "manualScaleConfig"
+//go:generate go run ../../tools/generator-tests resourceidentity -properties "name" -compare-values "managed_cluster_name:kubernetes_cluster_id,resource_group_name:kubernetes_cluster_id,subscription_id:kubernetes_cluster_id" -test-name "manualScaleConfig"
 
 func resourceKubernetesClusterNodePool() *pluginsdk.Resource {
 	return &pluginsdk.Resource{

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource_identity_gen_test.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource_identity_gen_test.go
@@ -17,8 +17,8 @@ func TestAccKubernetesClusterNodePool_resourceIdentity(t *testing.T) {
 	r := KubernetesClusterNodePoolResource{}
 
 	checkedFields := map[string]struct{}{
-		"managed_cluster_name": {},
 		"name":                 {},
+		"managed_cluster_name": {},
 		"resource_group_name":  {},
 		"subscription_id":      {},
 	}
@@ -28,8 +28,8 @@ func TestAccKubernetesClusterNodePool_resourceIdentity(t *testing.T) {
 			Config: r.manualScaleConfig(data),
 			ConfigStateChecks: []statecheck.StateCheck{
 				customstatecheck.ExpectAllIdentityFieldsAreChecked("azurerm_kubernetes_cluster_node_pool.test", checkedFields),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_kubernetes_cluster_node_pool.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
 				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_kubernetes_cluster_node_pool.test", tfjsonpath.New("managed_cluster_name"), tfjsonpath.New("kubernetes_cluster_id")),
-				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_kubernetes_cluster_node_pool.test", tfjsonpath.New("name"), tfjsonpath.New("kubernetes_cluster_id")),
 				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_kubernetes_cluster_node_pool.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("kubernetes_cluster_id")),
 				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_kubernetes_cluster_node_pool.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("kubernetes_cluster_id")),
 			},

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource_identity_gen_test.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource_identity_gen_test.go
@@ -1,0 +1,40 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package containers_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
+)
+
+func TestAccKubernetesClusterNodePool_resourceIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster_node_pool", "test")
+	r := KubernetesClusterNodePoolResource{}
+
+	checkedFields := map[string]struct{}{
+		"managed_cluster_name": {},
+		"name":                 {},
+		"resource_group_name":  {},
+		"subscription_id":      {},
+	}
+
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.manualScaleConfig(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				customstatecheck.ExpectAllIdentityFieldsAreChecked("azurerm_kubernetes_cluster_node_pool.test", checkedFields),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_kubernetes_cluster_node_pool.test", tfjsonpath.New("managed_cluster_name"), tfjsonpath.New("kubernetes_cluster_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_kubernetes_cluster_node_pool.test", tfjsonpath.New("name"), tfjsonpath.New("kubernetes_cluster_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_kubernetes_cluster_node_pool.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("kubernetes_cluster_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_kubernetes_cluster_node_pool.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("kubernetes_cluster_id")),
+			},
+		},
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
+}

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource_list.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource_list.go
@@ -1,0 +1,100 @@
+package containers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-azure-helpers/framework/typehelpers"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2025-10-01/agentpools"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-framework/list/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type KubernetesClusterNodePoolListResource struct{}
+
+type KubernetesClusterNodePoolListModel struct {
+	KubernetesClusterId types.String `tfsdk:"kubernetes_cluster_id"`
+}
+
+var _ sdk.FrameworkListWrappedResource = new(KubernetesClusterNodePoolListResource)
+
+func (KubernetesClusterNodePoolListResource) Metadata(_ context.Context, _ resource.MetadataRequest, response *resource.MetadataResponse) {
+	response.TypeName = azureKubernetesClusterNodePoolResourceName
+}
+
+func (KubernetesClusterNodePoolListResource) ResourceFunc() *pluginsdk.Resource {
+	return resourceKubernetesClusterNodePool()
+}
+
+func (KubernetesClusterNodePoolListResource) ListResourceConfigSchema(_ context.Context, _ list.ListResourceSchemaRequest, response *list.ListResourceSchemaResponse) {
+	response.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"kubernetes_cluster_id": schema.StringAttribute{
+				Required: true,
+				Validators: []validator.String{
+					typehelpers.WrappedStringValidator{Func: commonids.ValidateKubernetesClusterID},
+				},
+			},
+		},
+	}
+}
+
+func (KubernetesClusterNodePoolListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream, metadata sdk.ResourceMetadata) {
+	client := metadata.Client.Containers.AgentPoolsClient
+
+	var data KubernetesClusterNodePoolListModel
+	diags := request.Config.Get(ctx, &data)
+	if diags.HasError() {
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+
+	parentID, err := commonids.ParseKubernetesClusterID(data.KubernetesClusterId.ValueString())
+	if err != nil {
+		sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("parsing Kubernetes Cluster ID for `%s`", azureKubernetesClusterNodePoolResourceName), err)
+		return
+	}
+
+	resp, err := client.ListComplete(ctx, *parentID)
+	if err != nil {
+		sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("listing `%s`", azureKubernetesClusterNodePoolResourceName), err)
+		return
+	}
+
+	stream.Results = func(push func(list.ListResult) bool) {
+		for _, item := range resp.Items {
+			result := request.NewListResult(ctx)
+			result.DisplayName = pointer.From(item.Name)
+
+			rd := resourceKubernetesClusterNodePool().Data(&terraform.InstanceState{})
+			id, err := agentpools.ParseAgentPoolIDInsensitively(pointer.From(item.Id))
+			if err != nil {
+				sdk.SetErrorDiagnosticAndPushListResult(result, push, fmt.Sprintf("parsing ID for `%s`", azureKubernetesClusterNodePoolResourceName), err)
+				return
+			}
+			rd.SetId(id.ID())
+
+			if err := resourceKubernetesClusterNodePoolFlatten(rd, id, &item); err != nil {
+				sdk.SetErrorDiagnosticAndPushListResult(result, push, fmt.Sprintf("encoding `%s` resource data", azureKubernetesClusterNodePoolResourceName), err)
+				return
+			}
+
+			sdk.EncodeListResult(ctx, rd, &result)
+			if result.Diagnostics.HasError() {
+				push(result)
+				return
+			}
+			if !push(result) {
+				return
+			}
+		}
+	}
+}

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource_list_test.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource_list_test.go
@@ -1,0 +1,59 @@
+package containers_test
+
+import (
+	"context"
+	"regexp"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
+)
+
+func TestAccKubernetesClusterNodePool_listByKubernetesClusterID(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster_node_pool", "testlist1")
+	r := KubernetesClusterNodePoolResource{}
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []resource.TestStep{
+			{
+				Config: r.manualScaleConfig(data),
+			},
+			{
+				Query:  true,
+				Config: r.basicQuery(),
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectLengthAtLeast("azurerm_kubernetes_cluster_node_pool.list", 1),
+					querycheck.ExpectIdentity(
+						"azurerm_kubernetes_cluster_node_pool.list",
+						map[string]knownvalue.Check{
+							"name":                 knownvalue.StringExact("internal"),
+							"resource_group_name":  knownvalue.StringRegexp(regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
+							"managed_cluster_name": knownvalue.StringRegexp(regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
+							"subscription_id":      knownvalue.StringExact(data.Subscriptions.Primary),
+						},
+					),
+				},
+			},
+		},
+	})
+}
+
+func (r KubernetesClusterNodePoolResource) basicQuery() string {
+	return `
+list "azurerm_kubernetes_cluster_node_pool" "list" {
+  provider = azurerm
+  config {
+    kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
+  }
+}
+`
+}

--- a/internal/services/containers/registration.go
+++ b/internal/services/containers/registration.go
@@ -111,5 +111,6 @@ func (r Registration) EphemeralResources() []func() ephemeral.EphemeralResource 
 func (r Registration) ListResources() []sdk.FrameworkListWrappedResource {
 	return []sdk.FrameworkListWrappedResource{
 		KubernetesAutomaticClusterListResource{},
+		KubernetesClusterNodePoolListResource{},
 	}
 }

--- a/website/docs/list-resources/kubernetes_cluster_node_pool.html.markdown
+++ b/website/docs/list-resources/kubernetes_cluster_node_pool.html.markdown
@@ -1,0 +1,30 @@
+---
+subcategory: "Container"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_kubernetes_cluster_node_pool"
+description: |-
+    Lists Kubernetes Cluster Node Pool resources.
+---
+
+# List resource: azurerm_kubernetes_cluster_node_pool
+
+Lists Kubernetes Cluster Node Pool resources.
+
+## Example Usage
+
+### List Kubernetes Cluster Node Pools in a Kubernetes Cluster
+
+```hcl
+list "azurerm_kubernetes_cluster_node_pool" "example" {
+  provider = azurerm
+  config {
+    kubernetes_cluster_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.ContainerService/managedClusters/cluster1"
+  }
+}
+```
+
+## Argument Reference
+
+This list resource supports the following arguments:
+
+* `kubernetes_cluster_id` - (Required) The ID of the Kubernetes Cluster to query.


### PR DESCRIPTION
<!-- markdownlint-disable-file first-line-heading -->
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”

<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->

## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.

## Testing

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change

## Related Issue(s)

Fixes #0000

## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE]
> If this PR changes meaningfully during the course of review please update the title and description as required.
