### PR TITLE
azurerm_orchestrated_virtual_machine_scale_set: disk_controller_type and NvmeDisk placement

### DIFF
--- a/internal/services/compute/orchestrated_virtual_machine_scale_set.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set.go
@@ -637,6 +637,7 @@ func OrchestratedVirtualMachineScaleSetOSDiskSchema() *pluginsdk.Schema {
 								ValidateFunc: validation.StringInSlice([]string{
 									string(virtualmachinescalesets.DiffDiskPlacementCacheDisk),
 									string(virtualmachinescalesets.DiffDiskPlacementResourceDisk),
+									string(virtualmachinescalesets.DiffDiskPlacementNVMeDisk),
 								}, false),
 							},
 						},

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
@@ -173,6 +173,18 @@ func resourceOrchestratedVirtualMachineScaleSet() *pluginsdk.Resource {
 
 			"data_disk": OrchestratedVirtualMachineScaleSetDataDiskSchema(),
 
+			"disk_controller_type": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				// NOTE: O+C Azure may return a default value for some SKUs, so we need to mark this as computed to avoid diffs in that scenario
+				Computed: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(virtualmachinescalesets.DiskControllerTypesNVMe),
+					string(virtualmachinescalesets.DiskControllerTypesSCSI),
+				}, false),
+			},
+
 			// Optional
 			"additional_capabilities": OrchestratedVirtualMachineScaleSetAdditionalCapabilitiesSchema(),
 
@@ -756,6 +768,10 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 			return fmt.Errorf("expanding `data_disk`: %w", err)
 		}
 		virtualMachineProfile.StorageProfile.DataDisks = dataDisks
+	}
+
+	if diskControllerType, ok := d.GetOk("disk_controller_type"); ok {
+		virtualMachineProfile.StorageProfile.DiskControllerType = pointer.To(virtualmachinescalesets.DiskControllerTypes(diskControllerType.(string)))
 	}
 
 	if v, ok := d.GetOk("network_interface"); ok {
@@ -1463,6 +1479,8 @@ func resourceOrchestratedVirtualMachineScaleSetRead(d *pluginsdk.ResourceData, m
 				d.Set("priority", priority)
 
 				if storageProfile := profile.StorageProfile; storageProfile != nil {
+					d.Set("disk_controller_type", string(pointer.From(storageProfile.DiskControllerType)))
+
 					if err := d.Set("os_disk", FlattenOrchestratedVirtualMachineScaleSetOSDisk(storageProfile.OsDisk)); err != nil {
 						return fmt.Errorf("setting `os_disk`: %w", err)
 					}

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_disk_os_test.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_disk_os_test.go
@@ -41,6 +41,21 @@ func TestAccOrchestratedVirtualMachineScaleSet_diskOSControllerTypeNVMe(t *testi
 	})
 }
 
+func TestAccOrchestratedVirtualMachineScaleSet_disksOSDiskEphemeralNvmeDisk(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_orchestrated_virtual_machine_scale_set", "test")
+	r := OrchestratedVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.disksOSDiskEphemeralNvmeDisk(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("os_profile.0.linux_configuration.0.admin_password"),
+	})
+}
+
 func TestAccOrchestratedVirtualMachineScaleSet_disksOSDiskCaching(t *testing.T) {
 	t.Skipf("Needs investigation into recreate issue due to `diff_disk_settings` change which is ForceNew, skipping for now.")
 	data := acceptance.BuildTestData(t, "azurerm_orchestrated_virtual_machine_scale_set", "test")
@@ -412,6 +427,79 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "test" {
   os_disk {
     storage_account_type = "Standard_LRS"
     caching              = "ReadWrite"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "0001-com-ubuntu-server-jammy"
+    sku       = "22_04-lts-gen2"
+    version   = "latest"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, r.natgateway_template(data))
+}
+
+func (r OrchestratedVirtualMachineScaleSetResource) disksOSDiskEphemeralNvmeDisk(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-OVMSS-%[1]d"
+  location = "%[2]s"
+}
+
+%[3]s
+
+resource "azurerm_orchestrated_virtual_machine_scale_set" "test" {
+  name                = "acctestOVMSS-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  zones = []
+
+  sku_name  = "Standard_D2ads_v6"
+  instances = 1
+
+  platform_fault_domain_count = 2
+  disk_controller_type        = "NVMe"
+
+  os_profile {
+    linux_configuration {
+      computer_name_prefix = "testvm-%[1]d"
+      admin_username       = "myadmin"
+      admin_password       = "Passwword1234"
+
+      disable_password_authentication = false
+    }
+  }
+
+  network_interface {
+    name    = "TestNetworkProfile-%[1]d"
+    primary = true
+
+    ip_configuration {
+      name      = "TestIPConfiguration"
+      primary   = true
+      subnet_id = azurerm_subnet.test.id
+
+      public_ip_address {
+        name                    = "TestPublicIPConfiguration"
+        domain_name_label       = "test-domain-label"
+        idle_timeout_in_minutes = 4
+      }
+    }
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadOnly"
+
+    diff_disk_settings {
+      option    = "Local"
+      placement = "NvmeDisk"
+    }
   }
 
   source_image_reference {

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_disk_os_test.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_disk_os_test.go
@@ -11,6 +11,36 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 )
 
+func TestAccOrchestratedVirtualMachineScaleSet_diskOSControllerTypeSCSI(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_orchestrated_virtual_machine_scale_set", "test")
+	r := OrchestratedVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.diskOSControllerTypeSCSI(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("os_profile.0.linux_configuration.0.admin_password"),
+	})
+}
+
+func TestAccOrchestratedVirtualMachineScaleSet_diskOSControllerTypeNVMe(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_orchestrated_virtual_machine_scale_set", "test")
+	r := OrchestratedVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.diskOSControllerTypeNVMe(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("os_profile.0.linux_configuration.0.admin_password"),
+	})
+}
+
 func TestAccOrchestratedVirtualMachineScaleSet_disksOSDiskCaching(t *testing.T) {
 	t.Skipf("Needs investigation into recreate issue due to `diff_disk_settings` change which is ForceNew, skipping for now.")
 	data := acceptance.BuildTestData(t, "azurerm_orchestrated_virtual_machine_scale_set", "test")
@@ -256,4 +286,140 @@ func (r OrchestratedVirtualMachineScaleSetResource) disksOSDiskStorageAccountTyp
 	// Limited regional availability for some storage account type
 	data.Locations.Primary = location
 	return r.disksOSDiskStorageAccountType(data, storageAccountType)
+}
+
+func (r OrchestratedVirtualMachineScaleSetResource) diskOSControllerTypeSCSI(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-OVMSS-%[1]d"
+  location = "%[2]s"
+}
+
+%[3]s
+
+resource "azurerm_orchestrated_virtual_machine_scale_set" "test" {
+  name                = "acctestOVMSS-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  zones = []
+
+  sku_name  = "Standard_D1_v2"
+  instances = 1
+
+  platform_fault_domain_count = 2
+  disk_controller_type        = "SCSI"
+
+  os_profile {
+    linux_configuration {
+      computer_name_prefix = "testvm-%[1]d"
+      admin_username       = "myadmin"
+      admin_password       = "Passwword1234"
+
+      disable_password_authentication = false
+    }
+  }
+
+  network_interface {
+    name    = "TestNetworkProfile-%[1]d"
+    primary = true
+
+    ip_configuration {
+      name      = "TestIPConfiguration"
+      primary   = true
+      subnet_id = azurerm_subnet.test.id
+
+      public_ip_address {
+        name                    = "TestPublicIPConfiguration"
+        domain_name_label       = "test-domain-label"
+        idle_timeout_in_minutes = 4
+      }
+    }
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "0001-com-ubuntu-server-jammy"
+    sku       = "22_04-lts-gen2"
+    version   = "latest"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, r.natgateway_template(data))
+}
+
+func (r OrchestratedVirtualMachineScaleSetResource) diskOSControllerTypeNVMe(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-OVMSS-%[1]d"
+  location = "%[2]s"
+}
+
+%[3]s
+
+resource "azurerm_orchestrated_virtual_machine_scale_set" "test" {
+  name                = "acctestOVMSS-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  zones = []
+
+  sku_name  = "Standard_E2bds_v5"
+  instances = 1
+
+  platform_fault_domain_count = 2
+  disk_controller_type        = "NVMe"
+
+  os_profile {
+    linux_configuration {
+      computer_name_prefix = "testvm-%[1]d"
+      admin_username       = "myadmin"
+      admin_password       = "Passwword1234"
+
+      disable_password_authentication = false
+    }
+  }
+
+  network_interface {
+    name    = "TestNetworkProfile-%[1]d"
+    primary = true
+
+    ip_configuration {
+      name      = "TestIPConfiguration"
+      primary   = true
+      subnet_id = azurerm_subnet.test.id
+
+      public_ip_address {
+        name                    = "TestPublicIPConfiguration"
+        domain_name_label       = "test-domain-label"
+        idle_timeout_in_minutes = 4
+      }
+    }
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "0001-com-ubuntu-server-jammy"
+    sku       = "22_04-lts-gen2"
+    version   = "latest"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, r.natgateway_template(data))
 }

--- a/website/docs/r/orchestrated_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/orchestrated_virtual_machine_scale_set.html.markdown
@@ -66,6 +66,8 @@ The following arguments are supported:
 
 * `data_disk` - (Optional) One or more `data_disk` blocks as defined below.
 
+* `disk_controller_type` - (Optional) Specifies the Disk Controller Type used for the Virtual Machines in this Scale Set. Possible values are `SCSI` and `NVMe`. Changing this forces a new resource to be created.
+
 * `encryption_at_host_enabled` - (Optional) Should disks attached to this Virtual Machine Scale Set be encrypted by enabling Encryption at Host?
 
 * `eviction_policy` - (Optional) The Policy which should be used by Spot Virtual Machines that are Evicted from the Scale Set. Possible values are `Deallocate` and `Delete`. Changing this forces a new resource to be created.

--- a/website/docs/r/orchestrated_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/orchestrated_virtual_machine_scale_set.html.markdown
@@ -236,7 +236,9 @@ A `diff_disk_settings` block supports the following:
 
 * `option` - (Required) Specifies the Ephemeral Disk Settings for the OS Disk. At this time the only possible value is `Local`. Changing this forces a new resource to be created.
 
-* `placement` - (Optional) Specifies where to store the Ephemeral Disk. Possible values are `CacheDisk` and `ResourceDisk`. Defaults to `CacheDisk`. Changing this forces a new resource to be created.
+* `placement` - (Optional) Specifies where to store the Ephemeral Disk. Possible values are `CacheDisk`, `ResourceDisk`, and `NvmeDisk`. Defaults to `CacheDisk`. Changing this forces a new resource to be created.
+
+-> **Note:** `NvmeDisk` can only be used for v6 VMs in combination with a supported `source_image_reference`. More information can be found [here](https://learn.microsoft.com/en-us/azure/virtual-machines/ephemeral-os-disks)
 
 ---
 


### PR DESCRIPTION
## Community Note
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

Adds NVMe support for orchestrated VMSS in two places:

1. **`disk_controller_type`** - optional SCSI or NVMe disk controller for v6+ SKUs and NVMe gallery images
2. **`os_disk.diff_disk_settings.placement`** - adds `NvmeDisk` for ephemeral OS disks on v6 (analogous to #29922 for single VMs; extends stalled #30044)

Use case: ephemeral GitHub Actions runner VMSS pools moving from v5 to v6.

Supersedes closed #33293 (branch was accidentally deleted during DCO sign-off rewrite).

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.

## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them.
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally.

Acceptance tests not run locally (no Azure test subscription). `go build ./internal/services/compute/...` passes.

## Testing

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md).

## Change Log

* `azurerm_orchestrated_virtual_machine_scale_set` - support for the `disk_controller_type` property [GH-22058]
* `azurerm_orchestrated_virtual_machine_scale_set` - support for `NvmeDisk` in `os_disk.diff_disk_settings.placement` [GH-29670]

This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature
- [x] Enhancement
- [ ] Breaking Change

## Related Issue(s)

Fixes #22058
Related: #29670, #30044

## AI Assistance Disclosure

- [ ] AI Assisted

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

No changes to security controls.
