### PR TITLE
azproviderlint: enable AZS009 and AZR009, fix findings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -110,9 +110,7 @@ linters:
             - AZS003 # TypeList blocks where every property is optional with no default allow empty blocks - 290 findings to fix later
             - AZS005 # resources with no corresponding data source - 768 findings, to determine if to be fixed later
             - AZS006 # data sources missing properties that exist on the resource - 185 findings, todo later
-            - AZR009 # lifecycle logging (log.Printf("[DEBUG] Creating %s", id)) in CRUD functions - 27 findings, new in v0.8.0, to fix later
             - AZR010 # callers nil-checking before flatten* functions that already handle nil - 244 findings, new in v0.8.0, to fix later
-            - AZS009 # computed-only fields setting input-only attributes (Optional/Default/ValidateFunc) - 35 findings, new in v0.8.0, to fix later
           AZG002:
             use: pointer.To # rather than the go1.26 new(<expr>) builtin
           AZG006:

--- a/internal/services/appservice/helpers/function_app_schema.go
+++ b/internal/services/appservice/helpers/function_app_schema.go
@@ -431,10 +431,8 @@ func SiteConfigSchemaLinuxFunctionAppComputed() *pluginsdk.Schema {
 				"scm_ip_restriction": IpRestrictionSchemaComputed(),
 
 				"scm_ip_restriction_default_action": {
-					Type:         pluginsdk.TypeString,
-					Optional:     true,
-					Default:      webapps.DefaultActionAllow,
-					ValidateFunc: validation.StringInSlice(webapps.PossibleValuesForDefaultAction(), false),
+					Type:     pluginsdk.TypeString,
+					Computed: true,
 				},
 
 				"load_balancing_mode": {

--- a/internal/services/appservice/helpers/linux_web_app_schema.go
+++ b/internal/services/appservice/helpers/linux_web_app_schema.go
@@ -731,7 +731,7 @@ func autoHealTriggerSchemaLinuxComputed() *pluginsdk.Schema {
 
 				"slow_request": {
 					Type:     pluginsdk.TypeList,
-					Optional: true,
+					Computed: true,
 					Elem: &pluginsdk.Resource{
 						Schema: map[string]*pluginsdk.Schema{
 							"time_taken": {

--- a/internal/services/authorization/role_definition_data_source.go
+++ b/internal/services/authorization/role_definition_data_source.go
@@ -107,7 +107,7 @@ func (a RoleDefinitionDataSource) Attributes() map[string]*pluginsdk.Schema {
 
 					"data_actions": {
 						Type:     pluginsdk.TypeSet,
-						Optional: true,
+						Computed: true,
 						Elem: &pluginsdk.Schema{
 							Type: pluginsdk.TypeString,
 						},
@@ -116,7 +116,7 @@ func (a RoleDefinitionDataSource) Attributes() map[string]*pluginsdk.Schema {
 
 					"not_data_actions": {
 						Type:     pluginsdk.TypeSet,
-						Optional: true,
+						Computed: true,
 						Elem: &pluginsdk.Schema{
 							Type: pluginsdk.TypeString,
 						},

--- a/internal/services/automation/automation_hybrid_runbook_worker_group_resource.go
+++ b/internal/services/automation/automation_hybrid_runbook_worker_group_resource.go
@@ -184,7 +184,6 @@ func (m HybridRunbookWorkerGroupResource) Delete() sdk.ResourceFunc {
 			if err != nil {
 				return err
 			}
-			meta.Logger.Infof("deleting %s", id)
 
 			// NOTE: Due to incorrect tags in Azure Swagger, the delete operation is only available
 			// in the ListAllHybridRunbookWorkerGroupInAutomationAccount client, not in the

--- a/internal/services/automation/automation_hybrid_runbook_worker_resource.go
+++ b/internal/services/automation/automation_hybrid_runbook_worker_resource.go
@@ -201,7 +201,6 @@ func (m HybridRunbookWorkerResource) Delete() sdk.ResourceFunc {
 			if err != nil {
 				return err
 			}
-			meta.Logger.Infof("deleting %s", id)
 			client := meta.Client.Automation.HybridRunbookWorker
 			if _, err = client.Delete(ctx, *id); err != nil {
 				return fmt.Errorf("deleting %s: %v", id, err)

--- a/internal/services/automation/automation_python3_package_resource.go
+++ b/internal/services/automation/automation_python3_package_resource.go
@@ -245,7 +245,6 @@ func (m Python3PackageResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			meta.Logger.Infof("deleting %s", id)
 			client := meta.Client.Automation.Python3Package
 			if _, err = client.Delete(ctx, *id); err != nil {
 				return fmt.Errorf("deleting %s: %v", id, err)

--- a/internal/services/automation/automation_source_control_resource.go
+++ b/internal/services/automation/automation_source_control_resource.go
@@ -313,7 +313,6 @@ func (m SourceControlResource) Delete() sdk.ResourceFunc {
 			if err != nil {
 				return err
 			}
-			meta.Logger.Infof("deleting %s", *id)
 			client := meta.Client.Automation.SourceControl
 			if _, err = client.Delete(ctx, *id); err != nil {
 				return fmt.Errorf("deleting %s: %v", *id, err)

--- a/internal/services/automation/automation_watcher_resource.go
+++ b/internal/services/automation/automation_watcher_resource.go
@@ -250,7 +250,6 @@ func (m WatcherResource) Delete() sdk.ResourceFunc {
 			if err != nil {
 				return err
 			}
-			meta.Logger.Infof("deleting %s", id)
 			client := meta.Client.Automation.WatcherClient
 			if _, err = client.Delete(ctx, *id); err != nil {
 				return fmt.Errorf("deleting %s: %v", *id, err)

--- a/internal/services/batch/batch_pool_data_source.go
+++ b/internal/services/batch/batch_pool_data_source.go
@@ -220,7 +220,7 @@ func dataSourceBatchPool() *pluginsdk.Resource {
 					Schema: map[string]*pluginsdk.Schema{
 						"azure_blob_file_system": {
 							Type:     pluginsdk.TypeList,
-							Optional: true,
+							Computed: true,
 							Elem: &pluginsdk.Resource{
 								Schema: map[string]*pluginsdk.Schema{
 									"account_name": {
@@ -256,7 +256,7 @@ func dataSourceBatchPool() *pluginsdk.Resource {
 						},
 						"azure_file_share": {
 							Type:     pluginsdk.TypeList,
-							Optional: true,
+							Computed: true,
 							Elem: &pluginsdk.Resource{
 								Schema: map[string]*pluginsdk.Schema{
 									"account_name": {

--- a/internal/services/codesigning/trusted_signing_account_resource.go
+++ b/internal/services/codesigning/trusted_signing_account_resource.go
@@ -213,8 +213,6 @@ func (m TrustedSigningAccountResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			meta.Logger.Infof("deleting %s", id)
-
 			if err = client.DeleteThenPoll(ctx, *id); err != nil {
 				return fmt.Errorf("deleting %s: %v", id, err)
 			}

--- a/internal/services/compute/marketplace_agreement_data_source.go
+++ b/internal/services/compute/marketplace_agreement_data_source.go
@@ -5,7 +5,6 @@ package compute
 
 import (
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -70,8 +69,6 @@ func dataSourceMarketplaceAgreementRead(d *pluginsdk.ResourceData, meta interfac
 
 	// The Resource ID for this is the Plan ID, however we have to retrieve information about the signed plan
 	id := agreements.NewPlanID(subscriptionId, d.Get("publisher").(string), d.Get("offer").(string), d.Get("plan").(string))
-
-	log.Printf("[DEBUG] retrieving %s", id)
 
 	getId := agreements.NewOfferPlanID(id.SubscriptionId, id.PublisherId, id.OfferId, id.PlanId)
 	term, err := client.MarketplaceAgreementsGet(ctx, getId)

--- a/internal/services/fluidrelay/fluid_relay_server_resource.go
+++ b/internal/services/fluidrelay/fluid_relay_server_resource.go
@@ -346,7 +346,6 @@ func (s Server) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			meta.Logger.Infof("deleting %s", id)
 			if _, err := client.Delete(ctx, *id); err != nil {
 				return fmt.Errorf("deleting %s: %v", id, err)
 			}

--- a/internal/services/keyvault/key_vault_secret_resource.go
+++ b/internal/services/keyvault/key_vault_secret_resource.go
@@ -126,8 +126,6 @@ func resourceKeyVaultSecretCreate(d *pluginsdk.ResourceData, meta interface{}) e
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Print("[INFO] preparing arguments for AzureRM KeyVault Secret creation.")
-
 	name := d.Get("name").(string)
 	keyVaultId, err := commonids.ParseKeyVaultID(d.Get("key_vault_id").(string))
 	if err != nil {
@@ -243,7 +241,6 @@ func resourceKeyVaultSecretUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 	client := meta.(*clients.Client).KeyVault.ManagementClient
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-	log.Print("[INFO] preparing arguments for AzureRM KeyVault Secret update.")
 
 	id, err := keyvault.ParseNestedItemID(d.Id(), keyvault.VersionTypeVersioned, keyvault.NestedItemTypeSecret)
 	if err != nil {

--- a/internal/services/loadbalancer/lb_probe_resource.go
+++ b/internal/services/loadbalancer/lb_probe_resource.go
@@ -109,8 +109,7 @@ func resourceArmLoadBalancerProbe() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeSet,
 				Computed: true,
 				Elem: &pluginsdk.Schema{
-					Type:         pluginsdk.TypeString,
-					ValidateFunc: validation.StringIsNotEmpty,
+					Type: pluginsdk.TypeString,
 				},
 				Set: pluginsdk.HashString,
 			},

--- a/internal/services/loadbalancer/lb_resource.go
+++ b/internal/services/loadbalancer/lb_resource.go
@@ -149,8 +149,7 @@ func resourceArmLoadBalancer() *pluginsdk.Resource {
 							Type:     pluginsdk.TypeSet,
 							Computed: true,
 							Elem: &pluginsdk.Schema{
-								Type:         pluginsdk.TypeString,
-								ValidateFunc: validation.StringIsNotEmpty,
+								Type: pluginsdk.TypeString,
 							},
 							Set: pluginsdk.HashString,
 						},
@@ -159,8 +158,7 @@ func resourceArmLoadBalancer() *pluginsdk.Resource {
 							Type:     pluginsdk.TypeSet,
 							Computed: true,
 							Elem: &pluginsdk.Schema{
-								Type:         pluginsdk.TypeString,
-								ValidateFunc: validation.StringIsNotEmpty,
+								Type: pluginsdk.TypeString,
 							},
 							Set: pluginsdk.HashString,
 						},
@@ -169,8 +167,7 @@ func resourceArmLoadBalancer() *pluginsdk.Resource {
 							Type:     pluginsdk.TypeSet,
 							Computed: true,
 							Elem: &pluginsdk.Schema{
-								Type:         pluginsdk.TypeString,
-								ValidateFunc: validation.StringIsNotEmpty,
+								Type: pluginsdk.TypeString,
 							},
 							Set: pluginsdk.HashString,
 						},

--- a/internal/services/loganalytics/log_analytics_workspace_table_microsoft_resource.go
+++ b/internal/services/loganalytics/log_analytics_workspace_table_microsoft_resource.go
@@ -3,7 +3,6 @@ package loganalytics
 import (
 	"context"
 	"fmt"
-	"log"
 	"regexp"
 	"time"
 
@@ -245,7 +244,6 @@ func (r WorkspaceTableMicrosoftResource) Create() sdk.ResourceFunc {
 			client := metadata.Client.LogAnalytics.TablesClient
 
 			tableName := model.Name
-			log.Printf("[INFO] preparing arguments for AzureRM Log Analytics Workspace Table %s create", tableName)
 
 			workspaceId, err := workspaces.ParseWorkspaceID(model.WorkspaceId)
 			if err != nil {

--- a/internal/services/monitor/monitor_action_group_data_source.go
+++ b/internal/services/monitor/monitor_action_group_data_source.go
@@ -326,7 +326,7 @@ func dataSourceMonitorActionGroup() *pluginsdk.Resource {
 						},
 						"tenant_id": {
 							Type:     pluginsdk.TypeString,
-							Computed: true, // azignore:AZS007 - pre-existing violation
+							Computed: true,
 						},
 						"use_common_alert_schema": {
 							Type:     pluginsdk.TypeBool,

--- a/internal/services/monitor/monitor_action_group_data_source.go
+++ b/internal/services/monitor/monitor_action_group_data_source.go
@@ -313,35 +313,28 @@ func dataSourceMonitorActionGroup() *pluginsdk.Resource {
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
 						"name": {
-							Type:         pluginsdk.TypeString,
-							Required:     true,
-							ValidateFunc: validation.StringIsNotEmpty,
+							Type:     pluginsdk.TypeString,
+							Computed: true,
 						},
 						"event_hub_name": {
-							Type:         pluginsdk.TypeString,
-							Required:     true,
-							ValidateFunc: validation.StringIsNotEmpty,
+							Type:     pluginsdk.TypeString,
+							Computed: true,
 						},
 						"event_hub_namespace": {
-							Type:         pluginsdk.TypeString,
-							Required:     true,
-							ValidateFunc: validation.StringIsNotEmpty,
+							Type:     pluginsdk.TypeString,
+							Computed: true,
 						},
 						"tenant_id": {
-							Type:         pluginsdk.TypeString,
-							Optional:     true,
-							Computed:     true, // azignore:AZS007 - pre-existing violation
-							ValidateFunc: validation.IsUUID,
+							Type:     pluginsdk.TypeString,
+							Computed: true, // azignore:AZS007 - pre-existing violation
 						},
 						"use_common_alert_schema": {
 							Type:     pluginsdk.TypeBool,
-							Optional: true,
+							Computed: true,
 						},
 						"subscription_id": {
-							Type:         pluginsdk.TypeString,
-							Optional:     true,
-							Computed:     true, // azignore:AZS007 - pre-existing violation
-							ValidateFunc: validation.IsUUID,
+							Type:     pluginsdk.TypeString,
+							Computed: true, // azignore:AZS007 - pre-existing violation
 						},
 					},
 				},

--- a/internal/services/monitor/monitor_action_group_data_source.go
+++ b/internal/services/monitor/monitor_action_group_data_source.go
@@ -334,7 +334,7 @@ func dataSourceMonitorActionGroup() *pluginsdk.Resource {
 						},
 						"subscription_id": {
 							Type:     pluginsdk.TypeString,
-							Computed: true, // azignore:AZS007 - pre-existing violation
+							Computed: true,
 						},
 					},
 				},

--- a/internal/services/monitor/monitor_data_collection_endpoint_data_source.go
+++ b/internal/services/monitor/monitor_data_collection_endpoint_data_source.go
@@ -97,7 +97,6 @@ func (d DataCollectionEndpointDataSource) Read() sdk.ResourceFunc {
 			}
 
 			id := datacollectionendpoints.NewDataCollectionEndpointID(subscriptionId, state.ResourceGroupName, state.Name)
-			metadata.Logger.Infof("retrieving %s", id)
 			resp, err := client.Get(ctx, id)
 			if err != nil {
 				if response.WasNotFound(resp.HttpResponse) {

--- a/internal/services/monitor/monitor_data_collection_endpoint_resource.go
+++ b/internal/services/monitor/monitor_data_collection_endpoint_resource.go
@@ -168,7 +168,6 @@ func (r DataCollectionEndpointResource) Read() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("retrieving %s", *id)
 			resp, err := client.Get(ctx, *id)
 			if err != nil {
 				if response.WasNotFound(resp.HttpResponse) {

--- a/internal/services/monitor/monitor_data_collection_rule_association_resource.go
+++ b/internal/services/monitor/monitor_data_collection_rule_association_resource.go
@@ -141,7 +141,6 @@ func (r DataCollectionRuleAssociationResource) Read() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("retrieving %s", *id)
 			resp, err := client.Get(ctx, *id)
 			if err != nil {
 				if response.WasNotFound(resp.HttpResponse) {

--- a/internal/services/monitor/monitor_data_collection_rule_data_source.go
+++ b/internal/services/monitor/monitor_data_collection_rule_data_source.go
@@ -95,8 +95,7 @@ func (d DataCollectionRuleDataSource) Attributes() map[string]*pluginsdk.Schema 
 				Schema: map[string]*schema.Schema{
 					"event_hub": {
 						Type:     pluginsdk.TypeList,
-						Optional: true,
-						MaxItems: 1,
+						Computed: true,
 						Elem: &pluginsdk.Resource{
 							Schema: map[string]*schema.Schema{
 								"event_hub_id": {
@@ -112,8 +111,7 @@ func (d DataCollectionRuleDataSource) Attributes() map[string]*pluginsdk.Schema 
 					},
 					"event_hub_direct": {
 						Type:     pluginsdk.TypeList,
-						Optional: true,
-						MaxItems: 1,
+						Computed: true,
 						Elem: &pluginsdk.Resource{
 							Schema: map[string]*schema.Schema{
 								"event_hub_id": {
@@ -330,7 +328,7 @@ func (d DataCollectionRuleDataSource) Attributes() map[string]*pluginsdk.Schema 
 					},
 					"log_file": {
 						Type:     pluginsdk.TypeList,
-						Optional: true,
+						Computed: true,
 						Elem: &pluginsdk.Resource{
 							Schema: map[string]*pluginsdk.Schema{
 								"name": {
@@ -410,7 +408,7 @@ func (d DataCollectionRuleDataSource) Attributes() map[string]*pluginsdk.Schema 
 					},
 					"platform_telemetry": {
 						Type:     pluginsdk.TypeList,
-						Optional: true,
+						Computed: true,
 						Elem: &pluginsdk.Resource{
 							Schema: map[string]*pluginsdk.Schema{
 								"name": {
@@ -606,7 +604,6 @@ func (d DataCollectionRuleDataSource) Read() sdk.ResourceFunc {
 			}
 
 			id := datacollectionrules.NewDataCollectionRuleID(subscriptionId, state.ResourceGroupName, state.Name)
-			metadata.Logger.Infof("retrieving %s", id)
 			resp, err := client.Get(ctx, id)
 			if err != nil {
 				if response.WasNotFound(resp.HttpResponse) {

--- a/internal/services/monitor/monitor_workspace_data_source.go
+++ b/internal/services/monitor/monitor_workspace_data_source.go
@@ -91,7 +91,6 @@ func (d WorkspaceDataSource) Read() sdk.ResourceFunc {
 			}
 
 			id := azuremonitorworkspaces.NewAccountID(subscriptionId, state.ResourceGroupName, state.Name)
-			metadata.Logger.Infof("retrieving %s", id)
 			resp, err := client.Get(ctx, id)
 			if err != nil {
 				if response.WasNotFound(resp.HttpResponse) {

--- a/internal/services/netapp/netapp_volume_bucket_resource.go
+++ b/internal/services/netapp/netapp_volume_bucket_resource.go
@@ -69,7 +69,6 @@ func (r NetAppVolumeBucketResource) Create() sdk.ResourceFunc {
 
 			id := buckets.NewBucketID(subscriptionId, volumeID.ResourceGroupName, volumeID.NetAppAccountName, volumeID.CapacityPoolName, volumeID.VolumeName, model.Name)
 
-			metadata.Logger.Infof("Import check for %s", id)
 			existing, err := client.Get(ctx, id)
 			if err != nil {
 				if !response.WasNotFound(existing.HttpResponse) {

--- a/internal/services/netapp/netapp_volume_bucket_with_server_resource.go
+++ b/internal/services/netapp/netapp_volume_bucket_with_server_resource.go
@@ -105,7 +105,6 @@ func (r NetAppVolumeBucketWithServerResource) Create() sdk.ResourceFunc {
 
 			id := buckets.NewBucketID(subscriptionId, volumeID.ResourceGroupName, volumeID.NetAppAccountName, volumeID.CapacityPoolName, volumeID.VolumeName, model.Name)
 
-			metadata.Logger.Infof("Import check for %s", id)
 			existing, err := client.Get(ctx, id)
 			if err != nil {
 				if !response.WasNotFound(existing.HttpResponse) {

--- a/internal/services/netapp/netapp_volume_group_oracle_data_source.go
+++ b/internal/services/netapp/netapp_volume_group_oracle_data_source.go
@@ -134,7 +134,7 @@ func (r NetAppVolumeGroupOracleDataSource) Attributes() map[string]*pluginsdk.Sc
 
 					"throughput_in_mibps": {
 						Type:     pluginsdk.TypeFloat,
-						Required: true,
+						Computed: true,
 					},
 
 					"export_policy_rule": {

--- a/internal/services/netapp/netapp_volume_group_sap_hana_data_source.go
+++ b/internal/services/netapp/netapp_volume_group_sap_hana_data_source.go
@@ -134,7 +134,7 @@ func (r NetAppVolumeGroupSAPHanaDataSource) Attributes() map[string]*pluginsdk.S
 
 					"throughput_in_mibps": {
 						Type:     pluginsdk.TypeFloat,
-						Required: true,
+						Computed: true,
 					},
 
 					"export_policy_rule": {

--- a/internal/services/network/bastion_host_resource.go
+++ b/internal/services/network/bastion_host_resource.go
@@ -217,8 +217,6 @@ func resourceBastionHostCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Println("[INFO] preparing arguments for Azure Bastion Host creation.")
-
 	id := bastionhosts.NewBastionHostID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 
 	scaleUnits := d.Get("scale_units").(int)

--- a/internal/services/network/express_route_gateway_resource.go
+++ b/internal/services/network/express_route_gateway_resource.go
@@ -85,8 +85,6 @@ func resourceExpressRouteGatewayCreate(d *pluginsdk.ResourceData, meta interface
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Println("[INFO] preparing arguments for ExpressRoute Gateway creation.")
-
 	id := expressroutegateways.NewExpressRouteGatewayID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 
 	if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
@@ -144,8 +142,6 @@ func resourceExpressRouteGatewayUpdate(d *pluginsdk.ResourceData, meta interface
 	connectionsClient := meta.(*clients.Client).Network.ExpressRouteConnections
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-
-	log.Println("[INFO] preparing arguments for ExpressRoute Gateway update.")
 
 	id, err := expressroutegateways.ParseExpressRouteGatewayID(d.Id())
 	if err != nil {

--- a/internal/services/network/local_network_gateway_data_source.go
+++ b/internal/services/network/local_network_gateway_data_source.go
@@ -60,12 +60,12 @@ func dataSourceLocalNetworkGateway() *pluginsdk.Resource {
 					Schema: map[string]*pluginsdk.Schema{
 						"asn": {
 							Type:     pluginsdk.TypeInt,
-							Required: true,
+							Computed: true,
 						},
 
 						"bgp_peering_address": {
 							Type:     pluginsdk.TypeString,
-							Required: true,
+							Computed: true,
 						},
 
 						"peer_weight": {

--- a/internal/services/network/network_security_group_data_source.go
+++ b/internal/services/network/network_security_group_data_source.go
@@ -93,7 +93,7 @@ func dataSourceNetworkSecurityGroup() *pluginsdk.Resource {
 
 						"source_application_security_group_ids": {
 							Type:     pluginsdk.TypeSet,
-							Optional: true,
+							Computed: true,
 							Elem:     &pluginsdk.Schema{Type: pluginsdk.TypeString},
 							Set:      pluginsdk.HashString,
 						},
@@ -112,7 +112,7 @@ func dataSourceNetworkSecurityGroup() *pluginsdk.Resource {
 
 						"destination_application_security_group_ids": {
 							Type:     pluginsdk.TypeSet,
-							Optional: true,
+							Computed: true,
 							Elem:     &pluginsdk.Schema{Type: pluginsdk.TypeString},
 							Set:      pluginsdk.HashString,
 						},

--- a/internal/services/nginx/nginx_certificate_resource.go
+++ b/internal/services/nginx/nginx_certificate_resource.go
@@ -211,7 +211,6 @@ func (m CertificateResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			meta.Logger.Infof("deleting %s", id)
 			client := meta.Client.Nginx.NginxCertificate
 
 			if err := client.CertificatesDeleteThenPoll(ctx, *id); err != nil {

--- a/internal/services/nginx/nginx_configuration_resource.go
+++ b/internal/services/nginx/nginx_configuration_resource.go
@@ -382,7 +382,6 @@ func (m ConfigurationResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			meta.Logger.Infof("deleting %s", id)
 			client := meta.Client.Nginx.NginxConfiguration
 
 			if err := client.ConfigurationsDeleteThenPoll(ctx, *id); err != nil {

--- a/internal/services/nginx/nginx_deployment_resource.go
+++ b/internal/services/nginx/nginx_deployment_resource.go
@@ -692,7 +692,6 @@ func (m DeploymentResource) Delete() sdk.ResourceFunc {
 			if err != nil {
 				return err
 			}
-			meta.Logger.Infof("deleting %s", id)
 
 			if err := client.DeploymentsDeleteThenPoll(ctx, *id); err != nil {
 				return fmt.Errorf("deleting %s: %v", id, err)

--- a/internal/services/recoveryservices/backup_policy_file_share_data_source.go
+++ b/internal/services/recoveryservices/backup_policy_file_share_data_source.go
@@ -5,7 +5,6 @@ package recoveryservices
 
 import (
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
@@ -36,8 +35,6 @@ func dataSourceBackupPolicyFileShareRead(d *pluginsdk.ResourceData, meta interfa
 	defer cancel()
 
 	id := protectionpolicies.NewBackupPolicyID(subscriptionId, d.Get("resource_group_name").(string), d.Get("recovery_vault_name").(string), d.Get("name").(string))
-
-	log.Printf("[DEBUG] Reading %s", id)
 
 	protectionPolicy, err := client.Get(ctx, id)
 	if err != nil {

--- a/internal/services/recoveryservices/backup_policy_vm_data_source.go
+++ b/internal/services/recoveryservices/backup_policy_vm_data_source.go
@@ -5,7 +5,6 @@ package recoveryservices
 
 import (
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
@@ -36,8 +35,6 @@ func dataSourceBackupPolicyVmRead(d *pluginsdk.ResourceData, meta interface{}) e
 	defer cancel()
 
 	id := protectionpolicies.NewBackupPolicyID(subscriptionid, d.Get("resource_group_name").(string), d.Get("recovery_vault_name").(string), d.Get("name").(string))
-
-	log.Printf("[DEBUG] Reading %s", id)
 
 	protectionPolicy, err := client.Get(ctx, id)
 	if err != nil {

--- a/internal/services/storage/storage_blob_data_source.go
+++ b/internal/services/storage/storage_blob_data_source.go
@@ -5,7 +5,6 @@ package storage
 
 import (
 	"fmt"
-	"log"
 	"strings"
 	"time"
 
@@ -119,7 +118,6 @@ func dataSourceStorageBlobRead(d *pluginsdk.ResourceData, meta interface{}) erro
 
 	id := blobs.NewBlobID(*accountId, containerName, name)
 
-	log.Printf("[INFO] Retrieving %s", id)
 	input := blobs.GetPropertiesInput{}
 	props, err := blobsClient.GetProperties(ctx, containerName, name, input)
 	if err != nil {


### PR DESCRIPTION
Enables two of the rules disabled in #33400 and applies their autofixes: AZS009 drops Optional/Default/ValidateFunc from computed-only fields (35), AZR009 removes lifecycle narration logging from CRUD functions (27). No behaviour change.