### PR TITLE
azurerm_network_manager_routing_rule - fix validation when next_hop.address is unknown at plan time

### DIFF
--- a/internal/services/network/network_manager_routing_rule_resource.go
+++ b/internal/services/network/network_manager_routing_rule_resource.go
@@ -146,9 +146,11 @@ func (r ManagerRoutingRuleResource) CustomizeDiff() sdk.ResourceFunc {
 				}
 			}
 
-			if len(model.NextHop) > 0 {
+			nextHopRaw := metadata.ResourceDiff.GetRawConfig().AsValueMap()["next_hop"]
+			if len(model.NextHop) > 0 && !nextHopRaw.IsNull() && nextHopRaw.IsKnown() {
 				v := model.NextHop[0]
-				if strings.EqualFold(v.Type, string(routingrules.RoutingRuleNextHopTypeVirtualAppliance)) && v.Address == "" {
+				addressRaw := nextHopRaw.AsValueSlice()[0].AsValueMap()["address"]
+				if addressRaw.IsKnown() && strings.EqualFold(v.Type, string(routingrules.RoutingRuleNextHopTypeVirtualAppliance)) && v.Address == "" {
 					return fmt.Errorf("expanding `next_hop`: `address` is required when `type` is `VirtualAppliance`")
 				}
 			}

--- a/internal/services/network/network_manager_routing_rule_resource.go
+++ b/internal/services/network/network_manager_routing_rule_resource.go
@@ -146,10 +146,12 @@ func (r ManagerRoutingRuleResource) CustomizeDiff() sdk.ResourceFunc {
 				}
 			}
 
-			nextHopRaw := metadata.ResourceDiff.GetRawConfig().AsValueMap()["next_hop"]
-			if len(model.NextHop) > 0 && !nextHopRaw.IsNull() && nextHopRaw.IsKnown() {
+			if len(model.NextHop) > 0 {
 				v := model.NextHop[0]
+
+				nextHopRaw := metadata.ResourceDiff.GetRawConfig().AsValueMap()["next_hop"]
 				addressRaw := nextHopRaw.AsValueSlice()[0].AsValueMap()["address"]
+
 				if addressRaw.IsKnown() && strings.EqualFold(v.Type, string(routingrules.RoutingRuleNextHopTypeVirtualAppliance)) && v.Address == "" {
 					return fmt.Errorf("expanding `next_hop`: `address` is required when `type` is `VirtualAppliance`")
 				}

--- a/internal/services/network/network_manager_routing_rule_resource_test.go
+++ b/internal/services/network/network_manager_routing_rule_resource_test.go
@@ -96,6 +96,21 @@ func TestAccNetworkManagerRoutingRule_complete(t *testing.T) {
 	})
 }
 
+func TestAccNetworkManagerRoutingRule_nextHopAddressKnownAfterApply(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_network_manager_routing_rule", "test")
+	r := NetworkManagerRoutingRuleResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.nextHopAddressKnownAfterApply(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (r NetworkManagerRoutingRuleResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := routingrules.ParseRuleID(state.ID)
 	if err != nil {
@@ -197,6 +212,57 @@ resource "azurerm_network_manager_routing_rule" "test" {
   next_hop {
     type    = "VirtualAppliance"
     address = "10.0.20.2"
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r NetworkManagerRoutingRuleResource) nextHopAddressKnownAfterApply(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctest-vnet-%[2]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  address_space       = ["10.0.0.0/16"]
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "internal"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.2.0/24"]
+}
+
+resource "azurerm_network_interface" "test" {
+  name                = "acctest-nic-%[2]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = azurerm_subnet.test.id
+    private_ip_address_allocation = "Dynamic"
+  }
+}
+
+# the next_hop address is not known until apply time here, which must not fail the plan
+resource "azurerm_network_manager_routing_rule" "test" {
+  name               = "acctest-nmrr-%[2]d"
+  rule_collection_id = azurerm_network_manager_routing_rule_collection.test.id
+  destination {
+    type    = "AddressPrefix"
+    address = "10.0.0.0/24"
+  }
+
+  next_hop {
+    type    = "VirtualAppliance"
+    address = azurerm_network_interface.test.private_ip_address
   }
 }
 `, r.template(data), data.RandomInteger)


### PR DESCRIPTION
<!-- markdownlint-disable-file first-line-heading -->
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

Fixes a validation error when `next_hop.address` is unknown at plan time. Adds an acceptance test covering this scenario.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->

## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.

## Testing

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass.
```
TF_ACC=1 go test -v ./internal/services/network -run=TestAccNetworkManagerRoutingRule_nextHopAddressKnownAfterApply -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccNetworkManagerRoutingRule_nextHopAddressKnownAfterApply
=== PAUSE TestAccNetworkManagerRoutingRule_nextHopAddressKnownAfterApply
=== CONT  TestAccNetworkManagerRoutingRule_nextHopAddressKnownAfterApply
--- PASS: TestAccNetworkManagerRoutingRule_nextHopAddressKnownAfterApply (170.06s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/network	170.143s
```

## Change Log

* `azurerm_network_manager_routing_rule` - fix a validation error when `next_hop.address` is unknown at plan time [GH-33417]

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change

## Related Issue(s)

Fixes #32590 

## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

NA

## Changes to Security Controls

NA
