### PR TITLE
`azurerm_virtual_network_gateway_connection` - only read the Shared Key for connection types that have one

### DIFF
--- a/internal/services/network/virtual_network_gateway_connection_helpers_test.go
+++ b/internal/services/network/virtual_network_gateway_connection_helpers_test.go
@@ -1,0 +1,47 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package network
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/virtualnetworkgatewayconnections"
+)
+
+func TestConnectionTypeUsesSharedKey(t *testing.T) {
+	testData := []struct {
+		name           string
+		connectionType virtualnetworkgatewayconnections.VirtualNetworkGatewayConnectionType
+		expected       bool
+	}{
+		{
+			name:           "IPsec uses a Shared Key",
+			connectionType: virtualnetworkgatewayconnections.VirtualNetworkGatewayConnectionTypeIPsec,
+			expected:       true,
+		},
+		{
+			name:           "Vnet2Vnet uses a Shared Key",
+			connectionType: virtualnetworkgatewayconnections.VirtualNetworkGatewayConnectionTypeVnetTwoVnet,
+			expected:       true,
+		},
+		{
+			name:           "ExpressRoute uses an Authorization Key, not a Shared Key",
+			connectionType: virtualnetworkgatewayconnections.VirtualNetworkGatewayConnectionTypeExpressRoute,
+			expected:       false,
+		},
+		{
+			name:           "an empty connection type is not assumed to be ExpressRoute",
+			connectionType: "",
+			expected:       true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Run(v.name, func(t *testing.T) {
+			if actual := connectionTypeUsesSharedKey(v.connectionType); actual != v.expected {
+				t.Fatalf("expected %t for connection type %q but got %t", v.expected, string(v.connectionType), actual)
+			}
+		})
+	}
+}

--- a/internal/services/network/virtual_network_gateway_connection_resource.go
+++ b/internal/services/network/virtual_network_gateway_connection_resource.go
@@ -379,6 +379,13 @@ func resourceVirtualNetworkGatewayConnectionCreate(d *pluginsdk.ResourceData, me
 	return resourceVirtualNetworkGatewayConnectionRead(d, meta)
 }
 
+// connectionTypeUsesSharedKey reports whether a connection type authenticates with a
+// Shared Key. IPsec and Vnet2Vnet do; ExpressRoute uses an Authorization Key and has no
+// Shared Key to retrieve.
+func connectionTypeUsesSharedKey(connectionType virtualnetworkgatewayconnections.VirtualNetworkGatewayConnectionType) bool {
+	return connectionType != virtualnetworkgatewayconnections.VirtualNetworkGatewayConnectionTypeExpressRoute
+}
+
 func resourceVirtualNetworkGatewayConnectionRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Network.VirtualNetworkGatewayConnections
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
@@ -401,17 +408,6 @@ func resourceVirtualNetworkGatewayConnectionRead(d *pluginsdk.ResourceData, meta
 	d.Set("name", id.ConnectionName)
 	d.Set("resource_group_name", id.ResourceGroupName)
 
-	respKey, err := client.GetSharedKey(ctx, *id)
-	if err != nil {
-		return fmt.Errorf("retrieving Shared Key for %s: %+v", id, err)
-	}
-
-	if model := respKey.Model; model != nil {
-		if model.Value != "" {
-			d.Set("shared_key", model.Value)
-		}
-	}
-
 	if model := resp.Model; model != nil {
 		d.Set("location", location.NormalizeNilable(model.Location))
 
@@ -419,6 +415,23 @@ func resourceVirtualNetworkGatewayConnectionRead(d *pluginsdk.ResourceData, meta
 
 		if string(props.ConnectionType) != "" {
 			d.Set("type", string(props.ConnectionType))
+		}
+
+		// A Shared Key only exists for connection types that use one. ExpressRoute
+		// connections authenticate with an Authorization Key instead, so the Shared
+		// Key endpoint has nothing to return for them and reading it here breaks
+		// every subsequent plan for an otherwise healthy connection.
+		if connectionTypeUsesSharedKey(props.ConnectionType) {
+			respKey, err := client.GetSharedKey(ctx, *id)
+			if err != nil {
+				return fmt.Errorf("retrieving Shared Key for %s: %+v", id, err)
+			}
+
+			if keyModel := respKey.Model; keyModel != nil {
+				if keyModel.Value != "" {
+					d.Set("shared_key", keyModel.Value)
+				}
+			}
 		}
 
 		d.Set("virtual_network_gateway_id", props.VirtualNetworkGateway1.Id)


### PR DESCRIPTION
#### Changes to existing Resource / Data Source

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your resource or datasource changes?
- [ ] Have you successfully run tests with your changes locally? — unit test yes, acceptance tests no; see below.

#### Description

`ExpressRoute` connections authenticate with an Authorization Key and have no Shared Key, but `resourceVirtualNetworkGatewayConnectionRead` called `GetSharedKey` for every connection regardless of type.

Since the `Microsoft.Network/connections/sharedKey/action` permission began being enforced, that call can return `200` with a body of `{"value": []}`. The API definition declares `value` as a required string, so unmarshalling fails:

```
cannot unmarshal array into Go struct field ConnectionSharedKey.value of type string
```

The connection itself is healthy. Creation succeeds, and then every subsequent `plan` and `apply` fails, which blocks day-2 operations on the resource completely. Reporters on #30322 have hit this on both `2023-11-01` and `2024-05-01`, and on provider versions from 3.108.0 through 4.38.1.

The connection type is already available from the `Get` response earlier in `Read`, so this moves the Shared Key retrieval inside that block and guards it on the type. An empty connection type keeps the existing behaviour rather than assuming ExpressRoute, so the only path that changes is the one that was broken.

This is the provider-side fix suggested in the issue thread by @aldairzamoramsft of Microsoft support:

> My suggestion is to implement a check the type of the connection, or handle the empty response from us when get shared is called to an Expressroute connection.

I've deliberately not tried to make the unmarshalling itself tolerant of an array, since the API spec says `value` is a required string and @wuxu92 is right that a response of `{"value": []}` is a service-side defect worth fixing separately. This change only stops the provider asking a question that has no answer for this connection type.

#### Testing

`TestConnectionTypeUsesSharedKey` is a new unit test covering IPsec, Vnet2Vnet, ExpressRoute and the empty-type fallback:

```
--- PASS: TestConnectionTypeUsesSharedKey (0.00s)
    --- PASS: TestConnectionTypeUsesSharedKey/IPsec_uses_a_Shared_Key (0.00s)
    --- PASS: TestConnectionTypeUsesSharedKey/Vnet2Vnet_uses_a_Shared_Key (0.00s)
    --- PASS: TestConnectionTypeUsesSharedKey/ExpressRoute_uses_an_Authorization_Key,_not_a_Shared_Key (0.00s)
    --- PASS: TestConnectionTypeUsesSharedKey/an_empty_connection_type_is_not_assumed_to_be_ExpressRoute (0.00s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/network
```

`go vet ./internal/services/network/` is clean and `gofmt` reports no changes.

I have not run `TestAccVirtualNetworkGatewayConnection_expressRoute` or `_expressRouteWithFastPath`, which are the acceptance tests that exercise this Read path — I don't have an ExpressRoute circuit to run them against. I'd appreciate a maintainer running those two.

#### Related Issue(s)

Fixes #30322

#### Change Log

* `azurerm_virtual_network_gateway_connection` - the Shared Key is no longer read for `ExpressRoute` connections, which do not have one [GH-00000]

- [x] Bug Fix
- [ ] New Feature