### PR TITLE
`azurerm_eventgrid_system_topic_event_subscription` - document `included_event_types` values and managed identity prerequisites

### DIFF
--- a/website/docs/r/eventgrid_system_topic_event_subscription.html.markdown
+++ b/website/docs/r/eventgrid_system_topic_event_subscription.html.markdown
@@ -87,11 +87,15 @@ The following arguments are supported:
 
 * `included_event_types` - (Optional) A list of applicable event types that need to be part of the event subscription.
 
+-> **Note:** Event types must be specified using their full name, e.g. `Microsoft.Storage.BlobCreated` rather than `BlobCreated`, and the event types that are available depend on the `topic_type` of the System Topic. When not specified, all event types for the System Topic are included. See the [official documentation](https://learn.microsoft.com/azure/event-grid/system-topics#azure-services-that-support-system-topics) for the event types supported by each topic type, or list them using `az eventgrid topic-type list-event-types --name Microsoft.Storage.StorageAccounts`.
+
 * `subject_filter` - (Optional) A `subject_filter` block as defined below.
 
 * `advanced_filter` - (Optional) A `advanced_filter` block as defined below.
 
 * `delivery_identity` - (Optional) A `delivery_identity` block as defined below.
+
+~> **Note:** The Managed Service Identity used for `delivery_identity` or `dead_letter_identity` must be configured on the System Topic via the `identity` block of the `azurerm_eventgrid_system_topic` resource, and must be granted the appropriate role on the destination (e.g. `Storage Queue Data Message Sender` for a `storage_queue_endpoint`, or `Storage Blob Data Contributor` for a `storage_blob_dead_letter_destination`) before the Event Subscription is created. As Terraform cannot infer this dependency, a `depends_on` reference to the `azurerm_role_assignment` resources may be required. See the [official documentation](https://learn.microsoft.com/azure/event-grid/add-identity-roles) for the roles required by each destination type.
 
 * `delivery_property` - (Optional) One or more `delivery_property` blocks as defined below.
 


### PR DESCRIPTION
<!-- markdownlint-disable-file first-line-heading -->
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

The `azurerm_eventgrid_system_topic_event_subscription` page doesn't explain two things users need to get a working subscription, as reported in #33369. This PR adds a note for each:

- `included_event_types` takes full event type names such as `Microsoft.Storage.BlobCreated`, not `BlobCreated`. The available types depend on the System Topic's `topic_type`, and the note links to where they are listed.
- `delivery_identity` and `dead_letter_identity` require the identity to already be configured on the System Topic and granted the destination role before the subscription is created. The note suggests `depends_on` for the role assignments, as the `systemIdentity` and `userIdentity` acceptance tests do.

Documentation only. No existing lines, argument ordering or examples are changed. Note types follow `contributing/topics/reference-documentation-standards.md` (`->` for supported-values information with an external link, `~>` for a prerequisite whose absence causes an apply error).

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”

## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation. (Documentation-only change; no tests required.)
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests. (Not applicable; no Go changes.)

## Testing

Documentation only. `document-fmt validate`, `document-lint` and `misspell` pass locally on the changed file.

## Change Log

Documentation only - no changelog entry required.

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change

## Related Issue(s)

Fixes #33369

## AI Assistance Disclosure

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

Extent: the wording of the two notes, the commit message and this PR description were drafted with Claude Code and reviewed and edited by me before submission. No code was changed. Replies to review comments will be written by me (possibly with AI assistance, which I will disclose).

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

None - documentation-only change.
