### PR TITLE
`servicebus_topic_authorization_rule` - add List Resource support

### DIFF
--- a/internal/services/servicebus/registration.go
+++ b/internal/services/servicebus/registration.go
@@ -96,5 +96,6 @@ func (r Registration) ListResources() []sdk.FrameworkListWrappedResource {
 	return []sdk.FrameworkListWrappedResource{
 		ServiceBusNamespaceCustomerManagedKeyListResource{},
 		ServiceBusNamespaceListResource{},
+		ServiceBusTopicAuthorizationRuleListResource{},
 	}
 }

--- a/internal/services/servicebus/servicebus_topic_authorization_rule_data_source_test.go
+++ b/internal/services/servicebus/servicebus_topic_authorization_rule_data_source_test.go
@@ -61,7 +61,7 @@ data "azurerm_servicebus_topic_authorization_rule" "test" {
   name     = azurerm_servicebus_topic_authorization_rule.test.name
   topic_id = azurerm_servicebus_topic.test.id
 }
-`, ServiceBusTopicAuthorizationRuleResource{}.base(data, true, true, true))
+`, ServicebusTopicAuthorizationRuleResource{}.base(data, true, true, true))
 }
 
 func (ServiceBusTopicAuthorizationRuleDataSource) topicAliasPolicy(data acceptance.TestData) string {
@@ -72,5 +72,5 @@ data "azurerm_servicebus_topic_authorization_rule" "test" {
   name     = azurerm_servicebus_topic_authorization_rule.test.name
   topic_id = azurerm_servicebus_topic.example.id
 }
-`, ServiceBusTopicAuthorizationRuleResource{}.withAliasConnectionString(data))
+`, ServicebusTopicAuthorizationRuleResource{}.withAliasConnectionString(data))
 }

--- a/internal/services/servicebus/servicebus_topic_authorization_rule_resource.go
+++ b/internal/services/servicebus/servicebus_topic_authorization_rule_resource.go
@@ -4,6 +4,7 @@
 package servicebus
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"time"
@@ -13,12 +14,17 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2024-01-01/namespaces"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2024-01-01/topics"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2024-01-01/topicsauthorizationrule"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/servicebus/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
+
+//go:generate go run ../../tools/generator-tests resourceidentity -parent-id topic_id -test-name base -test-params "(true),(false),(false)"
+
+const serviceBusTopicAuthorizationRuleResourceName = "azurerm_servicebus_topic_authorization_rule"
 
 func resourceServiceBusTopicAuthorizationRule() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
@@ -27,10 +33,11 @@ func resourceServiceBusTopicAuthorizationRule() *pluginsdk.Resource {
 		Update: resourceServiceBusTopicAuthorizationRuleCreateUpdate,
 		Delete: resourceServiceBusTopicAuthorizationRuleDelete,
 
-		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
-			_, err := topicsauthorizationrule.ParseTopicAuthorizationRuleID(id)
-			return err
-		}),
+		Identity: &schema.ResourceIdentity{
+			SchemaFunc: pluginsdk.GenerateIdentitySchema(&topicsauthorizationrule.TopicAuthorizationRuleId{}),
+		},
+
+		Importer: pluginsdk.ImporterValidatingIdentity(&topicsauthorizationrule.TopicAuthorizationRuleId{}),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
@@ -88,7 +95,7 @@ func resourceServiceBusTopicAuthorizationRuleCreateUpdate(d *pluginsdk.ResourceD
 			}
 
 			if !response.WasNotFound(existing.HttpResponse) {
-				return tf.ImportAsExistsError("azurerm_servicebus_topic_authorization_rule", id.ID())
+				return tf.ImportAsExistsError(serviceBusTopicAuthorizationRuleResourceName, id.ID())
 			}
 		}
 	}
@@ -106,6 +113,9 @@ func resourceServiceBusTopicAuthorizationRuleCreateUpdate(d *pluginsdk.ResourceD
 
 	if d.IsNewResource() {
 		d.SetId(id.ID())
+		if err := pluginsdk.SetResourceIdentityData(d, &id); err != nil {
+			return err
+		}
 	}
 
 	namespaceId := namespaces.NewNamespaceID(id.SubscriptionId, id.ResourceGroupName, id.NamespaceName)
@@ -135,10 +145,14 @@ func resourceServiceBusTopicAuthorizationRuleRead(d *pluginsdk.ResourceData, met
 		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
+	return resourceServiceBusTopicAuthorizationRuleFlatten(ctx, client, d, id, resp.Model, true)
+}
+
+func resourceServiceBusTopicAuthorizationRuleFlatten(ctx context.Context, client *topicsauthorizationrule.TopicsAuthorizationRuleClient, d *pluginsdk.ResourceData, id *topicsauthorizationrule.TopicAuthorizationRuleId, model *topicsauthorizationrule.SBAuthorizationRule, includeResource bool) error {
 	d.Set("name", id.AuthorizationRuleName)
 	d.Set("topic_id", topicsauthorizationrule.NewTopicID(id.SubscriptionId, id.ResourceGroupName, id.NamespaceName, id.TopicName).ID())
 
-	if model := resp.Model; model != nil {
+	if model != nil {
 		if props := model.Properties; props != nil {
 			listen, send, manage := flattenTopicAuthorizationRuleRights(&props.Rights)
 			d.Set("listen", listen)
@@ -147,21 +161,23 @@ func resourceServiceBusTopicAuthorizationRuleRead(d *pluginsdk.ResourceData, met
 		}
 	}
 
-	keysResp, err := client.TopicsListKeys(ctx, *id)
-	if err != nil {
-		return fmt.Errorf("listing keys for %s: %+v", id, err)
+	if includeResource {
+		keysResp, err := client.TopicsListKeys(ctx, *id)
+		if err != nil {
+			return fmt.Errorf("listing keys for %s: %+v", id, err)
+		}
+
+		if model := keysResp.Model; model != nil {
+			d.Set("primary_key", model.PrimaryKey)
+			d.Set("primary_connection_string", model.PrimaryConnectionString)
+			d.Set("secondary_key", model.SecondaryKey)
+			d.Set("secondary_connection_string", model.SecondaryConnectionString)
+			d.Set("primary_connection_string_alias", model.AliasPrimaryConnectionString)
+			d.Set("secondary_connection_string_alias", model.AliasSecondaryConnectionString)
+		}
 	}
 
-	if model := keysResp.Model; model != nil {
-		d.Set("primary_key", model.PrimaryKey)
-		d.Set("primary_connection_string", model.PrimaryConnectionString)
-		d.Set("secondary_key", model.SecondaryKey)
-		d.Set("secondary_connection_string", model.SecondaryConnectionString)
-		d.Set("primary_connection_string_alias", model.AliasPrimaryConnectionString)
-		d.Set("secondary_connection_string_alias", model.AliasSecondaryConnectionString)
-	}
-
-	return nil
+	return pluginsdk.SetResourceIdentityData(d, id)
 }
 
 func resourceServiceBusTopicAuthorizationRuleDelete(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/servicebus/servicebus_topic_authorization_rule_resource_identity_gen_test.go
+++ b/internal/services/servicebus/servicebus_topic_authorization_rule_resource_identity_gen_test.go
@@ -1,0 +1,42 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package servicebus_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
+)
+
+func TestAccServicebusTopicAuthorizationRule_resourceIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_servicebus_topic_authorization_rule", "test")
+	r := ServicebusTopicAuthorizationRuleResource{}
+
+	checkedFields := map[string]struct{}{
+		"name":                {},
+		"namespace_name":      {},
+		"resource_group_name": {},
+		"subscription_id":     {},
+		"topic_name":          {},
+	}
+
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.base(data, (true), (false), (false)),
+			ConfigStateChecks: []statecheck.StateCheck{
+				customstatecheck.ExpectAllIdentityFieldsAreChecked("azurerm_servicebus_topic_authorization_rule.test", checkedFields),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_servicebus_topic_authorization_rule.test", tfjsonpath.New("name"), tfjsonpath.New("topic_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_servicebus_topic_authorization_rule.test", tfjsonpath.New("namespace_name"), tfjsonpath.New("topic_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_servicebus_topic_authorization_rule.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("topic_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_servicebus_topic_authorization_rule.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("topic_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_servicebus_topic_authorization_rule.test", tfjsonpath.New("topic_name"), tfjsonpath.New("topic_id")),
+			},
+		},
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
+}

--- a/internal/services/servicebus/servicebus_topic_authorization_rule_resource_list.go
+++ b/internal/services/servicebus/servicebus_topic_authorization_rule_resource_list.go
@@ -1,0 +1,108 @@
+package servicebus
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-azure-helpers/framework/typehelpers"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2024-01-01/topicsauthorizationrule"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-framework/list/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type ServiceBusTopicAuthorizationRuleListResource struct{}
+
+type ServiceBusTopicAuthorizationRuleListModel struct {
+	TopicId types.String `tfsdk:"servicebus_topic_id"`
+}
+
+var _ sdk.FrameworkListWrappedResource = new(ServiceBusTopicAuthorizationRuleListResource)
+
+func (ServiceBusTopicAuthorizationRuleListResource) Metadata(_ context.Context, _ resource.MetadataRequest, response *resource.MetadataResponse) {
+	response.TypeName = serviceBusTopicAuthorizationRuleResourceName
+}
+
+func (ServiceBusTopicAuthorizationRuleListResource) ResourceFunc() *pluginsdk.Resource {
+	return resourceServiceBusTopicAuthorizationRule()
+}
+
+func (ServiceBusTopicAuthorizationRuleListResource) ListResourceConfigSchema(_ context.Context, _ list.ListResourceSchemaRequest, response *list.ListResourceSchemaResponse) {
+	response.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"servicebus_topic_id": schema.StringAttribute{
+				Required: true,
+				Validators: []validator.String{
+					typehelpers.WrappedStringValidator{Func: topicsauthorizationrule.ValidateTopicID},
+				},
+			},
+		},
+	}
+}
+
+func (ServiceBusTopicAuthorizationRuleListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream, metadata sdk.ResourceMetadata) {
+	client := metadata.Client.ServiceBus.TopicsAuthClient
+
+	var data ServiceBusTopicAuthorizationRuleListModel
+	diags := request.Config.Get(ctx, &data)
+	if diags.HasError() {
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+
+	parentID, err := topicsauthorizationrule.ParseTopicID(data.TopicId.ValueString())
+	if err != nil {
+		sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("parsing Topic ID for `%s`", serviceBusTopicAuthorizationRuleResourceName), err)
+		return
+	}
+
+	resp, err := client.TopicsListAuthorizationRulesComplete(ctx, *parentID)
+	if err != nil {
+		sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("listing `%s`", serviceBusTopicAuthorizationRuleResourceName), err)
+		return
+	}
+
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		sdk.SetResponseErrorDiagnostic(stream, "internal-error", "context had no deadline")
+		return
+	}
+
+	stream.Results = func(push func(list.ListResult) bool) {
+		ctx, cancel := context.WithDeadline(context.Background(), deadline)
+		defer cancel()
+
+		for _, item := range resp.Items {
+			result := request.NewListResult(ctx)
+			result.DisplayName = pointer.From(item.Name)
+
+			rd := resourceServiceBusTopicAuthorizationRule().Data(&terraform.InstanceState{})
+			id, err := topicsauthorizationrule.ParseTopicAuthorizationRuleIDInsensitively(pointer.From(item.Id))
+			if err != nil {
+				sdk.SetErrorDiagnosticAndPushListResult(result, push, fmt.Sprintf("parsing ID for `%s`", serviceBusTopicAuthorizationRuleResourceName), err)
+				return
+			}
+			rd.SetId(id.ID())
+
+			if err := resourceServiceBusTopicAuthorizationRuleFlatten(ctx, client, rd, id, &item, request.IncludeResource); err != nil {
+				sdk.SetErrorDiagnosticAndPushListResult(result, push, fmt.Sprintf("encoding `%s` resource data", serviceBusTopicAuthorizationRuleResourceName), err)
+				return
+			}
+
+			sdk.EncodeListResult(ctx, rd, &result)
+			if result.Diagnostics.HasError() {
+				push(result)
+				return
+			}
+			if !push(result) {
+				return
+			}
+		}
+	}
+}

--- a/internal/services/servicebus/servicebus_topic_authorization_rule_resource_list_test.go
+++ b/internal/services/servicebus/servicebus_topic_authorization_rule_resource_list_test.go
@@ -1,0 +1,94 @@
+package servicebus_test
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
+)
+
+func TestAccServiceBusTopicAuthorizationRule_listByTopicID(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_servicebus_topic_authorization_rule", "testlist1")
+	r := ServicebusTopicAuthorizationRuleResource{}
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []resource.TestStep{
+			{
+				Config: r.basicList(data),
+			},
+			{
+				Query:  true,
+				Config: r.basicQuery(),
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectLengthAtLeast("azurerm_servicebus_topic_authorization_rule.list", 3),
+					querycheck.ExpectIdentity(
+						"azurerm_servicebus_topic_authorization_rule.list",
+						map[string]knownvalue.Check{
+							"name":                knownvalue.StringRegexp(regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
+							"resource_group_name": knownvalue.StringRegexp(regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
+							"topic_name":          knownvalue.StringRegexp(regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
+							"subscription_id":     knownvalue.StringExact(data.Subscriptions.Primary),
+							"namespace_name":      knownvalue.StringRegexp(regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
+						},
+					),
+				},
+			},
+		},
+	})
+}
+
+func (r ServicebusTopicAuthorizationRuleResource) basicList(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_servicebus_namespace" "test" {
+  name                = "acctest-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Standard"
+}
+
+resource "azurerm_servicebus_topic" "test" {
+  name         = "acctestservicebustopic-%[1]d"
+  namespace_id = azurerm_servicebus_namespace.test.id
+}
+
+resource "azurerm_servicebus_topic_authorization_rule" "test" {
+  count = 3
+
+  name     = "acctest-%[1]d-${count.index}"
+  topic_id = azurerm_servicebus_topic.test.id
+  listen   = true
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (r ServicebusTopicAuthorizationRuleResource) basicQuery() string {
+	return `
+list "azurerm_servicebus_topic_authorization_rule" "list" {
+  provider = azurerm
+  config {
+    servicebus_topic_id = azurerm_servicebus_topic.test.id
+  }
+}
+`
+}

--- a/internal/services/servicebus/servicebus_topic_authorization_rule_resource_test.go
+++ b/internal/services/servicebus/servicebus_topic_authorization_rule_resource_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
-type ServiceBusTopicAuthorizationRuleResource struct{}
+type ServicebusTopicAuthorizationRuleResource struct{}
 
 func TestAccServiceBusTopicAuthorizationRule_listen(t *testing.T) {
 	testAccServiceBusTopicAuthorizationRule(t, true, false, false)
@@ -37,7 +37,7 @@ func TestAccServiceBusTopicAuthorizationRule_manage(t *testing.T) {
 
 func testAccServiceBusTopicAuthorizationRule(t *testing.T, listen, send, manage bool) {
 	data := acceptance.BuildTestData(t, "azurerm_servicebus_topic_authorization_rule", "test")
-	r := ServiceBusTopicAuthorizationRuleResource{}
+	r := ServicebusTopicAuthorizationRuleResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -63,7 +63,7 @@ func testAccServiceBusTopicAuthorizationRule(t *testing.T, listen, send, manage 
 
 func TestAccServiceBusTopicAuthorizationRule_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_servicebus_topic_authorization_rule", "test")
-	r := ServiceBusTopicAuthorizationRuleResource{}
+	r := ServicebusTopicAuthorizationRuleResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -84,7 +84,7 @@ func TestAccServiceBusTopicAuthorizationRule_requiresImport(t *testing.T) {
 
 func TestAccServiceBusTopicAuthorizationRule_rightsUpdate(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_servicebus_topic_authorization_rule", "test")
-	r := ServiceBusTopicAuthorizationRuleResource{}
+	r := ServicebusTopicAuthorizationRuleResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -119,7 +119,7 @@ func TestAccServiceBusTopicAuthorizationRule_rightsUpdate(t *testing.T) {
 
 func TestAccServiceBusTopicAuthorizationRule_withAliasConnectionString(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_servicebus_topic_authorization_rule", "test")
-	r := ServiceBusTopicAuthorizationRuleResource{}
+	r := ServicebusTopicAuthorizationRuleResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -139,7 +139,7 @@ func TestAccServiceBusTopicAuthorizationRule_withAliasConnectionString(t *testin
 	})
 }
 
-func (t ServiceBusTopicAuthorizationRuleResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+func (t ServicebusTopicAuthorizationRuleResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := topicsauthorizationrule.ParseTopicAuthorizationRuleID(state.ID)
 	if err != nil {
 		return nil, err
@@ -153,7 +153,7 @@ func (t ServiceBusTopicAuthorizationRuleResource) Exists(ctx context.Context, cl
 	return pointer.To(resp.Model != nil), nil
 }
 
-func (ServiceBusTopicAuthorizationRuleResource) base(data acceptance.TestData, listen, send, manage bool) string {
+func (ServicebusTopicAuthorizationRuleResource) base(data acceptance.TestData, listen, send, manage bool) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -187,7 +187,7 @@ resource "azurerm_servicebus_topic_authorization_rule" "test" {
 `, data.RandomInteger, data.Locations.Primary, listen, send, manage)
 }
 
-func (r ServiceBusTopicAuthorizationRuleResource) requiresImport(data acceptance.TestData, listen, send, manage bool) string {
+func (r ServicebusTopicAuthorizationRuleResource) requiresImport(data acceptance.TestData, listen, send, manage bool) string {
 	return fmt.Sprintf(`
 %s
 
@@ -202,7 +202,7 @@ resource "azurerm_servicebus_topic_authorization_rule" "import" {
 `, r.base(data, listen, send, manage))
 }
 
-func (ServiceBusTopicAuthorizationRuleResource) withAliasConnectionString(data acceptance.TestData) string {
+func (ServicebusTopicAuthorizationRuleResource) withAliasConnectionString(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}

--- a/website/docs/list-resources/servicebus_topic_authorization_rule.html.markdown
+++ b/website/docs/list-resources/servicebus_topic_authorization_rule.html.markdown
@@ -1,0 +1,30 @@
+---
+subcategory: "Messaging"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_servicebus_topic_authorization_rule"
+description: |-
+    Lists ServiceBus Topic Authorization Rule resources.
+---
+
+# List resource: azurerm_servicebus_topic_authorization_rule
+
+Lists ServiceBus Topic Authorization Rule resources.
+
+## Example Usage
+
+### List all ServiceBus Topic Authorization Rules in a Topic
+
+```hcl
+list "azurerm_servicebus_topic_authorization_rule" "example" {
+  provider = azurerm
+  config {
+    servicebus_topic_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example-rg/providers/Microsoft.ServiceBus/namespaces/example-namespace/topics/example-topic"
+  }
+}
+```
+
+## Argument Reference
+
+This list resource supports the following arguments:
+
+* `servicebus_topic_id` - (Required) The ID of the Topic to query.


### PR DESCRIPTION
<!-- markdownlint-disable-file first-line-heading -->
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”

<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->

## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.

## Testing

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change

## Related Issue(s)

Fixes #0000

## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE]
> If this PR changes meaningfully during the course of review please update the title and description as required.
