### PR TITLE
teamcity: wait for test results before posting the PR comment

### DIFF
--- a/.teamcity/scripts/post_github_comment.sh
+++ b/.teamcity/scripts/post_github_comment.sh
@@ -93,17 +93,28 @@ set_testing_label() {
   fi
 }
 
-# Fetch test results for this build from the TeamCity REST API
+# Fetch test results for this build from the TeamCity REST API.
+#
+# This step runs immediately after the test step, while the build is still running, and
+# TeamCity indexes test service messages asynchronously - a short test step can finish a
+# second before this runs and the API will briefly return no occurrences at all. Poll until
+# at least one result is visible (bounded), so small runs are not reported as "Total: 0".
 TEAMCITY_ERROR=""
-RAW_TEST_RESULTS_JSON=$(curl -sS -f \
-  -H "Authorization: Bearer $TEAMCITY_TOKEN" \
-  -H "Accept: application/json" \
-  "$TEAMCITY_SERVER_URL/app/rest/testOccurrences?locator=build:(id:$BUILD_ID),count:100000&fields=testOccurrence(name,status,duration,newFailure,test(id),firstFailed(build(id,number,branchName)))")
+TEST_RESULTS=""
+RESULTS_ATTEMPTS=12
+RESULTS_DELAY_S=5
+for attempt in $(seq 1 "$RESULTS_ATTEMPTS"); do
+  RAW_TEST_RESULTS_JSON=$(curl -sS -f \
+    -H "Authorization: Bearer $TEAMCITY_TOKEN" \
+    -H "Accept: application/json" \
+    "$TEAMCITY_SERVER_URL/app/rest/testOccurrences?locator=build:(id:$BUILD_ID),count:100000&fields=testOccurrence(name,status,duration,newFailure,test(id),firstFailed(build(id,number,branchName)))")
 
-if [ $? -ne 0 ] || [ -z "$RAW_TEST_RESULTS_JSON" ]; then
-  TEAMCITY_ERROR="Failed to fetch test results from TeamCity for build $BUILD_ID."
-  TEST_RESULTS=""
-else
+  if [ $? -ne 0 ] || [ -z "$RAW_TEST_RESULTS_JSON" ]; then
+    TEAMCITY_ERROR="Failed to fetch test results from TeamCity for build $BUILD_ID."
+    TEST_RESULTS=""
+    break
+  fi
+
   TEST_RESULTS=$(echo "$RAW_TEST_RESULTS_JSON" | jq -r '(.testOccurrence // [])[]
       | select(.status == "SUCCESS" or .status == "FAILURE")
       | "\(.name)|\(if .status == "SUCCESS" then "PASS" else "FAIL" end)|\((.duration // 0) / 1000)|"')
@@ -111,8 +122,16 @@ else
   if [ $? -ne 0 ]; then
     TEAMCITY_ERROR="Failed to parse TeamCity test results for build $BUILD_ID."
     TEST_RESULTS=""
+    break
   fi
-fi
+
+  if [ -n "$TEST_RESULTS" ]; then
+    break
+  fi
+
+  echo "No test results visible yet for build $BUILD_ID (attempt $attempt/$RESULTS_ATTEMPTS), retrying in ${RESULTS_DELAY_S}s..."
+  sleep "$RESULTS_DELAY_S"
+done
 
 PASS_COUNT=$(echo "$TEST_RESULTS" | awk -F'|' 'BEGIN{c=0} $1!="" && $2=="PASS"{c++} END{print c}')
 FAIL_COUNT=$(echo "$TEST_RESULTS" | awk -F'|' 'BEGIN{c=0} $1!="" && $2=="FAIL"{c++} END{print c}')
@@ -273,6 +292,12 @@ if [ -z "$TEAMCITY_ERROR" ]; then
   done <<< "$ALL_TEST_NAMES"
 fi
 
+NO_RESULTS_NOTE=""
+if [ -z "$TEAMCITY_ERROR" ] && [ "$TOTAL" -eq 0 ]; then
+  NO_RESULTS_NOTE="
+> TeamCity reported no test results for this build after waiting $((RESULTS_ATTEMPTS * RESULTS_DELAY_S))s. Check the build log: the test filter may have matched nothing, or the build may have failed before the tests ran."
+fi
+
 if [ -n "$TEAMCITY_ERROR" ]; then
   COMMENT="Build: [$BUILD_ID]($TEAMCITY_SERVER_URL/viewLog.html?buildId=$BUILD_ID)
 PR: #$PR_NUMBER
@@ -341,6 +366,7 @@ PR: #$PR_NUMBER
 **Passed:** $PASS_COUNT
 **Failed:** $FAIL_COUNT
 **Test Duration:** ${BUILD_HOURS}h ${BUILD_MINUTES}m ${BUILD_SECONDS}s
+${NO_RESULTS_NOTE}
 
 <details>
 <summary>Test Details</summary>

--- a/.teamcity/scripts/post_github_comment.sh
+++ b/.teamcity/scripts/post_github_comment.sh
@@ -96,18 +96,21 @@ set_testing_label() {
 # Fetch test results for this build from the TeamCity REST API.
 #
 # This step runs immediately after the test step, while the build is still running, and
-# TeamCity indexes test service messages asynchronously - a short test step can finish a
-# second before this runs and the API will briefly return no occurrences at all. Poll until
-# at least one result is visible (bounded), so small runs are not reported as "Total: 0".
+# TeamCity indexes test service messages asynchronously - the tests that finished last
+# (often several at once, since they run in parallel) may not be visible yet, and a short
+# run can briefly return no occurrences at all. Poll (bounded) until at least one result is
+# visible and the count has not changed between two consecutive polls.
 TEAMCITY_ERROR=""
 TEST_RESULTS=""
 RESULTS_ATTEMPTS=12
 RESULTS_DELAY_S=5
+SEEN_COUNT=0
+PREV_SEEN_COUNT=-1
 for attempt in $(seq 1 "$RESULTS_ATTEMPTS"); do
   RAW_TEST_RESULTS_JSON=$(curl -sS -f \
     -H "Authorization: Bearer $TEAMCITY_TOKEN" \
     -H "Accept: application/json" \
-    "$TEAMCITY_SERVER_URL/app/rest/testOccurrences?locator=build:(id:$BUILD_ID),count:100000&fields=testOccurrence(name,status,duration,newFailure,test(id),firstFailed(build(id,number,branchName)))")
+    "$TEAMCITY_SERVER_URL/app/rest/testOccurrences?locator=build:(id:$BUILD_ID),count:100000&fields=testOccurrence(name,status,ignored,duration,newFailure,test(id),firstFailed(build(id,number,branchName)))")
 
   if [ $? -ne 0 ] || [ -z "$RAW_TEST_RESULTS_JSON" ]; then
     TEAMCITY_ERROR="Failed to fetch test results from TeamCity for build $BUILD_ID."
@@ -116,8 +119,8 @@ for attempt in $(seq 1 "$RESULTS_ATTEMPTS"); do
   fi
 
   TEST_RESULTS=$(echo "$RAW_TEST_RESULTS_JSON" | jq -r '(.testOccurrence // [])[]
-      | select(.status == "SUCCESS" or .status == "FAILURE")
-      | "\(.name)|\(if .status == "SUCCESS" then "PASS" else "FAIL" end)|\((.duration // 0) / 1000)|"')
+      | select(.status == "SUCCESS" or .status == "FAILURE" or .ignored == true)
+      | "\(.name)|\(if .status == "SUCCESS" then "PASS" elif .status == "FAILURE" then "FAIL" else "SKIP" end)|\((.duration // 0) / 1000)|"')
 
   if [ $? -ne 0 ]; then
     TEAMCITY_ERROR="Failed to parse TeamCity test results for build $BUILD_ID."
@@ -125,17 +128,43 @@ for attempt in $(seq 1 "$RESULTS_ATTEMPTS"); do
     break
   fi
 
-  if [ -n "$TEST_RESULTS" ]; then
+  SEEN_COUNT=$(echo "$RAW_TEST_RESULTS_JSON" | jq -r '(.testOccurrence // []) | length')
+
+  if [ "$SEEN_COUNT" -gt 0 ] && [ "$SEEN_COUNT" -eq "$PREV_SEEN_COUNT" ]; then
     break
   fi
 
-  echo "No test results visible yet for build $BUILD_ID (attempt $attempt/$RESULTS_ATTEMPTS), retrying in ${RESULTS_DELAY_S}s..."
+  echo "Test results for build $BUILD_ID not settled yet: $SEEN_COUNT visible (attempt $attempt/$RESULTS_ATTEMPTS), retrying in ${RESULTS_DELAY_S}s..."
+  PREV_SEEN_COUNT=$SEEN_COUNT
   sleep "$RESULTS_DELAY_S"
 done
 
+# The build's own status catches failures the test list cannot show: a test step that
+# failed before or without reporting tests, or failed tests that were still not indexed.
+BUILD_STATUS=""
+BUILD_STATUS_TEXT=""
+BUILD_INFO_JSON=$(curl -sS -f \
+  -H "Authorization: Bearer $TEAMCITY_TOKEN" \
+  -H "Accept: application/json" \
+  "$TEAMCITY_SERVER_URL/app/rest/builds/id:$BUILD_ID?fields=status,statusText")
+if [ $? -eq 0 ] && [ -n "$BUILD_INFO_JSON" ]; then
+  BUILD_STATUS=$(echo "$BUILD_INFO_JSON" | jq -r '.status // ""' 2>/dev/null)
+  BUILD_STATUS_TEXT=$(echo "$BUILD_INFO_JSON" | jq -r '.statusText // ""' 2>/dev/null)
+else
+  echo "Warning: could not fetch build status for build $BUILD_ID"
+fi
+
 PASS_COUNT=$(echo "$TEST_RESULTS" | awk -F'|' 'BEGIN{c=0} $1!="" && $2=="PASS"{c++} END{print c}')
 FAIL_COUNT=$(echo "$TEST_RESULTS" | awk -F'|' 'BEGIN{c=0} $1!="" && $2=="FAIL"{c++} END{print c}')
-TOTAL=$((PASS_COUNT + FAIL_COUNT))
+SKIP_COUNT=$(echo "$TEST_RESULTS" | awk -F'|' 'BEGIN{c=0} $1!="" && $2=="SKIP"{c++} END{print c}')
+TOTAL=$((PASS_COUNT + FAIL_COUNT + SKIP_COUNT))
+
+# A build that failed without any failed tests (test step crashed, results not indexed)
+# must not be reported or labelled as passing.
+BUILD_FAILED_WITHOUT_TEST_FAILURES="false"
+if [ -z "$TEAMCITY_ERROR" ] && [ "$BUILD_STATUS" = "FAILURE" ] && [ "$FAIL_COUNT" -eq 0 ]; then
+  BUILD_FAILED_WITHOUT_TEST_FAILURES="true"
+fi
 
 # Fetch main branch test results early to identify new failures for comment marking
 NEW_FAILURES=""
@@ -203,7 +232,7 @@ if [ -z "$TEAMCITY_ERROR" ]; then
   echo "Fetching per-test main branch history..."
 
   ALL_TEST_NAMES=$(echo "$RAW_TEST_RESULTS_JSON" \
-    | jq -r '(.testOccurrence // [])[] | select(.status == "SUCCESS" or .status == "FAILURE") | .name' \
+    | jq -r '(.testOccurrence // [])[] | select(.status == "SUCCESS" or .status == "FAILURE" or .ignored == true) | .name' \
     2>/dev/null || echo "")
 
   while IFS= read -r test_name; do
@@ -298,6 +327,12 @@ if [ -z "$TEAMCITY_ERROR" ] && [ "$TOTAL" -eq 0 ]; then
 > TeamCity reported no test results for this build after waiting $((RESULTS_ATTEMPTS * RESULTS_DELAY_S))s. Check the build log: the test filter may have matched nothing, or the build may have failed before the tests ran."
 fi
 
+BUILD_FAILED_NOTE=""
+if [ "$BUILD_FAILED_WITHOUT_TEST_FAILURES" = "true" ]; then
+  BUILD_FAILED_NOTE="
+> TeamCity reports this build as **FAILURE** (${BUILD_STATUS_TEXT:-no status text}) but no failed tests were returned. Treating the run as failed; check the build log."
+fi
+
 if [ -n "$TEAMCITY_ERROR" ]; then
   COMMENT="Build: [$BUILD_ID]($TEAMCITY_SERVER_URL/viewLog.html?buildId=$BUILD_ID)
 PR: #$PR_NUMBER
@@ -349,6 +384,8 @@ $1 == "" { next }
 
     if (status == "PASS") {
       label = "✅ PASS"
+    } else if (status == "SKIP") {
+      label = "⏭️ SKIP"
     } else if (is_new == "true") {
       label = "❌ NEW"
     } else {
@@ -365,8 +402,9 @@ PR: #$PR_NUMBER
 **Total:** $TOTAL
 **Passed:** $PASS_COUNT
 **Failed:** $FAIL_COUNT
+**Skipped:** $SKIP_COUNT
 **Test Duration:** ${BUILD_HOURS}h ${BUILD_MINUTES}m ${BUILD_SECONDS}s
-${NO_RESULTS_NOTE}
+${NO_RESULTS_NOTE}${BUILD_FAILED_NOTE}
 
 <details>
 <summary>Test Details</summary>
@@ -380,14 +418,17 @@ fi
 
 # Fetch PR author if there are failures
 AUTHOR_MESSAGE=""
-if [ -z "$TEAMCITY_ERROR" ] && [ "$FAIL_COUNT" -gt 0 ]; then
+if [ -z "$TEAMCITY_ERROR" ] && { [ "$FAIL_COUNT" -gt 0 ] || [ "$BUILD_FAILED_WITHOUT_TEST_FAILURES" = "true" ]; }; then
   PR_AUTHOR=$(github_api_request "/pulls/${PR_NUMBER}" \
   | jq -r '.user.login')
 
   if [ -z "$PR_AUTHOR" ] || [ "$PR_AUTHOR" = "null" ]; then
     echo "Warning: Could not fetch PR author"
   else
-    if [ "$HAS_NEW_FAILURES" = "true" ]; then
+    if [ "$BUILD_FAILED_WITHOUT_TEST_FAILURES" = "true" ]; then
+      AUTHOR_MESSAGE="@${PR_AUTHOR} - The TeamCity build failed without reporting failed tests. Please review the build log.
+      "
+    elif [ "$HAS_NEW_FAILURES" = "true" ]; then
       AUTHOR_MESSAGE="@${PR_AUTHOR} - One or more tests newly failed in this PR. Please review the failures.
       "
     else
@@ -475,6 +516,13 @@ if [ "$APPLY_TESTING_LABELS_ENABLED" = "true" ]; then
 
   if [ -n "$TEAMCITY_ERROR" ]; then
     echo "Skipping label application due to TeamCity error"
+    exit 0
+  fi
+
+  # A failed build never gets the passed label, even with no failed tests reported
+  if [ "$BUILD_FAILED_WITHOUT_TEST_FAILURES" = "true" ]; then
+    echo "Build status is FAILURE with no failed tests reported"
+    set_testing_label "$LABEL_FAILURE"
     exit 0
   fi
 


### PR DESCRIPTION
Port of hashicorp/terraform-provider-azuread#1941, plus the gaps that port leaves. The comment step queries `/app/rest/testOccurrences` right after the test step, before TeamCity has indexed the last results, and treats whatever it gets as the final result.

Changes to `post_github_comment.sh`:
- Poll (5s, up to 60s) until at least one occurrence is visible **and the count is unchanged between two polls**, since the last tests to finish (often several, they run in parallel) land together. If still nothing, the comment says so.
- Count ignored/skipped tests (`ignored: true`, status `UNKNOWN`) as **Skipped**, so an all-skipped run no longer reads as "matched nothing".
- Fetch the build's own `status`; a `FAILURE` build with no failed tests reported gets a note, an author ping, and `teamcity-failed` instead of `teamcity-passed`.

Contrary to the azuread PR's note, build length doesn't protect azurerm. Comments that said **Total: 0** for builds where TeamCity has passing tests:

| PR | Build | TeamCity |
|---|---|---|
| [#33342](https://github.com/hashicorp/terraform-provider-azurerm/pull/33342#issuecomment-5542883085) | [737419](https://hashicorp.teamcity.com/viewLog.html?buildId=737419) | Tests passed: 2 |
| [#33351](https://github.com/hashicorp/terraform-provider-azurerm/pull/33351#issuecomment-5547113324) | [737441](https://hashicorp.teamcity.com/viewLog.html?buildId=737441) | Tests passed: 1 |
| [#33324](https://github.com/hashicorp/terraform-provider-azurerm/pull/33324#issuecomment-5530941533) | [736958](https://hashicorp.teamcity.com/viewLog.html?buildId=736958) | Tests passed: 1 |
| [#33300](https://github.com/hashicorp/terraform-provider-azurerm/pull/33300#issuecomment-5516597265) | [736358](https://hashicorp.teamcity.com/viewLog.html?buildId=736358) | Tests passed: 1 |
| [#32562](https://github.com/hashicorp/terraform-provider-azurerm/pull/32562#issuecomment-4967642119) | [705446](https://hashicorp.teamcity.com/viewLog.html?buildId=705446) | Tests passed: 1 (35m build) |
| [#32413](https://github.com/hashicorp/terraform-provider-azurerm/pull/32413#issuecomment-4930917648) | [702132](https://hashicorp.teamcity.com/viewLog.html?buildId=702132) | Tests passed: 1 (7h build) |

Of 25 zero-total comments found, 14 more were all-skipped runs that the script reported as 0 tests.

The same race also undercounts: of 720 recent results comments, 166 report fewer tests than TeamCity (usually one short). In some the missing test was a failure, so the comment said Failed: 0 and `teamcity-passed` was applied to a failed build, e.g. [#32453](https://github.com/hashicorp/terraform-provider-azurerm/pull/32453#issuecomment-4557642674) ([674491](https://hashicorp.teamcity.com/viewLog.html?buildId=674491): 9 failed) and [#32588](https://github.com/hashicorp/terraform-provider-azurerm/pull/32588#issuecomment-4682631944) ([683988](https://hashicorp.teamcity.com/viewLog.html?buildId=683988): 3 failed).