### PR TITLE
new resource: `azurerm_trusted_signing_certificate_profile`

### DIFF
--- a/.github/labeler-issue-triage-generated.yml
+++ b/.github/labeler-issue-triage-generated.yml
@@ -337,7 +337,7 @@ service/traffic-manager:
   - '### (|New or )Affected Resource\(s\)\/Data Source\(s\)((.|\n)*)azurerm_traffic_manager_((.|\n)*)###'
 
 service/trustedsigning:
-  - '### (|New or )Affected Resource\(s\)\/Data Source\(s\)((.|\n)*)azurerm_trusted_signing_account((.|\n)*)###'
+  - '### (|New or )Affected Resource\(s\)\/Data Source\(s\)((.|\n)*)azurerm_trusted_signing_((.|\n)*)###'
 
 service/video-indexer:
   - '### (|New or )Affected Resource\(s\)\/Data Source\(s\)((.|\n)*)azurerm_video_indexer_account((.|\n)*)###'

--- a/internal/services/codesigning/registration.go
+++ b/internal/services/codesigning/registration.go
@@ -43,6 +43,7 @@ func (r Registration) DataSources() []sdk.DataSource {
 func (r Registration) Resources() []sdk.Resource {
 	return []sdk.Resource{
 		TrustedSigningAccountResource{},
+		TrustedSigningCertificateProfileResource{},
 	}
 }
 
@@ -63,5 +64,7 @@ func (r Registration) EphemeralResources() []func() ephemeral.EphemeralResource 
 }
 
 func (r Registration) ListResources() []sdk.FrameworkListWrappedResource {
-	return []sdk.FrameworkListWrappedResource{}
+	return []sdk.FrameworkListWrappedResource{
+		TrustedSigningCertificateProfileListResource{},
+	}
 }

--- a/internal/services/codesigning/trusted_signing_certificate_profile_resource.go
+++ b/internal/services/codesigning/trusted_signing_certificate_profile_resource.go
@@ -1,0 +1,261 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package codesigning
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/codesigning/2025-10-13/certificateprofiles"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/codesigning/2025-10-13/codesigningaccounts"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+//go:generate go run ../../tools/generator-tests resourceidentity -properties name -compare-values subscription_id:trusted_signing_account_id,resource_group_name:trusted_signing_account_id,code_signing_account_name:trusted_signing_account_id -test-env-vars ARM_TEST_TRUSTED_SIGNING_IDENTITY_ID
+
+type TrustedSigningCertificateProfileResource struct{}
+
+var (
+	_ sdk.ResourceWithUpdate   = TrustedSigningCertificateProfileResource{}
+	_ sdk.ResourceWithIdentity = TrustedSigningCertificateProfileResource{}
+)
+
+type TrustedSigningCertificateProfileModel struct {
+	Name                    string `tfschema:"name"`
+	TrustedSigningAccountId string `tfschema:"trusted_signing_account_id"`
+	IdentityValidationId    string `tfschema:"identity_validation_id"`
+	ProfileType             string `tfschema:"profile_type"`
+	IncludeCity             *bool  `tfschema:"include_city"`
+	IncludeCountry          *bool  `tfschema:"include_country"`
+	IncludePostalCode       *bool  `tfschema:"include_postal_code"`
+	IncludeState            *bool  `tfschema:"include_state"`
+	IncludeStreetAddress    *bool  `tfschema:"include_street_address"`
+}
+
+func (TrustedSigningCertificateProfileResource) ResourceType() string {
+	return "azurerm_trusted_signing_certificate_profile"
+}
+
+func (TrustedSigningCertificateProfileResource) ModelObject() interface{} {
+	return &TrustedSigningCertificateProfileModel{}
+}
+
+func (TrustedSigningCertificateProfileResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return certificateprofiles.ValidateCertificateProfileID
+}
+
+func (TrustedSigningCertificateProfileResource) Identity() resourceids.ResourceId {
+	return &certificateprofiles.CertificateProfileId{}
+}
+
+func (TrustedSigningCertificateProfileResource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+			ValidateFunc: validation.All(
+				validation.StringLenBetween(5, 100),
+				validation.StringMatch(regexp.MustCompile("^[A-Za-z][A-Za-z0-9]*(-[A-Za-z0-9]+)*$"), "must begin with a letter, end with a letter or digit, and contain only alphanumeric characters and non-consecutive hyphens"),
+			),
+		},
+
+		"trusted_signing_account_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: codesigningaccounts.ValidateCodeSigningAccountID,
+		},
+
+		"identity_validation_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"profile_type": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringInSlice(certificateprofiles.PossibleValuesForProfileType(), false),
+		},
+
+		"include_city": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Default:  false,
+		},
+
+		"include_country": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Default:  false,
+		},
+
+		"include_postal_code": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Default:  false,
+		},
+
+		"include_state": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Default:  false,
+		},
+
+		"include_street_address": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Default:  false,
+		},
+	}
+}
+
+func (TrustedSigningCertificateProfileResource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{}
+}
+
+func (r TrustedSigningCertificateProfileResource) Create() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.CodeSigning.Client.CertificateProfiles
+			var model TrustedSigningCertificateProfileModel
+			if err := metadata.Decode(&model); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			accountId, err := codesigningaccounts.ParseCodeSigningAccountID(model.TrustedSigningAccountId)
+			if err != nil {
+				return err
+			}
+			id := certificateprofiles.NewCertificateProfileID(accountId.SubscriptionId, accountId.ResourceGroupName, accountId.CodeSigningAccountName, model.Name)
+
+			if !metadata.Client.Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+				existing, err := client.Get(ctx, id)
+				if err != nil && !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+				}
+				if !response.WasNotFound(existing.HttpResponse) {
+					return metadata.ResourceRequiresImport(r.ResourceType(), id)
+				}
+			}
+
+			if err := client.CreateThenPoll(ctx, id, expandTrustedSigningCertificateProfileResource(model), metadata.SetIDAndIdentityCallback(&id)); err != nil {
+				return fmt.Errorf("creating %s: %+v", id, err)
+			}
+
+			metadata.SetID(id)
+			return pluginsdk.SetResourceIdentityData(metadata.ResourceData, &id)
+		},
+	}
+}
+
+func (TrustedSigningCertificateProfileResource) Update() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.CodeSigning.Client.CertificateProfiles
+			id, err := certificateprofiles.ParseCertificateProfileID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			var model TrustedSigningCertificateProfileModel
+			if err := metadata.Decode(&model); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			if err := client.CreateThenPoll(ctx, *id, expandTrustedSigningCertificateProfileResource(model)); err != nil {
+				return fmt.Errorf("updating %s: %+v", id, err)
+			}
+			return nil
+		},
+	}
+}
+
+func (r TrustedSigningCertificateProfileResource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.CodeSigning.Client.CertificateProfiles
+			id, err := certificateprofiles.ParseCertificateProfileID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.Get(ctx, *id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return metadata.MarkAsGone(id)
+				}
+				return fmt.Errorf("retrieving %s: %+v", id, err)
+			}
+			return flattenTrustedSigningCertificateProfileResource(metadata, id, resp.Model)
+		},
+	}
+}
+
+func (TrustedSigningCertificateProfileResource) Delete() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.CodeSigning.Client.CertificateProfiles
+			id, err := certificateprofiles.ParseCertificateProfileID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+			if err := client.DeleteThenPoll(ctx, *id); err != nil {
+				return fmt.Errorf("deleting %s: %+v", id, err)
+			}
+			return nil
+		},
+	}
+}
+
+func expandTrustedSigningCertificateProfileResource(model TrustedSigningCertificateProfileModel) certificateprofiles.CertificateProfile {
+	return certificateprofiles.CertificateProfile{
+		Properties: &certificateprofiles.CertificateProfileProperties{
+			IdentityValidationId: model.IdentityValidationId,
+			ProfileType:          certificateprofiles.ProfileType(model.ProfileType),
+			IncludeCity:          model.IncludeCity,
+			IncludeCountry:       model.IncludeCountry,
+			IncludePostalCode:    model.IncludePostalCode,
+			IncludeState:         model.IncludeState,
+			IncludeStreetAddress: model.IncludeStreetAddress,
+		},
+	}
+}
+
+func flattenTrustedSigningCertificateProfileResource(metadata sdk.ResourceMetaData, id *certificateprofiles.CertificateProfileId, model *certificateprofiles.CertificateProfile) error {
+	state := TrustedSigningCertificateProfileModel{
+		Name:                    id.CertificateProfileName,
+		TrustedSigningAccountId: codesigningaccounts.NewCodeSigningAccountID(id.SubscriptionId, id.ResourceGroupName, id.CodeSigningAccountName).ID(),
+	}
+	if model != nil {
+		if props := model.Properties; props != nil {
+			state.IdentityValidationId = props.IdentityValidationId
+			state.ProfileType = string(props.ProfileType)
+			state.IncludeCity = pointer.To(pointer.From(props.IncludeCity))
+			state.IncludeCountry = pointer.To(pointer.From(props.IncludeCountry))
+			state.IncludePostalCode = pointer.To(pointer.From(props.IncludePostalCode))
+			state.IncludeState = pointer.To(pointer.From(props.IncludeState))
+			state.IncludeStreetAddress = pointer.To(pointer.From(props.IncludeStreetAddress))
+		}
+	}
+
+	if err := pluginsdk.SetResourceIdentityData(metadata.ResourceData, id); err != nil {
+		return err
+	}
+	return metadata.Encode(&state)
+}

--- a/internal/services/codesigning/trusted_signing_certificate_profile_resource.go
+++ b/internal/services/codesigning/trusted_signing_certificate_profile_resource.go
@@ -151,7 +151,7 @@ func (r TrustedSigningCertificateProfileResource) Create() sdk.ResourceFunc {
 				}
 			}
 
-			if err := client.CreateThenPoll(ctx, id, expandTrustedSigningCertificateProfileResource(model), metadata.SetIDAndIdentityCallback(&id)); err != nil {
+			if err := client.CreateCallbackThenPoll(ctx, id, expandTrustedSigningCertificateProfileResource(model), metadata.SetIDAndIdentityCallback(&id)); err != nil {
 				return fmt.Errorf("creating %s: %+v", id, err)
 			}
 

--- a/internal/services/codesigning/trusted_signing_certificate_profile_resource_identity_gen_test.go
+++ b/internal/services/codesigning/trusted_signing_certificate_profile_resource_identity_gen_test.go
@@ -1,0 +1,47 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package codesigning_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
+)
+
+func TestAccTrustedSigningCertificateProfile_resourceIdentity(t *testing.T) {
+	for _, v := range []string{"ARM_TEST_TRUSTED_SIGNING_IDENTITY_ID"} {
+		if os.Getenv(v) == "" {
+			t.Skipf("Skipping as `%s` was not specified", v)
+		}
+	}
+
+	data := acceptance.BuildTestData(t, "azurerm_trusted_signing_certificate_profile", "test")
+	r := TrustedSigningCertificateProfileResource{}
+
+	checkedFields := map[string]struct{}{
+		"name":                      {},
+		"code_signing_account_name": {},
+		"resource_group_name":       {},
+		"subscription_id":           {},
+	}
+
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				customstatecheck.ExpectAllIdentityFieldsAreChecked("azurerm_trusted_signing_certificate_profile.test", checkedFields),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_trusted_signing_certificate_profile.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_trusted_signing_certificate_profile.test", tfjsonpath.New("code_signing_account_name"), tfjsonpath.New("trusted_signing_account_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_trusted_signing_certificate_profile.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("trusted_signing_account_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_trusted_signing_certificate_profile.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("trusted_signing_account_id")),
+			},
+		},
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
+}

--- a/internal/services/codesigning/trusted_signing_certificate_profile_resource_list.go
+++ b/internal/services/codesigning/trusted_signing_certificate_profile_resource_list.go
@@ -1,0 +1,106 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package codesigning
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-azure-helpers/framework/typehelpers"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/codesigning/2025-10-13/certificateprofiles"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-framework/list/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type (
+	TrustedSigningCertificateProfileListResource struct{}
+	TrustedSigningCertificateProfileListModel    struct {
+		TrustedSigningAccountId types.String `tfsdk:"trusted_signing_account_id"`
+	}
+)
+
+var _ sdk.FrameworkListWrappedResource = new(TrustedSigningCertificateProfileListResource)
+
+func (TrustedSigningCertificateProfileListResource) Metadata(_ context.Context, _ resource.MetadataRequest, response *resource.MetadataResponse) {
+	response.TypeName = TrustedSigningCertificateProfileResource{}.ResourceType()
+}
+
+func (TrustedSigningCertificateProfileListResource) ResourceFunc() *pluginsdk.Resource {
+	return sdk.WrappedResource(TrustedSigningCertificateProfileResource{})
+}
+
+func (TrustedSigningCertificateProfileListResource) ListResourceConfigSchema(_ context.Context, _ list.ListResourceSchemaRequest, response *list.ListResourceSchemaResponse) {
+	response.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"trusted_signing_account_id": schema.StringAttribute{
+				Required: true,
+				Validators: []validator.String{
+					typehelpers.WrappedStringValidator{Func: certificateprofiles.ValidateCodeSigningAccountID},
+				},
+			},
+		},
+	}
+}
+
+func (TrustedSigningCertificateProfileListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream, metadata sdk.ResourceMetadata) {
+	client := metadata.Client.CodeSigning.Client.CertificateProfiles
+
+	var data TrustedSigningCertificateProfileListModel
+	diags := request.Config.Get(ctx, &data)
+	if diags.HasError() {
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+
+	accountId, err := certificateprofiles.ParseCodeSigningAccountID(data.TrustedSigningAccountId.ValueString())
+	if err != nil {
+		sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("parsing Trusted Signing Account ID for `%s`", TrustedSigningCertificateProfileResource{}.ResourceType()), err)
+		return
+	}
+
+	resp, err := client.ListByCodeSigningAccountComplete(ctx, *accountId)
+	if err != nil {
+		sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("listing `%s`", TrustedSigningCertificateProfileResource{}.ResourceType()), err)
+		return
+	}
+
+	r := TrustedSigningCertificateProfileResource{}
+
+	stream.Results = func(push func(list.ListResult) bool) {
+		for _, item := range resp.Items {
+			result := request.NewListResult(ctx)
+			result.DisplayName = pointer.From(item.Name)
+
+			id, err := certificateprofiles.ParseCertificateProfileIDInsensitively(pointer.From(item.Id))
+			if err != nil {
+				sdk.SetErrorDiagnosticAndPushListResult(result, push, "parsing Certificate Profile ID", err)
+				return
+			}
+
+			rmd := sdk.NewResourceMetaData(metadata.Client, r)
+			rmd.SetID(id)
+
+			if err := flattenTrustedSigningCertificateProfileResource(rmd, id, &item); err != nil {
+				sdk.SetErrorDiagnosticAndPushListResult(result, push, fmt.Sprintf("encoding `%s` resource data", r.ResourceType()), err)
+				return
+			}
+
+			sdk.EncodeListResult(ctx, rmd.ResourceData, &result)
+			if result.Diagnostics.HasError() {
+				push(result)
+				return
+			}
+
+			if !push(result) {
+				return
+			}
+		}
+	}
+}

--- a/internal/services/codesigning/trusted_signing_certificate_profile_resource_list_test.go
+++ b/internal/services/codesigning/trusted_signing_certificate_profile_resource_list_test.go
@@ -1,0 +1,71 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package codesigning_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/codesigning/2025-10-13/codesigningaccounts"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck/queryfilter"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
+)
+
+func TestAccTrustedSigningCertificateProfile_list(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_trusted_signing_certificate_profile", "test")
+	r := TrustedSigningCertificateProfileResource{}
+	r.preCheck(t)
+	accountId := codesigningaccounts.NewCodeSigningAccountID(data.Subscriptions.Primary, fmt.Sprintf("acctestRG-%d", data.RandomInteger), "acctest-"+data.RandomString)
+	name := "acctest-" + data.RandomString
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { acceptance.PreCheck(t) },
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInitWithTestName(context.Background(), t.Name(), "azurerm"),
+		Steps: []resource.TestStep{
+			{Config: r.complete(data)},
+			{
+				Query: true,
+				Config: fmt.Sprintf(`
+list "azurerm_trusted_signing_certificate_profile" "list" {
+  provider         = azurerm
+  include_resource = true
+  config {
+    trusted_signing_account_id = "%s"
+  }
+}
+`, accountId.ID()),
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectLengthAtLeast("azurerm_trusted_signing_certificate_profile.list", 1),
+					querycheck.ExpectIdentity("azurerm_trusted_signing_certificate_profile.list", map[string]knownvalue.Check{
+						"name":                      knownvalue.StringExact(name),
+						"subscription_id":           knownvalue.StringExact(accountId.SubscriptionId),
+						"resource_group_name":       knownvalue.StringExact(accountId.ResourceGroupName),
+						"code_signing_account_name": knownvalue.StringExact(accountId.CodeSigningAccountName),
+					}),
+					querycheck.ExpectResourceKnownValues("azurerm_trusted_signing_certificate_profile.list", queryfilter.ByDisplayName(knownvalue.StringExact(name)), []querycheck.KnownValueCheck{
+						{Path: tfjsonpath.New("trusted_signing_account_id"), KnownValue: knownvalue.StringExact(accountId.ID())},
+						{Path: tfjsonpath.New("identity_validation_id"), KnownValue: knownvalue.StringExact(os.Getenv("ARM_TEST_TRUSTED_SIGNING_IDENTITY_ID"))},
+						{Path: tfjsonpath.New("profile_type"), KnownValue: knownvalue.StringExact("PrivateTrust")},
+						{Path: tfjsonpath.New("include_city"), KnownValue: knownvalue.Bool(true)},
+						{Path: tfjsonpath.New("include_country"), KnownValue: knownvalue.Bool(true)},
+						{Path: tfjsonpath.New("include_postal_code"), KnownValue: knownvalue.Bool(true)},
+						{Path: tfjsonpath.New("include_state"), KnownValue: knownvalue.Bool(true)},
+						{Path: tfjsonpath.New("include_street_address"), KnownValue: knownvalue.Bool(true)},
+					}),
+				},
+			},
+		},
+	})
+}

--- a/internal/services/codesigning/trusted_signing_certificate_profile_resource_test.go
+++ b/internal/services/codesigning/trusted_signing_certificate_profile_resource_test.go
@@ -1,0 +1,206 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package codesigning_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/codesigning/2025-10-13/certificateprofiles"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type TrustedSigningCertificateProfileResource struct{}
+
+func TestAccTrustedSigningCertificateProfile_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_trusted_signing_certificate_profile", "test")
+	r := TrustedSigningCertificateProfileResource{}
+	r.preCheck(t)
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("profile_type").HasValue("PrivateTrust"),
+				check.That(data.ResourceName).Key("include_city").HasValue("false"),
+				check.That(data.ResourceName).Key("include_country").HasValue("false"),
+				check.That(data.ResourceName).Key("include_postal_code").HasValue("false"),
+				check.That(data.ResourceName).Key("include_state").HasValue("false"),
+				check.That(data.ResourceName).Key("include_street_address").HasValue("false"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccTrustedSigningCertificateProfile_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_trusted_signing_certificate_profile", "test")
+	r := TrustedSigningCertificateProfileResource{}
+	r.preCheck(t)
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check:  check.That(data.ResourceName).ExistsInAzure(r),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func TestAccTrustedSigningCertificateProfile_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_trusted_signing_certificate_profile", "test")
+	r := TrustedSigningCertificateProfileResource{}
+	r.preCheck(t)
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("include_city").HasValue("true"),
+				check.That(data.ResourceName).Key("include_country").HasValue("true"),
+				check.That(data.ResourceName).Key("include_postal_code").HasValue("true"),
+				check.That(data.ResourceName).Key("include_state").HasValue("true"),
+				check.That(data.ResourceName).Key("include_street_address").HasValue("true"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccTrustedSigningCertificateProfile_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_trusted_signing_certificate_profile", "test")
+	r := TrustedSigningCertificateProfileResource{}
+	r.preCheck(t)
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{Config: r.basic(data)},
+		data.ImportStep(),
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("include_city").HasValue("true"),
+				check.That(data.ResourceName).Key("include_country").HasValue("true"),
+				check.That(data.ResourceName).Key("include_postal_code").HasValue("true"),
+				check.That(data.ResourceName).Key("include_state").HasValue("true"),
+				check.That(data.ResourceName).Key("include_street_address").HasValue("true"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("include_city").HasValue("false"),
+				check.That(data.ResourceName).Key("include_country").HasValue("false"),
+				check.That(data.ResourceName).Key("include_postal_code").HasValue("false"),
+				check.That(data.ResourceName).Key("include_state").HasValue("false"),
+				check.That(data.ResourceName).Key("include_street_address").HasValue("false"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccTrustedSigningCertificateProfile_privateTrustCIPolicy(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_trusted_signing_certificate_profile", "test")
+	r := TrustedSigningCertificateProfileResource{}
+	r.preCheck(t)
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: strings.ReplaceAll(r.basic(data), "PrivateTrust", "PrivateTrustCIPolicy"),
+			Check:  check.That(data.ResourceName).ExistsInAzure(r),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccTrustedSigningCertificateProfile_publicTrust(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_trusted_signing_certificate_profile", "test")
+	r := TrustedSigningCertificateProfileResource{}
+	identityId := os.Getenv("ARM_TEST_TRUSTED_SIGNING_PUBLIC_IDENTITY_ID")
+	if identityId == "" {
+		t.Skip("ARM_TEST_TRUSTED_SIGNING_PUBLIC_IDENTITY_ID is required: complete a Public Trust identity validation in the test subscription using the Azure Portal")
+	}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.profile(data, identityId, "PublicTrust", ""),
+			Check:  check.That(data.ResourceName).ExistsInAzure(r),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (TrustedSigningCertificateProfileResource) preCheck(t *testing.T) {
+	// Identity validation requires the Azure Portal and can be shared by accounts in
+	// the same subscription. The test creates its own resource group and account.
+	// https://learn.microsoft.com/azure/artifact-signing/quickstart#create-an-artifact-signing-account
+	if os.Getenv("ARM_TEST_TRUSTED_SIGNING_IDENTITY_ID") == "" {
+		t.Skip("ARM_TEST_TRUSTED_SIGNING_IDENTITY_ID is required: complete a Private Trust identity validation in the test subscription using the Azure Portal")
+	}
+}
+
+func (TrustedSigningCertificateProfileResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := certificateprofiles.ParseCertificateProfileID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.CodeSigning.Client.CertificateProfiles.Get(ctx, *id)
+	if err != nil {
+		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+	return pointer.To(resp.Model != nil), nil
+}
+
+func (r TrustedSigningCertificateProfileResource) basic(data acceptance.TestData) string {
+	return r.profile(data, os.Getenv("ARM_TEST_TRUSTED_SIGNING_IDENTITY_ID"), "PrivateTrust", "")
+}
+
+func (r TrustedSigningCertificateProfileResource) complete(data acceptance.TestData) string {
+	return r.profile(data, os.Getenv("ARM_TEST_TRUSTED_SIGNING_IDENTITY_ID"), "PrivateTrust", `
+  include_city           = true
+  include_country        = true
+  include_postal_code    = true
+  include_state          = true
+  include_street_address = true
+`)
+}
+
+func (TrustedSigningCertificateProfileResource) profile(data acceptance.TestData, identityId, profileType, options string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_trusted_signing_certificate_profile" "test" {
+  name                       = "acctest-%[2]s"
+  trusted_signing_account_id = azurerm_trusted_signing_account.test.id
+  identity_validation_id     = "%[3]s"
+  profile_type               = "%[4]s"
+  %[5]s
+}
+`, TrustedSigningAccountResource{}.basic(data), data.RandomString, identityId, profileType, options)
+}
+
+func (r TrustedSigningCertificateProfileResource) requiresImport(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_trusted_signing_certificate_profile" "import" {
+  name                       = azurerm_trusted_signing_certificate_profile.test.name
+  trusted_signing_account_id = azurerm_trusted_signing_certificate_profile.test.trusted_signing_account_id
+  identity_validation_id     = azurerm_trusted_signing_certificate_profile.test.identity_validation_id
+  profile_type               = azurerm_trusted_signing_certificate_profile.test.profile_type
+}
+`, r.basic(data))
+}

--- a/website/docs/list-resources/trusted_signing_certificate_profile.html.markdown
+++ b/website/docs/list-resources/trusted_signing_certificate_profile.html.markdown
@@ -1,0 +1,29 @@
+---
+subcategory: "Trusted Signing"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_trusted_signing_certificate_profile"
+description: |-
+  Lists Trusted Signing Certificate Profiles (Artifact Signing Certificate Profiles).
+---
+
+# List resource: azurerm_trusted_signing_certificate_profile
+
+Lists Trusted Signing Certificate Profiles (Artifact Signing Certificate Profiles) in a Trusted Signing Account.
+
+## Example Usage
+
+```hcl
+list "azurerm_trusted_signing_certificate_profile" "example" {
+  provider         = azurerm
+  include_resource = true
+  config {
+    trusted_signing_account_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example-resources/providers/Microsoft.CodeSigning/codeSigningAccounts/example-account"
+  }
+}
+```
+
+## Argument Reference
+
+This list resource supports the following arguments:
+
+* `trusted_signing_account_id` - (Required) The ID of the Trusted Signing Account to query.

--- a/website/docs/r/trusted_signing_certificate_profile.html.markdown
+++ b/website/docs/r/trusted_signing_certificate_profile.html.markdown
@@ -1,0 +1,82 @@
+---
+subcategory: "Trusted Signing"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_trusted_signing_certificate_profile"
+description: |-
+  Manages a Trusted Signing Certificate Profile (Artifact Signing Certificate Profile).
+---
+
+# azurerm_trusted_signing_certificate_profile
+
+Manages a Trusted Signing Certificate Profile (Artifact Signing Certificate Profile).
+
+~> **Note:** Trusted Signing has been rebranded to [Artifact Signing](https://learn.microsoft.com/azure/artifact-signing/overview).
+
+~> **Note:** Before creating a certificate profile, complete an [identity validation](https://learn.microsoft.com/azure/artifact-signing/quickstart#create-an-identity-validation-request) in the Azure Portal. Identity validations can be shared across Trusted Signing Accounts in the same subscription. Private identity validations support `PrivateTrust` and `PrivateTrustCIPolicy`; public identity validations support `PublicTrust`, `PublicTrustTest`, and `VBSEnclave`.
+
+## Example Usage
+
+```hcl
+data "azurerm_trusted_signing_account" "example" {
+  name                = "example-account"
+  resource_group_name = "example-resources"
+}
+
+resource "azurerm_trusted_signing_certificate_profile" "example" {
+  name                       = "example-profile"
+  trusted_signing_account_id = data.azurerm_trusted_signing_account.example.id
+  identity_validation_id     = "00000000-0000-0000-0000-000000000000"
+  profile_type               = "PrivateTrust"
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the Trusted Signing Certificate Profile. Must be between 5 and 100 characters, begin with a letter, end with a letter or digit, and contain only alphanumeric characters and non-consecutive hyphens. Changing this forces a new resource to be created.
+
+* `trusted_signing_account_id` - (Required) The ID of the Trusted Signing Account in which to create this certificate profile. Changing this forces a new resource to be created.
+
+* `identity_validation_id` - (Required) The ID of a completed identity validation in the same subscription as the Trusted Signing Account, used for the certificate subject name. Changing this forces a new resource to be created.
+
+* `profile_type` - (Required) The type of the certificate profile. Possible values are `PrivateTrust`, `PrivateTrustCIPolicy`, `PublicTrust`, `PublicTrustTest`, and `VBSEnclave`. Changing this forces a new resource to be created.
+
+* `include_city` - (Optional) Whether to include the city (`L`) in the certificate subject name. Applicable only to `PrivateTrust` and `PrivateTrustCIPolicy` profiles. Defaults to `false`.
+
+* `include_country` - (Optional) Whether to include the country (`C`) in the certificate subject name. Applicable only to `PrivateTrust` and `PrivateTrustCIPolicy` profiles. Defaults to `false`.
+
+* `include_postal_code` - (Optional) Whether to include the postal code (`PC`) in the certificate subject name. Defaults to `false`.
+
+* `include_state` - (Optional) Whether to include the state (`S`) in the certificate subject name. Applicable only to `PrivateTrust` and `PrivateTrustCIPolicy` profiles. Defaults to `false`.
+
+* `include_street_address` - (Optional) Whether to include the street address (`STREET`) in the certificate subject name. Defaults to `false`.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the Trusted Signing Certificate Profile.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/configure#timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Trusted Signing Certificate Profile.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Trusted Signing Certificate Profile.
+* `update` - (Defaults to 30 minutes) Used when updating the Trusted Signing Certificate Profile.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Trusted Signing Certificate Profile.
+
+## Import
+
+Trusted Signing Certificate Profiles can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_trusted_signing_certificate_profile.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example-resources/providers/Microsoft.CodeSigning/codeSigningAccounts/example-account/certificateProfiles/example-profile
+```
+
+## API Providers
+<!-- This section is generated, changes will be overwritten -->
+This resource uses the following Azure API Providers:
+
+* `Microsoft.CodeSigning` - 2025-10-13


### PR DESCRIPTION
<!-- markdownlint-disable-file first-line-heading -->
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

adding a new resource for trsuted signing (artifacts signing)
document: https://learn.microsoft.com/en-us/azure/artifact-signing/
swagger:  https://github.com/Azure/azure-rest-api-specs/blob/c20bf553ad64f20c6d5e3f56080380c086cb1fde/specification/codesigning/resource-manager/Microsoft.CodeSigning/CodeSigning/stable/2025-10-13/codeSigningAccount.json#L465


<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”

<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->

## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.

## Testing

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

```
❯ tftest codesigning TestAccTrustedSigningCertificateProfile_
=== RUN   TestAccTrustedSigningCertificateProfile_resourceIdentity
=== PAUSE TestAccTrustedSigningCertificateProfile_resourceIdentity
=== RUN   TestAccTrustedSigningCertificateProfile_list
--- PASS: TestAccTrustedSigningCertificateProfile_list (283.61s)
=== RUN   TestAccTrustedSigningCertificateProfile_basic
=== PAUSE TestAccTrustedSigningCertificateProfile_basic
=== RUN   TestAccTrustedSigningCertificateProfile_requiresImport
=== PAUSE TestAccTrustedSigningCertificateProfile_requiresImport
=== RUN   TestAccTrustedSigningCertificateProfile_complete
=== PAUSE TestAccTrustedSigningCertificateProfile_complete
=== RUN   TestAccTrustedSigningCertificateProfile_privateTrustCIPolicy
=== PAUSE TestAccTrustedSigningCertificateProfile_privateTrustCIPolicy
=== RUN   TestAccTrustedSigningCertificateProfile_publicTrust
=== PAUSE TestAccTrustedSigningCertificateProfile_publicTrust
=== CONT  TestAccTrustedSigningCertificateProfile_resourceIdentity
=== CONT  TestAccTrustedSigningCertificateProfile_complete
=== CONT  TestAccTrustedSigningCertificateProfile_publicTrust
=== CONT  TestAccTrustedSigningCertificateProfile_privateTrustCIPolicy
=== CONT  TestAccTrustedSigningCertificateProfile_requiresImport
=== CONT  TestAccTrustedSigningCertificateProfile_basic
--- PASS: TestAccTrustedSigningCertificateProfile_complete (300.78s)
--- PASS: TestAccTrustedSigningCertificateProfile_privateTrustCIPolicy (303.18s)
--- PASS: TestAccTrustedSigningCertificateProfile_publicTrust (308.41s)
--- PASS: TestAccTrustedSigningCertificateProfile_requiresImport (311.96s)
--- PASS: TestAccTrustedSigningCertificateProfile_basic (312.47s)
--- PASS: TestAccTrustedSigningCertificateProfile_resourceIdentity (320.13s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/codesigning   603.838s
```

These test cases can not be performed on TeamCity currently due to it requires identity verfication on Portal.

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* new resource: `azurerm_trusted_signing_certificate_profile`[GH-00000]

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [x] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change

## Related Issue(s)

Fixes #0000

## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE]
> If this PR changes meaningfully during the course of review please update the title and description as required.
