### PR TITLE
`app_service_custom_hostname_binding` - add List Resource support

### DIFF
--- a/internal/services/web/app_service_custom_hostname_binding_resource.go
+++ b/internal/services/web/app_service_custom_hostname_binding_resource.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/web/2023-12-01/webapps"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
@@ -20,6 +21,8 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
 
+//go:generate go run ../../tools/generator-tests resourceidentity -properties "name:hostname,site_name:app_service_name,resource_group_name" -test-name basicConfig -test-env-vars ARM_TEST_DNS_ZONE,ARM_TEST_DATA_RESOURCE_GROUP
+
 const appServiceCustomHostnameBindingResourceName = "azurerm_app_service_custom_hostname_binding"
 
 func resourceAppServiceCustomHostnameBinding() *pluginsdk.Resource {
@@ -27,10 +30,11 @@ func resourceAppServiceCustomHostnameBinding() *pluginsdk.Resource {
 		Create: resourceAppServiceCustomHostnameBindingCreate,
 		Read:   resourceAppServiceCustomHostnameBindingRead,
 		Delete: resourceAppServiceCustomHostnameBindingDelete,
-		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
-			_, err := webapps.ParseHostNameBindingID(id)
-			return err
-		}),
+		Identity: &schema.ResourceIdentity{
+			SchemaFunc: pluginsdk.GenerateIdentitySchema(&webapps.HostNameBindingId{}),
+		},
+
+		Importer: pluginsdk.ImporterValidatingIdentity(&webapps.HostNameBindingId{}),
 
 		SchemaVersion: 1,
 		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
@@ -135,6 +139,9 @@ func resourceAppServiceCustomHostnameBindingCreate(d *pluginsdk.ResourceData, me
 	}
 
 	d.SetId(id.ID())
+	if err := pluginsdk.SetResourceIdentityData(d, &id); err != nil {
+		return err
+	}
 
 	return resourceAppServiceCustomHostnameBindingRead(d, meta)
 }
@@ -159,11 +166,15 @@ func resourceAppServiceCustomHostnameBindingRead(d *pluginsdk.ResourceData, meta
 		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
+	return resourceAppServiceCustomHostnameBindingFlatten(d, id, resp.Model)
+}
+
+func resourceAppServiceCustomHostnameBindingFlatten(d *pluginsdk.ResourceData, id *webapps.HostNameBindingId, model *webapps.HostNameBinding) error {
 	d.Set("hostname", id.HostNameBindingName)
 	d.Set("app_service_name", id.SiteName)
 	d.Set("resource_group_name", id.ResourceGroupName)
 
-	if model := resp.Model; model != nil {
+	if model != nil {
 		if props := model.Properties; props != nil {
 			d.Set("ssl_state", pointer.FromEnum(props.SslState))
 			d.Set("thumbprint", props.Thumbprint)
@@ -171,7 +182,7 @@ func resourceAppServiceCustomHostnameBindingRead(d *pluginsdk.ResourceData, meta
 		}
 	}
 
-	return nil
+	return pluginsdk.SetResourceIdentityData(d, id)
 }
 
 func resourceAppServiceCustomHostnameBindingDelete(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/web/app_service_custom_hostname_binding_resource_identity_gen_test.go
+++ b/internal/services/web/app_service_custom_hostname_binding_resource_identity_gen_test.go
@@ -1,0 +1,48 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package web_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
+)
+
+func TestAccAppServiceCustomHostnameBinding_resourceIdentity(t *testing.T) {
+	for _, v := range []string{"ARM_TEST_DNS_ZONE", "ARM_TEST_DATA_RESOURCE_GROUP"} {
+		if os.Getenv(v) == "" {
+			t.Skipf("Skipping as `%s` was not specified", v)
+		}
+	}
+
+	data := acceptance.BuildTestData(t, "azurerm_app_service_custom_hostname_binding", "test")
+	r := AppServiceCustomHostnameBindingResource{}
+
+	checkedFields := map[string]struct{}{
+		"subscription_id":     {},
+		"name":                {},
+		"resource_group_name": {},
+		"site_name":           {},
+	}
+
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basicConfig(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				customstatecheck.ExpectAllIdentityFieldsAreChecked("azurerm_app_service_custom_hostname_binding.test", checkedFields),
+				statecheck.ExpectIdentityValue("azurerm_app_service_custom_hostname_binding.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_app_service_custom_hostname_binding.test", tfjsonpath.New("name"), tfjsonpath.New("hostname")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_app_service_custom_hostname_binding.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_app_service_custom_hostname_binding.test", tfjsonpath.New("site_name"), tfjsonpath.New("app_service_name")),
+			},
+		},
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
+}

--- a/internal/services/web/app_service_custom_hostname_binding_resource_list.go
+++ b/internal/services/web/app_service_custom_hostname_binding_resource_list.go
@@ -1,0 +1,100 @@
+package web
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-azure-helpers/framework/typehelpers"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/web/2023-12-01/webapps"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-framework/list/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type AppServiceCustomHostnameBindingListResource struct{}
+
+type AppServiceCustomHostnameBindingListModel struct {
+	AppServiceId types.String `tfsdk:"app_service_id"`
+}
+
+var _ sdk.FrameworkListWrappedResource = new(AppServiceCustomHostnameBindingListResource)
+
+func (AppServiceCustomHostnameBindingListResource) Metadata(_ context.Context, _ resource.MetadataRequest, response *resource.MetadataResponse) {
+	response.TypeName = appServiceCustomHostnameBindingResourceName
+}
+
+func (AppServiceCustomHostnameBindingListResource) ResourceFunc() *pluginsdk.Resource {
+	return resourceAppServiceCustomHostnameBinding()
+}
+
+func (AppServiceCustomHostnameBindingListResource) ListResourceConfigSchema(_ context.Context, _ list.ListResourceSchemaRequest, response *list.ListResourceSchemaResponse) {
+	response.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"app_service_id": schema.StringAttribute{
+				Required: true,
+				Validators: []validator.String{
+					typehelpers.WrappedStringValidator{Func: commonids.ValidateAppServiceID},
+				},
+			},
+		},
+	}
+}
+
+func (AppServiceCustomHostnameBindingListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream, metadata sdk.ResourceMetadata) {
+	client := metadata.Client.Web.WebAppsClient
+
+	var data AppServiceCustomHostnameBindingListModel
+	diags := request.Config.Get(ctx, &data)
+	if diags.HasError() {
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+
+	parentID, err := commonids.ParseAppServiceID(data.AppServiceId.ValueString())
+	if err != nil {
+		sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("parsing App Service ID for `%s`", appServiceCustomHostnameBindingResourceName), err)
+		return
+	}
+
+	resp, err := client.ListHostNameBindingsComplete(ctx, *parentID)
+	if err != nil {
+		sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("listing `%s`", appServiceCustomHostnameBindingResourceName), err)
+		return
+	}
+
+	stream.Results = func(push func(list.ListResult) bool) {
+		for _, item := range resp.Items {
+			result := request.NewListResult(ctx)
+			result.DisplayName = pointer.From(item.Name)
+
+			rd := resourceAppServiceCustomHostnameBinding().Data(&terraform.InstanceState{})
+			id, err := webapps.ParseHostNameBindingIDInsensitively(pointer.From(item.Id))
+			if err != nil {
+				sdk.SetErrorDiagnosticAndPushListResult(result, push, fmt.Sprintf("parsing ID for `%s`", appServiceCustomHostnameBindingResourceName), err)
+				return
+			}
+			rd.SetId(id.ID())
+
+			if err := resourceAppServiceCustomHostnameBindingFlatten(rd, id, &item); err != nil {
+				sdk.SetErrorDiagnosticAndPushListResult(result, push, fmt.Sprintf("encoding `%s` resource data", appServiceCustomHostnameBindingResourceName), err)
+				return
+			}
+
+			sdk.EncodeListResult(ctx, rd, &result)
+			if result.Diagnostics.HasError() {
+				push(result)
+				return
+			}
+			if !push(result) {
+				return
+			}
+		}
+	}
+}

--- a/internal/services/web/app_service_custom_hostname_binding_resource_list_test.go
+++ b/internal/services/web/app_service_custom_hostname_binding_resource_list_test.go
@@ -1,0 +1,64 @@
+package web_test
+
+import (
+	"context"
+	"os"
+	"regexp"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
+)
+
+func TestAccAppServiceCustomHostnameBinding_listByAppServiceID(t *testing.T) {
+	if os.Getenv("ARM_TEST_DNS_ZONE") == "" || os.Getenv("ARM_TEST_DATA_RESOURCE_GROUP") == "" {
+		t.Skip("Skipping as ARM_TEST_DNS_ZONE and/or ARM_TEST_DATA_RESOURCE_GROUP are not specified")
+	}
+
+	data := acceptance.BuildTestData(t, "azurerm_app_service_custom_hostname_binding", "test")
+	r := AppServiceCustomHostnameBindingResource{}
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []resource.TestStep{
+			{
+				Config: r.basicConfig(data),
+			},
+			{
+				Query:  true,
+				Config: r.basicQuery(),
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectLengthAtLeast("azurerm_app_service_custom_hostname_binding.list", 1),
+					querycheck.ExpectIdentity(
+						"azurerm_app_service_custom_hostname_binding.list",
+						map[string]knownvalue.Check{
+							"name":                knownvalue.StringExact(data.RandomString + "." + os.Getenv("ARM_TEST_DNS_ZONE")),
+							"resource_group_name": knownvalue.StringRegexp(regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
+							"site_name":           knownvalue.StringRegexp(regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
+							"subscription_id":     knownvalue.StringExact(data.Subscriptions.Primary),
+						},
+					),
+				},
+			},
+		},
+	})
+}
+
+func (r AppServiceCustomHostnameBindingResource) basicQuery() string {
+	return `
+list "azurerm_app_service_custom_hostname_binding" "list" {
+  provider = azurerm
+  config {
+    app_service_id = azurerm_app_service.test.id
+  }
+}
+`
+}

--- a/internal/services/web/app_service_custom_hostname_binding_resource_test.go
+++ b/internal/services/web/app_service_custom_hostname_binding_resource_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
-type ServiceCustomHostnameBindingResource struct{}
+type AppServiceCustomHostnameBindingResource struct{}
 
 func TestAccAppServiceCustomHostnameBinding_basic(t *testing.T) {
 	if os.Getenv("ARM_TEST_DNS_ZONE") == "" || os.Getenv("ARM_TEST_DATA_RESOURCE_GROUP") == "" {
@@ -26,7 +26,7 @@ func TestAccAppServiceCustomHostnameBinding_basic(t *testing.T) {
 	}
 
 	data := acceptance.BuildTestData(t, "azurerm_app_service_custom_hostname_binding", "test")
-	r := ServiceCustomHostnameBindingResource{}
+	r := AppServiceCustomHostnameBindingResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -46,7 +46,7 @@ func TestAccAppServiceCustomHostnameBinding_requiresImport(t *testing.T) {
 	}
 
 	data := acceptance.BuildTestData(t, "azurerm_app_service_custom_hostname_binding", "test")
-	r := ServiceCustomHostnameBindingResource{}
+	r := AppServiceCustomHostnameBindingResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -66,7 +66,7 @@ func TestAccAppServiceCustomHostnameBinding_multiple(t *testing.T) {
 	}
 
 	data := acceptance.BuildTestData(t, "azurerm_app_service_custom_hostname_binding", "test")
-	r := ServiceCustomHostnameBindingResource{}
+	r := AppServiceCustomHostnameBindingResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -85,7 +85,7 @@ func TestAccAppServiceCustomHostnameBinding_ssl(t *testing.T) {
 	}
 
 	data := acceptance.BuildTestData(t, "azurerm_app_service_custom_hostname_binding", "test")
-	r := ServiceCustomHostnameBindingResource{}
+	r := AppServiceCustomHostnameBindingResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -98,7 +98,7 @@ func TestAccAppServiceCustomHostnameBinding_ssl(t *testing.T) {
 	})
 }
 
-func (r ServiceCustomHostnameBindingResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+func (r AppServiceCustomHostnameBindingResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := webapps.ParseHostNameBindingID(state.ID)
 	if err != nil {
 		return nil, err
@@ -112,7 +112,7 @@ func (r ServiceCustomHostnameBindingResource) Exists(ctx context.Context, client
 	return pointer.To(resp.Model != nil), nil
 }
 
-func (r ServiceCustomHostnameBindingResource) basicConfig(data acceptance.TestData) string {
+func (r AppServiceCustomHostnameBindingResource) basicConfig(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -128,7 +128,7 @@ resource "azurerm_app_service_custom_hostname_binding" "test" {
 `, r.template(data))
 }
 
-func (r ServiceCustomHostnameBindingResource) requiresImport(data acceptance.TestData) string {
+func (r AppServiceCustomHostnameBindingResource) requiresImport(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -140,7 +140,7 @@ resource "azurerm_app_service_custom_hostname_binding" "import" {
 `, r.basicConfig(data))
 }
 
-func (r ServiceCustomHostnameBindingResource) multipleConfig(data acceptance.TestData) string {
+func (r AppServiceCustomHostnameBindingResource) multipleConfig(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -171,7 +171,7 @@ resource "azurerm_app_service_custom_hostname_binding" "test2" {
 `, r.basicConfig(data), data.RandomStringOfLength(7))
 }
 
-func (r ServiceCustomHostnameBindingResource) sslConfig(data acceptance.TestData) string {
+func (r AppServiceCustomHostnameBindingResource) sslConfig(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -253,7 +253,7 @@ resource "azurerm_app_service_custom_hostname_binding" "test" {
 `, r.template(data), data.RandomInteger, data.RandomString)
 }
 
-func (r ServiceCustomHostnameBindingResource) template(data acceptance.TestData) string {
+func (r AppServiceCustomHostnameBindingResource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%[1]d"

--- a/internal/services/web/registration.go
+++ b/internal/services/web/registration.go
@@ -79,5 +79,7 @@ func (r Registration) EphemeralResources() []func() ephemeral.EphemeralResource 
 }
 
 func (r Registration) ListResources() []sdk.FrameworkListWrappedResource {
-	return []sdk.FrameworkListWrappedResource{}
+	return []sdk.FrameworkListWrappedResource{
+		AppServiceCustomHostnameBindingListResource{},
+	}
 }

--- a/website/docs/list-resources/app_service_custom_hostname_binding.html.markdown
+++ b/website/docs/list-resources/app_service_custom_hostname_binding.html.markdown
@@ -1,0 +1,30 @@
+---
+subcategory: "App Service (Web Apps)"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_app_service_custom_hostname_binding"
+description: |-
+    Lists App Service Custom Hostname Binding resources.
+---
+
+# List resource: azurerm_app_service_custom_hostname_binding
+
+Lists App Service Custom Hostname Binding resources.
+
+## Example Usage
+
+### List all App Service Custom Hostname Bindings in an App Service
+
+```hcl
+list "azurerm_app_service_custom_hostname_binding" "example" {
+  provider = azurerm
+  config {
+    app_service_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example-rg/providers/Microsoft.Web/sites/example-app-service"
+  }
+}
+```
+
+## Argument Reference
+
+This list resource supports the following arguments:
+
+* `app_service_id` - (Required) The ID of the App Service to query.


### PR DESCRIPTION
<!-- markdownlint-disable-file first-line-heading -->
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”

<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->

## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.

## Testing

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change

## Related Issue(s)

Fixes #0000

## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE]
> If this PR changes meaningfully during the course of review please update the title and description as required.
