### PR TITLE
`azurerm_storage_object_replication` - Add support for `priority_replication_enabled` and `tags_replication_enabled` properties

### DIFF
--- a/internal/services/storage/storage_object_replication_resource.go
+++ b/internal/services/storage/storage_object_replication_resource.go
@@ -107,9 +107,21 @@ func resourceStorageObjectReplication() *pluginsdk.Resource {
 				Default:  false,
 			},
 
+			"priority_replication_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
 			"source_object_replication_id": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
+			},
+
+			"tags_replication_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				Default:  false,
 			},
 
 			"destination_object_replication_id": {
@@ -169,6 +181,12 @@ func resourceStorageObjectReplicationCreate(d *pluginsdk.ResourceData, meta inte
 			Metrics: &objectreplicationpolicyoperationgroup.ObjectReplicationPolicyPropertiesMetrics{
 				Enabled: pointer.To(d.Get("metrics_enabled").(bool)),
 			},
+			PriorityReplication: &objectreplicationpolicyoperationgroup.ObjectReplicationPolicyPropertiesPriorityReplication{
+				Enabled: pointer.To(d.Get("priority_replication_enabled").(bool)),
+			},
+			TagsReplication: &objectreplicationpolicyoperationgroup.ObjectReplicationPolicyPropertiesTagsReplication{
+				Enabled: pointer.To(d.Get("tags_replication_enabled").(bool)),
+			},
 		},
 	}
 
@@ -226,6 +244,12 @@ func resourceStorageObjectReplicationUpdate(d *pluginsdk.ResourceData, meta inte
 			Rules:              expandArmObjectReplicationRuleArray(d.Get("rules").(*pluginsdk.Set).List()),
 			Metrics: &objectreplicationpolicyoperationgroup.ObjectReplicationPolicyPropertiesMetrics{
 				Enabled: pointer.To(d.Get("metrics_enabled").(bool)),
+			},
+			PriorityReplication: &objectreplicationpolicyoperationgroup.ObjectReplicationPolicyPropertiesPriorityReplication{
+				Enabled: pointer.To(d.Get("priority_replication_enabled").(bool)),
+			},
+			TagsReplication: &objectreplicationpolicyoperationgroup.ObjectReplicationPolicyPropertiesTagsReplication{
+				Enabled: pointer.To(d.Get("tags_replication_enabled").(bool)),
 			},
 		},
 	}
@@ -296,6 +320,8 @@ func resourceStorageObjectReplicationRead(d *pluginsdk.ResourceData, meta interf
 	if model := srcResp.Model; model != nil {
 		if props := model.Properties; props != nil {
 			d.Set("metrics_enabled", props.Metrics != nil && pointer.From(props.Metrics.Enabled))
+			d.Set("priority_replication_enabled", props.PriorityReplication != nil && pointer.From(props.PriorityReplication.Enabled))
+			d.Set("tags_replication_enabled", props.TagsReplication != nil && pointer.From(props.TagsReplication.Enabled))
 		}
 	}
 

--- a/internal/services/storage/storage_object_replication_resource_test.go
+++ b/internal/services/storage/storage_object_replication_resource_test.go
@@ -283,6 +283,8 @@ resource "azurerm_storage_object_replication" "test" {
   source_storage_account_id      = azurerm_storage_account.src.id
   destination_storage_account_id = azurerm_storage_account.dst.id
   metrics_enabled                = true
+  priority_replication_enabled   = true
+  tags_replication_enabled       = true
   rules {
     source_container_name        = azurerm_storage_container.src.name
     destination_container_name   = azurerm_storage_container.dst.name

--- a/website/docs/r/storage_object_replication.html.markdown
+++ b/website/docs/r/storage_object_replication.html.markdown
@@ -81,6 +81,10 @@ The following arguments are supported:
 
 * `metrics_enabled` - (Optional) Whether metrics are enabled for this object replication. Defaults to `false`.
 
+* `priority_replication_enabled` - (Optional) Whether priority replication is enabled for this object replication. Defaults to `false`.
+
+* `tags_replication_enabled` - (Optional) Whether tag replication is enabled for this object replication. Defaults to `false`.
+
 ---
 
 A `rules` block supports the following:


### PR DESCRIPTION
<!-- markdownlint-disable-file first-line-heading -->
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Add support for `priority_replication_enabled` and `tags_replication_enabled` in the `azurerm_storage_object_replication` resource. Currently, if the user sets them as enabled through the portal, and runs a terraform apply afterwards, it defaults back to disabled.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”

<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->

## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.

## Testing

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

<pre>
=== RUN   TestAccStorageObjectReplication_basic
=== PAUSE TestAccStorageObjectReplication_basic
=== RUN   TestAccStorageObjectReplication_requiresImport
=== PAUSE TestAccStorageObjectReplication_requiresImport
=== RUN   TestAccStorageObjectReplication_complete
=== PAUSE TestAccStorageObjectReplication_complete
=== RUN   TestAccStorageObjectReplication_update
=== PAUSE TestAccStorageObjectReplication_update
=== RUN   TestAccStorageObjectReplication_crossTenantDisabled
=== PAUSE TestAccStorageObjectReplication_crossTenantDisabled
=== RUN   TestAccStorageObjectReplication_crossSubscription
    storage_object_replication_resource_test.go:142: The secondary subscription is not specified
--- SKIP: TestAccStorageObjectReplication_crossSubscription (0.00s)
=== CONT  TestAccStorageObjectReplication_basic
=== CONT  TestAccStorageObjectReplication_update
=== CONT  TestAccStorageObjectReplication_complete
=== CONT  TestAccStorageObjectReplication_crossTenantDisabled
=== CONT  TestAccStorageObjectReplication_requiresImport
--- PASS: TestAccStorageObjectReplication_crossTenantDisabled (204.86s)
--- PASS: TestAccStorageObjectReplication_requiresImport (208.41s)
--- PASS: TestAccStorageObjectReplication_basic (233.31s)
--- PASS: TestAccStorageObjectReplication_complete (238.72s)
--- PASS: TestAccStorageObjectReplication_update (399.44s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/storage       399.473s
</pre>

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_storage_object_replication` - Add support for `priority_replication_enabled` and `tags_replication_enabled` properties

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change

## Related Issue(s)

Fixes #33213

## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE]
> If this PR changes meaningfully during the course of review please update the title and description as required.
