### PR TITLE
`azurerm_virtual_network_peering` - recreate when subnet names change the peering kind

### DIFF
--- a/internal/services/network/virtual_network_peering_helpers_test.go
+++ b/internal/services/network/virtual_network_peering_helpers_test.go
@@ -1,0 +1,64 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package network
+
+import (
+	"testing"
+)
+
+func TestSubnetNamesChangePeeringKind(t *testing.T) {
+	names := func(v ...string) []interface{} {
+		out := make([]interface{}, 0, len(v))
+		for _, s := range v {
+			out = append(out, s)
+		}
+		return out
+	}
+
+	testData := []struct {
+		name     string
+		old      []interface{}
+		new      []interface{}
+		expected bool
+	}{
+		{
+			name:     "complete virtual network peering becomes a subnet peering",
+			old:      names(),
+			new:      names("subnet1"),
+			expected: true,
+		},
+		{
+			name:     "subnet peering becomes a complete virtual network peering",
+			old:      names("subnet1"),
+			new:      names(),
+			expected: true,
+		},
+		{
+			name:     "a subnet is added to an existing subnet peering",
+			old:      names("subnet1"),
+			new:      names("subnet1", "subnet2"),
+			expected: false,
+		},
+		{
+			name:     "a subnet peering swaps which subnet it covers",
+			old:      names("subnet1"),
+			new:      names("subnet2"),
+			expected: false,
+		},
+		{
+			name:     "no subnet names before or after",
+			old:      names(),
+			new:      names(),
+			expected: false,
+		},
+	}
+
+	for _, v := range testData {
+		t.Run(v.name, func(t *testing.T) {
+			if actual := subnetNamesChangePeeringKind(v.old, v.new); actual != v.expected {
+				t.Fatalf("expected %t but got %t for %v -> %v", v.expected, actual, v.old, v.new)
+			}
+		})
+	}
+}

--- a/internal/services/network/virtual_network_peering_resource.go
+++ b/internal/services/network/virtual_network_peering_resource.go
@@ -4,6 +4,7 @@
 package network
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -25,12 +26,40 @@ import (
 
 //go:generate go run ../../tools/generator-tests resourceidentity
 
+// subnetNamesChangePeeringKind reports whether a change to one of the subnet name lists
+// switches the peering between a complete virtual network peering and a subnet peering.
+// Going from empty to populated, or populated to empty, is that switch. Editing the
+// contents of an already-populated list is not.
+func subnetNamesChangePeeringKind(old, new interface{}) bool {
+	wasSubnetPeering := len(old.([]interface{})) > 0
+	isSubnetPeering := len(new.([]interface{})) > 0
+	return wasSubnetPeering != isSubnetPeering
+}
+
 func resourceVirtualNetworkPeering() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
 		Create: resourceVirtualNetworkPeeringCreate,
 		Read:   resourceVirtualNetworkPeeringRead,
 		Update: resourceVirtualNetworkPeeringUpdate,
 		Delete: resourceVirtualNetworkPeeringDelete,
+
+		// A peering is either a complete virtual network peering or a subnet peering, and
+		// Azure fixes that at creation. `peer_complete_virtual_networks_enabled` and
+		// `only_ipv6_peering_enabled` are already ForceNew for that reason, but adding or
+		// removing subnet names switches the same setting implicitly: the update returns
+		// 200, the service ignores it, and every subsequent plan shows the change again.
+		// Recreate when the peering changes kind. Editing the list of an existing subnet
+		// peering is left as an in-place update.
+		// Issue: https://github.com/hashicorp/terraform-provider-azurerm/issues/31992
+		CustomizeDiff: pluginsdk.CustomDiffWithAll(
+			pluginsdk.ForceNewIfChange("local_subnet_names", func(ctx context.Context, old, new, meta interface{}) bool {
+				return subnetNamesChangePeeringKind(old, new)
+			}),
+
+			pluginsdk.ForceNewIfChange("remote_subnet_names", func(ctx context.Context, old, new, meta interface{}) bool {
+				return subnetNamesChangePeeringKind(old, new)
+			}),
+		),
 
 		Importer: pluginsdk.ImporterValidatingIdentity(&virtualnetworkpeerings.VirtualNetworkPeeringId{}),
 

--- a/website/docs/r/virtual_network_peering.html.markdown
+++ b/website/docs/r/virtual_network_peering.html.markdown
@@ -174,13 +174,13 @@ The following arguments are supported:
 
 * `allow_gateway_transit` - (Optional) Controls gatewayLinks can be used in the remote virtual network’s link to the local virtual network. Defaults to `false`.
 
-* `local_subnet_names` - (Optional) A list of local Subnet names that are Subnet peered with remote Virtual Network.
+* `local_subnet_names` - (Optional) A list of local Subnet names that are Subnet peered with remote Virtual Network. Adding this to a peering that has none, or removing it entirely, changes the peering between a complete Virtual Network peering and a Subnet peering and forces a new resource to be created.
 
 * `only_ipv6_peering_enabled` - (Optional) Specifies whether only IPv6 address space is peered for Subnet peering. Changing this forces a new resource to be created.
 
 * `peer_complete_virtual_networks_enabled` - (Optional) Specifies whether complete Virtual Network address space is peered. Defaults to `true`. Changing this forces a new resource to be created.
 
-* `remote_subnet_names` - (Optional) A list of remote Subnet names from remote Virtual Network that are Subnet peered.
+* `remote_subnet_names` - (Optional) A list of remote Subnet names from remote Virtual Network that are Subnet peered. Adding this to a peering that has none, or removing it entirely, changes the peering between a complete Virtual Network peering and a Subnet peering and forces a new resource to be created.
 
 * `use_remote_gateways` - (Optional) Controls if remote gateways can be used on the local virtual network. If the flag is set to `true`, and `allow_gateway_transit` on the remote peering is also `true`, virtual network will use gateways of remote virtual network for transit. Only one peering can have this flag set to `true`. This flag cannot be set if virtual network already has a gateway. Defaults to `false`.
 


### PR DESCRIPTION
#### Changes to existing Resource / Data Source

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your resource or datasource changes?
- [ ] Have you successfully run tests with your changes locally? — unit tests yes, acceptance tests no; see below.

#### Description

A peering is either a complete Virtual Network peering or a Subnet peering, and Azure fixes that at creation. `peer_complete_virtual_networks_enabled` and `only_ipv6_peering_enabled` are already `ForceNew` for exactly that reason.

`local_subnet_names` and `remote_subnet_names` were not, but adding or removing them switches the same setting implicitly. So the provider issues an update, the service returns `200` and ignores it, nothing changes, and every subsequent plan shows the same diff again. Terraform never converges and the user gets no error — #31992 describes this as the operation being a "success" while the subnets stay in the plan forever.

This adds a `CustomizeDiff` that recreates the peering **only when the peering changes kind** — an empty list becoming populated, or a populated list becoming empty.

Editing the contents of an already-populated list stays an in-place update. I deliberately did not make these fields plain `ForceNew`: that would also destroy and recreate a peering when someone adds a second subnet to an existing Subnet peering, and I have no evidence the service rejects that. If maintainers know it does, the predicate is one line to widen.

#### Testing

`TestSubnetNamesChangePeeringKind` is a new unit test covering both kind changes and the three cases that must *not* force recreation:

```
--- PASS: TestSubnetNamesChangePeeringKind
    --- PASS: .../complete_virtual_network_peering_becomes_a_subnet_peering
    --- PASS: .../subnet_peering_becomes_a_complete_virtual_network_peering
    --- PASS: .../a_subnet_is_added_to_an_existing_subnet_peering
    --- PASS: .../a_subnet_peering_swaps_which_subnet_it_covers
    --- PASS: .../no_subnet_names_before_or_after
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/network
```

`go test ./internal/services/network/` passes, `go vet` is clean and `gofmt` reports no changes.

I have not run `TestAccVirtualNetworkPeering_subnetPeering` or the other acceptance tests — I don't have a subscription with `Microsoft.Network/AllowMultiplePeeringLinksBetweenVnets` registered, which Subnet peering requires. I'd appreciate a maintainer running the peering acceptance tests.

#### Related Issue(s)

Fixes #31992

#### Change Log

* `azurerm_virtual_network_peering` - changing `local_subnet_names` or `remote_subnet_names` between empty and non-empty now forces a new resource, as it changes the peering kind [GH-00000]

- [x] Bug Fix
- [ ] New Feature