### PR TITLE
azurerm_private_endpoint - validate that at most one `subresource_names` entry is specified

### DIFF
--- a/internal/services/network/private_endpoint_resource.go
+++ b/internal/services/network/private_endpoint_resource.go
@@ -313,7 +313,8 @@ func resourcePrivateEndpoint() *pluginsdk.Resource {
 					return fmt.Errorf(`"private_service_connection":%q is invalid, the "request_message" attribute must not be empty`, name)
 				}
 			}
-			return nil
+
+			return validatePrivateEndpointSubResourceNames(privateServiceConnections)
 		},
 	}
 }
@@ -442,6 +443,23 @@ func resourcePrivateEndpointCreate(d *pluginsdk.ResourceData, meta interface{}) 
 	}
 
 	return resourcePrivateEndpointRead(d, meta)
+}
+
+func validatePrivateEndpointSubResourceNames(privateServiceConnections []interface{}) error {
+	for _, psc := range privateServiceConnections {
+		privateServiceConnection := psc.(map[string]interface{})
+
+		subResourceNames := privateServiceConnection["subresource_names"].([]interface{})
+		if len(subResourceNames) < 2 {
+			continue
+		}
+
+		names := pointer.From(helpers.ExpandStringSlice(subResourceNames))
+
+		return fmt.Errorf(`"private_service_connection":%q is invalid, at most one "subresource_names" entry is permitted, got %d (%s) - connecting to additional subresources requires additional "azurerm_private_endpoint" resources`, privateServiceConnection["name"].(string), len(names), strings.Join(names, ", "))
+	}
+
+	return nil
 }
 
 func validatePrivateLinkServiceId(endpoints []privateendpoints.PrivateLinkServiceConnection) error {

--- a/internal/services/network/private_endpoint_resource_test.go
+++ b/internal/services/network/private_endpoint_resource_test.go
@@ -132,6 +132,26 @@ func TestAccPrivateEndpoint_invalidRequestMessage(t *testing.T) {
 	})
 }
 
+func TestAccPrivateEndpoint_multipleSubresourceNames(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_private_endpoint", "test")
+	r := PrivateEndpointResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.subresourceNames(data, `["blob"]`),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config:      r.subresourceNames(data, `["blob", "file"]`),
+			PlanOnly:    true,
+			ExpectError: regexp.MustCompile(`at most one "subresource_names" entry is permitted`),
+		},
+	})
+}
+
 // The update and complete test cases had to be totally removed since there is a bug with tags and the support for
 // tags has been removed, all other attributes are ForceNew.
 // API Issue "Unable to remove Tags from Private Endpoint": https://github.com/Azure/azure-sdk-for-go/issues/6467
@@ -744,6 +764,57 @@ resource "azurerm_private_endpoint" "test" {
   }
 }
 `, r.template(data, r.serviceAutoApprove(data)), data.RandomInteger)
+}
+
+func (PrivateEndpointResource) subresourceNames(data acceptance.TestData, subresourceNames string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-privatelink-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvnet-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  address_space       = ["10.5.0.0/16"]
+}
+
+resource "azurerm_subnet" "endpoint" {
+  name                 = "acctestsnetendpoint-%[1]d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.5.2.0/24"]
+
+  private_endpoint_network_policies = "Disabled"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctestsa%[3]s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_private_endpoint" "test" {
+  name                = "acctest-privatelink-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  subnet_id           = azurerm_subnet.endpoint.id
+
+  private_service_connection {
+    name                           = "acctest-privatelink-psc-%[1]d"
+    private_connection_resource_id = azurerm_storage_account.test.id
+    subresource_names              = %[4]s
+    is_manual_connection           = false
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, subresourceNames)
 }
 
 func (PrivateEndpointResource) privateDnsZoneGroup(data acceptance.TestData) string {

--- a/website/docs/r/private_endpoint.html.markdown
+++ b/website/docs/r/private_endpoint.html.markdown
@@ -237,9 +237,9 @@ A `private_service_connection` block supports the following:
 
 * `subresource_names` - (Optional) A list of subresource names which the Private Endpoint is able to connect to. `subresource_names` corresponds to `group_id`. Possible values are detailed in the product [documentation](https://docs.microsoft.com/azure/private-link/private-endpoint-overview#private-link-resource) in the `Subresources` column. Changing this forces a new resource to be created. 
 
--> **Note:** Some resource types (such as Storage Account) only support 1 subresource per private endpoint.
+-> **Note:** Only one subresource is permitted per Private Endpoint, connecting to additional subresources requires additional `azurerm_private_endpoint` resources.
 
--> **Note:** For most Private Links one or more `subresource_names` will need to be specified, please see the linked documentation for details.
+-> **Note:** For most Private Links a `subresource_names` value will need to be specified, please see the linked documentation for details.
 
 * `request_message` - (Optional) A message passed to the owner of the remote resource when the private endpoint attempts to establish the connection to the remote resource. The provider allows a maximum request message length of `140` characters, however the request message maximum length is dependent on the service the private endpoint is connected to. Only valid if `is_manual_connection` is set to `true`.
 


### PR DESCRIPTION
<!-- markdownlint-disable-file first-line-heading -->
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

This PR validates the `subresource_names`(which is `ForceNew`) value in `CustomizeDiff` to allow issue being pointed out before apply.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->

## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.

## Testing

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass.
```
TF_ACC=1 go test -v ./internal/services/network -run=TestAccPrivateEndpoint_multipleSubresourceNames -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccPrivateEndpoint_multipleSubresourceNames
=== PAUSE TestAccPrivateEndpoint_multipleSubresourceNames
=== CONT  TestAccPrivateEndpoint_multipleSubresourceNames
--- PASS: TestAccPrivateEndpoint_multipleSubresourceNames (210.26s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/network	210.356s
```

## Change Log

* `azurerm_private_endpoint` - validate that at most one `subresource_names` entry is specified [GH-33420]

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change

## Related Issue(s)

Fixes #32689 

## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

NA

## Changes to Security Controls

NA
