### PR TITLE
azurerm_cdn_frontdoor_custom_domain - fix perpetual diff when cipher_suite type is TLS12_2022

### DIFF
--- a/internal/services/cdn/cdn_frontdoor_custom_domain_cipher_suite_test.go
+++ b/internal/services/cdn/cdn_frontdoor_custom_domain_cipher_suite_test.go
@@ -1,0 +1,47 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package cdn
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestResourceCdnFrontDoorCustomDomainCipherSuiteConfigured(t *testing.T) {
+	resource := resourceCdnFrontDoorCustomDomain()
+
+	// A configured `cipher_suite` block must be detected even when the raw
+	// configuration is unavailable (the refresh path, where Terraform only sends
+	// prior state). `schema.TestResourceDataRaw` builds a ResourceData whose
+	// `GetRawConfig()` is null while `d.Get("tls")` returns the supplied value,
+	// faithfully reproducing the refresh scenario that previously caused the
+	// default `TLS12_2022` cipher suite to be dropped from state.
+	d := schema.TestResourceDataRaw(t, resource.Schema, map[string]interface{}{
+		"tls": []interface{}{
+			map[string]interface{}{
+				"cipher_suite": []interface{}{
+					map[string]interface{}{
+						"type": "TLS12_2022",
+					},
+				},
+			},
+		},
+	})
+	if !resourceCdnFrontDoorCustomDomainCipherSuiteConfigured(d) {
+		t.Fatal("expected a configured cipher_suite block to be detected")
+	}
+
+	// No cipher_suite block configured: the helper must return false so the
+	// service-returned default `TLS12_2022` value is dropped and does not cause a
+	// perpetual diff.
+	dWithoutCipherSuite := schema.TestResourceDataRaw(t, resource.Schema, map[string]interface{}{
+		"tls": []interface{}{
+			map[string]interface{}{},
+		},
+	})
+	if resourceCdnFrontDoorCustomDomainCipherSuiteConfigured(dWithoutCipherSuite) {
+		t.Fatal("expected the absence of a cipher_suite block to be detected")
+	}
+}

--- a/internal/services/cdn/cdn_frontdoor_custom_domain_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_custom_domain_resource.go
@@ -489,28 +489,29 @@ func expandAfdResourceReference(id string) *afddomains.ResourceReference {
 }
 
 func resourceCdnFrontDoorCustomDomainCipherSuiteConfigured(d *pluginsdk.ResourceData) bool {
-	raw := d.GetRawConfig()
-	if raw.IsNull() {
+	// The raw configuration is not available during a refresh: Terraform sends only
+	// prior state to a ReadResource request, so `d.GetRawConfig()` is null and the
+	// helper would wrongly report the block as unconfigured. That caused a configured
+	// default `TLS12_2022` cipher suite to be dropped from state on every refresh and
+	// re-added on the following plan. Read the value from state instead, which reflects
+	// the incoming configuration during create/update and the last applied value during
+	// a refresh.
+	tls := d.Get("tls").([]interface{})
+	if len(tls) == 0 || tls[0] == nil {
 		return false
 	}
 
-	tlsConfig := raw.GetAttr("tls")
-	if tlsConfig.IsNull() || tlsConfig.LengthInt() == 0 {
+	tlsBlock, ok := tls[0].(map[string]interface{})
+	if !ok {
 		return false
 	}
 
-	tlsBlock := tlsConfig.AsValueSlice()[0]
-	if tlsBlock.IsNull() {
+	cipherSuiteRaw, ok := tlsBlock["cipher_suite"].([]interface{})
+	if !ok || len(cipherSuiteRaw) == 0 || cipherSuiteRaw[0] == nil {
 		return false
 	}
 
-	cipherConfig := tlsBlock.GetAttr("cipher_suite")
-	if cipherConfig.IsNull() || cipherConfig.LengthInt() == 0 {
-		return false
-	}
-
-	cipherBlock := cipherConfig.AsValueSlice()[0]
-	return !cipherBlock.IsNull()
+	return true
 }
 
 func flattenAfdDomainHttpsParameters(input *afddomains.AFDDomainHTTPSParameters, includeDefaultCipherSuite bool) []interface{} {


### PR DESCRIPTION
## Description

The `cipher_suite` block with `type = "TLS12_2022"` causes a perpetual diff: after a successful apply, every subsequent `terraform plan` wants to re-add the block.

The resource read decides whether to emit the default `TLS12_2022` cipher suite block by inspecting `d.GetRawConfig()`. Terraform does not send configuration with a `ReadResource` (refresh) request, only prior state, so during a refresh the raw config is null and the block is dropped from state. The next plan then sees the block missing versus the configured value and re-adds it, indefinitely.

This change reads the `cipher_suite` block from state (`d.Get("tls")`) instead. State reflects the incoming configuration during create/update and the last applied value during a refresh, so the block is preserved and the diff clears.

## Testing

Added `TestResourceCdnFrontDoorCustomDomainCipherSuiteConfigured`, which reproduces the refresh scenario via `schema.TestResourceDataRaw` (raw config null, state value present) and asserts the block is detected. The test fails against the previous implementation and passes with this change.

```
=== RUN   TestResourceCdnFrontDoorCustomDomainCipherSuiteConfigured
--- PASS: TestResourceCdnFrontDoorCustomDomainCipherSuiteConfigured (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/cdn	0.040s
```

## Change Log

* `azurerm_cdn_frontdoor_custom_domain` - fix a perpetual diff on the `cipher_suite` block when `type` is set to `TLS12_2022` [GH-33395]

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Enhancement
- [ ] Breaking Change

## Related Issue(s)

Fixes #33395
