### PR TITLE
`azurerm_site_recovery_replicated_vm` - add caseInsensitiveProps to new `CustomDiffComputedSet` to avoid false-positive drift detection with IDs

### DIFF
--- a/internal/services/recoveryservices/site_recovery_replicated_vm_resource.go
+++ b/internal/services/recoveryservices/site_recovery_replicated_vm_resource.go
@@ -343,6 +343,7 @@ func resourceSiteRecoveryReplicatedVMCustomizeDiff(ctx context.Context, diff *pl
 			resourceSiteRecoveryReplicatedVMDiskHash,
 			[]string{"staging_storage_account_id", "target_resource_group_id", "target_disk_encryption_set_id"},
 			[]string{"target_disk_type", "target_replica_disk_type"},
+			[]string{"staging_storage_account_id", "target_resource_group_id", "target_disk_encryption_set_id"},
 		)
 		if err := managedDiskCustomDiff(ctx, diff, v); err != nil {
 			return err

--- a/internal/tf/pluginsdk/customize_diff_computed_set.go
+++ b/internal/tf/pluginsdk/customize_diff_computed_set.go
@@ -3,6 +3,8 @@ package pluginsdk
 import (
 	"context"
 	"fmt"
+	"slices"
+	"strings"
 
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -13,18 +15,18 @@ import (
 // if their identity hash matches.
 //
 // Removals from the set are treated natively (i.e. as an in-place update to the Set).
-func CustomDiffComputedSet(setKey string, hashFunc schema.SchemaSetFunc, forceNewProps []string, inPlaceProps []string) CustomizeDiffFunc {
-	return customDiffComputedSet(setKey, false, hashFunc, forceNewProps, inPlaceProps)
+func CustomDiffComputedSet(setKey string, hashFunc schema.SchemaSetFunc, forceNewProps []string, inPlaceProps []string, caseInsensitiveProps []string) CustomizeDiffFunc {
+	return customDiffComputedSet(setKey, false, hashFunc, forceNewProps, inPlaceProps, caseInsensitiveProps)
 }
 
 // CustomDiffComputedSetCannotRemove is identical to CustomDiffComputedSet, but
 // explicitly forces a replacement of the entire resource if an element is removed
 // from the Set.
-func CustomDiffComputedSetCannotRemove(setKey string, hashFunc schema.SchemaSetFunc, forceNewProps []string, inPlaceProps []string) CustomizeDiffFunc {
-	return customDiffComputedSet(setKey, true, hashFunc, forceNewProps, inPlaceProps)
+func CustomDiffComputedSetCannotRemove(setKey string, hashFunc schema.SchemaSetFunc, forceNewProps []string, inPlaceProps []string, caseInsensitiveProps []string) CustomizeDiffFunc {
+	return customDiffComputedSet(setKey, true, hashFunc, forceNewProps, inPlaceProps, caseInsensitiveProps)
 }
 
-func customDiffComputedSet(setKey string, forceNewOnRemoval bool, hashFunc schema.SchemaSetFunc, forceNewProps []string, inPlaceProps []string) CustomizeDiffFunc {
+func customDiffComputedSet(setKey string, forceNewOnRemoval bool, hashFunc schema.SchemaSetFunc, forceNewProps []string, inPlaceProps []string, caseInsensitiveProps []string) CustomizeDiffFunc {
 	return func(ctx context.Context, diff *ResourceDiff, meta interface{}) error {
 		oldRaw, _ := diff.GetChange(setKey)
 		var oldSet *schema.Set
@@ -103,7 +105,14 @@ func customDiffComputedSet(setKey string, forceNewOnRemoval bool, hashFunc schem
 					oldPropStr = fmt.Sprintf("%v", oldVal)
 				}
 
-				if newPropStr != oldPropStr {
+				var propsAreDifferent bool
+				if slices.Contains(caseInsensitiveProps, prop) {
+					propsAreDifferent = !strings.EqualFold(newPropStr, oldPropStr)
+				} else {
+					propsAreDifferent = newPropStr != oldPropStr
+				}
+
+				if propsAreDifferent {
 					if triggersForceNew {
 						forceNew = true
 					} else {


### PR DESCRIPTION
<!-- markdownlint-disable-file first-line-heading -->
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

The new `pluginsdk.CustomDiffComputedSet` function will compare strings of set properties to determine if there are any changes that can be performed in-place or if a new resource is needed (ForceNew). The string comparison is done in a case-sensitive way to determine difference.

This change introduces a new parameter to the function to allow for certain properties to be compared case-insensitive, to avoid a false-positive with certain Azure IDs or other values that may get returned from APIs in a different case then when deployed.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”

<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->

## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.

## Testing

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_site_recovery_replicated_vm` - include ID properties for new caseInsensitiveProps in `CustomDiffComputedSet` to avoid false-positive drift detection [GH-00000]

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change

## Related Issue(s)

Fixes #33261 

## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE]
> If this PR changes meaningfully during the course of review please update the title and description as required.
